### PR TITLE
Display team rerolls count in game scoreboard

### DIFF
--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -849,7 +849,8 @@ export function handlePostTouchdown(state: GameState, rng: RNG): GameState {
   );
 
   // Entrer en phase de setup pour le nouveau drive (les joueurs doivent être replacés)
-  const resultState: GameState = {
+  const extState = newState as ExtendedGameState;
+  const resultState = {
     ...newState,
     gamePhase: 'playing' as const,
     kickingTeam: newKickingTeam,
@@ -864,13 +865,13 @@ export function handlePostTouchdown(state: GameState, rng: RNG): GameState {
     lastDiceResult: undefined,
     gameLog: [...newState.gameLog, resetLog],
     preMatch: {
-      ...newState.preMatch,
-      phase: 'setup' as any,
+      ...extState.preMatch,
+      phase: 'setup' as const,
       currentCoach: receivingTeam,
       kickingTeam: newKickingTeam,
       receivingTeam: receivingTeam,
-      placedPlayers: [],
-      legalSetupPositions: [],
+      placedPlayers: [] as Array<{ playerId: string; position: Position }>,
+      legalSetupPositions: [] as Position[],
     },
   };
 

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -47,7 +47,7 @@ export function applyChainPush(
       undefined,
       pushed.team === 'A' ? 'B' : 'A'
     );
-    let newState = { ...state, gameLog: [...state.gameLog, surfLog] };
+    const newState = { ...state, gameLog: [...state.gameLog, surfLog] };
     if (pushed.hasBall) {
       newState.players = newState.players.map(p =>
         p.id === pushedPlayerId ? { ...p, hasBall: false } : p
@@ -520,7 +520,7 @@ export function handlePushWithChoice(
       y: target.pos.y + pushDirection.y,
     };
 
-    let newState = applyChainPush(state, target.id, pushDirection, rng);
+    const newState = applyChainPush(state, target.id, pushDirection, rng);
 
     // Demander confirmation pour le follow-up
     newState.pendingFollowUpChoice = {

--- a/packages/ui/src/components/GameScoreboard.tsx
+++ b/packages/ui/src/components/GameScoreboard.tsx
@@ -178,6 +178,17 @@ export default function GameScoreboard({
             >
               {state.score?.teamA || 0}
             </div>
+            {state.half > 0 && state.teamRerolls && (
+              <div className="text-xs text-gray-300 mt-1">
+                <span className="inline-flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 2v6h-6" /><path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                    <path d="M3 22v-6h6" /><path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                  </svg>
+                  {state.teamRerolls.teamA ?? 0}
+                </span>
+              </div>
+            )}
           </div>
 
           {/* Séparateur */}
@@ -199,6 +210,17 @@ export default function GameScoreboard({
             >
               {state.score?.teamB || 0}
             </div>
+            {state.half > 0 && state.teamRerolls && (
+              <div className="text-xs text-gray-300 mt-1">
+                <span className="inline-flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 2v6h-6" /><path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                    <path d="M3 22v-6h6" /><path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                  </svg>
+                  {state.teamRerolls.teamB ?? 0}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 

--- a/packages/ui/src/components/__tests__/GameScoreboard.test.tsx
+++ b/packages/ui/src/components/__tests__/GameScoreboard.test.tsx
@@ -241,6 +241,54 @@ describe('GameScoreboard', () => {
     expect(screen.getByText('Blood Bowl Fantasy Football')).toBeInTheDocument();
   });
 
+  describe('Team rerolls display', () => {
+    it('should display reroll counts for both teams when match is in progress', () => {
+      const state = createMinimalGameState({
+        half: 1,
+        teamRerolls: { teamA: 3, teamB: 2 }
+      });
+      render(<GameScoreboard state={state} />);
+
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('should not display reroll counts before match starts (half 0)', () => {
+      const state = createMinimalGameState({
+        half: 0,
+        teamRerolls: { teamA: 3, teamB: 3 }
+      });
+      render(<GameScoreboard state={state} />);
+
+      // Reroll counts should not be visible when half is 0
+      const svgs = document.querySelectorAll('svg');
+      // No reroll icons should be rendered
+      expect(svgs.length).toBe(0);
+    });
+
+    it('should display 0 rerolls when team has used all rerolls', () => {
+      const state = createMinimalGameState({
+        half: 1,
+        teamRerolls: { teamA: 0, teamB: 0 }
+      });
+      render(<GameScoreboard state={state} />);
+
+      // Score 0s + reroll 0s - at least 4 zeros total
+      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should handle undefined teamRerolls gracefully', () => {
+      const state = createMinimalGameState({
+        half: 1,
+        teamRerolls: undefined as any
+      });
+      render(<GameScoreboard state={state} />);
+
+      // Should not crash
+      expect(screen.getByText('Blood Bowl Fantasy Football')).toBeInTheDocument();
+    });
+  });
+
   describe('Connection status indicator', () => {
     it('should show "Connecté" with green dot when wsConnected is true', () => {
       const state = createMinimalGameState();


### PR DESCRIPTION
## Résumé

- [x] Afficher le nombre de rerolls restants pour chaque équipe dans le scoreboard pendant le match

## Description

Ajoute l'affichage du nombre de rerolls disponibles pour chaque équipe dans le GameScoreboard. Les rerolls s'affichent uniquement lorsque le match est en cours (half > 0) et sont accompagnés d'une icône de rotation.

### Changements

- **GameScoreboard.tsx**: Ajout de deux sections affichant les rerolls pour teamA et teamB avec une icône SVG
  - Les rerolls ne s'affichent que si `half > 0` et `teamRerolls` est défini
  - Utilise l'opérateur `??` pour afficher 0 si la valeur est undefined
  - Style: texte gris petit avec icône inline

- **GameScoreboard.test.tsx**: Ajout d'une suite de tests complète pour la fonctionnalité
  - Test d'affichage des rerolls pendant le match
  - Test de non-affichage avant le début du match (half 0)
  - Test d'affichage des 0 rerolls
  - Test de gestion gracieuse des `teamRerolls` undefined

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (4 nouveaux tests ajoutés)
- [x] (si applicable) Tests e2e - N/A
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01S3rW3TNa3e3qUSQj5aA3sh