### PR TITLE
chore(sprint-13): cocher J.10 foul-appearance (deja implemente)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -222,7 +222,7 @@
 |---|-------|------|--------|
 | J.8 | Implementer `bloodlust` (3 variantes) | Regle | [x] |
 | J.9 | Implementer `always-hungry` | Regle | [x] |
-| J.10 | Implementer `foul-appearance` | Regle | [ ] |
+| J.10 | Implementer `foul-appearance` | Regle | [x] |
 | J.11 | Implementer `instable` | Regle | [ ] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [ ] |
 | K.2 | Implementer `stab` | Regle | [ ] |


### PR DESCRIPTION
## Resume

Tache **J.10 Sprint 13** : Implementer `foul-appearance` (Repulsion).

La compétence est **déjà implémentée et testée** dans la codebase. Cette PR coche simplement la case dans `TODO.md` pour refléter l'état réel.

## Etat de l'implementation

- **Mécanique** : `packages/game-engine/src/mechanics/negative-traits.ts` → `checkFoulAppearance()`
- **Câblage** : `packages/game-engine/src/actions/actions.ts`
  - `handleBlock` (ligne 1325)
  - `handleBlitz` (ligne 1812)
- **Registre** : `packages/game-engine/src/skills/skill-registry.ts` → trigger `on-block-defender`

## Règle BB3 Season 2/3

Quand un joueur adverse déclare un Blocage ciblant un joueur avec Foul Appearance :
- L'attaquant lance un D6 **avant** les dés de bloc
- Sur **2+** : le blocage se déroule normalement
- Sur **1** : le blocage est annulé, l'activation de l'attaquant est consommée (PM=0), **ce n'est PAS un turnover**

Le même check s'applique au blocage pendant un Blitz.

## Plan de test

- [x] `pnpm test foul-appearance` → 9/9 tests passent
- [x] `pnpm test` (game-engine) → 3501/3501 tests passent
- [x] `pnpm typecheck` → OK (0 erreur)
- [x] `pnpm lint` → OK (0 erreur, warnings pré-existants seulement)

## Tests couverts

- Registration du skill + trigger `on-block-defender`
- Pas de roll si la cible n'a pas `foul-appearance`
- Sur 2+: le blocage se déroule (pendingBlock ou log Blocage)
- Sur 1: annulation du bloc (aucun dé de bloc lancé)
- Sur 1: pas de turnover
- Sur 1: activation consommée (PM=0, action enregistrée)
- Log de répulsion présent
- Distribution statistique ~1/6 d'échec (sur 600 seeds)
