### PR TITLE
claude/fix-missing-teams-2025-87vYL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,37 @@ jobs:
             docker compose -f docker-compose.prod.yml build --no-cache
             docker compose -f docker-compose.prod.yml up -d
 
+            # Appliquer le schéma Prisma puis seeder les données de référence
+            # (rosters, star players, compétences...) pour chaque ruleset.
+            # Sans cette étape, les nouveautés du schéma (ex. ajout du ruleset
+            # `season_3`) ne sont jamais propagées en prod et la liste
+            # /teams apparaît vide pour les nouvelles saisons.
+            echo "⏳ Attente de Postgres (max 60s)..."
+            DB_TIMEOUT=60
+            DB_ELAPSED=0
+            until docker compose -f docker-compose.prod.yml exec -T db \
+                pg_isready -U "${POSTGRES_USER:-bb_user}" \
+                -d "${POSTGRES_DB:-bb_db}" >/dev/null 2>&1; do
+              if [ $DB_ELAPSED -ge $DB_TIMEOUT ]; then
+                echo "❌ Postgres toujours indisponible après ${DB_TIMEOUT}s"
+                exit 1
+              fi
+              sleep 3
+              DB_ELAPSED=$((DB_ELAPSED + 3))
+            done
+            echo "✅ Postgres prêt"
+
+            echo "🗄️  Application du schéma Prisma (db push)..."
+            docker compose -f docker-compose.prod.yml exec -T server \
+              pnpm -w exec prisma db push \
+              --schema prisma/schema.prisma \
+              --accept-data-loss \
+              --skip-generate
+
+            echo "🌱 Seed des données de référence (rosters, skills, ...)..."
+            docker compose -f docker-compose.prod.yml exec -T server \
+              sh -c "cd apps/server && pnpm run db:seed"
+
             # Attendre que les health checks passent (max 90s)
             echo "⏳ Attente que les services soient healthy..."
             TIMEOUT=90

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -239,45 +239,54 @@ if (process.env.TEST_SQLITE === "1") {
         },
       ];
 
-      for (const r of rosters) {
-        const roster = await prisma.roster.upsert({
-          where: { slug_ruleset: { slug: r.slug, ruleset: "season_2" } },
-          update: {},
-          create: {
-            slug: r.slug,
-            ruleset: "season_2",
-            name: r.name,
-            nameEn: r.nameEn,
-            budget: 1_000_000,
-            tier: r.tier,
-          },
-        });
+      // Seed for both rulesets so tests covering either season_2 or
+      // season_3 endpoints have data.
+      const rulesets = ["season_2", "season_3"] as const;
+      for (const ruleset of rulesets) {
+        for (const r of rosters) {
+          const roster = await prisma.roster.upsert({
+            where: { slug_ruleset: { slug: r.slug, ruleset } },
+            update: {},
+            create: {
+              slug: r.slug,
+              ruleset,
+              name: r.name,
+              nameEn: r.nameEn,
+              budget: 1_000_000,
+              tier: r.tier,
+            },
+          });
 
-        await prisma.position.upsert({
-          where: {
-            rosterId_slug: {
+          await prisma.position.upsert({
+            where: {
+              rosterId_slug: {
+                rosterId: roster.id,
+                slug: `${r.slug}_lineman`,
+              },
+            },
+            update: {},
+            create: {
               rosterId: roster.id,
               slug: `${r.slug}_lineman`,
+              displayName: "Lineman",
+              cost: 50_000,
+              min: 0,
+              max: 16, // getLinemanStats prend la position avec le plus grand max
+              ma: 6,
+              st: 3,
+              ag: 3,
+              pa: 4,
+              av: 8,
             },
-          },
-          update: {},
-          create: {
-            rosterId: roster.id,
-            slug: `${r.slug}_lineman`,
-            displayName: "Lineman",
-            cost: 50_000,
-            min: 0,
-            max: 16, // getLinemanStats prend la position avec le plus grand max
-            ma: 6,
-            st: 3,
-            ag: 3,
-            pa: 4,
-            av: 8,
-          },
-        });
+          });
+        }
       }
 
-      return res.json({ ok: true, rosters: rosters.map((r) => r.slug) });
+      return res.json({
+        ok: true,
+        rulesets,
+        rosters: rosters.map((r) => r.slug),
+      });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       console.error("[__test/seed-rosters]", msg);

--- a/apps/server/src/routes/public-rosters.ts
+++ b/apps/server/src/routes/public-rosters.ts
@@ -5,7 +5,11 @@
 
 import { Router } from "express";
 import { prisma } from "../prisma";
-import { resolveRuleset, DEFAULT_RULESET } from "../utils/ruleset-helpers";
+import {
+  resolveRuleset,
+  DEFAULT_RULESET,
+  RULESETS,
+} from "../utils/ruleset-helpers";
 
 const router = Router();
 
@@ -47,11 +51,26 @@ router.get("/rosters", async (req, res) => {
       ruleset: roster.ruleset,
       _count: roster._count,
     }));
-    
-    res.json({ rosters: transformedRosters, ruleset });
-  } catch (error: any) {
+
+    // Empty results are a strong smell that the DB has not been seeded
+    // for this ruleset (e.g. prod Postgres missing `season_3` rosters).
+    // Emitting a warning here makes that regression discoverable in logs.
+    if (transformedRosters.length === 0) {
+      console.warn(
+        `[public-rosters] No rosters found for ruleset=${ruleset}. ` +
+          "The database may need a seed for this ruleset.",
+      );
+    }
+
+    res.json({
+      rosters: transformedRosters,
+      ruleset,
+      availableRulesets: RULESETS,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Erreur serveur";
     console.error("Erreur lors de la récupération des rosters:", error);
-    res.status(500).json({ error: error.message || "Erreur serveur" });
+    res.status(500).json({ error: message });
   }
 });
 
