### PR TITLE
feat(J.3): implement wild-animal activation roll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -192,7 +192,7 @@
 | SEC-4 | Restreindre CORS aux origines specifiques | Securite | [x] |
 | J.1 | Implementer `bone-head` (activation roll) | Regle | [x] |
 | J.2 | Implementer `really-stupid` (1/2) | Regle | [x] |
-| J.3 | Implementer `wild-animal` | Regle | [ ] |
+| J.3 | Implementer `wild-animal` | Regle | [x] |
 | J.4 | Implementer `animal-savagery` | Regle | [ ] |
 | J.5 | Implementer `take-root` | Regle | [ ] |
 | J.6 | Implementer `no-hands` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -72,7 +72,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -440,6 +440,10 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       const reallyStupidCheck = checkReallyStupid(activeState, player, rng);
       if (!reallyStupidCheck.passed) return reallyStupidCheck.newState;
       activeState = reallyStupidCheck.newState;
+
+      const wildAnimalCheck = checkWildAnimal(activeState, player, rng, move.type);
+      if (!wildAnimalCheck.passed) return wildAnimalCheck.newState;
+      activeState = wildAnimalCheck.newState;
     }
   }
 

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -151,8 +151,8 @@ export { expelSecretWeapons, getSecretWeaponPlayers } from './mechanics/secret-w
 // Export du système d'animosité
 export { extractLineage, hasAnimosityAgainst, checkAnimosity } from './mechanics/animosity';
 
-// Export des traits négatifs (Bone Head, etc.)
-export { checkBoneHead, checkReallyStupid } from './mechanics/negative-traits';
+// Export des traits négatifs (Bone Head, Really Stupid, Wild Animal, etc.)
+export { checkBoneHead, checkReallyStupid, checkWildAnimal } from './mechanics/negative-traits';
 export type { ActivationCheckResult } from './mechanics/negative-traits';
 
 // Export des effets météo

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -174,3 +174,79 @@ export function checkReallyStupid(
 
   return { passed: success, newState };
 }
+
+/**
+ * Check Wild Animal activation roll.
+ * BB3 Rule: At the start of this player's activation, roll a D6.
+ * Add +2 to the result if the player is attempting a Block or Blitz action.
+ * - On a total of 1-3: activation ends immediately (NOT a turnover)
+ *   -> Block/Blitz: only fails on natural 1 (1+2=3)
+ *   -> Other actions: fails on natural 1-3
+ *
+ * @param moveType The type of action being attempted (used for Block/Blitz modifier)
+ * @returns { passed: true, newState } if player doesn't have wild-animal or passes the roll
+ * @returns { passed: false, newState } with modified state if roll fails
+ */
+export function checkWildAnimal(
+  state: GameState,
+  player: Player,
+  rng: RNG,
+  moveType: string
+): ActivationCheckResult {
+  // No wild-animal: always pass (no state change)
+  if (!hasSkill(player, 'wild-animal')) {
+    return { passed: true, newState: state };
+  }
+
+  // Already acted this turn: skip check (not first action)
+  if (hasPlayerActed(state, player.id)) {
+    return { passed: true, newState: state };
+  }
+
+  // Roll D6
+  const roll = Math.floor(rng() * 6) + 1;
+  // +2 modifier for Block or Blitz actions
+  const isBlockOrBlitz = moveType === 'BLOCK' || moveType === 'BLITZ';
+  const modifier = isBlockOrBlitz ? 2 : 0;
+  const total = roll + modifier;
+  const success = total >= 4;
+
+  const modifierText = modifier > 0 ? ` (+${modifier})` : '';
+  const rollLog = createLogEntry(
+    'dice',
+    `Fureur Debridee: ${roll}${modifierText}/${4} ${success ? '✓' : '✗'}`,
+    player.id,
+    player.team,
+    { diceRoll: roll, targetNumber: 4, success, skill: 'wild-animal', modifier }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, rollLog],
+  };
+
+  if (!success) {
+    // Failed: activation ends immediately, NOT a turnover
+    const failLog = createLogEntry(
+      'info',
+      `${player.name} est pris de fureur et ne peut pas agir !`,
+      player.id,
+      player.team
+    );
+    newState = {
+      ...newState,
+      gameLog: [...newState.gameLog, failLog],
+    };
+
+    // Mark player as having acted and remove all movement points
+    newState = setPlayerAction(newState, player.id, 'MOVE');
+    newState = {
+      ...newState,
+      players: newState.players.map(p =>
+        p.id === player.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+      ),
+    };
+  }
+
+  return { passed: success, newState };
+}

