### PR TITLE
feat(game-engine): implement fend skill (P1.9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -237,7 +237,7 @@
 | P1.6 | Implementer `armored-skull` (Dwarf Deathroller) | Regle | [x] |
 | P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [x] |
 | P1.8 | Implementer `shadowing` (Lizardmen Chameleon Skink) | Regle | [x] |
-| P1.9 | Implementer `fend` (Imperial Retainer Lineman) — verifier | Regle | [ ] |
+| P1.9 | Implementer `fend` (Imperial Retainer Lineman) — verifier | Regle | [x] |
 | P1.10 | Implementer `running-pass` (Imperial Thrower) | Regle | [ ] |
 | P1.11 | Audit : verifier que `prehensile-tail`, `frenzy`, `throw-team-mate`, `thick-skull`, `on-the-ball`, `loner` s'appliquent correctement aux joueurs des 5 equipes | Regle | [ ] |
 | TEST-2 | Tests unitaires + integration pour chacun des skills ci-dessus | Tests | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -73,6 +73,7 @@ import { canChainsaw, executeChainsaw } from '../mechanics/chainsaw';
 import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import { checkDauntless } from '../mechanics/dauntless';
 import { canApplyBreakTackle, markBreakTackleUsed } from '../mechanics/break-tackle';
+import { isFendActiveForFollowUp } from '../mechanics/fend';
 import { resolveShadowingAfterDodge } from '../mechanics/shadowing';
 import {
   resolveKickoffPerfectDefence,
@@ -1581,17 +1582,33 @@ function handlePushChoose(
 
   let newState = { ...state, pendingPushChoice: undefined } as GameState;
 
+  // Fend : verifier avant la poussee (la cible doit etre debout). Sur POW/
+  // STUMBLE sans Dodge, la cible est deja stunned avant d'arriver ici, donc
+  // isFendActiveForFollowUp renverra false naturellement.
+  const fendActive = isFendActiveForFollowUp(newState, attacker, target);
+
   // Chain push : si la destination est occupée, pousser le joueur qui y est d'abord
   const rng = () => Math.random(); // RNG pour les surfs en chaîne
   newState = applyChainPush(newState, target.id, move.direction, rng);
 
-  // Demander confirmation pour le follow-up
-  newState.pendingFollowUpChoice = {
-    attackerId: attacker.id,
-    targetId: target.id,
-    targetNewPosition: newTargetPos,
-    targetOldPosition: target.pos,
-  };
+  if (fendActive) {
+    const fendLog = createLogEntry(
+      'action',
+      `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+      target.id,
+      target.team,
+      { skill: 'fend' },
+    );
+    newState.gameLog = [...newState.gameLog, fendLog];
+  } else {
+    // Demander confirmation pour le follow-up
+    newState.pendingFollowUpChoice = {
+      attackerId: attacker.id,
+      targetId: target.id,
+      targetNewPosition: newTargetPos,
+      targetOldPosition: target.pos,
+    };
+  }
 
   // Log de la poussée
   const pushLog = createLogEntry(

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -194,6 +194,12 @@ export {
   isStandFirmActiveForBlock,
   isStandFirmActiveForChainPush,
 } from './mechanics/stand-firm';
+
+// Export du skill Fend (empeche le follow-up de l'attaquant apres une poussee)
+export {
+  hasFend,
+  isFendActiveForFollowUp,
+} from './mechanics/fend';
 export {
   hasBreakTackle,
   getBreakTackleDodgeBonus,

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -25,6 +25,7 @@ import {
   isStandFirmActiveForBlock,
   isStandFirmActiveForChainPush,
 } from './stand-firm';
+import { isFendActiveForFollowUp } from './fend';
 
 /**
  * Applique un chain push : si la case de destination est occupée, le joueur qui s'y trouve
@@ -547,13 +548,27 @@ export function handlePushWithChoice(
       // Note: bounceBall sera appelé par la fonction appelante
     }
 
-    // Blessure automatique par la foule (pas de jet d'armure, minimum KO)
-    const resultState = handleInjuryByCrowd(newState, target, rng);
+    // Fend : verifier avant la blessure par la foule (qui stun la cible)
+    const fendActiveSurf = isFendActiveForFollowUp(state, attacker, target);
 
-    // L'attaquant peut suivre (follow-up) sur la case liberee
-    resultState.players = resultState.players.map(p =>
-      p.id === attacker.id ? { ...p, pos: target.pos } : p
-    );
+    // Blessure automatique par la foule (pas de jet d'armure, minimum KO)
+    let resultState = handleInjuryByCrowd(newState, target, rng);
+
+    if (fendActiveSurf) {
+      const fendLog = createLogEntry(
+        'action',
+        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+        target.id,
+        target.team,
+        { skill: 'fend' },
+      );
+      resultState = { ...resultState, gameLog: [...resultState.gameLog, fendLog] };
+    } else {
+      // L'attaquant peut suivre (follow-up) sur la case liberee
+      resultState.players = resultState.players.map(p =>
+        p.id === attacker.id ? { ...p, pos: target.pos } : p
+      );
+    }
 
     return resultState;
   } else if (availableDirections.length === 0) {
@@ -573,15 +588,32 @@ export function handlePushWithChoice(
       y: target.pos.y + pushDirection.y,
     };
 
+    // Fend : verifier avant la poussee (la cible doit etre debout). En
+    // pratique, quand handlePushWithChoice est appele depuis POW/STUMBLE
+    // knockdown, la cible est deja stunned et Fend n'est pas actif ; mais on
+    // verifie quand meme pour le cas Dodge → PUSH_BACK si on passait par ici.
+    const fendActive = isFendActiveForFollowUp(state, attacker, target);
+
     const newState = applyChainPush(state, target.id, pushDirection, rng);
 
-    // Demander confirmation pour le follow-up
-    newState.pendingFollowUpChoice = {
-      attackerId: attacker.id,
-      targetId: target.id,
-      targetNewPosition: newTargetPos,
-      targetOldPosition: target.pos,
-    };
+    if (fendActive) {
+      const fendLog = createLogEntry(
+        'action',
+        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+        target.id,
+        target.team,
+        { skill: 'fend' },
+      );
+      newState.gameLog = [...newState.gameLog, fendLog];
+    } else {
+      // Demander confirmation pour le follow-up
+      newState.pendingFollowUpChoice = {
+        attackerId: attacker.id,
+        targetId: target.id,
+        targetNewPosition: newTargetPos,
+        targetOldPosition: target.pos,
+      };
+    }
 
     const pushLog = createLogEntry(
       'action',
@@ -920,13 +952,28 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
       // Note: bounceBall sera appelé par la fonction appelante
     }
 
+    // Fend : l'attaquant ne peut pas suivre (meme vers la case liberee par la
+    // foule). Verifier AVANT d'appliquer la blessure (qui stun la cible).
+    const fendActiveSurf = isFendActiveForFollowUp(state, attacker, target);
+
     // Blessure automatique par la foule (pas de jet d'armure, minimum KO)
     state = handleInjuryByCrowd(state, target, rng);
 
-    // L'attaquant peut suivre (follow-up) sur la case liberee
-    state.players = state.players.map(p =>
-      p.id === attacker.id ? { ...p, pos: target.pos } : p
-    );
+    if (fendActiveSurf) {
+      const fendLog = createLogEntry(
+        'action',
+        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+        target.id,
+        target.team,
+        { skill: 'fend' },
+      );
+      state.gameLog = [...state.gameLog, fendLog];
+    } else {
+      // L'attaquant peut suivre (follow-up) sur la case liberee
+      state.players = state.players.map(p =>
+        p.id === attacker.id ? { ...p, pos: target.pos } : p
+      );
+    }
   } else if (availableDirections.length === 0) {
     // Aucune direction disponible (toutes occupées, aucune hors limites) - ne pas pousser
     const noPushLog = createLogEntry(
@@ -944,15 +991,29 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
       y: target.pos.y + pushDirection.y,
     };
 
+    // Fend : verifier avant la poussee (la cible doit etre debout)
+    const fendActive = isFendActiveForFollowUp(state, attacker, target);
+
     state = applyChainPush(state, target.id, pushDirection, rng);
 
-    // Follow-up is optional on PUSH_BACK — let the attacker choose
-    state.pendingFollowUpChoice = {
-      attackerId: attacker.id,
-      targetId: target.id,
-      targetNewPosition: newTargetPos,
-      targetOldPosition: target.pos,
-    };
+    if (fendActive) {
+      const fendLog = createLogEntry(
+        'action',
+        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+        target.id,
+        target.team,
+        { skill: 'fend' },
+      );
+      state.gameLog = [...state.gameLog, fendLog];
+    } else {
+      // Follow-up is optional on PUSH_BACK — let the attacker choose
+      state.pendingFollowUpChoice = {
+        attackerId: attacker.id,
+        targetId: target.id,
+        targetNewPosition: newTargetPos,
+        targetOldPosition: target.pos,
+      };
+    }
 
     const pushLog = createLogEntry(
       'action',

--- a/packages/game-engine/src/mechanics/fend.test.ts
+++ b/packages/game-engine/src/mechanics/fend.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setup,
+  resolveBlockResult,
+  applyMove,
+  makeRNG,
+  type GameState,
+  type Player,
+  type Move,
+} from '../index';
+import { hasFend, isFendActiveForFollowUp } from './fend';
+
+/**
+ * Fend (BB3 Season 2/3) :
+ *  - Sur PUSH_BACK, l'attaquant ne peut pas faire de follow-up.
+ *  - Sur STUMBLE converti en PUSH_BACK par Dodge, l'attaquant ne peut pas non
+ *    plus faire de follow-up.
+ *  - Sur POW ou STUMBLE sans Dodge, la cible est knocked-down avant la
+ *    poussee : Fend n'est PAS actif.
+ *  - Annule par Juggernaut sur un Blitz contre le defenseur direct.
+ *
+ * Utilisateurs principaux : Imperial Retainer Lineman (Noblesse Imperiale).
+ */
+
+function makeBlockResult(
+  attackerId: string,
+  targetId: string,
+  result: 'BOTH_DOWN' | 'PUSH_BACK' | 'POW' | 'STUMBLE' | 'PLAYER_DOWN',
+) {
+  return {
+    type: 'block' as const,
+    playerId: attackerId,
+    targetId: targetId,
+    diceRoll: 2,
+    result,
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+function placePlayersForBlock(
+  baseState: GameState,
+  attackerSkills: string[],
+  defenderSkills: string[],
+  opts: { isBlitz?: boolean; defenderStunned?: boolean } = {},
+): GameState {
+  const nextState: GameState = {
+    ...baseState,
+    players: baseState.players.map(p => {
+      if (p.id === 'A2')
+        return {
+          ...p,
+          pos: { x: 10, y: 7 },
+          stunned: false,
+          pm: 6,
+          skills: attackerSkills,
+        };
+      if (p.id === 'B2')
+        return {
+          ...p,
+          pos: { x: 11, y: 7 },
+          stunned: opts.defenderStunned ?? false,
+          pm: 6,
+          skills: defenderSkills,
+        };
+      // Eloigner les autres joueurs pour eviter les interferences
+      if (p.team === 'A') return { ...p, pos: { x: 0, y: 0 } };
+      if (p.team === 'B') return { ...p, pos: { x: 24, y: 14 } };
+      return p;
+    }),
+  };
+  if (opts.isBlitz) {
+    return {
+      ...nextState,
+      playerActions: { ...nextState.playerActions, A2: 'BLITZ' },
+    };
+  }
+  return nextState;
+}
+
+describe('Regle: Fend', () => {
+  let state: GameState;
+  let rng: ReturnType<typeof makeRNG>;
+
+  beforeEach(() => {
+    state = setup();
+    rng = makeRNG('fend-test-seed');
+  });
+
+  describe('Helpers', () => {
+    it('hasFend retourne faux sans le skill', () => {
+      const p = { skills: [] } as unknown as Player;
+      expect(hasFend(p)).toBe(false);
+    });
+
+    it('hasFend retourne vrai avec le skill', () => {
+      const p = { skills: ['fend'] } as unknown as Player;
+      expect(hasFend(p)).toBe(true);
+    });
+
+    it("isFendActiveForFollowUp est faux si la cible n'a pas Fend", () => {
+      const testState = placePlayersForBlock(state, [], []);
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isFendActiveForFollowUp(testState, attacker, target)).toBe(false);
+    });
+
+    it('isFendActiveForFollowUp est vrai si la cible a Fend et est debout', () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isFendActiveForFollowUp(testState, attacker, target)).toBe(true);
+    });
+
+    it('isFendActiveForFollowUp est faux si la cible est stunned', () => {
+      const testState = placePlayersForBlock(state, [], ['fend'], {
+        defenderStunned: true,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isFendActiveForFollowUp(testState, attacker, target)).toBe(false);
+    });
+
+    it('isFendActiveForFollowUp est faux si Juggernaut actif sur Blitz', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['fend'], {
+        isBlitz: true,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isFendActiveForFollowUp(testState, attacker, target)).toBe(false);
+    });
+
+    it('isFendActiveForFollowUp reste vrai si Juggernaut sans Blitz', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['fend'], {
+        isBlitz: false,
+      });
+      const attacker = testState.players.find(p => p.id === 'A2')!;
+      const target = testState.players.find(p => p.id === 'B2')!;
+      expect(isFendActiveForFollowUp(testState, attacker, target)).toBe(true);
+    });
+  });
+
+  describe('PUSH_BACK', () => {
+    it("empeche le follow-up de l'attaquant (pendingFollowUpChoice absent)", () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      expect(result.pendingFollowUpChoice).toBeUndefined();
+    });
+
+    it("laisse l'attaquant sur sa case initiale (pas de follow-up)", () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const attacker = result.players.find(p => p.id === 'A2')!;
+      expect(attacker.pos).toEqual({ x: 10, y: 7 });
+    });
+
+    it('la cible est quand meme poussee', () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const defender = result.players.find(p => p.id === 'B2')!;
+      const moved = defender.pos.x !== 11 || defender.pos.y !== 7;
+      const hasChoice = result.pendingPushChoice !== undefined;
+      expect(moved || hasChoice).toBe(true);
+    });
+
+    it('log explicite Fend apres PUSH_CHOOSE', () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const intermediate = resolveBlockResult(testState, blockResult, rng);
+
+      // En configuration standard, plusieurs directions sont disponibles
+      // → on choisit via PUSH_CHOOSE.
+      if (intermediate.pendingPushChoice) {
+        const dir = intermediate.pendingPushChoice.availableDirections[0];
+        const pushMove: Move = {
+          type: 'PUSH_CHOOSE',
+          playerId: 'A2',
+          targetId: 'B2',
+          direction: dir,
+        };
+        const after = applyMove(intermediate, pushMove, rng);
+        const fendLog = after.gameLog.find(log =>
+          log.message.toLowerCase().includes('fend'),
+        );
+        expect(fendLog).toBeDefined();
+      } else {
+        // Cas single-direction (ou surf) : log genere directement
+        const fendLog = intermediate.gameLog.find(log =>
+          log.message.toLowerCase().includes('fend'),
+        );
+        expect(fendLog).toBeDefined();
+      }
+    });
+
+    it("sans Fend, l'attaquant peut faire un follow-up", () => {
+      const testState = placePlayersForBlock(state, [], []);
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      // Soit pendingFollowUpChoice defini, soit pendingPushChoice (multi-dir)
+      const hasFollowUp = result.pendingFollowUpChoice !== undefined;
+      const hasPushChoice = result.pendingPushChoice !== undefined;
+      expect(hasFollowUp || hasPushChoice).toBe(true);
+    });
+
+    it('Juggernaut sur Blitz annule Fend (follow-up possible)', () => {
+      const testState = placePlayersForBlock(state, ['juggernaut'], ['fend'], {
+        isBlitz: true,
+      });
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const hasFollowUp = result.pendingFollowUpChoice !== undefined;
+      const hasPushChoice = result.pendingPushChoice !== undefined;
+      expect(hasFollowUp || hasPushChoice).toBe(true);
+    });
+  });
+
+  describe('STUMBLE converti en PUSH_BACK par Dodge', () => {
+    it("Fend empeche aussi le follow-up apres conversion Dodge", () => {
+      const testState = placePlayersForBlock(state, [], ['dodge', 'fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'STUMBLE');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      expect(result.pendingFollowUpChoice).toBeUndefined();
+      const defender = result.players.find(p => p.id === 'B2')!;
+      // Le defenseur reste debout (pas knocked down car Dodge a negate)
+      expect(defender.stunned).toBeFalsy();
+    });
+  });
+
+  describe('POW', () => {
+    it("Fend n'est PAS actif sur POW (cible knocked-down)", () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'POW');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      // Soit pendingFollowUpChoice est defini (single dir), soit pendingPushChoice (multi)
+      // Dans tous les cas, Fend ne doit pas avoir bloque le follow-up.
+      const hasFollowUp = result.pendingFollowUpChoice !== undefined;
+      const hasPushChoice = result.pendingPushChoice !== undefined;
+      const targetSurfed = result.players
+        .find(p => p.id === 'B2')!
+        .pos.x < 0 || result.players.find(p => p.id === 'B2')!.pos.x > 25;
+      expect(hasFollowUp || hasPushChoice || targetSurfed).toBe(true);
+    });
+  });
+
+  describe('STUMBLE sans Dodge', () => {
+    it("Fend n'est pas actif (cible knocked-down)", () => {
+      const testState = placePlayersForBlock(state, [], ['fend']);
+      const blockResult = makeBlockResult('A2', 'B2', 'STUMBLE');
+
+      const result = resolveBlockResult(testState, blockResult, rng);
+
+      const hasFollowUp = result.pendingFollowUpChoice !== undefined;
+      const hasPushChoice = result.pendingPushChoice !== undefined;
+      expect(hasFollowUp || hasPushChoice).toBe(true);
+    });
+  });
+
+  describe('Integration PUSH_CHOOSE', () => {
+    it('Fend empeche aussi le follow-up quand plusieurs directions disponibles', () => {
+      // Placer A2 et B2 en diagonale pour avoir plusieurs directions disponibles
+      const testState: GameState = {
+        ...state,
+        players: state.players.map(p => {
+          if (p.id === 'A2') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2') return { ...p, pos: { x: 11, y: 8 }, stunned: false, pm: 6, skills: ['fend'] };
+          if (p.team === 'A') return { ...p, pos: { x: 0, y: 0 } };
+          if (p.team === 'B') return { ...p, pos: { x: 24, y: 14 } };
+          return p;
+        }),
+      };
+      const blockResult = makeBlockResult('A2', 'B2', 'PUSH_BACK');
+
+      const intermediate = resolveBlockResult(testState, blockResult, rng);
+
+      // Attendre un pendingPushChoice avec plusieurs directions
+      expect(intermediate.pendingPushChoice).toBeDefined();
+      const directions = intermediate.pendingPushChoice!.availableDirections;
+      expect(directions.length).toBeGreaterThanOrEqual(1);
+
+      // Choisir une direction
+      const pushMove: Move = {
+        type: 'PUSH_CHOOSE',
+        playerId: 'A2',
+        targetId: 'B2',
+        direction: directions[0],
+      };
+      const after = applyMove(intermediate, pushMove, rng);
+
+      // Fend doit empecher le pendingFollowUpChoice
+      expect(after.pendingFollowUpChoice).toBeUndefined();
+      const attacker = after.players.find(p => p.id === 'A2')!;
+      // L'attaquant n'a pas suivi
+      expect(attacker.pos).toEqual({ x: 10, y: 7 });
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/fend.ts
+++ b/packages/game-engine/src/mechanics/fend.ts
@@ -1,0 +1,59 @@
+/**
+ * Fend (BB3 Season 2/3 rules).
+ *
+ * Quand un joueur avec Fend est pousse (Push Back) suite a un Block, l'attaquant
+ * ne peut pas faire de follow-up. Fend s'applique sur un resultat PUSH_BACK ou
+ * sur un STUMBLE converti en PUSH_BACK par Dodge.
+ *
+ * La regle ne s'applique PAS si le joueur avec Fend est mis au sol par le
+ * blocage (POW, ou STUMBLE sans Dodge) : dans ce cas le joueur est stunned
+ * avant la resolution de la poussee, donc Fend n'est pas actif.
+ *
+ * La regle est annulee si l'attaquant effectue un Blitz avec Juggernaut et que
+ * la cible est le joueur directement bloque.
+ *
+ * Utilisateurs principaux (5 equipes prioritaires) : Imperial Retainer Lineman
+ * (Noblesse Imperiale), ainsi que Wood Elf Wardancer, certains Catchers, etc.
+ *
+ * On applique systematiquement Fend quand il est disponible : empecher le
+ * follow-up de l'attaquant est toujours au moins aussi avantageux que de
+ * l'autoriser (la "may" clause se resout automatiquement au profit du
+ * defenseur).
+ *
+ * L'implementation se limite ici a exposer les predicats ; le cablage dans le
+ * flux de blocage vit dans `blocking.ts` et `actions.ts` (handlePushChoose).
+ */
+
+import type { GameState, Player } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { isJuggernautActiveForBlock } from './juggernaut';
+
+/**
+ * Retourne vrai si le joueur possede le skill Fend (accepte les variantes de
+ * slug : fend, "Fend").
+ */
+export function hasFend(player: Player): boolean {
+  return hasSkill(player, 'fend');
+}
+
+/**
+ * Retourne vrai si Fend empeche le follow-up de `attacker` apres une poussee
+ * de `target`.
+ *
+ * Conditions :
+ *  - La cible possede Fend.
+ *  - La cible est debout (pas stunned/prone). Si elle est au sol, elle ne peut
+ *    pas utiliser Fend (regle BB2020).
+ *  - L'attaquant n'utilise pas Juggernaut sur un Blitz (auquel cas Fend est
+ *    annule sur le defenseur direct).
+ */
+export function isFendActiveForFollowUp(
+  state: GameState,
+  attacker: Player,
+  target: Player,
+): boolean {
+  if (!hasFend(target)) return false;
+  if (target.stunned) return false;
+  if (isJuggernautActiveForBlock(state, attacker)) return false;
+  return true;
+}


### PR DESCRIPTION
## Resume

Implemente le skill `fend` (BB3 Season 2/3) — tache **P1.9** du Sprint 13.

**Regle BB3** : quand un joueur avec Fend est repousse (Push Back) suite a un Block, l'attaquant ne peut pas faire de follow-up. Fend s'applique sur un resultat PUSH_BACK ou sur un STUMBLE converti en PUSH_BACK par Dodge. Fend ne s'applique PAS si le joueur est mis au sol par le bloc (POW, ou STUMBLE sans Dodge), puisque la regle requiert que le joueur soit debout. Juggernaut sur un Blitz annule Fend sur le defenseur direct.

Equipe notamment le **Imperial Retainer Lineman** (Noblesse Imperiale, roster des 5 equipes prioritaires), ainsi que d'autres utilisateurs comme le Wood Elf Wardancer.

## Changements

- `packages/game-engine/src/mechanics/fend.ts` : nouveau module avec `hasFend(player)` et `isFendActiveForFollowUp(state, attacker, target)`. La fonction refuse Fend si la cible est `stunned` (knocked-down) ou si Juggernaut est actif sur un Blitz.
- `packages/game-engine/src/mechanics/blocking.ts` : cable Fend dans `handlePushBack` (chemins surf et single-direction) et dans `handlePushWithChoice` (chemin Dodge → PUSH_BACK). Quand Fend est actif, on skip `pendingFollowUpChoice`, on ne deplace pas l'attaquant (y compris sur surf), et on log "utilise Fend".
- `packages/game-engine/src/actions/actions.ts` : cable Fend dans `handlePushChoose` (chemin PUSH_CHOOSE multi-direction) avant de poser `pendingFollowUpChoice`.
- `packages/game-engine/src/mechanics/fend.test.ts` : **17 tests unitaires** couvrant helpers, PUSH_BACK (pendingFollowUpChoice absent, attaquant reste en place, Fend n'empeche pas la poussee, log explicite, Juggernaut annule Fend), STUMBLE converti par Dodge, POW (negatif), STUMBLE sans Dodge (negatif), et l'integration PUSH_CHOOSE.
- `packages/game-engine/src/index.ts` : export public de `hasFend` et `isFendActiveForFollowUp`.
- `TODO.md` : tache P1.9 cochee.

## Plan de test

- [x] Tests unitaires : 17 nouveaux tests Vitest dans `fend.test.ts`
- [x] Tests game-engine : **3577/3577 passent** (102 fichiers de tests)
- [x] Tests serveur : 313/313 passent
- [x] `pnpm lint` : 0 erreur
- [x] `pnpm typecheck` : 0 erreur sur tous les packages
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Test e2e manuel : un Imperial Retainer Lineman pousse par un bloc normal doit empecher le follow-up de l'attaquant
- [ ] Test e2e manuel : Juggernaut (Dwarf Deathroller) en Blitz doit annuler Fend et permettre le follow-up

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `P1.9 | Implementer fend (Imperial Retainer Lineman) — verifier`