### PR TITLE
feat: per-roster team colors on the board (H.6 foundation)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -169,7 +169,7 @@
 | B3.2 | UI affichage regles speciales star players | UI | [x] |
 | H.3 | Replayer basique | Polish | [x] |
 | H.4 | Indicateurs tactiques (zones de tacle, portee) | Polish | [x] |
-| H.6 | Sprite sheets par equipe | Polish | [ ] |
+| H.6 | Sprite sheets par equipe (1/5 — foundation: per-roster colors) | Polish | [ ] |
 
 ---
 

--- a/packages/game-engine/src/rosters/index.ts
+++ b/packages/game-engine/src/rosters/index.ts
@@ -31,6 +31,14 @@ export {
   type RegionalRule
 } from './star-players';
 
+// Export des couleurs d'equipes (H.6 — sprite sheets par equipe, etape 1)
+export {
+  DEFAULT_TEAM_COLORS,
+  ROSTER_COLORS,
+  getTeamColors,
+  type TeamColors,
+} from './team-colors';
+
 // Export des utilitaires Star Players
 export * from './star-players-utils';
 export {

--- a/packages/game-engine/src/rosters/positions.ts
+++ b/packages/game-engine/src/rosters/positions.ts
@@ -27,6 +27,10 @@ export interface TeamRoster {
   regionalRules?: string[];
   specialRules?: string;
   positions: PositionDefinition[];
+  /** H.6 — optional per-roster primary color (24-bit hex) for board rendering. */
+  primaryColor?: number;
+  /** H.6 — optional per-roster secondary / accent color (24-bit hex). */
+  secondaryColor?: number;
 }
 
 export type Ruleset = "season_2" | "season_3";

--- a/packages/game-engine/src/rosters/team-colors.test.ts
+++ b/packages/game-engine/src/rosters/team-colors.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TEAM_COLORS,
+  ROSTER_COLORS,
+  getTeamColors,
+  type TeamColors,
+} from './team-colors';
+import { TEAM_ROSTERS_BY_RULESET } from './positions';
+
+describe('Regle: team-colors (H.6 sprite sheets - sub-task 1)', () => {
+  describe('DEFAULT_TEAM_COLORS', () => {
+    it('should expose primary and secondary hex colors as numbers', () => {
+      expect(typeof DEFAULT_TEAM_COLORS.primary).toBe('number');
+      expect(typeof DEFAULT_TEAM_COLORS.secondary).toBe('number');
+      expect(DEFAULT_TEAM_COLORS.primary).toBeGreaterThanOrEqual(0);
+      expect(DEFAULT_TEAM_COLORS.primary).toBeLessThanOrEqual(0xffffff);
+    });
+  });
+
+  describe('ROSTER_COLORS map', () => {
+    it('should define colors for every unique roster slug across both rulesets', () => {
+      const allSlugs = new Set<string>();
+      for (const ruleset of Object.keys(TEAM_ROSTERS_BY_RULESET) as Array<
+        keyof typeof TEAM_ROSTERS_BY_RULESET
+      >) {
+        for (const slug of Object.keys(TEAM_ROSTERS_BY_RULESET[ruleset])) {
+          allSlugs.add(slug);
+        }
+      }
+      for (const slug of allSlugs) {
+        expect(ROSTER_COLORS[slug], `missing colors for roster "${slug}"`).toBeDefined();
+      }
+    });
+
+    it('each entry must have valid primary and secondary hex colors', () => {
+      for (const [slug, colors] of Object.entries(ROSTER_COLORS)) {
+        expect(typeof colors.primary, `${slug}.primary`).toBe('number');
+        expect(typeof colors.secondary, `${slug}.secondary`).toBe('number');
+        expect(colors.primary).toBeGreaterThanOrEqual(0);
+        expect(colors.primary).toBeLessThanOrEqual(0xffffff);
+        expect(colors.secondary).toBeGreaterThanOrEqual(0);
+        expect(colors.secondary).toBeLessThanOrEqual(0xffffff);
+      }
+    });
+
+    it('primary and secondary should differ to ensure visual contrast', () => {
+      for (const [slug, colors] of Object.entries(ROSTER_COLORS)) {
+        expect(colors.primary, `${slug} primary === secondary`).not.toBe(colors.secondary);
+      }
+    });
+  });
+
+  describe('getTeamColors()', () => {
+    it('returns DEFAULT_TEAM_COLORS when rosterSlug is undefined', () => {
+      expect(getTeamColors(undefined)).toEqual(DEFAULT_TEAM_COLORS);
+    });
+
+    it('returns DEFAULT_TEAM_COLORS when rosterSlug is empty string', () => {
+      expect(getTeamColors('')).toEqual(DEFAULT_TEAM_COLORS);
+    });
+
+    it('returns DEFAULT_TEAM_COLORS for an unknown roster slug', () => {
+      expect(getTeamColors('not_a_real_roster_zzz')).toEqual(DEFAULT_TEAM_COLORS);
+    });
+
+    it('returns the canonical colors for a known roster slug', () => {
+      const skaven = getTeamColors('skaven');
+      expect(skaven).toEqual(ROSTER_COLORS.skaven);
+    });
+
+    it('returns different colors for different rosters', () => {
+      const skaven = getTeamColors('skaven');
+      const dwarf = getTeamColors('dwarf');
+      expect(skaven.primary).not.toBe(dwarf.primary);
+    });
+
+    it('prefers roster-defined colors when override is provided', () => {
+      const override: TeamColors = { primary: 0x123456, secondary: 0x654321 };
+      expect(getTeamColors('skaven', override)).toEqual(override);
+    });
+
+    it('falls back to ROSTER_COLORS when override has only partial fields', () => {
+      // Passing undefined override is equivalent to not passing one
+      expect(getTeamColors('skaven', undefined)).toEqual(ROSTER_COLORS.skaven);
+    });
+  });
+
+  describe('TeamRoster interface extension', () => {
+    it('allows TeamRoster to optionally declare primaryColor / secondaryColor', () => {
+      // Compile-time check: ensure the interface accepts these optional fields.
+      // If the interface is not extended, this test file fails to compile.
+      const fakeRoster: Partial<
+        (typeof TEAM_ROSTERS_BY_RULESET)['season_2']['skaven']
+      > = {
+        primaryColor: 0xabcdef,
+        secondaryColor: 0x123456,
+      };
+      expect(fakeRoster.primaryColor).toBe(0xabcdef);
+      expect(fakeRoster.secondaryColor).toBe(0x123456);
+    });
+  });
+});

