### PR TITLE
feat(J.4): implement animal-savagery activation roll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -193,7 +193,7 @@
 | J.1 | Implementer `bone-head` (activation roll) | Regle | [x] |
 | J.2 | Implementer `really-stupid` (1/2) | Regle | [x] |
 | J.3 | Implementer `wild-animal` | Regle | [x] |
-| J.4 | Implementer `animal-savagery` | Regle | [ ] |
+| J.4 | Implementer `animal-savagery` | Regle | [x] |
 | J.5 | Implementer `take-root` | Regle | [ ] |
 | J.6 | Implementer `no-hands` | Regle | [ ] |
 | J.7 | Implementer `right-stuff` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -72,7 +72,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid, checkWildAnimal } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -444,6 +444,10 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       const wildAnimalCheck = checkWildAnimal(activeState, player, rng, move.type);
       if (!wildAnimalCheck.passed) return wildAnimalCheck.newState;
       activeState = wildAnimalCheck.newState;
+
+      const animalSavageryCheck = checkAnimalSavagery(activeState, player, rng);
+      if (!animalSavageryCheck.passed) return animalSavageryCheck.newState;
+      activeState = animalSavageryCheck.newState;
     }
   }
 

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -152,7 +152,7 @@ export { expelSecretWeapons, getSecretWeaponPlayers } from './mechanics/secret-w
 export { extractLineage, hasAnimosityAgainst, checkAnimosity } from './mechanics/animosity';
 
 // Export des traits négatifs (Bone Head, Really Stupid, Wild Animal, etc.)
-export { checkBoneHead, checkReallyStupid, checkWildAnimal } from './mechanics/negative-traits';
+export { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery } from './mechanics/negative-traits';
 export type { ActivationCheckResult } from './mechanics/negative-traits';
 
 // Export des effets météo

