### PR TITLE
claude/refine-prompt-file-limits-WGT1G

### DIFF
--- a/.claude/commands/next-feature.md
+++ b/.claude/commands/next-feature.md
@@ -1,26 +1,82 @@
 ---
-description: Identifie et implémente la prochaine tâche non cochée du premier sprint non terminé dans TODO.md. Workflow autonome TDD complet avec agents spécialisés.
+description: Identifie et implemente la prochaine tache non cochee du premier sprint non termine dans TODO.md. Workflow autonome TDD complet avec agents specialises, execution progressive et garde-fous fichiers.
 allowed_tools: ["Bash", "Read", "Write", "Edit", "Grep", "Glob", "Agent", "AskUserQuestion", "TodoWrite", "Skill"]
 ---
 
+# Next Feature — Workflow progressif
+
 ## Identite
+
 Developpeur autonome sur Nuffle Arena, jeu Blood Bowl 3 en TypeScript.
 Monorepo pnpm + Turborepo : `apps/web` (Next.js 14), `apps/server` (Express + socket.io),
 `packages/game-engine` (logique deterministe), `packages/ui` (Pixi.js).
 
-## Objectif
-Implemente UNE tache non cochee (`- [ ]`) du **premier sprint non termine** dans TODO.md.
+## Garde-fous critiques
 
-## Selection de la tache
-1. Lis TODO.md, identifie le premier sprint ayant des `- [ ]`
-2. Dans ce sprint, prends la tache suivante dans l'ordre du tableau
+### Limite de taille des fichiers
+- **300-500 lignes max** par fichier cree ou modifie.
+- Si un fichier depasse 300 lignes apres tes modifications, refactorise en extrayant
+  dans des sous-modules AVANT de continuer.
+- Si un fichier existant depasse deja 500 lignes et que ta modification l'allongerait
+  davantage, **demande confirmation a l'utilisateur** via `AskUserQuestion` avant de proceder.
+
+### Execution progressive (anti-timeout)
+- **Jamais plus d'une phase a la fois.** Termine et valide chaque phase avant la suivante.
+- **Tests incrementaux** : lance `pnpm test` apres chaque bloc de code (~50 lignes),
+  pas uniquement a la fin.
+- **Commits intermediaires** : si une phase est substantielle (>100 lignes de changement),
+  fais un commit intermediaire avant de passer a la suivante.
+- **Si un build ou test depasse 2 min**, diagnostique immediatement au lieu de relancer.
+
+---
+
+## Phase 0 — Verification des outils (< 30 sec)
+
+Verifie la disponibilite des outils critiques avant tout travail :
+
+1. **Outils MCP GitHub** : tente un appel simple (`list_issues` ou `list_pull_requests`)
+2. **CLI gh** : `gh --version` en fallback si MCP indisponible
+3. **pnpm** : `pnpm --version`
+
+> Si aucun outil GitHub n'est disponible, **previens l'utilisateur immediatement**
+> et propose de continuer sans la partie PR.
+
+---
+
+## Phase 1 — Selection de la tache (lecture seule)
+
+1. Lis `TODO.md`, identifie le **premier sprint** ayant des `- [ ]`
+2. Dans ce sprint, prends la **premiere tache non cochee** dans l'ordre du tableau
 3. Si la tache a des dependances non resolues (`[ ]` anterieures), passe a la suivante
-4. Si la tache estimee > 1h de code, decoupe en sous-taches et n'implemente que la premiere
+4. Si la tache semble > 1h de code, decoupe en sous-taches et n'implemente que la premiere
+5. **Affiche clairement** la tache selectionnee a l'utilisateur
 
