### PR TITLE
feat: implement always-hungry trait (J.9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -207,7 +207,7 @@
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
 | J.8 | Implementer `bloodlust` (3 variantes) | Regle | [x] |
-| J.9 | Implementer `always-hungry` | Regle | [ ] |
+| J.9 | Implementer `always-hungry` | Regle | [x] |
 | J.10 | Implementer `foul-appearance` | Regle | [ ] |
 | J.11 | Implementer `instable` | Regle | [ ] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -74,7 +74,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -1825,7 +1825,17 @@ function handleThrowTeamMate(
   const range = getThrowRange(thrower.pos, move.targetPos);
   if (!range) return state;
 
-  let newState = executeThrowTeamMate(state, thrower, thrown, move.targetPos, rng);
+  // Always Hungry check (BB3): test AVANT le jet de passe. Un double-1 devore
+  // le coequipier, un 1+2+ place le coequipier prone + turnover, 2+ continue.
+  const hungryResult = checkAlwaysHungry(state, thrower, thrown, rng);
+  if (!hungryResult.shouldContinueThrow) {
+    let newState = hungryResult.newState;
+    newState = setPlayerAction(newState, thrower.id, 'THROW_TEAM_MATE');
+    newState = checkPlayerTurnEnd(newState, thrower.id);
+    return newState;
+  }
+
+  let newState = executeThrowTeamMate(hungryResult.newState, thrower, thrown, move.targetPos, rng);
   newState = setPlayerAction(newState, thrower.id, 'THROW_TEAM_MATE');
   newState = checkPlayerTurnEnd(newState, thrower.id);
   return newState;

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -152,8 +152,8 @@ export { expelSecretWeapons, getSecretWeaponPlayers } from './mechanics/secret-w
 export { extractLineage, hasAnimosityAgainst, checkAnimosity } from './mechanics/animosity';
 
 // Export des traits négatifs (Bone Head, Really Stupid, Wild Animal, etc.)
-export { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust } from './mechanics/negative-traits';
-export type { ActivationCheckResult } from './mechanics/negative-traits';
+export { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry } from './mechanics/negative-traits';
+export type { ActivationCheckResult, AlwaysHungryResult } from './mechanics/negative-traits';
 
 // Export des effets météo
 export {

--- a/packages/game-engine/src/mechanics/always-hungry.test.ts
+++ b/packages/game-engine/src/mechanics/always-hungry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests unitaires pour le trait Always Hungry (Toujours Affamé) — BB2020/BB3.
+ *
+ * Regle : lorsque ce joueur tente de lancer un coequipier, jet D6 AVANT le jet
+ * de passe.
+ *   - 2+  : le lancer se deroule normalement.
+ *   - 1   : tentative de devorer le coequipier, nouveau jet D6.
+ *           - 2+ : le coequipier s'echappe, place au sol (stunned) dans sa
+ *             case actuelle, TURNOVER, aucun lancer effectue.
+ *           - 1  : le coequipier est devore (casualty Dead), TURNOVER.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../index';
+import { GameState, RNG } from '../core/types';
+import { checkAlwaysHungry } from './negative-traits';
+
+/**
+ * Deterministe : retourne la prochaine valeur (0..1 exclu) sequentiellement.
+ * Pour obtenir un roll D6 = N, passer (N-1)/6 + epsilon.
+ */
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const val = values[i % values.length];
+    i++;
+    return val;
+  };
+}
+
+/** rng val that yields a D6 roll of `n` via Math.floor(rng()*6)+1 */
+function d6(n: number): number {
+  // n in 1..6 → rng returns (n-1)/6 + small epsilon
+  return (n - 1) / 6 + 0.01;
+}
+
+function createAlwaysHungryState(): GameState {
+  const state = setup();
+  state.players = [
+    {
+      id: 'A1',
+      team: 'A',
+      pos: { x: 10, y: 7 },
+      name: 'Troll',
+      number: 1,
+      position: 'Troll',
+      ma: 4,
+      st: 5,
+      ag: 5,
+      pa: 5,
+      av: 10,
+      skills: ['throw-team-mate', 'always-hungry'],
+      pm: 2,
+      hasBall: false,
+      state: 'active',
+    },
+    {
+      id: 'A2',
+      team: 'A',
+      pos: { x: 11, y: 7 },
+      name: 'Snotling',
+      number: 2,
+      position: 'Snotling',
+      ma: 5,
+      st: 1,
+      ag: 3,
+      pa: 6,
+      av: 5,
+      skills: ['right-stuff', 'stunty'],
+      pm: 5,
+      hasBall: false,
+      state: 'active',
+    },
+  ];
+  state.ball = { x: 5, y: 7 };
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamBlitzCount = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 0, teamB: 0 };
+  return state;
+}
+
+describe("Regle: Always Hungry (Toujours Affame)", () => {
+  it("ne fait rien si le lanceur n'a pas le trait always-hungry", () => {
+    const state = createAlwaysHungryState();
+    state.players = state.players.map(p =>
+      p.id === 'A1' ? { ...p, skills: ['throw-team-mate'] } : p,
+    );
+    const thrower = state.players.find(p => p.id === 'A1')!;
+    const thrown = state.players.find(p => p.id === 'A2')!;
+
+    const rng: RNG = makeTestRNG([d6(1), d6(1)]); // would be worst case
+    const result = checkAlwaysHungry(state, thrower, thrown, rng);
+
+    expect(result.shouldContinueThrow).toBe(true);
+    expect(result.newState).toBe(state); // no state change
+  });
+
+  it("le lancer continue normalement quand le D6 est 2+ (pas affame)", () => {
+    const state = createAlwaysHungryState();
+    const thrower = state.players.find(p => p.id === 'A1')!;
+    const thrown = state.players.find(p => p.id === 'A2')!;
+
+    // Roll = 2 → success (2+)
+    const rng: RNG = makeTestRNG([d6(2)]);
+    const result = checkAlwaysHungry(state, thrower, thrown, rng);
+
+    expect(result.shouldContinueThrow).toBe(true);
+    // pas de turnover
+    expect(result.newState.isTurnover).toBeFalsy();
+    // le coequipier reste debout
+    const a2 = result.newState.players.find(p => p.id === 'A2')!;
+    expect(a2.state).toBe('active');
+    expect(a2.stunned).toBeFalsy();
+    // un log du jet doit avoir ete ajoute
+    const hungryLog = result.newState.gameLog.find(l =>
+      l.message.toLowerCase().includes('toujours affam'),
+    );
+    expect(hungryLog).toBeDefined();
+  });
+
+  it("sur un 1 puis 2+ : le coequipier s'echappe (stunned, turnover, pas de lancer)", () => {
+    const state = createAlwaysHungryState();
+    const thrower = state.players.find(p => p.id === 'A1')!;
+    const thrown = state.players.find(p => p.id === 'A2')!;
+    const originalPos = { ...thrown.pos };
+
+    // First roll = 1 (hungry), second roll = 4 (escape)
+    const rng: RNG = makeTestRNG([d6(1), d6(4)]);
+    const result = checkAlwaysHungry(state, thrower, thrown, rng);
+
+    expect(result.shouldContinueThrow).toBe(false);
+    expect(result.newState.isTurnover).toBe(true);
+
+    const a2 = result.newState.players.find(p => p.id === 'A2')!;
+    expect(a2.stunned).toBe(true);
+    // Le coequipier reste sur le terrain (pas casualty)
+    expect(a2.state).toBe('active');
+    // Position inchangee (place dans sa case)
+    expect(a2.pos).toEqual(originalPos);
+
+    // Le lanceur n'est pas affecte
+    const a1 = result.newState.players.find(p => p.id === 'A1')!;
+    expect(a1.stunned).toBeFalsy();
+    expect(a1.state).toBe('active');
+  });
+
+  it("sur un double 1 : le coequipier est devore (casualty dead, turnover)", () => {
+    const state = createAlwaysHungryState();
+    const thrower = state.players.find(p => p.id === 'A1')!;
+    const thrown = state.players.find(p => p.id === 'A2')!;
+
+    const rng: RNG = makeTestRNG([d6(1), d6(1)]);
+    const result = checkAlwaysHungry(state, thrower, thrown, rng);
+
+    expect(result.shouldContinueThrow).toBe(false);
+    expect(result.newState.isTurnover).toBe(true);
+
+    const a2 = result.newState.players.find(p => p.id === 'A2')!;
+    expect(a2.state).toBe('casualty');
+    expect(result.newState.casualtyResults?.[a2.id]).toBe('dead');
+    // Le coequipier est retire du terrain (dugout)
+    expect(a2.pos.x).toBeLessThan(0);
+
+    const deadLog = result.newState.gameLog.find(l =>
+      l.message.toLowerCase().includes('devor') ||
+      l.message.toLowerCase().includes('mang'),
+    );
+    expect(deadLog).toBeDefined();
+  });
+
+  it("utilise le RNG seede (jets reproductibles)", () => {
+    const state1 = createAlwaysHungryState();
+    const state2 = createAlwaysHungryState();
+    const thrower1 = state1.players.find(p => p.id === 'A1')!;
+    const thrown1 = state1.players.find(p => p.id === 'A2')!;
+    const thrower2 = state2.players.find(p => p.id === 'A1')!;
+    const thrown2 = state2.players.find(p => p.id === 'A2')!;
+
+    const rng1 = makeTestRNG([d6(1), d6(4)]);
+    const rng2 = makeTestRNG([d6(1), d6(4)]);
+
+    const r1 = checkAlwaysHungry(state1, thrower1, thrown1, rng1);
+    const r2 = checkAlwaysHungry(state2, thrower2, thrown2, rng2);
+
+    expect(r1.shouldContinueThrow).toBe(r2.shouldContinueThrow);
+    expect(r1.newState.isTurnover).toBe(r2.newState.isTurnover);
+    const a2_1 = r1.newState.players.find(p => p.id === 'A2')!;
+    const a2_2 = r2.newState.players.find(p => p.id === 'A2')!;
+    expect(a2_1.stunned).toBe(a2_2.stunned);
+    expect(a2_1.state).toBe(a2_2.state);
+  });
+});

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -3,7 +3,7 @@
  * These are checked at the start of a player's activation before their first action.
  */
 
