### PR TITLE
feat(e2e): add 3 new E2E UI test scenarios + fix team-select flow

### DIFF
--- a/apps/web/app/leaderboard/page.tsx
+++ b/apps/web/app/leaderboard/page.tsx
@@ -92,7 +92,7 @@ export default function LeaderboardPage() {
   }
 
   return (
-    <div className="w-full p-4 sm:p-6 space-y-4 sm:space-y-6">
+    <div data-testid="leaderboard-page" className="w-full p-4 sm:p-6 space-y-4 sm:space-y-6">
       <div>
         <h1 className="text-2xl sm:text-3xl font-bold mb-2">
           {t.leaderboard.title}
@@ -104,7 +104,7 @@ export default function LeaderboardPage() {
 
       {/* Statistics cards */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
-        <div className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
+        <div data-testid="leaderboard-total-players" className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
           <div className="text-sm text-nuffle-bronze font-medium">
             {t.leaderboard.totalPlayers}
           </div>
@@ -112,7 +112,7 @@ export default function LeaderboardPage() {
             {meta.total}
           </div>
         </div>
-        <div className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
+        <div data-testid="leaderboard-top-rating" className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
           <div className="text-sm text-nuffle-bronze font-medium">
             {t.leaderboard.topRating}
           </div>
@@ -120,7 +120,7 @@ export default function LeaderboardPage() {
             {topRating}
           </div>
         </div>
-        <div className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
+        <div data-testid="leaderboard-avg-rating" className="bg-nuffle-gold/10 border border-nuffle-gold/30 rounded-lg p-4">
           <div className="text-sm text-nuffle-bronze font-medium">
             {t.leaderboard.averageRating}
           </div>
@@ -132,12 +132,12 @@ export default function LeaderboardPage() {
 
       {/* Leaderboard table */}
       {entries.length === 0 ? (
-        <div className="text-center py-8 text-gray-500">
+        <div data-testid="leaderboard-empty" className="text-center py-8 text-gray-500">
           {t.leaderboard.noPlayers}
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full border-collapse">
+          <table data-testid="leaderboard-table" className="w-full border-collapse">
             <thead>
               <tr className="bg-nuffle-anthracite text-nuffle-ivory">
                 <th className="px-4 py-3 text-left text-sm font-semibold w-20">

--- a/apps/web/app/me/teams/new/page.tsx
+++ b/apps/web/app/me/teams/new/page.tsx
@@ -195,9 +195,10 @@ export default function NewTeamBuilder() {
   return (
     <div className="w-full p-6 space-y-6">
       <h1 className="text-2xl font-bold">{t.teams.createTeamTitle}</h1>
-      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {error && <p data-testid="team-builder-error" className="text-red-600 text-sm">{error}</p>}
       <div className="grid gap-3">
         <input
+          data-testid="team-name-input"
           className="border p-2 rounded"
           placeholder={t.teams.teamNamePlaceholder}
           value={name}
@@ -209,6 +210,7 @@ export default function NewTeamBuilder() {
               {t.teams.rulesetLabel}
             </label>
             <select
+              data-testid="ruleset-select"
               className="border p-2 w-full rounded"
               value={ruleset}
               onChange={(e) => setRuleset(e.target.value as Ruleset)}
@@ -225,6 +227,7 @@ export default function NewTeamBuilder() {
               {t.teams.roster}
             </label>
             <select
+              data-testid="roster-select"
               className="border p-2 w-full rounded"
               value={rosterId}
               onChange={(e) => setRosterId(e.target.value)}
@@ -287,6 +290,7 @@ export default function NewTeamBuilder() {
                 <td className="p-2">{counts[p.slug] || 0}</td>
                 <td className="p-2">
                   <button
+                    data-testid={`position-remove-${p.slug}`}
                     className="px-2 py-1 border mr-2 rounded hover:bg-gray-100 transition-colors"
                     onClick={() => change(p.slug, -1)}
                     disabled={(counts[p.slug] || 0) <= (p.min || 0)}
@@ -294,6 +298,7 @@ export default function NewTeamBuilder() {
                     -
                   </button>
                   <button
+                    data-testid={`position-add-${p.slug}`}
                     className={`px-2 py-1 border rounded ${
                       (counts[p.slug] || 0) >= (p.max || 16) || 
                       total + p.cost > teamValue 
@@ -364,6 +369,7 @@ export default function NewTeamBuilder() {
             )}
           </div>
           <button
+            data-testid="create-team-submit"
             className="px-6 py-3 bg-emerald-600 text-white rounded font-medium disabled:bg-gray-400 disabled:cursor-not-allowed hover:bg-emerald-700 transition-colors"
             onClick={submit}
             disabled={totalPlayersWithStars < 11 || totalPlayersWithStars > 16}

--- a/apps/web/app/team/select/page.tsx
+++ b/apps/web/app/team/select/page.tsx
@@ -64,6 +64,7 @@ export default function TeamSelectPage() {
         {teams.map((t) => (
           <button
             key={t.id}
+            data-testid="team-option"
             onClick={() => choose(t.id)}
             className="rounded-xl border p-6 bg-white hover:shadow text-left"
           >

--- a/tests/e2e-ui/pages/LeaderboardPage.ts
+++ b/tests/e2e-ui/pages/LeaderboardPage.ts
@@ -1,0 +1,40 @@
+import type { Page, Locator } from "@playwright/test";
+
+/**
+ * Page Object pour `/leaderboard` (classement ELO).
+ *
+ * Page publique (pas d'auth requise) qui affiche les coachs classés
+ * par ELO décroissant avec des cartes de statistiques.
+ */
+export class LeaderboardPage {
+  readonly page: Page;
+  readonly root: Locator;
+  readonly totalPlayersCard: Locator;
+  readonly topRatingCard: Locator;
+  readonly avgRatingCard: Locator;
+  readonly table: Locator;
+  readonly emptyState: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.root = page.getByTestId("leaderboard-page");
+    this.totalPlayersCard = page.getByTestId("leaderboard-total-players");
+    this.topRatingCard = page.getByTestId("leaderboard-top-rating");
+    this.avgRatingCard = page.getByTestId("leaderboard-avg-rating");
+    this.table = page.getByTestId("leaderboard-table");
+    this.emptyState = page.getByTestId("leaderboard-empty");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/leaderboard");
+  }
+
+  async waitUntilLoaded(): Promise<void> {
+    await this.root.waitFor({ state: "visible", timeout: 15_000 });
+  }
+
+  /** Retourne le nombre de lignes dans le tbody du classement. */
+  async entryCount(): Promise<number> {
+    return this.table.locator("tbody tr").count();
+  }
+}

--- a/tests/e2e-ui/pages/LobbyPage.ts
+++ b/tests/e2e-ui/pages/LobbyPage.ts
@@ -35,23 +35,34 @@ export class LobbyPage {
   }
 
   /**
-   * Clique sur "Créer une partie" et attend la redirection vers la waiting
-   * room. Retourne le matchId extrait de l'URL.
+   * Clique sur "Créer une partie", sélectionne la première équipe
+   * disponible sur /team/select, puis attend la redirection vers la
+   * waiting room. Retourne le matchId extrait de l'URL.
    */
   async createMatch(): Promise<string> {
     await this.createMatchButton.click();
-    await this.page.waitForURL(/\/waiting\/[^/]+$/, {
-      timeout: 15_000,
-    });
+    await this.selectTeamAndProceed();
     return extractMatchIdFromUrl(this.page.url());
   }
 
   async joinMatch(matchId: string): Promise<void> {
     await this.matchIdInput.fill(matchId);
     await this.joinMatchButton.click();
-    await this.page.waitForURL(/\/waiting\/[^/]+$/, {
-      timeout: 15_000,
-    });
+    await this.selectTeamAndProceed();
+  }
+
+  /**
+   * Étape intermédiaire commune : sur /team/select, choisit la première
+   * équipe puis attend la redirection vers /waiting/<id>.
+   */
+  private async selectTeamAndProceed(): Promise<void> {
+    await this.page.waitForURL(/\/team\/select/, { timeout: 15_000 });
+    const teamOption = this.page
+      .locator('[data-testid="team-option"]')
+      .first();
+    await teamOption.waitFor({ state: "visible", timeout: 10_000 });
+    await teamOption.click();
+    await this.page.waitForURL(/\/waiting\/[^/]+$/, { timeout: 15_000 });
   }
 }
 

--- a/tests/e2e-ui/pages/TeamBuilderPage.ts
+++ b/tests/e2e-ui/pages/TeamBuilderPage.ts
@@ -1,0 +1,52 @@
+import type { Page, Locator } from "@playwright/test";
+
+/**
+ * Page Object pour `/me/teams/new` (team builder).
+ *
+ * Permet de remplir le formulaire de création d'équipe : nom, roster,
+ * ajout de joueurs par position, et soumission.
+ */
+export class TeamBuilderPage {
+  readonly page: Page;
+  readonly nameInput: Locator;
+  readonly rosterSelect: Locator;
+  readonly rulesetSelect: Locator;
+  readonly submitButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.nameInput = page.getByTestId("team-name-input");
+    this.rosterSelect = page.getByTestId("roster-select");
+    this.rulesetSelect = page.getByTestId("ruleset-select");
+    this.submitButton = page.getByTestId("create-team-submit");
+    this.errorMessage = page.getByTestId("team-builder-error");
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/me/teams/new");
+  }
+
+  async fillName(name: string): Promise<void> {
+    await this.nameInput.fill(name);
+  }
+
+  async selectRoster(slug: string): Promise<void> {
+    await this.rosterSelect.selectOption(slug);
+  }
+
+  /**
+   * Clique N fois sur le bouton "+" d'une position donnée.
+   * Attend que le bouton soit visible avant chaque clic.
+   */
+  async addPlayers(positionSlug: string, count: number): Promise<void> {
+    const addButton = this.page.getByTestId(`position-add-${positionSlug}`);
+    for (let i = 0; i < count; i++) {
+      await addButton.click();
+    }
+  }
+
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+}

--- a/tests/e2e-ui/specs/leaderboard.spec.ts
+++ b/tests/e2e-ui/specs/leaderboard.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { resetDb, seedUser } from "../helpers/api-seed";
+import { LeaderboardPage } from "../pages/LeaderboardPage";
+
+/**
+ * Specs Leaderboard : couvrent l'affichage du classement ELO public.
+ *
+ * La page /leaderboard est accessible sans authentification. On valide :
+ *  - les cartes de statistiques s'affichent (total joueurs, meilleur ELO, moyenne)
+ *  - le tableau de classement rend les entrées avec rang, coach et ELO
+ *  - l'état vide s'affiche correctement sans utilisateurs
+ */
+test.describe("E2E UI — leaderboard", () => {
+  test.beforeEach(async () => {
+    await resetDb();
+  });
+
+  test("affiche les cartes statistiques et le tableau avec des coachs seedés", async ({
+    page,
+  }) => {
+    // Seed 3 coachs pour remplir le classement.
+    await Promise.all([
+      seedUser("alice@playwright.test", "password-a", "Alice"),
+      seedUser("bob@playwright.test", "password-b", "Bob"),
+      seedUser("carol@playwright.test", "password-c", "Carol"),
+    ]);
+
+    const leaderboard = new LeaderboardPage(page);
+    await leaderboard.goto();
+    await leaderboard.waitUntilLoaded();
+
+    // Les cartes de statistiques doivent être visibles.
+    await expect(leaderboard.totalPlayersCard).toBeVisible();
+    await expect(leaderboard.topRatingCard).toBeVisible();
+    await expect(leaderboard.avgRatingCard).toBeVisible();
+
+    // Le tableau doit contenir au moins 3 lignes (une par coach seedé).
+    await expect(leaderboard.table).toBeVisible();
+    const rows = await leaderboard.entryCount();
+    expect(rows).toBeGreaterThanOrEqual(3);
+  });
+
+  test("le tableau affiche le nom du coach pour chaque entrée", async ({
+    page,
+  }) => {
+    await seedUser("alice@playwright.test", "password-a", "Alice");
+
+    const leaderboard = new LeaderboardPage(page);
+    await leaderboard.goto();
+    await leaderboard.waitUntilLoaded();
+
+    await expect(leaderboard.table).toBeVisible({ timeout: 10_000 });
+
+    // Vérifier que la première ligne contient "Alice" et un rang numérique.
+    const firstRow = leaderboard.table.locator("tbody tr").first();
+    await expect(firstRow).toContainText("Alice");
+  });
+
+  test("affiche l'état vide quand aucun coach n'existe", async ({ page }) => {
+    const leaderboard = new LeaderboardPage(page);
+    await leaderboard.goto();
+    await leaderboard.waitUntilLoaded();
+
+    // Sans coach, l'état vide doit s'afficher et le tableau doit être absent.
+    await expect(leaderboard.emptyState).toBeVisible();
+    await expect(leaderboard.table).not.toBeVisible();
+  });
+});

--- a/tests/e2e-ui/specs/matchmaking.spec.ts
+++ b/tests/e2e-ui/specs/matchmaking.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "../fixtures/two-players";
+import { LobbyPage } from "../pages/LobbyPage";
+
+/**
+ * Specs Matchmaking Queue : couvrent le flux de recherche automatique
+ * d'adversaire via la file d'attente côté UI (/play).
+ *
+ * Le happy path "match privé" est couvert par full-match.spec.ts.
+ * Ici on valide le matchmaking automatique :
+ *  - sélection d'équipe → lancement de la recherche → UI "searching"
+ *  - annulation de la recherche → retour à l'état initial
+ *  - le bouton matchmaking-start est désactivé sans équipe sélectionnée
+ *
+ * On utilise la fixture two-players pour avoir Alice avec une équipe
+ * seedée, mais on ne teste qu'Alice (pas de match found, juste le
+ * parcours queue start/cancel).
+ */
+test.describe("E2E UI — matchmaking queue", () => {
+  test("sélection d'équipe + lancement recherche affiche l'UI de recherche", async ({
+    alice,
+  }) => {
+    const lobby = new LobbyPage(alice.page);
+    await lobby.goto();
+
+    // Le select d'équipe doit être visible et contenir au moins une option.
+    await expect(lobby.teamSelect).toBeVisible({ timeout: 8_000 });
+
+    // Sélectionner la première équipe disponible (valeur non-vide).
+    const options = lobby.teamSelect.locator("option");
+    const optionCount = await options.count();
+    let selectedValue = "";
+    for (let i = 0; i < optionCount; i++) {
+      const val = await options.nth(i).getAttribute("value");
+      if (val && val.trim() !== "") {
+        selectedValue = val;
+        break;
+      }
+    }
+    expect(selectedValue).toBeTruthy();
+    await lobby.teamSelect.selectOption(selectedValue);
+
+    // Cliquer sur matchmaking-start.
+    await lobby.matchmakingStart.click();
+
+    // L'UI de recherche doit apparaître : le bouton "cancel" devient visible.
+    await expect(lobby.matchmakingCancel).toBeVisible({ timeout: 10_000 });
+
+    // Le bouton "matchmaking-start" ne doit plus être visible (remplacé par
+    // le panneau de recherche en cours).
+    await expect(lobby.matchmakingStart).not.toBeVisible();
+  });
+
+  test("annulation de la recherche revient à l'état initial", async ({
+    alice,
+  }) => {
+    const lobby = new LobbyPage(alice.page);
+    await lobby.goto();
+
+    await expect(lobby.teamSelect).toBeVisible({ timeout: 8_000 });
+
+    // Sélectionner la première équipe.
+    const options = lobby.teamSelect.locator("option");
+    const optionCount = await options.count();
+    let selectedValue = "";
+    for (let i = 0; i < optionCount; i++) {
+      const val = await options.nth(i).getAttribute("value");
+      if (val && val.trim() !== "") {
+        selectedValue = val;
+        break;
+      }
+    }
+    await lobby.teamSelect.selectOption(selectedValue);
+
+    // Lancer puis annuler.
+    await lobby.matchmakingStart.click();
+    await expect(lobby.matchmakingCancel).toBeVisible({ timeout: 10_000 });
+
+    await lobby.matchmakingCancel.click();
+
+    // Après annulation, on doit retrouver le bouton start et le select.
+    await expect(lobby.matchmakingStart).toBeVisible({ timeout: 10_000 });
+    await expect(lobby.teamSelect).toBeVisible();
+  });
+
+  test("matchmaking-start est désactivé sans équipe sélectionnée", async ({
+    alice,
+  }) => {
+    const lobby = new LobbyPage(alice.page);
+    await lobby.goto();
+
+    await expect(lobby.teamSelect).toBeVisible({ timeout: 8_000 });
+
+    // S'assurer qu'aucune équipe n'est sélectionnée (option vide par défaut).
+    await lobby.teamSelect.selectOption("");
+
+    // Le bouton start doit être visible ET désactivé.
+    await expect(lobby.matchmakingStart).toBeVisible({ timeout: 5_000 });
+    await expect(lobby.matchmakingStart).toBeDisabled();
+  });
+});

--- a/tests/e2e-ui/specs/team-creation.spec.ts
+++ b/tests/e2e-ui/specs/team-creation.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { resetDb, seedUser } from "../helpers/api-seed";
+import { LoginPage } from "../pages/LoginPage";
+import { TeamBuilderPage } from "../pages/TeamBuilderPage";
+
+/**
+ * Specs Team Creation : couvrent le parcours critique de création
+ * d'équipe via le team builder (/me/teams/new).
+ *
+ * Un utilisateur ne peut pas jouer sans équipe — ce flow est donc
+ * un prérequis fonctionnel de toute la boucle multijoueur.
+ *
+ * On valide :
+ *  - le formulaire refuse la soumission avec moins de 11 joueurs
+ *  - la création réussie redirige vers la page détail de l'équipe
+ *  - l'équipe créée apparaît dans la liste /me/teams
+ */
+
+/**
+ * Ajoute des joueurs position par position jusqu'à ce que le bouton
+ * submit soit activé (>= 11 joueurs). Attend la stabilisation du DOM
+ * après chaque clic pour éviter les races sur l'état disabled.
+ */
+async function fillRosterUntilValid(
+  page: Page,
+  builder: TeamBuilderPage,
+): Promise<void> {
+  const allAddButtons = page.locator('[data-testid^="position-add-"]');
+  const count = await allAddButtons.count();
+
+  for (let i = 0; i < count; i++) {
+    const btn = allAddButtons.nth(i);
+    for (let clicks = 0; clicks < 12; clicks++) {
+      // Vérifier si le submit est déjà actif avant de cliquer.
+      const submitEnabled = !(await builder.submitButton.isDisabled());
+      if (submitEnabled) return;
+
+      const btnDisabled = await btn.isDisabled();
+      if (btnDisabled) break;
+
+      await btn.click();
+      // Attendre que le DOM se stabilise après le clic (le state React
+      // met à jour les compteurs et le disabled du submit).
+      await expect(btn).toBeAttached();
+    }
+  }
+}
+
+test.describe("E2E UI — team creation", () => {
+  test.beforeEach(async () => {
+    await resetDb();
+    await seedUser("coach@playwright.test", "password-c", "Coach");
+  });
+
+  test("le bouton créer est désactivé tant qu'on n'a pas 11 joueurs", async ({
+    page,
+  }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login("coach@playwright.test", "password-c");
+    await page.waitForURL(/\/(play|team|me)/, { timeout: 15_000 });
+
+    const builder = new TeamBuilderPage(page);
+    await builder.goto();
+
+    // Attendre que le formulaire se charge (le roster-select doit être visible).
+    await expect(builder.rosterSelect).toBeVisible({ timeout: 10_000 });
+
+    // Sans ajout de joueurs, le bouton créer doit être désactivé.
+    await expect(builder.submitButton).toBeDisabled();
+  });
+
+  test("création d'une équipe Skaven valide redirige vers la fiche équipe", async ({
+    page,
+  }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login("coach@playwright.test", "password-c");
+    await page.waitForURL(/\/(play|team|me)/, { timeout: 15_000 });
+
+    const builder = new TeamBuilderPage(page);
+    await builder.goto();
+
+    await expect(builder.rosterSelect).toBeVisible({ timeout: 10_000 });
+
+    await builder.fillName("Rats of E2E");
+
+    // On attend que les positions soient chargées avant de cliquer.
+    await page
+      .locator('[data-testid^="position-add-"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await fillRosterUntilValid(page, builder);
+
+    // Le bouton doit maintenant être activé.
+    await expect(builder.submitButton).toBeEnabled({ timeout: 5_000 });
+
+    await builder.submit();
+
+    // Après création, le front redirige vers /me/teams/<id>.
+    await page.waitForURL(/\/me\/teams\/[^/]+$/, { timeout: 15_000 });
+    expect(new URL(page.url()).pathname).toMatch(/^\/me\/teams\/[^/]+$/);
+  });
+
+  test("l'équipe créée apparaît dans la liste /me/teams", async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+    await login.login("coach@playwright.test", "password-c");
+    await page.waitForURL(/\/(play|team|me)/, { timeout: 15_000 });
+
+    const builder = new TeamBuilderPage(page);
+    await builder.goto();
+    await expect(builder.rosterSelect).toBeVisible({ timeout: 10_000 });
+
+    const teamName = `E2E Team ${Date.now()}`;
+    await builder.fillName(teamName);
+
+    await page
+      .locator('[data-testid^="position-add-"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+
+    await fillRosterUntilValid(page, builder);
+
+    await builder.submit();
+    await page.waitForURL(/\/me\/teams\/[^/]+$/, { timeout: 15_000 });
+
+    // Revenir à la liste des équipes et vérifier la présence de l'équipe.
+    await page.goto("/me/teams");
+    await expect(page.getByText(teamName)).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- **3 new E2E UI test suites** covering previously untested critical user flows:
  1. **Team Creation** (`team-creation.spec.ts`) — Validates the `/me/teams/new` builder: submit disabled with <11 players, successful creation redirects to team detail, created team appears in `/me/teams` list
  2. **Matchmaking Queue** (`matchmaking.spec.ts`) — Validates `/play` matchmaking UX: team selection + search start shows searching UI, cancel returns to initial state, start button disabled without team selected
  3. **Leaderboard** (`leaderboard.spec.ts`) — Validates `/leaderboard` public page: stats cards + table render with seeded data, entry content verification, empty state display

- **Fix LobbyPage** `createMatch`/`joinMatch` to handle the `/team/select` intermediate step in the match creation flow (create → team-select → waiting)
- **Add `data-testid` attributes** to team builder, leaderboard, and team-select pages for reliable E2E selectors
- **New page objects**: `TeamBuilderPage`, `LeaderboardPage`

## Changes

| File | Change |
|------|--------|
| `apps/web/app/me/teams/new/page.tsx` | Add data-testid to form inputs, buttons, error |
| `apps/web/app/leaderboard/page.tsx` | Add data-testid to stats cards, table, empty state |
| `apps/web/app/team/select/page.tsx` | Add data-testid to team option buttons |
| `tests/e2e-ui/pages/LobbyPage.ts` | Fix createMatch/joinMatch for team-select step |
| `tests/e2e-ui/pages/TeamBuilderPage.ts` | New page object |
| `tests/e2e-ui/pages/LeaderboardPage.ts` | New page object |
| `tests/e2e-ui/specs/team-creation.spec.ts` | 3 tests |
| `tests/e2e-ui/specs/matchmaking.spec.ts` | 3 tests |
| `tests/e2e-ui/specs/leaderboard.spec.ts` | 3 tests |

## Test plan

- [ ] Run existing E2E UI suite (`pnpm --filter @bb/tests-e2e-ui test`) — verify no regressions from LobbyPage fix
- [ ] Run new `team-creation.spec.ts` — verify team builder flow works end-to-end
- [ ] Run new `matchmaking.spec.ts` — verify matchmaking queue start/cancel UX
- [ ] Run new `leaderboard.spec.ts` — verify leaderboard renders with seeded data and empty state
- [ ] Verify `data-testid` attributes render correctly in browser DevTools

https://claude.ai/code/session_018Vp1sPK9TaNGki2NfJR1vf