### PR TITLE
feat(H.7): terrain skin variants (grass/ruins/snow)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -178,7 +178,7 @@
 | I.7 | Differencier star players S3 vs S2 (overrides, Slann regional rules) | Contenu | [x] |
 | B2.6 | Verifier connexion Sweltering Heat dans le flow (deja cable) | Regle | [x] |
 | I.6 | Rediger regles speciales star players manquantes (~60) | Contenu | [x] |
-| H.7 | Variantes de terrain (skins herbe/ruine/neige) | Polish | [ ] |
+| H.7 | Variantes de terrain (skins herbe/ruine/neige) | Polish | [x] |
 
 ---
 

--- a/packages/ui/src/board/PixiBoard.tsx
+++ b/packages/ui/src/board/PixiBoard.tsx
@@ -18,6 +18,7 @@ import { useDiceEffects } from "./useDiceEffects";
 import { useSpriteTextures } from "./useSpriteTextures";
 import { resolvePlayerSpriteFrame } from "./sprite-frame-resolver";
 import { resolveTeamSpriteManifest } from "./team-color-resolver";
+import { getTerrainSkin, type TerrainSkinId } from "./terrain-skins";
 
 /** Extract up to 2 initials from a player's name (e.g. "Grim Ironjaw" -> "GI") */
 function getInitials(player: Player): string {
@@ -67,6 +68,8 @@ type Props = {
   teamRosters?: TeamRostersMap;
   /** H.6 — optional explicit color override per team (bypasses rosterSlug lookup). */
   teamColorOverrides?: TeamColorOverridesMap;
+  /** H.7 — terrain skin variant (grass/ruins/snow). Defaults to grass. */
+  terrainSkin?: TerrainSkinId;
 };
 
 export default function PixiBoard({
@@ -88,9 +91,13 @@ export default function PixiBoard({
   showPassRange = false,
   teamRosters,
   teamColorOverrides,
+  terrainSkin: terrainSkinId,
 }: Props) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [responsiveCellSize, setResponsiveCellSize] = React.useState(cellSize);
+
+  /* ── H.7 — Terrain skin ──────────────────────────────────────────── */
+  const skin = getTerrainSkin(terrainSkinId);
 
   /* ── Viewport state (zoom + pan) ──────────────────────────────────── */
   const [scale, setScale] = React.useState(1);
@@ -281,15 +288,15 @@ export default function PixiBoard({
       <Stage
         width={width}
         height={height}
-        options={{ backgroundColor: 0x6b8e23 }}
+        options={{ backgroundColor: skin.fieldColor }}
         onPointerDown={handleStageClick}
       >
         <Container scale={scale} x={offset.x} y={offset.y}>
-          {/* Fond vert kaki */}
+          {/* Fond terrain (H.7 — skin-driven) */}
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.beginFill(0x6b8e23);
+              g.beginFill(skin.fieldColor);
               g.drawRect(0, 0, width, height);
               g.endFill();
             }}
@@ -303,8 +310,8 @@ export default function PixiBoard({
               const squareSize = cs / 2;
               for (let x = 0; x < width; x += squareSize) {
                 for (let y = 0; y < tdHeight; y += squareSize) {
-                  const isRed = (x / squareSize + y / squareSize) % 2 === 0;
-                  g.beginFill(isRed ? 0xff0000 : 0xf5f5f5);
+                  const isPrimary = (x / squareSize + y / squareSize) % 2 === 0;
+                  g.beginFill(isPrimary ? skin.endzoneTeamAColor : skin.endzoneSecondaryColor);
                   g.drawRect(x, y, squareSize, squareSize);
                   g.endFill();
                 }
@@ -323,8 +330,8 @@ export default function PixiBoard({
               const startY = height - tdHeight;
               for (let x = 0; x < width; x += squareSize) {
                 for (let y = 0; y < tdHeight; y += squareSize) {
-                  const isBlue = (x / squareSize + y / squareSize) % 2 === 0;
-                  g.beginFill(isBlue ? 0x0000ff : 0xf5f5f5);
+                  const isPrimary = (x / squareSize + y / squareSize) % 2 === 0;
+                  g.beginFill(isPrimary ? skin.endzoneTeamBColor : skin.endzoneSecondaryColor);
                   g.drawRect(x, startY + y, squareSize, squareSize);
                   g.endFill();
                 }
@@ -338,7 +345,7 @@ export default function PixiBoard({
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(3, 0xffffff, 1);
+              g.lineStyle(3, skin.lineColor, 1);
               g.drawRect(0, 0, cs * 4, height);
             }}
           />
@@ -347,7 +354,7 @@ export default function PixiBoard({
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(3, 0xffffff, 1);
+              g.lineStyle(3, skin.lineColor, 1);
               g.drawRect(width - cs * 4, 0, cs * 4, height);
             }}
           />
@@ -356,7 +363,7 @@ export default function PixiBoard({
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(4, 0xffff00, 1);
+              g.lineStyle(4, skin.centerLineColor, 1);
               const centerY = 13 * cs;
               g.moveTo(0, centerY);
               g.lineTo(width, centerY);
@@ -367,7 +374,7 @@ export default function PixiBoard({
           <Graphics
             draw={(g: PixiGraphics) => {
               g.clear();
-              g.lineStyle(1, 0xcccccc, 0.3);
+              g.lineStyle(1, skin.gridColor, skin.gridAlpha);
               for (let x = 0; x <= safeHeight; x++) {
                 g.moveTo(x * cs, 0);
                 g.lineTo(x * cs, height);

--- a/packages/ui/src/board/terrain-skins.test.ts
+++ b/packages/ui/src/board/terrain-skins.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  TERRAIN_SKINS,
+  DEFAULT_TERRAIN_SKIN_ID,
+  getTerrainSkin,
+  resolveTerrainSkinFromWeather,
+  type TerrainSkin,
+  type TerrainSkinId,
+} from "./terrain-skins";
+
+describe("Regle: terrain-skins (H.7 variantes de terrain)", () => {
+  describe("TERRAIN_SKINS registry", () => {
+    it("contains exactly 3 skins: grass, ruins, snow", () => {
+      const ids = Object.keys(TERRAIN_SKINS);
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain("grass");
+      expect(ids).toContain("ruins");
+      expect(ids).toContain("snow");
+    });
+
+    it("every skin has all required color fields", () => {
+      const requiredFields: (keyof TerrainSkin)[] = [
+        "id",
+        "name",
+        "fieldColor",
+        "endzoneTeamAColor",
+        "endzoneTeamBColor",
+        "endzoneSecondaryColor",
+        "lineColor",
+        "centerLineColor",
+        "gridColor",
+        "gridAlpha",
+      ];
+      for (const [id, skin] of Object.entries(TERRAIN_SKINS)) {
+        for (const field of requiredFields) {
+          expect(skin[field], `${id} missing ${field}`).toBeDefined();
+        }
+      }
+    });
+
+    it("every skin has numeric color values (24-bit hex)", () => {
+      for (const [id, skin] of Object.entries(TERRAIN_SKINS)) {
+        expect(typeof skin.fieldColor, `${id}.fieldColor`).toBe("number");
+        expect(typeof skin.endzoneTeamAColor, `${id}.endzoneTeamAColor`).toBe("number");
+        expect(typeof skin.endzoneTeamBColor, `${id}.endzoneTeamBColor`).toBe("number");
+        expect(typeof skin.endzoneSecondaryColor, `${id}.endzoneSecondaryColor`).toBe("number");
+        expect(typeof skin.lineColor, `${id}.lineColor`).toBe("number");
+        expect(typeof skin.centerLineColor, `${id}.centerLineColor`).toBe("number");
+        expect(typeof skin.gridColor, `${id}.gridColor`).toBe("number");
+      }
+    });
+
+    it("gridAlpha is between 0 and 1 for every skin", () => {
+      for (const [id, skin] of Object.entries(TERRAIN_SKINS)) {
+        expect(skin.gridAlpha, `${id}.gridAlpha`).toBeGreaterThanOrEqual(0);
+        expect(skin.gridAlpha, `${id}.gridAlpha`).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe("DEFAULT_TERRAIN_SKIN_ID", () => {
+    it("defaults to grass", () => {
+      expect(DEFAULT_TERRAIN_SKIN_ID).toBe("grass");
+    });
+
+    it("points to a valid skin in the registry", () => {
+      expect(TERRAIN_SKINS[DEFAULT_TERRAIN_SKIN_ID]).toBeDefined();
+    });
+  });
+
+  describe("getTerrainSkin()", () => {
+    it("returns grass skin for 'grass'", () => {
+      const skin = getTerrainSkin("grass");
+      expect(skin.id).toBe("grass");
+    });
+
+    it("returns ruins skin for 'ruins'", () => {
+      const skin = getTerrainSkin("ruins");
+      expect(skin.id).toBe("ruins");
+    });
+
+    it("returns snow skin for 'snow'", () => {
+      const skin = getTerrainSkin("snow");
+      expect(skin.id).toBe("snow");
+    });
+
+    it("returns default (grass) for undefined", () => {
+      const skin = getTerrainSkin(undefined);
+      expect(skin.id).toBe("grass");
+    });
+
+    it("returns default (grass) for unknown skin id", () => {
+      const skin = getTerrainSkin("lava" as TerrainSkinId);
+      expect(skin.id).toBe("grass");
+    });
+  });
+
+  describe("resolveTerrainSkinFromWeather()", () => {
+    it("maps hivernale weather conditions to snow", () => {
+      expect(resolveTerrainSkinFromWeather("Blizzard")).toBe("snow");
+    });
+
+    it("maps snow-related conditions to snow", () => {
+      expect(resolveTerrainSkinFromWeather("Neige épaisse")).toBe("snow");
+    });
+
+    it("maps souterraine/cimetiere conditions to ruins", () => {
+      expect(resolveTerrainSkinFromWeather("Éboulement")).toBe("ruins");
+    });
+
+    it("maps ruins-related conditions to ruins", () => {
+      expect(resolveTerrainSkinFromWeather("Ruines instables")).toBe("ruins");
+    });
+
+    it("returns grass for standard conditions", () => {
+      expect(resolveTerrainSkinFromWeather("Conditions parfaites")).toBe("grass");
+    });
+
+    it("returns grass for undefined condition", () => {
+      expect(resolveTerrainSkinFromWeather(undefined)).toBe("grass");
+    });
+
+    it("returns grass for unknown condition", () => {
+      expect(resolveTerrainSkinFromWeather("Something unknown")).toBe("grass");
+    });
+  });
+
+  describe("grass skin has original hardcoded colors", () => {
+    it("fieldColor matches original 0x6b8e23", () => {
+      expect(TERRAIN_SKINS.grass.fieldColor).toBe(0x6b8e23);
+    });
+
+    it("endzoneTeamAColor matches original red", () => {
+      expect(TERRAIN_SKINS.grass.endzoneTeamAColor).toBe(0xff0000);
+    });
+
+    it("endzoneTeamBColor matches original blue", () => {
+      expect(TERRAIN_SKINS.grass.endzoneTeamBColor).toBe(0x0000ff);
+    });
+
+    it("lineColor matches original white", () => {
+      expect(TERRAIN_SKINS.grass.lineColor).toBe(0xffffff);
+    });
+
+    it("centerLineColor matches original yellow", () => {
+      expect(TERRAIN_SKINS.grass.centerLineColor).toBe(0xffff00);
+    });
+
+    it("gridColor matches original light grey", () => {
+      expect(TERRAIN_SKINS.grass.gridColor).toBe(0xcccccc);
+    });
+
+    it("gridAlpha matches original 0.3", () => {
+      expect(TERRAIN_SKINS.grass.gridAlpha).toBe(0.3);
+    });
+  });
+
+  describe("visual contrast: skins are visually distinct", () => {
+    it("each skin has a different fieldColor", () => {
+      const colors = Object.values(TERRAIN_SKINS).map((s) => s.fieldColor);
+      const unique = new Set(colors);
+      expect(unique.size).toBe(colors.length);
+    });
+
+    it("each skin has a different centerLineColor", () => {
+      const colors = Object.values(TERRAIN_SKINS).map((s) => s.centerLineColor);
+      const unique = new Set(colors);
+      expect(unique.size).toBe(colors.length);
+    });
+  });
+});

--- a/packages/ui/src/board/terrain-skins.ts
+++ b/packages/ui/src/board/terrain-skins.ts
@@ -1,0 +1,132 @@
+/**
+ * Terrain skin registry — H.7 variantes de terrain (herbe/ruine/neige).
+ *
+ * Defines the visual palette for each terrain variant. The renderer
+ * (PixiBoard) consumes a TerrainSkin to draw the field background,
+ * endzones, grid lines and center line with thematic colors.
+ *
+ * Pure data module — no side effects, trivially unit-testable.
+ */
+
+/** Available terrain skin identifiers. */
+export type TerrainSkinId = "grass" | "ruins" | "snow";
+
+/** Full visual palette for a terrain variant. */
+export interface TerrainSkin {
+  id: TerrainSkinId;
+  name: string;
+  /** Main field background color (24-bit hex). */
+  fieldColor: number;
+  /** Endzone checkerboard primary color for team A. */
+  endzoneTeamAColor: number;
+  /** Endzone checkerboard primary color for team B. */
+  endzoneTeamBColor: number;
+  /** Endzone checkerboard secondary color (alternating squares). */
+  endzoneSecondaryColor: number;
+  /** Sideline border and lane marker color. */
+  lineColor: number;
+  /** Midfield center line color. */
+  centerLineColor: number;
+  /** Grid line color. */
+  gridColor: number;
+  /** Grid line opacity (0–1). */
+  gridAlpha: number;
+}
+
+/** Canonical terrain skin definitions. */
+export const TERRAIN_SKINS: Record<TerrainSkinId, TerrainSkin> = {
+  grass: {
+    id: "grass",
+    name: "Herbe classique",
+    fieldColor: 0x6b8e23,
+    endzoneTeamAColor: 0xff0000,
+    endzoneTeamBColor: 0x0000ff,
+    endzoneSecondaryColor: 0xf5f5f5,
+    lineColor: 0xffffff,
+    centerLineColor: 0xffff00,
+    gridColor: 0xcccccc,
+    gridAlpha: 0.3,
+  },
+  ruins: {
+    id: "ruins",
+    name: "Ruines antiques",
+    fieldColor: 0x6b5e4f,
+    endzoneTeamAColor: 0x8b3a3a,
+    endzoneTeamBColor: 0x3a4f8b,
+    endzoneSecondaryColor: 0xd4c5a9,
+    lineColor: 0xc8b89a,
+    centerLineColor: 0xd4a053,
+    gridColor: 0x8a7a6a,
+    gridAlpha: 0.35,
+  },
+  snow: {
+    id: "snow",
+    name: "Terrain enneige",
+    fieldColor: 0xc8dce8,
+    endzoneTeamAColor: 0xb03030,
+    endzoneTeamBColor: 0x2060b0,
+    endzoneSecondaryColor: 0xf0f4f8,
+    lineColor: 0x90b8d8,
+    centerLineColor: 0x4a90c8,
+    gridColor: 0xa0c0d8,
+    gridAlpha: 0.25,
+  },
+};
+
+/** Default skin used when no terrain is specified. */
+export const DEFAULT_TERRAIN_SKIN_ID: TerrainSkinId = "grass";
+
+/**
+ * Resolve a terrain skin by id. Returns the default (grass) skin for
+ * unknown or undefined ids — callers never get `null`.
+ */
+export function getTerrainSkin(id: TerrainSkinId | undefined): TerrainSkin {
+  if (!id) return TERRAIN_SKINS[DEFAULT_TERRAIN_SKIN_ID];
+  return TERRAIN_SKINS[id] ?? TERRAIN_SKINS[DEFAULT_TERRAIN_SKIN_ID];
+}
+
+/**
+ * Weather condition strings that map to the snow terrain skin.
+ * Matches conditions from hivernale, montagnard and some classique weather.
+ */
+const SNOW_CONDITIONS = new Set([
+  "Blizzard",
+  "Neige épaisse",
+  "Neige légère",
+  "Grêle",
+  "Tempête de neige",
+  "Gel intense",
+  "Verglas",
+  "Avalanche",
+  "Froid mordant",
+]);
+
+/**
+ * Weather condition strings that map to the ruins terrain skin.
+ * Matches conditions from souterraine, cimetiere and terres-gastes weather.
+ */
+const RUINS_CONDITIONS = new Set([
+  "Éboulement",
+  "Ruines instables",
+  "Obscurité",
+  "Tremblements",
+  "Brume sépulcrale",
+  "Esprits agités",
+  "Sol instable",
+  "Poussière ancienne",
+  "Vent des cryptes",
+  "Terrain maudit",
+]);
+
+/**
+ * Infer the most fitting terrain skin from a weather condition string.
+ * Returns the skin id (not the full skin object) so callers can override.
+ */
+export function resolveTerrainSkinFromWeather(
+  condition: string | undefined,
+): TerrainSkinId {
+  if (!condition) return DEFAULT_TERRAIN_SKIN_ID;
+  if (SNOW_CONDITIONS.has(condition)) return "snow";
+  if (RUINS_CONDITIONS.has(condition)) return "ruins";
+  return DEFAULT_TERRAIN_SKIN_ID;
+}

--- a/packages/ui/src/components/GameBoardWithDugouts.tsx
+++ b/packages/ui/src/components/GameBoardWithDugouts.tsx
@@ -7,6 +7,7 @@ import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { GameState, Player, calculateTackleZoneHeatmap, getReachableCells, getPassRangeBands, type TeamColors } from "@bb/game-engine";
 import PixiBoard from "../board/PixiBoard";
 import { resolveTeamRostersFromState } from "../board/team-color-resolver";
+import { TERRAIN_SKINS, type TerrainSkinId } from "../board/terrain-skins";
 import TeamDugoutComponent from "./TeamDugout";
 import PlayerDetails from "./PlayerDetails";
 
@@ -62,6 +63,7 @@ export default function GameBoardWithDugouts({
   const [showTackleZones, setShowTackleZones] = useState(false);
   const [showReachability, setShowReachability] = useState(false);
   const [showPassRange, setShowPassRange] = useState(false);
+  const [terrainSkin, setTerrainSkin] = useState<TerrainSkinId>("grass");
 
   // H.6 — merge per-side rosters from state + prop override.
   // Prop override wins per side; falls back to state.teamRosters; undefined triggers
@@ -215,6 +217,18 @@ export default function GameBoardWithDugouts({
         >
           {showPassRange ? "Hide" : "Show"} Pass Range (P)
         </button>
+        <select
+          value={terrainSkin}
+          onChange={(e) => setTerrainSkin(e.target.value as TerrainSkinId)}
+          className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-green-100 text-green-800 border border-green-300 cursor-pointer"
+          title="Terrain skin"
+        >
+          {Object.values(TERRAIN_SKINS).map((skin) => (
+            <option key={skin.id} value={skin.id}>
+              {skin.name}
+            </option>
+          ))}
+        </select>
       </div>
 
       {/* Main layout: desktop side-by-side, mobile board-only */}
@@ -247,6 +261,7 @@ export default function GameBoardWithDugouts({
             showPassRange={showPassRange}
             teamRosters={effectiveTeamRosters}
             teamColorOverrides={teamColorOverrides}
+            terrainSkin={terrainSkin}
           />
         </div>
 

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -42,6 +42,8 @@ export function Board({
 
 // Board components
 export { default as PixiBoard } from "./board/PixiBoard";
+export { TERRAIN_SKINS, getTerrainSkin, resolveTerrainSkinFromWeather } from "./board/terrain-skins";
+export type { TerrainSkin, TerrainSkinId } from "./board/terrain-skins";
 
 // Dugout components
 export { default as DugoutZone } from "./components/DugoutZone";


### PR DESCRIPTION
## Summary

- Add terrain skin system with 3 visual variants: **Herbe classique** (grass), **Ruines antiques** (ruins), **Terrain enneige** (snow)
- Replace 7 hardcoded color values in `PixiBoard.tsx` with skin-driven palette (field background, endzones A/B, endzone secondary, sidelines, center line, grid)
- Add terrain skin selector dropdown in the tactical overlay bar (`GameBoardWithDugouts`)
- Add `resolveTerrainSkinFromWeather()` for automatic weather-to-terrain mapping (snow conditions → snow skin, underground/cemetery → ruins skin)
- Export `TerrainSkin`, `TerrainSkinId`, `TERRAIN_SKINS`, `getTerrainSkin`, `resolveTerrainSkinFromWeather` from `@bb/ui`

**Roadmap task**: Sprint 11 — H.7 Variantes de terrain (skins herbe/ruine/neige)

### Files changed

| File | Change |
|------|--------|
| `packages/ui/src/board/terrain-skins.ts` | New — TerrainSkin type, TERRAIN_SKINS registry, getTerrainSkin(), resolveTerrainSkinFromWeather() |
| `packages/ui/src/board/terrain-skins.test.ts` | New — 27 unit tests (registry, resolution, weather mapping, visual contrast) |
| `packages/ui/src/board/PixiBoard.tsx` | Replace hardcoded colors with skin-driven values, add `terrainSkin` prop |
| `packages/ui/src/components/GameBoardWithDugouts.tsx` | Add terrain skin state + selector dropdown |
| `packages/ui/src/index.tsx` | Export terrain skin types and functions |
| `TODO.md` | Check off H.7 |

## Test plan

- [x] 27 unit tests pass (registry completeness, color types, grid alpha range, default fallback, weather mapping, visual distinctness)
- [ ] Visual check: select each skin in browser and verify board colors change
- [ ] Verify grass skin matches original hardcoded colors exactly (backward compatible)
- [ ] Verify dropdown appears alongside existing tactical overlay buttons

https://claude.ai/code/session_018pUiMLDhiCovpQcRBxhTYB