--- a/packages/game-engine/src/mechanics/animal-savagery.test.ts
+++ b/packages/game-engine/src/mechanics/animal-savagery.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG } from '../index';
+import type { GameState, Move } from '../core/types';
+import { getSkillEffect } from '../skills/skill-registry';
+
+/**
+ * Animal Savagery (BB3 Season 2/3 rules):
+ * - At the start of this player's activation, roll a D6
+ * - On a 2+: player may perform their declared action as normal
+ * - On a 1: player lashes out at a random adjacent standing teammate
+ *   -> If adjacent standing teammate exists: perform forced block, then continue action
+ *   -> If no adjacent standing teammate: activation ends immediately (NOT a turnover)
+ * - Neither outcome causes a Turnover (the forced block itself can if attacker goes down)
+ * - The check only happens once per activation (first action attempt)
+ */
+
+function makeTestState(): GameState {
+  const state = setup();
+  return {
+    ...state,
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/**
+ * A1 at (5,5) with optional animal-savagery (ST 5 big guy).
+ * A2 at adjacentTeammate position (6,5) if present, else far away.
+ * B1 placed far away to avoid interference.
+ */
+function setupAnimalSavageryScenario(
+  baseState: GameState,
+  hasAnimalSavagery: boolean,
+  options: {
+    adjacentTeammate?: boolean;
+    adjacentTeammatePos?: { x: number; y: number };
+    multipleAdjacentTeammates?: boolean;
+  } = {}
+): GameState {
+  const { adjacentTeammate = false, adjacentTeammatePos, multipleAdjacentTeammates = false } = options;
+  const teammatePos = adjacentTeammatePos ?? { x: 6, y: 5 };
+
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    players: baseState.players.map(p => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 6,
+          ma: 6,
+          st: 5,
+          state: 'active' as const,
+          stunned: false,
+          skills: hasAnimalSavagery ? ['animal-savagery'] : [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'A2') {
+        return {
+          ...p,
+          pos: adjacentTeammate ? teammatePos : { x: 1, y: 14 },
+          pm: 8,
+          ma: 8,
+          st: 3,
+          av: 8,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+          team: 'A' as const,
+        };
+      }
+      if (p.id === 'A3' && multipleAdjacentTeammates) {
+        return {
+          ...p,
+          pos: { x: 4, y: 5 },
+          pm: 8,
+          ma: 8,
+          st: 3,
+          av: 8,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+          team: 'A' as const,
+        };
+      }
+      // Move other team A players far away
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active' as const, stunned: false };
+      }
+      // Move team B players far away
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active' as const, stunned: false };
+    }),
+  };
+}
+
+const MOVE_LEFT: Move = { type: 'MOVE', playerId: 'A1', to: { x: 4, y: 5 } };
+
+describe('Regle: Animal Savagery (Sauvagerie Animale)', () => {
+  describe('Skill Registry', () => {
+    it('animal-savagery is registered in skill registry', () => {
+      const effect = getSkillEffect('animal-savagery');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('animal-savagery');
+    });
+
+    it('animal-savagery has on-activation trigger', () => {
+      const effect = getSkillEffect('animal-savagery');
+      expect(effect!.triggers).toContain('on-activation');
+    });
+  });
+
+  describe('Activation check on MOVE', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('player without animal-savagery can move normally (no activation roll)', () => {
+      const state = setupAnimalSavageryScenario(baseState, false);
+      const rng = makeRNG('no-animal-savagery');
+      const result = applyMove(state, MOVE_LEFT, rng);
+
+      const a1 = result.players.find(p => p.id === 'A1')!;
+      expect(a1.pos).toEqual({ x: 4, y: 5 });
+
+      const savageryLogs = result.gameLog.filter(l =>
+        l.message.includes('Sauvagerie')
+      );
+      expect(savageryLogs).toHaveLength(0);
+    });
+
+    it('roll of 2+ allows normal movement', () => {
+      const state = setupAnimalSavageryScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-pass-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 4, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll of 1 without adjacent teammate ends activation (player stays in place)', () => {
+      // No adjacent teammate — activation ends
+      const state = setupAnimalSavageryScenario(baseState, true, { adjacentTeammate: false });
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-fail-no-tm-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 5, y: 5 }); // Didn't move
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('failure without adjacent teammate is NOT a turnover', () => {
+      const state = setupAnimalSavageryScenario(baseState, true, { adjacentTeammate: false });
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-no-to-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('failure without adjacent teammate marks player as acted with 0 PM', () => {
+      const state = setupAnimalSavageryScenario(baseState, true, { adjacentTeammate: false });
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-acted-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.playerActions['A1']).toBeDefined();
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pm).toBe(0);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll of 1 with adjacent teammate triggers forced block and allows continued action', () => {
+      // Adjacent teammate present — forced block, then attacker can continue
+      const state = setupAnimalSavageryScenario(baseState, true, { adjacentTeammate: true });
+
+      let found = false;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`as-lash-continue-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        );
+        if (!failLog) continue;
+
+        const lashLog = result.gameLog.find(l =>
+          l.message.includes('attaque sauvagement')
+        );
+        if (!lashLog) continue;
+
+        // If the attacker is still standing (not PLAYER_DOWN / BOTH_DOWN),
+        // they should have been able to continue moving
+        const a1 = result.players.find(p => p.id === 'A1')!;
+        if (a1.state === 'active' && !a1.stunned) {
+          found = true;
+          // Attacker should have moved to (4,5)
+          expect(a1.pos).toEqual({ x: 4, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('forced block logs lash out message with target name', () => {
+      const state = setupAnimalSavageryScenario(baseState, true, { adjacentTeammate: true });
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-lash-log-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const lashLog = result.gameLog.find(l =>
+            l.message.includes('attaque sauvagement')
+          );
+          expect(lashLog).toBeDefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Check happens only once per activation', () => {
+    it('animal-savagery check not repeated on subsequent moves', () => {
+      const baseState = makeTestState();
+      const state = setupAnimalSavageryScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`as-once-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✓')
+        );
+        if (passLog) {
+          // First move succeeded, now do a second move
+          const MOVE_AGAIN: Move = { type: 'MOVE', playerId: 'A1', to: { x: 3, y: 5 } };
+          const rng2 = makeRNG(`as-once-2-${seed}`);
+          const result2 = applyMove(result, MOVE_AGAIN, rng2);
+
+          // Should only have 1 animal-savagery check log total
+          const savageryLogs = result2.gameLog.filter(l =>
+            l.message.includes('Sauvagerie')
+          );
+          expect(savageryLogs).toHaveLength(1);
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Statistical distribution', () => {
+    it('animal-savagery fails approximately 1/6 of the time (only on natural 1)', () => {
+      const baseState = makeTestState();
+      const state = setupAnimalSavageryScenario(baseState, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`as-stats-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Sauvagerie') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      // Animal Savagery fails on natural 1 only = ~16.7%
+      const failRate = fails / total;
+      expect(failRate).toBeGreaterThan(0.08);
+      expect(failRate).toBeLessThan(0.30);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -1,13 +1,18 @@
 /**
- * Negative trait activation checks (Bone Head, Really Stupid, Wild Animal, etc.)
+ * Negative trait activation checks (Bone Head, Really Stupid, Wild Animal, Animal Savagery, etc.)
  * These are checked at the start of a player's activation before their first action.
  */
 
-import type { GameState, Player, RNG } from '../core/types';
+import type { GameState, Player, RNG, Position, BlockResult } from '../core/types';
 import { hasSkill } from '../skills/skill-effects';
 import { hasPlayerActed, setPlayerAction } from '../core/game-state';
 import { createLogEntry } from '../utils/logging';
-import { getAdjacentPlayers } from './movement';
+import { getAdjacentPlayers, inBounds, isPositionOccupied } from './movement';
+import { blockResultFromRoll } from '../utils/dice';
+import { performArmorRoll } from '../utils/dice';
+import { performInjuryRoll } from './injury';
+import { getPushDirections } from './blocking';
+import { checkBlockNegatesBothDown, checkDodgeNegatesStumble } from '../skills/skill-bridge';
 
 export interface ActivationCheckResult {
   passed: boolean;
@@ -249,4 +254,274 @@ export function checkWildAnimal(
   }
 
   return { passed: success, newState };
+}
+
+/**
+ * Auto-push a target player away from the attacker.
+ * Picks the first available direction. No pending state.
+ */
+function autoPushPlayer(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+): { newState: GameState; pushed: boolean } {
+  const pushDirections = getPushDirections(attacker.pos, target.pos);
+  for (const dir of pushDirections) {
+    const newPos: Position = {
+      x: target.pos.x + dir.x,
+      y: target.pos.y + dir.y,
+    };
+    if (inBounds(state, newPos) && !isPositionOccupied(state, newPos)) {
+      const pushLog = createLogEntry(
+        'action',
+        `${target.name} repoussé vers (${newPos.x}, ${newPos.y})`,
+        attacker.id,
+        attacker.team
+      );
+      return {
+        newState: {
+          ...state,
+          players: state.players.map(p =>
+            p.id === target.id ? { ...p, pos: newPos } : p
+          ),
+          gameLog: [...state.gameLog, pushLog],
+        },
+        pushed: true,
+      };
+    }
+  }
+  return { newState: state, pushed: false };
+}
+
+/**
+ * Knock down a player in place: set stunned, perform armor + injury rolls.
+ */
+function knockDownPlayer(
+  state: GameState,
+  player: Player,
+  rng: RNG
+): GameState {
+  let newState: GameState = {
+    ...state,
+    players: state.players.map(p =>
+      p.id === player.id ? { ...p, stunned: true } : p
+    ),
+  };
+
+  const armorResult = performArmorRoll(player, rng);
+  const armorLog = createLogEntry(
+    'dice',
+    `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '✓' : '✗'}`,
+    player.id,
+    player.team,
+    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, success: armorResult.success }
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, armorLog] };
+
+  if (!armorResult.success) {
+    newState = performInjuryRoll(newState, player, rng);
+  }
+
+  return newState;
+}
+
+/**
+ * Resolve a forced Animal Savagery block inline (no pending states).
+ * Returns the updated state and whether the attacker is still standing.
+ */
+function resolveAnimalSavageryBlock(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+  blockResult: BlockResult,
+  rng: RNG
+): { newState: GameState; attackerStanding: boolean } {
+  let newState = state;
+
+  switch (blockResult) {
+    case 'PLAYER_DOWN': {
+      const downLog = createLogEntry(
+        'action',
+        `${attacker.name} tombe en attaquant sauvagement !`,
+        attacker.id,
+        attacker.team
+      );
+      newState = { ...newState, gameLog: [...newState.gameLog, downLog] };
+      newState = knockDownPlayer(newState, attacker, rng);
+      return { newState, attackerStanding: false };
+    }
+
+    case 'BOTH_DOWN': {
+      const attackerHasBlock = checkBlockNegatesBothDown(attacker, state);
+      const targetHasBlock = checkBlockNegatesBothDown(target, state);
+      const attackerFalls = !attackerHasBlock;
+      const targetFalls = !targetHasBlock;
+
+      if (!attackerFalls && !targetFalls) {
+        const log = createLogEntry(
+          'action',
+          `Les Deux Plaqués — ${attacker.name} et ${target.name} restent debout (Block)`,
+          attacker.id,
+          attacker.team
+        );
+        return { newState: { ...newState, gameLog: [...newState.gameLog, log] }, attackerStanding: true };
+      }
+
+      const log = createLogEntry(
+        'action',
+        `Les Deux Plaqués — ${attackerFalls ? attacker.name + ' tombe' : attacker.name + ' (Block)'}, ${targetFalls ? target.name + ' tombe' : target.name + ' (Block)'}`,
+        attacker.id,
+        attacker.team
+      );
+      newState = { ...newState, gameLog: [...newState.gameLog, log] };
+
+      if (targetFalls) {
+        const { newState: pushed } = autoPushPlayer(newState, attacker, target);
+        newState = pushed;
+        newState = knockDownPlayer(newState, target, rng);
+      }
+      if (attackerFalls) {
+        newState = knockDownPlayer(newState, attacker, rng);
+      }
+
+      return { newState, attackerStanding: !attackerFalls };
+    }
+
+    case 'PUSH_BACK': {
+      const { newState: pushed } = autoPushPlayer(newState, attacker, target);
+      newState = pushed;
+      return { newState, attackerStanding: true };
+    }
+
+    case 'STUMBLE': {
+      const dodgeNegates = checkDodgeNegatesStumble(target, attacker, state);
+      const { newState: pushed } = autoPushPlayer(newState, attacker, target);
+      newState = pushed;
+      if (!dodgeNegates) {
+        newState = knockDownPlayer(newState, target, rng);
+      }
+      return { newState, attackerStanding: true };
+    }
+
+    case 'POW': {
+      const { newState: pushed } = autoPushPlayer(newState, attacker, target);
+      newState = pushed;
+      newState = knockDownPlayer(newState, target, rng);
+      return { newState, attackerStanding: true };
+    }
+
+    default:
+      return { newState, attackerStanding: true };
+  }
+}
+
+/**
+ * Check Animal Savagery activation roll.
+ * BB3 Rule: At the start of this player's activation, roll a D6.
+ * - On a 2+: player may perform their declared action as normal.
+ * - On a 1: player lashes out at a random adjacent standing teammate.
+ *   -> If adjacent standing teammate exists: perform forced 1-die block, then
+ *      if attacker is still standing, continue declared action.
+ *   -> If no adjacent standing teammate: activation ends immediately (NOT a turnover).
+ *
+ * @returns { passed: true, newState } if player can continue their action
+ * @returns { passed: false, newState } if activation is lost
+ */
+export function checkAnimalSavagery(
+  state: GameState,
+  player: Player,
+  rng: RNG
+): ActivationCheckResult {
+  if (!hasSkill(player, 'animal-savagery')) {
+    return { passed: true, newState: state };
+  }
+
+  if (hasPlayerActed(state, player.id)) {
+    return { passed: true, newState: state };
+  }
+
+  const roll = Math.floor(rng() * 6) + 1;
+  const success = roll >= 2;
+
+  const rollLog = createLogEntry(
+    'dice',
+    `Sauvagerie Animale: ${roll}/2 ${success ? '✓' : '✗'}`,
+    player.id,
+    player.team,
+    { diceRoll: roll, targetNumber: 2, success, skill: 'animal-savagery' }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, rollLog],
+  };
+
+  if (success) {
+    return { passed: true, newState };
+  }
+
+  // Failed (roll 1): lash out at random adjacent standing teammate
+  const adjacents = getAdjacentPlayers(newState, player.pos);
+  const standingTeammates = adjacents.filter(
+    p => p.team === player.team && p.id !== player.id && p.state === 'active'
+  );
+
+  if (standingTeammates.length === 0) {
+    const failLog = createLogEntry(
+      'info',
+      `${player.name} est pris de sauvagerie mais n'a aucun coéquipier adjacent !`,
+      player.id,
+      player.team
+    );
+    newState = {
+      ...newState,
+      gameLog: [...newState.gameLog, failLog],
+    };
+
+    newState = setPlayerAction(newState, player.id, 'MOVE');
+    newState = {
+      ...newState,
+      players: newState.players.map(p =>
+        p.id === player.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+      ),
+    };
+
+    return { passed: false, newState };
+  }
+
+  // Pick random adjacent teammate
+  const targetIndex = Math.floor(rng() * standingTeammates.length);
+  const target = standingTeammates[targetIndex];
+
+  // Perform forced 1-die block against teammate
+  const blockRoll = Math.floor(rng() * 6) + 1;
+  const blockResult = blockResultFromRoll(blockRoll);
+
+  const lashLog = createLogEntry(
+    'action',
+    `${player.name} attaque sauvagement ${target.name} ! (${blockResult})`,
+    player.id,
+    player.team,
+    { skill: 'animal-savagery', targetId: target.id, blockResult, diceRoll: blockRoll }
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, lashLog] };
+
+  // Resolve forced block inline
+  const resolution = resolveAnimalSavageryBlock(newState, player, target, blockResult, rng);
+  newState = resolution.newState;
+
+  if (!resolution.attackerStanding) {
+    newState = setPlayerAction(newState, player.id, 'MOVE');
+    newState = {
+      ...newState,
+      isTurnover: true,
+      players: newState.players.map(p =>
+        p.id === player.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+      ),
+    };
+    return { passed: false, newState };
+  }
+
+  // Attacker still standing: can continue their declared action
+  return { passed: true, newState };
 }

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -623,6 +623,17 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'wild-animal'),
 });
 
