### PR TITLE
feat(game-engine): implement break-tackle skill (P1.3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -222,7 +222,7 @@
 |---|-------|------|--------|
 | P1.1 | Implementer `stunty` (Skinks, Lineman Gnome, joueurs petits) | Regle | [x] |
 | P1.2 | Implementer `dauntless` (Dwarf Troll Slayer) | Regle | [x] |
-| P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [ ] |
+| P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [x] |
 | P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [ ] |
 | P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [ ] |
 | P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -72,6 +72,7 @@ import { canStab, executeStab } from '../mechanics/stab';
 import { canChainsaw, executeChainsaw } from '../mechanics/chainsaw';
 import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import { checkDauntless } from '../mechanics/dauntless';
+import { canApplyBreakTackle, markBreakTackleUsed } from '../mechanics/break-tackle';
 import {
   resolveKickoffPerfectDefence,
   resolveKickoffHighKick,
@@ -637,6 +638,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
       teamFoulCount: {},
       rerollUsedThisTurn: false,
       hypnotizedPlayers: [],
+      usedBreakTackleThisTurn: [],
     };
   }
 
@@ -654,6 +656,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
     teamFoulCount: {} as Record<string, number>, // Réinitialiser les compteurs de foul
     rerollUsedThisTurn: false, // Réinitialiser le flag de relance
     hypnotizedPlayers: [], // Réinitialiser les joueurs hypnotisés
+    usedBreakTackleThisTurn: [], // Réinitialiser Break Tackle (une fois par tour)
   };
 
   // Log du changement de tour
