### PR TITLE
feat: interactive board with selection and mobile renderer

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,14 +1,47 @@
 import { View, Text, Pressable } from "react-native";
-import { useState } from "react";
-import { setup, getLegalMoves, applyMove, makeRNG } from "@bb/game-engine";
+import { useState, useMemo } from "react";
+import { PixiBoard } from "@bb/ui";
+import { setup, getLegalMoves, applyMove, makeRNG, type Position } from "@bb/game-engine";
 
 export default function Home() {
   const [state, setState] = useState(setup());
   const rng = makeRNG("mobile-seed");
-  const legal = getLegalMoves(state);
+  const [selected, setSelected] = useState<string | null>(null);
+  const legal = useMemo(() => getLegalMoves(state), [state]);
+  const movesForSelected = useMemo(
+    () =>
+      selected
+        ? legal.filter((m) => m.type === "MOVE" && m.playerId === selected).map((m) => m.to)
+        : [],
+    [legal, selected]
+  );
+
+  function onCellClick(pos: Position) {
+    const player = state.players.find((p) => p.pos.x === pos.x && p.pos.y === pos.y);
+    if (player && player.team === state.currentPlayer) {
+      setSelected(player.id);
+      return;
+    }
+    if (selected) {
+      const candidate = legal.find(
+        (m) => m.type === "MOVE" && m.playerId === selected && m.to.x === pos.x && m.to.y === pos.y
+      );
+      if (candidate && candidate.type === "MOVE") {
+        setState((s) => applyMove(s, candidate, rng));
+        setSelected(null);
+      }
+    }
+  }
+
   return (
     <View style={{ flex:1, alignItems:'center', justifyContent:'center', gap:12, padding: 24 }}>
       <Text style={{ fontSize: 20, fontWeight: 'bold' }}>BlooBowl – Mobile MVP</Text>
+      <PixiBoard
+        state={state}
+        onCellClick={onCellClick}
+        legalMoves={movesForSelected}
+        selectedPlayerId={selected}
+      />
       <Text>Tour: {state.turn} • Équipe: {state.currentPlayer}</Text>
       <Pressable
         onPress={() => setState(s => applyMove(s, { type: "END_TURN" }, rng))}
@@ -16,7 +49,6 @@ export default function Home() {
       >
         <Text>Fin du tour</Text>
       </Pressable>
-      <Text style={{ opacity: 0.7 }}>UI plateau à venir (Pixi/Canvas RN).</Text>
     </View>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,8 @@
     "expo": "^51.0.28",
     "react": "18.3.1",
     "react-native": "0.75.4",
-    "expo-router": "~3.6.0"
+    "expo-router": "~3.6.0",
+    "react-native-svg": "^15.2.0"
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,27 +2,67 @@
 
 import { useMemo, useState } from "react";
 import { PixiBoard } from "@bb/ui";
-import { setup, getLegalMoves, applyMove, makeRNG, type GameState, type Position } from "@bb/game-engine";
+import {
+  setup,
+  getLegalMoves,
+  applyMove,
+  makeRNG,
+  type GameState,
+  type Position,
+} from "@bb/game-engine";
 
 export default function HomePage() {
   const [state, setState] = useState<GameState>(() => setup());
   const rng = useMemo(() => makeRNG("ui-seed"), []);
 
+  const [selected, setSelected] = useState<string | null>(null);
+
   const legal = useMemo(() => getLegalMoves(state), [state]);
+  const movesForSelected = useMemo(
+    () =>
+      selected
+        ? legal.filter((m) => m.type === "MOVE" && m.playerId === selected).map((m) => m.to)
+        : [],
+    [legal, selected]
+  );
 
   function onCellClick(pos: Position) {
-    const candidate = legal.find(m => m.type === "MOVE" && m.to.x === pos.x && m.to.y === pos.y);
-    if (candidate && candidate.type === "MOVE") {
-      setState((s) => applyMove(s, candidate, rng));
+    const player = state.players.find((p) => p.pos.x === pos.x && p.pos.y === pos.y);
+    if (player && player.team === state.currentPlayer) {
+      setSelected(player.id);
+      return;
+    }
+    if (selected) {
+      const candidate = legal.find(
+        (m) => m.type === "MOVE" && m.playerId === selected && m.to.x === pos.x && m.to.y === pos.y
+      );
+      if (candidate && candidate.type === "MOVE") {
+        setState((s) => applyMove(s, candidate, rng));
+        setSelected(null);
+      }
     }
   }
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">BlooBowl – Pixi Renderer</h1>
-      <p className="text-sm opacity-80">Clique une case adjacente à un joueur de l'équipe courante pour le déplacer.</p>
-      <PixiBoard state={state} onCellClick={onCellClick} />
-      <div className="text-sm">Tour: {state.turn} • Équipe: <span className="font-mono">{state.currentPlayer}</span></div>
+      <p className="text-sm opacity-80">
+        Clique un joueur pour le sélectionner puis une case surbrillée pour le déplacer.
+      </p>
+      <PixiBoard
+        state={state}
+        onCellClick={onCellClick}
+        legalMoves={movesForSelected}
+        selectedPlayerId={selected}
+      />
+      {selected && (
+        <div className="text-sm">
+          Joueur sélectionné: <span className="font-mono">{selected}</span>
+        </div>
+      )}
+      <div className="text-sm">
+        Tour: {state.turn} • Équipe: <span className="font-mono">{state.currentPlayer}</span>
+      </div>
       <button
         className="px-3 py-2 rounded border bg-white hover:bg-neutral-100"
         onClick={() => setState((s) => applyMove(s, { type: "END_TURN" }, rng))}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.tsx",
   "types": "src/index.tsx",
   "dependencies": {
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "react-native-svg": "^15.2.0"
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/packages/ui/src/PixiBoard.native.tsx
+++ b/packages/ui/src/PixiBoard.native.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import Svg, { Rect, Line, G, Text as SvgText, Circle } from 'react-native-svg';
+import type { GameState, Position } from '@bb/game-engine';
+import { GestureResponderEvent } from 'react-native';
+
+type Props = {
+  state: GameState;
+  onCellClick?: (pos: Position) => void;
+  cellSize?: number;
+  legalMoves?: Position[];
+  selectedPlayerId?: string | null;
+};
+
+export default function PixiBoardNative({
+  state,
+  onCellClick,
+  cellSize = 28,
+  legalMoves = [],
+  selectedPlayerId,
+}: Props) {
+  const width = state.width * cellSize;
+  const height = state.height * cellSize;
+
+  const handlePress = (e: GestureResponderEvent) => {
+    if (!onCellClick) return;
+    const x = Math.floor(e.nativeEvent.locationX / cellSize);
+    const y = Math.floor(e.nativeEvent.locationY / cellSize);
+    if (x >= 0 && y >= 0 && x < state.width && y < state.height) {
+      onCellClick({ x, y });
+    }
+  };
+
+  const grid: React.ReactNode[] = [];
+  for (let x = 0; x <= state.width; x++) {
+    grid.push(
+      <Line
+        key={`v-${x}`}
+        x1={x * cellSize}
+        y1={0}
+        x2={x * cellSize}
+        y2={height}
+        stroke="#ccc"
+        strokeWidth={1}
+      />
+    );
+  }
+  for (let y = 0; y <= state.height; y++) {
+    grid.push(
+      <Line
+        key={`h-${y}`}
+        x1={0}
+        y1={y * cellSize}
+        x2={width}
+        y2={y * cellSize}
+        stroke="#ccc"
+        strokeWidth={1}
+      />
+    );
+  }
+
+  return (
+    <Svg width={width} height={height} onPress={handlePress}>
+      <G>{grid}</G>
+      {/* legal moves */}
+      {legalMoves.map((m) => (
+        <Rect
+          key={`lm-${m.x}-${m.y}`}
+          x={m.x * cellSize}
+          y={m.y * cellSize}
+          width={cellSize}
+          height={cellSize}
+          fill="rgba(34,197,94,0.35)"
+        />
+      ))}
+      {/* ball */}
+      {state.ball && (
+        <Circle
+          cx={state.ball.x * cellSize + cellSize / 2}
+          cy={state.ball.y * cellSize + cellSize / 2}
+          r={cellSize * 0.25}
+          fill="#222"
+        />
+      )}
+      {/* players */}
+      {state.players.map((p) => (
+        <G key={p.id}>
+          {p.id === selectedPlayerId && (
+            <Rect
+              x={p.pos.x * cellSize + cellSize * 0.1}
+              y={p.pos.y * cellSize + cellSize * 0.1}
+              width={cellSize * 0.8}
+              height={cellSize * 0.8}
+              stroke="#facc15"
+              strokeWidth={2}
+            />
+          )}
+          <Rect
+            x={p.pos.x * cellSize + cellSize * 0.1}
+            y={p.pos.y * cellSize + cellSize * 0.1}
+            width={cellSize * 0.8}
+            height={cellSize * 0.8}
+            fill={p.team === 'A' ? '#3B82F6' : '#EF4444'}
+          />
+          <SvgText
+            x={p.pos.x * cellSize + cellSize * 0.3}
+            y={p.pos.y * cellSize + cellSize * 0.6}
+            fontSize={12}
+            fill="#fff"
+          >
+            {p.team}
+          </SvgText>
+        </G>
+      ))}
+    </Svg>
+  );
+}

--- a/packages/ui/src/PixiBoard.tsx
+++ b/packages/ui/src/PixiBoard.tsx
@@ -1,32 +1,96 @@
 'use client';
 import * as React from "react";
-import { Stage, Container, Graphics, Text as PixiText } from "@pixi/react";
+import { useEffect, useRef, useState } from "react";
+import {
+  Stage,
+  Container,
+  Graphics,
+  Text as PixiText,
+  Sprite,
+} from "@pixi/react";
+import { Texture } from "pixi.js";
 import type { GameState, Position } from "@bb/game-engine";
 
 type Props = {
   state: GameState;
   onCellClick?: (pos: Position) => void;
   cellSize?: number;
+  legalMoves?: Position[];
+  selectedPlayerId?: string | null;
 };
 
-export default function PixiBoard({ state, onCellClick, cellSize = 28 }: Props) {
+export default function PixiBoard({
+  state,
+  onCellClick,
+  cellSize = 28,
+  legalMoves = [],
+  selectedPlayerId,
+}: Props) {
   const width = state.width * cellSize;
   const height = state.height * cellSize;
 
-  // Pointer -> grid cell
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const dragStart = useRef<{ x: number; y: number; ox: number; oy: number }>();
+  const isDragging = useRef(false);
+
+  const clampOffset = React.useCallback(
+    (x: number, y: number) => {
+      const minX = width - width * scale;
+      const minY = height - height * scale;
+      return {
+        x: Math.min(0, Math.max(minX, x)),
+        y: Math.min(0, Math.max(minY, y)),
+      };
+    },
+    [width, height, scale]
+  );
+
   const handlePointerDown = (e: any) => {
+    if (e.button === 2) {
+      isDragging.current = true;
+      dragStart.current = { x: e.clientX, y: e.clientY, ox: offset.x, oy: offset.y };
+      return;
+    }
     if (!onCellClick) return;
-    const x = Math.floor(e.nativeEvent.offsetX / cellSize);
-    const y = Math.floor(e.nativeEvent.offsetY / cellSize);
+    const px = (e.nativeEvent.offsetX - offset.x) / scale;
+    const py = (e.nativeEvent.offsetY - offset.y) / scale;
+    const x = Math.floor(px / cellSize);
+    const y = Math.floor(py / cellSize);
     if (x >= 0 && y >= 0 && x < state.width && y < state.height) {
       onCellClick({ x, y });
     }
   };
 
+  const handlePointerMove = (e: any) => {
+    if (!isDragging.current) return;
+    const ds = dragStart.current!;
+    const x = ds.ox + (e.clientX - ds.x);
+    const y = ds.oy + (e.clientY - ds.y);
+    setOffset(clampOffset(x, y));
+  };
+
+  const handlePointerUp = () => {
+    isDragging.current = false;
+  };
+
+  const handleWheel = (e: any) => {
+    const next = Math.min(2, Math.max(0.5, scale + e.deltaY * -0.001));
+    setScale(next);
+    setOffset((o) => clampOffset(o.x, o.y));
+  };
+
   return (
-    <div style={{ display: 'inline-block', background: 'white', borderRadius: 8, border: '1px solid #ddd' }} onPointerDown={handlePointerDown}>
+    <div
+      style={{ display: "inline-block", background: "white", borderRadius: 8, border: "1px solid #ddd" }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onWheel={handleWheel}
+      onContextMenu={(e) => e.preventDefault()}
+    >
       <Stage width={width} height={height} options={{ backgroundAlpha: 0 }}>
-        <Container>
+        <Container scale={scale} x={offset.x} y={offset.y}>
           {/* Grid */}
           <Graphics
             draw={g => {
@@ -57,32 +121,83 @@ export default function PixiBoard({ state, onCellClick, cellSize = 28 }: Props) 
               }}
             />
           )}
-          {/* Players */}
-          <Graphics
-            draw={g => {
-              g.clear();
-              for (const p of state.players) {
-                const cx = p.pos.x * cellSize + cellSize / 2;
-                const cy = p.pos.y * cellSize + cellSize / 2;
-                const color = p.team === "A" ? 0x3B82F6 : 0xEF4444; // blue / red
-                g.beginFill(color);
-                g.drawRoundedRect(cx - cellSize * 0.4, cy - cellSize * 0.4, cellSize * 0.8, cellSize * 0.8, 6);
+          {/* Highlight legal moves */}
+          {legalMoves.map((m) => (
+            <Graphics
+              key={`lm-${m.x}-${m.y}`}
+              draw={(g) => {
+                g.clear();
+                g.beginFill(0x22c55e, 0.35);
+                g.drawRect(m.x * cellSize, m.y * cellSize, cellSize, cellSize);
                 g.endFill();
-              }
-            }}
-          />
-          {/* Labels */}
-          {state.players.map((p, i) => (
-            <PixiText
+              }}
+            />
+          ))}
+          {/* Players */}
+          {state.players.map((p) => (
+            <PlayerSprite
               key={p.id}
-              text={p.team}
-              x={p.pos.x * cellSize + cellSize / 2 - 5}
-              y={p.pos.y * cellSize + cellSize / 2 - 8}
-              style={{ fontFamily: 'monospace', fontSize: 12, fill: 0xFFFFFF }}
+              player={p}
+              cellSize={cellSize}
+              selected={p.id === selectedPlayerId}
             />
           ))}
         </Container>
       </Stage>
     </div>
+  );
+}
+
+type PlayerSpriteProps = {
+  player: GameState["players"][number];
+  cellSize: number;
+  selected?: boolean;
+};
+
+function PlayerSprite({ player, cellSize, selected }: PlayerSpriteProps) {
+  const [pos, setPos] = useState({ x: player.pos.x, y: player.pos.y });
+  const prev = useRef(pos);
+
+  useEffect(() => {
+    const from = prev.current;
+    const to = player.pos;
+    const start = performance.now();
+    const animate = (now: number) => {
+      const t = Math.min(1, (now - start) / 200);
+      setPos({ x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t });
+      if (t < 1) requestAnimationFrame(animate);
+      else prev.current = { ...to };
+    };
+    requestAnimationFrame(animate);
+  }, [player.pos.x, player.pos.y]);
+
+  const color = player.team === "A" ? 0x3B82F6 : 0xEF4444;
+
+  return (
+    <Container x={pos.x * cellSize} y={pos.y * cellSize}>
+      {selected && (
+        <Graphics
+          draw={(g) => {
+            g.clear();
+            g.lineStyle(2, 0xFACC15);
+            g.drawRoundedRect(cellSize * 0.1, cellSize * 0.1, cellSize * 0.8, cellSize * 0.8, 6);
+          }}
+        />
+      )}
+      <Sprite
+        texture={Texture.WHITE}
+        width={cellSize * 0.8}
+        height={cellSize * 0.8}
+        tint={color}
+        x={cellSize * 0.1}
+        y={cellSize * 0.1}
+      />
+      <PixiText
+        text={player.team}
+        x={cellSize * 0.3}
+        y={cellSize * 0.3}
+        style={{ fontFamily: "monospace", fontSize: 12, fill: 0xffffff }}
+      />
+    </Container>
   );
 }


### PR DESCRIPTION
## Summary
- add zoomable Pixi board highlighting legal moves and animating players
- support player selection UX on web and mobile
- add simple React Native board implementation using `react-native-svg`

## Testing
- `pnpm install` *(fails: fetch failed)*
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e44c3788326a272bae3679531dc