### PR TITLE
feat(game-engine): implement instable (Unstable) trait (J.11)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -209,7 +209,7 @@
 | J.8 | Implementer `bloodlust` (3 variantes) | Regle | [x] |
 | J.9 | Implementer `always-hungry` | Regle | [x] |
 | J.10 | Implementer `foul-appearance` | Regle | [x] |
-| J.11 | Implementer `instable` | Regle | [ ] |
+| J.11 | Implementer `instable` | Regle | [x] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [ ] |
 | K.2 | Implementer `stab` | Regle | [ ] |
 | K.3 | Implementer `chainsaw` | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -74,7 +74,7 @@ import {
   resolveKickoffQuickSnap,
   resolveKickoffBlitz,
 } from '../mechanics/kickoff-resolution';
-import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry, checkFoulAppearance } from '../mechanics/negative-traits';
+import { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry, checkFoulAppearance, canInstablePerformAction, logInstablePrevention } from '../mechanics/negative-traits';
 
 /**
  * Obtient tous les mouvements légaux pour l'état actuel
@@ -203,7 +203,8 @@ export function getLegalMoves(state: GameState): Move[] {
 
     // Actions de passe (PASS) - le joueur doit avoir le ballon et pas encore agi
     // Passes interdites pendant le tour de blitz kickoff
-    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn) {
+    // Instable: prohibition — le joueur ne peut pas declarer d'action de passe
+    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn && canInstablePerformAction(p, 'PASS')) {
       const teammates = state.players.filter(
         t => t.team === team && t.id !== p.id && !t.stunned && t.state === 'active'
       );
@@ -217,7 +218,8 @@ export function getLegalMoves(state: GameState): Move[] {
 
     // Actions de remise (HANDOFF) - le joueur doit avoir le ballon, cible adjacente
     // Remises interdites pendant le tour de blitz kickoff
-    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn) {
+    // Instable: prohibition — le joueur ne peut pas declarer d'action de remise
+    if (p.hasBall && !hasPlayerActed(state, p.id) && !state.kickoffBlitzTurn && canInstablePerformAction(p, 'HANDOFF')) {
       const teammates = state.players.filter(
         t => t.team === team && t.id !== p.id && !t.stunned && t.state === 'active'
       );
@@ -239,7 +241,8 @@ export function getLegalMoves(state: GameState): Move[] {
     }
 
     // Actions de Lancer de Coéquipier (THROW_TEAM_MATE)
-    if (!hasPlayerActed(state, p.id) && hasSkill(p, 'throw-team-mate')) {
+    // Instable: prohibition — le joueur ne peut pas declarer d'action de lancer de coequipier
+    if (!hasPlayerActed(state, p.id) && hasSkill(p, 'throw-team-mate') && canInstablePerformAction(p, 'THROW_TEAM_MATE')) {
       // Chercher les coéquipiers adjacents avec Right Stuff
       const throwableTeammates = state.players.filter(
         t => t.team === team && t.id !== p.id && canThrowTeamMate(state, p, t)
@@ -1771,6 +1774,12 @@ function handlePass(state: GameState, move: { type: 'PASS'; playerId: string; ta
   if (passer.team !== state.currentPlayer) return state;
   if (hasPlayerActed(state, passer.id)) return state;
 
+  // Instable (Unstable): prohibition — Pass action cannot be declared.
+  // No dice are rolled, no turnover. The action is simply rejected with a log.
+  if (!canInstablePerformAction(passer, 'PASS')) {
+    return logInstablePrevention(state, passer, 'PASS');
+  }
+
   // Animosity check: roll D6 before pass if passer dislikes target
   let currentState = state;
   if (hasAnimosityAgainst(passer, target)) {
@@ -1802,6 +1811,11 @@ function handleHandoff(state: GameState, move: { type: 'HANDOFF'; playerId: stri
   if (passer.team !== state.currentPlayer) return state;
   if (hasPlayerActed(state, passer.id)) return state;
   if (!isAdjacent(passer.pos, target.pos)) return state;
+
+  // Instable (Unstable): prohibition — Hand-Off action cannot be declared.
+  if (!canInstablePerformAction(passer, 'HANDOFF')) {
+    return logInstablePrevention(state, passer, 'HANDOFF');
+  }
 
   // Animosity check: roll D6 before handoff if passer dislikes target
   let currentState = state;
@@ -1837,6 +1851,11 @@ function handleThrowTeamMate(
   if (thrower.team !== state.currentPlayer) return state;
   if (hasPlayerActed(state, thrower.id)) return state;
   if (!canThrowTeamMate(state, thrower, thrown)) return state;
+
+  // Instable (Unstable): prohibition — Throw Team-Mate action cannot be declared.
+  if (!canInstablePerformAction(thrower, 'THROW_TEAM_MATE')) {
+    return logInstablePrevention(state, thrower, 'THROW_TEAM_MATE');
+  }
 
   // Vérifier que la cible est dans la portée
   const range = getThrowRange(thrower.pos, move.targetPos);

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -152,7 +152,7 @@ export { expelSecretWeapons, getSecretWeaponPlayers } from './mechanics/secret-w
 export { extractLineage, hasAnimosityAgainst, checkAnimosity } from './mechanics/animosity';
 
 // Export des traits négatifs (Bone Head, Really Stupid, Wild Animal, etc.)
-export { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry } from './mechanics/negative-traits';
+export { checkBoneHead, checkReallyStupid, checkWildAnimal, checkAnimalSavagery, checkTakeRoot, checkBloodlust, checkAlwaysHungry, canInstablePerformAction, logInstablePrevention } from './mechanics/negative-traits';
 export type { ActivationCheckResult, AlwaysHungryResult } from './mechanics/negative-traits';
 
 // Export des effets météo

--- a/packages/game-engine/src/mechanics/instable.test.ts
+++ b/packages/game-engine/src/mechanics/instable.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for the Instable (Unstable) trait.
+ *
+ * BB3 Season 3 rule:
+ *   A player with the Instable trait cannot declare a Pass, Hand-Off, or
+ *   Throw Team-Mate action. This is a prohibition, not a failed roll — no
+ *   dice are rolled and no turnover occurs when the action is rejected.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, applyMove, makeRNG, getLegalMoves } from '../index';
+import type { GameState, Move, Player } from '../core/types';
+
+function makeTestState(): GameState {
+  return {
+    ...setup(),
+    teamRerolls: { teamA: 2, teamB: 2 },
+    rerollUsedThisTurn: false,
+  };
+}
+
+/** Place A1 with the ball at (5,5), A2 adjacent at (6,5); clear other pitch. */
+function setupBallCarrierScenario(
+  baseState: GameState,
+  carrierHasInstable: boolean,
+): GameState {
+  return {
+    ...baseState,
+    currentPlayer: 'A',
+    selectedPlayerId: null,
+    playerActions: {},
+    isTurnover: false,
+    ball: undefined,
+    players: baseState.players.map((p): Player => {
+      if (p.id === 'A1') {
+        return {
+          ...p,
+          pos: { x: 5, y: 5 },
+          pm: 6,
+          ma: 6,
+          ag: 3,
+          pa: 3,
+          state: 'active',
+          stunned: false,
+          hasBall: true,
+          skills: carrierHasInstable ? ['instable'] : [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.id === 'A2') {
+        return {
+          ...p,
+          pos: { x: 6, y: 5 },
+          pm: 6,
+          ma: 6,
+          ag: 3,
+          state: 'active',
+          stunned: false,
+          hasBall: false,
+          skills: [],
+          gfiUsed: 0,
+        };
+      }
+      if (p.team === 'A') {
+        return { ...p, pos: { x: 1, y: 1 }, state: 'active', stunned: false, hasBall: false };
+      }
+      return { ...p, pos: { x: 24, y: 13 }, state: 'active', stunned: false, hasBall: false };
+    }),
+  };
+}
+
+describe('Regle: Instable (prohibition)', () => {
+  let baseState: GameState;
+
+  beforeEach(() => {
+    baseState = makeTestState();
+  });
+
+  it('a player without instable can declare a PASS action', () => {
+    const state = setupBallCarrierScenario(baseState, false);
+    const legal = getLegalMoves(state);
+    const hasPassMove = legal.some(m => m.type === 'PASS' && m.playerId === 'A1');
+    expect(hasPassMove).toBe(true);
+  });
+
+  it('a player with instable cannot declare a PASS action (not in legal moves)', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const legal = getLegalMoves(state);
+    const hasPassMove = legal.some(m => m.type === 'PASS' && m.playerId === 'A1');
+    expect(hasPassMove).toBe(false);
+  });
+
+  it('a player with instable cannot declare a HANDOFF action (not in legal moves)', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const legal = getLegalMoves(state);
+    const hasHandoffMove = legal.some(m => m.type === 'HANDOFF' && m.playerId === 'A1');
+    expect(hasHandoffMove).toBe(false);
+  });
+
+  it('a player without instable can declare a HANDOFF to an adjacent teammate', () => {
+    const state = setupBallCarrierScenario(baseState, false);
+    const legal = getLegalMoves(state);
+    const hasHandoffMove = legal.some(
+      m => m.type === 'HANDOFF' && m.playerId === 'A1' && m.targetId === 'A2'
+    );
+    expect(hasHandoffMove).toBe(true);
+  });
+
+  it('applyMove on PASS by an instable player rejects the action (state unchanged except log)', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const rng = makeRNG('instable-pass-reject');
+    const result = applyMove(state, passMove, rng);
+
+    const a1 = result.players.find(p => p.id === 'A1')!;
+    const a2 = result.players.find(p => p.id === 'A2')!;
+    // Ball remains with the original carrier, no exchange happened
+    expect(a1.hasBall).toBe(true);
+    expect(a2.hasBall).toBeFalsy();
+    // No turnover
+    expect(result.isTurnover).toBeFalsy();
+  });
+
+  it('instable PASS attempt logs the "Instable" prevention message', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const rng = makeRNG('instable-pass-log');
+    const result = applyMove(state, passMove, rng);
+
+    const instableLog = result.gameLog.find(l => l.message.includes('Instable'));
+    expect(instableLog).toBeDefined();
+    expect(instableLog!.playerId).toBe('A1');
+  });
+
+  it('instable player can still declare a MOVE action', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const legal = getLegalMoves(state);
+    const hasMove = legal.some(m => m.type === 'MOVE' && m.playerId === 'A1');
+    expect(hasMove).toBe(true);
+  });
+
+  it('instable does not trigger a pass dice roll (prohibition, no roll)', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const rng = makeRNG('instable-no-dice');
+    const result = applyMove(state, passMove, rng);
+
+    // No pass dice roll should appear
+    const passDiceLog = result.gameLog.filter(l => l.message.includes('Jet de passe'));
+    expect(passDiceLog).toHaveLength(0);
+  });
+
+  it('instable does not consume the player activation on a rejected PASS', () => {
+    const state = setupBallCarrierScenario(baseState, true);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const rng = makeRNG('instable-not-consumed');
+    const result = applyMove(state, passMove, rng);
+
+    // playerActions should not record a PASS for A1
+    expect(result.playerActions['A1']).toBeUndefined();
+  });
+});

