### PR TITLE
feat(I.7): differentiate S3 star players from S2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -171,6 +171,15 @@
 | H.4 | Indicateurs tactiques (zones de tacle, portee) | Polish | [x] |
 | H.6 | Sprite sheets par equipe (5/5 — sprite manifest registry + UI resolver + PixiBoard integration, atlases directory ready) | Polish | [x] |
 
+### Sprint 11 — Donnees S3 & taches restantes
+
+| # | Tache | Type | Statut |
+|---|-------|------|--------|
+| I.7 | Differencier star players S3 vs S2 (overrides, Slann regional rules) | Contenu | [x] |
+| B2.6 | Verifier connexion Sweltering Heat dans le flow (deja cable) | Regle | [x] |
+| I.6 | Rediger regles speciales star players manquantes (~60) | Contenu | [ ] |
+| H.7 | Variantes de terrain (skins herbe/ruine/neige) | Polish | [ ] |
+
 ---
 
 ## Resume par phase
@@ -224,4 +233,5 @@ Sprint 0 (Bugfixes) ✅ ──→ Sprint 1 (WS + UI + skills) ✅ ──→ MATC
 > 8. ~~Sprint 7~~ ✅ — notifications push (Service Worker, web-push, integration)
 > 9. ~~Sprint 8~~ ✅ — polish & contenu (chat in-game, bugfixes donnees)
 > 10. ~~Sprint 9~~ ✅ — animations avancees, kickoff events, leaderboard
-> 11. **En cours** : Sprint 10 — contenu & polish restants (Slann S3, images, replayer)
+> 11. ~~Sprint 10~~ ✅ — contenu & polish restants (Slann S3, images, replayer)
+> 12. **En cours** : Sprint 11 — donnees S3, taches restantes

--- a/packages/game-engine/src/rosters/star-players.test.ts
+++ b/packages/game-engine/src/rosters/star-players.test.ts
@@ -4,6 +4,8 @@ import {
   getStarPlayerBySlug,
   getAvailableStarPlayers,
   TEAM_REGIONAL_RULES,
+  STAR_PLAYERS_BY_RULESET,
+  TEAM_REGIONAL_RULES_BY_RULESET,
   type StarPlayerDefinition,
 } from './star-players';
 