@@ -803,6 +806,7 @@ function handleDodgeRoll(
   idx: number
 ): GameState {
   // Calculer les modificateurs de désquive (malus pour adversaires à l'arrivée + skills)
+  const breakTackleApplied = canApplyBreakTackle(state, player);
   const baseDodgeModifiers = calculateDodgeModifiers(state, from, to, player.team);
   const skillDodgeModifiers = getDodgeSkillModifiers(state, player, from);
   const dodgeModifiers = baseDodgeModifiers + skillDodgeModifiers;
@@ -812,6 +816,9 @@ function handleDodgeRoll(
 
   let next = structuredClone(state) as GameState;
   next.lastDiceResult = dodgeResult;
+  if (breakTackleApplied) {
+    next = markBreakTackleUsed(next, player.id);
+  }
 
   // Log du jet d'esquive
   const logEntry = createLogEntry(
@@ -1163,6 +1170,7 @@ function handleDodge(
   const to = move.to;
 
   // Calculer les modificateurs de désquive (malus pour adversaires à l'arrivée + skills)
+  const breakTackleApplied = canApplyBreakTackle(state, player);
   const baseDodgeModifiers = calculateDodgeModifiers(state, from, to, player.team);
   const skillDodgeModifiers = getDodgeSkillModifiers(state, player, from);
   const dodgeModifiers = baseDodgeModifiers + skillDodgeModifiers;
@@ -1171,6 +1179,9 @@ function handleDodge(
 
   let next = structuredClone(state) as GameState;
   next.lastDiceResult = dodgeResult;
+  if (breakTackleApplied) {
+    next = markBreakTackleUsed(next, player.id);
+  }
 
   // Log du jet d'esquive
   const dodgeLogEntry = createLogEntry(
@@ -1815,6 +1826,7 @@ function handleBlitz(
 
   if (needsDodge) {
     // Calculer les modificateurs de désquive (adversaires à l'arrivée + skills)
+    const breakTackleApplied = canApplyBreakTackle(newState, attacker);
     const baseDodgeModifiers = calculateDodgeModifiers(newState, from, to, attacker.team);
     const skillDodgeModifiers = getDodgeSkillModifiers(newState, attacker, from);
     const dodgeModifiers = baseDodgeModifiers + skillDodgeModifiers;
@@ -1823,6 +1835,9 @@ function handleBlitz(
     const dodgeResult = performDodgeRollWithNotification(attacker, rng, dodgeModifiers);
 
     newState.lastDiceResult = dodgeResult;
+    if (breakTackleApplied) {
+      newState = markBreakTackleUsed(newState, attacker.id);
+    }
 
     // Log du jet d'esquive
     const dodgeLogEntry = createLogEntry(

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -254,6 +254,8 @@ export interface GameState {
   bribesRemaining: { teamA: number; teamB: number };
   // Joueurs hypnotisés (perdent leur zone de tacle jusqu'à leur prochaine activation)
   hypnotizedPlayers?: string[];
+  // IDs des joueurs qui ont déjà utilisé Break Tackle ce tour (une fois par tour par joueur).
+  usedBreakTackleThisTurn?: string[];
   // Condition météo active pour ce match (persistée depuis le pré-match)
   weatherCondition?: { condition: string; description: string };
   // État pré-match (setup, kickoff, inducements, etc.)

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -168,6 +168,13 @@ export type { ActivationCheckResult, AlwaysHungryResult } from './mechanics/nega
 // Export du skill Dauntless (applique au blocage)
 export { checkDauntless } from './mechanics/dauntless';
 export type { DauntlessCheckResult } from './mechanics/dauntless';
+export {
+  hasBreakTackle,
+  getBreakTackleDodgeBonus,
+  canApplyBreakTackle,
+  hasUsedBreakTackleThisTurn,
+  markBreakTackleUsed,
+} from './mechanics/break-tackle';
 
 // Export des effets météo
 export {

--- a/packages/game-engine/src/mechanics/break-tackle.test.ts
+++ b/packages/game-engine/src/mechanics/break-tackle.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasBreakTackle,
+  getBreakTackleDodgeBonus,
+  canApplyBreakTackle,
+  hasUsedBreakTackleThisTurn,
+  markBreakTackleUsed,
+} from './break-tackle';
+import { getDodgeSkillModifiers } from '../skills/skill-bridge';
+import type { Player, GameState } from '../core/types';
+import { setup } from '../core/game-state';
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Test Player',
+    number: 1,
+    position: 'Lineman',
+    ma: 6, st: 3, ag: 3, pa: 4, av: 9,
+    skills: [],
+    pm: 6,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  const state = setup();
+  state.players = players;
+  return state;
+}
+
+describe('Règle: Break Tackle - detection', () => {
+  it('hasBreakTackle retourne true pour un joueur avec le skill', () => {
+    const player = makePlayer({ skills: ['break-tackle'] });
+    expect(hasBreakTackle(player)).toBe(true);
+  });
+
+  it('hasBreakTackle retourne true pour la variante underscore', () => {
+    const player = makePlayer({ skills: ['break_tackle'] });
+    expect(hasBreakTackle(player)).toBe(true);
+  });
+
+  it('hasBreakTackle retourne false sans le skill', () => {
+    const player = makePlayer({ skills: [] });
+    expect(hasBreakTackle(player)).toBe(false);
+  });
+});
+
+describe('Règle: Break Tackle - bonus au jet d\'esquive', () => {
+  it('retourne ST - AG quand ST > AG (Dwarf Deathroller : ST 7, AG 5)', () => {
+    const deathroller = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    expect(getBreakTackleDodgeBonus(deathroller)).toBe(2);
+  });
+
+  it('retourne +1 quand ST = AG + 1 (Orc Blitzer : ST 4, AG 3)', () => {
+    const blitzer = makePlayer({ skills: ['break-tackle'], st: 4, ag: 3 });
+    expect(getBreakTackleDodgeBonus(blitzer)).toBe(1);
+  });
+
+  it('retourne 0 quand ST = AG', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 3, ag: 3 });
+    expect(getBreakTackleDodgeBonus(player)).toBe(0);
+  });
+
+  it('retourne 0 quand ST < AG (ne pénalise jamais)', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 2, ag: 3 });
+    expect(getBreakTackleDodgeBonus(player)).toBe(0);
+  });
+
+  it('retourne 0 quand le joueur n\'a pas le skill', () => {
+    const player = makePlayer({ skills: [], st: 7, ag: 5 });
+    expect(getBreakTackleDodgeBonus(player)).toBe(0);
+  });
+});
+
+describe('Règle: Break Tackle - tracking once-per-turn', () => {
+  it('canApplyBreakTackle retourne true quand skill present, ST > AG, pas encore utilise', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    expect(canApplyBreakTackle(state, player)).toBe(true);
+  });
+
+  it('canApplyBreakTackle retourne false quand ST <= AG', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 3, ag: 3 });
+    const state = makeState([player]);
+    expect(canApplyBreakTackle(state, player)).toBe(false);
+  });
+
+  it('canApplyBreakTackle retourne false sans le skill', () => {
+    const player = makePlayer({ skills: [], st: 7, ag: 5 });
+    const state = makeState([player]);
+    expect(canApplyBreakTackle(state, player)).toBe(false);
+  });
+
+  it('canApplyBreakTackle retourne false apres une utilisation ce tour', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    const usedState = markBreakTackleUsed(state, player.id);
+    expect(canApplyBreakTackle(usedState, player)).toBe(false);
+  });
+
+  it('hasUsedBreakTackleThisTurn retourne false par defaut', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    expect(hasUsedBreakTackleThisTurn(state, player.id)).toBe(false);
+  });
+
+  it('hasUsedBreakTackleThisTurn retourne true apres markBreakTackleUsed', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    const usedState = markBreakTackleUsed(state, player.id);
+    expect(hasUsedBreakTackleThisTurn(usedState, player.id)).toBe(true);
+  });
+
+  it('markBreakTackleUsed ne mute pas l\'etat source (immuabilite)', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    markBreakTackleUsed(state, player.id);
+    expect(state.usedBreakTackleThisTurn).toBeUndefined();
+  });
+
+  it('markBreakTackleUsed est idempotent pour un meme joueur', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([player]);
+    const once = markBreakTackleUsed(state, player.id);
+    const twice = markBreakTackleUsed(once, player.id);
+    expect(twice.usedBreakTackleThisTurn).toEqual([player.id]);
+  });
+
+  it('markBreakTackleUsed accumule plusieurs joueurs differents', () => {
+    const p1 = makePlayer({ id: 'p1', skills: ['break-tackle'], st: 7, ag: 5 });
+    const p2 = makePlayer({ id: 'p2', skills: ['break-tackle'], st: 5, ag: 4 });
+    const state = makeState([p1, p2]);
+    const afterP1 = markBreakTackleUsed(state, p1.id);
+    const afterP2 = markBreakTackleUsed(afterP1, p2.id);
+    expect(afterP2.usedBreakTackleThisTurn).toEqual([p1.id, p2.id]);
+  });
+});
+
+describe('Règle: Break Tackle - integration dans getDodgeSkillModifiers', () => {
+  it('applique le bonus Break Tackle quand ST > AG et non utilise', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 4, ag: 3 });
+    const state = makeState([player]);
+    const mod = getDodgeSkillModifiers(state, player, player.pos);
+    expect(mod).toBe(1);
+  });
+
+  it('retourne 0 apres utilisation (once per turn)', () => {
+    const player = makePlayer({ skills: ['break-tackle'], st: 4, ag: 3 });
+    const state = makeState([player]);
+    const usedState = markBreakTackleUsed(state, player.id);
+    const mod = getDodgeSkillModifiers(usedState, player, player.pos);
+    expect(mod).toBe(0);
+  });
+
+  it('applique le bonus sur une Deathroller (ST 7, AG 5 => +2)', () => {
+    const deathroller = makePlayer({ skills: ['break-tackle'], st: 7, ag: 5 });
+    const state = makeState([deathroller]);
+    const mod = getDodgeSkillModifiers(state, deathroller, deathroller.pos);
+    expect(mod).toBe(2);
+  });
+});

