### PR TITLE
Disable registration during pre-alpha phase

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -94,11 +94,9 @@ export default function LoginScreen() {
             )}
           </Pressable>
 
-          <Pressable style={styles.linkButton} onPress={() => router.push("/register")}>
-            <Text style={styles.linkText}>
-              Pas de compte ? S'inscrire
-            </Text>
-          </Pressable>
+          <Text style={styles.preAlphaText}>
+            Nuffle Arena est en pré-alpha. L'inscription sera bientôt disponible.
+          </Text>
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
@@ -161,13 +159,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
   },
-  linkButton: {
+  preAlphaText: {
     marginTop: 16,
-    alignItems: "center",
-  },
-  linkText: {
-    color: "#2563EB",
-    fontSize: 14,
-    textDecorationLine: "underline",
+    fontSize: 13,
+    color: "#6B7280",
+    textAlign: "center",
+    lineHeight: 18,
   },
 });

--- a/apps/mobile/app/register.tsx
+++ b/apps/mobile/app/register.tsx
@@ -1,181 +1,27 @@
-import { useState } from "react";
-import {
-  View,
-  Text,
-  TextInput,
-  Pressable,
-  ScrollView,
-  KeyboardAvoidingView,
-  Platform,
-  ActivityIndicator,
-  StyleSheet,
-} from "react-native";
+import { View, Text, Pressable, StyleSheet } from "react-native";
 import { useRouter } from "expo-router";