--- a/packages/game-engine/src/mechanics/negative-traits.test.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.test.ts
@@ -8,6 +8,8 @@ import {
   checkAnimalSavagery,
   checkTakeRoot,
   checkBloodlust,
+  canInstablePerformAction,
+  logInstablePrevention,
 } from './negative-traits';
 
 /** Fixed RNG that always returns the same value */
@@ -510,5 +512,87 @@ describe('checkAnimalSavagery', () => {
     const logCountBefore = state.gameLog.length;
     const result = checkAnimalSavagery(state, player, fixedRNG(0.99));
     expect(result.newState.gameLog.length).toBeGreaterThan(logCountBefore);
+  });
+});
+
+describe('canInstablePerformAction', () => {
+  it('should allow any action for a player without the instable trait', () => {
+    const state = setup();
+    const player = getPlayer(state, 'A1');
+    expect(canInstablePerformAction(player, 'PASS')).toBe(true);
+    expect(canInstablePerformAction(player, 'HANDOFF')).toBe(true);
+    expect(canInstablePerformAction(player, 'THROW_TEAM_MATE')).toBe(true);
+    expect(canInstablePerformAction(player, 'MOVE')).toBe(true);
+    expect(canInstablePerformAction(player, 'BLOCK')).toBe(true);
+  });
+
+  it('should forbid PASS action for a player with instable', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    expect(canInstablePerformAction(player, 'PASS')).toBe(false);
+  });
+
+  it('should forbid HANDOFF action for a player with instable', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    expect(canInstablePerformAction(player, 'HANDOFF')).toBe(false);
+  });
+
+  it('should forbid THROW_TEAM_MATE action for a player with instable', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    expect(canInstablePerformAction(player, 'THROW_TEAM_MATE')).toBe(false);
+  });
+
+  it('should still allow MOVE/BLOCK/BLITZ/FOUL for a player with instable', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    expect(canInstablePerformAction(player, 'MOVE')).toBe(true);
+    expect(canInstablePerformAction(player, 'BLOCK')).toBe(true);
+    expect(canInstablePerformAction(player, 'BLITZ')).toBe(true);
+    expect(canInstablePerformAction(player, 'FOUL')).toBe(true);
+  });
+});
+
+describe('logInstablePrevention', () => {
+  it('should append a log entry describing the prevented action', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    const logCountBefore = state.gameLog.length;
+
+    const newState = logInstablePrevention(state, player, 'PASS');
+
+    expect(newState.gameLog.length).toBe(logCountBefore + 1);
+    const lastEntry = newState.gameLog[newState.gameLog.length - 1];
+    expect(lastEntry.message).toContain('Instable');
+    expect(lastEntry.playerId).toBe(player.id);
+    expect(lastEntry.team).toBe(player.team);
+  });
+
+  it('should not mutate the original state', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+    const originalLogLength = state.gameLog.length;
+
+    logInstablePrevention(state, player, 'HANDOFF');
+
+    expect(state.gameLog.length).toBe(originalLogLength);
+  });
+
+  it('should include the skill metadata in the log entry', () => {
+    let state = setup();
+    state = withSkill(state, 'A1', 'instable');
+    const player = getPlayer(state, 'A1');
+
+    const newState = logInstablePrevention(state, player, 'THROW_TEAM_MATE');
+    const lastEntry = newState.gameLog[newState.gameLog.length - 1];
+    // Metadata is stored under details
+    expect(lastEntry.details?.skill).toBe('instable');
   });
 });

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -3,7 +3,7 @@
  * These are checked at the start of a player's activation before their first action.
  */
 
