### PR TITLE
feat: track movement points and selection

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,51 +1,82 @@
 import { View, Text, Pressable } from "react-native";
 import { useState, useMemo } from "react";
 import { PixiBoard } from "@bb/ui";
-import { setup, getLegalMoves, applyMove, makeRNG, type Position } from "@bb/game-engine";
+import {
+  setup,
+  getLegalMoves,
+  applyMove,
+  makeRNG,
+  type Position,
+} from "@bb/game-engine";
 
 export default function Home() {
   const [state, setState] = useState(setup());
   const rng = makeRNG("mobile-seed");
-  const [selected, setSelected] = useState<string | null>(null);
   const legal = useMemo(() => getLegalMoves(state), [state]);
   const movesForSelected = useMemo(
     () =>
-      selected
-        ? legal.filter((m) => m.type === "MOVE" && m.playerId === selected).map((m) => m.to)
+      state.selectedPlayerId
+        ? legal
+            .filter(
+              (m) => m.type === "MOVE" && m.playerId === state.selectedPlayerId,
+            )
+            .map((m) => m.to)
         : [],
-    [legal, selected]
+    [legal, state.selectedPlayerId],
   );
 
   function onCellClick(pos: Position) {
-    const player = state.players.find((p) => p.pos.x === pos.x && p.pos.y === pos.y);
+    const player = state.players.find(
+      (p) => p.pos.x === pos.x && p.pos.y === pos.y,
+    );
     if (player && player.team === state.currentPlayer) {
-      setSelected(player.id);
+      setState((s) => ({ ...s, selectedPlayerId: player.id }));
       return;
     }
-    if (selected) {
+    if (state.selectedPlayerId) {
       const candidate = legal.find(
-        (m) => m.type === "MOVE" && m.playerId === selected && m.to.x === pos.x && m.to.y === pos.y
+        (m) =>
+          m.type === "MOVE" &&
+          m.playerId === state.selectedPlayerId &&
+          m.to.x === pos.x &&
+          m.to.y === pos.y,
       );
       if (candidate && candidate.type === "MOVE") {
-        setState((s) => applyMove(s, candidate, rng));
-        setSelected(null);
+        setState((s) => {
+          const s2 = applyMove(s, candidate, rng);
+          const p = s2.players.find((pl) => pl.id === candidate.playerId);
+          if (!p || p.pm <= 0) s2.selectedPlayerId = null;
+          return s2;
+        });
       }
     }
   }
 
   return (
-    <View style={{ flex:1, alignItems:'center', justifyContent:'center', gap:12, padding: 24 }}>
-      <Text style={{ fontSize: 20, fontWeight: 'bold' }}>BlooBowl – Mobile MVP</Text>
+    <View
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 12,
+        padding: 24,
+      }}
+    >
+      <Text style={{ fontSize: 20, fontWeight: "bold" }}>
+        BlooBowl – Mobile MVP
+      </Text>
       <PixiBoard
         state={state}
         onCellClick={onCellClick}
         legalMoves={movesForSelected}
-        selectedPlayerId={selected}
+        selectedPlayerId={state.selectedPlayerId}
       />
-      <Text>Tour: {state.turn} • Équipe: {state.currentPlayer}</Text>
+      <Text>
+        Tour: {state.turn} • Équipe: {state.currentPlayer}
+      </Text>
       <Pressable
-        onPress={() => setState(s => applyMove(s, { type: "END_TURN" }, rng))}
-        style={{ padding: 12, borderRadius: 8, borderWidth:1 }}
+        onPress={() => setState((s) => applyMove(s, { type: "END_TURN" }, rng))}
+        style={{ padding: 12, borderRadius: 8, borderWidth: 1 }}
       >
         <Text>Fin du tour</Text>
       </Pressable>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { useMemo, useState } from "react";
 import { PixiBoard, PlayerDetails } from "@bb/ui";
@@ -16,29 +16,42 @@ export default function HomePage() {
   const [state, setState] = useState<GameState>(() => setup());
   const rng = useMemo(() => makeRNG("ui-seed"), []);
 
-  const [selected, setSelected] = useState<string | null>(null);
-
   const legal = useMemo(() => getLegalMoves(state), [state]);
   const isMove = (m: Move, pid: string): m is Extract<Move, { type: "MOVE" }> =>
     m.type === "MOVE" && (m as any).playerId === pid;
   const movesForSelected = useMemo(
-    () => (selected ? legal.filter((m) => isMove(m, selected)).map((m) => m.to) : []),
-    [legal, selected]
+    () =>
+      state.selectedPlayerId
+        ? legal
+            .filter((m) => isMove(m, state.selectedPlayerId!))
+            .map((m) => m.to)
+        : [],
+    [legal, state.selectedPlayerId],
   );
 
   function onCellClick(pos: Position) {
-    const player = state.players.find((p) => p.pos.x === pos.x && p.pos.y === pos.y);
+    const player = state.players.find(
+      (p) => p.pos.x === pos.x && p.pos.y === pos.y,
+    );
     if (player && player.team === state.currentPlayer) {
-      setSelected(player.id);
+      setState((s) => ({ ...s, selectedPlayerId: player.id }));
       return;
     }
-    if (selected) {
+    if (state.selectedPlayerId) {
       const candidate = legal.find(
-        (m) => m.type === "MOVE" && m.playerId === selected && m.to.x === pos.x && m.to.y === pos.y
+        (m) =>
+          m.type === "MOVE" &&
+          m.playerId === state.selectedPlayerId &&
+          m.to.x === pos.x &&
+          m.to.y === pos.y,
       );
       if (candidate && candidate.type === "MOVE") {
-        setState((s) => applyMove(s, candidate, rng));
-        setSelected(null);
+        setState((s) => {
+          const s2 = applyMove(s, candidate, rng);
+          const p = s2.players.find((pl) => pl.id === candidate.playerId);
+          if (!p || p.pm <= 0) s2.selectedPlayerId = null;
+          return s2;
+        });
       }
     }
   }
@@ -47,21 +60,24 @@ export default function HomePage() {
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">BlooBowl – Pixi Renderer</h1>
       <p className="text-sm opacity-80">
-        Clique un joueur pour le sélectionner puis une case surbrillée pour le déplacer.
+        Clique un joueur pour le sélectionner puis une case surbrillée pour le
+        déplacer.
       </p>
       <PixiBoard
         state={state}
         onCellClick={onCellClick}
         legalMoves={movesForSelected}
-        selectedPlayerId={selected}
+        selectedPlayerId={state.selectedPlayerId}
       />
-      {selected && (
+      {state.selectedPlayerId && (
         <div className="text-sm">
-          Joueur sélectionné: <span className="font-mono">{selected}</span>
+          Joueur sélectionné:{" "}
+          <span className="font-mono">{state.selectedPlayerId}</span>
         </div>
       )}
       <div className="text-sm">
-        Tour: {state.turn} • Équipe: <span className="font-mono">{state.currentPlayer}</span>
+        Tour: {state.turn} • Équipe:{" "}
+        <span className="font-mono">{state.currentPlayer}</span>
       </div>
       <button
         className="px-3 py-2 rounded border bg-white hover:bg-neutral-100"
@@ -69,12 +85,14 @@ export default function HomePage() {
       >
         Fin du tour
       </button>
-      
+
       {/* Encart des détails du joueur */}
-      {selected && (
+      {state.selectedPlayerId && (
         <PlayerDetails
-          player={state.players.find(p => p.id === selected) || null}
-          onClose={() => setSelected(null)}
+          player={
+            state.players.find((p) => p.id === state.selectedPlayerId) || null
+          }
+          onClose={() => setState((s) => ({ ...s, selectedPlayerId: null }))}
         />
       )}
     </div>

--- a/packages/ui/src/PixiBoard.native.tsx
+++ b/packages/ui/src/PixiBoard.native.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import Svg, { Rect, Line, G, Text as SvgText, Circle } from 'react-native-svg';
-import type { GameState, Position } from '@bb/game-engine';
-import { GestureResponderEvent } from 'react-native';
+import * as React from "react";
+import Svg, { Rect, Line, G, Text as SvgText, Circle } from "react-native-svg";
+import type { GameState, Position } from "@bb/game-engine";
+import { GestureResponderEvent } from "react-native";
 
 type Props = {
   state: GameState;
@@ -41,7 +41,7 @@ export default function PixiBoardNative({
         y2={height}
         stroke="#ccc"
         strokeWidth={1}
-      />
+      />,
     );
   }
   for (let y = 0; y <= state.height; y++) {
@@ -54,7 +54,7 @@ export default function PixiBoardNative({
         y2={y * cellSize}
         stroke="#ccc"
         strokeWidth={1}
-      />
+      />,
     );
   }
 
@@ -99,7 +99,7 @@ export default function PixiBoardNative({
             y={p.pos.y * cellSize + cellSize * 0.1}
             width={cellSize * 0.8}
             height={cellSize * 0.8}
-            fill={p.team === 'A' ? '#3B82F6' : '#EF4444'}
+            fill={p.team === "A" ? "#3B82F6" : "#EF4444"}
           />
           <SvgText
             x={p.pos.x * cellSize + cellSize * 0.3}
@@ -108,6 +108,22 @@ export default function PixiBoardNative({
             fill="#fff"
           >
             {p.team}
+          </SvgText>
+          {/* Badge PM */}
+          <Circle
+            cx={p.pos.x * cellSize + cellSize * 0.8}
+            cy={p.pos.y * cellSize + cellSize * 0.2}
+            r={cellSize * 0.2}
+            fill="#000"
+          />
+          <SvgText
+            x={p.pos.x * cellSize + cellSize * 0.8}
+            y={p.pos.y * cellSize + cellSize * 0.2 + cellSize * 0.08}
+            fontSize={cellSize * 0.25}
+            fill="#fff"
+            textAnchor="middle"
+          >
+            {p.pm}
           </SvgText>
         </G>
       ))}

--- a/packages/ui/src/PixiBoard.tsx
+++ b/packages/ui/src/PixiBoard.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 import * as React from "react";
 import { Stage, Container, Graphics, Text } from "@pixi/react";
 import type { Graphics as PixiGraphics } from "@pixi/graphics";
@@ -20,44 +20,55 @@ export default function PixiBoard({
   selectedPlayerId,
 }: Props) {
   // Orientation verticale : largeur devient hauteur et vice versa
-  const width = state.height * cellSize;  // 15 * cellSize = 420
-  const height = state.width * cellSize;  // 26 * cellSize = 728
+  const width = state.height * cellSize; // 15 * cellSize = 420
+  const height = state.width * cellSize; // 26 * cellSize = 728
 
-  console.log('Terrain dimensions:', { 
-    stateWidth: state.width, 
-    stateHeight: state.height, 
-    cellSize, 
-    width, 
-    height 
+  console.log("Terrain dimensions:", {
+    stateWidth: state.width,
+    stateHeight: state.height,
+    cellSize,
+    width,
+    height,
   });
 
   // Fonction pour gérer les clics sur le terrain
   const handleStageClick = (event: any) => {
     if (!onCellClick) return;
-    
+
     // Dans Pixi.js avec React, l'événement a une structure différente
     // event.nativeEvent contient les informations de la souris
     const nativeEvent = event.nativeEvent;
     if (!nativeEvent) return;
-    
+
     // Obtenir les coordonnées relatives au canvas
     const rect = event.currentTarget.getBoundingClientRect();
     const x = nativeEvent.clientX - rect.left;
     const y = nativeEvent.clientY - rect.top;
-    
+
     // Convertir les coordonnées de la souris en position de grille
     const gridX = Math.floor(x / cellSize);
     const gridY = Math.floor(y / cellSize);
-    
+
     // Vérifier que la position est dans les limites du terrain
-    if (gridX >= 0 && gridX < state.height && gridY >= 0 && gridY < state.width) {
+    if (
+      gridX >= 0 &&
+      gridX < state.height &&
+      gridY >= 0 &&
+      gridY < state.width
+    ) {
       // Créer la position (orientation verticale : inverser x et y)
       const position: Position = {
         x: gridY, // Inverser x et y pour l'orientation verticale
-        y: gridX
+        y: gridX,
       };
-      
-      console.log('Clic sur la cellule:', { gridX, gridY, position, clientX: nativeEvent.clientX, clientY: nativeEvent.clientY });
+
+      console.log("Clic sur la cellule:", {
+        gridX,
+        gridY,
+        position,
+        clientX: nativeEvent.clientX,
+        clientY: nativeEvent.clientY,
+      });
       onCellClick(position);
     }
   };
@@ -65,10 +76,10 @@ export default function PixiBoard({
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
       {/* Canvas Pixi.js */}
-      <Stage 
-        width={width} 
-        height={height} 
-        options={{ backgroundColor: 0x6B8E23 }}
+      <Stage
+        width={width}
+        height={height}
+        options={{ backgroundColor: 0x6b8e23 }}
         onPointerDown={handleStageClick}
       >
         <Container>
@@ -76,63 +87,63 @@ export default function PixiBoard({
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.beginFill(0x6B8E23); // Vert kaki pour tout le terrain
+              g.beginFill(0x6b8e23); // Vert kaki pour tout le terrain
               g.drawRect(0, 0, width, height);
               g.endFill();
             }}
           />
-          
+
           {/* Zone de TOUCHDOWN en haut (rouge et blanc clair) - 1 case de hauteur */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              
+
               // Motif en damier rouge et blanc clair
               const tdHeight = cellSize; // 1 case de hauteur
               const squareSize = cellSize / 2;
               const tdWidth = width; // Largeur complète du terrain
-              
+
               for (let x = 0; x < tdWidth; x += squareSize) {
                 for (let y = 0; y < tdHeight; y += squareSize) {
-                  const isRed = ((x / squareSize) + (y / squareSize)) % 2 === 0;
-                  g.beginFill(isRed ? 0xFF0000 : 0xF5F5F5); // Rouge et blanc clair
+                  const isRed = (x / squareSize + y / squareSize) % 2 === 0;
+                  g.beginFill(isRed ? 0xff0000 : 0xf5f5f5); // Rouge et blanc clair
                   g.drawRect(x, y, squareSize, squareSize);
                   g.endFill();
                 }
               }
-              
+
               // Bordure noire
               g.lineStyle(2, 0x000000, 1);
               g.drawRect(0, 0, tdWidth, tdHeight);
             }}
           />
-          
+
           {/* Zone de TOUCHDOWN en bas (rouge et blanc clair) - 1 case de hauteur */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              
+
               // Motif en damier rouge et blanc clair
               const tdHeight = cellSize; // 1 case de hauteur
               const squareSize = cellSize / 2;
               const startY = height - tdHeight;
               const tdWidth = width; // Largeur complète du terrain
-              
+
               for (let x = 0; x < tdWidth; x += squareSize) {
                 for (let y = 0; y < tdHeight; y += squareSize) {
-                  const isRed = ((x / squareSize) + (y / squareSize)) % 2 === 0;
-                  g.beginFill(isRed ? 0xFF0000 : 0xF5F5F5); // Rouge et blanc clair
+                  const isRed = (x / squareSize + y / squareSize) % 2 === 0;
+                  g.beginFill(isRed ? 0xff0000 : 0xf5f5f5); // Rouge et blanc clair
                   g.drawRect(x, startY + y, squareSize, squareSize);
                   g.endFill();
                 }
               }
-              
+
               // Bordure noire
               g.lineStyle(2, 0x000000, 1);
               g.drawRect(0, startY, tdWidth, tdHeight);
             }}
           />
-          
+
           {/* Couloir latéral gauche (4 cases de large) */}
           <Graphics
             draw={(g: PixiGraphics) => {
@@ -140,54 +151,54 @@ export default function PixiBoard({
               // g.beginFill(0x6B8E23, 0.9); // Vert kaki pour les couloirs (même couleur que le terrain)
               // g.drawRect(0, 0, cellSize * 4, height);
               // g.endFill();
-              
+
               // Bordure blanche
-              g.lineStyle(3, 0xFFFFFF, 1);
+              g.lineStyle(3, 0xffffff, 1);
               g.drawRect(0, 0, cellSize * 4, height);
             }}
           />
-          
+
           {/* Couloir latéral droit (4 cases de large) */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              const rightX = width - (cellSize * 4);
+              const rightX = width - cellSize * 4;
               // g.beginFill(0x6B8E23, 0.9); // Vert kaki pour les couloirs (même couleur que le terrain)
               // g.drawRect(rightX, 0, cellSize * 4, height);
               // g.endFill();
-              
+
               // Bordure blanche
-              g.lineStyle(3, 0xFFFFFF, 1);
+              g.lineStyle(3, 0xffffff, 1);
               g.drawRect(rightX, 0, cellSize * 4, height);
             }}
           />
-          
+
           {/* Ligne centrale (Line of Scrimmage) - jaune */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(4, 0xFFFF00, 1); // Jaune, épaisseur 4
-              
+              g.lineStyle(4, 0xffff00, 1); // Jaune, épaisseur 4
+
               // Ligne centrale au milieu (y = 13, car 26/2 = 13)
               const centerY = 13 * cellSize;
               g.moveTo(0, centerY);
               g.lineTo(width, centerY);
             }}
           />
-          
+
           {/* Grille de cellules (plus subtile) */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(1, 0xCCCCCC, 0.3); // Gris clair, très transparent
-              
+              g.lineStyle(1, 0xcccccc, 0.3); // Gris clair, très transparent
+
               // Lignes verticales
               for (let x = 0; x <= state.height; x++) {
                 const xPos = x * cellSize;
                 g.moveTo(xPos, 0);
                 g.lineTo(xPos, height);
               }
-              
+
               // Lignes horizontales
               for (let y = 0; y <= state.width; y++) {
                 const yPos = y * cellSize;
@@ -196,135 +207,163 @@ export default function PixiBoard({
               }
             }}
           />
-          
+
           {/* Mouvements légaux (cases surbrillées) */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(2, 0x00FF00, 1); // Vert, épaisseur 2
-              g.beginFill(0x00FF00, 0.3); // Vert transparent
-              
-              legalMoves.forEach(move => {
+              g.lineStyle(2, 0x00ff00, 1); // Vert, épaisseur 2
+              g.beginFill(0x00ff00, 0.3); // Vert transparent
+
+              legalMoves.forEach((move) => {
                 // legalMoves est déjà un tableau de Position[] (les positions 'to' des mouvements légaux)
                 // Orientation verticale : inverser x et y
                 const x = move.y * cellSize;
                 const y = move.x * cellSize;
                 g.drawRect(x, y, cellSize, cellSize);
               });
-              
+
               g.endFill();
             }}
           />
-          
+
           {/* Joueurs */}
-          {state.players.map(player => {
+          {state.players.map((player) => {
             const isSelected = player.id === selectedPlayerId;
             const isCurrentTeam = player.team === state.currentPlayer;
-            
+
             return (
               <React.Fragment key={player.id}>
                 <Graphics
                   draw={(g: PixiGraphics) => {
                     g.clear();
-                    
+
                     // Position (orientation verticale : inverser x et y)
                     const x = player.pos.y * cellSize + cellSize / 2;
                     const y = player.pos.x * cellSize + cellSize / 2;
                     const radius = cellSize / 2 - 2;
-                    
+
                     // Cercle du joueur
-                    g.beginFill(player.team === 'A' ? 0xFF0000 : 0x0000FF); // Rouge pour équipe A, Bleu pour équipe B
+                    g.beginFill(player.team === "A" ? 0xff0000 : 0x0000ff); // Rouge pour équipe A, Bleu pour équipe B
                     g.drawCircle(x, y, radius);
                     g.endFill();
-                    
+
                     // Bordure - améliorée pour la sélection
                     if (isSelected) {
                       // Bordure jaune épaisse pour le joueur sélectionné
-                      g.lineStyle(4, 0xFFFF00, 1);
+                      g.lineStyle(4, 0xffff00, 1);
                       g.drawCircle(x, y, radius + 2);
-                      
+
                       // Halo de sélection
-                      g.lineStyle(2, 0xFFFF00, 0.5);
+                      g.lineStyle(2, 0xffff00, 0.5);
                       g.drawCircle(x, y, radius + 8);
                     } else {
                       // Bordure blanche normale
-                      g.lineStyle(3, 0xFFFFFF, 1);
+                      g.lineStyle(3, 0xffffff, 1);
                       g.drawCircle(x, y, radius);
                     }
-                    
+
                     // Indicateur de tour actuel
                     if (isCurrentTeam) {
-                      g.lineStyle(2, 0x00FF00, 1); // Vert pour le tour actuel
+                      g.lineStyle(2, 0x00ff00, 1); // Vert pour le tour actuel
                       g.drawCircle(x, y, radius + 3);
                     }
                   }}
                 />
-                
+
                 {/* Numéro du joueur au centre */}
                 <Text
                   x={player.pos.y * cellSize + cellSize / 2}
                   y={player.pos.x * cellSize + cellSize / 2}
                   text={player.id}
                   anchor={{ x: 0.5, y: 0.5 }}
-                  style={{
-                    align: 'center',
-                    breakWords: false,
-                    dropShadow: false,
-                    dropShadowAlpha: 1,
-                    dropShadowAngle: 0,
-                    dropShadowBlur: 0,
-                    dropShadowColor: 0x000000,
-                    dropShadowDistance: 0,
-                    fill: 0xFFFFFF,
-                    fontFamily: 'Arial',
-                    fontSize: Math.max(12, cellSize / 3),
-                    fontStyle: 'normal',
-                    fontVariant: 'normal',
-                    fontWeight: 'normal',
-                    leading: 0,
-                    letterSpacing: 0,
-                    lineHeight: 0,
-                    lineJoin: 'miter',
-                    miterLimit: 10,
-                    padding: 0,
-                    stroke: 0x000000,
-                    strokeThickness: 2,
-                    textBaseline: 'alphabetic',
-                    trim: false,
-                    whiteSpace: 'pre',
-                    wordWrap: false,
-                    wordWrapWidth: 0,
-                    fillGradientType: 0,
-                    fillGradientStops: [],
-                    styleID: 0
+                  style={
+                    {
+                      align: "center",
+                      breakWords: false,
+                      dropShadow: false,
+                      dropShadowAlpha: 1,
+                      dropShadowAngle: 0,
+                      dropShadowBlur: 0,
+                      dropShadowColor: 0x000000,
+                      dropShadowDistance: 0,
+                      fill: 0xffffff,
+                      fontFamily: "Arial",
+                      fontSize: Math.max(12, cellSize / 3),
+                      fontStyle: "normal",
+                      fontVariant: "normal",
+                      fontWeight: "normal",
+                      leading: 0,
+                      letterSpacing: 0,
+                      lineHeight: 0,
+                      lineJoin: "miter",
+                      miterLimit: 10,
+                      padding: 0,
+                      stroke: 0x000000,
+                      strokeThickness: 2,
+                      textBaseline: "alphabetic",
+                      trim: false,
+                      whiteSpace: "pre",
+                      wordWrap: false,
+                      wordWrapWidth: 0,
+                      fillGradientType: 0,
+                      fillGradientStops: [],
+                      styleID: 0,
+                    } as any
+                  }
+                />
+
+                {/* Badge des points de mouvement */}
+                <Graphics
+                  draw={(g: PixiGraphics) => {
+                    g.clear();
+                    const r = cellSize / 4;
+                    const bx = player.pos.y * cellSize + cellSize - r;
+                    const by = player.pos.x * cellSize + r;
+                    g.beginFill(0x000000, 0.7);
+                    g.drawCircle(bx, by, r);
+                    g.endFill();
                   }}
+                />
+                <Text
+                  x={player.pos.y * cellSize + cellSize - cellSize / 4}
+                  y={player.pos.x * cellSize + cellSize / 4}
+                  text={String(player.pm)}
+                  anchor={{ x: 0.5, y: 0.5 }}
+                  style={
+                    {
+                      fill: 0xffffff,
+                      fontSize: Math.max(10, cellSize / 4),
+                      fontFamily: "Arial",
+                    } as any
+                  }
                 />
               </React.Fragment>
             );
           })}
-          
+
           {/* Balle */}
           {state.ball && (
             <Graphics
               draw={(g: PixiGraphics) => {
                 g.clear();
-                
+
                 // Position (orientation verticale : inverser x et y)
                 const x = state.ball!.y * cellSize + cellSize / 2;
                 const y = state.ball!.x * cellSize + cellSize / 2;
                 const radius = cellSize / 3;
-                
+
                 // Cercle de la balle
-                g.beginFill(0x8B4513); // Marron
+                g.beginFill(0x8b4513); // Marron
                 g.drawCircle(x, y, radius);
                 g.endFill();
-                
+
                 // Bordure blanche
-                g.lineStyle(2, 0xFFFFFF, 1);
+                g.lineStyle(2, 0xffffff, 1);
                 g.drawCircle(x, y, radius);
-                
+
                 // Lignes de la balle
-                g.lineStyle(1, 0xFFFFFF, 1);
+                g.lineStyle(1, 0xffffff, 1);
                 g.moveTo(x - radius, y);
                 g.lineTo(x + radius, y);
                 g.moveTo(x, y - radius);
@@ -334,27 +373,48 @@ export default function PixiBoard({
           )}
         </Container>
       </Stage>
-      
+
       {/* Boîte de debug */}
-      <div style={{ 
-        border: "2px solid #333", 
-        padding: "15px", 
-        backgroundColor: "#f5f5f5",
-        borderRadius: "8px"
-      }}>
+      <div
+        style={{
+          border: "2px solid #333",
+          padding: "15px",
+          backgroundColor: "#f5f5f5",
+          borderRadius: "8px",
+        }}
+      >
         <h3>Debug Info:</h3>
-        <p><strong>Pixi.js Status:</strong> ✅ Actif</p>
-        <p><strong>Dimensions:</strong> {width} x {height} pixels</p>
-        <p><strong>Grille:</strong> {state.width} x {state.height} cases</p>
-        <p><strong>Taille case:</strong> {cellSize} pixels</p>
-        <p><strong>Joueurs:</strong> {state.players.length}</p>
-        <p><strong>Balle:</strong> ({state.ball?.x}, {state.ball?.y})</p>
-        <p><strong>Tour:</strong> {state.turn} - Joueur: {state.currentPlayer}</p>
-        <p><strong>Mouvements légaux:</strong> {legalMoves.length}</p>
-        <p><strong>Joueur sélectionné:</strong> {selectedPlayerId || 'Aucun'}</p>
-        <p><strong>Interactivité:</strong> ✅ Clics activés</p>
+        <p>
+          <strong>Pixi.js Status:</strong> ✅ Actif
+        </p>
+        <p>
+          <strong>Dimensions:</strong> {width} x {height} pixels
+        </p>
+        <p>
+          <strong>Grille:</strong> {state.width} x {state.height} cases
+        </p>
+        <p>
+          <strong>Taille case:</strong> {cellSize} pixels
+        </p>
+        <p>
+          <strong>Joueurs:</strong> {state.players.length}
+        </p>
+        <p>
+          <strong>Balle:</strong> ({state.ball?.x}, {state.ball?.y})
+        </p>
+        <p>
+          <strong>Tour:</strong> {state.turn} - Joueur: {state.currentPlayer}
+        </p>
+        <p>
+          <strong>Mouvements légaux:</strong> {legalMoves.length}
+        </p>
+        <p>
+          <strong>Joueur sélectionné:</strong> {selectedPlayerId || "Aucun"}
+        </p>
+        <p>
+          <strong>Interactivité:</strong> ✅ Clics activés
+        </p>
       </div>
     </div>
   );
 }
-

--- a/packages/ui/src/PlayerDetails.tsx
+++ b/packages/ui/src/PlayerDetails.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import type { Player } from '@bb/game-engine';
+import React from "react";
+import type { Player } from "@bb/game-engine";
 
 interface PlayerDetailsProps {
   player: Player | null;
@@ -26,36 +26,61 @@ export default function PlayerDetails({ player, onClose }: PlayerDetailsProps) {
       <div className="space-y-4">
         {/* Numéro et nom */}
         <div className="text-center pb-3 border-b border-gray-200">
-          <div className="text-3xl font-bold text-blue-600">#{player.number}</div>
-          <div className="text-xl font-semibold text-gray-800">{player.name}</div>
+          <div className="text-3xl font-bold text-blue-600">
+            #{player.number}
+          </div>
+          <div className="text-xl font-semibold text-gray-800">
+            {player.name}
+          </div>
           <div className="text-sm text-gray-600">{player.position}</div>
         </div>
 
         {/* Statistiques */}
         <div className="grid grid-cols-2 gap-4">
+          <div className="text-center p-3 bg-teal-50 rounded-lg">
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              PM
+            </div>
+            <div className="text-2xl font-bold text-teal-600">{player.pm}</div>
+            <div className="text-xs text-gray-500">Points de mouvement</div>
+          </div>
           <div className="text-center p-3 bg-blue-50 rounded-lg">
-            <div className="text-xs text-gray-600 uppercase tracking-wide">MA</div>
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              MA
+            </div>
             <div className="text-2xl font-bold text-blue-600">{player.ma}</div>
             <div className="text-xs text-gray-500">Movement</div>
           </div>
           <div className="text-center p-3 bg-red-50 rounded-lg">
-            <div className="text-xs text-gray-600 uppercase tracking-wide">ST</div>
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              ST
+            </div>
             <div className="text-2xl font-bold text-red-600">{player.st}</div>
             <div className="text-xs text-gray-500">Strength</div>
           </div>
           <div className="text-center p-3 bg-green-50 rounded-lg">
-            <div className="text-xs text-gray-600 uppercase tracking-wide">AG</div>
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              AG
+            </div>
             <div className="text-2xl font-bold text-green-600">{player.ag}</div>
             <div className="text-xs text-gray-500">Agility</div>
           </div>
           <div className="text-center p-3 bg-purple-50 rounded-lg">
-            <div className="text-xs text-gray-600 uppercase tracking-wide">PA</div>
-            <div className="text-2xl font-bold text-purple-600">{player.pa}</div>
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              PA
+            </div>
+            <div className="text-2xl font-bold text-purple-600">
+              {player.pa}
+            </div>
             <div className="text-xs text-gray-500">Passing</div>
           </div>
           <div className="text-center p-3 bg-yellow-50 rounded-lg col-span-2">
-            <div className="text-xs text-gray-600 uppercase tracking-wide">AR</div>
-            <div className="text-2xl font-bold text-yellow-600">{player.av}</div>
+            <div className="text-xs text-gray-600 uppercase tracking-wide">
+              AR
+            </div>
+            <div className="text-2xl font-bold text-yellow-600">
+              {player.av}
+            </div>
             <div className="text-xs text-gray-500">Armour</div>
           </div>
         </div>
@@ -77,17 +102,23 @@ export default function PlayerDetails({ player, onClose }: PlayerDetailsProps) {
               ))}
             </div>
           ) : (
-            <div className="text-gray-500 text-sm italic">Aucune compétence spéciale</div>
+            <div className="text-gray-500 text-sm italic">
+              Aucune compétence spéciale
+            </div>
           )}
         </div>
 
         {/* Équipe */}
         <div className="pt-3 border-t border-gray-200">
           <div className="text-center">
-            <div className="text-xs text-gray-600 uppercase tracking-wide mb-1">Équipe</div>
-            <div className={`inline-block px-3 py-1 rounded-full text-white text-sm font-semibold ${
-              player.team === 'A' ? 'bg-red-500' : 'bg-blue-500'
-            }`}>
+            <div className="text-xs text-gray-600 uppercase tracking-wide mb-1">
+              Équipe
+            </div>
+            <div
+              className={`inline-block px-3 py-1 rounded-full text-white text-sm font-semibold ${
+                player.team === "A" ? "bg-red-500" : "bg-blue-500"
+              }`}
+            >
               Équipe {player.team}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- track selected player and movement points in game state
- show movement point badges on tokens and player panel
- update web and mobile apps to use shared selection state

## Testing
- `pnpm lint` (fails: ESLint couldn't find configuration)
- `pnpm test` (fails: no test tasks)
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5be91adb48326a29393c93b35833f