--- a/packages/game-engine/src/mechanics/wild-animal.test.ts
+++ b/packages/game-engine/src/mechanics/wild-animal.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG } from '../index';
+import type { GameState, Move } from '../core/types';
+import { getSkillEffect } from '../skills/skill-registry';
+
+/**
+ * Wild Animal (BB3 Season 2/3 rules):
+ * - At the start of this player's activation, roll a D6
+ * - Add +2 to the result if this player is attempting a Block or Blitz action
+ * - On a total of 1-3: the player can't perform any action, activation ends immediately
+ *   -> Block/Blitz: only fails on natural 1 (1+2=3 <= 3)
+ *   -> Other actions: fails on natural 1-3 (no modifier)
+ * - This is NOT a turnover
+ * - The check only happens once per activation (first action attempt)
+ */
+
+function makeTestState(): GameState {
+  const state = setup();
+  return {
+    ...state,
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/**
+ * A1 at (5,5) with optional wild-animal.
+ * B1 placed at (6,5) if adjacentTarget, else far away (20,10).
+ * Other players moved out of the way to avoid tackle zone interference.
+ */
+function setupWildAnimalScenario(
+  baseState: GameState,
+  hasWildAnimal: boolean,
+  adjacentTarget: boolean = false
+): GameState {
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    players: baseState.players.map(p => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 6,
+          ma: 6,
+          st: 5,
+          state: 'active' as const,
+          stunned: false,
+          skills: hasWildAnimal ? ['wild-animal'] : [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'B1') {
+        return {
+          ...p,
+          pos: adjacentTarget ? { x: 6, y: 5 } : { x: 20, y: 10 },
+          pm: 8,
+          st: 3,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+        };
+      }
+      // Move other players far away
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active' as const, stunned: false };
+      }
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active' as const, stunned: false };
+    }),
+  };
+}
+
+const MOVE_LEFT: Move = { type: 'MOVE', playerId: 'A1', to: { x: 4, y: 5 } };
+const BLOCK_B1: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+
+describe('Regle: Wild Animal (Fureur Debridee)', () => {
+  describe('Skill Registry', () => {
+    it('wild-animal is registered in skill registry', () => {
+      const effect = getSkillEffect('wild-animal');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('wild-animal');
+    });
+
+    it('wild-animal has on-activation trigger', () => {
+      const effect = getSkillEffect('wild-animal');
+      expect(effect!.triggers).toContain('on-activation');
+    });
+  });
+
+  describe('Wild Animal activation check on MOVE (no Block/Blitz modifier)', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('player without wild-animal can move normally (no activation roll)', () => {
+      const state = setupWildAnimalScenario(baseState, false);
+      const rng = makeRNG('no-wild-animal-move');
+      const result = applyMove(state, MOVE_LEFT, rng);
+
+      const a1 = result.players.find(p => p.id === 'A1')!;
+      expect(a1.pos).toEqual({ x: 4, y: 5 });
+
+      const wildAnimalLogs = result.gameLog.filter(l =>
+        l.message.includes('Fureur')
+      );
+      expect(wildAnimalLogs).toHaveLength(0);
+    });
+
+    it('wild-animal roll of 4+ allows normal movement', () => {
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-move-pass-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 4, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('wild-animal roll of 1-3 prevents movement (player stays in place)', () => {
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-move-fail-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 5, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('wild-animal failure on MOVE is NOT a turnover', () => {
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-move-no-to-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('wild-animal failure marks player as having acted with 0 PM', () => {
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-move-acted-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.playerActions['A1']).toBeDefined();
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pm).toBe(0);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('wild-animal failure logs rage message', () => {
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-move-log-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const rageLog = result.gameLog.find(l =>
+            l.message.includes('est pris de fureur') && l.message.includes('ne peut pas agir')
+          );
+          expect(rageLog).toBeDefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Wild Animal activation check on BLOCK (+2 modifier)', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('wild-animal roll of 2+ allows block to proceed (2+2=4 passes)', () => {
+      const state = setupWildAnimalScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-block-pass-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          // Block should have been attempted
+          const hasBlock = result.gameLog.some(l =>
+            l.message.includes('Blocage')
+          ) || result.pendingBlock !== undefined;
+          expect(hasBlock).toBe(true);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('wild-animal roll of 1 prevents block (1+2=3 fails)', () => {
+      const state = setupWildAnimalScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-block-fail-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          // No block dice should have been rolled
+          const blockLogs = result.gameLog.filter(l =>
+            l.message.includes('Blocage')
+          );
+          expect(blockLogs).toHaveLength(0);
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Check happens only once per activation', () => {
+    it('wild-animal check not repeated on subsequent moves', () => {
+      const baseState = makeTestState();
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`wa-once-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✓')
+        );
+        if (passLog) {
+          // First move succeeded, now do a second move
+          const MOVE_AGAIN: Move = { type: 'MOVE', playerId: 'A1', to: { x: 3, y: 5 } };
+          const rng2 = makeRNG(`wa-once-2-${seed}`);
+          const result2 = applyMove(result, MOVE_AGAIN, rng2);
+
+          // Should only have 1 wild-animal check log total
+          const wildAnimalLogs = result2.gameLog.filter(l =>
+            l.message.includes('Fureur')
+          );
+          expect(wildAnimalLogs).toHaveLength(1);
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Statistical distribution', () => {
+    it('wild-animal on MOVE fails approximately 50% of the time (1-3 out of 6)', () => {
+      const baseState = makeTestState();
+      const state = setupWildAnimalScenario(baseState, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`wa-move-stats-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      // Wild Animal on non-Block/Blitz fails on 1-3 out of 6 = 50%
+      const failRate = fails / total;
+      expect(failRate).toBeGreaterThan(0.35);
+      expect(failRate).toBeLessThan(0.65);
+    });
+
+    it('wild-animal on BLOCK fails approximately 1/6 of the time (only natural 1)', () => {
+      const baseState = makeTestState();
+      const state = setupWildAnimalScenario(baseState, true, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`wa-block-stats-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Fureur') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      // Wild Animal on Block/Blitz: only natural 1 fails (1+2=3 <= 3), so ~16.7%
+      const failRate = fails / total;
+      expect(failRate).toBeGreaterThan(0.08);
+      expect(failRate).toBeLessThan(0.30);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/index.ts
+++ b/packages/game-engine/src/skills/index.ts
@@ -587,9 +587,8 @@ export const SKILLS_DEFINITIONS: SkillDefinition[] = [
     slug: "wild-animal",
     nameFr: "Fureur Débridée*",
     nameEn: "Wild Animal",
-    description: "Au début de l'activation de ce joueur, jetez un D6. Sur un résultat de 1, ce joueur ne peut effectuer aucune action et son activation se termine immédiatement.",
-    category: "Trait",
-    isModified: true
+    description: "Au début de l'activation, jetez un D6 (+2 si Block/Blitz). Sur un total de 1-3, l'activation se termine immédiatement. Pas de turnover.",
+    category: "Trait"
   },
   {
     slug: "always-hungry",

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -612,6 +612,17 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'really-stupid-2'),
 });
 
+// ─── WILD ANIMAL ──────────────────────────────────────────────────────────────
+// Wild Animal check is performed in applyMove before dispatching to action handlers.
+// Registered here for lookup and metadata purposes.
+
+registerSkill({
+  slug: 'wild-animal',
+  triggers: ['on-activation'],
+  description: 'Au début de l\'activation, jet D6 (+2 si Block/Blitz). Sur 1-3 total, le joueur ne peut pas agir.',
+  canApply: (ctx) => hasSkill(ctx.player, 'wild-animal'),
+});
+
 // ─── ANIMOSITY (5 variants) ─────────────────────────────────────────────────
 // Animosity is checked in handlePass/handleHandoff before the action executes.
 // Registered here for lookup and metadata purposes.


### PR DESCRIPTION
## Summary

- Implement **Wild Animal** (`wild-animal`) negative trait — Sprint 12, task J.3
- BB3 rule: roll D6 at activation start with **+2 modifier for Block/Blitz** actions
- On total 1-3, activation ends immediately (NOT a turnover)
  - Non-Block/Blitz: fails on natural 1-3 (~50%)
  - Block/Blitz: only fails on natural 1 (~17%)
- Follows same TDD pattern as bone-head (J.1) and really-stupid (J.2)

### Changes

- `negative-traits.ts`: add `checkWildAnimal(state, player, rng, moveType)`
- `actions.ts`: wire activation check after bone-head and really-stupid
- `skill-registry.ts`: register `wild-animal` with `on-activation` trigger
- `index.ts`: export `checkWildAnimal`
- `skills/index.ts`: update description to match actual BB3 mechanics
- `wild-animal.test.ts`: 13 unit tests (registry, MOVE, BLOCK, stats, edge cases)
- `TODO.md`: mark J.3 as complete

### Roadmap

Sprint 12 — Fondations & Securite, task **J.3: Implementer `wild-animal`**

## Test plan

- [x] 13 wild-animal tests pass (skill registry, MOVE fail/pass, BLOCK fail/pass, no turnover, acted state, logs, once-per-activation, statistical distributions)
- [x] All 47 negative trait tests pass (bone-head + really-stupid + wild-animal)
- [x] TypeScript compiles with no new errors
- [x] No regressions in existing game-engine tests

https://claude.ai/code/session_01RjuZCRJwhPr5mqHtB9vs7M