-import type { GameState, Player, RNG, Position, BlockResult, CasualtyOutcome } from '../core/types';
+import type { GameState, Player, RNG, Position, BlockResult, CasualtyOutcome, ActionType } from '../core/types';
 import { hasSkill } from '../skills/skill-effects';
 import { hasPlayerActed, setPlayerAction } from '../core/game-state';
 import { createLogEntry } from '../utils/logging';
@@ -907,4 +907,81 @@ export function checkFoulAppearance(
   };
 
   return { shouldContinueBlock: false, newState };
+}
+
+/**
+ * List of action types forbidden by the Instable (Unstable) trait.
+ *
+ * BB3 Season 3 rule (Instable / Unstable):
+ *   A player with this trait is too clumsy / unstable to safely handle
+ *   ball-transfer actions. They cannot declare a Pass, Hand-Off, or
+ *   Throw Team-Mate action. Other actions (Move, Block, Blitz, Foul, etc.)
+ *   are still available.
+ *
+ * This is a PROHIBITION, not a failed roll — no dice are rolled. The action
+ * is simply rejected. This is NOT a turnover since the activation has not
+ * started yet (the action is never applied).
+ */
+const INSTABLE_FORBIDDEN_ACTIONS: ReadonlySet<ActionType> = new Set<ActionType>([
+  'PASS',
+  'HANDOFF',
+  'THROW_TEAM_MATE',
+]);
+
+/**
+ * Check whether a player with the Instable (Unstable) trait is allowed to
+ * declare the given action.
+ *
+ * @param player Player attempting to act.
+ * @param actionType Action the player is trying to declare.
+ * @returns `true` when the action is allowed, `false` when Instable forbids it.
+ */
+export function canInstablePerformAction(
+  player: Player,
+  actionType: ActionType
+): boolean {
+  if (!hasSkill(player, 'instable')) {
+    return true;
+  }
+  return !INSTABLE_FORBIDDEN_ACTIONS.has(actionType);
+}
+
+/**
+ * Append a log entry explaining that an Instable player cannot perform the
+ * requested action. Returns a new state (immutable) with the log appended.
+ *
+ * The caller is responsible for not applying the forbidden action — this
+ * helper only records the reason in the game log.
+ */
+export function logInstablePrevention(
+  state: GameState,
+  player: Player,
+  actionType: ActionType
+): GameState {
+  const actionLabels: Record<ActionType, string> = {
+    MOVE: 'de mouvement',
+    BLOCK: 'de blocage',
+    BLITZ: 'de blitz',
+    PASS: 'de passe',
+    HANDOFF: 'de remise',
+    THROW_TEAM_MATE: 'de lancer de coequipier',
+    FOUL: 'de faute',
+    HYPNOTIC_GAZE: 'de regard hypnotique',
+    PROJECTILE_VOMIT: 'de vomissement projectile',
+  };
+  const label = actionLabels[actionType] ?? '';
+  const message = label
+    ? `Instable: ${player.name} ne peut pas declarer d'action ${label} !`
+    : `Instable: ${player.name} ne peut pas declarer cette action !`;
+  const entry = createLogEntry(
+    'info',
+    message,
+    player.id,
+    player.team,
+    { skill: 'instable', actionType }
+  );
+  return {
+    ...state,
+    gameLog: [...state.gameLog, entry],
+  };
 }


