### PR TITLE
feat(J.1): implement bone-head activation roll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -190,7 +190,7 @@
 |---|-------|------|--------|
 | SEC-3 | Centraliser JWT_SECRET/MATCH_SECRET dans `config.ts`, crash si absent en prod | Securite | [x] |
 | SEC-4 | Restreindre CORS aux origines specifiques | Securite | [x] |
-| J.1 | Implementer `bone-head` (activation roll) | Regle | [ ] |
+| J.1 | Implementer `bone-head` (activation roll) | Regle | [x] |
 | J.2 | Implementer `really-stupid` (1/2) | Regle | [ ] |
 | J.3 | Implementer `wild-animal` | Regle | [ ] |
 | J.4 | Implementer `animal-savagery` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -72,6 +72,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
+import { checkBoneHead } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -420,49 +421,67 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
     return state;
   }
 
+  // ─── Negative trait activation checks (Bone Head, etc.) ───────────────
+  // These run once at the start of a player's activation (first action only).
+  // If the check fails, the player's activation ends without executing the action.
+  let activeState = state;
+  const ACTIVATION_MOVE_TYPES: string[] = [
+    'MOVE', 'DODGE', 'BLOCK', 'BLITZ', 'PASS', 'HANDOFF',
+    'THROW_TEAM_MATE', 'FOUL', 'HYPNOTIC_GAZE', 'PROJECTILE_VOMIT',
+  ];
+  if (ACTIVATION_MOVE_TYPES.includes(move.type) && 'playerId' in move) {
+    const playerId = (move as { playerId: string }).playerId;
+    const player = state.players.find(p => p.id === playerId);
+    if (player && !hasPlayerActed(state, player.id)) {
+      const activationCheck = checkBoneHead(state, player, rng);
+      if (!activationCheck.passed) return activationCheck.newState;
+      activeState = activationCheck.newState;
+    }
+  }
+
   switch (move.type) {
     case 'END_TURN':
-      return handleEndTurn(state, rng);
+      return handleEndTurn(activeState, rng);
     case 'MOVE':
-      return handleMove(state, move, rng);
+      return handleMove(activeState, move, rng);
     case 'DODGE':
-      return handleDodge(state, move, rng);
+      return handleDodge(activeState, move, rng);
     case 'BLOCK':
-      return handleBlock(state, move, rng);
+      return handleBlock(activeState, move, rng);
     case 'BLOCK_CHOOSE':
-      return handleBlockChoose(state, move, rng);
+      return handleBlockChoose(activeState, move, rng);
     case 'PUSH_CHOOSE':
-      return handlePushChoose(state, move);
+      return handlePushChoose(activeState, move);
     case 'FOLLOW_UP_CHOOSE':
-      return handleFollowUpChoose(state, move);
+      return handleFollowUpChoose(activeState, move);
     case 'BLITZ':
-      return handleBlitz(state, move, rng);
+      return handleBlitz(activeState, move, rng);
     case 'REROLL_CHOOSE':
-      return handleRerollChoose(state, move, rng);
+      return handleRerollChoose(activeState, move, rng);
     case 'APOTHECARY_CHOOSE':
-      return applyApothecaryChoice(state, move.useApothecary, rng);
+      return applyApothecaryChoice(activeState, move.useApothecary, rng);
     case 'PASS':
-      return handlePass(state, move, rng);
+      return handlePass(activeState, move, rng);
     case 'HANDOFF':
-      return handleHandoff(state, move, rng);
+      return handleHandoff(activeState, move, rng);
     case 'THROW_TEAM_MATE':
-      return handleThrowTeamMate(state, move, rng);
+      return handleThrowTeamMate(activeState, move, rng);
     case 'FOUL':
-      return handleFoul(state, move, rng);
+      return handleFoul(activeState, move, rng);
     case 'HYPNOTIC_GAZE':
-      return handleHypnoticGaze(state, move, rng);
+      return handleHypnoticGaze(activeState, move, rng);
     case 'PROJECTILE_VOMIT':
-      return handleProjectileVomit(state, move, rng);
+      return handleProjectileVomit(activeState, move, rng);
     case 'KICKOFF_PERFECT_DEFENCE':
-      return resolveKickoffPerfectDefence(state, move.positions);
+      return resolveKickoffPerfectDefence(activeState, move.positions);
     case 'KICKOFF_HIGH_KICK':
-      return resolveKickoffHighKick(state, move.playerId);
+      return resolveKickoffHighKick(activeState, move.playerId);
     case 'KICKOFF_QUICK_SNAP':
-      return resolveKickoffQuickSnap(state, move.moves);
+      return resolveKickoffQuickSnap(activeState, move.moves);
     case 'KICKOFF_BLITZ_RESOLVE':
-      return resolveKickoffBlitz(state);
+      return resolveKickoffBlitz(activeState);
     default:
-      return checkTouchdowns(state);
+      return checkTouchdowns(activeState);
   }
 }
 

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -151,6 +151,10 @@ export { expelSecretWeapons, getSecretWeaponPlayers } from './mechanics/secret-w
 // Export du système d'animosité
 export { extractLineage, hasAnimosityAgainst, checkAnimosity } from './mechanics/animosity';
 
