### PR TITLE
feat(J.5): implement take-root activation roll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -194,7 +194,7 @@
 | J.2 | Implementer `really-stupid` (1/2) | Regle | [x] |
 | J.3 | Implementer `wild-animal` | Regle | [x] |
 | J.4 | Implementer `animal-savagery` | Regle | [x] |
-| J.5 | Implementer `take-root` | Regle | [ ] |
+| J.5 | Implementer `take-root` | Regle | [x] |
 | J.6 | Implementer `no-hands` | Regle | [ ] |
 | J.7 | Implementer `right-stuff` | Regle | [ ] |
 | TEST-1 | Activer vitest coverage reporting | Qualite | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -72,7 +72,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -448,6 +448,10 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       const animalSavageryCheck = checkAnimalSavagery(activeState, player, rng);
       if (!animalSavageryCheck.passed) return animalSavageryCheck.newState;
       activeState = animalSavageryCheck.newState;
+
+      const takeRootCheck = checkTakeRoot(activeState, player, rng);
+      if (!takeRootCheck.passed) return takeRootCheck.newState;
+      activeState = takeRootCheck.newState;
     }
   }
 

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -525,3 +525,72 @@ export function checkAnimalSavagery(
   // Attacker still standing: can continue their declared action
   return { passed: true, newState };
 }
+
+/**
+ * Check Take Root activation roll.
+ * BB3 Rule: At the start of this player's activation, roll a D6.
+ * On a 1, the player becomes "rooted" — they can't perform any action
+ * and their activation ends immediately.
+ * On 2+, the player acts normally.
+ * This is NOT a turnover.
+ *
+ * @returns { passed: true, newState } if player doesn't have take-root or passes the roll
+ * @returns { passed: false, newState } with modified state if roll fails
+ */
+export function checkTakeRoot(
+  state: GameState,
+  player: Player,
+  rng: RNG
+): ActivationCheckResult {
+  // No take-root: always pass (no state change)
+  if (!hasSkill(player, 'take-root')) {
+    return { passed: true, newState: state };
+  }
+
+  // Already acted this turn: skip check (not first action)
+  if (hasPlayerActed(state, player.id)) {
+    return { passed: true, newState: state };
+  }
+
+  // Roll D6: succeed on 2+
+  const roll = Math.floor(rng() * 6) + 1;
+  const success = roll >= 2;
+
+  const rollLog = createLogEntry(
+    'dice',
+    `Prendre Racine: ${roll}/2 ${success ? '✓' : '✗'}`,
+    player.id,
+    player.team,
+    { diceRoll: roll, targetNumber: 2, success, skill: 'take-root' }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, rollLog],
+  };
+
+  if (!success) {
+    // Failed: player is rooted, activation ends immediately, NOT a turnover
+    const failLog = createLogEntry(
+      'info',
+      `${player.name} est enraciné et ne peut pas agir !`,
+      player.id,
+      player.team
+    );
+    newState = {
+      ...newState,
+      gameLog: [...newState.gameLog, failLog],
+    };
+
+    // Mark player as having acted and remove all movement points
+    newState = setPlayerAction(newState, player.id, 'MOVE');
+    newState = {
+      ...newState,
+      players: newState.players.map(p =>
+        p.id === player.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+      ),
+    };
+  }
+
+  return { passed: success, newState };
+}

