### PR TITLE
feat: implement 4 UI-delegated kickoff events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -155,7 +155,7 @@
 | E.5 | Animation de touchdown (flash + particules endzone) | UX | [x] |
 | E.6 | Animation de blessure (icone KO/casualty/mort) | UX | [x] |
 | E.7 | Animation de des (des 2D animes) | UX | [x] |
-| I.9 | Implementer 4 kickoff events delegues UI | Contenu | [ ] |
+| I.9 | Implementer 4 kickoff events delegues UI | Contenu | [x] |
 | F.3 | Page leaderboard | Classement | [ ] |
 | F.4 | ELO dans profil et lobby | Classement | [ ] |
 

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -65,6 +65,12 @@ import { applyApothecaryChoice } from '../mechanics/apothecary';
 import { canThrowTeamMate, getThrowRange, executeThrowTeamMate } from '../mechanics/throw-team-mate';
 import { canHypnoticGaze, executeHypnoticGaze } from '../mechanics/hypnotic-gaze';
 import { canProjectileVomit, executeProjectileVomit } from '../mechanics/projectile-vomit';
+import {
+  resolveKickoffPerfectDefence,
+  resolveKickoffHighKick,
+  resolveKickoffQuickSnap,
+  resolveKickoffBlitz,
+} from '../mechanics/kickoff-resolution';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -83,6 +89,20 @@ export function getLegalMoves(state: GameState): Move[] {
   // Vérifier que state.players existe
   if (!state.players || !Array.isArray(state.players)) {
     return moves;
+  }
+
+  // Si un pendingKickoffEvent est en attente, seules les actions kickoff sont possibles
+  if (state.pendingKickoffEvent) {
+    switch (state.pendingKickoffEvent.type) {
+      case 'perfect-defence':
+        return [{ type: 'KICKOFF_PERFECT_DEFENCE', positions: [] } as Move];
+      case 'high-kick':
+        return [{ type: 'KICKOFF_HIGH_KICK', playerId: null } as Move];
+      case 'quick-snap':
+        return [{ type: 'KICKOFF_QUICK_SNAP', moves: [] } as Move];
+      case 'blitz':
+        return [{ type: 'KICKOFF_BLITZ_RESOLVE' } as Move];
+    }
   }
 
   // Si un pendingApothecary est en attente, seul le choix d'apothecaire est possible
@@ -164,7 +184,8 @@ export function getLegalMoves(state: GameState): Move[] {
     }
 
     // Actions de passe (PASS) - le joueur doit avoir le ballon et pas encore agi
-    if (p.hasBall && !hasPlayerActed(state, p.id)) {
+    // Passes interdites pendant le tour de blitz kickoff
+    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn) {
       const teammates = state.players.filter(
         t => t.team === team && t.id !== p.id && !t.stunned && t.state === 'active'
       );
@@ -177,7 +198,8 @@ export function getLegalMoves(state: GameState): Move[] {
     }
 
     // Actions de remise (HANDOFF) - le joueur doit avoir le ballon, cible adjacente
-    if (p.hasBall && !hasPlayerActed(state, p.id)) {
+    // Remises interdites pendant le tour de blitz kickoff
+    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn) {
       const teammates = state.players.filter(
         t => t.team === team && t.id !== p.id && !t.stunned && t.state === 'active'
       );
@@ -365,6 +387,12 @@ function applyPickupFailure(state: GameState, playerIndex: number, rng: RNG): Ga
  * @returns Nouvel état du jeu
  */
 export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
+  // Si un pendingKickoffEvent est en attente, seules les actions kickoff sont acceptées
+  if (state.pendingKickoffEvent) {
+    const kickoffMoves = ['KICKOFF_PERFECT_DEFENCE', 'KICKOFF_HIGH_KICK', 'KICKOFF_QUICK_SNAP', 'KICKOFF_BLITZ_RESOLVE'];
+    if (!kickoffMoves.includes(move.type)) return state;
+  }
+
   // Si un pendingApothecary est en attente, seul APOTHECARY_CHOOSE est accepté
   if (state.pendingApothecary && move.type !== 'APOTHECARY_CHOOSE') {
     return state;
@@ -372,6 +400,11 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
 
   // Si un pendingReroll est en attente, seuls REROLL_CHOOSE et END_TURN sont acceptés
   if (state.pendingReroll && move.type !== 'REROLL_CHOOSE' && move.type !== 'END_TURN') {
+    return state;
+  }
+
+  // Pendant le tour de blitz kickoff, les passes et remises sont interdites
+  if (state.kickoffBlitzTurn && (move.type === 'PASS' || move.type === 'HANDOFF')) {
     return state;
   }
 
@@ -414,6 +447,14 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       return handleHypnoticGaze(state, move, rng);
     case 'PROJECTILE_VOMIT':
       return handleProjectileVomit(state, move, rng);
+    case 'KICKOFF_PERFECT_DEFENCE':
+      return resolveKickoffPerfectDefence(state, move.positions);
+    case 'KICKOFF_HIGH_KICK':
+      return resolveKickoffHighKick(state, move.playerId);
+    case 'KICKOFF_QUICK_SNAP':
+      return resolveKickoffQuickSnap(state, move.moves);
+    case 'KICKOFF_BLITZ_RESOLVE':
+      return resolveKickoffBlitz(state);
     default:
       return checkTouchdowns(state);
   }
@@ -429,6 +470,25 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
   // Si on est en phase post-TD, faire le reset et kickoff
   if (state.gamePhase === 'post-td') {
     return handlePostTouchdown(state, rng);
+  }
+
+  // Si c'est un tour de blitz kickoff, le tour du kicking team est terminé
+  // Retourner le contrôle à l'équipe qui reçoit
+  if (state.kickoffBlitzTurn) {
+    const receivingTeam = state.kickingTeam === 'A' ? 'B' : 'A';
+    return {
+      ...state,
+      kickoffBlitzTurn: undefined,
+      currentPlayer: receivingTeam,
+      selectedPlayerId: null,
+      players: state.players.map(p => ({ ...p, pm: p.ma, gfiUsed: 0 })),
+      isTurnover: false,
+      playerActions: {},
+      teamBlitzCount: {},
+      teamFoulCount: {},
+      rerollUsedThisTurn: false,
+      hypnotizedPlayers: [],
+    };
   }
 
   // Changement de tour - le porteur de ballon garde le ballon

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -87,6 +87,12 @@ export interface TeamDugout {
   };
 }
 
+export interface PendingKickoffEvent {
+  type: 'perfect-defence' | 'high-kick' | 'quick-snap' | 'blitz';
+  team: TeamId;
+  ballPosition?: Position; // for high-kick: where the ball will land
+}
+
 export interface PendingApothecary {
   playerId: string;
   team: TeamId;
@@ -110,6 +116,10 @@ export interface GameState {
   // Apothecaire
   apothecaryAvailable: { teamA: boolean; teamB: boolean };
   pendingApothecary?: PendingApothecary;
+  // Événement de kickoff en attente de résolution UI
+  pendingKickoffEvent?: PendingKickoffEvent;
+  // Tour de blitz kickoff en cours (équipe qui botte joue un tour immédiat)
+  kickoffBlitzTurn?: boolean;
   // Zones de dugout pour chaque équipe
   dugouts: {
     teamA: TeamDugout;
@@ -259,7 +269,11 @@ export type Move =
   | { type: 'THROW_TEAM_MATE'; playerId: string; thrownPlayerId: string; targetPos: Position }
   | { type: 'FOUL'; playerId: string; targetId: string }
   | { type: 'HYPNOTIC_GAZE'; playerId: string; targetId: string }
-  | { type: 'PROJECTILE_VOMIT'; playerId: string; targetId: string };
+  | { type: 'PROJECTILE_VOMIT'; playerId: string; targetId: string }
+  | { type: 'KICKOFF_PERFECT_DEFENCE'; positions: Array<{ playerId: string; position: Position }> }
+  | { type: 'KICKOFF_HIGH_KICK'; playerId: string | null }
+  | { type: 'KICKOFF_QUICK_SNAP'; moves: Array<{ playerId: string; to: Position }> }
+  | { type: 'KICKOFF_BLITZ_RESOLVE' };
 
 export type BlockResult = 'PLAYER_DOWN' | 'BOTH_DOWN' | 'PUSH_BACK' | 'STUMBLE' | 'POW';
 

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -167,6 +167,14 @@ export {
   type KickoffEvent,
 } from './mechanics/kickoff-events';
 
+// Export de la résolution des événements de kickoff UI
+export {
+  resolveKickoffPerfectDefence,
+  resolveKickoffHighKick,
+  resolveKickoffQuickSnap,
+  resolveKickoffBlitz,
+} from './mechanics/kickoff-resolution';
+
 // Export du calcul de zones de tacle (heatmap)
 export {
   calculateTackleZoneHeatmap,

--- a/packages/game-engine/src/mechanics/kickoff-events.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.ts
@@ -142,14 +142,18 @@ export function applyKickoffEvent(
     }
 
     case 'perfect-defence': {
-      // L'équipe qui botte peut réorganiser (marqué comme flag, géré côté UI)
+      newState.pendingKickoffEvent = { type: 'perfect-defence', team: kickingTeam };
       const log = createLogEntry('action', `Défense parfaite — L'équipe qui botte peut réorganiser ses joueurs`);
       newState.gameLog = [...newState.gameLog, log];
       break;
     }
 
     case 'high-kick': {
-      // Un joueur de l'équipe qui reçoit peut être déplacé sous le ballon (géré côté UI)
+      newState.pendingKickoffEvent = {
+        type: 'high-kick',
+        team: receivingTeam,
+        ballPosition: newState.ball,
+      };
       const log = createLogEntry('action', `Coup en hauteur — L'équipe qui reçoit peut placer un joueur sous le ballon`);
       newState.gameLog = [...newState.gameLog, log];
       break;
@@ -202,14 +206,14 @@ export function applyKickoffEvent(
     }
 
     case 'quick-snap': {
-      // L'équipe qui reçoit peut déplacer chaque joueur d'1 case (géré côté UI)
+      newState.pendingKickoffEvent = { type: 'quick-snap', team: receivingTeam };
       const log = createLogEntry('action', `Snap rapide ! ${receivingTeam === 'A' ? newState.teamNames.teamA : newState.teamNames.teamB} peut déplacer ses joueurs d'1 case`);
       newState.gameLog = [...newState.gameLog, log];
       break;
     }
 
     case 'blitz': {
-      // L'équipe qui botte joue un tour immédiat (géré côté UI/game flow)
+      newState.pendingKickoffEvent = { type: 'blitz', team: kickingTeam };
       const log = createLogEntry('action', `Blitz ! ${kickingTeam === 'A' ? newState.teamNames.teamA : newState.teamNames.teamB} joue un tour immédiat`);
       newState.gameLog = [...newState.gameLog, log];
       break;

--- a/packages/game-engine/src/mechanics/kickoff-resolution.test.ts
+++ b/packages/game-engine/src/mechanics/kickoff-resolution.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove, getLegalMoves } from '../actions/actions';
+import { makeRNG } from '../utils/rng';
+import { KICKOFF_EVENTS, applyKickoffEvent } from './kickoff-events';
+import {
+  resolveKickoffPerfectDefence,
+  resolveKickoffHighKick,
+  resolveKickoffQuickSnap,
+  resolveKickoffBlitz,
+} from './kickoff-resolution';
+import type { GameState, Position } from '../core/types';
+
+/**
+ * Helper: creates a game state with players placed on the pitch and a kickoff context.
+ * Team A kicks (left half x=1..12), Team B receives (right half x=13..24).
+ */
+function createKickoffState(overrides?: Partial<GameState>): GameState {
+  const base = setup();
+  return {
+    ...base,
+    gamePhase: 'playing' as const,
+    half: 1,
+    turn: 1,
+    kickingTeam: 'A',
+    currentPlayer: 'B', // Receiving team plays first
+    ball: { x: 18, y: 7 }, // Ball on receiving side
+    ...overrides,
+  };
+}
+
+describe('Regle: Kickoff Event — Perfect Defence', () => {
+  it('sets pendingKickoffEvent when applied', () => {
+    const state = createKickoffState();
+    const event = KICKOFF_EVENTS[4]; // Perfect Defence
+    const rng = makeRNG('perfect-defence-test');
+    const result = applyKickoffEvent(state, event, rng, 'A');
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+    expect(result.pendingKickoffEvent!.type).toBe('perfect-defence');
+    expect(result.pendingKickoffEvent!.team).toBe('A'); // kicking team rearranges
+  });
+
+  it('resolves: allows kicking team to rearrange players on their half', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+
+    // Move team A players to new valid positions on their half
+    const newPositions = [
+      { playerId: 'A1', position: { x: 5, y: 3 } },
+      { playerId: 'A2', position: { x: 8, y: 10 } },
+    ];
+    const result = resolveKickoffPerfectDefence(state, newPositions);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    const a1 = result.players.find(p => p.id === 'A1');
+    const a2 = result.players.find(p => p.id === 'A2');
+    expect(a1!.pos).toEqual({ x: 5, y: 3 });
+    expect(a2!.pos).toEqual({ x: 8, y: 10 });
+  });
+
+  it('resolves: rejects positions on the opponent half', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+
+    // Try to place team A player on team B half (x >= 13)
+    const newPositions = [
+      { playerId: 'A1', position: { x: 18, y: 7 } }, // B's half
+    ];
+    const result = resolveKickoffPerfectDefence(state, newPositions);
+
+    // Should remain unchanged (invalid move)
+    expect(result.pendingKickoffEvent).toBeDefined();
+    const a1 = result.players.find(p => p.id === 'A1');
+    expect(a1!.pos).toEqual(state.players.find(p => p.id === 'A1')!.pos);
+  });
+
+  it('resolves: rejects positions out of bounds', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+
+    const newPositions = [
+      { playerId: 'A1', position: { x: -1, y: 7 } }, // out of bounds
+    ];
+    const result = resolveKickoffPerfectDefence(state, newPositions);
+
+    // Should remain unchanged
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: rejects overlapping positions', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+
+    // Both A players on same position
+    const newPositions = [
+      { playerId: 'A1', position: { x: 5, y: 5 } },
+      { playerId: 'A2', position: { x: 5, y: 5 } },
+    ];
+    const result = resolveKickoffPerfectDefence(state, newPositions);
+
+    // Should remain unchanged
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: does not move opponent players', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+
+    const b1Before = state.players.find(p => p.id === 'B1')!;
+    const newPositions = [
+      { playerId: 'A1', position: { x: 5, y: 3 } },
+    ];
+    const result = resolveKickoffPerfectDefence(state, newPositions);
+
+    const b1After = result.players.find(p => p.id === 'B1')!;
+    expect(b1After.pos).toEqual(b1Before.pos);
+  });
+});
+
+describe('Regle: Kickoff Event — High Kick', () => {
+  it('sets pendingKickoffEvent when applied', () => {
+    const state = createKickoffState();
+    const event = KICKOFF_EVENTS[5]; // High Kick
+    const rng = makeRNG('high-kick-test');
+    const result = applyKickoffEvent(state, event, rng, 'A');
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+    expect(result.pendingKickoffEvent!.type).toBe('high-kick');
+    expect(result.pendingKickoffEvent!.team).toBe('B'); // receiving team
+  });
+
+  it('resolves: moves chosen player under the ball', () => {
+    const ballPos = { x: 18, y: 7 };
+    const state = createKickoffState({
+      ball: ballPos,
+      pendingKickoffEvent: { type: 'high-kick', team: 'B', ballPosition: ballPos },
+    });
+
+    // B2 is far from opponents, can be moved under ball
+    const result = resolveKickoffHighKick(state, 'B2');
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    const b2 = result.players.find(p => p.id === 'B2')!;
+    expect(b2.pos).toEqual(ballPos);
+  });
+
+  it('resolves: skipping (null playerId) clears pending state', () => {
+    const ballPos = { x: 18, y: 7 };
+    const state = createKickoffState({
+      ball: ballPos,
+      pendingKickoffEvent: { type: 'high-kick', team: 'B', ballPosition: ballPos },
+    });
+
+    const result = resolveKickoffHighKick(state, null);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    // No player should have moved
+    for (const p of result.players) {
+      const orig = state.players.find(o => o.id === p.id)!;
+      expect(p.pos).toEqual(orig.pos);
+    }
+  });
+
+  it('resolves: rejects player in enemy tackle zone', () => {
+    // Place B1 adjacent to A1 so B1 is in a tackle zone
+    const state = createKickoffState({
+      ball: { x: 20, y: 7 },
+      pendingKickoffEvent: { type: 'high-kick', team: 'B', ballPosition: { x: 20, y: 7 } },
+      players: [
+        ...setup().players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 14, y: 7 } };
+          if (p.id === 'B1') return { ...p, pos: { x: 15, y: 7 } }; // adjacent to A1
+          return p;
+        }),
+      ],
+    });
+
+    const result = resolveKickoffHighKick(state, 'B1');
+
+    // B1 is in a tackle zone, so it should be rejected
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: rejects player from wrong team', () => {
+    const ballPos = { x: 18, y: 7 };
+    const state = createKickoffState({
+      ball: ballPos,
+      pendingKickoffEvent: { type: 'high-kick', team: 'B', ballPosition: ballPos },
+    });
+
+    // Trying to select an A team player should be rejected
+    const result = resolveKickoffHighKick(state, 'A1');
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+});
+
+describe('Regle: Kickoff Event — Quick Snap', () => {
+  it('sets pendingKickoffEvent when applied', () => {
+    const state = createKickoffState();
+    const event = KICKOFF_EVENTS[9]; // Quick Snap
+    const rng = makeRNG('quick-snap-test');
+    const result = applyKickoffEvent(state, event, rng, 'A');
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+    expect(result.pendingKickoffEvent!.type).toBe('quick-snap');
+    expect(result.pendingKickoffEvent!.team).toBe('B'); // receiving team
+  });
+
+  it('resolves: moves receiving team players 1 square each', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+
+    const b1 = state.players.find(p => p.id === 'B1')!;
+    const b2 = state.players.find(p => p.id === 'B2')!;
+
+    const moves = [
+      { playerId: 'B1', to: { x: b1.pos.x + 1, y: b1.pos.y } },
+      { playerId: 'B2', to: { x: b2.pos.x, y: b2.pos.y + 1 } },
+    ];
+    const result = resolveKickoffQuickSnap(state, moves);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    expect(result.players.find(p => p.id === 'B1')!.pos).toEqual(moves[0].to);
+    expect(result.players.find(p => p.id === 'B2')!.pos).toEqual(moves[1].to);
+  });
+
+  it('resolves: rejects moves > 1 square', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+
+    const b1 = state.players.find(p => p.id === 'B1')!;
+    const moves = [
+      { playerId: 'B1', to: { x: b1.pos.x + 2, y: b1.pos.y } }, // 2 squares
+    ];
+    const result = resolveKickoffQuickSnap(state, moves);
+
+    // Should remain unchanged
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: rejects moves out of bounds', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+      players: setup().players.map(p => {
+        if (p.id === 'B1') return { ...p, pos: { x: 25, y: 7 } }; // edge of board
+        return p;
+      }),
+    });
+
+    const moves = [
+      { playerId: 'B1', to: { x: 26, y: 7 } }, // out of bounds
+    ];
+    const result = resolveKickoffQuickSnap(state, moves);
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: rejects moves into occupied squares', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+      players: setup().players.map(p => {
+        if (p.id === 'B1') return { ...p, pos: { x: 16, y: 7 } };
+        if (p.id === 'B2') return { ...p, pos: { x: 17, y: 7 } };
+        return p;
+      }),
+    });
+
+    // B1 tries to move into B2's square
+    const moves = [
+      { playerId: 'B1', to: { x: 17, y: 7 } },
+    ];
+    const result = resolveKickoffQuickSnap(state, moves);
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('resolves: empty moves array clears pending state', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+
+    const result = resolveKickoffQuickSnap(state, []);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+  });
+
+  it('resolves: rejects wrong team player moves', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+
+    const a1 = state.players.find(p => p.id === 'A1')!;
+    const moves = [
+      { playerId: 'A1', to: { x: a1.pos.x + 1, y: a1.pos.y } },
+    ];
+    const result = resolveKickoffQuickSnap(state, moves);
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+});
+
+describe('Regle: Kickoff Event — Blitz', () => {
+  it('sets pendingKickoffEvent when applied', () => {
+    const state = createKickoffState();
+    const event = KICKOFF_EVENTS[10]; // Blitz
+    const rng = makeRNG('blitz-test');
+    const result = applyKickoffEvent(state, event, rng, 'A');
+
+    expect(result.pendingKickoffEvent).toBeDefined();
+    expect(result.pendingKickoffEvent!.type).toBe('blitz');
+    expect(result.pendingKickoffEvent!.team).toBe('A'); // kicking team gets the blitz
+  });
+
+  it('resolves: activates kicking team turn with restrictions', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'blitz', team: 'A' },
+      currentPlayer: 'B', // receiving team was set as current
+    });
+
+    const result = resolveKickoffBlitz(state);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    expect(result.kickoffBlitzTurn).toBe(true);
+    expect(result.currentPlayer).toBe('A'); // kicking team now plays
+  });
+
+  it('resolves: logs the blitz activation', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'blitz', team: 'A' },
+    });
+
+    const result = resolveKickoffBlitz(state);
+
+    const blitzLogs = result.gameLog.filter(l =>
+      l.message.toLowerCase().includes('blitz')
+    );
+    expect(blitzLogs.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Regle: Kickoff Events — Integration with applyMove', () => {
+  it('applyMove resolves perfect defence via KICKOFF_PERFECT_DEFENCE', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'perfect-defence', team: 'A' },
+    });
+    const rng = makeRNG('integration-pd');
+
+    const result = applyMove(state, {
+      type: 'KICKOFF_PERFECT_DEFENCE',
+      positions: [
+        { playerId: 'A1', position: { x: 6, y: 3 } },
+        { playerId: 'A2', position: { x: 8, y: 10 } },
+      ],
+    }, rng);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    expect(result.players.find(p => p.id === 'A1')!.pos).toEqual({ x: 6, y: 3 });
+  });
+
+  it('applyMove resolves high kick via KICKOFF_HIGH_KICK', () => {
+    const ballPos = { x: 18, y: 7 };
+    const state = createKickoffState({
+      ball: ballPos,
+      pendingKickoffEvent: { type: 'high-kick', team: 'B', ballPosition: ballPos },
+    });
+    const rng = makeRNG('integration-hk');
+
+    const result = applyMove(state, {
+      type: 'KICKOFF_HIGH_KICK',
+      playerId: 'B2',
+    }, rng);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    expect(result.players.find(p => p.id === 'B2')!.pos).toEqual(ballPos);
+  });
+
+  it('applyMove resolves quick snap via KICKOFF_QUICK_SNAP', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+    const rng = makeRNG('integration-qs');
+    const b1 = state.players.find(p => p.id === 'B1')!;
+
+    // Move B1 one square up (y-1) to avoid collision with B2
+    const result = applyMove(state, {
+      type: 'KICKOFF_QUICK_SNAP',
+      moves: [{ playerId: 'B1', to: { x: b1.pos.x, y: b1.pos.y - 1 } }],
+    }, rng);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+  });
+
+  it('applyMove resolves blitz via KICKOFF_BLITZ_RESOLVE', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'blitz', team: 'A' },
+    });
+    const rng = makeRNG('integration-blitz');
+
+    const result = applyMove(state, {
+      type: 'KICKOFF_BLITZ_RESOLVE',
+    }, rng);
+
+    expect(result.pendingKickoffEvent).toBeUndefined();
+    expect(result.kickoffBlitzTurn).toBe(true);
+    expect(result.currentPlayer).toBe('A');
+  });
+
+  it('blocks normal moves when pendingKickoffEvent is set', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+    const rng = makeRNG('block-test');
+
+    // Try a regular MOVE — should be blocked
+    const result = applyMove(state, {
+      type: 'MOVE',
+      playerId: 'B1',
+      to: { x: 16, y: 7 },
+    }, rng);
+
+    // State should be unchanged
+    expect(result.pendingKickoffEvent).toBeDefined();
+  });
+
+  it('blocks PASS and HANDOFF during kickoff blitz turn', () => {
+    const state = createKickoffState({
+      kickoffBlitzTurn: true,
+      currentPlayer: 'A',
+      players: setup().players.map(p => {
+        if (p.id === 'A1') return { ...p, hasBall: true, pos: { x: 11, y: 7 } };
+        return p;
+      }),
+    });
+    const rng = makeRNG('blitz-pass-block');
+
+    // Try a PASS — should be blocked during blitz kickoff turn
+    const passResult = applyMove(state, {
+      type: 'PASS',
+      playerId: 'A1',
+      targetId: 'A2',
+    }, rng);
+
+    // State should be unchanged (same reference since PASS was blocked)
+    expect(passResult).toBe(state);
+
+    // Try a HANDOFF — should also be blocked
+    const handoffResult = applyMove(state, {
+      type: 'HANDOFF',
+      playerId: 'A1',
+      targetId: 'A2',
+    }, rng);
+
+    expect(handoffResult).toBe(state);
+  });
+
+  it('END_TURN during blitz turn restores receiving team control', () => {
+    const state = createKickoffState({
+      kickoffBlitzTurn: true,
+      currentPlayer: 'A',
+      kickingTeam: 'A',
+    });
+    const rng = makeRNG('blitz-end');
+
+    const result = applyMove(state, { type: 'END_TURN' }, rng);
+
+    expect(result.kickoffBlitzTurn).toBeUndefined();
+    expect(result.currentPlayer).toBe('B'); // receiving team takes over
+  });
+
+  it('getLegalMoves returns kickoff moves when pendingKickoffEvent is set', () => {
+    const state = createKickoffState({
+      pendingKickoffEvent: { type: 'quick-snap', team: 'B' },
+    });
+
+    const moves = getLegalMoves(state);
+    expect(moves.length).toBe(1);
+    expect(moves[0].type).toBe('KICKOFF_QUICK_SNAP');
+  });
+
+  it('getLegalMoves excludes PASS/HANDOFF during blitz turn', () => {
+    const state = createKickoffState({
+      kickoffBlitzTurn: true,
+      currentPlayer: 'A',
+      players: setup().players.map(p => {
+        if (p.id === 'A1') return { ...p, hasBall: true, pos: { x: 11, y: 7 } };
+        return p;
+      }),
+    });
+
+    const moves = getLegalMoves(state);
+    const passMoves = moves.filter(m => m.type === 'PASS');
+    const handoffMoves = moves.filter(m => m.type === 'HANDOFF');
+    expect(passMoves.length).toBe(0);
+    expect(handoffMoves.length).toBe(0);
+  });
+});

