### PR TITLE
chore: mark J.11 instable trait as complete in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -223,7 +223,7 @@
 | J.8 | Implementer `bloodlust` (3 variantes) | Regle | [x] |
 | J.9 | Implementer `always-hungry` | Regle | [x] |
 | J.10 | Implementer `foul-appearance` | Regle | [x] |
-| J.11 | Implementer `instable` | Regle | [ ] |
+| J.11 | Implementer `instable` | Regle | [x] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [ ] |
 | K.2 | Implementer `stab` | Regle | [ ] |
 | K.3 | Implementer `chainsaw` | Regle | [ ] |


### PR DESCRIPTION
## Resume

Synchronise le statut de la tache **J.11** du Sprint 13 dans `TODO.md` avec la realite du code.

Le trait **Instable (Unstable)** est deja entierement implemente depuis la PR #201 (commit `deb4a4a`), mais la case `[ ]` du Sprint 13 n'avait jamais ete cochee. Cette PR modifie uniquement le checkbox ; aucun code produit n'est touche.

## Etat de l'implementation existante

- **Logique** : `canInstablePerformAction()` + `logInstablePrevention()` dans `packages/game-engine/src/mechanics/negative-traits.ts` (lignes 984-1060)
- **Cablage** :
  - `getLegalMoves` (actions.ts l. 228/243/266) : filtre PASS / HANDOFF / THROW_TEAM_MATE pour les joueurs Instable
  - `applyMove` (actions.ts l. 2021/2065/2105) : rejette l'action et log la prevention pour ces 3 types
- **Regle BB3 S3** respectee : interdiction (pas un jet rate), pas de turnover, activation non consommee

## Tests

- 9 tests d'integration dans `packages/game-engine/src/mechanics/instable.test.ts`
- Tests unitaires `canInstablePerformAction` + `logInstablePrevention` dans `negative-traits.test.ts`
- Suite complete du game-engine : **3519/3519** passent
- `pnpm lint` : 0 erreur
- `pnpm typecheck` : 0 erreur
- `pnpm build` : OK pour game-engine / ui / server (le build web echoue uniquement sur une erreur reseau Google Fonts, sans rapport avec cette PR)

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `J.11 | Implementer instable`

## Plan de test

- [x] Lancer `pnpm --filter @bb/game-engine test src/mechanics/instable.test.ts` : 9/9 passent
- [x] Lancer `pnpm lint` : pas d'erreur
- [x] Lancer `pnpm typecheck` : pas d'erreur
- [ ] Verification manuelle : creer une equipe avec un Saurus Blocker (skill `instable`), verifier qu'il ne peut pas declarer Pass / Hand-Off / Throw Team-Mate dans l'UI
