### PR TITLE
feat(game-engine): implement Foul Appearance (J.10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -208,7 +208,7 @@
 |---|-------|------|--------|
 | J.8 | Implementer `bloodlust` (3 variantes) | Regle | [x] |
 | J.9 | Implementer `always-hungry` | Regle | [x] |
-| J.10 | Implementer `foul-appearance` | Regle | [ ] |
+| J.10 | Implementer `foul-appearance` | Regle | [x] |
 | J.11 | Implementer `instable` | Regle | [ ] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [ ] |
 | K.2 | Implementer `stab` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -74,7 +74,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry, checkFoulAppearance } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -1140,9 +1140,18 @@ function handleBlock(
     if (!canBlock(state, move.playerId, move.targetId)) return state;
   }
 
+  // ─── Foul Appearance check ─────────────────────────────────────────────
+  // Rolled by the attacker before any block dice. On 1, the declared action
+  // is wasted (no turnover) and the attacker's activation ends.
+  const foulAppearanceCheck = checkFoulAppearance(state, attacker, target, rng, isBlitzDuringMove);
+  if (!foulAppearanceCheck.shouldContinueBlock) {
+    return foulAppearanceCheck.newState;
+  }
+  const stateAfterFA = foulAppearanceCheck.newState;
+
   // Calculer les assists
-  const offensiveAssists = calculateOffensiveAssists(state, attacker, target);
-  const defensiveAssists = calculateDefensiveAssists(state, attacker, target);
+  const offensiveAssists = calculateOffensiveAssists(stateAfterFA, attacker, target);
+  const defensiveAssists = calculateDefensiveAssists(stateAfterFA, attacker, target);
 
   // Nombre de dés et qui choisit
   const attackerStrength = attacker.st + offensiveAssists;