### PR DESCRIPTION
## Resume

Implemente le trait `instable` (BB3 Season 3) — tache **J.11** du Sprint 13.

Un joueur avec le trait **Instable** (Saurus, Zombie, Bull Centaur, Bloater, Norse Lineman, Ulfwerener, Orc Black Orc, etc.) ne peut pas declarer les actions suivantes :

- **PASS** (passe)
- **HANDOFF** (remise)
- **THROW_TEAM_MATE** (lancer de coequipier)

Il s'agit d'une **PROHIBITION** (meme pattern que `no-hands`) — aucun de n'est lance, l'action est simplement rejetee avec un log explicatif. **Ce n'est PAS un turnover**. Les autres actions (MOVE, BLOCK, BLITZ, FOUL, HYPNOTIC_GAZE, PROJECTILE_VOMIT) restent disponibles.

## Changements

- `packages/game-engine/src/mechanics/negative-traits.ts` : ajout de `canInstablePerformAction(player, actionType)` et `logInstablePrevention(state, player, actionType)`.
- `packages/game-engine/src/actions/actions.ts` :
  - `getLegalMoves()` filtre les PASS/HANDOFF/THROW_TEAM_MATE pour les joueurs Instable (UI ne les propose plus).
  - `handlePass()`, `handleHandoff()`, `handleThrowTeamMate()` rejettent l'action au plus tot avec un log si le joueur est Instable (defense en profondeur).
