### PR TITLE
feat(game-engine): implement armored-skull trait (P1.6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -234,7 +234,7 @@
 | P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [x] |
 | P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [x] |
 | P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [x] |
-| P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [ ] |
+| P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [x] |
 | P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [ ] |
 | P1.8 | Implementer `shadowing` (Lizardmen Chameleon Skink) | Regle | [ ] |
 | P1.9 | Implementer `fend` (Imperial Retainer Lineman) — verifier | Regle | [ ] |

--- a/packages/game-engine/src/mechanics/armored-skull.test.ts
+++ b/packages/game-engine/src/mechanics/armored-skull.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regle: Armored Skull (Armure Blindee) - BB3 Season 2/3
+ *
+ * Tests for the Armored Skull trait: -1 modifier applied to any Injury roll
+ * made against this player. Reduces the chance of KO and Casualty results.
+ *
+ * Primary users: Dwarf Deathroller, Slayerpult star players.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { setup } from '../index';
+import { performInjuryRoll } from './injury';
+import type { GameState, Player } from '../core/types';
+
+function getPlayer(state: GameState, id: string): Player {
+  return state.players.find(p => p.id === id)!;
+}
+
+function fixedRNG(value: number) {
+  return () => value;
+}
+
+function sequencedRNG(values: number[]) {
+  let i = 0;
+  return () => {
+    const v = values[Math.min(i, values.length - 1)];
+    i++;
+    return v;
+  };
+}
+
+function giveSkill(state: GameState, playerId: string, skill: string): GameState {
+  return {
+    ...state,
+    players: state.players.map(p =>
+      p.id === playerId ? { ...p, skills: [...p.skills, skill] } : p
+    ),
+  };
+}
+
+describe('Regle: Armored Skull', () => {
+  describe('performInjuryRoll with armored-skull', () => {
+    it('applies -1 modifier that demotes a KO roll (8) to a Stunned result (7)', () => {
+      const base = setup();
+      const state = giveSkill(base, 'A1', 'armored-skull');
+      const player = getPlayer(state, 'A1');
+
+      // Without armored-skull: 4+4 = 8 → KO
+      // With armored-skull: 8 - 1 = 7 → Stunned
+      const result = performInjuryRoll(state, player, fixedRNG(0.5));
+
+      const updated = getPlayer(result, 'A1');
+      expect(updated.stunned).toBe(true);
+      expect(updated.state).toBe('stunned');
+      expect(result.dugouts.teamA.zones.knockedOut.players).not.toContain('A1');
+      expect(result.dugouts.teamA.zones.casualty.players).not.toContain('A1');
+    });
+
+    it('applies -1 modifier that demotes a Casualty roll (10) to a KO result (9)', () => {
+      const base = setup();
+      const state = giveSkill(base, 'A1', 'armored-skull');
+      const player = getPlayer(state, 'A1');
+
+      // Need 2d6 = 10: e.g. 5+5. 0.666... → face 5
+      // With armored-skull: 10 - 1 = 9 → KO
+      const result = performInjuryRoll(state, player, sequencedRNG([0.7, 0.7]));
+
+      expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
+      expect(result.dugouts.teamA.zones.casualty.players).not.toContain('A1');
+    });
+
+    it('does not prevent a high Casualty roll (12 - 1 = 11 still casualty)', () => {
+      const base = setup();
+      const state = giveSkill(base, 'A1', 'armored-skull');
+      const player = getPlayer(state, 'A1');
+
+      // 2d6 = 12, -1 = 11, still ≥10 → Casualty
+      const result = performInjuryRoll(state, player, fixedRNG(0.99));
+
+      expect(result.dugouts.teamA.zones.casualty.players).toContain('A1');
+    });
+
+    it('does not apply to players without armored-skull', () => {
+      const state = setup();
+      const player = getPlayer(state, 'A1');
+
+      // 4+4 = 8 → KO (no armored-skull malus)
+      const result = performInjuryRoll(state, player, fixedRNG(0.5));
+
+      expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
+      expect(getPlayer(result, 'A1').state).toBe('knocked_out');
+    });
+
+    it('stacks with external injury bonus (Mighty Blow +1 cancels armored-skull -1)', () => {
+      const base = setup();
+      const state = giveSkill(base, 'A1', 'armored-skull');
+      const player = getPlayer(state, 'A1');
+
+      // 4+4 = 8, +1 (mighty blow) -1 (armored skull) = 8 → KO
+      const result = performInjuryRoll(state, player, fixedRNG(0.5), 1);
+
+      expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
+    });
+
+    it('logs the injury roll including the armored-skull modifier', () => {
+      const base = setup();
+      const state = giveSkill(base, 'A1', 'armored-skull');
+      const player = getPlayer(state, 'A1');
+
+      const result = performInjuryRoll(state, player, fixedRNG(0.5));
+
+      const injuryLog = result.gameLog.find(l => l.type === 'dice' && l.message.includes('blessure'));
+      expect(injuryLog).toBeDefined();
+      // Final roll after modifier should be 7, not 8
+      expect(injuryLog?.message).toContain('7');
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/injury.ts
+++ b/packages/game-engine/src/mechanics/injury.ts
@@ -9,6 +9,16 @@ import { createLogEntry } from '../utils/logging';
 import { movePlayerToDugoutZone } from './dugout';
 import { isApothecaryAvailable } from './apothecary';
 import { hasRegeneration, tryRegeneration } from './regeneration';
+import { hasSkill } from '../skills/skill-effects';
+
+/**
+ * Armored Skull (BB3 Season 2/3): apply a -1 modifier to any Injury roll
+ * made against a player with this skill. Used by Dwarf Deathroller and
+ * similarly armored star players.
+ */
+function armoredSkullModifier(player: Player): number {
+  return hasSkill(player, 'armored-skull') ? -1 : 0;
+}
 
 /**
  * Effectue un jet de blessure contre un joueur
@@ -20,8 +30,9 @@ import { hasRegeneration, tryRegeneration } from './regeneration';
 export function performInjuryRoll(state: GameState, player: Player, rng: RNG, bonus: number = 0, causedById?: string): GameState {
   const newState = structuredClone(state) as GameState;
 
-  // Jet de 2D6 pour la blessure (+ bonus de Mighty Blow éventuel)
-  const injuryRoll = Math.floor(rng() * 6) + 1 + Math.floor(rng() * 6) + 1 + bonus;
+  // Jet de 2D6 pour la blessure (+ bonus de Mighty Blow éventuel, - Armored Skull si applicable)
+  const armoredSkullMod = armoredSkullModifier(player);
+  const injuryRoll = Math.floor(rng() * 6) + 1 + Math.floor(rng() * 6) + 1 + bonus + armoredSkullMod;
 
   // Log du jet de blessure
   const injuryLog = createLogEntry(
@@ -273,8 +284,9 @@ export function handleSentOff(state: GameState, player: Player): GameState {
 export function handleInjuryByCrowd(state: GameState, player: Player, rng: RNG): GameState {
   const newState = structuredClone(state) as GameState;
 
-  // Jet de 2D6 pour la blessure (pas de bonus)
-  const injuryRoll = Math.floor(rng() * 6) + 1 + Math.floor(rng() * 6) + 1;
+  // Jet de 2D6 pour la blessure (pas de bonus, - Armored Skull si applicable)
+  const armoredSkullMod = armoredSkullModifier(player);
+  const injuryRoll = Math.floor(rng() * 6) + 1 + Math.floor(rng() * 6) + 1 + armoredSkullMod;
 
   const injuryLog = createLogEntry(
     'dice',


### PR DESCRIPTION
## Resume

Implemente le trait **Armored Skull** (Armure Blindee) pour le Sprint 13 - tache **P1.6**.

- Applique un modificateur **-1** a tout jet de blessure (Injury Roll) effectue contre un joueur possedant `armored-skull`.
- Integre dans `performInjuryRoll` (blessures standards) et `handleInjuryByCrowd` (surf).
- Le malus est additif et se combine avec les bonus externes (Mighty Blow, etc.).
- Utilisateurs principaux dans les 5 equipes prioritaires : **Dwarf Deathroller**.

## Tache roadmap

Sprint 13 - P1.6 `armored-skull` (Dwarf Deathroller).

## Plan de test

- [x] 6 nouveaux tests unitaires dans `packages/game-engine/src/mechanics/armored-skull.test.ts`
  - [x] -1 demote un jet de 8 (KO) en 7 (Stunned)
  - [x] -1 demote un jet de 10 (Casualty) en 9 (KO)
  - [x] -1 ne previent pas une Casualty sur un jet eleve (12 -> 11 reste Casualty)
  - [x] Aucun effet sur un joueur sans le skill
  - [x] Stacking additif avec Mighty Blow (+1 -1 = 0)
  - [x] Le log affiche le resultat apres modificateur
- [x] Suite complete `game-engine` : **3507 tests passent**
- [x] `pnpm -F @bb/game-engine lint` : 0 erreurs
- [x] `pnpm -F @bb/game-engine typecheck` : OK
- [x] `pnpm -F @bb/game-engine build` : OK
- [x] TODO.md mis a jour (P1.6 cochee)
