### PR TITLE
chore(todo): mark K.4 dump-off as done (Sprint 13)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -227,7 +227,7 @@
 | K.1 | Implementer `leap` + `pogo-stick` | Regle | [x] |
 | K.2 | Implementer `stab` | Regle | [x] |
 | K.3 | Implementer `chainsaw` | Regle | [x] |
-| K.4 | Implementer `dump-off` | Regle | [ ] |
+| K.4 | Implementer `dump-off` | Regle | [x] |
 | K.5 | Implementer `on-the-ball` | Regle | [x] |
 | P1.1 | Implementer `stunty` (Skinks, Lineman Gnome, joueurs petits) | Regle | [x] |
 | P1.2 | Implementer `dauntless` (Dwarf Troll Slayer) | Regle | [x] |


### PR DESCRIPTION
## Resume

Le skill **`dump-off`** (tache **K.4** du Sprint 13) est deja integralement implemente dans le game-engine. La checkbox TODO.md n'avait simplement pas ete cochee. Ce PR met a jour le suivi.

## Etat actuel du code (verifie)

- `packages/game-engine/src/mechanics/dump-off.ts`
  - `canDumpOff(state, target)` : eligibilite (skill, hasBall, actif)
  - `getDumpOffReceivers(state, passer)` : coequipiers a portee Quick (1-3), filtres (stun, KO, no-hands)
  - `executeDumpOff(state, passerId, receiverId, rng)` : Passe Rapide + interception + rebond, **jamais de turnover**
- Integration BLOCK via `pendingDumpOff` + action `DUMP_OFF_CHOOSE` dans `packages/game-engine/src/actions/actions.ts`
- Exports publics dans `packages/game-engine/src/index.ts`
- Skill enregistre dans `skills/index.ts` avec effet

## Plan de test

- [x] `pnpm --filter @bb/game-engine test -- dump-off` — 25/25 tests passent (unitaires + integration flow BLOCK)
- [x] `pnpm --filter @bb/game-engine test` — 3542/3542 tests passent (100 fichiers)
- [x] `pnpm --filter @bb/game-engine typecheck` — 0 erreur

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `K.4 | Implementer dump-off`