### PR TITLE
feat(game-engine): implement dump-off skill (K.4)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -213,7 +213,7 @@
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [x] |
 | K.2 | Implementer `stab` | Regle | [x] |
 | K.3 | Implementer `chainsaw` | Regle | [x] |
-| K.4 | Implementer `dump-off` | Regle | [ ] |
+| K.4 | Implementer `dump-off` | Regle | [x] |
 | K.5 | Implementer `on-the-ball` | Regle | [ ] |
 | TEST-2 | Tests unitaires pour tous les nouveaux skills | Tests | [ ] |
 

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -70,6 +70,7 @@ import { canHypnoticGaze, executeHypnoticGaze } from '../mechanics/hypnotic-gaze
 import { canProjectileVomit, executeProjectileVomit } from '../mechanics/projectile-vomit';
 import { canStab, executeStab } from '../mechanics/stab';
 import { canChainsaw, executeChainsaw } from '../mechanics/chainsaw';
+import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import {
   resolveKickoffPerfectDefence,
   resolveKickoffHighKick,
@@ -564,6 +565,8 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       return handleStab(activeState, move, rng);
     case 'CHAINSAW':
       return handleChainsaw(activeState, move, rng);
+    case 'DUMP_OFF_CHOOSE':
+      return handleDumpOffChoose(activeState, move, rng);
     case 'KICKOFF_PERFECT_DEFENCE':
       return resolveKickoffPerfectDefence(activeState, move.positions);
     case 'KICKOFF_HIGH_KICK':
@@ -1251,7 +1254,8 @@ function handleDodge(
 function handleBlock(
   state: GameState,
   move: { type: 'BLOCK'; playerId: string; targetId: string },
-  rng: RNG
+  rng: RNG,
+  options: { skipDumpOff?: boolean } = {}
 ): GameState {
   const attacker = state.players.find(p => p.id === move.playerId);
   const target = state.players.find(p => p.id === move.targetId);
@@ -1269,6 +1273,38 @@ function handleBlock(
   } else {
     // Vérifier que le blocage est légal
     if (!canBlock(state, move.playerId, move.targetId)) return state;
+  }
+
+  // ─── Dump-off check ────────────────────────────────────────────────────
+  // Si la cible possède le skill `dump-off` et a le ballon, elle peut
+  // effectuer une Passe Rapide immédiate avant que les dés de bloc soient
+  // lancés. On interrompt le blocage en posant `pendingDumpOff`. Le blocage
+  // reprend ensuite via `handleDumpOffChoose` (avec `skipDumpOff: true`).
+  if (!options.skipDumpOff && canDumpOff(state, target)) {
+    const receivers = getDumpOffReceivers(state, target);
+    if (receivers.length > 0) {
+      const dumpLog = createLogEntry(
+        'info',
+        `${target.name} peut tenter un Délestage (Dump-off) !`,
+        target.id,
+        target.team,
+        { skill: 'dump-off' },
+      );
+      return {
+        ...state,
+        gameLog: [...state.gameLog, dumpLog],
+        pendingDumpOff: {
+          attackerId: attacker.id,
+          targetId: target.id,
+          receiverOptions: receivers.map(r => r.id),
+          pendingBlockMove: {
+            type: 'BLOCK',
+            playerId: move.playerId,
+            targetId: move.targetId,
+          },
+        },
+      };
+    }
   }
 
   // ─── Foul Appearance check ─────────────────────────────────────────────
@@ -1358,6 +1394,53 @@ function handleBlock(
       },
     };
   }
+}
+
+/**
+ * Gère le choix de Dump-off : la cible d'un blocage (porteuse du ballon, skill
+ * `dump-off`) choisit un receveur pour une Passe Rapide, ou passe son tour de
+ * Dump-off (receiverId = null). Après résolution, le blocage initial reprend.
+ */
+function handleDumpOffChoose(
+  state: GameState,
+  move: { type: 'DUMP_OFF_CHOOSE'; passerId: string; receiverId: string | null },
+  rng: RNG
+): GameState {
+  if (!state.pendingDumpOff) return state;
+  if (state.pendingDumpOff.targetId !== move.passerId) return state;
+
+  const pendingMove = state.pendingDumpOff.pendingBlockMove;
+  const receiverOptions = state.pendingDumpOff.receiverOptions;
+
+  // Nettoyer le pendingDumpOff dans tous les cas
+  const cleared: GameState = { ...state, pendingDumpOff: undefined };
+
+  let afterDumpOff: GameState = cleared;
+
+  if (move.receiverId !== null) {
+    // Vérifier que le receveur choisi est bien éligible (évite triche client)
+    if (!receiverOptions.includes(move.receiverId)) {
+      return cleared;
+    }
+    afterDumpOff = executeDumpOff(cleared, move.passerId, move.receiverId, rng);
+  } else {
+    const skipLog = createLogEntry(
+      'info',
+      `Délestage refusé par le coach défenseur`,
+      move.passerId,
+      undefined,
+      { skill: 'dump-off' },
+    );
+    afterDumpOff = { ...cleared, gameLog: [...cleared.gameLog, skipLog] };
+  }
+
+  // Reprendre le blocage initial en ignorant le nouveau check dump-off
+  if (pendingMove.type === 'BLOCK') {
+    return handleBlock(afterDumpOff, pendingMove, rng, { skipDumpOff: true });
+  }
+  // BLITZ : pour l'instant, non intégré (un follow-up portera l'intégration
+  // complète dans `handleBlitz`). Fallback : on renvoie l'état post-dump-off.
+  return afterDumpOff;
 }
 
 /**

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -136,6 +136,18 @@ export interface GameState {
     totalStrength: number;
     targetStrength: number;
   };
+  // Choix de Dump-off en attente : la cible d'un blocage a le skill `dump-off`
+  // et le ballon. Elle peut choisir un receveur (Quick Pass) ou passer son
+  // tour de Dump-off. Après résolution, le blocage initial reprend via la
+  // `pendingBlockMove` conservée ci-dessous.
+  pendingDumpOff?: {
+    attackerId: string;         // joueur effectuant le blocage (adversaire)
+    targetId: string;           // cible du blocage — passeur potentiel du Dump-off
+    receiverOptions: string[];  // IDs des receveurs éligibles (Quick range)
+    pendingBlockMove:
+      | { type: 'BLOCK'; playerId: string; targetId: string }
+      | { type: 'BLITZ'; playerId: string; to: Position; targetId: string };
+  };
   // Choix de direction de poussée en attente
   pendingPushChoice?: {
     attackerId: string;
@@ -330,6 +342,7 @@ export type Move =
   | { type: 'PROJECTILE_VOMIT'; playerId: string; targetId: string }
   | { type: 'STAB'; playerId: string; targetId: string }
   | { type: 'CHAINSAW'; playerId: string; targetId: string }
+  | { type: 'DUMP_OFF_CHOOSE'; passerId: string; receiverId: string | null }
   | { type: 'KICKOFF_PERFECT_DEFENCE'; positions: Array<{ playerId: string; position: Position }> }
   | { type: 'KICKOFF_HIGH_KICK'; playerId: string | null }
   | { type: 'KICKOFF_QUICK_SNAP'; moves: Array<{ playerId: string; to: Position }> }

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -149,6 +149,9 @@ export { canStab, executeStab } from './mechanics/stab';
 // Export de la Tronçonneuse (Chainsaw)
 export { canChainsaw, executeChainsaw } from './mechanics/chainsaw';
 
+// Export du Délestage (Dump-off)
+export { canDumpOff, getDumpOffReceivers, executeDumpOff } from './mechanics/dump-off';
+
 // Export des fonctions de faute
 export { canFoul, executeFoul, calculateFoulAssists } from './mechanics/foul';
 

--- a/packages/game-engine/src/mechanics/dump-off.test.ts
+++ b/packages/game-engine/src/mechanics/dump-off.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect } from 'vitest';
+import { setup, applyMove } from '../index';
+import { GameState, RNG, Player } from '../core/types';
+import {
+  canDumpOff,
+  getDumpOffReceivers,
+  executeDumpOff,
+} from './dump-off';
+
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const val = values[i % values.length];
+    i++;
+    return val;
+  };
+}
+
+/**
+ * Helper: convert a D6 target (1-6) to an rng() value producing rollD6 === value.
+ * rollD6 = Math.floor(rng() * 6) + 1. For value=V, return (V-1)/6 + 0.01
+ */
+function d6(value: number): number {
+  return (value - 1) / 6 + 0.01;
+}
+
+/**
+ * Scénario de test Dump-off :
+ *  - A1 est le porteur de balle adverse (team A), à (10,7), skill "dump-off", hasBall.
+ *  - B1 (attaquant team B) adjacent à (11,7) — va effectuer un blocage contre A1.
+ *  - A2 (coéquipier de A1) à (8,7) — à portée Quick (distance 2).
+ *  - A3 (coéquipier de A1) à (4,7) — hors de portée Quick (distance 6 = Short).
+ *  - A4 (coéquipier stun) à (9,7) — distance 1 mais stunné, pas éligible.
+ *  - B2 adverse à (5,5).
+ */
+function createDumpOffTestState(): GameState {
+  const state = setup();
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Elf Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8,
+      skills: ['dump-off'],
+      pm: 6, hasBall: true, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 8, y: 7 }, name: 'Elf Catcher', number: 2,
+      position: 'Catcher', ma: 8, st: 2, ag: 3, pa: 4, av: 7, skills: [],
+      pm: 8, hasBall: false, state: 'active',
+    },
+    {
+      id: 'A3', team: 'A', pos: { x: 4, y: 7 }, name: 'Elf Lineman', number: 3,
+      position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: [],
+      pm: 6, hasBall: false, state: 'active',
+    },
+    {
+      id: 'A4', team: 'A', pos: { x: 9, y: 7 }, name: 'Elf Stunned', number: 4,
+      position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: [],
+      pm: 0, hasBall: false, state: 'active', stunned: true,
+    },
+    {
+      id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Orc Blitzer', number: 1,
+      position: 'Blitzer', ma: 6, st: 4, ag: 3, pa: 5, av: 10, skills: [],
+      pm: 6, hasBall: false, state: 'active',
+    },
+    {
+      id: 'B2', team: 'B', pos: { x: 5, y: 5 }, name: 'Orc Lineman', number: 2,
+      position: 'Lineman', ma: 5, st: 3, ag: 3, pa: 5, av: 10, skills: [],
+      pm: 5, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = { x: 10, y: 7 };
+  state.currentPlayer = 'B';
+  state.playerActions = {};
+  state.teamBlitzCount = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 3, teamB: 3 };
+  return state;
+}
+
+function getPlayer(state: GameState, id: string): Player {
+  const p = state.players.find(pl => pl.id === id);
+  if (!p) throw new Error(`Player ${id} not found`);
+  return p;
+}
+
+describe('Regle: Dump-off', () => {
+  describe('canDumpOff', () => {
+    it('allows dump-off when target has the skill, has the ball, and is active', () => {
+      const state = createDumpOffTestState();
+      expect(canDumpOff(state, getPlayer(state, 'A1'))).toBe(true);
+    });
+
+    it('rejects dump-off when target does not have the skill', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, skills: [] } : p
+      );
+      expect(canDumpOff(state, getPlayer(state, 'A1'))).toBe(false);
+    });
+
+    it('rejects dump-off when target does not have the ball', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, hasBall: false } : p
+      );
+      expect(canDumpOff(state, getPlayer(state, 'A1'))).toBe(false);
+    });
+
+    it('rejects dump-off when target is stunned', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, stunned: true } : p
+      );
+      expect(canDumpOff(state, getPlayer(state, 'A1'))).toBe(false);
+    });
+
+    it('rejects dump-off when target is knocked_out', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, state: 'knocked_out' } : p
+      );
+      expect(canDumpOff(state, getPlayer(state, 'A1'))).toBe(false);
+    });
+  });
+
+  describe('getDumpOffReceivers', () => {
+    it('returns teammates within Quick Pass range (distance 1-3)', () => {
+      const state = createDumpOffTestState();
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      const ids = receivers.map(p => p.id);
+      expect(ids).toContain('A2'); // distance 2, Quick
+      expect(ids).not.toContain('A3'); // distance 6, too far
+    });
+
+    it('excludes the passer himself', () => {
+      const state = createDumpOffTestState();
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      expect(receivers.map(p => p.id)).not.toContain('A1');
+    });
+
+    it('excludes opponents', () => {
+      const state = createDumpOffTestState();
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      expect(receivers.map(p => p.id)).not.toContain('B1');
+      expect(receivers.map(p => p.id)).not.toContain('B2');
+    });
+
+    it('excludes stunned teammates', () => {
+      const state = createDumpOffTestState();
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      expect(receivers.map(p => p.id)).not.toContain('A4');
+    });
+
+    it('excludes knocked_out or casualty teammates', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A2' ? { ...p, state: 'knocked_out' } : p
+      );
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      expect(receivers.map(p => p.id)).not.toContain('A2');
+    });
+
+    it('excludes teammates with no-hands', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A2' ? { ...p, skills: ['no-hands'] } : p
+      );
+      const receivers = getDumpOffReceivers(state, getPlayer(state, 'A1'));
+      expect(receivers.map(p => p.id)).not.toContain('A2');
+    });
+  });
+
+  describe('executeDumpOff', () => {
+    it('completes successfully when pass + catch succeed', () => {
+      const state = createDumpOffTestState();
+      // pass roll needs 4+ (pa 3, -1 for adjacent opponent B1, so target = 3+1=4) → roll 5
+      // catch roll needs 3+ (ag 3) → roll 5
+      const rng = makeTestRNG([d6(5), d6(5)]);
+
+      const result = executeDumpOff(state, 'A1', 'A2', rng);
+
+      const receiver = getPlayer(result, 'A2');
+      const passer = getPlayer(result, 'A1');
+      expect(receiver.hasBall).toBe(true);
+      expect(passer.hasBall).toBe(false);
+      expect(result.ball).toBeUndefined();
+    });
+
+    it('never causes a turnover when the Quick Pass fails', () => {
+      const state = createDumpOffTestState();
+      // pass roll fails: roll 1
+      const rng = makeTestRNG([d6(1), d6(1), d6(1), d6(1)]);
+
+      const result = executeDumpOff(state, 'A1', 'A2', rng);
+
+      // The rule: "No Turnover is caused" — isTurnover must NOT be set
+      expect(result.isTurnover).toBe(false);
+      // The passer no longer holds the ball
+      const passer = getPlayer(result, 'A1');
+      expect(passer.hasBall).toBe(false);
+    });
+
+    it('never causes a turnover when the catch fails', () => {
+      const state = createDumpOffTestState();
+      // pass 5 OK, catch 1 fails
+      const rng = makeTestRNG([d6(5), d6(1), d6(1), d6(1)]);
+
+      const result = executeDumpOff(state, 'A1', 'A2', rng);
+
+      expect(result.isTurnover).toBe(false);
+      const passer = getPlayer(result, 'A1');
+      expect(passer.hasBall).toBe(false);
+    });
+
+    it('logs the dump-off action', () => {
+      const state = createDumpOffTestState();
+      const rng = makeTestRNG([d6(5), d6(5)]);
+
+      const result = executeDumpOff(state, 'A1', 'A2', rng);
+
+      const logs = result.gameLog.map(l => l.message).join(' | ');
+      expect(logs).toMatch(/Délestage|Dump-?off/i);
+    });
+
+    it('returns state unchanged if passer not found', () => {
+      const state = createDumpOffTestState();
+      const rng = makeTestRNG([d6(5)]);
+      const result = executeDumpOff(state, 'NOPE', 'A2', rng);
+      expect(result).toBe(state);
+    });
+
+    it('returns state unchanged if receiver not found', () => {
+      const state = createDumpOffTestState();
+      const rng = makeTestRNG([d6(5)]);
+      const result = executeDumpOff(state, 'A1', 'NOPE', rng);
+      expect(result).toBe(state);
+    });
+
+    it('awards touchdown if receiver is in opponent endzone with ball', () => {
+      const state = createDumpOffTestState();
+      // Move A2 to opponent endzone (team A attacks endzone of team B at x=1)
+      state.players = state.players.map(p =>
+        p.id === 'A2' ? { ...p, pos: { x: 10, y: 6 } } : p
+      );
+      const rng = makeTestRNG([d6(5), d6(5)]);
+
+      const result = executeDumpOff(state, 'A1', 'A2', rng);
+
+      const a2 = getPlayer(result, 'A2');
+      // Either hasBall on A2 or TD scored
+      expect(a2.hasBall || result.score.teamA > 0).toBe(true);
+    });
+  });
+
+  describe('Block flow integration', () => {
+    it('triggers pendingDumpOff when B1 blocks ball-carrier A1 with dump-off skill', () => {
+      const state = createDumpOffTestState();
+      // B1 (attacker) blocks A1 (ball carrier with dump-off)
+      const rng = makeTestRNG([d6(5), d6(5), d6(5)]);
+
+      const result = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+
+      expect(result.pendingDumpOff).toBeDefined();
+      expect(result.pendingDumpOff?.attackerId).toBe('B1');
+      expect(result.pendingDumpOff?.targetId).toBe('A1');
+      // A2 is in Quick range (distance 2) → eligible receiver
+      const receiverIds = result.pendingDumpOff?.receiverOptions ?? [];
+      expect(receiverIds).toContain('A2');
+      // Block not resolved yet → no pendingBlock or lastDiceResult of type 'block'
+      expect(result.pendingBlock).toBeUndefined();
+    });
+
+    it('does NOT trigger pendingDumpOff when target does not have dump-off skill', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, skills: [] } : p
+      );
+      const rng = makeTestRNG([d6(5), d6(5), d6(5)]);
+
+      const result = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+
+      expect(result.pendingDumpOff).toBeUndefined();
+    });
+
+    it('does NOT trigger pendingDumpOff when target has no ball', () => {
+      const state = createDumpOffTestState();
+      state.players = state.players.map(p =>
+        p.id === 'A1' ? { ...p, hasBall: false } : p
+      );
+      state.ball = { x: 3, y: 3 };
+      const rng = makeTestRNG([d6(5), d6(5), d6(5)]);
+
+      const result = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+
+      expect(result.pendingDumpOff).toBeUndefined();
+    });
+
+    it('resolves dump-off on DUMP_OFF_CHOOSE with receiverId, then resumes block', () => {
+      const state = createDumpOffTestState();
+      // Step 1: B1 declares a block on A1 → pendingDumpOff set
+      // Step 2: A1 dumps off to A2 (success) → ball moves to A2, then block resolves on empty-handed A1
+      const rng = makeTestRNG([
+        d6(5), d6(5), // pass, catch
+        d6(6),         // block die (2d6 needed is only 1 die: st 4 vs 3 → 2 dice attacker)
+        d6(6),         // second block die
+      ]);
+
+      const afterBlock = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+      expect(afterBlock.pendingDumpOff).toBeDefined();
+
+      const afterDumpOff = applyMove(
+        afterBlock,
+        { type: 'DUMP_OFF_CHOOSE', passerId: 'A1', receiverId: 'A2' },
+        rng
+      );
+
+      // pendingDumpOff cleared
+      expect(afterDumpOff.pendingDumpOff).toBeUndefined();
+      // Ball transferred to A2
+      expect(getPlayer(afterDumpOff, 'A2').hasBall).toBe(true);
+      expect(getPlayer(afterDumpOff, 'A1').hasBall).toBe(false);
+      // Block resumed: either pendingBlock set (multi-dice) or a block result has been applied
+      const blockHappened =
+        afterDumpOff.pendingBlock !== undefined ||
+        afterDumpOff.gameLog.some(l =>
+          l.message.includes('Blocage') || l.message.includes('est mis au sol')
+        );
+      expect(blockHappened).toBe(true);
+    });
+
+    it('resolves block normally when DUMP_OFF_CHOOSE skips with null receiver', () => {
+      const state = createDumpOffTestState();
+      const rng = makeTestRNG([d6(6), d6(6), d6(6)]);
+
+      const afterBlock = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+      expect(afterBlock.pendingDumpOff).toBeDefined();
+
+      const afterSkip = applyMove(
+        afterBlock,
+        { type: 'DUMP_OFF_CHOOSE', passerId: 'A1', receiverId: null },
+        rng
+      );
+
+      expect(afterSkip.pendingDumpOff).toBeUndefined();
+      // A1 still has the ball (dump-off skipped)
+      expect(getPlayer(afterSkip, 'A1').hasBall).toBe(true);
+      // Block has been resolved / progressed
+      const blockProgressed =
+        afterSkip.pendingBlock !== undefined ||
+        afterSkip.gameLog.some(l => l.message.includes('Blocage'));
+      expect(blockProgressed).toBe(true);
+    });
+
+    it('dump-off cannot be attempted when no eligible receivers exist', () => {
+      const state = createDumpOffTestState();
+      // Remove A2 & A3 (only teammates that could receive), keep only A4 stunned
+      state.players = state.players.filter(p =>
+        p.id !== 'A2' && p.id !== 'A3'
+      );
+      const rng = makeTestRNG([d6(6), d6(6), d6(6)]);
+
+      const result = applyMove(state, { type: 'BLOCK', playerId: 'B1', targetId: 'A1' }, rng);
+
+      // No eligible receivers → dump-off cannot interrupt; block proceeds immediately
+      expect(result.pendingDumpOff).toBeUndefined();
+    });
+
+    it('DUMP_OFF_CHOOSE is a no-op when there is no pending dump-off', () => {
+      const state = createDumpOffTestState();
+      const rng = makeTestRNG([d6(5)]);
+
+      const result = applyMove(
+        state,
+        { type: 'DUMP_OFF_CHOOSE', passerId: 'A1', receiverId: 'A2' },
+        rng
+      );
+
+      // State should be effectively unchanged (no dump-off executed)
+      expect(getPlayer(result, 'A1').hasBall).toBe(true);
+      expect(getPlayer(result, 'A2').hasBall).toBe(false);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/dump-off.ts
+++ b/packages/game-engine/src/mechanics/dump-off.ts
@@ -1,0 +1,113 @@
+/**
+ * Mécanique de Délestage (Dump-off) pour Blood Bowl — BB3 Season 2/3.
+ *
+ * Règles :
+ * - Déclenchement : lorsque ce joueur est **désigné comme cible d'une action
+ *   de Blocage** (ou Blitz) et qu'il **possède le ballon**, il peut
+ *   immédiatement effectuer une action de **Passe Rapide** (Quick Pass)
+ *   — interrompant l'activation du joueur adverse effectuant le blocage.
+ * - Un seul Dump-off par blocage/blitz.
+ * - La passe est une **Passe Rapide** (portée 1-3 cases uniquement).
+ * - Les modificateurs classiques s'appliquent (adversaires en zone de tacle
+ *   du passeur/receveur), ainsi que les interceptions.
+ * - **Ne provoque JAMAIS de turnover** si la passe ou la réception échoue
+ *   — le ballon rebondit simplement à l'endroit indiqué (rebond normal).
+ *   Note : un turnover peut tout de même résulter d'un rebond en zone
+ *   adverse, ce qui sort du cadre de cette fonction.
+ * - Après résolution (succès ou échec), le blocage initial se poursuit
+ *   normalement — la cible n'a alors plus le ballon.
+ */
+
+import { GameState, Player, RNG } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { getDistance, getPassRange, executePass } from './passing';
+import { samePos } from './movement';
+import { createLogEntry } from '../utils/logging';
+
+/**
+ * Indique si un joueur cible est éligible pour déclencher un Dump-off.
+ */
+export function canDumpOff(state: GameState, target: Player): boolean {
+  if (!hasSkill(target, 'dump-off')) return false;
+  if (!target.hasBall) return false;
+  if (target.stunned) return false;
+  if (target.state !== undefined && target.state !== 'active') return false;
+  return true;
+}
+
+/**
+ * Liste des coéquipiers pouvant recevoir un Dump-off :
+ * - Même équipe, debout, actif
+ * - À portée de Passe Rapide (1-3 cases)
+ * - Sans `no-hands`
+ */
+export function getDumpOffReceivers(state: GameState, passer: Player): Player[] {
+  return state.players.filter(p => {
+    if (p.id === passer.id) return false;
+    if (p.team !== passer.team) return false;
+    if (p.stunned) return false;
+    if (p.state !== undefined && p.state !== 'active') return false;
+    if (samePos(p.pos, passer.pos)) return false;
+    if (hasSkill(p, 'no-hands')) return false;
+    const range = getPassRange(passer.pos, p.pos);
+    if (range !== 'quick') return false;
+    // Ignore la distance 0 (déjà filtré par samePos) et >3
+    const dist = getDistance(passer.pos, p.pos);
+    if (dist < 1 || dist > 3) return false;
+    return true;
+  });
+}
+
+/**
+ * Exécute une Passe Rapide de Dump-off depuis `passerId` vers `receiverId`.
+ *
+ * IMPORTANT : cette fonction ré-utilise `executePass` pour la mécanique
+ * mais force `isTurnover = false` à la sortie. Le Dump-off ne provoque
+ * jamais de turnover côté attaquant (qui effectue le blocage), ni côté
+ * défenseur (qui n'est pas en phase active).
+ */
+export function executeDumpOff(
+  state: GameState,
+  passerId: string,
+  receiverId: string,
+  rng: RNG,
+): GameState {
+  const passer = state.players.find(p => p.id === passerId);
+  const receiver = state.players.find(p => p.id === receiverId);
+  if (!passer || !receiver) return state;
+
+  const announceLog = createLogEntry(
+    'action',
+    `Délestage (Dump-off) — ${passer.name} tente une Passe Rapide vers ${receiver.name}`,
+    passer.id,
+    passer.team,
+    { skill: 'dump-off' },
+  );
+  let newState: GameState = {
+    ...state,
+    gameLog: [...state.gameLog, announceLog],
+  };
+
+  // Snapshot du drapeau de turnover avant la passe pour le restaurer si la
+  // passe échoue (Dump-off ne cause PAS de turnover).
+  const turnoverBefore = newState.isTurnover;
+
+  newState = executePass(newState, passer, receiver, rng);
+
+  // Dump-off ne provoque jamais de turnover (règle explicite). On restaure
+  // l'état initial de `isTurnover` pour annuler les éventuels flags levés
+  // par `executePass` en cas d'échec de passe/réception/interception.
+  if (newState.isTurnover && !turnoverBefore) {
+    newState = { ...newState, isTurnover: false };
+    const noTurnoverLog = createLogEntry(
+      'info',
+      `Délestage — pas de turnover (règle Dump-off)`,
+      passer.id,
+      passer.team,
+      { skill: 'dump-off' },
+    );
+    newState = { ...newState, gameLog: [...newState.gameLog, noTurnoverLog] };
+  }
+
+  return newState;
+}


### PR DESCRIPTION
## Resume

Implemente le skill passing `dump-off` (BB3) — tache **K.4** du Sprint 13.

Quand un joueur avec `dump-off` est designe comme cible d'une action de Blocage et qu'il possede le ballon, il peut immediatement effectuer une **Passe Rapide** (Quick Pass) vers un coequipier eligible, interrompant l'activation du joueur adverse effectuant le blocage.

### Regles implementees

- Declenchement automatique quand la cible a le skill `dump-off` + `hasBall` + est active.
- **Quick Pass uniquement** (portee 1-3 cases).
- Coequipiers eligibles : meme equipe, debout, actif, sans `no-hands`, a portee Quick.
- Modificateurs classiques de passe/reception (zones de tacle adverses).
- Interceptions possibles selon trajectoire.
- **Aucun turnover** provoque par un echec de la passe ou de la reception (regle explicite BB3).
- Apres resolution (succes ou echec), le blocage initial reprend normalement — la cible n'a alors plus le ballon.
- Refus possible : le coach defenseur peut ignorer le dump-off (`DUMP_OFF_CHOOSE` avec `receiverId: null`) — le blocage resume immediatement.
- Pas de receveurs eligibles : aucun `pendingDumpOff` n'est pose, le blocage se poursuit immediatement.

### Changements

- `packages/game-engine/src/mechanics/dump-off.ts` : nouveau module avec `canDumpOff()`, `getDumpOffReceivers()`, `executeDumpOff()`.
- `packages/game-engine/src/mechanics/dump-off.test.ts` : **25 tests unitaires** Vitest (eligibilite, receveurs, passe/reception, non-turnover, integration complete du flow de blocage).
- `packages/game-engine/src/core/types.ts` : ajout de `pendingDumpOff` dans `GameState` et du move `DUMP_OFF_CHOOSE`.
- `packages/game-engine/src/actions/actions.ts` : check dans `handleBlock` pour poser `pendingDumpOff`, nouveau handler `handleDumpOffChoose` qui execute (ou ignore) le dump-off puis reprend le blocage avec `skipDumpOff: true`.
- `packages/game-engine/src/index.ts` : exports publics de l'API du module.
- `TODO.md` : tache K.4 cochee.

### Limitation connue (follow-up possible)

L'integration cote `handleBlitz` (blitz = mouvement puis blocage) n'est pas dans ce PR — le dump-off se declenche aujourd'hui uniquement sur les actions `BLOCK` pures. Un suivi pourra dupliquer la meme logique dans `handleBlitz`. L'integration UI (popup de choix du receveur) pourra venir en parallele, les types `pendingDumpOff.receiverOptions` et le move `DUMP_OFF_CHOOSE` etant deja exposes.

## Tache roadmap

Sprint 13 — Equilibre des Equipes — `K.4 | Implementer dump-off`.

## Plan de test

- [x] **Tests unitaires** : 25 nouveaux tests Vitest dans `dump-off.test.ts`
  - `canDumpOff` : 5 cas (skill, ballon, stunned, KO, positif)
  - `getDumpOffReceivers` : 6 cas (portee Quick, exclusions, no-hands, KO)
  - `executeDumpOff` : 6 cas (succes, echec passe, echec catch, log, entrees invalides, TD)
  - Integration flow de blocage : 7 cas (pending trigger, non-trigger, resume, skip, no receivers, no-op)
- [x] **Tests game-engine** : 3413/3413 passent (+25 nouveaux)
- [x] **Tests serveur** : 313/313 passent
- [x] `pnpm lint` : 0 erreur
- [x] `pnpm typecheck` : 0 erreur
- [ ] Test e2e manuel d'un match online avec un Elf Thrower (skill dump-off) cible par un blocage, verifier les 3 issues : Quick Pass reussie, passe ratee (pas de turnover), refus du dump-off.
