### PR TITLE
chore(todo): mark K.3 chainsaw as complete in Sprint 13

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -226,7 +226,7 @@
 | J.11 | Implementer `instable` | Regle | [x] |
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [x] |
 | K.2 | Implementer `stab` | Regle | [x] |
-| K.3 | Implementer `chainsaw` | Regle | [ ] |
+| K.3 | Implementer `chainsaw` | Regle | [x] |
 | K.4 | Implementer `dump-off` | Regle | [ ] |
 | K.5 | Implementer `on-the-ball` | Regle | [x] |
 | P1.1 | Implementer `stunty` (Skinks, Lineman Gnome, joueurs petits) | Regle | [x] |


### PR DESCRIPTION
## Resume

Mark **K.3 — Implementer `chainsaw`** as complete in Sprint 13 of TODO.md.

Audit realise : l'implementation du skill Chainsaw etait deja presente dans le code mais la case n'avait pas ete cochee dans le backlog.

## Etat de l'implementation (verifie)

**Module** : `packages/game-engine/src/mechanics/chainsaw.ts`
- `canChainsaw(state, attacker, target)` : valide skill, adjacence, cible adverse debout et active
- `executeChainsaw(state, attacker, target, rng)` : jet d'armure direct +3, gestion du double 1 naturel

**Regles BB3 S2/S3 couvertes** :
- Action speciale remplacant un blocage (pas de des de bloc, pas d'assistance de force)
- Jet d'armure direct avec modificateur **+3** (ne soustrait pas sur la valeur d'armure)
- Mighty Blow **ne s'applique PAS** (ni armure, ni blessure)
- **Iron Hard Skin** annule le bonus +3 (interaction via `skill-bridge`)
- **Double 1 naturel** (avant modificateurs) : la tronconneuse frappe son utilisateur (armor roll +3 sur l'attaquant) + **turnover**
- Hors auto-blessure : pas de turnover
- Fin d'activation immediate (`pm = 0`)
- Un joueur knocked_out ou stunned ne peut pas etre cible

**Integration moteur** :
- `packages/game-engine/src/core/types.ts` : `Move` inclut `{ type: 'CHAINSAW', playerId, targetId }`
- `packages/game-engine/src/actions/actions.ts` : `getLegalMoves` genere les moves CHAINSAW, `applyMove` appelle `executeChainsaw` et `setPlayerAction`
- `packages/game-engine/src/index.ts` : `canChainsaw`, `executeChainsaw` exportes publiquement
- `packages/game-engine/src/skills/index.ts` : entree `chainsaw` avec `isModified: true` dans le catalogue

**Tests** : `packages/game-engine/src/mechanics/chainsaw.test.ts`
- 21 tests unitaires + integration (`canChainsaw`, `executeChainsaw`, `getLegalMoves`, `applyMove`)
- Couvre : succes/echec armure, pas de knockdown si armure tient, injury roll, Mighty Blow ignore, fin d'activation, double 1 naturel (turnover + self-injury), log entries

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `K.3 | Implementer chainsaw`

## Plan de test

- [x] `pnpm --filter @bb/game-engine test chainsaw` : 21/21 passent
- [x] `pnpm --filter @bb/game-engine test` : 3542/3542 passent (100 fichiers)
- [x] `pnpm lint` : 0 erreur (720 warnings pre-existants)
- [x] `pnpm typecheck` : 0 erreur sur les 4 packages
- [ ] Build complet : `@bb/web` echoue en sandbox uniquement a cause d'un fetch Google Fonts (`Montserrat`) — pas lie a la tache. Le package `@bb/game-engine` se build normalement.
- [ ] Test e2e manuel : blocage au Chainsaw d'un joueur adverse (Deathroller-style)
- [ ] Test e2e manuel : verifier l'auto-blessure sur double 1 naturel