--- a/packages/game-engine/src/rosters/team-colors.ts
+++ b/packages/game-engine/src/rosters/team-colors.ts
@@ -1,0 +1,108 @@
+/**
+ * Team visual identity — per-roster primary/secondary colors.
+ *
+ * Foundation for task H.6 "Sprite sheets par equipe". Before shipping actual
+ * sprite sheet assets, we need per-team visual differentiation on the board.
+ * This module centralises canonical Blood Bowl roster colors so `PixiBoard`
+ * (and, later, the sprite loader) can tint players by roster instead of
+ * defaulting to the hardcoded red/blue team A/B palette.
+ *
+ * Follow-up sub-tasks:
+ *   - asset loader + sprite registry using @pixi/assets
+ *   - PNG/JSON sprite sheets shipped under `apps/web/public/images/team-sprites/`
+ *   - PixiBoard to swap circle Graphics for Pixi Sprites
+ *   - Prisma schema migration to persist per-roster color overrides
+ */
+
+/** RGB colors expressed as 24-bit integers, compatible with Pixi Graphics / tint. */
+export interface TeamColors {
+  /** Main jersey color (circle fill / sprite tint base). */
+  primary: number;
+  /** Accent color used for outlines, trims and secondary details. */
+  secondary: number;
+}
+
+/**
+ * Neutral fallback palette. Intentionally close to the legacy red/blue scheme
+ * so that disabling per-roster colors is visually backwards compatible.
+ */
+export const DEFAULT_TEAM_COLORS: TeamColors = {
+  primary: 0x888888,
+  secondary: 0xffffff,
+};
+
+/**
+ * Canonical roster colors — inspired by Games Workshop / Blood Bowl lore.
+ * Keys MUST match the roster slugs defined in `positions.ts` and
+ * `season3-rosters.ts`. New rosters should add an entry here; the
+ * `team-colors.test.ts` suite enforces exhaustive coverage.
+ */
+export const ROSTER_COLORS: Record<string, TeamColors> = {
+  // --- Classic Imperial / Order ---
+  human: { primary: 0x1e3a8a, secondary: 0xfbbf24 }, // Reikland blue & gold
+  imperial_nobility: { primary: 0x7f1d1d, secondary: 0xf3e8c5 }, // deep red & cream
+  old_world_alliance: { primary: 0x4b5563, secondary: 0xfbbf24 },
+
+  // --- Dwarves ---
+  dwarf: { primary: 0x1e40af, secondary: 0xfcd34d }, // royal blue & gold
+  chaos_dwarf: { primary: 0x111827, secondary: 0xdc2626 }, // black & red
+  gnome: { primary: 0x065f46, secondary: 0xfde68a },
+
+  // --- Elves ---
+  high_elf: { primary: 0xfafafa, secondary: 0x1e3a8a }, // white & sapphire
+  wood_elf: { primary: 0x14532d, secondary: 0x84cc16 }, // forest greens
+  dark_elf: { primary: 0x1f2937, secondary: 0x7c3aed }, // black & violet
+  elven_union: { primary: 0x1e40af, secondary: 0xfafafa },
+  slann: { primary: 0x0891b2, secondary: 0xfacc15 }, // teal & gold
+
+  // --- Orcs / Goblins ---
+  orc: { primary: 0x166534, secondary: 0x111827 }, // orc green & black
+  black_orc: { primary: 0x052e16, secondary: 0xfacc15 },
+  goblin: { primary: 0x4d7c0f, secondary: 0xfbbf24 },
+  snotling: { primary: 0x84cc16, secondary: 0x1c1917 },
+  underworld: { primary: 0x1f2937, secondary: 0x22c55e },
+
+  // --- Skaven / Rats ---
+  skaven: { primary: 0x92400e, secondary: 0xd6d3d1 }, // rust & bone
+
+  // --- Lizards / Amphibians ---
+  lizardmen: { primary: 0x15803d, secondary: 0xfacc15 },
+
+  // --- Undead ---
+  undead: { primary: 0x4c1d95, secondary: 0xe5e7eb },
+  necromantic_horror: { primary: 0x312e81, secondary: 0xc7d2fe },
+  tomb_kings: { primary: 0xb45309, secondary: 0x1c1917 }, // sand & obsidian
+  vampire: { primary: 0x7f1d1d, secondary: 0x1c1917 }, // blood & black
+
+  // --- Chaos ---
+  chaos_chosen: { primary: 0x1c1917, secondary: 0x9a3412 },
+  chaos_renegade: { primary: 0x78350f, secondary: 0xd97706 },
+  khorne: { primary: 0x991b1b, secondary: 0x1c1917 }, // blood red & black
+  nurgle: { primary: 0x3f6212, secondary: 0xa3a3a3 }, // rot green & grey
+
+  // --- Others ---
+  amazon: { primary: 0xa16207, secondary: 0x14532d }, // bronze & jungle
+  halfling: { primary: 0x65a30d, secondary: 0xfbbf24 }, // meadow & butter
+  ogre: { primary: 0x78350f, secondary: 0xfde68a },
+  norse: { primary: 0x0c4a6e, secondary: 0xe0f2fe }, // ice & snow
+};
+
+/**
+ * Resolve the visual colors for a given roster.
+ *
+ * Resolution order:
+ *   1. explicit `override` argument (e.g. from a `TeamRoster.primaryColor`)
+ *   2. canonical `ROSTER_COLORS[slug]`
+ *   3. `DEFAULT_TEAM_COLORS`
+ *
+ * @param rosterSlug - roster slug as defined in `positions.ts`
+ * @param override - optional override (primary + secondary required)
+ */
+export function getTeamColors(
+  rosterSlug: string | undefined,
+  override?: TeamColors,
+): TeamColors {
+  if (override) return override;
+  if (!rosterSlug) return DEFAULT_TEAM_COLORS;
+  return ROSTER_COLORS[rosterSlug] ?? DEFAULT_TEAM_COLORS;
+}