-import { apiPost } from "../lib/api";
 
 export default function RegisterScreen() {
   const router = useRouter();
 
-  const [email, setEmail] = useState("");
-  const [coachName, setCoachName] = useState("");
-  const [password, setPassword] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-
-  const canSubmit = email.trim() !== "" && coachName.trim() !== "" && password.trim() !== "" && !loading;
-
-  async function onSubmit() {
-    if (!canSubmit) return;
-    setError(null);
-    setLoading(true);
-    try {
-      await apiPost("/auth/register", {
-        email: email.trim(),
-        password,
-        coachName: coachName.trim(),
-        firstName: firstName.trim() || undefined,
-        lastName: lastName.trim() || undefined,
-      });
-      setSuccess(true);
-    } catch (err: any) {
-      setError(err.message || "Erreur lors de l'inscription");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  if (success) {
-    return (
-      <View style={styles.container}>
-        <View style={styles.card}>
-          <Text style={styles.successIcon}>✓</Text>
-          <Text style={styles.title}>Compte créé !</Text>
-          <Text style={styles.successText}>
-            Un administrateur doit valider votre compte avant que vous puissiez
-            vous connecter.
-          </Text>
-          <Pressable style={styles.linkButton} onPress={() => router.replace("/login")}>
-            <Text style={styles.linkText}>Aller à la connexion</Text>
-          </Pressable>
-        </View>
-      </View>
-    );
-  }
-
   return (
-    <KeyboardAvoidingView
-      style={styles.flex}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
-      <ScrollView
-        contentContainerStyle={styles.scrollContent}
-        keyboardShouldPersistTaps="handled"
-      >
-        <View style={styles.card}>
-          <Text style={styles.title}>Créer un compte</Text>
-
-          <Text style={styles.label}>
-            Email <Text style={styles.required}>*</Text>
-          </Text>
-          <TextInput
-            style={styles.input}
-            placeholder="email@example.com"
-            placeholderTextColor="#9CA3AF"
-            value={email}
-            onChangeText={setEmail}
-            keyboardType="email-address"
-            autoCapitalize="none"
-            autoComplete="email"
-            textContentType="emailAddress"
-          />
-
-          <Text style={styles.label}>
-            Nom de coach <Text style={styles.required}>*</Text>
-          </Text>
-          <TextInput
-            style={styles.input}
-            placeholder="Coach Nuffleborg"
-            placeholderTextColor="#9CA3AF"
-            value={coachName}
-            onChangeText={setCoachName}
-            autoCapitalize="words"
-            autoComplete="username"
-            textContentType="username"
-          />
-
-          <Text style={styles.label}>Prénom</Text>
-          <TextInput
-            style={styles.input}
-            placeholder="Prénom"
-            placeholderTextColor="#9CA3AF"
-            value={firstName}
-            onChangeText={setFirstName}
-            autoCapitalize="words"
-            autoComplete="given-name"
-            textContentType="givenName"
-          />
-
-          <Text style={styles.label}>Nom</Text>
-          <TextInput
-            style={styles.input}
-            placeholder="Nom de famille"
-            placeholderTextColor="#9CA3AF"
-            value={lastName}
-            onChangeText={setLastName}
-            autoCapitalize="words"
-            autoComplete="family-name"
-            textContentType="familyName"
-          />
-
-          <Text style={styles.label}>
-            Mot de passe <Text style={styles.required}>*</Text>
-          </Text>
-          <TextInput
-            style={styles.input}
-            placeholder="8 caractères minimum"
-            placeholderTextColor="#9CA3AF"
-            value={password}
-            onChangeText={setPassword}
-            secureTextEntry
-            autoComplete="new-password"
-            textContentType="newPassword"
-          />
-
-          {error && <Text style={styles.error}>{error}</Text>}
-
-          <Pressable
-            style={[styles.submitButton, !canSubmit && styles.submitButtonDisabled]}
-            onPress={onSubmit}
-            disabled={!canSubmit}
-          >
-            {loading ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text style={styles.submitText}>S'inscrire</Text>
-            )}
-          </Pressable>
-
-          <Pressable style={styles.linkButton} onPress={() => router.push("/login")}>
-            <Text style={styles.linkText}>
-              Déjà un compte ? Se connecter
-            </Text>
-          </Pressable>
-        </View>
-      </ScrollView>
-    </KeyboardAvoidingView>
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.icon}>🚧</Text>
+        <Text style={styles.title}>Inscription indisponible</Text>
+        <Text style={styles.message}>
+          Nuffle Arena est actuellement en pré-alpha. L'inscription sera bientôt
+          disponible. Restez connectés !
+        </Text>
+        <Pressable style={styles.linkButton} onPress={() => router.replace("/login")}>
+          <Text style={styles.linkText}>Retour à la connexion</Text>
+        </Pressable>
+      </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1 },
-  scrollContent: {
-    flexGrow: 1,
-    justifyContent: "center",
-    padding: 24,
-  },
   container: {
     flex: 1,
     justifyContent: "center",
@@ -186,58 +32,19 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: 400,
     alignSelf: "center",
+    alignItems: "center",
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 16,
   },
   title: {
     fontSize: 24,
     fontWeight: "bold",
-    marginBottom: 20,
-    textAlign: "center",
-  },
-  label: {
-    fontSize: 14,
-    fontWeight: "500",
-    color: "#374151",
-    marginBottom: 6,
-    marginTop: 12,
-  },
-  required: {
-    color: "#EF4444",
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: "#D1D5DB",
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-    backgroundColor: "#fff",
-  },
-  error: {
-    color: "#DC2626",
-    fontSize: 14,
-    marginTop: 12,
-  },
-  submitButton: {
-    backgroundColor: "#16A34A",
-    paddingVertical: 14,
-    borderRadius: 8,
-    alignItems: "center",
-    marginTop: 20,
-  },
-  submitButtonDisabled: {
-    backgroundColor: "#9CA3AF",
-  },
-  submitText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "600",
-  },
-  successIcon: {
-    fontSize: 48,
-    color: "#16A34A",
-    textAlign: "center",
     marginBottom: 12,
+    textAlign: "center",
   },
