### PR TITLE
feat(game-engine): generalize iron-hard-skin (P1.7)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -235,7 +235,7 @@
 | P1.4 | Implementer `juggernaut` (Dwarf Deathroller) | Regle | [x] |
 | P1.5 | Implementer `stand-firm` (Deathroller, Bodyguard, Treeman Gnome) | Regle | [x] |
 | P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [x] |
-| P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [ ] |
+| P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [x] |
 | P1.8 | Implementer `shadowing` (Lizardmen Chameleon Skink) | Regle | [ ] |
 | P1.9 | Implementer `fend` (Imperial Retainer Lineman) — verifier | Regle | [ ] |
 | P1.10 | Implementer `running-pass` (Imperial Thrower) | Regle | [ ] |

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -124,19 +124,22 @@ function armorAndInjuryWithMightyBlow(
   attacker: Player,
   rng: RNG
 ): GameState {
-  const mbBonus = getMightyBlowBonusFromRegistry(attacker, state);
+  const mbBonusRaw = getMightyBlowBonusFromRegistry(attacker, state);
   const diceRoll = roll2D6(rng);
 
   // Claws: armor breaks on 8+ regardless of AV (unless defender has Iron Hard Skin)
+  // Iron Hard Skin: bloque les modificateurs positifs de l'attaquant sur le jet
+  // d'armure (Mighty Blow notamment). La blessure n'est pas concernée.
   // Stunty: la valeur d'armure du joueur cible est reduite de 1 (plus fragile).
   // Le malus s'applique toujours, cumulatif avec Claws et Mighty Blow.
-  const { clawsActive } = getArmorSkillContext(state, attacker, victim);
+  const { clawsActive, ironHardSkinActive } = getArmorSkillContext(state, attacker, victim);
+  const mbBonusOnArmor = ironHardSkinActive ? 0 : mbBonusRaw;
   const stuntyAdjust = hasSkill(victim, 'stunty') ? -1 : 0;
   const baseTarget = clawsActive ? Math.min(victim.av, 8) : victim.av;
   const armorTarget = baseTarget + stuntyAdjust;
 
   const armorBrokenNaturally = diceRoll >= armorTarget;
-  const armorBrokenWithMB = (diceRoll + mbBonus) >= armorTarget;
+  const armorBrokenWithMB = (diceRoll + mbBonusOnArmor) >= armorTarget;
 
   let armorBroken: boolean;
   let mbUsedOnArmor: boolean;
@@ -153,18 +156,19 @@ function armorAndInjuryWithMightyBlow(
   }
 
   // Log du jet d'armure
-  const effectiveRoll = mbUsedOnArmor ? diceRoll + mbBonus : diceRoll;
+  const effectiveRoll = mbUsedOnArmor ? diceRoll + mbBonusOnArmor : diceRoll;
   const armorLog = createLogEntry(
     'dice',
-    `Jet d'armure: ${effectiveRoll}/${armorTarget} ${armorBroken ? '✗ (percée)' : '✓ (tient)'}${mbBonus > 0 && mbUsedOnArmor ? ' [Mighty Blow +1]' : ''}${clawsActive ? ' [Claws]' : ''}`,
+    `Jet d'armure: ${effectiveRoll}/${armorTarget} ${armorBroken ? '✗ (percée)' : '✓ (tient)'}${mbBonusOnArmor > 0 && mbUsedOnArmor ? ' [Mighty Blow +1]' : ''}${clawsActive ? ' [Claws]' : ''}${ironHardSkinActive ? ' [Iron Hard Skin]' : ''}`,
     victim.id,
     victim.team,
     {
       diceRoll: effectiveRoll,
       targetNumber: armorTarget,
       success: !armorBroken,
-      mightyBlow: mbBonus > 0,
+      mightyBlow: mbBonusRaw > 0,
       mightyBlowAppliedTo: mbUsedOnArmor ? 'armor' : 'injury',
+      ironHardSkin: ironHardSkinActive,
     }
   );
   state.gameLog = [...state.gameLog, armorLog];
@@ -175,11 +179,13 @@ function armorAndInjuryWithMightyBlow(
     diceRoll: effectiveRoll,
     targetNumber: armorTarget,
     success: !armorBroken,
-    modifiers: mbUsedOnArmor ? mbBonus : 0,
+    modifiers: mbUsedOnArmor ? mbBonusOnArmor : 0,
   };
 
   if (armorBroken) {
-    const injuryBonus = mbUsedOnArmor ? 0 : mbBonus;
+    // Le bonus Mighty Blow est reporté sur la blessure si non utilisé sur
+    // l'armure. Iron Hard Skin NE bloque PAS Mighty Blow sur la blessure.
+    const injuryBonus = mbUsedOnArmor ? 0 : mbBonusRaw;
     // Thick Skull: -1 to injury roll (KO on 9+ instead of 8+)
     const injuryDefenderMod = getInjurySkillModifiers(state, victim);
     state = performInjuryRoll(state, victim, rng, injuryBonus + injuryDefenderMod, attacker.id);

--- a/packages/game-engine/src/mechanics/chainsaw.ts
+++ b/packages/game-engine/src/mechanics/chainsaw.ts
@@ -26,6 +26,7 @@ import { rollD6, calculateArmorTarget } from '../utils/dice';
 import { performInjuryRoll } from './injury';
 import { createLogEntry } from '../utils/logging';
 import { isAdjacent } from './movement';
+import { getArmorSkillContext } from '../skills/skill-bridge';
 
 const CHAINSAW_ARMOR_BONUS = 3;
 
@@ -133,15 +134,21 @@ export function executeChainsaw(
     newState.isTurnover = true;
   } else {
     // Jet d'armure sur la cible avec +3 (pas de Mighty Blow).
-    const armorResult = buildArmorResult(target, die1, die2, CHAINSAW_ARMOR_BONUS);
+    // Iron Hard Skin annule le bonus Chainsaw (modificateur de trait de
+    // l'attaquant sur le jet d'armure).
+    const { ironHardSkinActive } = getArmorSkillContext(newState, attacker, target);
+    const chainsawBonus = ironHardSkinActive ? 0 : CHAINSAW_ARMOR_BONUS;
+    const armorResult = buildArmorResult(target, die1, die2, chainsawBonus);
     newState.lastDiceResult = armorResult;
 
+    const bonusSign = chainsawBonus > 0 ? `+${chainsawBonus}` : '';
+    const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
     const armorLog = createLogEntry(
       'dice',
-      `Jet d'armure de ${target.name}: ${die1 + die2}+${CHAINSAW_ARMOR_BONUS} vs ${target.av} ${armorResult.success ? '(tient)' : '(percée)'}`,
+      `Jet d'armure de ${target.name}: ${die1 + die2}${bonusSign} vs ${target.av}${ihsTag} ${armorResult.success ? '(tient)' : '(percée)'}`,
       target.id,
       target.team,
-      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, chainsawBonus: CHAINSAW_ARMOR_BONUS },
+      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, chainsawBonus, ironHardSkin: ironHardSkinActive },
     );
     newState.gameLog = [...newState.gameLog, armorLog];
 

--- a/packages/game-engine/src/mechanics/foul.ts
+++ b/packages/game-engine/src/mechanics/foul.ts
@@ -8,7 +8,7 @@ import { rollD6 } from '../utils/dice';
 import { isAdjacent, getAdjacentOpponents } from './movement';
 import { createLogEntry } from '../utils/logging';
 import { performInjuryRoll, handleSentOff } from './injury';
-import { getFoulArmorSkillModifiers } from '../skills/skill-bridge';
+import { getFoulArmorSkillModifiers, getArmorSkillContext } from '../skills/skill-bridge';
 
 /**
  * Vérifie si un joueur peut faire une faute sur une cible
@@ -83,18 +83,25 @@ export function executeFoul(
   newState.gameLog = [...newState.gameLog, foulLog];
 
   // Jet d'armure avec bonus d'assists + Dirty Player
+  // Iron Hard Skin annule les modificateurs positifs de l'attaquant
+  // (ex. Dirty Player). Les assists de foul ne sont PAS un modificateur
+  // de skill de l'attaquant et restent appliqués.
   const die1 = rollD6(rng);
   const die2 = rollD6(rng);
-  const dirtyPlayerBonus = getFoulArmorSkillModifiers(newState, attacker);
+  const dirtyPlayerBonusRaw = getFoulArmorSkillModifiers(newState, attacker);
+  const { ironHardSkinActive } = getArmorSkillContext(newState, attacker, target);
+  const dirtyPlayerBonus = ironHardSkinActive ? 0 : dirtyPlayerBonusRaw;
   const armorRoll = die1 + die2 + assists + dirtyPlayerBonus;
   const armorBroken = armorRoll >= target.av;
 
+  const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
+  const dpTag = dirtyPlayerBonus > 0 ? ` [Dirty Player +${dirtyPlayerBonus}]` : '';
   const armorLog = createLogEntry(
     'dice',
-    `Jet d'armure (foul): ${die1}+${die2}${assists !== 0 ? (assists > 0 ? '+' + assists : assists.toString()) : ''}${dirtyPlayerBonus > 0 ? ` [Dirty Player +${dirtyPlayerBonus}]` : ''} = ${armorRoll}/${target.av} ${armorBroken ? '✗ (percée)' : '✓ (tient)'}`,
+    `Jet d'armure (foul): ${die1}+${die2}${assists !== 0 ? (assists > 0 ? '+' + assists : assists.toString()) : ''}${dpTag}${ihsTag} = ${armorRoll}/${target.av} ${armorBroken ? '✗ (percée)' : '✓ (tient)'}`,
     target.id,
     target.team,
-    { die1, die2, assists, total: armorRoll, target: target.av }
+    { die1, die2, assists, total: armorRoll, target: target.av, ironHardSkin: ironHardSkinActive }
   );
   newState.gameLog = [...newState.gameLog, armorLog];
 

--- a/packages/game-engine/src/mechanics/iron-hard-skin.test.ts
+++ b/packages/game-engine/src/mechanics/iron-hard-skin.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests d'intégration pour le trait Iron Hard Skin (P1.7).
+ *
+ * Règle BB3 Season 2/3 : quand un jet d'armure est effectué contre un joueur
+ * possédant Iron Hard Skin, l'adversaire ne peut pas appliquer les effets de
+ * ses propres Skills, Traits, Special Rules, Star Player Qualities ou
+ * Prayers to Nuffle qui s'ajouteraient à ce jet.
+ *
+ * Concrètement : Claws, Mighty Blow (sur armure), Dirty Player (sur faute),
+ * Chainsaw (+3) sont neutralisés quand la cible possède Iron Hard Skin.
+ * Mighty Blow reste applicable au jet de BLESSURE (la règle ne concerne que
+ * le jet d'armure).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { GameState, Player, RNG } from '../core/types';
+import { setup } from '../core/game-state';
+import { executeStab } from './stab';
+import { executeProjectileVomit } from './projectile-vomit';
+import { executeFoul } from './foul';
+import { executeChainsaw } from './chainsaw';
+import { getArmorSkillContext } from '../skills/skill-bridge';
+
+/**
+ * Construit une RNG déterministe à partir de valeurs flottantes.
+ * Pour un résultat de dé D voulu : passer (D-1)/6 ≤ v < D/6.
+ * Convention : 0.0 → 1, 0.17 → 2, 0.34 → 3, 0.5 → 4, 0.67 → 5, 0.84 → 6.
+ */
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+/** Conversion lisible : valeur de dé → float RNG. */
+function die(n: 1 | 2 | 3 | 4 | 5 | 6): number {
+  // On vise milieu de l'intervalle pour éviter les arrondis en bord.
+  return (n - 1) / 6 + 0.01;
+}
+
+function basePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Player',
+    number: 1,
+    position: 'Lineman',
+    ma: 6, st: 3, ag: 3, pa: 4, av: 9,
+    skills: [],
+    pm: 6,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  const state = setup();
+  state.players = players;
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 0, teamB: 0 };
+  return state;
+}
+
+describe('Règle: Iron Hard Skin (P1.7)', () => {
+  describe('getArmorSkillContext', () => {
+    it('reporte ironHardSkinActive=false pour un joueur sans Iron Hard Skin', () => {
+      const attacker = basePlayer({ id: 'att' });
+      const defender = basePlayer({ id: 'def', team: 'B' });
+      const state = makeState([attacker, defender]);
+      const ctx = getArmorSkillContext(state, attacker, defender);
+      expect(ctx.ironHardSkinActive).toBe(false);
+    });
+
+    it('reporte ironHardSkinActive=true pour un joueur avec Iron Hard Skin', () => {
+      const attacker = basePlayer({ id: 'att' });
+      const defender = basePlayer({
+        id: 'def', team: 'B', skills: ['iron-hard-skin'],
+      });
+      const state = makeState([attacker, defender]);
+      const ctx = getArmorSkillContext(state, attacker, defender);
+      expect(ctx.ironHardSkinActive).toBe(true);
+    });
+
+    it('reconnaît la variante avec underscore iron_hard_skin', () => {
+      const attacker = basePlayer({ id: 'att' });
+      const defender = basePlayer({
+        id: 'def', team: 'B', skills: ['iron_hard_skin'],
+      });
+      const state = makeState([attacker, defender]);
+      const ctx = getArmorSkillContext(state, attacker, defender);
+      expect(ctx.ironHardSkinActive).toBe(true);
+    });
+  });
+
+  describe('Stab vs Iron Hard Skin', () => {
+    it('nullifie le bonus Mighty Blow du Stabber sur le jet d\'armure', () => {
+      // 2D6 = 4+4 = 8 ; AV 9.
+      // Sans MB : armure tient (8 < 9). Avec MB : armure percée (8 ≥ 8).
+      // IHS doit forcer "armure tient".
+      const stabber = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['stab', 'mighty-blow'],
+      });
+      const defender = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B',
+        av: 9, skills: ['iron-hard-skin'],
+      });
+      const state = makeState([stabber, defender]);
+      const rng = makeTestRNG([die(4), die(4), die(1), die(1)]);
+      const after = executeStab(state, stabber, defender, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state).toBe('active');
+      expect(defAfter.stunned).toBeFalsy();
+      // Sanity : le log doit mentionner Iron Hard Skin.
+      const log = after.gameLog.map(l => l.message).join('\n');
+      expect(log).toContain('Iron Hard Skin');
+    });
+
+    it('laisse passer Mighty Blow contre une cible sans Iron Hard Skin (régression)', () => {
+      const stabber = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['stab', 'mighty-blow'],
+      });
+      const defender = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B', av: 9, skills: [],
+      });
+      const state = makeState([stabber, defender]);
+      // 4+4 = 8, -1 (MB) → target 8 ≤ 8 = percée. Injury 6+6 → casualty.
+      const rng = makeTestRNG([die(4), die(4), die(6), die(6), die(6), die(6)]);
+      const after = executeStab(state, stabber, defender, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state !== 'active' || defAfter.stunned).toBeTruthy();
+    });
+  });
+
+  describe('Projectile Vomit vs Iron Hard Skin', () => {
+    it('nullifie le bonus Mighty Blow du vomisseur sur le jet d\'armure', () => {
+      const vomiter = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['projectile-vomit', 'mighty-blow'],
+      });
+      const defender = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B',
+        av: 9, skills: ['iron-hard-skin'],
+      });
+      const state = makeState([vomiter, defender]);
+      // D6 vomit = 4 (succès, 2+), puis 2D6 armure = 4+4 = 8, target 9 (IHS) → tient.
+      const rng = makeTestRNG([die(4), die(4), die(4)]);
+      const after = executeProjectileVomit(state, vomiter, defender, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      // Cible mise à terre par le Vomit (succès), mais armure tient donc pas de blessure.
+      expect(defAfter.stunned).toBe(true);
+      expect(defAfter.state).toBe('active');
+    });
+  });
+
+  describe('Faute vs Iron Hard Skin', () => {
+    it('nullifie le bonus Dirty Player sur le jet d\'armure d\'une faute', () => {
+      const fouler = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['dirty-player-1'],
+      });
+      const victim = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B',
+        av: 9, skills: ['iron-hard-skin'],
+        stunned: true, pm: 0,
+      });
+      const state = makeState([fouler, victim]);
+      // 2D6 = 4+4 = 8 ; sans DP sous IHS, 8 < 9 → armure tient.
+      const rng = makeTestRNG([die(4), die(4), die(1), die(1)]);
+      const after = executeFoul(state, fouler, victim, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state).toBe('active');
+    });
+
+    it('laisse passer Dirty Player sans Iron Hard Skin (régression)', () => {
+      const fouler = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['dirty-player-1'],
+      });
+      const victim = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B',
+        av: 9, skills: [],
+        stunned: true, pm: 0,
+      });
+      const state = makeState([fouler, victim]);
+      // 2D6 = 4+4 = 8 + 1 DP = 9 ≥ 9 → armure percée ; injury 6+6 → casualty.
+      const rng = makeTestRNG([die(4), die(4), die(6), die(6), die(6), die(6)]);
+      const after = executeFoul(state, fouler, victim, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state !== 'active' || defAfter.stunned).toBeTruthy();
+    });
+  });
+
+  describe('Chainsaw vs Iron Hard Skin', () => {
+    it('nullifie le bonus +3 de Chainsaw sur le jet d\'armure de la cible', () => {
+      const sawyer = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['chainsaw'],
+      });
+      const defender = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B',
+        av: 9, skills: ['iron-hard-skin'],
+      });
+      const state = makeState([sawyer, defender]);
+      // 2D6 = 3+3 = 6 ; sans +3 sous IHS, 6 < 9 → armure tient.
+      const rng = makeTestRNG([die(3), die(3), die(1), die(1)]);
+      const after = executeChainsaw(state, sawyer, defender, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state).toBe('active');
+      expect(defAfter.stunned).toBeFalsy();
+    });
+
+    it('laisse passer le +3 de Chainsaw sans Iron Hard Skin (régression)', () => {
+      const sawyer = basePlayer({
+        id: 'att', pos: { x: 5, y: 5 }, team: 'A',
+        skills: ['chainsaw'],
+      });
+      const defender = basePlayer({
+        id: 'def', pos: { x: 6, y: 5 }, team: 'B', av: 9, skills: [],
+      });
+      const state = makeState([sawyer, defender]);
+      // 2D6 = 3+3 = 6 + 3 = 9 ≥ 9 → armure percée ; injury 6+6 → casualty.
+      const rng = makeTestRNG([die(3), die(3), die(6), die(6), die(6), die(6)]);
+      const after = executeChainsaw(state, sawyer, defender, rng);
+      const defAfter = after.players.find(p => p.id === 'def')!;
+      expect(defAfter.state !== 'active' || defAfter.stunned).toBeTruthy();
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/projectile-vomit.ts
+++ b/packages/game-engine/src/mechanics/projectile-vomit.ts
@@ -18,7 +18,7 @@ import { performArmorRoll } from '../utils/dice';
 import { performInjuryRoll } from './injury';
 import { createLogEntry } from '../utils/logging';
 import { isAdjacent } from './movement';
-import { getMightyBlowBonusFromRegistry } from '../skills/skill-bridge';
+import { getMightyBlowBonusFromRegistry, getArmorSkillContext } from '../skills/skill-bridge';
 import { bounceBall } from './ball';
 
 /**
@@ -113,17 +113,26 @@ export function executeProjectileVomit(
       newState = bounceBall(newState, rng);
     }
 
-    // Jet d'armure avec bonus Mighty Blow éventuel
-    const mightyBlowBonus = getMightyBlowBonusFromRegistry(vomiter, newState);
+    // Jet d'armure avec bonus Mighty Blow éventuel.
+    // Iron Hard Skin annule les modificateurs positifs de l'attaquant
+    // sur le jet d'armure (ex. Mighty Blow).
+    const mightyBlowBonusRaw = getMightyBlowBonusFromRegistry(vomiter, newState);
+    const { ironHardSkinActive } = getArmorSkillContext(
+      newState,
+      vomiter,
+      newState.players[targetIdx],
+    );
+    const mightyBlowBonus = ironHardSkinActive ? 0 : mightyBlowBonusRaw;
     const armorResult = performArmorRoll(newState.players[targetIdx], rng, -mightyBlowBonus);
     newState.lastDiceResult = armorResult;
 
+    const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
     const armorLog = createLogEntry(
       'dice',
-      `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '(tient)' : '(percée)'}`,
+      `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber}${ihsTag} ${armorResult.success ? '(tient)' : '(percée)'}`,
       target.id,
       target.team,
-      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus },
+      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus, ironHardSkin: ironHardSkinActive },
     );
     newState.gameLog = [...newState.gameLog, armorLog];
 

--- a/packages/game-engine/src/mechanics/stab.ts
+++ b/packages/game-engine/src/mechanics/stab.ts
@@ -21,7 +21,7 @@ import { performArmorRoll } from '../utils/dice';
 import { performInjuryRoll } from './injury';
 import { createLogEntry } from '../utils/logging';
 import { isAdjacent } from './movement';
-import { getMightyBlowBonusFromRegistry } from '../skills/skill-bridge';
+import { getMightyBlowBonusFromRegistry, getArmorSkillContext } from '../skills/skill-bridge';
 
 /**
  * Indique si un joueur peut utiliser Stab sur une cible donnée.
@@ -59,17 +59,22 @@ export function executeStab(
   );
   newState.gameLog = [...newState.gameLog, actionLog];
 
-  // Jet d'armure direct, avec bonus Mighty Blow éventuel
-  const mightyBlowBonus = getMightyBlowBonusFromRegistry(stabber, newState);
+  // Jet d'armure direct, avec bonus Mighty Blow éventuel.
+  // Iron Hard Skin annule les modificateurs positifs de l'attaquant
+  // sur le jet d'armure (ex. Mighty Blow).
+  const mightyBlowBonusRaw = getMightyBlowBonusFromRegistry(stabber, newState);
+  const { ironHardSkinActive } = getArmorSkillContext(newState, stabber, target);
+  const mightyBlowBonus = ironHardSkinActive ? 0 : mightyBlowBonusRaw;
   const armorResult = performArmorRoll(target, rng, -mightyBlowBonus);
   newState.lastDiceResult = armorResult;
 
+  const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
   const armorLog = createLogEntry(
     'dice',
-    `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '(tient)' : '(percée)'}`,
+    `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber}${ihsTag} ${armorResult.success ? '(tient)' : '(percée)'}`,
     target.id,
     target.team,
-    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus },
+    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus, ironHardSkin: ironHardSkinActive },
   );
   newState.gameLog = [...newState.gameLog, armorLog];
 

--- a/packages/game-engine/src/skills/armor-injury-skills.test.ts
+++ b/packages/game-engine/src/skills/armor-injury-skills.test.ts
@@ -77,6 +77,22 @@ describe('Règle: Claws + Iron Hard Skin (armor skills)', () => {
     const ctx = getArmorSkillContext(state, attacker, defender);
     expect(ctx.clawsActive).toBe(false);
   });
+
+  it('exposes ironHardSkinActive=false when defender lacks Iron Hard Skin', () => {
+    const attacker = makePlayer({ id: 'att', skills: ['claws'] });
+    const defender = makePlayer({ id: 'def', team: 'B', av: 10, skills: [] });
+    const state = makeState([attacker, defender]);
+    const ctx = getArmorSkillContext(state, attacker, defender);
+    expect(ctx.ironHardSkinActive).toBe(false);
+  });
+
+  it('exposes ironHardSkinActive=true when defender has Iron Hard Skin', () => {
+    const attacker = makePlayer({ id: 'att', skills: [] });
+    const defender = makePlayer({ id: 'def', team: 'B', av: 10, skills: ['iron-hard-skin'] });
+    const state = makeState([attacker, defender]);
+    const ctx = getArmorSkillContext(state, attacker, defender);
+    expect(ctx.ironHardSkinActive).toBe(true);
+  });
 });
 
 describe('Règle: Thick Skull (injury modifier)', () => {

--- a/packages/game-engine/src/skills/skill-bridge.ts
+++ b/packages/game-engine/src/skills/skill-bridge.ts
@@ -51,15 +51,21 @@ export function getPickupSkillModifiers(
  * Remplace les fonctions canRerollDodge, canRerollPickup, canRerollGFI hardcodées.
  */
 /**
- * Détermine si Claws est actif pour un jet d'armure.
- * Claws fait que l'armure casse toujours sur 8+, quel que soit l'AV.
- * Iron Hard Skin annule Claws.
+ * Détermine le contexte skills pour un jet d'armure donné.
+ *
+ * - `clawsActive` : Claws fait que l'armure casse toujours sur 8+ (Iron Hard
+ *   Skin l'annule).
+ * - `ironHardSkinActive` : le défenseur possède Iron Hard Skin. Quand ce
+ *   drapeau est levé, aucun modificateur positif au jet d'armure provenant
+ *   des Skills, Traits, Special Rules ou Prayers to Nuffle de l'attaquant
+ *   ne doit être appliqué (Claws, Mighty Blow sur l'armure, Dirty Player,
+ *   bonus Chainsaw, etc.). Le jet de BLESSURE n'est pas concerné.
  */
 export function getArmorSkillContext(
   state: GameState,
   attacker: Player,
   defender: Player
-): { clawsActive: boolean } {
+): { clawsActive: boolean; ironHardSkinActive: boolean } {
   const attackerHasClaws = getSkillEffect('claws');
   const defenderHasIronHardSkin = getSkillEffect('iron-hard-skin');
 
@@ -75,6 +81,7 @@ export function getArmorSkillContext(
 
   return {
     clawsActive: clawsApplies && !ironHardSkinApplies,
+    ironHardSkinActive: ironHardSkinApplies,
   };
 }
 

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -523,7 +523,7 @@ registerSkill({
 registerSkill({
   slug: 'iron-hard-skin',
   triggers: ['on-armor'],
-  description: 'Annule la compétence Claws de l\'adversaire.',
+  description: 'Annule tous les modificateurs positifs que l\'adversaire appliquerait au jet d\'armure contre ce joueur (Claws, Mighty Blow sur armure, Dirty Player, Chainsaw, etc.). N\'affecte pas le jet de blessure.',
   canApply: (ctx) => hasSkill(ctx.player, 'iron-hard-skin') || hasSkill(ctx.player, 'iron_hard_skin'),
 });
 


### PR DESCRIPTION
## Résumé

Implémente entièrement le trait **Iron Hard Skin** (BB3 Season 2/3) — tâche **P1.7** du Sprint 13.

Jusqu'ici, `iron-hard-skin` n'annulait que **Claws**. Or la règle BB3 est plus large :

> When determining if an Armour Roll against this player is successful, any modifiers from the opponent's Skills, Traits, Special Rules, Star Player Qualities or Prayers to Nuffle are ignored.

Le trait annule désormais **tous les modificateurs positifs** d'origine attaquante appliqués au jet d'armure :

| Modificateur | Source | Annulé sous IHS ? |
|---|---|---|
| Claws | Mutation de l'attaquant | ✅ (déjà OK) |
| Mighty Blow (+1 armure) | Bloc / Stab / Projectile Vomit | ✅ (nouveau) |
| Dirty Player (+1 armure) | Faute | ✅ (nouveau) |
| Bonus Chainsaw (+3) | Trait Secret Weapon | ✅ (nouveau) |
| Mighty Blow (+1 blessure) | Bloc | ❌ (volontaire — règle IHS concerne uniquement le jet d'armure) |
| Assists de foul | Support physique | ❌ (non listés dans la règle) |

Équipe les **Gnomes** (piston, beastmaster, treeman), le **Chaos Dwarf Blocker**, plusieurs Star Players, et toute future unité qui possède le trait.

## Fichiers modifiés

- `packages/game-engine/src/skills/skill-bridge.ts` : `getArmorSkillContext` expose désormais `{ clawsActive, ironHardSkinActive }`.
- `packages/game-engine/src/mechanics/blocking.ts` : `mbBonusOnArmor` forcé à 0 sous IHS, `mbBonusRaw` conservé pour la blessure.
- `packages/game-engine/src/mechanics/foul.ts` : Dirty Player nullifié sous IHS (les assists de foul restent appliqués).
- `packages/game-engine/src/mechanics/stab.ts`, `projectile-vomit.ts` : Mighty Blow nullifié sur l'armure sous IHS.
- `packages/game-engine/src/mechanics/chainsaw.ts` : bonus +3 nullifié sur le jet de la cible quand IHS actif ; auto-blessure sur double 1 inchangée.
- `packages/game-engine/src/skills/skill-registry.ts` : description mise à jour.
- `packages/game-engine/src/mechanics/iron-hard-skin.test.ts` **(nouveau)** : **10 tests** d'intégration couvrant stab/vomit/foul/chainsaw avec et sans IHS.
- `packages/game-engine/src/skills/armor-injury-skills.test.ts` : +2 tests unitaires sur `getArmorSkillContext` pour `ironHardSkinActive`.
- `TODO.md` : tâche P1.7 cochée.

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` : **3519/3519** tests passent (99 fichiers).
- [x] `pnpm --filter @bb/server test` : 313/313.
- [x] `pnpm --filter @bb/web test` : 200/200.
- [x] `pnpm --filter @bb/ui test` : 288/288.
- [x] `pnpm typecheck` : 0 erreur (game-engine, server, web, ui).
- [x] `pnpm lint` : 0 erreur (warnings pré-existants inchangés).
- [x] `pnpm --filter @bb/game-engine build` : OK.
- [ ] Test e2e manuel : match Gnomes vs équipe avec Claws + Mighty Blow → vérifier que les joueurs IHS encaissent sans bonus d'armure.
- [ ] Test e2e manuel : Dirty Player foulant un Gnome Treeman → vérifier que le bonus +1 n'est pas appliqué.

## Tâche roadmap

Sprint 13 — Skills intrinsèques des 5 équipes prioritaires — `P1.7 | Implementer iron-hard-skin (Gnomes : piston, beastmaster, treeman)`.

## Notes d'implémentation

- **Mighty Blow sur la blessure** : IHS **ne bloque pas** MB sur le jet de blessure. La règle cite textuellement "Armour Roll" uniquement. Le moteur applique donc toujours le bonus à la blessure quand l'armure casse naturellement (stratégie optimale déjà en place).
- **Assists de foul** : ne sont pas un modificateur issu d'un Skill/Trait/Special Rule/SPQ/Prayer. Ils restent donc cumulés normalement (conforme au wording BB3).
- **Chainsaw auto-blessure** : quand le chainsawyer se blesse sur double 1 naturel, l'IHS n'entre pas en jeu (il s'agit de l'attaquant lui-même).
- Les logs de jet d'armure affichent désormais `[Iron Hard Skin]` quand le trait annule des modificateurs.