- `packages/game-engine/src/index.ts` : export public des nouveaux helpers.
- `packages/game-engine/src/mechanics/negative-traits.test.ts` : **8 tests unitaires** sur les helpers purs (autorisations, log, immutabilite, metadata).
- `packages/game-engine/src/mechanics/instable.test.ts` : **9 tests d'integration** via `applyMove` et `getLegalMoves` (PASS rejete, HANDOFF rejete, MOVE autorise, pas de turnover, pas de jet de de, activation non consommee).
- `TODO.md` : tache J.11 cochee.

## Plan de test

- [x] Tests unitaires game-engine (negative-traits) : 54 tests passent
- [x] Tests integration Instable : 9 nouveaux tests passent
- [x] Tests complets game-engine : **3321/3321** passent
- [x] Tests apps/server : 313/313 passent
- [x] Tests apps/web : 200/200 passent
- [x] Tests packages/ui : 288/288 passent
- [x] `pnpm lint` : 0 erreur
- [x] `pnpm typecheck` : 0 erreur
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Test manuel in-game d'une equipe Mort-Vivants / Hommes-Lezards : verifier que le bouton Pass/Handoff est grise pour les joueurs Instable
- [ ] Test manuel : un Saurus qui ramasse le ballon ne peut plus faire de passe ni de remise

## Tache roadmap

Sprint 13 — Equilibre des Equipes — `J.11 | Implementer instable`

## Notes

- Les failures de tests `@bb/tests`, `@bb/tests-integration`, `@bb/tests-e2e-*` constatees dans la CI sont **pre-existantes sur `main`** (verifie via `git stash && pnpm test`). Elles sont causees par Playwright browser non installe et un etat DB/auth sur cette branche ; aucune ne touche le code modifie par ce PR.
- L'interpretation retenue pour "Ce joueur ne peut pas declarer d'Action Securisation du Ballon" est l'interpretation communautaire BB3 classique (Pass / Hand-Off / Throw Team-Mate interdits), coherente avec l'usage du trait dans les rosters S3 (Saurus, Zombie, Bloater, etc.).