### PR TITLE
feat(game-engine): implement running-pass skill (P1.10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -238,7 +238,7 @@
 | P1.7 | Implementer `iron-hard-skin` (Gnomes : piston, beastmaster, treeman) | Regle | [x] |
 | P1.8 | Implementer `shadowing` (Lizardmen Chameleon Skink) | Regle | [x] |
 | P1.9 | Implementer `fend` (Imperial Retainer Lineman) — verifier | Regle | [x] |
-| P1.10 | Implementer `running-pass` (Imperial Thrower) | Regle | [ ] |
+| P1.10 | Implementer `running-pass` (Imperial Thrower) | Regle | [x] |
 | P1.11 | Audit : verifier que `prehensile-tail`, `frenzy`, `throw-team-mate`, `thick-skull`, `on-the-ball`, `loner` s'appliquent correctement aux joueurs des 5 equipes | Regle | [ ] |
 | TEST-2 | Tests unitaires + integration pour chacun des skills ci-dessus | Tests | [ ] |
 | TEST-3 | Test E2E : un match complet Nains vs Skaven sans divergence de regles | Tests | [ ] |

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -62,6 +62,11 @@ import {
   canTeamBlitz,
 } from '../core/game-state';
 import { executePass, executeHandoff, getPassRange, canAttemptPassForRange } from '../mechanics/passing';
+import {
+  canApplyRunningPass,
+  canApplyRunningPassToHandoff,
+  markRunningPassUsed,
+} from '../mechanics/running-pass';
 import { canFoul, executeFoul } from '../mechanics/foul';
 import { isAdjacent } from '../mechanics/movement';
 import { applyApothecaryChoice } from '../mechanics/apothecary';
@@ -641,6 +646,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
       rerollUsedThisTurn: false,
       hypnotizedPlayers: [],
       usedBreakTackleThisTurn: [],
+      usedRunningPassThisTurn: [],
       usedOnTheBallThisTurn: [],
     };
   }
@@ -660,6 +666,7 @@ function handleEndTurn(state: GameState, rng: RNG): GameState {
     rerollUsedThisTurn: false, // Réinitialiser le flag de relance
     hypnotizedPlayers: [], // Réinitialiser les joueurs hypnotisés
     usedBreakTackleThisTurn: [], // Réinitialiser Break Tackle (une fois par tour)
+    usedRunningPassThisTurn: [], // Réinitialiser Running Pass (une fois par tour)
     usedOnTheBallThisTurn: [], // Réinitialiser On the Ball (une fois par tour d'equipe)
   };
 