-## Avant de coder
-1. Explore le code existant lie a la tache (fichiers, types, tests)
-2. Planifie l'approche technique (max 5 lignes)
-3. Invoque le bon agent specialise selon le domaine :
+---
+
+## Phase 2 — Detection de travail existant (< 2 min)
+
+Avant de coder quoi que ce soit :
+
+1. **Verifie les PR ouvertes** sur le repository (via MCP ou `gh pr list`)
+2. **Si une PR traite la meme tache** :
+   - Ne la re-implemente PAS
+   - Branche-toi sur la branche de la PR
+   - Analyse ce qui bloque (CI, conflits, review)
+   - Corrige les erreurs CI ou conflits de merge
+   - Verifie que la CI passe et que la PR est mergeable
+   - **Arrete-toi la** — la tache est traitee
+3. **Si aucune PR existante** : passe a la Phase 3
+
+---
+
+## Phase 3 — Exploration et planification (< 3 min)
+
+1. **Explore le code existant** lie a la tache :
+   - Fichiers source concernes (types, interfaces, implementations)
+   - Tests existants qui touchent au meme domaine
+   - Patterns utilises dans le code adjacent
+2. **Planifie l'approche technique** en **max 5 lignes**
+3. **Identifie le domaine** et invoque l'agent specialise si necessaire :
 
 | Domaine touche | Commande a invoquer |
 |----------------|---------------------|
@@ -31,29 +87,91 @@ Implemente UNE tache non cochee (`- [ ]`) du **premier sprint non termine** dans
 | Sequences de match (TD, mi-temps) | `/turn-sequence-agent` |
 | Schema Prisma, migrations | `/prisma-database-agent` |
 | Securite, anti-triche | `/api-security-agent` |
+| Frontend Next.js | `/nextjs-frontend-agent` |
+| Rendu Pixi.js | `/pixi-renderer-agent` |
+| Tests et qualite | `/testing-quality-agent` |
+| IA adversaire | `/ai-opponent-agent` |
+| DevOps / infra | `/devops-infrastructure-agent` |
 
-## Implementation
-- TDD : ecris les tests AVANT le code (RED -> GREEN -> REFACTOR)
-- Tests unitaires : `packages/game-engine/src/**/*.test.ts` (adjacent au source)
+---
+
+## Phase 4 — Implementation TDD (progressive)
+
+### Principe : RED -> GREEN -> REFACTOR, un test a la fois
+
+**Etape 4a — Ecrire les tests (RED)**
+- Ecris les tests AVANT le code d'implementation
+- Emplacement : adjacent au source (`*.test.ts` a cote du `*.ts`)
 - Tests integration : `tests/integration/`
 - Framework : Vitest, convention : `describe('Regle: [nom]')`
-- RNG : utilise UNIQUEMENT `utils/rng.ts`, jamais `Math.random()`
-- Immutabilite : retourne un nouveau GameState, ne mute jamais l'existant
+- Lance `pnpm test` — les nouveaux tests doivent **echouer** (RED)
 
-## Validation (obligatoire avant commit)
-Execute ces 4 commandes et corrige toute erreur avant de continuer :
-1. `pnpm test` — Tests unitaires + integration
-2. `pnpm lint` — ESLint
-3. `pnpm typecheck` — Verification TypeScript
-4. `pnpm build` — Build de production
+**Etape 4b — Implementer le minimum (GREEN)**
+- Ecris le code minimal pour faire passer les tests
+- **Increment de ~30-50 lignes max** entre chaque execution de tests
+- Lance `pnpm test` apres chaque increment — verifie que les tests passent
+- Si un test echoue, corrige AVANT d'ecrire plus de code
 
