### PR TITLE
feat(game-engine): implement chainsaw trait (K.3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -212,7 +212,7 @@
 | J.11 | Implementer `instable` | Regle | [x] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [x] |
 | K.2 | Implementer `stab` | Regle | [x] |
-| K.3 | Implementer `chainsaw` | Regle | [ ] |
+| K.3 | Implementer `chainsaw` | Regle | [x] |
 | K.4 | Implementer `dump-off` | Regle | [ ] |
 | K.5 | Implementer `on-the-ball` | Regle | [ ] |
 | TEST-2 | Tests unitaires pour tous les nouveaux skills | Tests | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -69,6 +69,7 @@ import { canThrowTeamMate, getThrowRange, executeThrowTeamMate } from '../mechan
 import { canHypnoticGaze, executeHypnoticGaze } from '../mechanics/hypnotic-gaze';
 import { canProjectileVomit, executeProjectileVomit } from '../mechanics/projectile-vomit';
 import { canStab, executeStab } from '../mechanics/stab';
+import { canChainsaw, executeChainsaw } from '../mechanics/chainsaw';
 import {
   resolveKickoffPerfectDefence,
   resolveKickoffHighKick,
@@ -314,6 +315,16 @@ export function getLegalMoves(state: GameState): Move[] {
       }
     }
 
+    // Actions de Tronçonneuse (CHAINSAW)
+    if (!hasPlayerActed(state, p.id) && hasSkill(p, 'chainsaw')) {
+      const adjacentOpponents = state.players.filter(
+        opp => opp.team !== team && canChainsaw(state, p, opp)
+      );
+      for (const target of adjacentOpponents) {
+        moves.push({ type: 'CHAINSAW', playerId: p.id, targetId: target.id });
+      }
+    }
+
     // END_PLAYER_TURN : permet d'arrêter l'activation d'un joueur en cours
     const pAction = state.playerActions?.[p.id];
     if (pAction === 'MOVE' || pAction === 'BLITZ') {
@@ -480,6 +491,7 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
   const ACTIVATION_MOVE_TYPES: string[] = [
     'MOVE', 'LEAP', 'DODGE', 'BLOCK', 'BLITZ', 'PASS', 'HANDOFF',
     'THROW_TEAM_MATE', 'FOUL', 'HYPNOTIC_GAZE', 'PROJECTILE_VOMIT', 'STAB',
+    'CHAINSAW',
   ];
   if (ACTIVATION_MOVE_TYPES.includes(move.type) && 'playerId' in move) {
     const playerId = (move as { playerId: string }).playerId;
@@ -550,6 +562,8 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       return handleProjectileVomit(activeState, move, rng);
     case 'STAB':
       return handleStab(activeState, move, rng);
+    case 'CHAINSAW':
+      return handleChainsaw(activeState, move, rng);
     case 'KICKOFF_PERFECT_DEFENCE':
       return resolveKickoffPerfectDefence(activeState, move.positions);
     case 'KICKOFF_HIGH_KICK':
@@ -2085,5 +2099,27 @@ function handleStab(
   let newState = executeStab(state, stabber, target, rng);
   newState = setPlayerAction(newState, stabber.id, 'STAB');
   newState = checkPlayerTurnEnd(newState, stabber.id);
+  return newState;
+}
+
+/**
+ * Gère une action de Tronçonneuse (Chainsaw)
+ */
+function handleChainsaw(
+  state: GameState,
+  move: { type: 'CHAINSAW'; playerId: string; targetId: string },
+  rng: RNG,
+): GameState {
+  const attacker = state.players.find(p => p.id === move.playerId);
+  const target = state.players.find(p => p.id === move.targetId);
+
+  if (!attacker || !target) return state;
+  if (attacker.team !== state.currentPlayer) return state;
+  if (hasPlayerActed(state, attacker.id)) return state;
+  if (!canChainsaw(state, attacker, target)) return state;
+
+  let newState = executeChainsaw(state, attacker, target, rng);
+  newState = setPlayerAction(newState, attacker.id, 'CHAINSAW');
+  newState = checkPlayerTurnEnd(newState, attacker.id);
   return newState;
 }

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -306,7 +306,8 @@ export type ActionType =
   | 'FOUL'
   | 'HYPNOTIC_GAZE'
   | 'PROJECTILE_VOMIT'
-  | 'STAB';
+  | 'STAB'
+  | 'CHAINSAW';
 
 export type Move =
   | { type: 'MOVE'; playerId: string; to: Position }
@@ -328,6 +329,7 @@ export type Move =
   | { type: 'HYPNOTIC_GAZE'; playerId: string; targetId: string }
   | { type: 'PROJECTILE_VOMIT'; playerId: string; targetId: string }
   | { type: 'STAB'; playerId: string; targetId: string }
+  | { type: 'CHAINSAW'; playerId: string; targetId: string }
   | { type: 'KICKOFF_PERFECT_DEFENCE'; positions: Array<{ playerId: string; position: Position }> }
   | { type: 'KICKOFF_HIGH_KICK'; playerId: string | null }
   | { type: 'KICKOFF_QUICK_SNAP'; moves: Array<{ playerId: string; to: Position }> }

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -146,6 +146,9 @@ export { canProjectileVomit, executeProjectileVomit } from './mechanics/projecti
 // Export du Poignard (Stab)
 export { canStab, executeStab } from './mechanics/stab';
 
+// Export de la Tronçonneuse (Chainsaw)
+export { canChainsaw, executeChainsaw } from './mechanics/chainsaw';
+
 // Export des fonctions de faute
 export { canFoul, executeFoul, calculateFoulAssists } from './mechanics/foul';
 

--- a/packages/game-engine/src/mechanics/chainsaw.test.ts
+++ b/packages/game-engine/src/mechanics/chainsaw.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import { setup, applyMove, getLegalMoves } from '../index';
+import { GameState, RNG } from '../core/types';
+import { canChainsaw, executeChainsaw } from './chainsaw';
+
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const val = values[i % values.length];
+    i++;
+    return val;
+  };
+}
+
+/**
+ * Joueur Chainsaw A1 at (10,7) with "chainsaw" + "secret-weapon" skills.
+ * Opponent B1 standing at (11,7) — adjacent.
+ * Teammate A2 far away at (5,7).
+ * Opponent B2 far away at (20,7) — non-adjacent.
+ */
+function createChainsawTestState(): GameState {
+  const state = setup();
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Goblin Looney', number: 1,
+      position: 'Looney', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+      skills: ['chainsaw', 'secret-weapon'],
+      pm: 6, hasBall: false, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 5, y: 7 }, name: 'Goblin Lineman', number: 2,
+      position: 'Lineman', ma: 6, st: 2, ag: 3, pa: 4, av: 7, skills: [],
+      pm: 6, hasBall: false, state: 'active',
+    },
+    {
+      id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Human Lineman', number: 1,
+      position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 9, skills: [],
+      pm: 6, hasBall: false, state: 'active',
+    },
+    {
+      id: 'B2', team: 'B', pos: { x: 20, y: 7 }, name: 'Human Blitzer', number: 2,
+      position: 'Blitzer', ma: 7, st: 3, ag: 3, pa: 4, av: 9, skills: [],
+      pm: 7, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = { x: 5, y: 7 };
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamBlitzCount = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 3, teamB: 3 };
+  return state;
+}
+
+describe('Regle: Chainsaw', () => {
+  describe('canChainsaw', () => {
+    it('allows chainsaw when player has chainsaw skill and target is adjacent standing opponent', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      expect(canChainsaw(state, attacker, target)).toBe(true);
+    });
+
+    it('rejects chainsaw when player does not have chainsaw skill', () => {
+      const state = createChainsawTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, skills: [] } : p
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      expect(canChainsaw(state, attacker, target)).toBe(false);
+    });
+
+    it('rejects chainsaw when target is not adjacent', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B2')!;
+      expect(canChainsaw(state, attacker, target)).toBe(false);
+    });
+
+    it('rejects chainsaw when target is a teammate', () => {
+      const state = createChainsawTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A2' ? { ...p, pos: { x: 9, y: 7 } } : p
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const teammate = state.players.find(p => p.id === 'A2')!;
+      expect(canChainsaw(state, attacker, teammate)).toBe(false);
+    });
+
+    it('rejects chainsaw when target is stunned (already prone)', () => {
+      const state = createChainsawTestState();
+      state.players = state.players.map(p =>
+        p.id === 'B1' ? { ...p, stunned: true } : p
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      expect(canChainsaw(state, attacker, target)).toBe(false);
+    });
+
+    it('rejects chainsaw when target is not active (e.g. knocked out)', () => {
+      const state = createChainsawTestState();
+      state.players = state.players.map(p =>
+        p.id === 'B1' ? { ...p, state: 'knocked_out' as const } : p
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      expect(canChainsaw(state, attacker, target)).toBe(false);
+    });
+  });
+
+  describe('executeChainsaw', () => {
+    it('records armor dice result in lastDiceResult with +3 modifier (−3 on target number)', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Dice: 3 + 3 = 6 raw; with +3 → 9 vs AV 9 → break
+      // rng values: (3-1)/6=0.333 → returns 3
+      const rng = makeTestRNG([0.34, 0.34, 0.0, 0.0]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      expect(result.lastDiceResult).toBeDefined();
+      expect(result.lastDiceResult!.type).toBe('armor');
+      expect(result.lastDiceResult!.modifiers).toBe(-3);
+    });
+
+    it('does NOT knock down target when armor holds (even with +3)', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Dice: 1+2=3 raw (not double 1); +3 → 6 vs AV 9 → holds
+      const rng = makeTestRNG([0.05, 0.25]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      const resultTarget = result.players.find(p => p.id === 'B1')!;
+      expect(resultTarget.stunned).toBeFalsy();
+      expect(resultTarget.state).toBe('active');
+    });
+
+    it('performs injury roll when armor is broken (with +3 modifier)', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Dice: 6+6=12 raw; +3 → 15 ≥ AV 9 → break. Injury rolls low → stunned.
+      const rng = makeTestRNG([0.99, 0.99, 0.0, 0.0]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      const injuryLogs = result.gameLog.filter(l => l.message.toLowerCase().includes('blessure'));
+      expect(injuryLogs.length).toBeGreaterThan(0);
+    });
+
+    it('does NOT apply Mighty Blow on armor roll (chainsaw rules)', () => {
+      const state = createChainsawTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, skills: ['chainsaw', 'secret-weapon', 'mighty-blow'] } : p,
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      const rng = makeTestRNG([0.34, 0.34]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      // Modifier should remain −3 (only chainsaw), not −4 (chainsaw+MB).
+      expect(result.lastDiceResult!.modifiers).toBe(-3);
+    });
+
+    it('ends attacker activation (pm = 0) after chainsaw attack', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      const rng = makeTestRNG([0.0, 0.0]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      const resultAttacker = result.players.find(p => p.id === 'A1')!;
+      expect(resultAttacker.pm).toBe(0);
+    });
+
+    it('does NOT cause turnover on normal chainsaw hit', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Not a double 1; armor holds.
+      const rng = makeTestRNG([0.05, 0.25]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      expect(result.isTurnover).toBe(false);
+    });
+
+    it('on natural double 1: chainsaw hits the user (armor roll on attacker)', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Both dice = 1 (natural double 1). Self-armor roll then rolls low → armor holds.
+      const rng = makeTestRNG([0.0, 0.0, 0.05, 0.05]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      // Self armor roll is the last DiceResult and applies to attacker A1.
+      expect(result.lastDiceResult).toBeDefined();
+      expect(result.lastDiceResult!.type).toBe('armor');
+      expect(result.lastDiceResult!.playerId).toBe('A1');
+    });
+
+    it('on natural double 1 causes a turnover', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      const rng = makeTestRNG([0.0, 0.0, 0.0, 0.0]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      expect(result.isTurnover).toBe(true);
+    });
+
+    it('on natural double 1 with broken self-armor, performs injury roll on attacker', () => {
+      const state = createChainsawTestState();
+      // Reduce attacker's AV so self-armor breaks easily.
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, av: 7 } : p,
+      );
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Double 1 (attack), then self-armor 6+6=12 +3 → break, injury low → stunned.
+      const rng = makeTestRNG([0.0, 0.0, 0.99, 0.99, 0.0, 0.0]);
+      const result = executeChainsaw(state, attacker, target, rng);
+      const injuryLogs = result.gameLog.filter(
+        l => l.message.toLowerCase().includes('blessure') && l.playerId === 'A1',
+      );
+      expect(injuryLogs.length).toBeGreaterThan(0);
+    });
+
+    it('adds log entries for the chainsaw action', () => {
+      const state = createChainsawTestState();
+      const attacker = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      const rng = makeTestRNG([0.0, 0.0]);
+      const initialLogLength = state.gameLog.length;
+      const result = executeChainsaw(state, attacker, target, rng);
+      expect(result.gameLog.length).toBeGreaterThan(initialLogLength);
+    });
+  });
+
+  describe('Integration: getLegalMoves', () => {
+    it('generates CHAINSAW moves for players with the chainsaw skill', () => {
+      const state = createChainsawTestState();
+      const moves = getLegalMoves(state);
+      const chainsawMoves = moves.filter(m => m.type === 'CHAINSAW');
+      expect(chainsawMoves.length).toBeGreaterThan(0);
+      const firstChainsaw = chainsawMoves[0] as { type: 'CHAINSAW'; playerId: string; targetId: string };
+      expect(firstChainsaw.playerId).toBe('A1');
+      expect(firstChainsaw.targetId).toBe('B1');
+    });
+
+    it('does not generate CHAINSAW moves if player has already acted', () => {
+      const state = createChainsawTestState();
+      state.playerActions = { A1: 'CHAINSAW' };
+      const moves = getLegalMoves(state);
+      const chainsawMoves = moves.filter(m => m.type === 'CHAINSAW');
+      expect(chainsawMoves.length).toBe(0);
+    });
+
+    it('does not generate CHAINSAW moves for non-adjacent opponents', () => {
+      const state = createChainsawTestState();
+      const moves = getLegalMoves(state);
+      const chainsawMoves = moves.filter(
+        m => m.type === 'CHAINSAW' && (m as { targetId: string }).targetId === 'B2',
+      );
+      expect(chainsawMoves.length).toBe(0);
+    });
+  });
+
+  describe('Integration: applyMove', () => {
+    it('applies CHAINSAW move and records armor result', () => {
+      const state = createChainsawTestState();
+      const rng = makeTestRNG([0.34, 0.34]);
+      const result = applyMove(state, { type: 'CHAINSAW', playerId: 'A1', targetId: 'B1' }, rng);
+      expect(result.lastDiceResult).toBeDefined();
+      expect(result.lastDiceResult!.type).toBe('armor');
+    });
+
+    it('sets player action to CHAINSAW after applying move', () => {
+      const state = createChainsawTestState();
+      const rng = makeTestRNG([0.34, 0.34]);
+      const result = applyMove(state, { type: 'CHAINSAW', playerId: 'A1', targetId: 'B1' }, rng);
+      expect(result.playerActions['A1']).toBe('CHAINSAW');
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/chainsaw.ts
+++ b/packages/game-engine/src/mechanics/chainsaw.ts
@@ -1,0 +1,162 @@
+/**
+ * Mécanique de Tronçonneuse (Chainsaw) pour Blood Bowl — BB3 Season 2/3.
+ *
+ * Règles :
+ * - Le joueur doit posséder le trait "Chainsaw" (Secret Weapon).
+ * - Action spéciale remplaçant un Blocage : cible adjacente (adversaire
+ *   debout et actif).
+ * - Aucun dé de bloc n'est lancé ni assistance de Force appliquée.
+ * - Jet d'armure direct (2D6) contre la cible avec un modificateur de +3
+ *   (on soustrait 3 au "target number" de l'armure).
+ * - Si l'armure est percée → jet de blessure. Mighty Blow ne s'applique PAS
+ *   (ni à l'armure, ni à la blessure).
+ * - La cible n'est PAS mise à terre par le jet lui-même (reste debout si
+ *   l'armure tient ou si la blessure n'aboutit qu'à un état "stunned").
+ * - Un double 1 "naturel" (avant modificateurs) sur le jet d'armure signifie
+ *   que la tronçonneuse touche son utilisateur : jet d'armure sur le joueur
+ *   à +3, suivi d'un jet de blessure si l'armure est percée, et TURNOVER.
+ * - Hors auto-blessure, Chainsaw ne provoque PAS de turnover.
+ * - L'activation du Chainsawyer prend fin immédiatement après l'action
+ *   (pm = 0).
+ */
+
+import { GameState, Player, RNG, DiceResult } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { rollD6, calculateArmorTarget } from '../utils/dice';
+import { performInjuryRoll } from './injury';
+import { createLogEntry } from '../utils/logging';
+import { isAdjacent } from './movement';
+
+const CHAINSAW_ARMOR_BONUS = 3;
+
+/**
+ * Indique si un joueur peut utiliser Chainsaw sur une cible donnée.
+ */
+export function canChainsaw(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+): boolean {
+  if (!hasSkill(attacker, 'chainsaw')) return false;
+  if (attacker.team === target.team) return false;
+  if (!isAdjacent(attacker.pos, target.pos)) return false;
+  if (target.stunned) return false;
+  if (target.state !== undefined && target.state !== 'active') return false;
+  return true;
+}
+
+/**
+ * Construit un DiceResult de type 'armor' à partir de deux dés explicites.
+ * - `bonus` positif s'ajoute à la somme des dés (+3 pour le modificateur chainsaw).
+ * - On conserve la convention existante : `modifiers = -bonus`, cible = av + modifiers
+ *   (c.-à-d. av - bonus), dé brut (non modifié) dans `diceRoll`, et
+ *   `success = true` signifie "armure tient".
+ */
+function buildArmorResult(
+  player: Player,
+  die1: number,
+  die2: number,
+  bonus: number,
+): DiceResult {
+  const modifiers = -bonus;
+  const targetNumber = calculateArmorTarget(player, modifiers);
+  const diceRoll = die1 + die2;
+  const success = diceRoll < targetNumber;
+  return {
+    type: 'armor',
+    playerId: player.id,
+    diceRoll,
+    targetNumber,
+    success,
+    modifiers,
+  };
+}
+
+/**
+ * Exécute une action Chainsaw : jet d'armure direct avec +3.
+ */
+export function executeChainsaw(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+  rng: RNG,
+): GameState {
+  let newState = structuredClone(state) as GameState;
+
+  // Log d'action
+  const actionLog = createLogEntry(
+    'action',
+    `${attacker.name} attaque ${target.name} à la tronçonneuse !`,
+    attacker.id,
+    attacker.team,
+  );
+  newState.gameLog = [...newState.gameLog, actionLog];
+
+  // Jet 2D6 explicite pour détecter le double 1 naturel.
+  const die1 = rollD6(rng);
+  const die2 = rollD6(rng);
+  const naturalDoubleOne = die1 === 1 && die2 === 1;
+
+  if (naturalDoubleOne) {
+    // La tronçonneuse rebondit sur son utilisateur.
+    const selfHitLog = createLogEntry(
+      'action',
+      `Double 1 ! La tronçonneuse échappe et frappe ${attacker.name} !`,
+      attacker.id,
+      attacker.team,
+    );
+    newState.gameLog = [...newState.gameLog, selfHitLog];
+
+    // Jet d'armure sur l'attaquant avec +3.
+    const selfDie1 = rollD6(rng);
+    const selfDie2 = rollD6(rng);
+    const selfArmor = buildArmorResult(attacker, selfDie1, selfDie2, CHAINSAW_ARMOR_BONUS);
+    newState.lastDiceResult = selfArmor;
+
+    const armorLog = createLogEntry(
+      'dice',
+      `Jet d'armure de ${attacker.name}: ${selfDie1 + selfDie2}+${CHAINSAW_ARMOR_BONUS} vs ${attacker.av} ${selfArmor.success ? '(tient)' : '(percée)'}`,
+      attacker.id,
+      attacker.team,
+      { diceRoll: selfArmor.diceRoll, targetNumber: selfArmor.targetNumber, chainsawBonus: CHAINSAW_ARMOR_BONUS },
+    );
+    newState.gameLog = [...newState.gameLog, armorLog];
+
+    if (!selfArmor.success) {
+      const currentAttacker = newState.players.find(p => p.id === attacker.id);
+      if (currentAttacker) {
+        newState = performInjuryRoll(newState, currentAttacker, rng, 0, attacker.id);
+      }
+    }
+
+    // Turnover systématique sur auto-blessure à la tronçonneuse.
+    newState.isTurnover = true;
+  } else {
+    // Jet d'armure sur la cible avec +3 (pas de Mighty Blow).
+    const armorResult = buildArmorResult(target, die1, die2, CHAINSAW_ARMOR_BONUS);
+    newState.lastDiceResult = armorResult;
+
+    const armorLog = createLogEntry(
+      'dice',
+      `Jet d'armure de ${target.name}: ${die1 + die2}+${CHAINSAW_ARMOR_BONUS} vs ${target.av} ${armorResult.success ? '(tient)' : '(percée)'}`,
+      target.id,
+      target.team,
+      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, chainsawBonus: CHAINSAW_ARMOR_BONUS },
+    );
+    newState.gameLog = [...newState.gameLog, armorLog];
+
+    if (!armorResult.success) {
+      const currentTarget = newState.players.find(p => p.id === target.id);
+      if (currentTarget) {
+        newState = performInjuryRoll(newState, currentTarget, rng, 0, attacker.id);
+      }
+    }
+  }
+
+  // L'activation de l'attaquant prend fin.
+  newState.players = newState.players.map(p =>
+    p.id === attacker.id ? { ...p, pm: 0 } : p,
+  );
+
+  return newState;
+}

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -969,6 +969,7 @@ export function logInstablePrevention(
     HYPNOTIC_GAZE: 'de regard hypnotique',
     PROJECTILE_VOMIT: 'de vomissement projectile',
     STAB: 'de poignard',
+    CHAINSAW: 'de tronconneuse',
   };
   const label = actionLabels[actionType] ?? '';
   const message = label


### PR DESCRIPTION
## Resume

Implemente le trait `chainsaw` (BB3) — tache **K.3** du Sprint 13.

Action speciale qui remplace un Blocage : le joueur muni d'une tronconneuse (Secret Weapon) n'effectue aucun jet de bloc ni calcul de Force, mais tente un jet d'armure direct contre une cible adjacente avec un gros bonus... au risque de se decouper lui-meme sur un double 1.

### Regles implementees

- Cible adjacente (adversaire debout et actif).
- Aucun de de bloc, aucune assistance de Force.
- Jet d'armure 2D6 avec **+3 de modificateur** contre la cible.
- Si l'armure est percee → jet de blessure. **Mighty Blow ne s'applique PAS** (ni a l'armure, ni a la blessure).
- La cible **n'est PAS mise a terre** par le jet lui-meme (reste debout si l'armure tient ou si la blessure n'aboutit qu'a un "stunned").
- **Double 1 naturel** (avant modificateurs) : la tronconneuse rebondit sur son utilisateur — jet d'armure sur l'attaquant a +3, suivi d'un jet de blessure si l'armure est percee, et **TURNOVER** systematique.
- Hors auto-blessure, Chainsaw ne provoque PAS de turnover.
- L'activation de l'attaquant prend fin (pm = 0).

## Changements

- `packages/game-engine/src/mechanics/chainsaw.ts` : nouvelles fonctions `canChainsaw()` + `executeChainsaw()`.
- `packages/game-engine/src/mechanics/chainsaw.test.ts` : 21 tests unitaires Vitest (canChainsaw, executeChainsaw, integration getLegalMoves/applyMove).
- `packages/game-engine/src/core/types.ts` : ajout du move/action `CHAINSAW`.
- `packages/game-engine/src/actions/actions.ts` : generation des moves `CHAINSAW` dans `getLegalMoves`, dispatch dans `applyMove`, handler `handleChainsaw()`, inclusion dans `ACTIVATION_MOVE_TYPES` (traits negatifs).
- `packages/game-engine/src/mechanics/negative-traits.ts` : libelle `CHAINSAW` pour `Instable`.
- `packages/game-engine/src/index.ts` : export public `canChainsaw` / `executeChainsaw`.
- `TODO.md` : tache K.3 cochee.

## Plan de test

- [x] Tests unitaires : 21 nouveaux tests Vitest dans `chainsaw.test.ts`
- [x] Tests game-engine : 3388/3388 passent
- [x] Tests serveur : 313/313 passent
- [x] `pnpm lint` : 0 erreur (warnings preexistants uniquement)
- [x] `pnpm typecheck` : 0 erreur
- [x] `pnpm --filter @bb/game-engine run build` : OK
- [ ] Test e2e manuel d'un match avec un Looney Goblin / Chainsaw Ogre (verifier les 3 issues : armure tient, armure percee, double 1 + auto-blessure + turnover)

## Tache roadmap

Sprint 13 — Equilibre des Equipes — `K.3 | Implementer chainsaw`