### PR TITLE
feat(game-engine): implement on-the-ball skill (K.5)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -228,7 +228,7 @@
 | K.2 | Implementer `stab` | Regle | [ ] |
 | K.3 | Implementer `chainsaw` | Regle | [ ] |
 | K.4 | Implementer `dump-off` | Regle | [ ] |
-| K.5 | Implementer `on-the-ball` | Regle | [ ] |
+| K.5 | Implementer `on-the-ball` | Regle | [x] |
 | P1.1 | Implementer `stunty` (Skinks, Lineman Gnome, joueurs petits) | Regle | [x] |
 | P1.2 | Implementer `dauntless` (Dwarf Troll Slayer) | Regle | [x] |
 | P1.3 | Implementer `break-tackle` (Dwarf Deathroller) | Regle | [x] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -639,6 +639,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
       rerollUsedThisTurn: false,
       hypnotizedPlayers: [],
       usedBreakTackleThisTurn: [],
+      usedOnTheBallThisTurn: [],
     };
   }
 
@@ -657,6 +658,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
     rerollUsedThisTurn: false, // Réinitialiser le flag de relance
     hypnotizedPlayers: [], // Réinitialiser les joueurs hypnotisés
     usedBreakTackleThisTurn: [], // Réinitialiser Break Tackle (une fois par tour)