--- a/packages/game-engine/src/mechanics/kickoff-resolution.ts
+++ b/packages/game-engine/src/mechanics/kickoff-resolution.ts
@@ -1,0 +1,249 @@
+/**
+ * Résolution des événements de kickoff délégués au UI
+ * Gère les 4 événements nécessitant une interaction joueur :
+ * - Perfect Defence (l'équipe qui botte réorganise)
+ * - High Kick (l'équipe qui reçoit place un joueur sous le ballon)
+ * - Quick Snap (l'équipe qui reçoit déplace chaque joueur d'1 case)
+ * - Blitz (l'équipe qui botte joue un tour immédiat)
+ */
+
+import { GameState, Position } from '../core/types';
+import { inBounds } from './movement';
+import { createLogEntry } from '../utils/logging';
+
+/**
+ * Vérifie si une position est sur la moitié de terrain d'une équipe
+ * Team A: x = 0..12 (left), Team B: x = 13..25 (right)
+ */
+function isOnTeamHalf(pos: Position, team: 'A' | 'B', state: GameState): boolean {
+  if (team === 'A') {
+    return pos.x >= 0 && pos.x <= 12;
+  }
+  return pos.x >= 13 && pos.x < state.width;
+}
+
+/**
+ * Résout l'événement Perfect Defence.
+ * L'équipe qui botte peut réorganiser ses joueurs sur sa moitié de terrain.
+ * Les joueurs doivent respecter les limites du terrain et ne pas chevaucher.
+ */
+export function resolveKickoffPerfectDefence(
+  state: GameState,
+  newPositions: Array<{ playerId: string; position: Position }>
+): GameState {
+  if (!state.pendingKickoffEvent || state.pendingKickoffEvent.type !== 'perfect-defence') {
+    return state;
+  }
+
+  const team = state.pendingKickoffEvent.team;
+
+  // Validate all positions
+  const positionSet = new Set<string>();
+  for (const { playerId, position } of newPositions) {
+    const player = state.players.find(p => p.id === playerId);
+    if (!player || player.team !== team) return state;
+    if (!inBounds(state, position)) return state;
+    if (!isOnTeamHalf(position, team, state)) return state;
+
+    const key = `${position.x},${position.y}`;
+    if (positionSet.has(key)) return state; // duplicate position
+    positionSet.add(key);
+  }
+
+  // Check no overlap with players not being moved (opponent players, own team not in the move list)
+  const movedIds = new Set(newPositions.map(p => p.playerId));
+  const fixedPlayers = state.players.filter(p => !movedIds.has(p.id) && p.pos.x >= 0);
+  for (const fp of fixedPlayers) {
+    if (positionSet.has(`${fp.pos.x},${fp.pos.y}`)) return state;
+  }
+
+  // Apply new positions
+  const updatedPlayers = state.players.map(p => {
+    const move = newPositions.find(m => m.playerId === p.id);
+    if (move) {
+      return { ...p, pos: { ...move.position } };
+    }
+    return p;
+  });
+
+  const log = createLogEntry(
+    'action',
+    `Défense parfaite : l'équipe qui botte a réorganisé ses joueurs`
+  );
+
+  return {
+    ...state,
+    players: updatedPlayers,
+    pendingKickoffEvent: undefined,
+    gameLog: [...state.gameLog, log],
+  };
+}
+
+/**
+ * Résout l'événement High Kick.
+ * Un joueur de l'équipe qui reçoit peut être déplacé sous le ballon,
+ * à condition qu'il ne soit pas dans une zone de tacle adverse.
+ * @param playerId - ID du joueur à déplacer, ou null pour décliner
+ */
+export function resolveKickoffHighKick(
+  state: GameState,
+  playerId: string | null
+): GameState {
+  if (!state.pendingKickoffEvent || state.pendingKickoffEvent.type !== 'high-kick') {
+    return state;
+  }
+
+  const team = state.pendingKickoffEvent.team;
+  const ballPosition = state.pendingKickoffEvent.ballPosition ?? state.ball;
+
+  // Decline the event
+  if (playerId === null) {
+    const log = createLogEntry('action', `Coup en hauteur décliné`);
+    return {
+      ...state,
+      pendingKickoffEvent: undefined,
+      gameLog: [...state.gameLog, log],
+    };
+  }
+
+  const player = state.players.find(p => p.id === playerId);
+  if (!player || player.team !== team) return state;
+
+  // Check the player is not in an enemy tackle zone
+  const opponents = state.players.filter(
+    p => p.team !== team && p.state === 'active' && !p.stunned
+  );
+  const isInTackleZone = opponents.some(opp => {
+    const dx = Math.abs(opp.pos.x - player.pos.x);
+    const dy = Math.abs(opp.pos.y - player.pos.y);
+    return dx <= 1 && dy <= 1 && !(dx === 0 && dy === 0);
+  });
+
+  if (isInTackleZone) return state;
+
+  if (!ballPosition) return state;
+
+  // Move player under the ball
+  const updatedPlayers = state.players.map(p =>
+    p.id === playerId ? { ...p, pos: { ...ballPosition } } : p
+  );
+
+  const log = createLogEntry(
+    'action',
+    `Coup en hauteur : ${player.name} se place sous le ballon en (${ballPosition.x}, ${ballPosition.y})`
+  );
+
+  return {
+    ...state,
+    players: updatedPlayers,
+    pendingKickoffEvent: undefined,
+    gameLog: [...state.gameLog, log],
+  };
+}
+
+/**
+ * Résout l'événement Quick Snap.
+ * Chaque joueur de l'équipe qui reçoit peut se déplacer d'1 case.
+ * @param moves - Array de déplacements { playerId, to } (max 1 case de distance)
+ */
+export function resolveKickoffQuickSnap(
+  state: GameState,
+  moves: Array<{ playerId: string; to: Position }>
+): GameState {
+  if (!state.pendingKickoffEvent || state.pendingKickoffEvent.type !== 'quick-snap') {
+    return state;
+  }
+
+  const team = state.pendingKickoffEvent.team;
+
+  // Empty moves = skip the event
+  if (moves.length === 0) {
+    const log = createLogEntry('action', `Snap rapide : aucun joueur déplacé`);
+    return {
+      ...state,
+      pendingKickoffEvent: undefined,
+      gameLog: [...state.gameLog, log],
+    };
+  }
+
+  // Validate all moves
+  const newPositions = new Map<string, Position>();
+  for (const { playerId, to } of moves) {
+    const player = state.players.find(p => p.id === playerId);
+    if (!player || player.team !== team) return state;
+
+    // Must be exactly 1 square (including diagonal)
+    const dx = Math.abs(to.x - player.pos.x);
+    const dy = Math.abs(to.y - player.pos.y);
+    if (dx > 1 || dy > 1 || (dx === 0 && dy === 0)) return state;
+
+    if (!inBounds(state, to)) return state;
+
+    newPositions.set(playerId, to);
+  }
+
+  // Check for collisions: new positions must not overlap with each other or with unmoved players
+  const positionSet = new Set<string>();
+  // Add positions of unmoved players
+  for (const p of state.players) {
+    if (!newPositions.has(p.id) && p.pos.x >= 0) {
+      positionSet.add(`${p.pos.x},${p.pos.y}`);
+    }
+  }
+  // Check moved player destinations
+  for (const [, to] of newPositions) {
+    const key = `${to.x},${to.y}`;
+    if (positionSet.has(key)) return state;
+    positionSet.add(key);
+  }
+
+  // Apply moves
+  const updatedPlayers = state.players.map(p => {
+    const newPos = newPositions.get(p.id);
+    if (newPos) {
+      return { ...p, pos: { ...newPos } };
+    }
+    return p;
+  });
+
+  const log = createLogEntry(
+    'action',
+    `Snap rapide : ${moves.length} joueur(s) déplacé(s) d'une case`
+  );
+
+  return {
+    ...state,
+    players: updatedPlayers,
+    pendingKickoffEvent: undefined,
+    gameLog: [...state.gameLog, log],
+  };
+}
+
+/**
+ * Résout l'événement Blitz.
+ * Active un tour immédiat pour l'équipe qui botte (sans passes ni remises).
+ */
+export function resolveKickoffBlitz(state: GameState): GameState {
+  if (!state.pendingKickoffEvent || state.pendingKickoffEvent.type !== 'blitz') {
+    return state;
+  }
+
+  const team = state.pendingKickoffEvent.team;
+
+  const log = createLogEntry(
+    'action',
+    `Blitz ! L'équipe qui botte joue un tour immédiat (sans passes ni remises)`
+  );
+
+  return {
+    ...state,
+    pendingKickoffEvent: undefined,
+    kickoffBlitzTurn: true,
+    currentPlayer: team,
+    playerActions: {},
+    teamBlitzCount: {},
+    teamFoulCount: {},
+    rerollUsedThisTurn: false,
+    gameLog: [...state.gameLog, log],
+  };
+}