-  successText: {
+  message: {
     fontSize: 15,
     color: "#374151",
     textAlign: "center",
@@ -245,12 +52,16 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   linkButton: {
-    marginTop: 16,
+    marginTop: 8,
+    backgroundColor: "#2563EB",
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 8,
     alignItems: "center",
   },
   linkText: {
-    color: "#2563EB",
-    fontSize: 14,
-    textDecorationLine: "underline",
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
   },
 });

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -6,7 +6,6 @@ import { authUser, AuthenticatedRequest } from "../middleware/authUser";
 import { normalizeRoles } from "../utils/roles";
 import { validate } from "../middleware/validate";
 import {
-  registerSchema,
   loginSchema,
   updateProfileSchema,
   changePasswordSchema,
@@ -16,57 +15,11 @@ const router = Router();
 
 const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-change-me";
 
-router.post("/register", validate(registerSchema), async (req, res) => {
-  try {
-    const { email, password, name, coachName, firstName, lastName, dateOfBirth } = req.body;
-
-    const existing = await prisma.user.findUnique({ where: { email } });
-    if (existing) {
-      return res.status(409).json({ error: "Email déjà utilisé" });
-    }
-
-    const passwordHash = await bcrypt.hash(password, 10);
-    const user = await prisma.user.create({
-      data: { 
-        email, 
-        passwordHash, 
-        name,
-        coachName,
-        firstName: typeof firstName === "string" ? firstName : null,
-        lastName: typeof lastName === "string" ? lastName : null,
-        dateOfBirth: dateOfBirth ? new Date(dateOfBirth) : null,
-        valid: false,
-      },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-        coachName: true,
-        firstName: true,
-        lastName: true,
-        dateOfBirth: true,
-        role: true,
-        roles: true,
-        valid: true,
-        createdAt: true,
-      },
-    });
-
-    const roles = normalizeRoles(user.roles ?? user.role);
-    const publicUser = {
-      ...user,
-      roles,
-    };
-
-    // Ne pas donner de token si le compte n'est pas validé
-    return res.status(201).json({ 
-      user: publicUser, 
-      message: "Votre compte a été créé avec succès. Un administrateur doit valider votre compte avant que vous puissiez vous connecter." 
-    });
-  } catch (err) {
-    console.error(err);
-    return res.status(500).json({ error: "Erreur serveur" });
-  }
+// Registration disabled during pre-alpha
+router.post("/register", (_req, res) => {
+  return res.status(403).json({
+    error: "L'inscription est actuellement désactivée. Nuffle Arena est en pré-alpha et sera bientôt disponible à l'inscription.",
+  });
 });
 
 router.post("/login", validate(loginSchema), async (req, res) => {

--- a/apps/web/app/AuthBar.tsx
+++ b/apps/web/app/AuthBar.tsx
@@ -274,9 +274,6 @@ export default function AuthBar({ isMobileMenu = false }: AuthBarProps) {
           <a className="underline text-xs sm:text-sm whitespace-nowrap" href="/login">
             {t.auth.login}
           </a>
-          <a className="underline text-xs sm:text-sm whitespace-nowrap" href="/register">
-            {t.auth.register}
-          </a>
         </div>
       )}
     </div>

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -134,6 +134,8 @@ export const translations = {
       login: "Connectez-vous",
       required: "requis",
       error: "Erreur",
+      preAlphaTitle: "Inscription indisponible",
+      preAlphaMessage: "Nuffle Arena est actuellement en pré-alpha. L'inscription sera bientôt disponible. Restez connectés !",
     },
     // Teams pages
     teams: {
@@ -488,6 +490,8 @@ export const translations = {
       login: "Log in",
       required: "required",
       error: "Error",
+      preAlphaTitle: "Registration unavailable",
+      preAlphaMessage: "Nuffle Arena is currently in pre-alpha. Registration will be available soon. Stay tuned!",
     },
     // Teams pages
     teams: {

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -70,11 +70,8 @@ export default function LoginPage() {
           {t.login.submit}
         </button>
       </form>
-      <p className="text-xs sm:text-sm mt-4 text-center">
-        {t.login.noAccount}{" "}
-        <a className="underline text-blue-600 hover:text-blue-700" href="/register">
-          {t.login.register}
-        </a>
+      <p className="text-xs sm:text-sm mt-4 text-center text-gray-500">
+        {t.register.preAlphaMessage}
       </p>
       </div>
     </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -50,12 +50,6 @@ export default function LandingPage() {
               >
                 {t.home.login}
               </a>
-              <a
-                href="/register"
-                className="px-6 py-3 rounded-lg border-2 border-nuffle-bronze/50 text-nuffle-ivory/90 hover:text-nuffle-ivory hover:bg-nuffle-bronze/20 font-subtitle font-semibold transition-all text-center"
-              >
-                {t.home.register}
-              </a>
             </div>
           </div>
           <div className="relative w-full md:w-auto">

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -327,12 +327,6 @@ export default function PlayPage() {
             >
               {t.auth.login}
             </a>
-            <a
-              href="/register"
-              className="px-6 py-3 rounded-lg border-2 border-nuffle-bronze/50 text-nuffle-anthracite hover:bg-nuffle-bronze/10 font-subtitle font-semibold transition-all text-center"
-            >
-              {t.auth.register}
-            </a>
           </div>
         </div>
       </div>

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -1,136 +1,23 @@
 "use client";
-import { useState } from "react";
-import { apiPost } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
 
 export default function RegisterPage() {
   const { t } = useLanguage();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [coachName, setCoachName] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [dateOfBirth, setDateOfBirth] = useState("");
-  const [error, setError] = useState<string | null>(null);
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    try {
-      const response = await apiPost("/auth/register", {
-        email,
-        password,
-        coachName,
-        firstName: firstName || undefined,
-        lastName: lastName || undefined,
-        dateOfBirth: dateOfBirth || undefined,
-      });
-      // Le compte est créé mais non validé, rediriger vers la page de login avec un message
-      const message = response.message || "Votre compte a été créé avec succès. Un administrateur doit valider votre compte avant que vous puissiez vous connecter.";
-      window.location.href = `/login?message=${encodeURIComponent(message)}`;
-    } catch (err: any) {
-      setError(err.message || t.register.error);
-    }
-  }
 
   return (
     <div className="w-full p-4 sm:p-6 flex justify-center min-h-[60vh]">
-      <div className="max-w-md w-full">
-      <h1 className="text-xl sm:text-2xl font-bold mb-4">{t.register.title}</h1>
-      <form onSubmit={onSubmit} className="space-y-3 sm:space-y-4">
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.email} <span className="text-red-500">*</span>
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="email"
-            placeholder="email@example.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-          />
-        </div>
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.coachName} <span className="text-red-500">*</span>
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="text"
-            placeholder={t.register.coachNamePlaceholder}
-            value={coachName}
-            onChange={(e) => setCoachName(e.target.value)}
-            required
-            autoComplete="username"
-          />
-        </div>
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.firstName}
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="text"
-            placeholder={t.register.firstNamePlaceholder}
-            value={firstName}
-            onChange={(e) => setFirstName(e.target.value)}
-            autoComplete="given-name"
-          />
-        </div>
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.lastName}
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="text"
-            placeholder={t.register.lastNamePlaceholder}
-            value={lastName}
-            onChange={(e) => setLastName(e.target.value)}
-            autoComplete="family-name"
-          />
-        </div>
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.dateOfBirth}
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="date"
-            value={dateOfBirth}
-            onChange={(e) => setDateOfBirth(e.target.value)}
-          />
-        </div>
-        <div>
-          <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5">
-            {t.register.password} <span className="text-red-500">*</span>
-          </label>
-          <input
-            className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-green-500 focus:border-transparent"
-            type="password"
-            placeholder={t.register.passwordPlaceholder}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="new-password"
-          />
-        </div>
-        {error && <p className="text-red-600 text-xs sm:text-sm">{error}</p>}
-        <button 
-          className="w-full bg-green-600 text-white py-2.5 sm:py-3 rounded-lg hover:bg-green-700 transition-colors font-medium text-sm sm:text-base disabled:bg-gray-400 disabled:cursor-not-allowed"
-          disabled={!email || !password || !coachName}
+      <div className="max-w-md w-full text-center">
+        <div className="mb-6 text-6xl">🚧</div>
+        <h1 className="text-xl sm:text-2xl font-bold mb-4">{t.register.preAlphaTitle}</h1>
+        <p className="text-gray-600 text-sm sm:text-base mb-6">
+          {t.register.preAlphaMessage}
+        </p>
+        <a
+          className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm sm:text-base"
+          href="/login"
         >
-          {t.register.submit}
-        </button>
-      </form>
-      <p className="text-xs sm:text-sm mt-4 text-center">
-        {t.register.hasAccount}{" "}
-        <a className="underline text-blue-600 hover:text-blue-700" href="/login">
-          {t.register.login}
+          {t.login.title}
         </a>
-      </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Résumé

- [x] Désactiver l'inscription pendant la phase pré-alpha
- [x] Afficher un message informatif aux utilisateurs sur tous les écrans d'inscription
- [x] Retirer les liens d'inscription de la navigation et des pages de connexion

## Description

Cette PR désactive complètement la fonctionnalité d'inscription pendant la phase pré-alpha de Nuffle Arena. Les changements incluent :

### Backend
- Le endpoint `/auth/register` retourne maintenant une erreur 403 avec un message explicite
- La logique d'enregistrement a été supprimée

### Frontend (Web)
- La page `/register` affiche un message pré-alpha au lieu du formulaire d'inscription
- Les liens d'inscription ont été retirés de :
  - La page d'accueil
  - La page de jeu
  - La barre d'authentification
- La page de connexion affiche le message pré-alpha à la place du lien d'inscription

### Frontend (Mobile)
- La page `/register` affiche un message pré-alpha au lieu du formulaire d'inscription
- Le lien d'inscription a été retiré de la page de connexion
- Un message informatif a été ajouté à la place

### Traductions
- Ajout des clés `preAlphaTitle` et `preAlphaMessage` pour les messages pré-alpha

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (N/A - changements UI/UX)
- [x] Tests e2e (N/A - changements UI/UX)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01VU9M3eHFSF7imgs2nCAFbF