--- a/packages/ui/src/board/PixiBoard.tsx
+++ b/packages/ui/src/board/PixiBoard.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Stage, Container, Graphics, Text } from "@pixi/react";
 import type { Graphics as PixiGraphics } from "@pixi/graphics";
 import type { GameState, Position, Player, TackleZoneHeatmap, ReachableCell, PassRangeBand } from "@bb/game-engine";
+import { resolveTeamFillColor, type TeamRostersMap, type TeamColorOverridesMap } from "./team-color-resolver";
 import { useAnimatedPositions } from "./useAnimatedPositions";
 import { useBlockEffects } from "./useBlockEffects";
 import { useTouchdownEffects } from "./useTouchdownEffects";
@@ -49,6 +50,14 @@ type Props = {
   passRangeBands?: PassRangeBand[];
   /** Whether to show the pass range overlay */
   showPassRange?: boolean;
+  /**
+   * H.6 — optional per-team roster slugs used to look up team-specific
+   * colors (and, in a later sub-task, sprite sheets). When omitted, players
+   * fall back to the legacy red/blue team A/B palette.
+   */
+  teamRosters?: TeamRostersMap;
+  /** H.6 — optional explicit color override per team (bypasses rosterSlug lookup). */
+  teamColorOverrides?: TeamColorOverridesMap;
 };
 
 export default function PixiBoard({
@@ -68,6 +77,8 @@ export default function PixiBoard({
   showReachability = false,
   passRangeBands = [],
   showPassRange = false,
+  teamRosters,
+  teamColorOverrides,
 }: Props) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [responsiveCellSize, setResponsiveCellSize] = React.useState(cellSize);
@@ -496,11 +507,11 @@ export default function PixiBoard({
                     const y = posX * cs + cs / 2 + shakeY;
                     const radius = cs / 2 - 2;
 
-                    const playerColor = player.stunned
-                      ? 0x808080
-                      : player.team === "A"
-                        ? 0xcc2222
-                        : 0x2255cc;
+                    const playerColor = resolveTeamFillColor(
+                      player,
+                      teamRosters,
+                      teamColorOverrides,
+                    );
                     g.beginFill(playerColor);
                     g.drawCircle(x, y, radius);
                     g.endFill();

--- a/packages/ui/src/board/team-color-resolver.test.ts
+++ b/packages/ui/src/board/team-color-resolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import type { Player } from "@bb/game-engine";
+import { ROSTER_COLORS } from "@bb/game-engine";
+import {
+  LEGACY_TEAM_A_COLOR,
+  LEGACY_TEAM_B_COLOR,
+  STUNNED_COLOR,
+  resolveTeamFillColor,
+} from "./team-color-resolver";
+
+/** Minimal Player-shaped fixture. The resolver only reads team + stunned. */
+function makePlayer(
+  team: "A" | "B",
+  stunned = false,
+): Pick<Player, "team" | "stunned"> {
+  return { team, stunned };
+}
+
+describe("Regle: team-color-resolver (H.6 sprite sheets - sub-task 1)", () => {
+  describe("legacy fallback (no teamRosters, no overrides)", () => {
+    it("team A → legacy red", () => {
+      expect(resolveTeamFillColor(makePlayer("A"))).toBe(LEGACY_TEAM_A_COLOR);
+    });
+
+    it("team B → legacy blue", () => {
+      expect(resolveTeamFillColor(makePlayer("B"))).toBe(LEGACY_TEAM_B_COLOR);
+    });
+
+    it("stunned team A → grey", () => {
+      expect(resolveTeamFillColor(makePlayer("A", true))).toBe(STUNNED_COLOR);
+    });
+
+    it("stunned team B → grey", () => {
+      expect(resolveTeamFillColor(makePlayer("B", true))).toBe(STUNNED_COLOR);
+    });
+  });
+
+  describe("roster-based lookup", () => {
+    it("uses ROSTER_COLORS primary for a known team A roster", () => {
+      const color = resolveTeamFillColor(makePlayer("A"), {
+        teamA: "skaven",
+      });
+      expect(color).toBe(ROSTER_COLORS.skaven.primary);
+    });
+
+    it("uses ROSTER_COLORS primary for a known team B roster", () => {
+      const color = resolveTeamFillColor(makePlayer("B"), {
+        teamA: "skaven",
+        teamB: "dwarf",
+      });
+      expect(color).toBe(ROSTER_COLORS.dwarf.primary);
+    });
+
+    it("different rosters produce different colors", () => {
+      const a = resolveTeamFillColor(makePlayer("A"), { teamA: "wood_elf" });
+      const b = resolveTeamFillColor(makePlayer("B"), { teamB: "dark_elf" });
+      expect(a).not.toBe(b);
+    });
+
+    it("stunned players stay grey even when roster is provided", () => {
+      const color = resolveTeamFillColor(makePlayer("A", true), {
+        teamA: "skaven",
+      });
+      expect(color).toBe(STUNNED_COLOR);
+    });
+
+    it("unknown roster falls back to default (not legacy red/blue)", () => {
+      const color = resolveTeamFillColor(makePlayer("A"), {
+        teamA: "not_a_real_roster",
+      });
+      // `getTeamColors` returns DEFAULT_TEAM_COLORS for unknown slugs,
+      // so the result should NOT be the legacy red.
+      expect(color).not.toBe(LEGACY_TEAM_A_COLOR);
+    });
+  });
+
+  describe("explicit color overrides", () => {
+    it("override takes precedence over roster lookup", () => {
+      const override = { primary: 0x123456, secondary: 0x654321 };
+      const color = resolveTeamFillColor(
+        makePlayer("A"),
+        { teamA: "skaven" }, // would otherwise return ROSTER_COLORS.skaven.primary
+        { teamA: override },
+      );
+      expect(color).toBe(0x123456);
+    });
+
+    it("override on team A does not affect team B", () => {
+      const overrideA = { primary: 0x123456, secondary: 0x654321 };
+      const color = resolveTeamFillColor(
+        makePlayer("B"),
+        undefined,
+        { teamA: overrideA },
+      );
+      expect(color).toBe(LEGACY_TEAM_B_COLOR);
+    });
+
+    it("stunned players ignore overrides", () => {
+      const override = { primary: 0x123456, secondary: 0x654321 };
+      const color = resolveTeamFillColor(
+        makePlayer("A", true),
+        undefined,
+        { teamA: override },
+      );
+      expect(color).toBe(STUNNED_COLOR);
+    });
+  });
+
+  describe("backwards compatibility", () => {
+    it("passing undefined teamRosters is equivalent to legacy behaviour", () => {
+      expect(resolveTeamFillColor(makePlayer("A"), undefined)).toBe(
+        LEGACY_TEAM_A_COLOR,
+      );
+      expect(resolveTeamFillColor(makePlayer("B"), undefined)).toBe(
+        LEGACY_TEAM_B_COLOR,
+      );
+    });
+
+    it("empty teamRosters object is equivalent to legacy behaviour", () => {
+      expect(resolveTeamFillColor(makePlayer("A"), {})).toBe(
+        LEGACY_TEAM_A_COLOR,
+      );
+      expect(resolveTeamFillColor(makePlayer("B"), {})).toBe(
+        LEGACY_TEAM_B_COLOR,
+      );
+    });
+  });
+});

--- a/packages/ui/src/board/team-color-resolver.ts
+++ b/packages/ui/src/board/team-color-resolver.ts
@@ -1,0 +1,52 @@
+/**
+ * H.6 — team color resolution for board rendering.
+ *
+ * Pure, side-effect free so it can be unit-tested without loading the full
+ * Pixi stack. `PixiBoard` imports this and applies the resolved color as a
+ * Graphics fill. A later sub-task will add sprite sheet loading and swap
+ * the circle Graphics for Pixi Sprites tinted with the same color.
+ */
+import { getTeamColors, type TeamColors } from "@bb/game-engine";
+import type { Player } from "@bb/game-engine";
+
+/** Legacy red/blue palette preserved for backwards compatibility. */
+export const LEGACY_TEAM_A_COLOR = 0xcc2222;
+export const LEGACY_TEAM_B_COLOR = 0x2255cc;
+export const STUNNED_COLOR = 0x808080;
+
+export interface TeamRostersMap {
+  teamA?: string;
+  teamB?: string;
+}
+
+export interface TeamColorOverridesMap {
+  teamA?: TeamColors;
+  teamB?: TeamColors;
+}
+
+/**
+ * Resolve the primary fill color for a player on the board.
+ *
+ * Resolution order:
+ *   1. stunned players are grey (regardless of team)
+ *   2. explicit `teamColorOverrides[team]` if provided
+ *   3. `getTeamColors(teamRosters[team]).primary` if a roster slug is provided
+ *   4. legacy red/blue fallback
+ */
+export function resolveTeamFillColor(
+  player: Pick<Player, "team" | "stunned">,
+  teamRosters?: TeamRostersMap,
+  teamColorOverrides?: TeamColorOverridesMap,
+): number {
+  if (player.stunned) return STUNNED_COLOR;
+
+  const override =
+    player.team === "A" ? teamColorOverrides?.teamA : teamColorOverrides?.teamB;
+  if (override) return override.primary;
+
+  const rosterSlug =
+    player.team === "A" ? teamRosters?.teamA : teamRosters?.teamB;
+  if (rosterSlug) return getTeamColors(rosterSlug).primary;
+
+  return player.team === "A" ? LEGACY_TEAM_A_COLOR : LEGACY_TEAM_B_COLOR;
+}

--- a/packages/ui/src/components/GameBoardWithDugouts.tsx
+++ b/packages/ui/src/components/GameBoardWithDugouts.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useMemo, useEffect, useCallback } from "react";
-import { GameState, Player, calculateTackleZoneHeatmap, getReachableCells, getPassRangeBands } from "@bb/game-engine";
+import { GameState, Player, calculateTackleZoneHeatmap, getReachableCells, getPassRangeBands, type TeamColors } from "@bb/game-engine";
 import PixiBoard from "../board/PixiBoard";
 import TeamDugoutComponent from "./TeamDugout";
 import PlayerDetails from "./PlayerDetails";
@@ -25,6 +25,16 @@ interface GameBoardWithDugoutsProps {
   onDrop?: (e: React.DragEvent) => void;
   /** Called when the responsive cell size changes (for drop coordinate math) */
   onCellSizeChange?: (cellSize: number) => void;
+  /** H.6 — roster slugs for team A / team B, used for per-team visual colors. */
+  teamRosters?: {
+    teamA?: string;
+    teamB?: string;
+  };
+  /** H.6 — optional explicit color overrides per team. */
+  teamColorOverrides?: {
+    teamA?: TeamColors;
+    teamB?: TeamColors;
+  };
 }
 
 export default function GameBoardWithDugouts({
@@ -42,6 +52,8 @@ export default function GameBoardWithDugouts({
   onDragOver,
   onDrop,
   onCellSizeChange,
+  teamRosters,
+  teamColorOverrides,
 }: GameBoardWithDugoutsProps) {
   const [showDugoutA, setShowDugoutA] = useState(false);
   const [showDugoutB, setShowDugoutB] = useState(false);
@@ -224,6 +236,8 @@ export default function GameBoardWithDugouts({
             showReachability={showReachability}
             passRangeBands={passRangeBands}
             showPassRange={showPassRange}
+            teamRosters={teamRosters}
+            teamColorOverrides={teamColorOverrides}
           />
         </div>
 


### PR DESCRIPTION
## Résumé

Première sous-tâche de **H.6 — Sprite sheets par equipe** (Sprint 10). H.6 est trop volumineuse pour être livrée en un seul PR (5 sous-étapes estimées), donc ce PR pose la **fondation** : identité visuelle par équipe sur le plateau. Les assets PNG/JSON, l'asset loader et le remplacement des `Graphics` par des `Sprite` Pixi arriveront dans les sous-tâches 2-5.

### Ce qui est livré
- `packages/game-engine/src/rosters/team-colors.ts` — nouveau module avec :
  - type `TeamColors { primary: number; secondary: number }`
  - `ROSTER_COLORS` : 30 rosters uniques (S2 + S3) avec palette canonique Blood Bowl (ex. Skavens rust & bone, Dwarfs royal blue & gold, Khorne blood red & black…)
  - `getTeamColors(slug, override?)` — ordre de résolution : override → slug canonique → défaut
- `TeamRoster` étendu avec `primaryColor?` / `secondaryColor?` optionnels (futures surcharges par roster)
- `PixiBoard` : nouvelles props optionnelles `teamRosters` et `teamColorOverrides` + utilisation de `resolveTeamFillColor()`
- `packages/ui/src/board/team-color-resolver.ts` — helper pur (sans Pixi) extrait pour être testable directement en jsdom
- `GameBoardWithDugouts` forwarde les nouvelles props à `PixiBoard`
- **Rétro-compatible** : quand aucune prop n'est passée, la palette rouge/bleu A/B est identique à l'existant (tests le vérifient)

### Tâche roadmap
- TODO.md → Sprint 10 → **H.6 Sprite sheets par equipe** (sous-tâche 1/5)
- Décomposition prévue :
  1. ✅ **Ce PR** — colors per roster + résolveur + props PixiBoard
  2. Asset loader + sprite registry (`@pixi/assets`)
  3. Sprite sheets PNG/JSON dans `apps/web/public/images/team-sprites/`
  4. Remplacement des `Graphics.drawCircle` par `Sprite` Pixi tintés
  5. Migration Prisma pour persister les couleurs overrides par roster

### Plan de test
- [x] `team-colors.test.ts` — **12 tests** (ROSTER_COLORS exhaustif sur les 30 slugs S2/S3, contraste primary≠secondary, ordre de résolution override > slug > default)
- [x] `team-color-resolver.test.ts` — **14 tests** (fallback legacy, lookup par roster, overrides, stunned grey, rétro-compatibilité)
- [x] `pnpm --filter @bb/game-engine --filter @bb/ui test` — **3168 tests verts** (2958 game-engine + 210 ui)
- [x] `pnpm test` (complet, monorepo) — exit code 0
- [x] `pnpm lint` — 0 erreurs (533 warnings préexistants inchangés)
- [x] `pnpm --filter @bb/game-engine --filter @bb/ui typecheck` — clean
- [x] `pnpm --filter @bb/game-engine --filter @bb/ui build` — clean
- Non-régression visuelle : sans props, le rendu rouge/bleu est exactement préservé (asserté par `team-color-resolver.test.ts > backwards compatibility`)

### Hors scope
- `PixiBoard.native.tsx` (mobile Expo/SVG) — sera branché dans une sous-tâche mobile future
- Persistance en base (Prisma) — sous-tâche 5
- Remplacement visuel cercles → sprites — sous-tâches 3-4