+// ─── ANIMAL SAVAGERY ────────────────────────────────────────────────────────
+// Animal Savagery check is performed in applyMove before dispatching to action handlers.
+// Registered here for lookup and metadata purposes.
+
+registerSkill({
+  slug: 'animal-savagery',
+  triggers: ['on-activation'],
+  description: 'Au début de l\'activation, jet D6. Sur 1, attaque un coéquipier adjacent aléatoire (bloc forcé). Sans coéquipier adjacent, activation terminée.',
+  canApply: (ctx) => hasSkill(ctx.player, 'animal-savagery'),
+});
+
 // ─── ANIMOSITY (5 variants) ─────────────────────────────────────────────────
 // Animosity is checked in handlePass/handleHandoff before the action executes.
 // Registered here for lookup and metadata purposes.


### PR DESCRIPTION
## Summary

- Implement **Animal Savagery** negative trait (BB3 Season 2/3 rules) — Sprint 12, task J.4
- At activation start, roll D6: on 2+ proceed normally; on 1 lash out at a random adjacent standing teammate with a forced 1-die block
- If no adjacent teammate on failure: activation ends immediately (NOT a turnover)
- If attacker goes down from the forced block: activation lost + turnover
- Forced block auto-resolves inline (PLAYER_DOWN, BOTH_DOWN, PUSH_BACK, STUMBLE, POW) with no pending states

### Files changed
- `packages/game-engine/src/mechanics/negative-traits.ts` — `checkAnimalSavagery()` + helpers (`autoPushPlayer`, `knockDownPlayer`, `resolveAnimalSavageryBlock`)
- `packages/game-engine/src/skills/skill-registry.ts` — register `animal-savagery` with `on-activation` trigger
- `packages/game-engine/src/actions/actions.ts` — integrate into activation check sequence
- `packages/game-engine/src/index.ts` — export `checkAnimalSavagery`
- `packages/game-engine/src/mechanics/animal-savagery.test.ts` — 11 tests (TDD)
- `TODO.md` — check off J.4

## Test plan

- [x] Skill registered in skill-registry with `on-activation` trigger
- [x] Player without animal-savagery moves normally (no roll)
- [x] Roll 2+ allows normal action
- [x] Roll 1 without adjacent teammate ends activation, NOT a turnover, PM=0
- [x] Roll 1 with adjacent teammate triggers forced block, attacker continues if standing
- [x] Forced block logs lash out message
- [x] Check runs only once per activation
- [x] Statistical distribution ~16.7% failure rate (natural 1 only)
- [x] No regressions on existing 3045 tests

https://claude.ai/code/session_01Ni9fFEhY5BdqeaMVkJayBL