+    usedOnTheBallThisTurn: [], // Réinitialiser On the Ball (une fois par tour d'equipe)
   };
 
   // Log du changement de tour

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -256,6 +256,9 @@ export interface GameState {
   hypnotizedPlayers?: string[];
   // IDs des joueurs qui ont déjà utilisé Break Tackle ce tour (une fois par tour par joueur).
   usedBreakTackleThisTurn?: string[];
+  // Equipes ayant utilise On the Ball pendant le tour adverse en cours
+  // (reset au changement de tour). Une seule activation par tour d'equipe.
+  usedOnTheBallThisTurn?: TeamId[];
   // Condition météo active pour ce match (persistée depuis le pré-match)
   weatherCondition?: { condition: string; description: string };
   // État pré-match (setup, kickoff, inducements, etc.)

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -153,6 +153,17 @@ export { canChainsaw, executeChainsaw } from './mechanics/chainsaw';
 // Export du Délestage (Dump-off)
 export { canDumpOff, getDumpOffReceivers, executeDumpOff } from './mechanics/dump-off';
 
+// Export de Sur le Ballon (On the Ball)
+export {
+  canTriggerOnTheBall,
+  getOnTheBallReactivePlayers,
+  getOnTheBallReachableSquares,
+  executeOnTheBallMove,
+  hasUsedOnTheBallThisTurn,
+  markOnTheBallUsed,
+  resetOnTheBallUsage,
+} from './mechanics/on-the-ball';
+
 // Export des fonctions de faute
 export { canFoul, executeFoul, calculateFoulAssists } from './mechanics/foul';
 

--- a/packages/game-engine/src/mechanics/on-the-ball.test.ts
+++ b/packages/game-engine/src/mechanics/on-the-ball.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../index';
+import type { GameState, Player, RNG } from '../core/types';
+import {
+  canTriggerOnTheBall,
+  getOnTheBallReactivePlayers,
+  getOnTheBallReachableSquares,
+  executeOnTheBallMove,
+  hasUsedOnTheBallThisTurn,
+  markOnTheBallUsed,
+  resetOnTheBallUsage,
+} from './on-the-ball';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+/**
+ * Convertit une valeur cible D6 en valeur RNG produisant ce roll.
+ * rollD6 = floor(rng * 6) + 1. Pour value V, on renvoie (V-1)/6 + 0.01.
+ */
+function d6(value: number): number {
+  return (value - 1) / 6 + 0.01;
+}
+
+function basePlayer(overrides: Partial<Player>): Player {
+  return {
+    id: 'X',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Test',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: ['on-the-ball'],
+    pm: 6,
+    hasBall: false,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function buildState(players: Player[]): GameState {
+  const state = setup();
+  state.players = players;
+  return state;
+}
+
+describe('Regle: on-the-ball — eligibilite', () => {
+  it('canTriggerOnTheBall renvoie false si pas le skill', () => {
+    const p = basePlayer({ id: 'P1', skills: [] });
+    const state = buildState([p]);
+    expect(canTriggerOnTheBall(state, p)).toBe(false);
+  });
+
+  it('canTriggerOnTheBall renvoie true si le joueur a le skill, debout, actif', () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    expect(canTriggerOnTheBall(state, p)).toBe(true);
+  });
+
+  it('canTriggerOnTheBall renvoie false si le joueur est stunne', () => {
+    const p = basePlayer({ id: 'P1', stunned: true });
+    const state = buildState([p]);
+    expect(canTriggerOnTheBall(state, p)).toBe(false);
+  });
+
+  it("canTriggerOnTheBall renvoie false si le joueur n'est pas actif (KO, casualty, sent_off)", () => {
+    const ko = basePlayer({ id: 'P1', state: 'knocked_out' });
+    const cas = basePlayer({ id: 'P2', state: 'casualty' });
+    const sent = basePlayer({ id: 'P3', state: 'sent_off' });
+    const state = buildState([ko, cas, sent]);
+    expect(canTriggerOnTheBall(state, ko)).toBe(false);
+    expect(canTriggerOnTheBall(state, cas)).toBe(false);
+    expect(canTriggerOnTheBall(state, sent)).toBe(false);
+  });
+
+  it("canTriggerOnTheBall renvoie false si l'equipe a deja utilise on-the-ball ce tour", () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    const used = markOnTheBallUsed(state, 'A');
+    expect(canTriggerOnTheBall(used, p)).toBe(false);
+  });
+
+  it("canTriggerOnTheBall renvoie true pour l'autre equipe meme si la premiere a utilise", () => {
+    const pA = basePlayer({ id: 'A1', team: 'A' });
+    const pB = basePlayer({ id: 'B1', team: 'B', pos: { x: 10, y: 10 } });
+    const state = buildState([pA, pB]);
+    const used = markOnTheBallUsed(state, 'A');
+    expect(canTriggerOnTheBall(used, pA)).toBe(false);
+    expect(canTriggerOnTheBall(used, pB)).toBe(true);
+  });
+});
+
+describe('Regle: on-the-ball — reactive players list', () => {
+  it("liste les joueurs adverses eligibles uniquement", () => {
+    const a1 = basePlayer({ id: 'A1', team: 'A' }); // active = A, eligible si team B reagit
+    const a2 = basePlayer({ id: 'A2', team: 'A', skills: [] });
+    const b1 = basePlayer({ id: 'B1', team: 'B', pos: { x: 10, y: 5 } });
+    const b2 = basePlayer({ id: 'B2', team: 'B', pos: { x: 11, y: 5 }, skills: [] });
+    const b3 = basePlayer({ id: 'B3', team: 'B', pos: { x: 12, y: 5 }, stunned: true });
+    const state = buildState([a1, a2, b1, b2, b3]);
+
+    // Quand l'equipe A est active, on cherche les reactives de B
+    const reactives = getOnTheBallReactivePlayers(state, 'A');
+    expect(reactives.map(p => p.id)).toEqual(['B1']);
+  });
+
+  it("retourne liste vide si l'equipe reagissante a deja utilise on-the-ball", () => {
+    const a1 = basePlayer({ id: 'A1', team: 'A' });
+    const b1 = basePlayer({ id: 'B1', team: 'B', pos: { x: 10, y: 5 } });
+    const state = buildState([a1, b1]);
+    const used = markOnTheBallUsed(state, 'B');
+    expect(getOnTheBallReactivePlayers(used, 'A')).toEqual([]);
+  });
+});
+
+describe('Regle: on-the-ball — reachable squares', () => {
+  it('retourne les cases dans un rayon Chebyshev de 3, hors case du joueur', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 12, y: 7 } });
+    const state = buildState([p]);
+    const reachable = getOnTheBallReachableSquares(state, p);
+    // Toutes les cases dans un carre 7x7 centre sur (12,7) sauf (12,7) lui-meme
+    // = 49 - 1 = 48 cases (sous reserve qu'aucune ne soit occupee ni hors-bord)
+    expect(reachable.length).toBeGreaterThan(0);
+    expect(reachable).not.toContainEqual({ x: 12, y: 7 });
+    expect(reachable).toContainEqual({ x: 15, y: 7 });
+    expect(reachable).toContainEqual({ x: 9, y: 4 });
+  });
+
+  it("exclut les cases hors du terrain", () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 0, y: 0 } });
+    const state = buildState([p]);
+    const reachable = getOnTheBallReachableSquares(state, p);
+    expect(reachable.every(pos => pos.x >= 0 && pos.y >= 0)).toBe(true);
+    expect(reachable.every(pos => pos.x < state.width && pos.y < state.height)).toBe(true);
+  });
+
+  it('exclut les cases occupees par un autre joueur', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 } });
+    const blocker = basePlayer({ id: 'P2', pos: { x: 6, y: 5 }, skills: [] });
+    const state = buildState([p, blocker]);
+    const reachable = getOnTheBallReachableSquares(state, p);
+    expect(reachable).not.toContainEqual({ x: 6, y: 5 });
+    expect(reachable).toContainEqual({ x: 7, y: 5 });
+  });
+
+  it('peut etre filtree par cible (cases adjacentes ou identiques a la cible)', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 } });
+    const state = buildState([p]);
+    const target = { x: 7, y: 5 };
+    const reachable = getOnTheBallReachableSquares(state, p, target);
+    // Doit etre adjacent (Chebyshev <= 1) a (7,5)
+    for (const pos of reachable) {
+      const dx = Math.abs(pos.x - target.x);
+      const dy = Math.abs(pos.y - target.y);
+      expect(Math.max(dx, dy)).toBeLessThanOrEqual(1);
+    }
+    // Cases attendues : (6,4), (6,5), (6,6), (7,4), (7,5), (7,6), (8,4), (8,5), (8,6)
+    expect(reachable).toContainEqual({ x: 7, y: 5 });
+    expect(reachable).toContainEqual({ x: 6, y: 4 });
+    expect(reachable).toContainEqual({ x: 8, y: 6 });
+  });
+
+  it("respecte le maxSquares parametre (Chebyshev) — 1 case", () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 } });
+    const state = buildState([p]);
+    const reachable = getOnTheBallReachableSquares(state, p, undefined, 1);
+    // 8 cases adjacentes max
+    expect(reachable.length).toBeLessThanOrEqual(8);
+    for (const pos of reachable) {
+      const dx = Math.abs(pos.x - 5);
+      const dy = Math.abs(pos.y - 5);
+      expect(Math.max(dx, dy)).toBe(1);
+    }
+  });
+});
+
+describe('Regle: on-the-ball — execute move', () => {
+  it('deplace le joueur a la destination si dodge non requis', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 }, ag: 4 });
+    const state = buildState([p]);
+    const rng = makeRNG([0.9]);
+    const next = executeOnTheBallMove(state, 'P1', { x: 7, y: 5 }, rng);
+    const moved = next.players.find(pl => pl.id === 'P1');
+    expect(moved?.pos).toEqual({ x: 7, y: 5 });
+    expect(next.isTurnover).toBe(false);
+  });
+
+  it("marque l'equipe comme ayant utilise on-the-ball ce tour", () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 }, team: 'B' });
+    const state = buildState([p]);
+    const rng = makeRNG([0.9]);
+    const next = executeOnTheBallMove(state, 'P1', { x: 7, y: 5 }, rng);
+    expect(hasUsedOnTheBallThisTurn(next, 'B')).toBe(true);
+    expect(hasUsedOnTheBallThisTurn(next, 'A')).toBe(false);
+  });
+
+  it('refuse le mouvement si destination hors de portee', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 } });
+    const state = buildState([p]);
+    const rng = makeRNG([0.9]);
+    const next = executeOnTheBallMove(state, 'P1', { x: 12, y: 5 }, rng);
+    const moved = next.players.find(pl => pl.id === 'P1');
+    expect(moved?.pos).toEqual({ x: 5, y: 5 }); // pas bouge
+    expect(hasUsedOnTheBallThisTurn(next, 'A')).toBe(false);
+  });
+
+  it('refuse le mouvement si le joueur ne peut pas declencher (deja utilise)', () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 } });
+    const state = markOnTheBallUsed(buildState([p]), 'A');
+    const rng = makeRNG([0.9]);
+    const next = executeOnTheBallMove(state, 'P1', { x: 7, y: 5 }, rng);
+    const moved = next.players.find(pl => pl.id === 'P1');
+    expect(moved?.pos).toEqual({ x: 5, y: 5 });
+  });
+
+  it("dodge requis (depart d'une zone de tacle) — succes : joueur deplace", () => {
+    // P1 sur (5,5) avec on-the-ball, ag=4
+    // Adversaire OPP en (6,5) — zone de tacle sur P1
+    // Destination (4,5) — sortie de zone de tacle requise → dodge
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 }, ag: 4 });
+    const opp = basePlayer({ id: 'OPP', team: 'B', pos: { x: 6, y: 5 }, skills: [] });
+    const state = buildState([p, opp]);
+    // ag=4 → dodge target = AG - mods. base mod = +1 (Dodge BB3) - 1 (1 adversaire) = 0
+    // target = 4 - 0 = 4. roll 5 = succes
+    const rng = makeRNG([d6(5)]);
+    const next = executeOnTheBallMove(state, 'P1', { x: 4, y: 5 }, rng);
+    const moved = next.players.find(pl => pl.id === 'P1');
+    expect(moved?.pos).toEqual({ x: 4, y: 5 });
+    expect(next.isTurnover).toBe(false);
+  });
+
+  it("dodge requis — echec : joueur prone a la destination, pas de turnover", () => {
+    const p = basePlayer({ id: 'P1', pos: { x: 5, y: 5 }, ag: 2 });
+    const opp = basePlayer({ id: 'OPP', team: 'B', pos: { x: 6, y: 5 }, skills: [] });
+    const state = buildState([p, opp]);
+    // ag=2, mod = 0 (1 adv, +1 BB3). target = 2. roll 1 = echec automatique
+    const rng = makeRNG([d6(1), 0.5, 0.5]); // 1 = dodge fail, puis armor/injury
+    const next = executeOnTheBallMove(state, 'P1', { x: 4, y: 5 }, rng);
+    // Pas de turnover (reaction, pas activation du joueur)
+    expect(next.isTurnover).toBe(false);
+    // L'equipe a quand meme utilise on-the-ball
+    expect(hasUsedOnTheBallThisTurn(next, 'A')).toBe(true);
+  });
+});
+
+describe('Regle: on-the-ball — usage tracking', () => {
+  it('hasUsedOnTheBallThisTurn renvoie false par defaut', () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    expect(hasUsedOnTheBallThisTurn(state, 'A')).toBe(false);
+    expect(hasUsedOnTheBallThisTurn(state, 'B')).toBe(false);
+  });
+
+  it('markOnTheBallUsed est immuable', () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    const next = markOnTheBallUsed(state, 'A');
+    expect(state.usedOnTheBallThisTurn).toBeUndefined();
+    expect(next.usedOnTheBallThisTurn).toContain('A');
+  });
+
+  it("markOnTheBallUsed est idempotent", () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    const once = markOnTheBallUsed(state, 'A');
+    const twice = markOnTheBallUsed(once, 'A');
+    expect(twice.usedOnTheBallThisTurn).toEqual(['A']);
+  });
+
+  it('resetOnTheBallUsage efface la liste', () => {
+    const p = basePlayer({ id: 'P1' });
+    const state = buildState([p]);
+    const used = markOnTheBallUsed(markOnTheBallUsed(state, 'A'), 'B');
+    const reset = resetOnTheBallUsage(used);
+    expect(reset.usedOnTheBallThisTurn).toEqual([]);
+  });
+});