-## Finalisation
-1. Coche la tache dans TODO.md
-2. Commit avec message conventionnel (`feat:`, `fix:`, `refactor:`, etc.)
-3. Push : `git push -u origin <branch>`
-4. Cree une Pull Request via les outils GitHub avec :
-   - Un titre court et descriptif (< 70 caracteres)
-   - Un body structure : resume des changements, tache roadmap concernee, plan de test
+**Etape 4c — Refactoriser (REFACTOR)**
+- Ameliore le code sans casser les tests
+- Verifie la taille des fichiers (< 300 lignes pour les nouveaux, < 500 pour les existants)
+- Si un fichier depasse la limite, extrait dans un sous-module maintenant
+
+### Contraintes techniques
+- **RNG** : utilise UNIQUEMENT `utils/rng.ts`, jamais `Math.random()`
+- **Immutabilite** : retourne un nouveau GameState, ne mute jamais l'existant
+- **Pas de fichier > 500 lignes** sans validation utilisateur
+
+---
+
+## Phase 5 — Validation complete (sequentielle)
+
+Execute ces commandes **une par une**, corrige toute erreur avant la suivante :
+
+```
+1. pnpm test          — Tests unitaires + integration
+2. pnpm lint          — ESLint
+3. pnpm typecheck     — Verification TypeScript
+4. pnpm build         — Build de production
+```
+
+> **Si une commande echoue** : diagnostique, corrige, relance uniquement
+> cette commande. Ne relance PAS toute la chaine.
+
+---
+
+## Phase 6 — Finalisation
+
+### 6a. Mise a jour TODO.md
+- Coche la tache terminee (`- [x]`)
+
+### 6b. Commit et push
+- Commit avec message conventionnel (`feat:`, `fix:`, `refactor:`, `test:`, etc.)
+- Push : `git push -u origin <branch>`
+
+### 6c. Creation de Pull Request
+
+**Verification prealable des outils GitHub :**
+
+1. **Outils MCP GitHub** (prioritaire) : `mcp__github__create_pull_request`
+2. **Fallback CLI `gh`** : `gh pr create --title "<titre>" --body "<body>" --base main`
+3. **Dernier recours** : affiche la commande manuelle a l'utilisateur
+
+**Format PR (quel que soit l'outil) :**
+- Titre court et descriptif (< 70 caracteres)
+- Body structure :
+  ```
+  ## Resume
+  - <changements principaux>
+
+  ## Tache roadmap
+  - <reference TODO.md : Sprint X, tache Y>
+
+  ## Plan de test
+  - [ ] <tests ajoutes/modifies>
+  ```
+
+---
 
 ## Arguments supplementaires
 

--- a/docs/prompts/next-feature.md
+++ b/docs/prompts/next-feature.md
@@ -1,26 +1,73 @@
-# Prompt : Next Feature (version resiliente)
+# Prompt : Next Feature (v2 — execution progressive)
+
+> Version optimisee avec garde-fous fichiers (300-500 lignes max),
+> execution progressive (anti-timeout), et detection de travail existant.
+>
+> Fichier de commande : `.claude/commands/next-feature.md`
 
 ## Identite
+
 Developpeur autonome sur Nuffle Arena, jeu Blood Bowl 3 en TypeScript.
 Monorepo pnpm + Turborepo : `apps/web` (Next.js 14), `apps/server` (Express + socket.io),
 `packages/game-engine` (logique deterministe), `packages/ui` (Pixi.js).
 
-## Objectif
-Implemente UNE tache non cochee (`- [ ]`) du **premier sprint non termine** dans TODO.md.
+## Principes d'execution
 
-## Selection de la tache
-1. Lis TODO.md, identifie le premier sprint ayant des `- [ ]`
-2. Dans ce sprint, prends la tache suivante dans l'ordre du tableau
-3. Si la tache a des dependances non resolues (`[ ]` anterieures), passe a la suivante
-4. Si la tache estimee > 1h de code, decoupe en sous-taches et n'implemente que la premiere
+### 1. Progressivite (anti-timeout)
+- **Une phase a la fois** : terminer et valider chaque phase avant la suivante
+- **Increments de 30-50 lignes** entre chaque execution de tests
+- **Commits intermediaires** si une phase depasse ~100 lignes de changement
+- **Diagnostic immediat** si un build/test depasse 2 min (pas de relance aveugle)
 
-## Avant de coder
-1. Explore le code existant lie a la tache (fichiers, types, tests)
-2. Planifie l'approche technique (max 5 lignes)
-3. Invoque le bon agent specialise selon le domaine :
+### 2. Garde-fous fichiers
+- **300 lignes** : seuil de refactorisation pour les nouveaux fichiers
+- **500 lignes** : seuil maximum, demander confirmation utilisateur au-dela
+- **Extraire proactivement** en sous-modules plutot que laisser grossir
 
-| Domaine touche | Commande a invoquer |
-|----------------|---------------------|
+### 3. Pas de travail en double
+- Toujours verifier les PR ouvertes avant de coder
+- Si une PR existe pour la meme tache : corriger/debloquer au lieu de reimplementer
+
+---
+
+## Workflow detaille
+
+### Phase 0 — Verification des outils (< 30 sec)
+
+Verifier avant tout :
+
+1. **Outils MCP GitHub** : tenter `list_issues` ou `list_pull_requests`
+2. **CLI gh** (fallback) : `gh --version`
+3. **pnpm** : `pnpm --version`
+
+Si aucun outil GitHub disponible : prevenir l'utilisateur, proposer de continuer sans PR.
+
+### Phase 1 — Selection de la tache (lecture seule)
+
+1. Lire `TODO.md`, identifier le premier sprint avec des `- [ ]`
+2. Prendre la premiere tache non cochee dans l'ordre
+3. Sauter les taches avec dependances non resolues
+4. Decouper en sous-taches si estimee > 1h de code
+5. Afficher clairement la tache selectionnee
+
+### Phase 2 — Detection de travail existant (< 2 min)
+
+1. Lister les PR ouvertes sur le repository
+2. Si une PR traite la meme tache :
+   - Se brancher sur la branche de la PR
+   - Analyser les blocages (CI, conflits, review)
+   - Corriger et s'assurer que la PR est mergeable
+   - S'arreter la
+3. Sinon, passer a la Phase 3
+
+### Phase 3 — Exploration et planification (< 3 min)
+
+1. Explorer le code lie a la tache (types, implementations, tests existants)
+2. Planifier en max 5 lignes
+3. Invoquer l'agent specialise si necessaire :
+
+| Domaine | Agent |
+|---------|-------|
 | Game engine (regles, mecaniques) | `/bloodbowl-rules-agent` |
 | Pipeline etat/actions, GameState | `/game-state-integration-agent` |
 | WebSocket / multijoueur | `/websocket-multiplayer-agent` |
@@ -28,61 +75,82 @@ Implemente UNE tache non cochee (`- [ ]`) du **premier sprint non termine** dans
 | Sequences de match (TD, mi-temps) | `/turn-sequence-agent` |
 | Schema Prisma, migrations | `/prisma-database-agent` |
 | Securite, anti-triche | `/api-security-agent` |
+| Frontend Next.js | `/nextjs-frontend-agent` |
+| Rendu Pixi.js | `/pixi-renderer-agent` |
+| Tests et qualite | `/testing-quality-agent` |
+| IA adversaire | `/ai-opponent-agent` |
+| DevOps / infra | `/devops-infrastructure-agent` |
 
-## Implementation
-- TDD : ecris les tests AVANT le code (RED -> GREEN -> REFACTOR)
-- Tests unitaires : `packages/game-engine/src/**/*.test.ts` (adjacent au source)
-- Tests integration : `tests/integration/`
-- Framework : Vitest, convention : `describe('Regle: [nom]')`
-- RNG : utilise UNIQUEMENT `utils/rng.ts`, jamais `Math.random()`
-- Immutabilite : retourne un nouveau GameState, ne mute jamais l'existant
+### Phase 4 — Implementation TDD (progressive)
 
-## Validation (obligatoire avant commit)
-Execute ces 4 commandes et corrige toute erreur avant de continuer :
-1. `pnpm test` -- Tests unitaires + integration
-2. `pnpm lint` -- ESLint
-3. `pnpm typecheck` -- Verification TypeScript
-4. `pnpm build` -- Build de production
+**Etape 4a : Tests d'abord (RED)**
+- Ecrire les tests AVANT le code
+- Emplacement : adjacent au source (`*.test.ts`)
+- Integration : `tests/integration/`
+- Convention : `describe('Regle: [nom]')`
+- Lancer `pnpm test` — les tests doivent echouer
 
-## Finalisation
+**Etape 4b : Implementation minimale (GREEN)**
+- Code minimal pour passer les tests
+- ~30-50 lignes max entre chaque `pnpm test`
+- Corriger immediatement si un test echoue
 
-### 1. Coche la tache dans TODO.md
+**Etape 4c : Refactorisation (REFACTOR)**
+- Ameliorer sans casser les tests
+- Verifier taille des fichiers (< 300 nouveaux, < 500 existants)
+- Extraire en sous-modules si necessaire
 
-### 2. Commit et push
-- Commit avec message conventionnel (`feat:`, `fix:`, `refactor:`, etc.)
-- Push : `git push -u origin <branch>`
+**Contraintes techniques :**
+- RNG : `utils/rng.ts` uniquement, jamais `Math.random()`
+- Immutabilite : nouveau GameState, jamais de mutation
+- Fichier > 500 lignes = validation utilisateur obligatoire
 
-### 3. Creation de Pull Request (avec fallback)
+### Phase 5 — Validation (sequentielle)
 
-**Verification prealable des outils GitHub :**
-Avant de creer la PR, verifie la disponibilite des outils dans cet ordre :
+Executer une par une, corriger avant de passer a la suivante :
 
-1. **Outils MCP GitHub (`mcp__github__*`)** : utilise `mcp__github__create_pull_request`
-   si les outils `mcp__github__` sont disponibles dans la session.
+1. `pnpm test` — Tests
+2. `pnpm lint` — ESLint
+3. `pnpm typecheck` — TypeScript
+4. `pnpm build` — Build production
 
-2. **Fallback CLI `gh`** : si les outils MCP ne sont pas disponibles, utilise :
-   ```bash
-   gh pr create --title "<titre>" --body "<body>" --base main
-   ```
+Si echec : diagnostiquer, corriger, relancer uniquement la commande en echec.
 
-3. **Dernier recours** : si ni MCP ni `gh` ne fonctionnent, affiche a l'utilisateur
-   la commande exacte a executer manuellement :
-   ```
-   [MANUAL PR REQUIRED]
-   Branche : <branch>
-   Titre : <titre court < 70 chars>
-   Base : main
-   Body :
-   ## Resume
-   - <changements>
+### Phase 6 — Finalisation
 
-   ## Tache roadmap
-   - <reference TODO.md>
+**6a. TODO.md** : cocher la tache `- [x]`
 
-   ## Plan de test
-   - [ ] <tests>
-   ```
+**6b. Commit et push** :
+- Message conventionnel (`feat:`, `fix:`, `refactor:`, `test:`)
+- `git push -u origin <branch>`
 
-**Format PR (quel que soit l'outil) :**
-- Titre court et descriptif (< 70 caracteres)
-- Body structure : resume des changements, tache roadmap concernee, plan de test
+**6c. Pull Request** :
+
+Outils (par ordre de priorite) :
+1. MCP GitHub : `mcp__github__create_pull_request`
+2. CLI `gh` : `gh pr create --title "<titre>" --body "<body>" --base main`
+3. Dernier recours : afficher commande manuelle
+
+Format PR :
+```
+Titre : < 70 caracteres
+Body :
+## Resume
+- <changements>
+
+## Tache roadmap
+- Sprint X, tache Y
+
+## Plan de test
+- [ ] <tests>
+```
+
+---
+
+## Historique des versions
+
+| Version | Date | Changements |
+|---------|------|-------------|
+| v1.0 | 2026-04-02 | Version initiale |
+| v1.1 | 2026-04-12 | Ajout fallback PR (MCP → gh → manuel) |
+| v2.0 | 2026-04-16 | Execution progressive, garde-fous fichiers 300-500 lignes, detection PR existantes, table agents etendue |


### PR DESCRIPTION
- Add 300-500 line file size guards with user confirmation for oversize files
- Structure execution in 7 progressive phases to prevent timeouts
- Add Phase 2: detect existing PRs before coding to avoid duplicate work
- Add tool verification phase (MCP GitHub, gh CLI, pnpm)
- Enforce incremental TDD (30-50 lines between test runs)
- Expand agent routing table (12 specialized agents)
- Add commit intermediaire strategy for large changes
- Both files stay under 180 lines (well within 300-500 limit)

https://claude.ai/code/session_01M1Aqfg2mfPfZhcfW4KkwHM