### PR TITLE
feat(game-engine): implement stand-firm skill (P1.5)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -224,7 +224,7 @@
 | P1.2 | Implementer `dauntless` (Dwarf Troll Slayer) | Regle | [x] |
 | P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [x] |
 | P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [x] |
-| P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [ ] |
+| P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [x] |
 | P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [ ] |
 | P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [ ] |
 | P1.8 | Implementer `shadowing` (Lizardmen Chameleon Skink) | Regle | [ ] |

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -171,6 +171,9 @@ export type { DauntlessCheckResult } from './mechanics/dauntless';
 
 // Export du skill Juggernaut (applique au blocage pendant un blitz)
 export { hasJuggernaut, isJuggernautActiveForBlock } from './mechanics/juggernaut';
+
+// Export du skill Stand Firm (resiste a la poussee sur un blocage)
+export { hasStandFirm, isStandFirmActiveAgainstBlock, isStandFirmActiveAgainstChainPush } from './mechanics/stand-firm';
 export {
   hasBreakTackle,
   getBreakTackleDodgeBonus,

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -21,6 +21,7 @@ import { createLogEntry } from '../utils/logging';
 import { canTeamBlitz } from '../core/game-state';
 import { performInjuryRoll, handleSentOff, handleInjuryByCrowd } from './injury';
 import { isJuggernautActiveForBlock } from './juggernaut';
+import { isStandFirmActiveAgainstBlock, isStandFirmActiveAgainstChainPush } from './stand-firm';
 
 /**
  * Applique un chain push : si la case de destination est occupée, le joueur qui s'y trouve
@@ -35,6 +36,20 @@ export function applyChainPush(
 ): GameState {
   const pushed = state.players.find(p => p.id === pushedPlayerId);
   if (!pushed) return state;
+
+  // Stand Firm : une victime de chain push peut refuser la poussee.
+  // Juggernaut ne neutralise PAS Stand Firm sur une victime de chain push
+  // (seulement sur la cible directe du Blitz).
+  if (isStandFirmActiveAgainstChainPush(pushed)) {
+    const standFirmLog = createLogEntry(
+      'action',
+      `${pushed.name} utilise Stand Firm : resiste au chain push`,
+      pushed.id,
+      pushed.team,
+      { skill: 'stand-firm', blockResult: 'CHAIN_PUSH' }
+    );
+    return { ...state, gameLog: [...state.gameLog, standFirmLog] };
+  }
 
   const newPos = {
     x: pushed.pos.x + direction.x,
@@ -464,6 +479,20 @@ export function handlePushWithChoice(
   blockResult: string,
   rng: RNG
 ): GameState {
+  // Stand Firm : la cible peut refuser la poussee.
+  // Elle tombe dans sa propre case (le knockdown a deja ete applique par l'appelant).
+  // Aucun follow-up n'est possible (la case de la cible reste occupee).
+  if (isStandFirmActiveAgainstBlock(state, target, attacker)) {
+    const standFirmLog = createLogEntry(
+      'action',
+      `${target.name} utilise Stand Firm : tombe sur sa propre case (pas de poussee)`,
+      target.id,
+      target.team,
+      { skill: 'stand-firm', blockResult }
+    );
+    return { ...state, gameLog: [...state.gameLog, standFirmLog] };
+  }
+
   const pushDirections = getPushDirections(attacker.pos, target.pos);
   const availableDirections: Position[] = [];
   let hasOutOfBounds = false;
@@ -821,6 +850,19 @@ function handleBothDown(state: GameState, attacker: Player, target: Player, rng:
  * Gère le résultat PUSH_BACK
  */
 function handlePushBack(state: GameState, attacker: Player, target: Player, rng: RNG): GameState {
+  // Stand Firm : la cible peut choisir de ne pas etre repoussee.
+  // On applique systematiquement la resistance (toujours avantageux).
+  if (isStandFirmActiveAgainstBlock(state, target, attacker)) {
+    const standFirmLog = createLogEntry(
+      'action',
+      `${target.name} utilise Stand Firm : n'est pas repousse(e)`,
+      target.id,
+      target.team,
+      { skill: 'stand-firm', blockResult: 'PUSH_BACK' }
+    );
+    return { ...state, gameLog: [...state.gameLog, standFirmLog] };
+  }
+
   // La cible est repoussée d'une case - vérifier les directions disponibles
   const pushDirections = getPushDirections(attacker.pos, target.pos);
   const availableDirections: Position[] = [];

--- a/packages/game-engine/src/mechanics/stand-firm.test.ts
+++ b/packages/game-engine/src/mechanics/stand-firm.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setup,
+  resolveBlockResult,
+  makeRNG,
+  type GameState,
+} from '../index';
+import { hasStandFirm, isStandFirmActiveAgainstBlock } from './stand-firm';
+
+/**
+ * Stand Firm (BB3 Season 2/3 rules):
+ * - A player with this skill may choose whether or not to be pushed back
+ *   following a Block action. If they choose not to be pushed back, they
+ *   remain in the square they occupy.
+ * - If the block result knocks the defender down (POW, STUMBLE without Dodge),
+ *   the defender falls in their own square (they are NOT pushed before falling).
+ * - Stand Firm resists chain pushes too (the player can choose not to be chain-pushed).
+ * - Juggernaut (on a Blitz) suppresses Stand Firm on the blitz target.
+ *
+ * Primary users:
+ *   - Dwarf Deathroller
+ *   - Treeman (Halflings, Wood Elves, Gnomes)
+ *   - Bodyguard-like positionals (Ogre, Troll, Bloater, etc.)
+ */
+
+function makeBlockResult(
+  attackerId: string,
+  targetId: string,
+  result: 'BOTH_DOWN' | 'PUSH_BACK' | 'POW' | 'STUMBLE' | 'PLAYER_DOWN',
+) {
+  return {
+    type: 'block' as const,
+    playerId: attackerId,
+    targetId: targetId,
+    diceRoll: 2,
+    result,
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+function placePlayersForBlock(
+  baseState: GameState,
+  attackerSkills: string[],
+  defenderSkills: string[],
+  opts: { isBlitz?: boolean; attackerPos?: { x: number; y: number }; defenderPos?: { x: number; y: number } } = {},
+): GameState {
+  const attackerPos = opts.attackerPos ?? { x: 10, y: 7 };
+  const defenderPos = opts.defenderPos ?? { x: 11, y: 7 };
+  const nextState: GameState = {
+    ...baseState,
+    players: baseState.players.map(p => {
+      if (p.id === 'A2')
+        return {
+          ...p,
+          pos: attackerPos,
+          stunned: false,
+          pm: 6,
+          skills: attackerSkills,
+        };
+      if (p.id === 'B2')
+        return {
+          ...p,
+          pos: defenderPos,
+          stunned: false,
+          pm: 6,
+          skills: defenderSkills,
+        };
+      return p;
+    }),
+  };
+  if (opts.isBlitz) {
+    return {
+      ...nextState,
+      playerActions: { ...nextState.playerActions, A2: 'BLITZ' },
+    };
+  }
+  return nextState;
+}
+
+describe('Regle: Stand Firm', () => {
+  let state: GameState;
+  let rng: ReturnType<typeof makeRNG>;
+
+  beforeEach(() => {
+    state = setup();
+    rng = makeRNG('stand-firm-test-seed');
+  });
+
+  describe('helpers', () => {
+    it('hasStandFirm retourne false sans le skill', () => {
+      const p = state.players.find(p => p.id === 'B2')!;
+      expect(hasStandFirm({ ...p, skills: [] })).toBe(false);
+    });
+
+    it('hasStandFirm detecte le skill (slug standard)', () => {
+      const p = state.players.find(p => p.id === 'B2')!;
+      expect(hasStandFirm({ ...p, skills: ['stand-firm'] })).toBe(true);
+    });
+
+    it('hasStandFirm accepte la variante underscore', () => {
+      const p = state.players.find(p => p.id === 'B2')!;
+      expect(hasStandFirm({ ...p, skills: ['stand_firm'] })).toBe(true);
+    });
+
+    it('isStandFirmActiveAgainstBlock retourne true si defenseur a stand-firm', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isStandFirmActiveAgainstBlock(testState, target, attacker)).toBe(true);
+    });
+
+    it('isStandFirmActiveAgainstBlock retourne false sans le skill', () => {
+      const testState = placePlayersForBlock(state, [], []);
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isStandFirmActiveAgainstBlock(testState, target, attacker)).toBe(false);
+    });
+
+    it('isStandFirmActiveAgainstBlock retourne false si attaquant a Juggernaut + Blitz', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['stand-firm'], {
+        isBlitz: true,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isStandFirmActiveAgainstBlock(testState, target, attacker)).toBe(false);
+    });
+
+    it('isStandFirmActiveAgainstBlock retourne true si Juggernaut mais pas Blitz', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['stand-firm'], {
+        isBlitz: false,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isStandFirmActiveAgainstBlock(testState, target, attacker)).toBe(true);
+    });
+  });
+
+  describe('PUSH_BACK', () => {
+    it('ne repousse pas un defenseur avec Stand Firm (reste sur sa case)', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+      const originalPos = testState.players.find(p => p.id === 'B2')!.pos;
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(defender.pos).toEqual(originalPos);
+      expect(defender.stunned).toBeFalsy();
+    });
+
+    it('ne genere pas de pendingFollowUpChoice quand Stand Firm annule le push', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      expect(result.pendingFollowUpChoice).toBeUndefined();
+      expect(result.pendingPushChoice).toBeUndefined();
+    });
+
+    it('log explicite l\'utilisation de Stand Firm', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const standFirmLog = result.gameLog.find(
+        log => log.message.toLowerCase().includes('stand firm')
+          || log.message.toLowerCase().includes('stabilit')
+      );
+      expect(standFirmLog).toBeDefined();
+    });
+
+    it('repousse normalement un defenseur sans Stand Firm', () => {
+      const testState = placePlayersForBlock(state, [], []);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      // Soit un pendingPushChoice (multi-dir) soit un follow-up choice
+      const hasPushFlow = !!(result.pendingPushChoice || result.pendingFollowUpChoice);
+      expect(hasPushFlow).toBe(true);
+    });
+
+    it('Stand Firm protege contre le surf (push vers la foule)', () => {
+      // Defenseur adjacent au bord du terrain - normalement pousse dans la foule
+      const testState = placePlayersForBlock(state, [], ['stand-firm'], {
+        attackerPos: { x: 10, y: 1 },
+        defenderPos: { x: 10, y: 0 },
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(defender.pos).toEqual({ x: 10, y: 0 });
+      // Pas de blessure par foule
+      const crowdLogs = result.gameLog.filter(
+        log => log.message.toLowerCase().includes('foule'),
+      );
+      expect(crowdLogs).toHaveLength(0);
+    });
+  });
+
+  describe('POW et knockdown', () => {
+    it('sur POW, un defenseur avec Stand Firm tombe dans sa propre case (pas de push)', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'POW');
+      const originalPos = testState.players.find(p => p.id === 'B2')!.pos;
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(defender.stunned).toBe(true);
+      expect(defender.pos).toEqual(originalPos);
+      // Pas de follow-up possible car la cible occupe encore sa case
+      expect(result.pendingFollowUpChoice).toBeUndefined();
+      expect(result.pendingPushChoice).toBeUndefined();
+    });
+
+    it('sur STUMBLE (sans Dodge), un defenseur avec Stand Firm tombe en place', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'STUMBLE');
+      const originalPos = testState.players.find(p => p.id === 'B2')!.pos;
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(defender.stunned).toBe(true);
+      expect(defender.pos).toEqual(originalPos);
+    });
+  });
+
+  describe('Juggernaut counter', () => {
+    it('sur PUSH_BACK, Juggernaut + Blitz annule Stand Firm (push se fait)', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['stand-firm'], {
+        isBlitz: true,
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      // Le push doit etre initie (soit resolu direct soit choix en attente)
+      const defender = result.players.find(p => p.id === 'B2')!;
+      const originalPos = { x: 11, y: 7 };
+      const wasPushed = defender.pos.x !== originalPos.x || defender.pos.y !== originalPos.y;
+      const hasPendingChoice = !!(result.pendingPushChoice || result.pendingFollowUpChoice);
+      expect(wasPushed || hasPendingChoice).toBe(true);
+    });
+
+    it('sans Blitz, Juggernaut n\'annule pas Stand Firm', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['stand-firm'], {
+        isBlitz: false,
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+      const originalPos = testState.players.find(p => p.id === 'B2')!.pos;
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(defender.pos).toEqual(originalPos);
+    });
+  });
+
+  describe('BOTH_DOWN', () => {
+    it('sur BOTH_DOWN, Stand Firm n\'empeche pas la chute (pas de push impliqué)', () => {
+      const testState = placePlayersForBlock(state, [], ['stand-firm']);
+      const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      // Les deux joueurs tombent (comportement BOTH_DOWN standard)
+      expect(defender.stunned).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/stand-firm.ts
+++ b/packages/game-engine/src/mechanics/stand-firm.ts
@@ -1,0 +1,58 @@
+/**
+ * Stand Firm (BB3 Season 2/3 rules).
+ *
+ * A player with this skill may choose whether or not to be pushed back
+ * following a Block action. If they choose not to be pushed back, they
+ * remain in the square they occupy.
+ *
+ * Mechanical consequences:
+ *  - On PUSH_BACK: the defender stays put; no follow-up is granted because
+ *    the defender still occupies the target square.
+ *  - On POW / STUMBLE (without Dodge): the defender falls in their own
+ *    square instead of being pushed then falling. No follow-up is granted.
+ *  - BOTH_DOWN does not involve a push, so Stand Firm has no effect there.
+ *  - Stand Firm also resists chain pushes.
+ *
+ * Countered by:
+ *  - Juggernaut (only when the attacker is performing a Blitz action).
+ *
+ * Primary users: Dwarf Deathroller, Treemen (Gnomes/Halflings/Wood Elves),
+ * Bodyguards/Bloaters, and several Star Players.
+ *
+ * In practice, we always let the player "choose" to resist the push — it is
+ * always advantageous for the defender, so there is no reason to decline.
+ */
+
+import type { GameState, Player } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { isJuggernautActiveForBlock } from './juggernaut';
+
+/**
+ * Returns true if the player owns the Stand Firm skill (accepts slug variants).
+ */
+export function hasStandFirm(player: Player): boolean {
+  return hasSkill(player, 'stand-firm') || hasSkill(player, 'stand_firm');
+}
+
+/**
+ * Returns true if the defender has Stand Firm AND the attacker is not
+ * suppressing it via Juggernaut (on a Blitz).
+ */
+export function isStandFirmActiveAgainstBlock(
+  state: GameState,
+  target: Player,
+  attacker: Player,
+): boolean {
+  if (!hasStandFirm(target)) return false;
+  if (isJuggernautActiveForBlock(state, attacker)) return false;
+  return true;
+}
+
+/**
+ * Returns true if the chain-pushed victim can use Stand Firm to resist the
+ * chain push. Juggernaut does NOT nullify Stand Firm on chain-pushed victims
+ * (only on the direct target of the Blitz).
+ */
+export function isStandFirmActiveAgainstChainPush(player: Player): boolean {
+  return hasStandFirm(player);
+}


### PR DESCRIPTION
## Fermée (doublon)

Cette PR est un doublon de #210 qui a été mergée pendant que je travaillais sur P1.5. Les deux implémentations sont très proches (helpers légèrement différents). L'implémentation déjà mergée dans `main` couvre l'ensemble du besoin (Stand Firm sur PUSH_BACK, POW, STUMBLE, chain push, Juggernaut counter).

Aucune action supplémentaire nécessaire — la tâche P1.5 est déjà complétée sur `main` via #210.