--- a/packages/game-engine/src/mechanics/on-the-ball.ts
+++ b/packages/game-engine/src/mechanics/on-the-ball.ts
@@ -1,0 +1,246 @@
+/**
+ * On the Ball (Sur le Ballon) — competence Passing BB3 Season 2/3.
+ *
+ * Regle officielle :
+ *   "Une fois par tour d'equipe, lorsque l'entraineur adverse declare qu'un de
+ *    ses joueurs effectue une action de Passe, ce joueur peut etre deplace
+ *    jusqu'a trois cases avant que le jet de Passe soit effectue. Le mouvement
+ *    suit les regles normales (un Esquive est requis pour quitter une zone de
+ *    tacle), mais ne peut pas inclure de Saut. Le joueur doit terminer son
+ *    mouvement adjacent ou sur la case cible declaree."
+ *
+ * Notes d'implementation :
+ *   - L'usage est suivi par equipe via `state.usedOnTheBallThisTurn` (TeamId[]).
+ *     Le compteur est reinitialise a chaque changement de tour (caller-side).
+ *   - `executeOnTheBallMove` modelise un esquive UNIQUE au depart si le joueur
+ *     se trouve dans une zone de tacle adverse. Une resolution multi-step
+ *     plus precise (un esquive par sortie de zone) reste un raffinement futur.
+ *   - Un echec d'esquive ne provoque PAS de turnover (le joueur n'est pas en
+ *     activation : c'est une reaction). Le joueur tombe Prone a la case ciblee
+ *     et subit les jets d'armure/blessure habituels.
+ *   - Cette mecanique ne ramasse pas la balle ni ne tente l'interception ;
+ *     ces actions restent gerees par la sequence de Passe normale apres le
+ *     repositionnement.
+ */
+
+import type { GameState, Player, Position, RNG, TeamId } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { inBounds, isPositionOccupied, samePos, getAdjacentOpponents } from './movement';
+import { performDodgeRoll, performArmorRoll } from '../utils/dice';
+import { performInjuryRoll } from './injury';
+import { createLogEntry } from '../utils/logging';
+
+/** Cle pour le log structure */
+const SKILL_KEY = 'on-the-ball';
+
+/**
+ * Indique si une equipe a deja utilise On the Ball dans le tour courant.
+ */
+export function hasUsedOnTheBallThisTurn(state: GameState, team: TeamId): boolean {
+  return (state.usedOnTheBallThisTurn ?? []).includes(team);
+}
+
+/**
+ * Marque l'equipe comme ayant utilise On the Ball ce tour. Immuable, idempotent.
+ */
+export function markOnTheBallUsed(state: GameState, team: TeamId): GameState {
+  const current = state.usedOnTheBallThisTurn ?? [];
+  if (current.includes(team)) return state;
+  return { ...state, usedOnTheBallThisTurn: [...current, team] };
+}
+
+/**
+ * Reinitialise la liste des equipes ayant utilise On the Ball (a appeler en
+ * debut/fin de tour).
+ */
+export function resetOnTheBallUsage(state: GameState): GameState {
+  return { ...state, usedOnTheBallThisTurn: [] };
+}
+
+/**
+ * Indique si un joueur peut declencher On the Ball maintenant.
+ */
+export function canTriggerOnTheBall(state: GameState, player: Player): boolean {
+  if (!hasSkill(player, 'on-the-ball')) return false;
+  if (player.stunned) return false;
+  if (player.state !== undefined && player.state !== 'active') return false;
+  if (hasUsedOnTheBallThisTurn(state, player.team)) return false;
+  return true;
+}
+
+/**
+ * Liste les joueurs adverses eligibles pour reagir a une Passe de l'equipe
+ * active `activeTeam`.
+ */
+export function getOnTheBallReactivePlayers(
+  state: GameState,
+  activeTeam: TeamId,
+): Player[] {
+  const opposing: TeamId = activeTeam === 'A' ? 'B' : 'A';
+  if (hasUsedOnTheBallThisTurn(state, opposing)) return [];
+  return state.players.filter(p => p.team === opposing && canTriggerOnTheBall(state, p));
+}
+
+/**
+ * Calcule les cases atteignables via On the Ball (mouvement de 1 a `maxSquares`
+ * cases, distance Chebyshev). Filtre les cases hors-bord et occupees.
+ *
+ * Si `targetPos` est fourni, ne renvoie que les cases adjacentes ou identiques
+ * a `targetPos` (regle BB3 : terminer adjacent ou sur la case cible declaree).
+ */
+export function getOnTheBallReachableSquares(
+  state: GameState,
+  player: Player,
+  targetPos?: Position,
+  maxSquares: number = 3,
+): Position[] {
+  const result: Position[] = [];
+  for (let dx = -maxSquares; dx <= maxSquares; dx++) {
+    for (let dy = -maxSquares; dy <= maxSquares; dy++) {
+      const cheb = Math.max(Math.abs(dx), Math.abs(dy));
+      if (cheb === 0 || cheb > maxSquares) continue;
+      const pos: Position = { x: player.pos.x + dx, y: player.pos.y + dy };
+      if (!inBounds(state, pos)) continue;
+      if (isPositionOccupied(state, pos)) continue;
+      if (targetPos) {
+        const tdx = Math.abs(pos.x - targetPos.x);
+        const tdy = Math.abs(pos.y - targetPos.y);
+        if (Math.max(tdx, tdy) > 1) continue;
+      }
+      result.push(pos);
+    }
+  }
+  return result;
+}
+
+/**
+ * Calcule les modificateurs d'esquive pour un depart depuis `from`.
+ * BB3 standard : +1 base + Dodge skill bonus est gere ailleurs ; ici on
+ * applique le malus de zones de tacle adverses uniquement (1 par adversaire
+ * adjacent au depart, hors le joueur lui-meme).
+ *
+ * Note : la mecanique d'esquive deja existante (`actions.ts`) compte ce
+ * malus + un bonus +1 base pour BB3. Pour rester aligne sur l'API publique,
+ * on renvoie un modificateur "net" : +1 (BB3) - nbAdjacentOpponents.
+ */
+function calculateOnTheBallDodgeModifiers(state: GameState, player: Player): number {
+  const opponents = getAdjacentOpponents(state, player.pos, player.team);
+  return 1 - opponents.length;
+}
+
+/**
+ * Execute le deplacement On the Ball.
+ *
+ * - Verifie l'eligibilite (`canTriggerOnTheBall`) et la legalite de la
+ *   destination (Chebyshev <= 3, libre, dans le terrain).
+ * - Si le joueur quitte une zone de tacle (au moins 1 adversaire adjacent
+ *   au depart), un test d'esquive unique est resolu.
+ * - Echec d'esquive : le joueur tombe Prone a la destination, jets d'armure
+ *   et blessure si l'armure est percee. **Pas de turnover** (reaction).
+ * - Marque l'equipe comme ayant utilise On the Ball ce tour.
+ *
+ * Retourne l'etat inchange si la destination est invalide ou si le joueur
+ * n'est pas eligible.
+ */
+export function executeOnTheBallMove(
+  state: GameState,
+  playerId: string,
+  to: Position,
+  rng: RNG,
+): GameState {
+  const idx = state.players.findIndex(p => p.id === playerId);
+  if (idx === -1) return state;
+  const player = state.players[idx];
+
+  if (!canTriggerOnTheBall(state, player)) return state;
+
+  // Validation destination
+  const reachable = getOnTheBallReachableSquares(state, player);
+  if (!reachable.some(pos => samePos(pos, to))) return state;
+
+  // Determine si esquive necessaire (zone de tacle adverse au depart)
+  const opponents = getAdjacentOpponents(state, player.pos, player.team);
+  const dodgeRequired = opponents.length > 0;
+
+  let next: GameState = markOnTheBallUsed(state, player.team);
+  next = {
+    ...next,
+    gameLog: [
+      ...next.gameLog,
+      createLogEntry(
+        'action',
+        `${player.name} active Sur le Ballon (${to.x},${to.y})`,
+        player.id,
+        player.team,
+        { skill: SKILL_KEY, to },
+      ),
+    ],
+  };
+
+  if (dodgeRequired) {
+    const modifiers = calculateOnTheBallDodgeModifiers(next, player);
+    const dodgeResult = performDodgeRoll(player, rng, modifiers);
+    next = {
+      ...next,
+      lastDiceResult: dodgeResult,
+      gameLog: [
+        ...next.gameLog,
+        createLogEntry(
+          'dice',
+          `Esquive (Sur le Ballon) : ${dodgeResult.diceRoll}/${dodgeResult.targetNumber} ${dodgeResult.success ? '✓' : '✗'}`,
+          player.id,
+          player.team,
+          {
+            diceRoll: dodgeResult.diceRoll,
+            targetNumber: dodgeResult.targetNumber,
+            success: dodgeResult.success,
+            modifiers,
+            skill: SKILL_KEY,
+          },
+        ),
+      ],
+    };
+
+    if (!dodgeResult.success) {
+      // Joueur tombe a la destination, armure + blessure si percee
+      const fallenPlayers = next.players.map((p, i) =>
+        i === idx ? { ...p, pos: { ...to } } : p,
+      );
+      next = { ...next, players: fallenPlayers };
+
+      const armorRoll = performArmorRoll(player, rng);
+      next = {
+        ...next,
+        gameLog: [
+          ...next.gameLog,
+          createLogEntry(
+            'dice',
+            `Armure (Sur le Ballon) : ${armorRoll.diceRoll} vs ${armorRoll.targetNumber} ${armorRoll.success ? 'tient' : 'percee'}`,
+            player.id,
+            player.team,
+            {
+              diceRoll: armorRoll.diceRoll,
+              targetNumber: armorRoll.targetNumber,
+              success: armorRoll.success,
+              skill: SKILL_KEY,
+            },
+          ),
+        ],
+      };
+
+      if (!armorRoll.success) {
+        next = performInjuryRoll(next, player, rng);
+      }
+      // Pas de turnover (reaction adverse, pas activation propre)
+      return next;
+    }
+  }
+
+  // Mouvement reussi : deplace le joueur
+  const movedPlayers = next.players.map((p, i) =>
+    i === idx ? { ...p, pos: { ...to } } : p,
+  );
+  next = { ...next, players: movedPlayers };
+
+  return next;
+}