-import type { GameState, Player, RNG, Position, BlockResult } from '../core/types';
+import type { GameState, Player, RNG, Position, BlockResult, CasualtyOutcome } from '../core/types';
 import { hasSkill } from '../skills/skill-effects';
 import { hasPlayerActed, setPlayerAction } from '../core/game-state';
 import { createLogEntry } from '../utils/logging';
@@ -11,6 +11,7 @@ import { getAdjacentPlayers, inBounds, isPositionOccupied } from './movement';
 import { blockResultFromRoll } from '../utils/dice';
 import { performArmorRoll } from '../utils/dice';
 import { performInjuryRoll } from './injury';
+import { movePlayerToDugoutZone } from './dugout';
 import { getPushDirections } from './blocking';
 import { checkBlockNegatesBothDown, checkDodgeNegatesStumble } from '../skills/skill-bridge';
 
@@ -692,4 +693,120 @@ export function checkTakeRoot(
   }
 
   return { passed: success, newState };
+}
+
+/**
+ * Resultat du test Always Hungry pour un lancer de coequipier.
+ * - `shouldContinueThrow`: `true` si le lancer doit continuer normalement,
+ *   `false` si le coequipier s'est echappe ou s'est fait devorer.
+ * - `newState`: etat mis a jour (logs, turnover, casualty eventuelle).
+ */
+export interface AlwaysHungryResult {
+  shouldContinueThrow: boolean;
+  newState: GameState;
+}
+
+/**
+ * Check Always Hungry (Toujours Affame) roll.
+ * BB2020/BB3 rule (Deathzone Big Guys):
+ *   When a player with Always Hungry attempts to throw a team-mate, they must
+ *   roll a D6 BEFORE the Pass roll.
+ *     - 2+ : the throw continues as normal.
+ *     - 1  : the player tries to eat the team-mate. Roll another D6:
+ *         - 2+ : the team-mate escapes, placed Prone (stunned) in their current
+ *           square. No pass is made. TURNOVER.
+ *         - 1  : the team-mate is EATEN. Removed from play as a casualty
+ *           (Dead). TURNOVER.
+ *
+ * This function does NOT remove the thrower's activation nor mark the action
+ * as taken — the caller (handleThrowTeamMate) remains responsible for the
+ * surrounding action bookkeeping.
+ */
+export function checkAlwaysHungry(
+  state: GameState,
+  thrower: Player,
+  thrown: Player,
+  rng: RNG
+): AlwaysHungryResult {
+  // No always-hungry: always continue (no state change)
+  if (!hasSkill(thrower, 'always-hungry')) {
+    return { shouldContinueThrow: true, newState: state };
+  }
+
+  // First roll: are we hungry?
+  const firstRoll = Math.floor(rng() * 6) + 1;
+  const hungrySuccess = firstRoll >= 2;
+
+  const firstLog = createLogEntry(
+    'dice',
+    `Toujours Affame: ${firstRoll}/2 ${hungrySuccess ? '✓' : '✗'}`,
+    thrower.id,
+    thrower.team,
+    { diceRoll: firstRoll, targetNumber: 2, success: hungrySuccess, skill: 'always-hungry' }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, firstLog],
+  };
+
+  if (hungrySuccess) {
+    // Pas faim — le lancer continue normalement
+    return { shouldContinueThrow: true, newState };
+  }
+
+  // 1 on first roll: try to eat the team-mate. Roll again.
+  const eatRoll = Math.floor(rng() * 6) + 1;
+  const teammateEscapes = eatRoll >= 2;
+
+  const eatLog = createLogEntry(
+    'dice',
+    `Tentative de devorer ${thrown.name}: ${eatRoll}/2 ${teammateEscapes ? '✓ (echappe)' : '✗ (devore)'}`,
+    thrower.id,
+    thrower.team,
+    { diceRoll: eatRoll, targetNumber: 2, success: teammateEscapes, skill: 'always-hungry' }
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, eatLog] };
+
+  if (teammateEscapes) {
+    // Le coequipier s'echappe : place prone (stunned) dans sa case, turnover
+    const escapeLog = createLogEntry(
+      'action',
+      `${thrown.name} s'echappe au dernier moment et tombe au sol !`,
+      thrown.id,
+      thrown.team
+    );
+    newState = {
+      ...newState,
+      gameLog: [...newState.gameLog, escapeLog],
+      isTurnover: true,
+      players: newState.players.map(p =>
+        p.id === thrown.id ? { ...p, stunned: true } : p
+      ),
+    };
+    return { shouldContinueThrow: false, newState };
+  }
+
+  // Double 1: le coequipier est devore (casualty Dead), turnover.
+  const eatenLog = createLogEntry(
+    'action',
+    `${thrower.name} devore ${thrown.name} ! MORT !`,
+    thrower.id,
+    thrower.team,
+    { targetId: thrown.id }
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, eatenLog] };
+
+  // Deplace le coequipier dans la zone casualty du dugout
+  newState = movePlayerToDugoutZone(newState, thrown.id, 'casualty', thrown.team);
+
+  // Marque l'issue de la blessure comme Dead
+  const outcome: CasualtyOutcome = 'dead';
+  newState = {
+    ...newState,
+    casualtyResults: { ...(newState.casualtyResults ?? {}), [thrown.id]: outcome },
+    isTurnover: true,
+  };
+
+  return { shouldContinueThrow: false, newState };
 }