@@ -360,6 +362,131 @@ describe('Star Players', () => {
         const starPlayer = getStarPlayerBySlug(slug);
         expect(starPlayer).toBeDefined();
         expect(starPlayer?.cost).toBe(expectedCost);
+      });
+    });
+  });
+
+  describe('Season 3 star player differentiation (I.7)', () => {
+    describe('S3 star players are separate from S2', () => {
+      it('devrait avoir des maps distinctes pour S2 et S3', () => {
+        const s2Map = STAR_PLAYERS_BY_RULESET.season_2;
+        const s3Map = STAR_PLAYERS_BY_RULESET.season_3;
+
+        expect(s2Map).toBeDefined();
+        expect(s3Map).toBeDefined();
+        expect(s2Map).not.toBe(s3Map);
+      });
+
+      it('les mutations S3 ne devraient pas affecter S2', () => {
+        const s2Hakflem = STAR_PLAYERS_BY_RULESET.season_2['hakflem_skuttlespike'];
+        const s3Hakflem = STAR_PLAYERS_BY_RULESET.season_3['hakflem_skuttlespike'];
+
+        expect(s2Hakflem).toBeDefined();
+        expect(s3Hakflem).toBeDefined();
+        expect(s2Hakflem).not.toBe(s3Hakflem);
+
+        // Verify they're separate objects
+        expect(s2Hakflem.hirableBy).not.toBe(s3Hakflem.hirableBy);
+      });
+
+      it('S3 devrait avoir tous les star players de base de S2', () => {
+        const s2Slugs = Object.keys(STAR_PLAYERS_BY_RULESET.season_2);
+        const s3Slugs = Object.keys(STAR_PLAYERS_BY_RULESET.season_3);
+
+        // All S2 star players should exist in S3
+        for (const slug of s2Slugs) {
+          expect(s3Slugs).toContain(slug);
+        }
+      });
+    });
+
+    describe('S3-specific star player changes', () => {
+      it('Hakflem Skuttlespike devrait être disponible pour sylvanian_spotlight en S3', () => {
+        const s3Hakflem = getStarPlayerBySlug('hakflem_skuttlespike', 'season_3');
+        expect(s3Hakflem).toBeDefined();
+        expect(s3Hakflem?.hirableBy).toContain('underworld_challenge');
+        expect(s3Hakflem?.hirableBy).toContain('sylvanian_spotlight');
+      });
+
+      it('Hakflem Skuttlespike S2 ne devrait PAS avoir sylvanian_spotlight', () => {
+        const s2Hakflem = getStarPlayerBySlug('hakflem_skuttlespike', 'season_2');
+        expect(s2Hakflem).toBeDefined();
+        expect(s2Hakflem?.hirableBy).toContain('underworld_challenge');
+        expect(s2Hakflem?.hirableBy).not.toContain('sylvanian_spotlight');
+      });
+
+      it('S3 devrait avoir au moins une différence avec S2', () => {
+        const s2Map = STAR_PLAYERS_BY_RULESET.season_2;
+        const s3Map = STAR_PLAYERS_BY_RULESET.season_3;
+
+        let hasDifference = false;
+        for (const slug of Object.keys(s2Map)) {
+          const s2Player = s2Map[slug];
+          const s3Player = s3Map[slug];
+          if (!s3Player) continue;
+
+          if (
+            s2Player.cost !== s3Player.cost ||
+            s2Player.skills !== s3Player.skills ||
+            JSON.stringify(s2Player.hirableBy) !== JSON.stringify(s3Player.hirableBy)
+          ) {
+            hasDifference = true;
+            break;
+          }
+        }
+
+        expect(hasDifference).toBe(true);
+      });
+    });
+
+    describe('S3 regional rules', () => {
+      it('slann devrait avoir lustrian_superleague dans les règles régionales S3', () => {
+        const s3Rules = TEAM_REGIONAL_RULES_BY_RULESET.season_3;
+        expect(s3Rules['slann']).toBeDefined();
+        expect(s3Rules['slann']).toContain('lustrian_superleague');
+      });
+
+      it('slann devrait pouvoir recruter des star players lustrian_superleague en S3', () => {
+        const availablePlayers = getAvailableStarPlayers('slann', [], 'season_3');
+
+        // Should include "all" players plus lustrian_superleague players
+        const lustrians = availablePlayers.filter(
+          sp => sp.hirableBy.includes('lustrian_superleague')
+        );
+        expect(lustrians.length).toBeGreaterThan(0);
+
+        // Check specific lustrian star players
+        const anqi = availablePlayers.find(sp => sp.slug === 'anqi_panqi');
+        expect(anqi).toBeDefined();
+
+        const boa = availablePlayers.find(sp => sp.slug === 'boa_konssstriktr');
+        expect(boa).toBeDefined();
+      });
+
+      it('les équipes undead S3 devraient avoir accès à Hakflem via sylvanian_spotlight', () => {
+        const availablePlayers = getAvailableStarPlayers('undead', [], 'season_3');
+        const hakflem = availablePlayers.find(sp => sp.slug === 'hakflem_skuttlespike');
+        expect(hakflem).toBeDefined();
+      });
+
+      it('les équipes undead S2 ne devraient PAS avoir accès à Hakflem', () => {
+        const availablePlayers = getAvailableStarPlayers('undead', [], 'season_2');
+        const hakflem = availablePlayers.find(sp => sp.slug === 'hakflem_skuttlespike');
+        expect(hakflem).toBeUndefined();
+      });
+    });
+
+    describe('getStarPlayerBySlug avec ruleset', () => {
+      it('devrait retourner le star player S3 quand ruleset=season_3', () => {
+        const s3Glart = getStarPlayerBySlug('glart_smashrip', 'season_3');
+        expect(s3Glart).toBeDefined();
+        expect(s3Glart?.displayName).toBe('Glart Smashrip');
+      });
+
+      it('devrait retourner le star player S2 quand ruleset=season_2', () => {
+        const s2Glart = getStarPlayerBySlug('glart_smashrip', 'season_2');
+        expect(s2Glart).toBeDefined();
+        expect(s2Glart?.displayName).toBe('Glart Smashrip');
       });
     });
   });

--- a/packages/game-engine/src/rosters/star-players.ts
+++ b/packages/game-engine/src/rosters/star-players.ts
@@ -982,10 +982,49 @@ const cloneStarPlayersMap = (source: Record<string, StarPlayerDefinition>): Reco
     Object.entries(source).map(([slug, player]) => [slug, cloneStarPlayer(player)]),
   );
 