@@ -108,9 +127,10 @@ router.get("/rosters/:slug", async (req, res) => {
     }
 
     res.json({ roster: transformRoster(roster, isEnglish), ruleset });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Erreur serveur";
     console.error("Erreur lors de la récupération du roster:", error);
-    res.status(500).json({ error: error.message || "Erreur serveur" });
+    res.status(500).json({ error: message });
   }
 });
 

--- a/docs/DEPLOY-DB.md
+++ b/docs/DEPLOY-DB.md
@@ -1,0 +1,81 @@
+# Déploiement de la base de données
+
+## Contexte
+
+Nuffle Arena utilise Prisma avec PostgreSQL en production (voir
+`prisma/schema.prisma`). Les **rosters**, **star players**, **compétences** et
+autres données de référence sont maintenues en code (dans
+`packages/game-engine/src/rosters/`) et chargées en base via un script de
+seed idempotent (`apps/server/src/seed.ts`).
+
+Le projet n'utilise **pas** encore `prisma migrate` : le schéma est appliqué
+avec `prisma db push`. Une adoption future de `prisma migrate` est suivie
+dans un ticket dédié (cf. « Futur »).
+
+## Flux automatique (déploiement CI)
+
+À chaque push sur `main`, le workflow `.github/workflows/deploy.yml`
+exécute les étapes suivantes **après** avoir redémarré les containers :
+
+1. Attente que Postgres soit prêt (`pg_isready`, timeout 60s).
+2. `prisma db push --accept-data-loss --skip-generate` — aligne le schéma
+   Postgres sur `prisma/schema.prisma` (ajoute enum `Ruleset`, colonnes
+   `ruleset`, nouvelles contraintes d'unicité, etc.).
+3. `pnpm run db:seed` (depuis `apps/server`) — itère sur tous les
+   rulesets (`season_2`, `season_3`, …) et upsert les rosters, positions,
+   compétences et star players correspondants.
+
+Le seed est **idempotent** (findUnique + update/create). Il met à jour les
+rosters existants avec le contenu actuel du code — toute modification
+manuelle en base sur les données de référence sera écrasée.
+
+## Exécution manuelle
+
+Si un déploiement a été fait sans `db push`/`seed` (ancienne version du
+workflow), ou si un incident nécessite un re-seed, depuis le serveur de
+prod :
+
+```bash
+cd ~/fantasy-football-game
+
+# 1. Aligner le schéma Postgres
+docker compose -f docker-compose.prod.yml exec -T server \
+  pnpm -w exec prisma db push \
+  --schema prisma/schema.prisma \
+  --accept-data-loss \
+  --skip-generate
+
+# 2. Re-seeder les données de référence
+docker compose -f docker-compose.prod.yml exec -T server \
+  sh -c "cd apps/server && pnpm run db:seed"
+```
+
+## Vérification
+
+Pour confirmer qu'une saison donnée a bien des rosters :
+
+```bash
+curl -s "https://api.nufflearena.fr/api/rosters?ruleset=season_3" \
+  | jq '.rosters | length'
+```
+
+La réponse doit renvoyer un entier positif. La liste des rulesets
+supportés est également exposée par l'API via le champ
+`availableRulesets`.
+
+## Ajouter un nouveau ruleset
+
+1. Ajouter la valeur à l'enum `Ruleset` dans `prisma/schema.prisma`.
+2. Ajouter la valeur dans `RULESETS` / `Ruleset` de
+   `packages/game-engine/src/rosters/positions.ts`.
+3. Ajouter les rosters correspondants
+   (ex. `packages/game-engine/src/rosters/season4-rosters.ts`) et brancher
+   la map dans `TEAM_ROSTERS_BY_RULESET`.
+4. Pousser sur `main` — le déploiement CI applique automatiquement le
+   nouveau schéma et seed les données.
+
+## Futur
+
+Adoption de `prisma migrate deploy` pour tracer l'historique des schémas
+et sécuriser les migrations de données : voir le ticket de suivi ouvert
+après la correction du bug « Saison 3 vide » sur `/teams`.

--- a/tests/integration/public-rosters.test.ts
+++ b/tests/integration/public-rosters.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for GET /api/rosters — ensures that the public roster
+ * listing returns results for every supported `ruleset`.
+ *
+ * Background: production had a bug where the frontend asked for
+ * `?ruleset=season_3` but the database only contained season_2 rosters,
+ * so the /teams page appeared empty for "Saison 3 (2025)". This test
+ * locks in the expected behaviour.
+ */
+
+import fetch from "node-fetch";
+
+const API_BASE =
+  process.env.API_BASE ||
+  process.env.NEXT_PUBLIC_API_BASE ||
+  `http://localhost:${process.env.API_PORT || "18001"}`;
+
+interface RosterSummary {
+  slug: string;
+  name: string;
+  budget: number;
+  tier: string;
+  naf: boolean;
+  ruleset?: string;
+}
+
+interface RostersResponse {
+  rosters: RosterSummary[];
+  ruleset: string;
+  availableRulesets?: string[];
+}
+
+async function waitForServer(maxWaitMs = 20_000): Promise<void> {
+  const start = Date.now();
+  let lastError: unknown;
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const res = await fetch(`${API_BASE}/health`);
+      if (res.ok) return;
+    } catch (error: unknown) {
+      lastError = error;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `Server at ${API_BASE} did not become ready within ${maxWaitMs}ms: ${String(lastError)}`,
+  );
+}
+
+async function seedRosters(): Promise<void> {
+  await waitForServer();
+  const res = await fetch(`${API_BASE}/__test/seed-rosters`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to seed rosters: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+describe("GET /api/rosters (public rosters listing)", () => {
+  beforeAll(async () => {
+    await seedRosters();
+  });
+
+  it("returns season_2 rosters when ?ruleset=season_2", async () => {
+    const res = await fetch(`${API_BASE}/api/rosters?ruleset=season_2`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as RostersResponse;
+    expect(data.ruleset).toBe("season_2");
+    expect(Array.isArray(data.rosters)).toBe(true);
+    expect(data.rosters.length).toBeGreaterThan(0);
+  });
+
+  it("returns season_3 rosters when ?ruleset=season_3 (regression for empty /teams in 2025)", async () => {
+    const res = await fetch(`${API_BASE}/api/rosters?ruleset=season_3`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as RostersResponse;
+    expect(data.ruleset).toBe("season_3");
+    expect(Array.isArray(data.rosters)).toBe(true);
+    expect(data.rosters.length).toBeGreaterThan(0);
+  });
+
+  it("exposes the list of available rulesets in the response metadata", async () => {
+    const res = await fetch(`${API_BASE}/api/rosters?ruleset=season_3`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as RostersResponse;
+    expect(Array.isArray(data.availableRulesets)).toBe(true);
+    expect(data.availableRulesets).toEqual(
+      expect.arrayContaining(["season_2", "season_3"]),
+    );
+  });
+
+  it("falls back to the default ruleset when the query param is invalid", async () => {
+    const res = await fetch(`${API_BASE}/api/rosters?ruleset=not_a_season`);
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as RostersResponse;
+    // resolveRuleset() returns DEFAULT_RULESET for unknown values.
+    expect(["season_2", "season_3"]).toContain(data.ruleset);
+    expect(data.rosters.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The /teams page showed an empty list when filtering by "Saison 3 (2025)"
(ruleset=season_3) because the production Postgres database was never
re-synchronized with schema.prisma after the ruleset field was added, and
the seed for season_3 rosters was never run. The API endpoint
GET /api/rosters?ruleset=season_3 therefore returned an empty array.

Root cause: the deploy workflow rebuilds the containers but never runs
`prisma db push` nor `pnpm db:seed`, so schema changes and new reference
data (rosters, skills, star players) stay in code only.

This change:
- Adds a prisma db push + db:seed step to .github/workflows/deploy.yml,
  gated on Postgres being ready (pg_isready loop).
- Surfaces availableRulesets in GET /api/rosters responses and logs a
  warning when a ruleset returns zero rosters, so a repeat of this
  regression is discoverable in logs.
- Extends the /__test/seed-rosters helper to cover both season_2 and
  season_3 so we can test multi-ruleset scenarios in SQLite.
- Adds tests/integration/public-rosters.test.ts as a regression lock.
- Documents the schema+seed flow in docs/DEPLOY-DB.md.

A follow-up issue will track migrating from `prisma db push` to proper
`prisma migrate deploy` with tracked migrations.