### PR TITLE
claude/focused-brahmagupta-K5pFs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -223,7 +223,7 @@
 | P1.1 | Implementer `stunty` (Skinks, Lineman Gnome, joueurs petits) | Regle | [x] |
 | P1.2 | Implementer `dauntless` (Dwarf Troll Slayer) | Regle | [x] |
 | P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [x] |
-| P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [ ] |
+| P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [x] |
 | P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [ ] |
 | P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [ ] |
 | P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [ ] |

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -168,6 +168,9 @@ export type { ActivationCheckResult, AlwaysHungryResult } from './mechanics/nega
 // Export du skill Dauntless (applique au blocage)
 export { checkDauntless } from './mechanics/dauntless';
 export type { DauntlessCheckResult } from './mechanics/dauntless';
+
+// Export du skill Juggernaut (applique au blocage lors d'un Blitz)
+export { isJuggernautActive, shouldConvertBothDownToPushBack } from './mechanics/juggernaut';
 export {
   hasBreakTackle,
   getBreakTackleDodgeBonus,

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -20,6 +20,7 @@ import { performArmorRollWithNotification } from '../utils/dice-notifications';
 import { createLogEntry } from '../utils/logging';
 import { canTeamBlitz } from '../core/game-state';
 import { performInjuryRoll, handleSentOff, handleInjuryByCrowd } from './injury';
+import { shouldConvertBothDownToPushBack } from './juggernaut';
 
 /**
  * Applique un chain push : si la case de destination est occupée, le joueur qui s'y trouve
@@ -678,6 +679,26 @@ function handlePlayerDown(state: GameState, attacker: Player, target: Player, rn
  * Wrestle prévaut sur Block (BB2020)
  */
 function handleBothDown(state: GameState, attacker: Player, target: Player, rng: RNG): GameState {
+  // Juggernaut (BB2020): during a Blitz action, a player with Juggernaut may
+  // apply a Both Down result as if it were a Push Back result. When that
+  // happens, Wrestle and Block never enter the resolution because the roll is
+  // no longer treated as Both Down.
+  if (shouldConvertBothDownToPushBack(state, attacker)) {
+    const juggernautLog = createLogEntry(
+      'action',
+      `${attacker.name} utilise Juggernaut : Les Deux Plaqués est traité comme une Poussée`,
+      attacker.id,
+      attacker.team,
+      { skill: 'juggernaut' },
+    );
+    return handlePushBack(
+      { ...state, gameLog: [...state.gameLog, juggernautLog] },
+      attacker,
+      target,
+      rng,
+    );
+  }
+
   const attackerHasWrestle = checkWrestleOnBothDown(attacker, state);
   const targetHasWrestle = checkWrestleOnBothDown(target, state);
   const wrestleActive = attackerHasWrestle || targetHasWrestle;

--- a/packages/game-engine/src/mechanics/juggernaut.test.ts
+++ b/packages/game-engine/src/mechanics/juggernaut.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setup,
+  resolveBlockResult,
+  makeRNG,
+  setPlayerAction,
+  type GameState,
+} from '../index';
+import { isJuggernautActive, shouldConvertBothDownToPushBack } from './juggernaut';
+
+/**
+ * Juggernaut (BB2020 / BB3 rules):
+ * - When this player performs a Blitz action, during the Block step:
+ *   - Apply a Both Down result as if a Push Back result had been rolled instead.
+ *   - Cancel the effect of Fend and Stand Firm on the opposing player for this
+ *     block step.
+ * - Outside of a Blitz action (e.g. a standard Block action), Juggernaut has
+ *   no effect.
+ */
+
+function makeBlockResult(attackerId: string, targetId: string, result: string) {
+  return {
+    type: 'block' as const,
+    playerId: attackerId,
+    targetId: targetId,
+    diceRoll: 2,
+    result: result as 'BOTH_DOWN',
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+function placePlayers(
+  base: GameState,
+  attackerSkills: string[],
+  defenderSkills: string[],
+): GameState {
+  return {
+    ...base,
+    players: base.players.map(p => {
+      if (p.id === 'A2') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 6, skills: attackerSkills };
+      if (p.id === 'B2') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: defenderSkills };
+      // Move everyone else away to avoid interference.
+      if (p.team === 'B' && p.id !== 'B2') return { ...p, pos: { x: 24, y: 13 } };
+      if (p.team === 'A' && p.id !== 'A2') return { ...p, pos: { x: 1, y: 1 } };
+      return p;
+    }),
+  };
+}
+
+describe('Regle: Juggernaut — activation (isJuggernautActive)', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = setup();
+  });
+
+  it("retourne true si le joueur a juggernaut ET l'action est BLITZ", () => {
+    const testState = setPlayerAction(placePlayers(state, ['juggernaut'], []), 'A2', 'BLITZ');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(isJuggernautActive(testState, attacker)).toBe(true);
+  });
+
+  it("retourne false si le joueur n'a pas juggernaut", () => {
+    const testState = setPlayerAction(placePlayers(state, [], []), 'A2', 'BLITZ');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(isJuggernautActive(testState, attacker)).toBe(false);
+  });
+
+  it("retourne false si le joueur a juggernaut mais l'action est BLOCK", () => {
+    const testState = setPlayerAction(placePlayers(state, ['juggernaut'], []), 'A2', 'BLOCK');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(isJuggernautActive(testState, attacker)).toBe(false);
+  });
+
+  it("retourne false si aucune action n'a ete enregistree", () => {
+    const testState = placePlayers(state, ['juggernaut'], []);
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(isJuggernautActive(testState, attacker)).toBe(false);
+  });
+});
+
+describe('Regle: Juggernaut — conversion BOTH_DOWN (shouldConvertBothDownToPushBack)', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = setup();
+  });
+
+  it('convertit si juggernaut actif et pas de Block', () => {
+    const testState = setPlayerAction(placePlayers(state, ['juggernaut'], []), 'A2', 'BLITZ');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(true);
+  });
+
+  it("ne convertit pas si l'attaquant a aussi Block (Block donne un meilleur resultat)", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut', 'block'], []),
+      'A2',
+      'BLITZ',
+    );
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(false);
+  });
+
+  it('ne convertit pas si ce n\'est pas un Blitz', () => {
+    const testState = setPlayerAction(placePlayers(state, ['juggernaut'], []), 'A2', 'BLOCK');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(false);
+  });
+
+  it("ne convertit pas si le joueur n'a pas juggernaut", () => {
+    const testState = setPlayerAction(placePlayers(state, [], []), 'A2', 'BLITZ');
+    const attacker = testState.players.find(p => p.id === 'A2')!;
+    expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(false);
+  });
+});
+
+describe('Regle: Juggernaut — integration BOTH_DOWN lors d\'un Blitz', () => {
+  let state: GameState;
+  let rng: ReturnType<typeof makeRNG>;
+
+  beforeEach(() => {
+    state = setup();
+    rng = makeRNG('juggernaut-seed');
+  });
+
+  it("BOTH_DOWN est converti en PUSH_BACK : aucun joueur n'est a terre, pas de turnover", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], []),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+
+    const attacker = result.players.find(p => p.id === 'A2')!;
+    const defender = result.players.find(p => p.id === 'B2')!;
+
+    expect(attacker.stunned).toBeFalsy();
+    expect(defender.stunned).toBeFalsy();
+    expect(result.isTurnover).toBe(false);
+  });
+
+  it("BOTH_DOWN converti : le defenseur est repousse (sa position change ou une direction est en attente)", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], []),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+    const defender = result.players.find(p => p.id === 'B2')!;
+
+    // Soit le defenseur a bouge (poussee directe), soit un choix de direction est en attente
+    const wasMoved = defender.pos.x !== 11 || defender.pos.y !== 7;
+    expect(wasMoved || result.pendingPushChoice !== undefined).toBe(true);
+  });
+
+  it("aucun jet d'armure n'est lance (Push Back n'en declenche pas)", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], []),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+    const armorLogs = result.gameLog.filter(
+      log => log.type === 'dice' && log.message.includes("Jet d'armure"),
+    );
+    expect(armorLogs).toHaveLength(0);
+  });
+
+  it("un log annonce l'utilisation de Juggernaut", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], []),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+    const juggernautLog = result.gameLog.find(log =>
+      log.message.toLowerCase().includes('juggernaut'),
+    );
+    expect(juggernautLog).toBeDefined();
+  });
+});
+
+describe('Regle: Juggernaut — integration BOTH_DOWN hors Blitz', () => {
+  let state: GameState;
+  let rng: ReturnType<typeof makeRNG>;
+
+  beforeEach(() => {
+    state = setup();
+    rng = makeRNG('juggernaut-seed');
+  });
+
+  it("ne s'active pas lors d'un BLOCK standard : les deux joueurs tombent normalement", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], []),
+      'A2',
+      'BLOCK',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+
+    const attacker = result.players.find(p => p.id === 'A2')!;
+    const defender = result.players.find(p => p.id === 'B2')!;
+
+    expect(attacker.stunned).toBe(true);
+    expect(defender.stunned).toBe(true);
+    expect(result.isTurnover).toBe(true);
+  });
+});
+
+describe('Regle: Juggernaut — interactions avec Block et Wrestle', () => {
+  let state: GameState;
+  let rng: ReturnType<typeof makeRNG>;
+
+  beforeEach(() => {
+    state = setup();
+    rng = makeRNG('juggernaut-seed');
+  });
+
+  it("si l'attaquant a Block + juggernaut : Block prevaut (defenseur tombe, attaquant debout)", () => {
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut', 'block'], []),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+
+    const attacker = result.players.find(p => p.id === 'A2')!;
+    const defender = result.players.find(p => p.id === 'B2')!;
+
+    expect(attacker.stunned).toBeFalsy();
+    expect(defender.stunned).toBe(true);
+    expect(result.isTurnover).toBe(false);
+  });
+
+  it('si le defenseur a Wrestle : Juggernaut prevaut (conversion en Push Back) — le Blitz continue', () => {
+    // Per BB2020 rules, Juggernaut converts the Both Down result itself, so
+    // Wrestle (which requires a Both Down result) no longer applies.
+    const testState = setPlayerAction(
+      placePlayers(state, ['juggernaut'], ['wrestle']),
+      'A2',
+      'BLITZ',
+    );
+    const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+    const result = resolveBlockResult(testState, blockResult, rng);
+
+    const attacker = result.players.find(p => p.id === 'A2')!;
+
+    expect(attacker.stunned).toBeFalsy();
+    expect(result.isTurnover).toBe(false);
+  });
+});

