### PR TITLE
feat(game-engine): skip juggernaut conversion when attacker has Block

### DIFF
--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -171,7 +171,11 @@ export { checkDauntless } from './mechanics/dauntless';
 export type { DauntlessCheckResult } from './mechanics/dauntless';
 
 // Export du skill Juggernaut (applique au blocage pendant un blitz)
-export { hasJuggernaut, isJuggernautActiveForBlock } from './mechanics/juggernaut';
+export {
+  hasJuggernaut,
+  isJuggernautActiveForBlock,
+  shouldConvertBothDownToPushBack,
+} from './mechanics/juggernaut';
 
 // Export du skill Stand Firm (applique au blocage pour refuser d'etre pousse)
 export {

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -20,7 +20,7 @@ import { performArmorRollWithNotification } from '../utils/dice-notifications';
 import { createLogEntry } from '../utils/logging';
 import { canTeamBlitz } from '../core/game-state';
 import { performInjuryRoll, handleSentOff, handleInjuryByCrowd } from './injury';
-import { isJuggernautActiveForBlock } from './juggernaut';
+import { shouldConvertBothDownToPushBack } from './juggernaut';
 import {
   isStandFirmActiveForBlock,
   isStandFirmActiveForChainPush,
@@ -721,10 +721,11 @@ function handlePlayerDown(state: GameState, attacker: Player, target: Player, rn
  */
 function handleBothDown(state: GameState, attacker: Player, target: Player, rng: RNG): GameState {
   // Juggernaut : pendant un Blitz, l'attaquant peut convertir BOTH_DOWN en
-  // PUSH_BACK. On applique systematiquement la conversion puisque c'est
-  // toujours avantageux pour l'attaquant. La regle annule aussi Wrestle,
-  // Fend et Stand Firm du defenseur cible (traites ici / dans handlePushBack).
-  if (isJuggernautActiveForBlock(state, attacker)) {
+  // PUSH_BACK. `shouldConvertBothDownToPushBack` auto-resout le choix "may" :
+  // on garde BOTH_DOWN quand l'attaquant a Block (Block donne un meilleur
+  // resultat : defenseur au sol, attaquant debout). La regle annule aussi
+  // Wrestle/Fend/Stand Firm du defenseur cible (traites ici / dans handlePushBack).
+  if (shouldConvertBothDownToPushBack(state, attacker)) {
     const juggernautLog = createLogEntry(
       'action',
       `${attacker.name} utilise Juggernaut : BOTH_DOWN devient PUSH_BACK`,

--- a/packages/game-engine/src/mechanics/juggernaut.test.ts
+++ b/packages/game-engine/src/mechanics/juggernaut.test.ts
@@ -5,7 +5,10 @@ import {
   makeRNG,
   type GameState,
 } from '../index';
-import { isJuggernautActiveForBlock } from './juggernaut';
+import {
+  isJuggernautActiveForBlock,
+  shouldConvertBothDownToPushBack,
+} from './juggernaut';
 
 /**
  * Juggernaut (BB3 Season 2/3 rules):
@@ -243,6 +246,60 @@ describe('Regle: Juggernaut', () => {
       // Personne ne tombe, c'est juste une poussee.
       expect(attacker.stunned).toBeFalsy();
       expect(defender.stunned).toBeFalsy();
+    });
+  });
+
+  describe('Auto-choix quand l\'attaquant a aussi Block', () => {
+    it('shouldConvertBothDownToPushBack retourne false si l\'attaquant a Block', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut', 'block'], [], {
+        isBlitz: true,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      // isJuggernautActiveForBlock reste vrai (pour Fend/Stand Firm/Wrestle
+      // annules), mais la conversion BOTH_DOWN → PUSH_BACK est skippee.
+      expect(isJuggernautActiveForBlock(testState, attacker)).toBe(true);
+      expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(false);
+    });
+
+    it('shouldConvertBothDownToPushBack retourne true sans Block', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], [], {
+        isBlitz: true,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      expect(shouldConvertBothDownToPushBack(testState, attacker)).toBe(true);
+    });
+
+    it('BOTH_DOWN avec Block+Juggernaut : Block gagne (defenseur au sol, attaquant debout)', () => {
+      // Avec Block, le comportement standard du BOTH_DOWN est strictement
+      // meilleur (defenseur prone, attaquant debout, pas de turnover) que la
+      // conversion Juggernaut (personne ne tombe, defenseur juste pousse).
+      // On doit donc garder le BOTH_DOWN et laisser Block le resoudre.
+      const testState = placePlayersForBlock(state, ['juggernaut', 'block'], [], {
+        isBlitz: true,
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const attacker = result.players.find(p => p.id === 'A2')!;
+      const defender = result.players.find(p => p.id === 'B2')!;
+      expect(attacker.stunned).toBeFalsy();
+      expect(defender.stunned).toBe(true);
+      expect(result.isTurnover).toBe(false);
+    });
+
+    it('BOTH_DOWN avec Block+Juggernaut : pas de log Juggernaut (conversion skippee)', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut', 'block'], [], {
+        isBlitz: true,
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const juggernautLog = result.gameLog.find(
+        log => log.message.toLowerCase().includes('juggernaut'),
+      );
+      expect(juggernautLog).toBeUndefined();
     });
   });
 });

--- a/packages/game-engine/src/mechanics/juggernaut.ts
+++ b/packages/game-engine/src/mechanics/juggernaut.ts
@@ -13,9 +13,9 @@
  * bestiary).
  *
  * This file only exposes predicates; the actual block-resolution wiring lives
- * in `blocking.ts` (inside `handleBothDown`). We always convert BOTH_DOWN to
- * PUSH_BACK when Juggernaut is active — the attacker always benefits from
- * the conversion, so the "may choose" clause is resolved automatically.
+ * in `blocking.ts` (inside `handleBothDown`). The conversion is "may choose",
+ * so the engine auto-resolves it to whichever option yields the best outcome
+ * for the attacker — see `shouldConvertBothDownToPushBack`.
  */
 
 import type { GameState, Player } from '../core/types';
@@ -39,4 +39,29 @@ export function isJuggernautActiveForBlock(
 ): boolean {
   if (!hasJuggernaut(attacker)) return false;
   return state.playerActions?.[attacker.id] === 'BLITZ';
+}
+
+/**
+ * Decides whether a BOTH_DOWN block result should be converted to PUSH_BACK
+ * under Juggernaut. The rule says "may choose", so we pick the option that is
+ * strictly best for the attacker:
+ *
+ *  - Without Block: convert to PUSH_BACK (nobody falls, no turnover).
+ *  - With Block: keep BOTH_DOWN so the standard Block handling applies
+ *    (attacker stays up, defender falls prone — strictly better outcome).
+ *
+ * The anti-Fend/Stand Firm/Wrestle clauses still apply even when the
+ * conversion is skipped — callers that care about those should use
+ * `isJuggernautActiveForBlock` instead.
+ */
+export function shouldConvertBothDownToPushBack(
+  state: GameState,
+  attacker: Player,
+): boolean {
+  if (!isJuggernautActiveForBlock(state, attacker)) return false;
+  // If the attacker has Block, the standard BOTH_DOWN handling already puts
+  // the defender on the ground while keeping the attacker up — strictly
+  // better than a Push Back. Skip the conversion in that case.
+  if (hasSkill(attacker, 'block')) return false;
+  return true;
 }


### PR DESCRIPTION
## Résumé

Follow-up sur #209. Raffine la conversion **BOTH_DOWN → PUSH_BACK** de Juggernaut pour qu'elle soit skippée quand l'attaquant possède aussi `Block`.

La règle BB2020 dit que Juggernaut « may » convertir un BOTH_DOWN en PUSH_BACK. Le moteur auto-résout donc ce choix vers la meilleure option pour l'attaquant :

| Situation | Avec Block | Sans Block |
|---|---|---|
| Block seul (BOTH_DOWN garde le comportement standard) | Attaquant debout, défenseur au sol, **pas de turnover** | N/A |
| Conversion Juggernaut → PUSH_BACK | Défenseur debout, juste poussé | Défenseur debout, juste poussé |

Avec Block, garder le BOTH_DOWN est strictement meilleur (le défenseur finit au sol au lieu d'être simplement poussé). Le moteur doit donc skipper la conversion.

Les clauses anti-Fend / anti-Stand Firm / anti-Wrestle de Juggernaut continuent de s'appliquer dans tous les cas (le `isJuggernautActiveForBlock` reste vrai).

## Changements

- `packages/game-engine/src/mechanics/juggernaut.ts` : nouveau helper `shouldConvertBothDownToPushBack(state, attacker)` qui skippe la conversion si l'attaquant a Block. Le doc-comment explique l'auto-choix.
- `packages/game-engine/src/mechanics/blocking.ts` : `handleBothDown` appelle maintenant `shouldConvertBothDownToPushBack` au lieu de `isJuggernautActiveForBlock`.
- `packages/game-engine/src/index.ts` : re-export de `shouldConvertBothDownToPushBack`.
- `packages/game-engine/src/mechanics/juggernaut.test.ts` : 4 nouveaux tests :
  - `shouldConvertBothDownToPushBack` retourne `false` avec Block, `true` sans.
  - `isJuggernautActiveForBlock` reste `true` dans les deux cas (pour Fend/Stand Firm/Wrestle).
  - BOTH_DOWN avec Block+Juggernaut : Block gagne (défenseur au sol, attaquant debout, pas de turnover).
  - Aucun log Juggernaut quand la conversion est skippée.

## Plan de test

- [x] Tests unitaires : 16 tests Juggernaut passent (dont 4 nouveaux)
- [x] `pnpm test` (game-engine) : 3495/3495 passent
- [x] `pnpm lint` : 0 erreur
- [x] `pnpm typecheck` : OK
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Test manuel d'un match où un Star Player avec Block+Juggernaut blitz une cible BOTH_DOWN — vérifier que le défenseur tombe et que l'attaquant reste debout

## Tâche roadmap

Follow-up sur Sprint 13 — `P1.4 | Implementer juggernaut (Dwarf Deathroller)`. Les 5 équipes prioritaires actuelles n'ont pas de joueur avec Block+Juggernaut cumulés, mais plusieurs Star Players du jeu combinent les deux (ex. Grashnak Blackhoof, Bertha Bigfist, Morg 'n' Thorg), donc le raffinement évite de mal auto-résoudre leurs blitz.