+// Export des traits négatifs (Bone Head, etc.)
+export { checkBoneHead } from './mechanics/negative-traits';
+export type { ActivationCheckResult } from './mechanics/negative-traits';
+
 // Export des effets météo
 export {
   getWeatherModifiers,

--- a/packages/game-engine/src/mechanics/bone-head.test.ts
+++ b/packages/game-engine/src/mechanics/bone-head.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG } from '../index';
+import type { GameState, Move } from '../core/types';
+import { getSkillEffect } from '../skills/skill-registry';
+
+/**
+ * Bone Head (BB3 Season 2/3 rules):
+ * - At the start of this player's activation, roll a D6
+ * - On a 1: the player can't perform any action, activation ends immediately
+ * - On 2+: the player acts normally
+ * - This is NOT a turnover
+ * - The check only happens once per activation (first action attempt)
+ */
+
+function makeTestState(): GameState {
+  const state = setup();
+  return {
+    ...state,
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/**
+ * A1 at (5,5) with optional bone-head.
+ * B1 placed at (6,5) if adjacentTarget, else far away (20,10).
+ * Other players moved out of the way to avoid tackle zone interference.
+ */
+function setupBoneHeadScenario(
+  baseState: GameState,
+  hasBoneHead: boolean,
+  adjacentTarget: boolean = false
+): GameState {
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    players: baseState.players.map(p => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 6,
+          ma: 6,
+          st: 5,
+          state: 'active' as const,
+          stunned: false,
+          skills: hasBoneHead ? ['bone-head'] : [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'B1') {
+        return {
+          ...p,
+          pos: adjacentTarget ? { x: 6, y: 5 } : { x: 20, y: 10 },
+          pm: 8,
+          st: 3,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+        };
+      }
+      // Move other players far away
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active' as const, stunned: false };
+      }
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active' as const, stunned: false };
+    }),
+  };
+}
+
+const MOVE_LEFT: Move = { type: 'MOVE', playerId: 'A1', to: { x: 4, y: 5 } };
+const BLOCK_B1: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+
+describe('Regle: Bone Head (Cerveau Lent)', () => {
+  describe('Skill Registry', () => {
+    it('bone-head is registered in skill registry', () => {
+      const effect = getSkillEffect('bone-head');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('bone-head');
+    });
+
+    it('bone-head has on-activation trigger', () => {
+      const effect = getSkillEffect('bone-head');
+      expect(effect!.triggers).toContain('on-activation');
+    });
+  });
+
+  describe('Bone Head activation check on MOVE', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('player without bone-head can move normally (no activation roll)', () => {
+      const state = setupBoneHeadScenario(baseState, false);
+      const rng = makeRNG('no-bone-head-move');
+      const result = applyMove(state, MOVE_LEFT, rng);
+
+      const a1 = result.players.find(p => p.id === 'A1')!;
+      expect(a1.pos).toEqual({ x: 4, y: 5 });
+
+      const boneHeadLogs = result.gameLog.filter(l =>
+        l.message.includes('Cerveau Lent')
+      );
+      expect(boneHeadLogs).toHaveLength(0);
+    });
+
+    it('bone-head roll of 2+ allows normal movement', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-pass-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 4, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head roll of 1 prevents movement (player stays in place)', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-fail-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 5, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head failure is NOT a turnover', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-no-to-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head failure marks player as having acted with 0 PM', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-acted-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.playerActions['A1']).toBeDefined();
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pm).toBe(0);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head check happens only once per activation (not on subsequent moves)', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-once-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✓')
+        );
+        if (passLog) {
+          // First move succeeded, now do a second move
+          const MOVE_AGAIN: Move = { type: 'MOVE', playerId: 'A1', to: { x: 3, y: 5 } };
+          const rng2 = makeRNG(`bh-once-2-${seed}`);
+          const result2 = applyMove(result, MOVE_AGAIN, rng2);
+
+          // Should only have 1 bone-head check log total
+          const boneHeadLogs = result2.gameLog.filter(l =>
+            l.message.includes('Cerveau Lent')
+          );
+          expect(boneHeadLogs).toHaveLength(1);
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head failure logs confusion message', () => {
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-log-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const confusionLog = result.gameLog.find(l =>
+            l.message.includes('confus') && l.message.includes('ne peut pas agir')
+          );
+          expect(confusionLog).toBeDefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Bone Head activation check on BLOCK', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('bone-head roll of 1 prevents block action', () => {
+      const state = setupBoneHeadScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-block-fail-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          // No block dice should have been rolled
+          const blockLogs = result.gameLog.filter(l =>
+            l.message.includes('Blocage')
+          );
+          expect(blockLogs).toHaveLength(0);
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('bone-head roll of 2+ allows block to proceed', () => {
+      const state = setupBoneHeadScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`bh-block-pass-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          // Block should have been attempted (block dice log or pending block)
+          const hasBlock = result.gameLog.some(l =>
+            l.message.includes('Blocage')
+          ) || result.pendingBlock !== undefined;
+          expect(hasBlock).toBe(true);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Statistical distribution', () => {
+    it('bone-head fails approximately 1/6 of the time', () => {
+      const baseState = makeTestState();
+      const state = setupBoneHeadScenario(baseState, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`bh-stats-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Cerveau Lent') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      // Bone-head fails on 1 out of 6 ≈ 16.7%
+      const failRate = fails / total;
+      expect(failRate).toBeGreaterThan(0.08);
+      expect(failRate).toBeLessThan(0.30);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -1,0 +1,81 @@
+/**
+ * Negative trait activation checks (Bone Head, Really Stupid, Wild Animal, etc.)
+ * These are checked at the start of a player's activation before their first action.
+ */
+
+import type { GameState, Player, RNG } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { hasPlayerActed, setPlayerAction } from '../core/game-state';
+import { createLogEntry } from '../utils/logging';
+
+export interface ActivationCheckResult {
+  passed: boolean;
+  newState: GameState;
+}
+
+/**
+ * Check Bone Head activation roll.
+ * BB3 Rule: At the start of this player's activation, roll a D6.
+ * On a 1, the player can't perform any action and their activation ends immediately.
+ * This is NOT a turnover.
+ *
+ * @returns { passed: true, newState } if player doesn't have bone-head or passes the roll
+ * @returns { passed: false, newState } with modified state if roll fails
+ */
+export function checkBoneHead(
+  state: GameState,
+  player: Player,
+  rng: RNG
+): ActivationCheckResult {
+  // No bone-head: always pass (no state change)
+  if (!hasSkill(player, 'bone-head')) {
+    return { passed: true, newState: state };
+  }
+
+  // Already acted this turn: skip check (not first action)
+  if (hasPlayerActed(state, player.id)) {
+    return { passed: true, newState: state };
+  }
+
+  // Roll D6: succeed on 2+
+  const roll = Math.floor(rng() * 6) + 1;
+  const success = roll >= 2;
+
+  const rollLog = createLogEntry(
+    'dice',
+    `Cerveau Lent: ${roll}/2 ${success ? '✓' : '✗'}`,
+    player.id,
+    player.team,
+    { diceRoll: roll, targetNumber: 2, success, skill: 'bone-head' }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, rollLog],
+  };
+
+  if (!success) {
+    // Failed: activation ends immediately, NOT a turnover
+    const failLog = createLogEntry(
+      'info',
+      `${player.name} est confus et ne peut pas agir !`,
+      player.id,
+      player.team
+    );
+    newState = {
+      ...newState,
+      gameLog: [...newState.gameLog, failLog],
+    };
+
+    // Mark player as having acted and remove all movement points
+    newState = setPlayerAction(newState, player.id, 'MOVE');
+    newState = {
+      ...newState,
+      players: newState.players.map(p =>
+        p.id === player.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+      ),
+    };
+  }
+
+  return { passed: success, newState };
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -25,6 +25,7 @@ export type SkillTrigger =
   | 'on-turnover'            // Lors d'un turnover
   | 'on-setup'               // Lors du placement
   | 'on-kickoff'             // Lors du kickoff
+  | 'on-activation'          // Au début de l'activation du joueur (ex: Bone Head)
   | 'passive';               // Effet passif permanent
 
 export interface SkillContext {
@@ -580,6 +581,17 @@ registerSkill({
   triggers: ['passive'],
   description: 'Ce joueur doit obtenir 5+ sur un D6 pour utiliser une relance d\'équipe.',
   canApply: (ctx) => hasSkill(ctx.player, 'loner-5'),
+});
+
+// ─── BONE HEAD ──────────────────────────────────────────────────────────────
+// Bone Head check is performed in applyMove before dispatching to action handlers.
+// Registered here for lookup and metadata purposes.
+
+registerSkill({
+  slug: 'bone-head',
+  triggers: ['on-activation'],
+  description: 'Au début de l\'activation, jet D6. Sur 1, le joueur ne peut pas agir (activation terminée).',
+  canApply: (ctx) => hasSkill(ctx.player, 'bone-head'),
 });
 
 // ─── ANIMOSITY (5 variants) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Implement **Bone Head** negative trait (Sprint 12 - J.1): at the start of a player's activation, roll D6 — on a 1, activation ends immediately (not a turnover)
- Add centralized negative trait activation check in `applyMove()` dispatcher, before all player action types (MOVE, BLOCK, BLITZ, PASS, etc.)
- Register `bone-head` skill in skill-registry with new `on-activation` trigger type
- Create `checkBoneHead()` in `mechanics/negative-traits.ts` — reusable pattern for future traits (really-stupid, wild-animal, etc.)

### Files changed
| File | Change |
|------|--------|
| `mechanics/negative-traits.ts` | New — `checkBoneHead()` activation roll logic |
| `mechanics/bone-head.test.ts` | New — 12 unit tests (TDD) |
| `skills/skill-registry.ts` | Add `on-activation` trigger type + register bone-head |
| `actions/actions.ts` | Centralized activation check before switch dispatcher |
| `index.ts` | Export new module |
| `TODO.md` | Mark J.1 as done |

## Test plan

- [x] 12 unit tests pass (registry, MOVE success/failure, BLOCK success/failure, not-a-turnover, marks-as-acted, once-per-activation, confusion log, statistical distribution)
- [x] 0 regressions (2999 other tests still pass, 3 pre-existing failures unrelated)
- [x] TypeScript typecheck passes
- [x] ESLint: 0 errors
- [x] Production build succeeds

https://claude.ai/code/session_01TdHKtkpZaB9DwqViCvfa53