### PR TITLE
fix: remove dummy DiceResult overwrite after block resolution

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -1248,7 +1248,7 @@ function handleBlockChoose(
     targetStrength: state.pendingBlock.targetStrength,
   };
 
-  let newState = resolveBlockResult({ ...state, pendingBlock: undefined }, blockResult, rng);
+  let newState = resolveBlockResult({ ...state, pendingBlock: undefined, lastDiceResult: undefined }, blockResult, rng);
 
   // Déterminer si c'était un blitz ou un blocage normal
   // Si le joueur a déjà l'action BLITZ enregistrée, c'est un blitz
@@ -1281,15 +1281,6 @@ function handleBlockChoose(
     newState = checkPlayerTurnEnd(newState, attacker.id);
   }
 
-  // lastDiceResult est déjà renseigné par resolveBlockResult pour l'armure; on peut aussi logguer le block
-  newState.lastDiceResult = {
-    type: 'block',
-    playerId: attacker.id,
-    diceRoll: 0,
-    targetNumber: 0,
-    success: true,
-    modifiers: 0,
-  };
   return newState;
 }
 


### PR DESCRIPTION
After resolving a block choice, handleBlockChoose() was overwriting
lastDiceResult with a dummy object (diceRoll: 0, targetNumber: 0,
success: true), which triggered a nonsensical popup showing
"jet de des 0 pour cible 0 : reussi".

resolveBlockResult() already sets lastDiceResult correctly when an
armor roll occurs (PLAYER_DOWN, BOTH_DOWN, STUMBLE, POW). For
PUSH_BACK where no armor roll happens, lastDiceResult is now cleared
beforehand so no stale popup appears.

https://claude.ai/code/session_016BNbscH2ULxQQKFMnsHpcf