@@ -1153,13 +1162,13 @@ function handleBlock(
   // Enregistrer l'action — blitz consomme le compteur de blitz de l'équipe
   let newState: GameState;
   if (isBlitzDuringMove) {
-    newState = setPlayerAction(state, attacker.id, 'BLITZ');
+    newState = setPlayerAction(stateAfterFA, attacker.id, 'BLITZ');
     newState.teamBlitzCount = {
       ...newState.teamBlitzCount,
       [attacker.team]: (newState.teamBlitzCount[attacker.team] || 0) + 1,
     };
   } else {
-    newState = setPlayerAction(state, attacker.id, 'BLOCK');
+    newState = setPlayerAction(stateAfterFA, attacker.id, 'BLOCK');
   }
 
   // Si un seul dé, résoudre immédiatement
@@ -1556,8 +1565,16 @@ function handleBlitz(
   // Vérifier que le blitz est légal
   if (!canBlitz(state, move.playerId, move.to, move.targetId)) return state;
 
+  // ─── Foul Appearance check ─────────────────────────────────────────────
+  // Rolled by the attacker before the blitz begins. On 1, the declared
+  // action is wasted (no turnover) and the attacker's activation ends.
+  const foulAppearanceCheck = checkFoulAppearance(state, attacker, target, rng, true);
+  if (!foulAppearanceCheck.shouldContinueBlock) {
+    return foulAppearanceCheck.newState;
+  }
+
   // Gérer le changement de joueur
-  let newState = handlePlayerSwitch(state, move.playerId);
+  let newState = handlePlayerSwitch(foulAppearanceCheck.newState, move.playerId);
 
   // 1. Effectuer le mouvement
   const from = attacker.pos;

--- a/packages/game-engine/src/mechanics/foul-appearance.test.ts
+++ b/packages/game-engine/src/mechanics/foul-appearance.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG } from '../index';
+import type { GameState, Move } from '../core/types';
+import { getSkillEffect } from '../skills/skill-registry';
+
+/**
+ * Foul Appearance (Répulsion*) — BB3 Season 2/3:
+ * - When an opposing player declares a Block action targeting this player,
+ *   the attacker's coach must first roll a D6.
+ * - On a 1: the attacker can't perform the declared Block and the action is
+ *   wasted (activation ends). This is NOT a turnover.
+ * - On 2+: the Block proceeds as normal.
+ *
+ * The same check applies to the block portion of a Blitz action.
+ */
+
+function makeTestState(): GameState {
+  const state = setup();
+  return {
+    ...state,
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/**
+ * Place A1 at (5,5) as the attacker and B1 at (6,5) as the target.
+ * Move every other player far away so they do not interfere with the test.
+ */
+function setupFoulAppearanceScenario(
+  baseState: GameState,
+  targetHasFoulAppearance: boolean,
+): GameState {
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    players: baseState.players.map(p => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 6,
+          ma: 6,
+          st: 4,
+          state: 'active' as const,
+          stunned: false,
+          skills: [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'B1') {
+        return {
+          ...p,
+          pos: { x: 6, y: 5 },
+          pm: 6,
+          st: 3,
+          state: 'active' as const,
+          stunned: false,
+          skills: targetHasFoulAppearance ? ['foul-appearance'] : [],
+        };
+      }
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active' as const, stunned: false };
+      }
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active' as const, stunned: false };
+    }),
+  };
+}
+
+const BLOCK_B1: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+
+describe('Regle: Foul Appearance (Répulsion)', () => {
+  describe('Skill Registry', () => {
+    it('foul-appearance is registered in skill registry', () => {
+      const effect = getSkillEffect('foul-appearance');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('foul-appearance');
+    });
+
+    it('foul-appearance has on-block-defender trigger', () => {
+      const effect = getSkillEffect('foul-appearance');
+      expect(effect!.triggers).toContain('on-block-defender');
+    });
+  });
+
+  describe('Foul Appearance activation check on BLOCK', () => {
+    let baseState: GameState;
+
+    beforeEach(() => {
+      baseState = makeTestState();
+    });
+
+    it('target without foul-appearance: no check is rolled', () => {
+      const state = setupFoulAppearanceScenario(baseState, false);
+      const rng = makeRNG('no-fa-seed');
+      const result = applyMove(state, BLOCK_B1, rng);
+
+      const faLogs = result.gameLog.filter(l => l.message.includes('Répulsion'));
+      expect(faLogs).toHaveLength(0);
+    });
+
+    it('roll 2+: block proceeds normally', () => {
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`fa-pass-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const passLog = result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✓')
+        );
+        if (passLog) {
+          found = true;
+          const hasBlock = result.gameLog.some(l =>
+            l.message.includes('Blocage')
+          ) || result.pendingBlock !== undefined;
+          expect(hasBlock).toBe(true);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll 1: block is cancelled (no block dice rolled)', () => {
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`fa-fail-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const blockLogs = result.gameLog.filter(l =>
+            l.message.includes('Blocage')
+          );
+          expect(blockLogs).toHaveLength(0);
+          expect(result.pendingBlock).toBeUndefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll 1 is NOT a turnover', () => {
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`fa-no-to-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.isTurnover).toBe(false);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll 1 consumes the attacker activation (action registered, 0 PM)', () => {
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`fa-consumed-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          expect(result.playerActions['A1']).toBeDefined();
+          const a1 = result.players.find(p => p.id === 'A1')!;
+          expect(a1.pm).toBe(0);
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    it('roll 1 logs a repulsion message', () => {
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const rng = makeRNG(`fa-log-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        const failLog = result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✗')
+        );
+        if (failLog) {
+          found = true;
+          const repLog = result.gameLog.find(l =>
+            l.message.includes('répugné') || l.message.includes('repugne')
+          );
+          expect(repLog).toBeDefined();
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Statistical distribution', () => {
+    it('foul-appearance fails approximately 1/6 of the time', () => {
+      const baseState = makeTestState();
+      const state = setupFoulAppearanceScenario(baseState, true);
+
+      let passes = 0;
+      let fails = 0;
+      for (let seed = 0; seed < 600; seed++) {
+        const rng = makeRNG(`fa-stats-${seed}`);
+        const result = applyMove(state, BLOCK_B1, rng);
+
+        if (result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✓')
+        )) passes++;
+        if (result.gameLog.find(l =>
+          l.message.includes('Répulsion') && l.message.includes('✗')
+        )) fails++;
+      }
+
+      const total = passes + fails;
+      expect(total).toBeGreaterThan(0);
+      const failRate = fails / total;
+      // 1/6 ≈ 16.7%. Generous bounds to avoid flakiness.
+      expect(failRate).toBeGreaterThan(0.08);
+      expect(failRate).toBeLessThan(0.30);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -810,3 +810,101 @@ export function checkAlwaysHungry(
 
   return { shouldContinueThrow: false, newState };
 }
+
+/**
+ * Resultat du test Foul Appearance (Repulsion).
+ * - `shouldContinueBlock`: `true` si le blocage peut se dérouler normalement,
+ *   `false` si l'attaquant est repoussé par l'apparence du défenseur.
+ * - `newState`: état mis à jour (logs, consommation d'activation si échec).
+ */
+export interface FoulAppearanceResult {
+  shouldContinueBlock: boolean;
+  newState: GameState;
+}
+
+/**
+ * Check Foul Appearance (Répulsion) roll.
+ * BB3 Rule (Mutation): when an opposing player declares a Block action targeting
+ * a player with Foul Appearance, the attacker's coach must first roll a D6.
+ * - On 2+: the block proceeds as normal.
+ * - On a 1: the attacker cannot perform the declared block. The action is
+ *   wasted: the attacker's activation ends (pm = 0) without a turnover.
+ *
+ * The check is done by the attacker, but the trait belongs to the target.
+ *
+ * @param state Current game state.
+ * @param attacker Player declaring the Block/Blitz action.
+ * @param target Player being targeted (must have foul-appearance for a roll).
+ * @param rng Seeded RNG.
+ * @param isBlitz When true, the wasted action is recorded as a Blitz (and the
+ *   team's blitz counter is incremented).
+ */
+export function checkFoulAppearance(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+  rng: RNG,
+  isBlitz: boolean = false
+): FoulAppearanceResult {
+  // No foul-appearance on the target: block proceeds (no state change)
+  if (!hasSkill(target, 'foul-appearance')) {
+    return { shouldContinueBlock: true, newState: state };
+  }
+
+  // Roll D6: succeed on 2+
+  const roll = Math.floor(rng() * 6) + 1;
+  const success = roll >= 2;
+
+  const rollLog = createLogEntry(
+    'dice',
+    `Répulsion: ${roll}/2 ${success ? '✓' : '✗'}`,
+    attacker.id,
+    attacker.team,
+    { diceRoll: roll, targetNumber: 2, success, skill: 'foul-appearance', targetId: target.id }
+  );
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, rollLog],
+  };
+
+  if (success) {
+    return { shouldContinueBlock: true, newState };
+  }
+
+  // Failed: the declared block/blitz is wasted. NOT a turnover.
+  const failLog = createLogEntry(
+    'info',
+    `${attacker.name} est répugné par ${target.name} et ne peut pas effectuer son blocage !`,
+    attacker.id,
+    attacker.team
+  );
+  newState = {
+    ...newState,
+    gameLog: [...newState.gameLog, failLog],
+  };
+
+  // Register the wasted action on the attacker
+  const actionType = isBlitz ? 'BLITZ' : 'BLOCK';
+  newState = setPlayerAction(newState, attacker.id, actionType);
+
+  if (isBlitz) {
+    newState = {
+      ...newState,
+      teamBlitzCount: {
+        ...newState.teamBlitzCount,
+        [attacker.team]: (newState.teamBlitzCount[attacker.team] || 0) + 1,
+      },
+    };
+  }
+
+  // End the attacker's activation (no more movement, no GFI)
+  newState = {
+    ...newState,
+    players: newState.players.map(p =>
+      p.id === attacker.id ? { ...p, pm: 0, gfiUsed: 2 } : p
+    ),
+  };
+
+  return { shouldContinueBlock: false, newState };
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -707,3 +707,16 @@ registerSkill({
   description: 'Si ce joueur a une Force de 3 ou moins, il peut être lancé par un coéquipier ayant la compétence Lancer d\'Équipier.',
   canApply: (ctx) => hasSkill(ctx.player, 'right-stuff'),
 });
+
+// ─── FOUL APPEARANCE ───────────────────────────────────────────────────────
+// Foul Appearance check is performed in handleBlock / handleBlitz before any
+// block dice are rolled. The attacker's coach rolls a D6; on 1, the declared
+// block action is wasted (no turnover). Registered here for lookup and
+// metadata purposes.
+
+registerSkill({
+  slug: 'foul-appearance',
+  triggers: ['on-block-defender'],
+  description: 'Quand un joueur adverse déclare un Blocage ciblant ce joueur, l\'attaquant lance un D6 avant le blocage. Sur 1, le blocage est annulé et l\'action est gaspillée.',
+  canApply: (ctx) => hasSkill(ctx.player, 'foul-appearance'),
+});


### PR DESCRIPTION
## Résumé

Implémente le trait BB3 **Foul Appearance (Répulsion)** — tâche roadmap **J.10** du Sprint 13.

Quand un joueur adverse déclare un Blocage ciblant un joueur avec `foul-appearance`, l'attaquant lance un D6 avant toute autre résolution :
- **2+** : le blocage se déroule normalement.
- **1**  : l'action est gaspillée (pas de turnover). L'activation de l'attaquant se termine (`pm = 0`), l'action `BLOCK`/`BLITZ` est enregistrée, et pour un Blitz le compteur d'équipe est incrémenté.

## Changements

- `packages/game-engine/src/mechanics/negative-traits.ts` : nouvelle fonction `checkFoulAppearance(state, attacker, target, rng, isBlitz)` + type `FoulAppearanceResult`.
- `packages/game-engine/src/actions/actions.ts` :
  - hook dans `handleBlock` (couvre `BLOCK` direct + blitz-during-move) après la validation de légalité, avant le premier jet de dé ou `setPlayerAction`.
  - hook dans `handleBlitz` (avant le mouvement), pour que l'action soit effectivement "gaspillée" si elle échoue.
- `packages/game-engine/src/skills/skill-registry.ts` : enregistrement de `foul-appearance` avec le trigger `on-block-defender`.
- `packages/game-engine/src/mechanics/foul-appearance.test.ts` : 9 tests (registry, passages 2+, échec 1, non-turnover, consommation d'activation, log, distribution statistique ~1/6).
- `TODO.md` : case J.10 cochée.

## Tâche roadmap

- Sprint 13 — **J.10 Implementer `foul-appearance`**

## Plan de test

- [x] `pnpm test` (3304 tests, dont 9 nouveaux pour foul-appearance) — ✅
- [x] `pnpm lint` — 0 erreur
- [x] `pnpm typecheck` — ✅
- [x] `pnpm build` — game-engine/server/ui OK (échec `apps/web` uniquement dû à un DNS indisponible pour Google Fonts dans la sandbox, non lié à ce changement)
- [ ] Smoke manuel : déclarer un Block sur un joueur Rotter/Fleshie avec Foul Appearance et vérifier le log `Répulsion: X/2 ✓/✗`