### PR DESCRIPTION
## Summary

- Implement game engine support for the 4 kickoff events that were previously log-only stubs: **Perfect Defence** (roll 4), **High Kick** (roll 5), **Quick Snap** (roll 9), **Blitz** (roll 10)
- Add `PendingKickoffEvent` type and `pendingKickoffEvent` field to `GameState` so the UI knows when player interaction is needed
- Add 4 new `Move` types (`KICKOFF_PERFECT_DEFENCE`, `KICKOFF_HIGH_KICK`, `KICKOFF_QUICK_SNAP`, `KICKOFF_BLITZ_RESOLVE`) wired into `applyMove()` and `getLegalMoves()`
- Add `kickoffBlitzTurn` flag to manage the kicking team's immediate turn with PASS/HANDOFF restrictions

**Roadmap task:** I.9 — Implementer 4 kickoff events delegues UI

## Test plan

- [x] 30 tests covering all 4 events (unit + applyMove integration)
- [ ] Verify Perfect Defence rejects invalid positions (out of bounds, wrong half, overlapping)
- [ ] Verify High Kick rejects players in enemy tackle zones and allows decline
- [ ] Verify Quick Snap rejects moves > 1 square, out of bounds, and collisions
- [ ] Verify Blitz sets kickoffBlitzTurn, blocks PASS/HANDOFF, and END_TURN restores receiving team
- [ ] Verify getLegalMoves returns only kickoff moves when pendingKickoffEvent is set
- [ ] Verify existing kickoff event tests still pass (32 total)

https://claude.ai/code/session_01GLbaaBKGLs2Y8p3NRQ1uSC