--- a/packages/game-engine/src/mechanics/take-root.test.ts
+++ b/packages/game-engine/src/mechanics/take-root.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG } from '../index';
+import type { GameState, Move } from '../core/types';
+import { getSkillEffect } from '../skills/skill-registry';
+
+/**
+ * Take Root (BB3 Season 2/3 rules):
+ * - At the start of this player's activation, roll a D6
+ * - On a 1: the player is "rooted" — can't perform any action, activation ends immediately
+ * - On 2+: the player acts normally
+ * - This is NOT a turnover
+ * - The check only happens once per activation (first action attempt)
+ */
+
+function makeTestState(): GameState {
+  const state = setup();
+  return {
+    ...state,
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/**
+ * A1 at (5,5) with optional take-root.
+ * B1 placed at (6,5) if adjacentTarget, else far away (20,10).
+ * Other players moved out of the way to avoid tackle zone interference.
+ */
+function setupTakeRootScenario(
+  baseState: GameState,
+  hasTakeRoot: boolean,
+  adjacentTarget: boolean = false
+): GameState {
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    players: baseState.players.map(p => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 2,
+          ma: 2,
+          st: 6,
+          ag: 5,
+          pa: 5,
+          av: 11,
+          state: 'active' as const,
+          stunned: false,
+          skills: hasTakeRoot ? ['take-root'] : [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'B1') {
+        return {
+          ...p,
+          pos: adjacentTarget ? { x: 6, y: 5 } : { x: 20, y: 10 },
+          pm: 8,
+          st: 3,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+        };
+      }
+      // Move other players far away
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active' as const, stunned: false };
+      }
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active' as const, stunned: false };
+    }),
+  };
+}
+
+const MOVE_LEFT: Move = { type: 'MOVE', playerId: 'A1', to: { x: 4, y: 5 } };
+const BLOCK_B1: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+
+describe('Regle: Take Root (Prendre Racine)', () => {
+  describe('Skill Registry', () => {
+    it('take-root is registered in skill registry', () => {
+      const effect = getSkillEffect('take-root');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('take-root');
+    });
+
+    it('take-root has on-activation trigger', () => {
+      const effect = getSkillEffect('take-root');
+      expect(effect!.triggers).toContain('on-activation');
+    });
+  });
+
+  describe('Take Root activation check on MOVE', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('player without take-root can move normally (no activation roll)', () => {
+      const state = setupTakeRootScenario(baseState, false);
+      const rng = makeRNG('no-take-root-move');
+      const result = applyMove(state, MOVE_LEFT, rng);
+
+      const a1 = result.players.find(p => p.id === 'A1')!;
+      expect(a1.pos).toEqual({ x: 4, y: 5 });
+
+      const takeRootLogs = result.gameLog.filter(l =>
+        l.message.includes('Prendre Racine')
+      );
+      expect(takeRootLogs).toHaveLength(0);
+    });
+
+    it('take-root roll of 2+ allows normal movement', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-pass-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 4, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root roll of 1 prevents movement (player stays in place)', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-fail-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pos).toEqual({ x: 5, y: 5 });
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root failure is NOT a turnover', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-no-to-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root failure marks player as having acted with 0 PM', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-acted-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.playerActions['A1']).toBeDefined();
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pm).toBe(0);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root check happens only once per activation (not on subsequent moves)', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-once-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✓')
+        );
+        if (passLog) {
+          // First move succeeded, now do a second move
+          const MOVE_AGAIN: Move = { type: 'MOVE', playerId: 'A1', to: { x: 3, y: 5 } };
+          const rng2 = makeRNG(`tr-once-2-${seed}`);
+          const result2 = applyMove(result, MOVE_AGAIN, rng2);
+
+          // Should only have 1 take-root check log total
+          const takeRootLogs = result2.gameLog.filter(l =>
+            l.message.includes('Prendre Racine')
+          );
+          expect(takeRootLogs).toHaveLength(1);
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root failure logs rooting message', () => {
+      const state = setupTakeRootScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-log-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const rootedLog = result.gameLog.find(l =>
+            l.message.includes('enraciné') && l.message.includes('ne peut pas')
+          );
+          expect(rootedLog).toBeDefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Take Root activation check on BLOCK', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('take-root roll of 1 prevents block action', () => {
+      const state = setupTakeRootScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-block-fail-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          // No block dice should have been rolled
+          const blockLogs = result.gameLog.filter(l =>
+            l.message.includes('Blocage')
+          );
+          expect(blockLogs).toHaveLength(0);
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('take-root roll of 2+ allows block to proceed', () => {
+      const state = setupTakeRootScenario(baseState, true, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`tr-block-pass-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          // Block should have been attempted (block dice log or pending block)
+          const hasBlock = result.gameLog.some(l =>
+            l.message.includes('Blocage')
+          ) || result.pendingBlock !== undefined;
+          expect(hasBlock).toBe(true);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Statistical distribution', () => {
+    it('take-root fails approximately 1/6 of the time', () => {
+      const baseState = makeTestState();
+      const state = setupTakeRootScenario(baseState, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 500; seed++) {
+        const rng = makeRNG(`tr-stats-${seed}`);
+        const result = applyMove(state, MOVE_LEFT, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Prendre Racine') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      // Take-root fails on 1 out of 6 ≈ 16.7%
+      const failRate = fails / total;
+      expect(failRate).toBeGreaterThan(0.08);
+      expect(failRate).toBeLessThan(0.30);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -634,6 +634,17 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'animal-savagery'),
 });
 
+// ─── TAKE ROOT ──────────────────────────────────────────────────────────────
+// Take Root check is performed in applyMove before dispatching to action handlers.
+// Registered here for lookup and metadata purposes.
+
+registerSkill({
+  slug: 'take-root',
+  triggers: ['on-activation'],
+  description: 'Au début de l\'activation, jet D6. Sur 1, le joueur est enraciné et ne peut pas agir (activation terminée).',
+  canApply: (ctx) => hasSkill(ctx.player, 'take-root'),
+});
+
 // ─── ANIMOSITY (5 variants) ─────────────────────────────────────────────────
 // Animosity is checked in handlePass/handleHandoff before the action executes.
 // Registered here for lookup and metadata purposes.


### PR DESCRIPTION
## Summary

- Implement **Take Root** negative trait (J.5 — Sprint 12) for Treeman positions (Halflings, Wood Elves, etc.)
- At activation start, roll D6: on 1, player is "rooted" and cannot act (activation ends immediately, NOT a turnover). On 2+, player acts normally.
- Follows the same architecture as bone-head, really-stupid, wild-animal, and animal-savagery

## Changes

- **`packages/game-engine/src/mechanics/negative-traits.ts`** — Add `checkTakeRoot()` function following the established pattern
- **`packages/game-engine/src/skills/skill-registry.ts`** — Register `take-root` with `on-activation` trigger
- **`packages/game-engine/src/actions/actions.ts`** — Wire `checkTakeRoot` into the activation check chain (after animal-savagery)
- **`packages/game-engine/src/mechanics/take-root.test.ts`** — 12 unit tests (registry, move/block pass/fail, turnover check, acted state, once-per-activation, log messages, statistical distribution)
- **`TODO.md`** — Mark J.5 as complete

## Tache roadmap

Sprint 12 — Fondations & Securite, tache J.5

## Test plan

- [x] 12 unit tests pass (`npx vitest run packages/game-engine/src/mechanics/take-root.test.ts`)
- [x] All negative trait tests pass (bone-head, really-stupid, wild-animal, animal-savagery)
- [x] Skill registry tests pass
- [x] No regressions in game-engine test suite (3060 tests, 3 pre-existing failures unrelated)
- [x] TypeScript type check passes (only pre-existing baseUrl deprecation warning)

https://claude.ai/code/session_019QXGvXzrjNsyoBRBWFdyca