--- a/packages/game-engine/src/mechanics/juggernaut.ts
+++ b/packages/game-engine/src/mechanics/juggernaut.ts
@@ -1,0 +1,45 @@
+/**
+ * Juggernaut (BB2020 / BB3 rules).
+ *
+ * When a player with the Juggernaut skill performs a Blitz action, during the
+ * block step the following effects apply:
+ *  - A `BOTH_DOWN` result may be applied as if it were a `PUSH_BACK` result.
+ *  - The `Fend` and `Stand Firm` skills of the opposing player are cancelled
+ *    for that block step.
+ *
+ * Outside of a Blitz action (e.g. during a standard Block action), Juggernaut
+ * has no effect.
+ *
+ * Auto-resolution note: when the attacker also has the `Block` skill, keeping
+ * the `BOTH_DOWN` result yields a strictly better outcome (defender falls,
+ * attacker stays up). In that case the conversion is skipped.
+ */
+
+import type { GameState, Player } from '../core/types';
+import { getPlayerAction } from '../core/game-state';
+import { hasSkill } from '../skills/skill-effects';
+
+/**
+ * Returns true when the player currently has an active Blitz action and owns
+ * the Juggernaut skill. Used by the block resolution and by opponent skills
+ * (Fend, Stand Firm) that Juggernaut can cancel.
+ */
+export function isJuggernautActive(state: GameState, attacker: Player): boolean {
+  if (!hasSkill(attacker, 'juggernaut')) return false;
+  return getPlayerAction(state, attacker.id) === 'BLITZ';
+}
+
+/**
+ * Returns true when Juggernaut should convert a `BOTH_DOWN` block result into
+ * a `PUSH_BACK`. The conversion is skipped when the attacker also has `Block`
+ * because the standard Block handling yields a better outcome for the
+ * attacker (defender falls, attacker stays up, no turnover).
+ */
+export function shouldConvertBothDownToPushBack(
+  state: GameState,
+  attacker: Player,
+): boolean {
+  if (!isJuggernautActive(state, attacker)) return false;
+  if (hasSkill(attacker, 'block')) return false;
+  return true;
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -361,17 +361,15 @@ registerSkill({
 });
 
 // JUGGERNAUT
+// Effect applied in `mechanics/juggernaut.ts` and invoked from `handleBothDown`
+// in `mechanics/blocking.ts`. The registry entry is kept for lookup and
+// metadata purposes only.
 registerSkill({
   slug: 'juggernaut',
   triggers: ['on-block-attacker'],
-  description: 'Lors d\'un Blitz, BOTH_DOWN et PUSH_BACK sont traités comme POW. Annule Fend et Stand Firm.',
+  description:
+    'Lors d\'un Blitz, un résultat "Les Deux Plaqués" peut être appliqué comme "Repoussé". Annule Fend et Stand Firm pour ce blocage.',
   canApply: (ctx) => hasSkill(ctx.player, 'juggernaut'),
-  modifyBlockResult: (ctx) => {
-    if (ctx.blockResult === 'BOTH_DOWN' || ctx.blockResult === 'PUSH_BACK') {
-      return 'POW';
-    }
-    return null;
-  },
 });
 
 // NERVES OF STEEL


### PR DESCRIPTION
Implements the Juggernaut skill (BB2020/BB3 rules) for Sprint 13 task P1.4.

When a player with Juggernaut performs a Blitz action, they may apply a
Both Down block result as if a Push Back had been rolled instead. The
conversion skips when the attacker also has Block because Block yields a
strictly better outcome (defender knocked down, attacker stays up).

Changes:
- Add `mechanics/juggernaut.ts` exposing `isJuggernautActive` and
  `shouldConvertBothDownToPushBack`. The `isJuggernautActive` helper is
  reusable by future Fend (P1.9) and Stand Firm (P1.5) implementations
  which Juggernaut cancels for the block step.
- Wire the conversion into `handleBothDown` in `mechanics/blocking.ts`.
- Fix the Juggernaut description in `skill-registry.ts` (previous text
  incorrectly claimed Both Down and Push Back become Pow) and drop the
  incorrect `modifyBlockResult` implementation; the effect now lives in
  the dedicated mechanic file.
- Add 15 unit tests covering activation conditions, conversion logic,
  log emission, Block interaction, Wrestle interaction, and standard
  Block (non-blitz) fallback.
- Check off P1.4 in TODO.md.