@@ -2075,6 +2082,24 @@ function handlePass(state: GameState, move: { type: 'PASS'; playerId: string; ta
 
   let newState = executePass(currentState, passer, target, rng);
   newState = setPlayerAction(newState, passer.id, 'PASS');
+
+  // Running Pass : si le passeur a le skill, qu'il s'agit d'une Quick Pass
+  // sans turnover et qu'il lui reste de la MA, il peut continuer son mouvement
+  // apres la passe (une fois par tour). On ne le marque pas avant le passe pour
+  // permettre la lecture du flag dans canApplyRunningPass / canPlayerContinueMoving.
+  const passerAfter = newState.players.find(p => p.id === passer.id);
+  if (passerAfter && canApplyRunningPass(newState, passerAfter, passRange, newState.isTurnover)) {
+    newState = markRunningPassUsed(newState, passer.id);
+    const rpLog = createLogEntry(
+      'info',
+      `Passe dans la Course : ${passer.name} peut continuer son mouvement`,
+      passer.id,
+      passer.team,
+      { skill: 'running-pass' },
+    );
+    newState = { ...newState, gameLog: [...newState.gameLog, rpLog] };
+  }
+
   newState = checkPlayerTurnEnd(newState, passer.id);
   return newState;
 }
@@ -2112,6 +2137,22 @@ function handleHandoff(state: GameState, move: { type: 'HANDOFF'; playerId: stri
 
   let newState = executeHandoff(currentState, passer, target, rng);
   newState = setPlayerAction(newState, passer.id, 'HANDOFF');
+
+  // Running Pass (variante S3) : un Hand-Off s'integre dans la regle ; meme
+  // resolution que pour une Quick Pass.
+  const passerAfter = newState.players.find(p => p.id === passer.id);
+  if (passerAfter && canApplyRunningPassToHandoff(newState, passerAfter, newState.isTurnover)) {
+    newState = markRunningPassUsed(newState, passer.id);
+    const rpLog = createLogEntry(
+      'info',
+      `Transmission dans la course : ${passer.name} peut continuer son mouvement`,
+      passer.id,
+      passer.team,
+      { skill: 'running-pass-2025' },
+    );
+    newState = { ...newState, gameLog: [...newState.gameLog, rpLog] };
+  }
+
   newState = checkPlayerTurnEnd(newState, passer.id);
   return newState;
 }

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -886,14 +886,19 @@ export function canPlayerContinueMoving(state: GameState, playerId: string): boo
   if (!player) return false;
 
   // Un joueur peut continuer à bouger s'il n'est pas étourdi, a des PM (ou du GFI disponible),
-  // c'est le tour de son équipe, et soit il n'a pas encore agi, soit il a déjà commencé à bouger ou fait un blitz
+  // c'est le tour de son équipe, et soit il n'a pas encore agi, soit il a déjà commencé à bouger ou fait un blitz.
+  // Cas particulier : Running Pass autorise le passeur a continuer sa MA apres une Quick Pass
+  // (ou un Hand-Off pour la variante S3) sans changer son action principale.
   const playerAction = getPlayerAction(state, playerId);
   const hasMovement = player.pm > 0 || (player.gfiUsed ?? 0) < 2;
+  const runningPassActive =
+    (state.usedRunningPassThisTurn ?? []).includes(playerId) &&
+    (playerAction === 'PASS' || playerAction === 'HANDOFF');
   return (
     !player.stunned &&
     hasMovement &&
     player.team === state.currentPlayer &&
-    (!hasPlayerActed(state, playerId) || playerAction === 'MOVE' || playerAction === 'BLITZ')
+    (!hasPlayerActed(state, playerId) || playerAction === 'MOVE' || playerAction === 'BLITZ' || runningPassActive)
   );
 }
 
@@ -1032,10 +1037,15 @@ export function checkPlayerTurnEnd(state: GameState, playerId: string): GameStat
   if (!player) return state;
 
   // Si le joueur n'a plus de PM et a commencé à bouger, finir son tour
+  // Inclut Running Pass : action PASS/HANDOFF + flag usedRunningPassThisTurn => poursuite autorisee
+  const action = getPlayerAction(state, playerId);
+  const runningPassActive =
+    (state.usedRunningPassThisTurn ?? []).includes(playerId) &&
+    (action === 'PASS' || action === 'HANDOFF');
   if (
     player.pm <= 0 &&
     hasPlayerActed(state, playerId) &&
-    (getPlayerAction(state, playerId) === 'MOVE' || getPlayerAction(state, playerId) === 'BLITZ')
+    (action === 'MOVE' || action === 'BLITZ' || runningPassActive)
   ) {
     return endPlayerTurn(state, playerId);
   }

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -256,6 +256,10 @@ export interface GameState {
   hypnotizedPlayers?: string[];
   // IDs des joueurs qui ont déjà utilisé Break Tackle ce tour (une fois par tour par joueur).
   usedBreakTackleThisTurn?: string[];
+  // IDs des joueurs qui ont déjà utilisé Running Pass ce tour (une fois par tour par joueur).
+  // La presence d'un id ici autorise aussi la poursuite du mouvement apres
+  // une Action de Passe (cf. canPlayerContinueMoving dans game-state.ts).
+  usedRunningPassThisTurn?: string[];
   // Equipes ayant utilise On the Ball pendant le tour adverse en cours
   // (reset au changement de tour). Une seule activation par tour d'equipe.
   usedOnTheBallThisTurn?: TeamId[];

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -208,6 +208,16 @@ export {
   markBreakTackleUsed,
 } from './mechanics/break-tackle';
 
+// Export du skill Running Pass (Imperial Thrower, etc.)
+export {
+  hasRunningPass,
+  hasRunningPassHandoffVariant,
+  canApplyRunningPass,
+  canApplyRunningPassToHandoff,
+  hasUsedRunningPassThisTurn,
+  markRunningPassUsed,
+} from './mechanics/running-pass';
+
 // Export du skill Shadowing (Lizardmen Chameleon Skink, etc.)
 export {
   hasShadowing,

--- a/packages/game-engine/src/mechanics/running-pass.test.ts
+++ b/packages/game-engine/src/mechanics/running-pass.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasRunningPass,
+  hasRunningPassHandoffVariant,
+  canApplyRunningPass,
+  canApplyRunningPassToHandoff,
+  hasUsedRunningPassThisTurn,
+  markRunningPassUsed,
+} from './running-pass';
+import { setup, applyMove, canPlayerContinueMoving, getLegalMoves } from '../index';
+import type { GameState, Player, Move, RNG } from '../core/types';
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Test Player',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 3,
+    av: 9,
+    skills: [],
+    pm: 6,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  const state = setup();
+  state.players = players;
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamFoulCount = {};
+  return state;
+}
+
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const val = values[i % values.length];
+    i++;
+    return val;
+  };
+}
+
+describe("Regle: Running Pass - detection du skill", () => {
+  it("hasRunningPass retourne true pour la variante S2 'running-pass'", () => {
+    const player = makePlayer({ skills: ['running-pass'] });
+    expect(hasRunningPass(player)).toBe(true);
+  });
+
+  it("hasRunningPass retourne true pour la variante underscore 'running_pass'", () => {
+    const player = makePlayer({ skills: ['running_pass'] });
+    expect(hasRunningPass(player)).toBe(true);
+  });
+
+  it("hasRunningPass retourne true pour la variante S3 'running-pass-2025'", () => {
+    const player = makePlayer({ skills: ['running-pass-2025'] });
+    expect(hasRunningPass(player)).toBe(true);
+  });
+
+  it("hasRunningPass retourne false sans le skill", () => {
+    const player = makePlayer({ skills: [] });
+    expect(hasRunningPass(player)).toBe(false);
+  });
+
+  it("hasRunningPassHandoffVariant retourne true seulement pour la variante S3", () => {
+    expect(hasRunningPassHandoffVariant(makePlayer({ skills: ['running-pass-2025'] }))).toBe(true);
+    expect(hasRunningPassHandoffVariant(makePlayer({ skills: ['running-pass'] }))).toBe(false);
+    expect(hasRunningPassHandoffVariant(makePlayer({ skills: [] }))).toBe(false);
+  });
+});
+
+describe("Regle: Running Pass - canApplyRunningPass", () => {
+  it("retourne true pour une Quick Pass sans turnover, skill present, MA restant", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'quick', false)).toBe(true);
+  });
+
+  it("retourne false sans le skill", () => {
+    const player = makePlayer({ skills: [], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'quick', false)).toBe(false);
+  });
+
+  it("retourne false pour une Short Pass (Running Pass S2 = Quick Pass uniquement)", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'short', false)).toBe(false);
+  });
+
+  it("retourne false pour une Long Pass", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'long', false)).toBe(false);
+  });
+
+  it("retourne false pour une Long Bomb", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'bomb', false)).toBe(false);
+  });
+
+  it("retourne false si la passe a cause un turnover (interception, drop, fumble)", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'quick', true)).toBe(false);
+  });
+
+  it("retourne false si le joueur n'a plus de PM", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 0 });
+    const state = makeState([player]);
+    expect(canApplyRunningPass(state, player, 'quick', false)).toBe(false);
+  });
+
+  it("retourne false si Running Pass a deja ete utilise ce tour", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = markRunningPassUsed(makeState([player]), player.id);
+    expect(canApplyRunningPass(state, player, 'quick', false)).toBe(false);
+  });
+});
+
+describe("Regle: Running Pass - canApplyRunningPassToHandoff", () => {
+  it("retourne true pour la variante S3 sans turnover", () => {
+    const player = makePlayer({ skills: ['running-pass-2025'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPassToHandoff(state, player, false)).toBe(true);
+  });
+
+  it("retourne false pour la variante S2 (handoff non couvert par 'running-pass')", () => {
+    const player = makePlayer({ skills: ['running-pass'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPassToHandoff(state, player, false)).toBe(false);
+  });
+
+  it("retourne false sans aucun skill", () => {
+    const player = makePlayer({ skills: [], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPassToHandoff(state, player, false)).toBe(false);
+  });
+
+  it("retourne false en cas de turnover", () => {
+    const player = makePlayer({ skills: ['running-pass-2025'], pm: 4 });
+    const state = makeState([player]);
+    expect(canApplyRunningPassToHandoff(state, player, true)).toBe(false);
+  });
+});
+
+describe("Regle: Running Pass - tracking once-per-turn (immutabilite)", () => {
+  it("hasUsedRunningPassThisTurn retourne false par defaut", () => {
+    const player = makePlayer({ skills: ['running-pass'] });
+    const state = makeState([player]);
+    expect(hasUsedRunningPassThisTurn(state, player.id)).toBe(false);
+  });
+
+  it("hasUsedRunningPassThisTurn retourne true apres markRunningPassUsed", () => {
+    const player = makePlayer({ skills: ['running-pass'] });
+    const state = markRunningPassUsed(makeState([player]), player.id);
+    expect(hasUsedRunningPassThisTurn(state, player.id)).toBe(true);
+  });
+
+  it("markRunningPassUsed ne mute pas l'etat source", () => {
+    const player = makePlayer({ skills: ['running-pass'] });
+    const state = makeState([player]);
+    markRunningPassUsed(state, player.id);
+    expect(state.usedRunningPassThisTurn).toBeUndefined();
+  });
+
+  it("markRunningPassUsed est idempotent", () => {
+    const player = makePlayer({ skills: ['running-pass'] });
+    const state = makeState([player]);
+    const once = markRunningPassUsed(state, player.id);
+    const twice = markRunningPassUsed(once, player.id);
+    expect(twice.usedRunningPassThisTurn).toEqual([player.id]);
+  });
+
+  it("markRunningPassUsed accumule plusieurs joueurs", () => {
+    const p1 = makePlayer({ id: 'p1', skills: ['running-pass'] });
+    const p2 = makePlayer({ id: 'p2', skills: ['running-pass'] });
+    const state = makeState([p1, p2]);
+    const after1 = markRunningPassUsed(state, p1.id);
+    const after2 = markRunningPassUsed(after1, p2.id);
+    expect(after2.usedRunningPassThisTurn).toEqual([p1.id, p2.id]);
+  });
+});
+
+describe("Regle: Running Pass - integration handlePass (Imperial Thrower)", () => {
+  function createRunningPassScenario(): GameState {
+    const state = setup();
+    state.players = [
+      // Imperial Thrower au centre, avec running-pass et la balle
+      {
+        id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Thrower', number: 1,
+        position: 'Imperial Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 9,
+        skills: ['pass', 'running-pass'], pm: 6, hasBall: true, state: 'active',
+      },
+      // Receveur a 2 cases (Quick Pass)
+      {
+        id: 'A2', team: 'A', pos: { x: 12, y: 7 }, name: 'Receiver', number: 2,
+        position: 'Catcher', ma: 7, st: 3, ag: 3, pa: 4, av: 8,
+        skills: [], pm: 7, hasBall: false, state: 'active',
+      },
+      // Adversaire eloigne pour ne pas interferer
+      {
+        id: 'B1', team: 'B', pos: { x: 22, y: 7 }, name: 'Defender', number: 1,
+        position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 9,
+        skills: [], pm: 6, hasBall: false, state: 'active',
+      },
+    ];
+    state.ball = undefined;
+    state.currentPlayer = 'A';
+    state.playerActions = {};
+    state.teamFoulCount = {};
+    state.teamRerolls = { teamA: 0, teamB: 0 };
+    return state;
+  }
+
+  it("apres une Quick Pass reussie, le passeur peut continuer a bouger (canPlayerContinueMoving=true)", () => {
+    const state = createRunningPassScenario();
+    // RNG: pass success (5), catch success (5)
+    const rng = makeTestRNG([0.8, 0.8]);
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    // Pas de turnover
+    expect(result.isTurnover).toBe(false);
+    // Le receveur a la balle
+    expect(result.players.find(p => p.id === 'A2')!.hasBall).toBe(true);
+    // Le passeur n'a plus la balle
+    expect(result.players.find(p => p.id === 'A1')!.hasBall).toBeFalsy();
+
+    // Running Pass marque comme utilise
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(true);
+    // Le passeur peut continuer a bouger
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(true);
+  });
+
+  it("apres une Quick Pass reussie, getLegalMoves contient des MOVE pour le passeur", () => {
+    const state = createRunningPassScenario();
+    const rng = makeTestRNG([0.8, 0.8]);
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    const moves: Move[] = getLegalMoves(result, 'A');
+    const passerMoves = moves.filter(m => m.type === 'MOVE' && (m as { playerId: string }).playerId === 'A1');
+    expect(passerMoves.length).toBeGreaterThan(0);
+  });
+
+  it("sans Running Pass, le passeur ne peut pas continuer a bouger apres la passe", () => {
+    const state = createRunningPassScenario();
+    const passer = state.players[0];
+    // Retirer le skill
+    state.players = state.players.map(p =>
+      p.id === passer.id ? { ...p, skills: ['pass'] } : p,
+    );
+    const rng = makeTestRNG([0.8, 0.8]);
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.isTurnover).toBe(false);
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(false);
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(false);
+  });
+
+  it("sur une Short Pass (hors quick), Running Pass ne s'active pas", () => {
+    const state = createRunningPassScenario();
+    // Deplacer le receveur a 5 cases (Short Pass)
+    state.players = state.players.map(p =>
+      p.id === 'A2' ? { ...p, pos: { x: 15, y: 7 } } : p,
+    );
+    const rng = makeTestRNG([0.95, 0.95]);
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.isTurnover).toBe(false);
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(false);
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(false);
+  });
+
+  it("en cas de turnover (passe ratee), Running Pass ne s'active pas", () => {
+    const state = createRunningPassScenario();
+    // RNG: pass roll = 1 (echec garanti pour PA 3+) -> turnover
+    const rng = makeTestRNG([0.0]);
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.isTurnover).toBe(true);
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(false);
+    // En turnover, getLegalMoves ne renvoie de toute facon plus rien
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(false);
+  });
+
+  it("le passeur peut consommer ses PM restants apres une Running Pass", () => {
+    const state = createRunningPassScenario();
+    // Forcer pm = 1 sur le passeur
+    state.players = state.players.map(p =>
+      p.id === 'A1' ? { ...p, pm: 1 } : p,
+    );
+    const rng = makeTestRNG([0.8, 0.8]);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const afterPass = applyMove(state, passMove, rng);
+
+    expect(hasUsedRunningPassThisTurn(afterPass, 'A1')).toBe(true);
+    // Le passeur a encore le droit de bouger
+    expect(canPlayerContinueMoving(afterPass, 'A1')).toBe(true);
+
+    // Maintenant le passeur depense son dernier point de mouvement
+    const moveTo: Move = { type: 'MOVE', playerId: 'A1', to: { x: 11, y: 7 } };
+    const afterMove = applyMove(afterPass, moveTo, rng);
+    const passerAfter = afterMove.players.find(p => p.id === 'A1')!;
+    expect(passerAfter.pm).toBe(0);
+    expect(passerAfter.pos).toEqual({ x: 11, y: 7 });
+  });
+
+  it("Running Pass est reinitialise au changement de tour (END_TURN)", () => {
+    const state = createRunningPassScenario();
+    const rng = makeTestRNG([0.8, 0.8]);
+    const passMove: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const afterPass = applyMove(state, passMove, rng);
+    expect(hasUsedRunningPassThisTurn(afterPass, 'A1')).toBe(true);
+
+    const endTurn: Move = { type: 'END_TURN' };
+    const afterEnd = applyMove(afterPass, endTurn, rng);
+    expect(afterEnd.usedRunningPassThisTurn).toEqual([]);
+    expect(hasUsedRunningPassThisTurn(afterEnd, 'A1')).toBe(false);
+  });
+
+  it("la variante S3 (running-pass-2025) declenche aussi sur un Hand-Off", () => {
+    const state = createRunningPassScenario();
+    // Donner au passeur la variante S3 et placer le receveur adjacent
+    state.players = state.players.map(p => {
+      if (p.id === 'A1') return { ...p, skills: ['pass', 'running-pass-2025'] };
+      if (p.id === 'A2') return { ...p, pos: { x: 11, y: 7 } };
+      return p;
+    });
+    const rng = makeTestRNG([0.95, 0.95]);
+    const handoff: Move = { type: 'HANDOFF', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, handoff, rng);
+
+    expect(result.isTurnover).toBe(false);
+    expect(result.players.find(p => p.id === 'A2')!.hasBall).toBe(true);
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(true);
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(true);
+  });
+
+  it("la variante S2 (running-pass) ne declenche PAS sur un Hand-Off", () => {
+    const state = createRunningPassScenario();
+    state.players = state.players.map(p => {
+      if (p.id === 'A2') return { ...p, pos: { x: 11, y: 7 } };
+      return p;
+    });
+    const rng = makeTestRNG([0.95, 0.95]);
+    const handoff: Move = { type: 'HANDOFF', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, handoff, rng);
+
+    expect(result.isTurnover).toBe(false);
+    expect(hasUsedRunningPassThisTurn(result, 'A1')).toBe(false);
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(false);
+  });
+});

--- a/packages/game-engine/src/mechanics/running-pass.ts
+++ b/packages/game-engine/src/mechanics/running-pass.ts
@@ -1,0 +1,118 @@
+/**
+ * Running Pass (BB3 Season 2/3 rules).
+ *
+ * Quand un joueur avec Running Pass effectue une Action de Passe Rapide, son
+ * activation ne se termine pas une fois la passe resolue. Si le joueur a encore
+ * de l'allocation de mouvement, il peut continuer a se deplacer apres la passe.
+ *
+ * Variantes de slug supportees :
+ *  - `running-pass` : variante BB3 Season 2 — uniquement Quick Pass.
+ *  - `running_pass` : meme effet (compatibilite slug underscore).
+ *  - `running-pass-2025` : variante Season 3 — Quick Pass OU Action de Transmission
+ *    (Hand-Off). Les autres portees (Short, Long, Long Bomb) restent exclues.
+ *
+ * Conditions d'activation (toutes obligatoires) :
+ *  - Le joueur possede l'un des slugs ci-dessus.
+ *  - L'action est une Quick Pass (ou un Hand-Off pour la variante S3).
+ *  - La passe ne provoque pas de turnover (interception adverse, jet de passe
+ *    rate ou reception ratee : la regle ne s'applique pas car le tour de
+ *    l'equipe se termine de toute facon).
+ *  - Le joueur a encore au moins 1 PM (sinon il ne peut pas continuer).
+ *  - Le joueur n'a pas deja utilise Running Pass durant ce tour d'equipe.
+ *
+ * Quand Running Pass s'active, on enregistre l'utilisation dans
+ * `state.usedRunningPassThisTurn`. Le tableau est reinitialise au changement
+ * de tour (`handleEndTurn` dans `actions.ts`), exactement comme pour
+ * `usedBreakTackleThisTurn`. La fonction `canPlayerContinueMoving` du moteur
+ * traite ce flag pour autoriser la suite du mouvement meme si l'action
+ * principale du joueur reste enregistree comme `PASS` ou `HANDOFF`.
+ *
+ * Utilisateur principal (5 equipes prioritaires) : Imperial Thrower (Noblesse
+ * Imperiale). Egalement utilisable par les Throwers Skaven (en S3 via
+ * `running-pass-2025`) et plusieurs star players hirables.
+ */
+
+import type { GameState, Player } from '../core/types';
+import type { PassRange } from './passing';
+import { hasSkill } from '../skills/skill-effects';
+
+const RUNNING_PASS_SLUGS = ['running-pass', 'running_pass', 'running-pass-2025'] as const;
+const RUNNING_PASS_HANDOFF_SLUGS = ['running-pass-2025'] as const;
+
+/**
+ * Retourne vrai si le joueur possede une variante du skill Running Pass.
+ */
+export function hasRunningPass(player: Player): boolean {
+  return RUNNING_PASS_SLUGS.some(slug => hasSkill(player, slug));
+}
+
+/**
+ * Retourne vrai si le joueur possede la variante S3 qui couvre aussi
+ * l'Action de Transmission (Hand-Off).
+ */
+export function hasRunningPassHandoffVariant(player: Player): boolean {
+  return RUNNING_PASS_HANDOFF_SLUGS.some(slug => hasSkill(player, slug));
+}
+
+/**
+ * Retourne vrai si Running Pass a deja ete utilise par ce joueur durant le
+ * tour d'equipe en cours.
+ */
+export function hasUsedRunningPassThisTurn(state: GameState, playerId: string): boolean {
+  return (state.usedRunningPassThisTurn ?? []).includes(playerId);
+}
+
+/**
+ * Retourne vrai si Running Pass peut s'activer pour cette Action de Passe.
+ *
+ * @param state - etat courant du jeu (apres resolution de la passe)
+ * @param player - le passeur
+ * @param range - portee de la passe declaree
+ * @param hadTurnover - true si la passe a provoque un turnover
+ */
+export function canApplyRunningPass(
+  state: GameState,
+  player: Player,
+  range: PassRange | null,
+  hadTurnover: boolean,
+): boolean {
+  if (!hasRunningPass(player)) return false;
+  if (range !== 'quick') return false;
+  if (hadTurnover) return false;
+  if (player.pm <= 0) return false;
+  if (hasUsedRunningPassThisTurn(state, player.id)) return false;
+  return true;
+}
+
+/**
+ * Retourne vrai si Running Pass peut s'activer pour une Action de Transmission
+ * (Hand-Off). Reserve a la variante S3 du skill.
+ */
+export function canApplyRunningPassToHandoff(
+  state: GameState,
+  player: Player,
+  hadTurnover: boolean,
+): boolean {
+  if (!hasRunningPassHandoffVariant(player)) return false;
+  if (hadTurnover) return false;
+  if (player.pm <= 0) return false;
+  if (hasUsedRunningPassThisTurn(state, player.id)) return false;
+  return true;
+}
+
+/**
+ * Marque le joueur comme ayant utilise Running Pass durant ce tour d'equipe.
+ * Retourne un nouvel etat ; ne mute jamais l'entree. Idempotent.
+ */
+export function markRunningPassUsed(state: GameState, playerId: string): GameState {
+  const current = state.usedRunningPassThisTurn ?? [];
+  if (current.includes(playerId)) {
+    return state.usedRunningPassThisTurn
+      ? state
+      : { ...state, usedRunningPassThisTurn: current };
+  }
+  return {
+    ...state,
+    usedRunningPassThisTurn: [...current, playerId],
+  };
+}


### PR DESCRIPTION
## Resume

Implemente le skill `running-pass` (BB3 Season 2/3) — tache **P1.10** du Sprint 13.

**Regle BB3** : quand un joueur effectue une **Quick Pass**, son activation ne se termine pas. Si du mouvement reste, il peut continuer son deplacement apres la passe. Equipe l'**Imperial Thrower** (Noblesse Imperiale, equipe prioritaire). La variante S3 `running-pass-2025` etend la regle aux Hand-Off.

**Conditions d'activation** (toutes obligatoires) :
- skill present (`running-pass`, `running_pass`, ou `running-pass-2025`)
- portee Quick Pass (ou Hand-Off pour la variante S3)
- pas de turnover sur la passe
- PM restants > 0
- Running Pass non encore utilise ce tour (suivi par joueur)

## Changements

- `packages/game-engine/src/mechanics/running-pass.ts` : nouveau module avec `hasRunningPass`, `hasRunningPassHandoffVariant`, `canApplyRunningPass`, `canApplyRunningPassToHandoff`, `hasUsedRunningPassThisTurn`, `markRunningPassUsed`.
- `packages/game-engine/src/core/types.ts` : ajout de `usedRunningPassThisTurn?: string[]` sur `GameState`.
- `packages/game-engine/src/core/game-state.ts` : `canPlayerContinueMoving` et `checkPlayerTurnEnd` traitent l'action `PASS`/`HANDOFF` combinee au flag Running Pass pour autoriser la suite du mouvement et l'auto-fin d'activation.
- `packages/game-engine/src/actions/actions.ts` : cablage post-pass et post-handoff (marquer Running Pass + log d'activation). Reset du flag a chaque changement de tour (handleEndTurn et tour de blitz kickoff).
- `packages/game-engine/src/index.ts` : exports publics du module.
- `packages/game-engine/src/mechanics/running-pass.test.ts` : **31 tests Vitest** couvrant detection, conditions d'activation, immutabilite, et flux complet handlePass / handleHandoff / END_TURN.
- `TODO.md` : tache P1.10 cochee.

## Tache roadmap

Sprint 13 — Skills intrinseques des 5 equipes prioritaires — `P1.10 | Implementer running-pass (Imperial Thrower)`

## Plan de test

- [x] Tests unitaires : 31 nouveaux tests Vitest dans `running-pass.test.ts`
- [x] Tests game-engine : 3608/3608 passent (103 fichiers de tests)
- [x] Tests serveur : 313/313 passent
- [x] `pnpm typecheck` : 0 erreur sur tous les packages
- [x] `pnpm lint` : 0 erreur (warnings inchanges, pre-existants)
- [x] `pnpm --filter @bb/game-engine build` : OK
- [ ] Test e2e manuel : Quick Pass reussie d'un Imperial Thrower → verifier qu'il peut continuer a se deplacer (mouvement, dodge, GFI)
- [ ] Test e2e manuel : verifier que Running Pass ne s'active pas sur Short/Long/Long Bomb
- [ ] Test e2e manuel : verifier qu'apres un turnover (passe ratee), Running Pass ne s'active pas
- [ ] Test e2e manuel : verifier que Running Pass est limite a une utilisation par tour