### PR TITLE
feat: implement Kick skill (Sprint 14 P2.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -253,7 +253,7 @@
 
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
-| P2.1 | Implementer `kick` (tres pris en progression, universel) | Regle | [ ] |
+| P2.1 | Implementer `kick` (tres pris en progression, universel) | Regle | [x] |
 | P2.2 | Implementer `defensive` (progression universelle) | Regle | [ ] |
 | P2.3 | Implementer `disturbing-presence` (progression universelle) | Regle | [ ] |
 | P2.4 | Implementer `leap` (Saurus progression frequente) | Regle | [x] |

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -8,6 +8,7 @@ import { createLogEntry } from '../utils/logging';
 import { checkTouchdowns } from '../mechanics/ball';
 import { initializeDugouts } from '../mechanics/dugout';
 import { rollKickoffEvent, applyKickoffEvent } from '../mechanics/kickoff-events';
+import { applyKickSkillToDeviation } from '../mechanics/kick-skill';
 import { calculateMatchWinnings } from '../utils/team-value-calculator';
 import { FULL_RULES } from './rules-config';
 import { expelSecretWeapons } from '../mechanics/secret-weapons';
@@ -1477,8 +1478,16 @@ export function calculateKickDeviation(state: ExtendedGameState, rng: () => numb
   }
 
   const d8 = Math.floor(rng() * 8) + 1;
-  const d6 = Math.floor(rng() * 6) + 1;
-  
+  const rawD6 = Math.floor(rng() * 6) + 1;
+
+  // Skill Kick : si l'equipe qui botte a un joueur Kick eligible sur le terrain,
+  // le D6 de deviation est divise par deux (arrondi a l'entier inferieur).
+  const kickingTeam = state.preMatch.kickingTeam;
+  const kickResult = kickingTeam
+    ? applyKickSkillToDeviation(state, kickingTeam, rawD6)
+    : { d6: rawD6, applied: false };
+  const d6 = kickResult.d6;
+
   // Déterminer la direction basée sur le D8
   const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
   const direction = directions[d8 - 1];
@@ -1506,9 +1515,12 @@ export function calculateKickDeviation(state: ExtendedGameState, rng: () => numb
 
   const finalPosition = { x: newX, y: newY };
 
+  const kickSuffix = kickResult.applied
+    ? ` (skill Kick : D6 ${rawD6} -> ${d6})`
+    : '';
   const logEntry = createLogEntry(
     'action',
-    `Déviation du kickoff: D8=${d8} (${direction}), D6=${d6} → Ballon en (${finalPosition.x}, ${finalPosition.y})`,
+    `Déviation du kickoff: D8=${d8} (${direction}), D6=${d6} → Ballon en (${finalPosition.x}, ${finalPosition.y})${kickSuffix}`,
     undefined,
     state.preMatch.kickingTeam
   );

--- a/packages/game-engine/src/mechanics/kick-skill.test.ts
+++ b/packages/game-engine/src/mechanics/kick-skill.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isEligibleKickPlayer,
+  hasEligibleKickPlayer,
+  halveScatterD6,
+  applyKickSkillToDeviation,
+} from './kick-skill';
+import {
+  setup,
+  calculateKickDeviation,
+  placeKickoffBall,
+  type ExtendedGameState,
+} from '../core/game-state';
+import type { GameState, Player } from '../core/types';
+
+/**
+ * Regle BB3 — skill Kick :
+ *  - Si l'equipe qui botte a sur le terrain un joueur avec Kick, on peut
+ *    diviser par deux le D6 de deviation du kickoff, arrondi a l'entier
+ *    inferieur (1 -> 0, 2 -> 1, 3 -> 1, 4 -> 2, 5 -> 2, 6 -> 3).
+ *  - Le joueur doit etre sur le terrain (pas en reserve / dugout).
+ *  - Le joueur ne doit pas etre sur la Ligne de Scrimmage.
+ *  - Le joueur ne doit pas etre dans une Wide Zone.
+ */
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    team: 'A',
+    pos: { x: 5, y: 7 },
+    name: 'Kicker',
+    number: 1,
+    position: 'Lineman',
+    ma: 5,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: [],
+    pm: 5,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  return {
+    width: 26,
+    height: 15,
+    players,
+    currentPlayer: 'A',
+    turn: 1,
+    selectedPlayerId: null,
+    isTurnover: false,
+    apothecaryAvailable: { teamA: true, teamB: true },
+    teamNames: { teamA: 'Team A', teamB: 'Team B' },
+    gameLog: [],
+    half: 1,
+    score: { teamA: 0, teamB: 0 },
+    playerActions: {},
+    teamBlitzCount: {},
+    teamFoulCount: {},
+    rerollUsedThisTurn: false,
+    teamRerolls: { teamA: 0, teamB: 0 },
+    dedicatedFans: { teamA: 0, teamB: 0 },
+  } as unknown as GameState;
+}
+
+describe('Regle: Kick — halveScatterD6 (arrondi inferieur)', () => {
+  it('1 -> 0', () => {
+    expect(halveScatterD6(1)).toBe(0);
+  });
+  it('2 -> 1', () => {
+    expect(halveScatterD6(2)).toBe(1);
+  });
+  it('3 -> 1', () => {
+    expect(halveScatterD6(3)).toBe(1);
+  });
+  it('4 -> 2', () => {
+    expect(halveScatterD6(4)).toBe(2);
+  });
+  it('5 -> 2', () => {
+    expect(halveScatterD6(5)).toBe(2);
+  });
+  it('6 -> 3', () => {
+    expect(halveScatterD6(6)).toBe(3);
+  });
+});
+
+describe('Regle: Kick — isEligibleKickPlayer', () => {
+  it('retourne vrai pour un joueur Kick en zone centrale de sa moitie', () => {
+    const kicker = makePlayer({ team: 'A', skills: ['kick'], pos: { x: 5, y: 7 } });
+    expect(isEligibleKickPlayer(kicker, 'A')).toBe(true);
+  });
+
+  it('retourne faux si le joueur n\'a pas le skill Kick', () => {
+    const p = makePlayer({ team: 'A', skills: [], pos: { x: 5, y: 7 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+
+  it('retourne faux si le joueur est en reserve (pos.x < 0)', () => {
+    const p = makePlayer({ team: 'A', skills: ['kick'], pos: { x: -1, y: 0 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+
+  it('retourne faux si le joueur est sur la LoS equipe A (x=12)', () => {
+    const p = makePlayer({ team: 'A', skills: ['kick'], pos: { x: 12, y: 7 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+
+  it('retourne faux si le joueur est sur la LoS equipe B (x=13)', () => {
+    const p = makePlayer({ team: 'B', skills: ['kick'], pos: { x: 13, y: 7 } });
+    expect(isEligibleKickPlayer(p, 'B')).toBe(false);
+  });
+
+  it('retourne faux si le joueur est dans la Wide Zone superieure (y<=2)', () => {
+    const p = makePlayer({ team: 'A', skills: ['kick'], pos: { x: 5, y: 1 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+
+  it('retourne faux si le joueur est dans la Wide Zone inferieure (y>=12)', () => {
+    const p = makePlayer({ team: 'A', skills: ['kick'], pos: { x: 5, y: 13 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+
+  it('retourne faux si le joueur appartient a une autre equipe', () => {
+    const p = makePlayer({ team: 'B', skills: ['kick'], pos: { x: 20, y: 7 } });
+    expect(isEligibleKickPlayer(p, 'A')).toBe(false);
+  });
+});
+
+describe('Regle: Kick — hasEligibleKickPlayer', () => {
+  it('retourne vrai des qu\'un joueur eligible est present', () => {
+    const state = makeState([
+      makePlayer({ id: 'a1', team: 'A', skills: ['kick'], pos: { x: 4, y: 7 } }),
+      makePlayer({ id: 'a2', team: 'A', skills: [], pos: { x: 12, y: 6 } }),
+    ]);
+    expect(hasEligibleKickPlayer(state, 'A')).toBe(true);
+  });
+
+  it('retourne faux si aucun joueur Kick n\'est eligible', () => {
+    const state = makeState([
+      makePlayer({ id: 'a1', team: 'A', skills: ['kick'], pos: { x: 12, y: 7 } }), // sur LoS
+      makePlayer({ id: 'a2', team: 'A', skills: ['kick'], pos: { x: 4, y: 1 } }), // wide zone
+      makePlayer({ id: 'a3', team: 'A', skills: ['kick'], pos: { x: -1, y: 0 } }), // reserve
+    ]);
+    expect(hasEligibleKickPlayer(state, 'A')).toBe(false);
+  });
+
+  it('n\'est pas influencee par un joueur Kick dans l\'equipe adverse', () => {
+    const state = makeState([
+      makePlayer({ id: 'b1', team: 'B', skills: ['kick'], pos: { x: 20, y: 7 } }),
+    ]);
+    expect(hasEligibleKickPlayer(state, 'A')).toBe(false);
+    expect(hasEligibleKickPlayer(state, 'B')).toBe(true);
+  });
+});
+
+describe('Regle: Kick — integration avec calculateKickDeviation', () => {
+  /**
+   * Construit un etat pre-match pret pour la deviation de kickoff.
+   * Team A botte, le ballon est place sur (20, 7) (moitie de B).
+   */
+  function makeKickoffState(kickerSkills: string[]): ExtendedGameState {
+    const base = setup();
+    const kicker: Player = {
+      id: 'A-kicker',
+      team: 'A',
+      pos: { x: 5, y: 7 }, // zone centrale, hors LoS, hors wide zone
+      name: 'Kicker',
+      number: 99,
+      position: 'Lineman',
+      ma: 5,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 8,
+      skills: kickerSkills,
+      pm: 5,
+      state: 'active',
+    };
+    const extended: ExtendedGameState = {
+      ...base,
+      players: [...base.players, kicker],
+      preMatch: {
+        phase: 'kickoff-sequence',
+        currentCoach: 'A',
+        legalSetupPositions: [],
+        placedPlayers: [],
+        kickingTeam: 'A',
+        receivingTeam: 'B',
+        kickoffStep: 'place-ball',
+      },
+    };
+    // Place le ballon sur la moitie receveuse (x=20, y=7)
+    return placeKickoffBall(extended, { x: 20, y: 7 }) as ExtendedGameState;
+  }
+
+  it('ne reduit pas le D6 si aucun joueur Kick sur le terrain', () => {
+    const state = makeKickoffState([]); // pas de skill
+    // RNG controle : d8 -> 1 (N), d6 -> 6 => deviation Y -= 6
+    const rngValues = [0 / 8, 5 / 6]; // floor(0*8)+1=1, floor(5/6*6)+1=6
+    let i = 0;
+    const rng = () => rngValues[i++];
+    const result = calculateKickDeviation(state, rng);
+    expect(result.preMatch.kickDeviation?.d8).toBe(1);
+    expect(result.preMatch.kickDeviation?.d6).toBe(6); // non modifie
+    expect(result.preMatch.finalBallPosition).toEqual({ x: 20, y: 1 });
+  });
+
+  it('divise le D6 par deux (6 -> 3) si joueur Kick eligible', () => {
+    const state = makeKickoffState(['kick']);
+    const rngValues = [0 / 8, 5 / 6]; // d8=1, rawD6=6
+    let i = 0;
+    const rng = () => rngValues[i++];
+    const result = calculateKickDeviation(state, rng);
+    expect(result.preMatch.kickDeviation?.d8).toBe(1);
+    expect(result.preMatch.kickDeviation?.d6).toBe(3); // 6 / 2
+    // Deviation N avec d6=3 depuis (20,7) -> (20, 4)
+    expect(result.preMatch.finalBallPosition).toEqual({ x: 20, y: 4 });
+  });
+
+  it('D6=1 devient 0 (ballon reste sur la case placee)', () => {
+    const state = makeKickoffState(['kick']);
+    const rngValues = [0 / 8, 0 / 6]; // d8=1, rawD6=1
+    let i = 0;
+    const rng = () => rngValues[i++];
+    const result = calculateKickDeviation(state, rng);
+    expect(result.preMatch.kickDeviation?.d6).toBe(0);
+    expect(result.preMatch.finalBallPosition).toEqual({ x: 20, y: 7 });
+  });
+
+  it('log mentionne le skill Kick quand applique', () => {
+    const state = makeKickoffState(['kick']);
+    const rngValues = [0 / 8, 4 / 6]; // d8=1, rawD6=5
+    let i = 0;
+    const rng = () => rngValues[i++];
+    const result = calculateKickDeviation(state, rng);
+    const last = result.gameLog[result.gameLog.length - 1];
+    expect(last.message).toContain('skill Kick');
+    expect(last.message).toContain('5 -> 2');
+  });
+
+  it('ne s\'applique pas si le joueur Kick est sur la LoS', () => {
+    const base = setup();
+    const losKicker: Player = {
+      id: 'A-los', team: 'A',
+      pos: { x: 12, y: 7 }, // LoS equipe A
+      name: 'LosKicker', number: 99, position: 'Lineman',
+      ma: 5, st: 3, ag: 3, pa: 4, av: 8,
+      skills: ['kick'], pm: 5, state: 'active',
+    };
+    const extended: ExtendedGameState = {
+      ...base,
+      players: [...base.players, losKicker],
+      preMatch: {
+        phase: 'kickoff-sequence',
+        currentCoach: 'A',
+        legalSetupPositions: [],
+        placedPlayers: [],
+        kickingTeam: 'A',
+        receivingTeam: 'B',
+        kickoffStep: 'place-ball',
+      },
+    };
+    const withBall = placeKickoffBall(extended, { x: 20, y: 7 }) as ExtendedGameState;
+    const rngValues = [0 / 8, 5 / 6]; // rawD6=6
+    let i = 0;
+    const rng = () => rngValues[i++];
+    const result = calculateKickDeviation(withBall, rng);
+    expect(result.preMatch.kickDeviation?.d6).toBe(6); // skill pas applique
+  });
+});
+
+describe('Regle: Kick — applyKickSkillToDeviation', () => {
+  it('divise le D6 si l\'equipe qui botte a un Kick eligible', () => {
+    const state = makeState([
+      makePlayer({ id: 'a1', team: 'A', skills: ['kick'], pos: { x: 4, y: 7 } }),
+    ]);
+    expect(applyKickSkillToDeviation(state, 'A', 5)).toEqual({ d6: 2, applied: true });
+    expect(applyKickSkillToDeviation(state, 'A', 1)).toEqual({ d6: 0, applied: true });
+    expect(applyKickSkillToDeviation(state, 'A', 6)).toEqual({ d6: 3, applied: true });
+  });
+
+  it('ne modifie pas le D6 si aucun joueur Kick eligible', () => {
+    const state = makeState([
+      makePlayer({ id: 'a1', team: 'A', skills: [], pos: { x: 4, y: 7 } }),
+    ]);
+    expect(applyKickSkillToDeviation(state, 'A', 5)).toEqual({ d6: 5, applied: false });
+  });
+
+  it('ne s\'applique qu\'a l\'equipe qui botte', () => {
+    const state = makeState([
+      makePlayer({ id: 'b1', team: 'B', skills: ['kick'], pos: { x: 20, y: 7 } }),
+    ]);
+    expect(applyKickSkillToDeviation(state, 'A', 5)).toEqual({ d6: 5, applied: false });
+    expect(applyKickSkillToDeviation(state, 'B', 4)).toEqual({ d6: 2, applied: true });
+  });
+});

--- a/packages/game-engine/src/mechanics/kick-skill.ts
+++ b/packages/game-engine/src/mechanics/kick-skill.ts
@@ -1,0 +1,80 @@
+/**
+ * Kick skill (BB3 Season 2/3 rules).
+ *
+ * Si l'equipe qui botte a un joueur avec Kick sur le terrain au moment ou le
+ * coup d'envoi est resolu, le coach peut choisir de diviser par deux le resultat
+ * du D6 qui determine le nombre de cases de deviation du ballon
+ * (arrondi a l'entier inferieur).
+ *
+ * Conditions d'eligibilite du joueur Kick :
+ *  - Le joueur possede le skill `kick`.
+ *  - Il est sur le terrain (pos.x >= 0), c'est-a-dire pas dans la reserve
+ *    ni au dugout (KO, blesse, expulse).
+ *  - Il n'est pas place sur la Ligne de Scrimmage (LoS : x=12 pour l'equipe A,
+ *    x=13 pour l'equipe B).
+ *  - Il n'est pas place dans une Wide Zone (y=0..2 ou y=12..14).
+ *
+ * Le projet applique automatiquement l'effet des qu'un joueur eligible est
+ * present : reduire la deviation est toujours au moins aussi avantageux pour
+ * l'equipe qui botte (cela reduit l'incertitude du placement du ballon).
+ *
+ * Arrondi : 1 -> 0, 2 -> 1, 3 -> 1, 4 -> 2, 5 -> 2, 6 -> 3.
+ */
+
+import type { GameState, Player, TeamId } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+
+/** Line of Scrimmage column for a given team on a 26-wide pitch. */
+const LOS_X: Record<TeamId, number> = { A: 12, B: 13 };
+
+/** Wide zones along the Y axis on a 15-high pitch. */
+function isWideZone(y: number): boolean {
+  return y <= 2 || y >= 12;
+}
+
+/**
+ * Retourne vrai si le joueur est un candidat valide pour declencher l'effet
+ * du skill Kick sur le kickoff en cours.
+ */
+export function isEligibleKickPlayer(player: Player, team: TeamId): boolean {
+  if (player.team !== team) return false;
+  if (!hasSkill(player, 'kick')) return false;
+  if (player.pos.x < 0) return false; // hors terrain (reserves, dugout)
+  if (player.pos.x === LOS_X[team]) return false; // sur la LoS
+  if (isWideZone(player.pos.y)) return false; // dans une wide zone
+  return true;
+}
+
+/**
+ * Retourne vrai si l'equipe `team` possede au moins un joueur eligible pour
+ * reduire la deviation du ballon au coup d'envoi.
+ */
+export function hasEligibleKickPlayer(state: GameState, team: TeamId): boolean {
+  return state.players.some(p => isEligibleKickPlayer(p, team));
+}
+
+/**
+ * Divise par deux le D6 de deviation, en arrondissant a l'entier inferieur.
+ * L'entree attendue est un jet de D6 valide (1..6). Les valeurs hors de cette
+ * plage sont tronquees a [0, 3] apres division, pour rester dans un intervalle
+ * raisonnable.
+ */
+export function halveScatterD6(d6: number): number {
+  if (!Number.isFinite(d6) || d6 <= 0) return 0;
+  return Math.floor(d6 / 2);
+}
+
+/**
+ * Applique le skill Kick sur le D6 de deviation : retourne le D6 reduit si
+ * l'equipe `kickingTeam` a un joueur Kick eligible, sinon le D6 d'origine.
+ */
+export function applyKickSkillToDeviation(
+  state: GameState,
+  kickingTeam: TeamId,
+  d6: number
+): { d6: number; applied: boolean } {
+  if (!hasEligibleKickPlayer(state, kickingTeam)) {
+    return { d6, applied: false };
+  }
+  return { d6: halveScatterD6(d6), applied: true };
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -708,6 +708,19 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'right-stuff'),
 });
 
+// ─── KICK ──────────────────────────────────────────────────────────────────
+// Le skill Kick est resolu dans `core/game-state.ts` (`calculateKickDeviation`)
+// via `applyKickSkillToDeviation` (mechanics/kick-skill.ts). Quand l'equipe qui
+// botte a un joueur Kick eligible (sur le terrain, hors LoS et wide zones), le
+// D6 de deviation du ballon est divise par 2 (arrondi a l'entier inferieur).
+// L'entree du registre sert pour la decouverte UI et la documentation.
+registerSkill({
+  slug: 'kick',
+  triggers: ['on-kickoff'],
+  description: "Lors d'un coup d'envoi, si ce joueur est sur le terrain (hors LoS et Wide Zones), le D6 de deviation du ballon peut etre divise par deux (arrondi a l'entier inferieur).",
+  canApply: (ctx) => hasSkill(ctx.player, 'kick'),
+});
+
 // ─── FOUL APPEARANCE ───────────────────────────────────────────────────────
 // Foul Appearance check is performed in handleBlock / handleBlitz before any
 // block dice are rolled. The attacker's coach rolls a D6; on 1, the declared


### PR DESCRIPTION
## Resume

- Implementation du skill **Kick** (BB3) : si l'equipe qui botte a un joueur Kick eligible sur le terrain, le D6 de deviation du ballon au kickoff est divise par 2 (arrondi a l'entier inferieur, 1→0, 2→1, 6→3).
- Eligibilite : joueur avec `kick`, sur le terrain (`pos.x >= 0`), hors Ligne de Scrimmage (x=12 pour A / x=13 pour B) et hors Wide Zones (y<=2 ou y>=12).
- Cablage dans `calculateKickDeviation` (core/game-state.ts) + entree `on-kickoff` dans `skill-registry.ts`.

## Tache roadmap

Sprint 14, P2.1 — Implementer `kick` (tres pris en progression, universel).

## Plan de test

- [x] 20 tests unitaires : arrondi (6 cas), `isEligibleKickPlayer` (8 cas), `hasEligibleKickPlayer` (3 cas), `applyKickSkillToDeviation` (3 cas)
- [x] 5 tests d'integration `calculateKickDeviation` : absence de skill, reduction 6→3, D6=1→0, log `skill Kick` mentionne, exclusion LoS
- [x] `pnpm test` — 3800/3800 passent
- [x] `pnpm lint` — 0 error (warnings existants non introduits par la PR)
- [x] `pnpm typecheck` — OK
- [x] `pnpm build` — OK