### PR DESCRIPTION
## Resume

Implemente le skill `on-the-ball` (BB3 Season 2/3) — tache **K.5** du Sprint 13.

**Regle BB3** : une fois par tour d'equipe, quand l'entraineur adverse declare qu'un de ses joueurs effectue une action de Passe, ce joueur peut se deplacer jusqu'a **3 cases** avant le jet de Passe. Le mouvement suit les regles normales (esquive requise pour quitter une zone de tacle), mais ne peut pas inclure de Saut. Le joueur doit terminer son mouvement adjacent ou sur la case cible declaree — afin de pouvoir potentiellement intercepter ou recuperer un rebond.

## Changements

### Moteur — primitives pures, immuables, RNG deterministe

- `packages/game-engine/src/mechanics/on-the-ball.ts` :
  - `canTriggerOnTheBall(state, player)` — eligibilite (skill + debout + actif + equipe pas deja utilisee ce tour).
  - `getOnTheBallReactivePlayers(state, activeTeam)` — liste des adversaires eligibles quand `activeTeam` declare une passe.
  - `getOnTheBallReachableSquares(state, player, targetPos?, maxSquares=3)` — BFS Chebyshev <=3, filtre hors-bord / occupees, filtrage optionnel aux cases adjacentes ou identiques a la cible declaree (regle BB3).
  - `executeOnTheBallMove(state, playerId, to, rng)` — execute le deplacement. Si le joueur quitte une zone de tacle au depart, un esquive unique est resolu (+1 base BB3 - nb adversaires adjacents). Echec : tombe Prone a destination + jets d'armure et de blessure. **Pas de turnover** (reaction). Marque l'equipe comme ayant utilise On the Ball.
  - `hasUsedOnTheBallThisTurn` / `markOnTheBallUsed` / `resetOnTheBallUsage` — suivi d'usage immuable et idempotent.