--- a/packages/game-engine/src/mechanics/break-tackle.ts
+++ b/packages/game-engine/src/mechanics/break-tackle.ts
@@ -1,0 +1,87 @@
+/**
+ * Break Tackle (BB3 Season 2/3 rules).
+ *
+ * Once per team turn, a player with the Break Tackle skill may attempt to
+ * Dodge using their ST characteristic in place of their AG characteristic.
+ *
+ * Implementation:
+ * - Only meaningful when the player's ST is strictly greater than their AG
+ *   (otherwise replacing AG with ST would not help). In that case, we model
+ *   the effect as a dodge-roll bonus equal to `ST - AG`. This is equivalent
+ *   to computing the AG target number using ST instead of AG.
+ * - Usage is tracked per-player per-team-turn via `state.usedBreakTackleThisTurn`.
+ *   The bonus only applies when the player has not yet used Break Tackle
+ *   during the current team turn.
+ * - The tracking array is cleared at the start of each team turn (in
+ *   `handleEndTurn`), matching the lifetime of other per-turn flags
+ *   (`rerollUsedThisTurn`, `teamBlitzCount`, ...).
+ *
+ * Primary users: Dwarf Deathroller (ST 7, AG 5 → +2 on dodge), Orc Blitzer
+ * (ST 4, AG 3 → +1), various Big Guys.
+ */
+
+import type { GameState, Player } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+
+/**
+ * Returns true if the player owns the Break Tackle skill (either slug form).
+ */
+export function hasBreakTackle(player: Player): boolean {
+  return hasSkill(player, 'break-tackle') || hasSkill(player, 'break_tackle');
+}
+
+/**
+ * Returns the raw dodge bonus (ST - AG, never negative) granted by Break Tackle.
+ * Returns 0 when the player lacks the skill or ST <= AG.
+ *
+ * Does NOT take into account the once-per-turn restriction — use
+ * {@link canApplyBreakTackle} for that.
+ */
+export function getBreakTackleDodgeBonus(player: Player): number {
+  if (!hasBreakTackle(player)) return 0;
+  return Math.max(0, player.st - player.ag);
+}
+
+/**
+ * Returns true if the player has already used Break Tackle during the current
+ * team turn.
+ */
+export function hasUsedBreakTackleThisTurn(
+  state: GameState,
+  playerId: string,
+): boolean {
+  return (state.usedBreakTackleThisTurn ?? []).includes(playerId);
+}
+
+/**
+ * Returns true if Break Tackle is applicable right now for this player:
+ * - skill is present,
+ * - ST > AG (otherwise replacing AG with ST is not beneficial),
+ * - the player has not yet used Break Tackle this team turn.
+ */
+export function canApplyBreakTackle(state: GameState, player: Player): boolean {
+  if (!hasBreakTackle(player)) return false;
+  if (player.st <= player.ag) return false;
+  if (hasUsedBreakTackleThisTurn(state, player.id)) return false;
+  return true;
+}
+
+/**
+ * Records that `playerId` has used Break Tackle this turn. Returns a new
+ * GameState; does not mutate the input. Idempotent for the same player.
+ */
+export function markBreakTackleUsed(
+  state: GameState,
+  playerId: string,
+): GameState {
+  const current = state.usedBreakTackleThisTurn ?? [];
+  if (current.includes(playerId)) {
+    return state.usedBreakTackleThisTurn
+      ? state
+      : { ...state, usedBreakTackleThisTurn: current };
+  }
+  return {
+    ...state,
+    usedBreakTackleThisTurn: [...current, playerId],
+  };
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -332,10 +332,18 @@ registerSkill({
 registerSkill({
   slug: 'break-tackle',
   triggers: ['on-dodge'],
-  description: 'Peut utiliser la Force (ST) au lieu de l\'Agilité (AG) pour un jet d\'esquive.',
-  canApply: (ctx) => hasSkill(ctx.player, 'break-tackle') || hasSkill(ctx.player, 'break_tackle'),
+  description: 'Une fois par tour, peut utiliser la Force (ST) au lieu de l\'Agilité (AG) pour un jet d\'esquive.',
+  canApply: (ctx) => {
+    if (!(hasSkill(ctx.player, 'break-tackle') || hasSkill(ctx.player, 'break_tackle'))) {
+      return false;
+    }
+    // Une fois par tour : si déjà utilisé ce tour, le skill ne s'applique plus.
+    const used = ctx.state?.usedBreakTackleThisTurn ?? [];
+    if (used.includes(ctx.player.id)) return false;
+    // Uniquement bénéfique quand ST > AG (remplacer AG par ST plus petit serait défavorable).
+    return ctx.player.st > ctx.player.ag;
+  },
   getModifiers: (ctx) => {
-    // Si ST > AG, c'est avantageux
     if (ctx.player.st > ctx.player.ag) {
       return { dodgeModifier: ctx.player.st - ctx.player.ag };
     }


### PR DESCRIPTION
## Resume

Implemente le skill `break-tackle` (BB3) — tache **P1.3** du Sprint 13.

Une fois par tour d'equipe, un joueur avec Break Tackle peut utiliser sa caracteristique **ST** a la place de l'**AG** pour un jet d'esquive. L'effet est modelise comme un bonus `ST - AG` applique quand ST > AG, equivalent a utiliser ST pour calculer le target number.

Principaux beneficiaires :
- **Dwarf Deathroller** (ST 7, AG 5) → +2 sur les esquives
- **Orc Blitzer** (ST 4, AG 3) → +1 sur les esquives

## Changements

- `packages/game-engine/src/mechanics/break-tackle.ts` : module dedie avec `hasBreakTackle`, `getBreakTackleDodgeBonus`, `canApplyBreakTackle`, `hasUsedBreakTackleThisTurn`, `markBreakTackleUsed`.
- `packages/game-engine/src/mechanics/break-tackle.test.ts` : 20 tests unitaires (detection, bonus, once-per-turn, immuabilite, integration).
- `packages/game-engine/src/core/types.ts` : ajout du champ optionnel `usedBreakTackleThisTurn?: string[]` dans `GameState`.
- `packages/game-engine/src/skills/skill-registry.ts` : `canApply` de break-tackle retourne `false` si deja utilise ce tour.
- `packages/game-engine/src/actions/actions.ts` : marque Break Tackle comme utilise apres application du bonus dans `handleDodgeRoll`, `handleDodge` et `handleBlitz`. Reset du flag dans `handleEndTurn` (changement de tour et fin de tour kickoff blitz).
- `packages/game-engine/src/index.ts` : export public des utilitaires.
- `TODO.md` : tache P1.3 cochee.

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `P1.3 | Implementer break-tackle (Dwarf Deathroller)`

## Plan de test

- [x] Tests unitaires : 20 nouveaux tests Vitest dans `break-tackle.test.ts`
- [x] Tests game-engine : 3460/3460 passent
- [x] Tests serveur : 313/313 passent
- [x] `pnpm lint` : 0 erreur (warnings pre-existants uniquement)
- [x] `pnpm typecheck` : 0 erreur
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Test manuel en match en ligne : faire esquiver un Deathroller (ST 7, AG 5) pour verifier le bonus +2 et le reset au changement de tour
