### PR TITLE
feat(SEC-4): restrict CORS to specific origins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -189,7 +189,7 @@
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
 | SEC-3 | Centraliser JWT_SECRET/MATCH_SECRET dans `config.ts`, crash si absent en prod | Securite | [x] |
-| SEC-4 | Restreindre CORS aux origines specifiques | Securite | [ ] |
+| SEC-4 | Restreindre CORS aux origines specifiques | Securite | [x] |
 | J.1 | Implementer `bone-head` (activation roll) | Regle | [ ] |
 | J.2 | Implementer `really-stupid` (1/2) | Regle | [ ] |
 | J.3 | Implementer `wild-animal` | Regle | [ ] |

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -75,11 +75,76 @@ describe("config", () => {
     it("succeeds in production when all secrets are provided", async () => {
       process.env.JWT_SECRET = "prod-jwt-secret";
       process.env.MATCH_SECRET = "prod-match-secret";
+      process.env.CORS_ORIGINS = "https://nuffle-arena.com";
       process.env.NODE_ENV = "production";
 
       const { JWT_SECRET, MATCH_SECRET } = await import("./config");
       expect(JWT_SECRET).toBe("prod-jwt-secret");
       expect(MATCH_SECRET).toBe("prod-match-secret");
+    });
+  });
+
+  describe("CORS_ORIGINS", () => {
+    it("returns dev default when CORS_ORIGINS is not set in development", async () => {
+      delete process.env.CORS_ORIGINS;
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "development";
+
+      const { CORS_ORIGINS } = await import("./config");
+      expect(CORS_ORIGINS).toEqual(["http://localhost:3100"]);
+    });
+
+    it("parses comma-separated origins from env var", async () => {
+      process.env.CORS_ORIGINS = "https://nuffle-arena.com,https://www.nuffle-arena.com";
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "development";
+
+      const { CORS_ORIGINS } = await import("./config");
+      expect(CORS_ORIGINS).toEqual([
+        "https://nuffle-arena.com",
+        "https://www.nuffle-arena.com",
+      ]);
+    });
+
+    it("trims whitespace from origins", async () => {
+      process.env.CORS_ORIGINS = " https://a.com , https://b.com ";
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "development";
+
+      const { CORS_ORIGINS } = await import("./config");
+      expect(CORS_ORIGINS).toEqual(["https://a.com", "https://b.com"]);
+    });
+
+    it("filters out empty entries from trailing commas", async () => {
+      process.env.CORS_ORIGINS = "https://a.com,,https://b.com,";
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "development";
+
+      const { CORS_ORIGINS } = await import("./config");
+      expect(CORS_ORIGINS).toEqual(["https://a.com", "https://b.com"]);
+    });
+
+    it("throws when CORS_ORIGINS is missing in production", async () => {
+      delete process.env.CORS_ORIGINS;
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "production";
+
+      await expect(() => import("./config")).rejects.toThrow("CORS_ORIGINS");
+    });
+
+    it("uses CORS_ORIGINS from env in production", async () => {
+      process.env.CORS_ORIGINS = "https://nuffle-arena.com";
+      process.env.JWT_SECRET = "s";
+      process.env.MATCH_SECRET = "s";
+      process.env.NODE_ENV = "production";
+
+      const { CORS_ORIGINS } = await import("./config");
+      expect(CORS_ORIGINS).toEqual(["https://nuffle-arena.com"]);
     });
   });
 });

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -29,3 +29,29 @@ export const MATCH_SECRET = getRequiredSecret(
   "MATCH_SECRET",
   "dev-match-secret",
 );
+
+/**
+ * Allowed CORS origins, parsed from a comma-separated env var.
+ * In production, CORS_ORIGINS must be set explicitly.
+ * In dev/test, defaults to the Next.js dev server origin.
+ */
+function parseCorsOrigins(): string[] {
+  const raw = process.env.CORS_ORIGINS;
+  if (raw) {
+    return raw
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean);
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      `FATAL: Missing required environment variable "CORS_ORIGINS". ` +
+        `The server cannot start in production without it.`,
+    );
+  }
+
+  return ["http://localhost:3100"];
+}
+
+export const CORS_ORIGINS: string[] = parseCorsOrigins();

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -22,6 +22,7 @@ import { execSync } from "node:child_process";
 import { prisma } from "./prisma";
 import { authRateLimiter, apiRateLimiter } from "./middleware/rateLimiter";
 import { setupSocket } from "./socket";
+import { CORS_ORIGINS } from "./config";
 
 dotenv.config({ path: "../../prisma/.env" });
 // Si tests SQLite: pousser le schéma SQLite en mémoire partagée au démarrage
@@ -47,7 +48,7 @@ const API_PORT = parseInt(process.env.API_PORT || "8201", 10);
 
 // Serveur Express API
 const app = express();
-app.use(cors());
+app.use(cors({ origin: CORS_ORIGINS }));
 app.use(bodyParser.json());
 
 // Rate limiting global sur toutes les routes API (100 req/min par IP)

--- a/apps/server/src/socket.ts
+++ b/apps/server/src/socket.ts
@@ -6,6 +6,7 @@ import { registerResyncHandler } from "./game-resync";
 import { registerGameChatHandlers } from "./game-chat";
 import { registerSpectatorHandlers } from "./game-spectator";
 import { authSocket } from "./middleware/authSocket";
+import { CORS_ORIGINS } from "./config";
 
 let io: Server | null = null;
 let gameNamespace: Namespace | null = null;
@@ -27,7 +28,7 @@ export function setupSocket(
 ): Server {
   io = new Server(httpServer, {
     cors: options.cors ?? {
-      origin: "*",
+      origin: CORS_ORIGINS,
       methods: ["GET", "POST"],
     },
     // Only enable websocket (upgrade from polling) for lower latency


### PR DESCRIPTION
## Summary

- Replace permissive CORS (`origin: "*"`) with a configurable origin whitelist via `CORS_ORIGINS` env var (comma-separated)
- Apply restriction to both Express middleware (`cors()`) and socket.io server
- Crash at startup in production if `CORS_ORIGINS` is not set (same pattern as `JWT_SECRET`/`MATCH_SECRET`)
- Default to `http://localhost:3100` in dev/test (matches Next.js dev port)

**Roadmap task**: Sprint 12 — SEC-4

## Test plan

- [x] 6 new unit tests for `CORS_ORIGINS` config parsing (dev default, comma-separated, whitespace trimming, empty entries, production crash, production success)
- [x] Existing config tests updated (production test now sets `CORS_ORIGINS`)
- [x] All 13 config tests pass
- [x] No new TypeScript errors introduced
- [ ] Manual verification: set `CORS_ORIGINS=https://example.com` and confirm cross-origin requests from other domains are blocked

https://claude.ai/code/session_01JsSGDomUN6zZGjrfjyVJrc