+// ---------------------------------------------------------------------------
+// Season 3 Star Player overrides (BB 2020 Season 2 rulebook changes)
+// ---------------------------------------------------------------------------
+
+/**
+ * S3-specific overrides: only the fields that differ from S2.
+ * To add a future S3 change, add an entry here with only the changed fields.
+ */
+const SEASON_THREE_STAR_PLAYER_OVERRIDES: Record<string, Partial<StarPlayerDefinition>> = {
+  // Hakflem Skuttlespike: expanded availability in S3 (BB 2020 S2 rules)
+  // Now also available to Sylvanian Spotlight teams (Undead, Necromantic Horror, Vampire)
+  hakflem_skuttlespike: {
+    hirableBy: ["underworld_challenge", "sylvanian_spotlight"],
+  },
+};
+
+/**
+ * Build the Season 3 star player map from S2 base + S3-specific overrides.
+ * This approach avoids duplicating all data while allowing precise S3 changes.
+ */
+function buildSeasonThreeStarPlayers(): Record<string, StarPlayerDefinition> {
+  const base = cloneStarPlayersMap(SEASON_TWO_STAR_PLAYERS);
+
+  for (const [slug, overrides] of Object.entries(SEASON_THREE_STAR_PLAYER_OVERRIDES)) {
+    if (base[slug]) {
+      base[slug] = {
+        ...base[slug],
+        ...overrides,
+        // Deep-copy hirableBy if overridden to prevent shared references
+        hirableBy: overrides.hirableBy
+          ? [...overrides.hirableBy]
+          : [...base[slug].hirableBy],
+      };
+    }
+  }
+
+  return base;
+}
+
 // Export du mapping des Star Players par ruleset
 export const STAR_PLAYERS_BY_RULESET: Record<Ruleset, Record<string, StarPlayerDefinition>> = {
   season_2: SEASON_TWO_STAR_PLAYERS,
-  season_3: cloneStarPlayersMap(SEASON_TWO_STAR_PLAYERS),
+  season_3: buildSeasonThreeStarPlayers(),
 };
 
 // Export de STAR_PLAYERS pour la compatibilité avec le code existant (utilise le ruleset par défaut)
@@ -1067,6 +1106,7 @@ export const TEAM_REGIONAL_RULES: Record<string, string[]> = {
   khorne: ["favoured_of"],
   chaos_dwarf: ["badlands_brawl", "worlds_edge_superleague", "favoured_of"],
   gnome: ["halfling_thimble_cup"],
+  slann: ["lustrian_superleague"],
 };
 
 const cloneRegionalRules = (


### PR DESCRIPTION
## Summary

- **Replace S3 star player clone with override-based builder**: Instead of deep-cloning all S2 data, S3 now uses `SEASON_THREE_STAR_PLAYER_OVERRIDES` + `buildSeasonThreeStarPlayers()` — only changed fields are specified, future S3 changes are trivial to add.
- **Fix missing Slann regional rules**: Added `slann: ["lustrian_superleague"]` to `TEAM_REGIONAL_RULES` so Slann teams can now hire Lustrian Superleague star players (Anqi Panqi, Boa Kon'ssstriktr, Glotl Stop, etc.).
- **Apply S3-specific change**: Hakflem Skuttlespike gains `sylvanian_spotlight` availability in S3 (BB 2020 S2 rules), enabling Undead/Necromantic Horror/Vampire teams to hire him.
- **Add Sprint 11 to TODO.md** with remaining roadmap tasks (I.6, H.7).

Roadmap task: **I.7 — Star players spécifiques Season 3** (phases.md)

## Test plan

- [x] 12 new tests in `star-players.test.ts` covering S3 differentiation
- [x] S3/S2 map isolation (mutations don't cross)
- [x] Hakflem S3 availability vs S2 (sylvanian_spotlight)
- [x] Slann can hire lustrian_superleague stars in S3
- [x] Undead S3 can hire Hakflem, Undead S2 cannot
- [x] All 2992 game-engine tests pass (0 regressions)
- [x] TypeScript type check clean
- [x] ESLint: 0 errors

https://claude.ai/code/session_013kmZwGRR6smRruussFBhtR