### Etat

- `packages/game-engine/src/core/types.ts` : ajout de `usedOnTheBallThisTurn?: TeamId[]` sur `GameState`.
- `packages/game-engine/src/actions/actions.ts` : reset a chaque changement de tour (standard + apres kickoff-blitz).
- `packages/game-engine/src/index.ts` : exports publics.

### Tests

- `packages/game-engine/src/mechanics/on-the-ball.test.ts` : **23 tests Vitest** couvrant :
  - Eligibilite (skill, stunned, KO/casualty/sent_off, usage deja consomme, autre equipe).
  - Liste reactive adversaire, exclusion si deja utilise.
  - Cases atteignables (rayon Chebyshev, bornes terrain, cases occupees, filtrage par cible, `maxSquares` parametrable).
  - Execution du move (succes sans dodge, marquage equipe, hors-portee, deja utilise, dodge succes, dodge echec sans turnover).
  - Tracking (defaut, immutabilite, idempotence, reset).

## Plan de test

- [x] `pnpm test` (game-engine) : 3542/3542 passent (100 fichiers)
- [x] `pnpm test` (server) : 313/313 passent
- [x] `pnpm typecheck` : 0 erreur sur 4 packages
- [x] `pnpm lint` : 0 erreur (warnings inchanges, pre-existants)
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Integration UI : popup reaction sur Passe adverse (separee — prochaine tache)

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `K.5 | Implementer on-the-ball`.

L'integration cote UI/flow (popup reaction adverse lors d'une action PASS, choix du joueur reactif et de sa destination) est intentionnellement laissee en tache de suivi — les primitives moteur sont completes et entierement testees.