### PR DESCRIPTION
## Resume

Implements the **Always Hungry** negative trait (BB2020/BB3 Deathzone — Big Guys) for players like Troll, Ogre, Trained Troll.

When a player with `always-hungry` attempts a Throw Team-Mate action, a D6 is rolled **before** the Pass roll:
- **2+** — throw continues as normal.
- **1** — the player tries to eat the team-mate. Roll again:
  - **2+** — team-mate escapes, placed Prone (stunned) in their current square. No pass. **Turnover.**
  - **1** — team-mate is **eaten** (removed as casualty `dead`). **Turnover.**

## Roadmap

Closes task **J.9** in Sprint 13 (`TODO.md`).

## Changes

- `packages/game-engine/src/mechanics/negative-traits.ts` — new `checkAlwaysHungry()` + `AlwaysHungryResult` type following the same pattern as `checkBoneHead`/`checkBloodlust` (immutable state, seeded RNG, structured log entries).
- `packages/game-engine/src/actions/actions.ts` — `handleThrowTeamMate()` now consults `checkAlwaysHungry()` before `executeThrowTeamMate()`; on failure the thrower's action is consumed, turnover set, no pass happens.
- `packages/game-engine/src/index.ts` — exports `checkAlwaysHungry` and `AlwaysHungryResult`.
- `packages/game-engine/src/mechanics/always-hungry.test.ts` — 5 new unit tests (no-trait / 2+ / escape / eaten / RNG reproducibility).
- `TODO.md` — tick J.9.

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` — 3295/3295 passing (5 new)
- [x] `pnpm typecheck` — all packages clean
- [x] `pnpm lint` — 0 errors (warnings unchanged, same pattern as existing test files)
- [x] `pnpm --filter @bb/game-engine build` — tsc clean
- [ ] Full monorepo build: `@bb/web` build fails in sandbox on Google Fonts fetch (unrelated, network issue in CI environment)

## Notes

- Trait uses the seeded RNG (`rng()` passed through), no `Math.random()`.
- Pure/immutable state update — returns a new `GameState`, original untouched.
- Casualty is routed through `movePlayerToDugoutZone(..., 'casualty', ...)` and `casualtyResults[id] = 'dead'` — matches the Apothecary/Regeneration contract (though neither applies to being eaten).