### PR TITLE
feat: implement Defensive skill (Sprint 14 P2.2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -254,7 +254,7 @@
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
 | P2.1 | Implementer `kick` (tres pris en progression, universel) | Regle | [x] |
-| P2.2 | Implementer `defensive` (progression universelle) | Regle | [ ] |
+| P2.2 | Implementer `defensive` (progression universelle) | Regle | [x] |
 | P2.3 | Implementer `disturbing-presence` (progression universelle) | Regle | [ ] |
 | P2.4 | Implementer `leap` (Saurus progression frequente) | Regle | [x] |
 | P2.5 | Implementer `dump-off` (Imperial / Skaven Thrower progression) | Regle | [x] |

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -27,6 +27,7 @@ import {
 } from './stand-firm';
 import { isFendActiveForFollowUp } from './fend';
 import { hasFrenzy } from './frenzy';
+import { isGuardCancelledByDefensive } from './defensive';
 
 /**
  * Applique un chain push : si la case de destination est occupée, le joueur qui s'y trouve
@@ -295,8 +296,12 @@ export function calculateOffensiveAssists(
   for (const teammate of teammates) {
     // Le coéquipier doit marquer la cible
     if (isAdjacent(teammate.pos, target.pos)) {
-      // Guard : un joueur avec Guard peut assister même s'il est marqué par d'autres adversaires
-      if (checkGuard(teammate, state)) {
+      // Guard : un joueur avec Guard peut assister même s'il est marqué par d'autres adversaires.
+      // Defensive (BB3) : pendant le tour adverse, le Guard est annulé si un adversaire
+      // Defensive adjacent marque le joueur Guard.
+      const guardActive =
+        checkGuard(teammate, state) && !isGuardCancelledByDefensive(state, teammate);
+      if (guardActive) {
         assists++;
       } else {
         // Vérifier que le coéquipier n'est pas marqué par un autre adversaire que la cible

--- a/packages/game-engine/src/mechanics/defensive.test.ts
+++ b/packages/game-engine/src/mechanics/defensive.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setup,
+  calculateOffensiveAssists,
+  calculateDefensiveAssists,
+  type GameState,
+  type Player,
+} from '../index';
+import {
+  hasDefensive,
+  isGuardCancelledByDefensive,
+} from './defensive';
+
+/**
+ * Defensive (BB3 Season 2/3 — General / Agility category) :
+ *  - Pendant le tour d'equipe de l'adversaire UNIQUEMENT, tous les joueurs
+ *    adverses Marques (adjacents) par ce joueur ne peuvent pas utiliser le
+ *    skill Guard pour fournir des assists.
+ *  - Ne s'applique pas pendant le propre tour du joueur Defensive.
+ *  - Le joueur Defensive doit etre debout (pas stunned) pour appliquer l'effet.
+ *  - L'effet annule le Guard du joueur marque : si ce dernier est marque par
+ *    d'autres adversaires, il ne peut plus fournir d'assist offensif.
+ *
+ * Utilisateurs principaux (5 equipes prioritaires) : Dwarf Blocker, Dwarf
+ * Blocker Lineman (Nains), Jaguar Warrior Blocker (Hommes-Lezards).
+ */
+
+describe('Regle: Defensive', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = setup();
+  });
+
+  describe('hasDefensive helper', () => {
+    it('retourne false sans le skill', () => {
+      const p = { skills: [] } as unknown as Player;
+      expect(hasDefensive(p)).toBe(false);
+    });
+
+    it('retourne true avec le skill defensive', () => {
+      const p = { skills: ['defensive'] } as unknown as Player;
+      expect(hasDefensive(p)).toBe(true);
+    });
+
+    it('retourne true avec variante underscore', () => {
+      const p = { skills: ['defensive'] } as unknown as Player;
+      expect(hasDefensive(p)).toBe(true);
+    });
+  });
+
+  describe('isGuardCancelledByDefensive', () => {
+    it('retourne false si aucun adversaire Defensive adjacent', () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'] };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 20, y: 14 }, skills: ['defensive'] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(false);
+    });
+
+    it('retourne true quand un adversaire Defensive adjacent pendant le tour du joueur Guard', () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'], stunned: false };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 11, y: 7 }, skills: ['defensive'], stunned: false };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(true);
+    });
+
+    it("retourne false si c'est le tour de l'equipe du joueur Defensive (pas le tour adverse)", () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'B', // tour de l'equipe Defensive
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'], stunned: false };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 11, y: 7 }, skills: ['defensive'], stunned: false };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(false);
+    });
+
+    it('retourne false si le joueur Defensive est stunned', () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'], stunned: false };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 11, y: 7 }, skills: ['defensive'], stunned: true };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(false);
+    });
+
+    it("retourne false si le joueur adjacent n'a pas Defensive", () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'], stunned: false };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 11, y: 7 }, skills: ['block'], stunned: false };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(false);
+    });
+
+    it("retourne true meme si plusieurs adversaires Defensive sont adjacents", () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1')
+            return { ...p, pos: { x: 10, y: 7 }, skills: ['guard'], stunned: false };
+          if (p.id === 'B1')
+            return { ...p, pos: { x: 11, y: 7 }, skills: ['defensive'], stunned: false };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 9, y: 7 }, skills: ['defensive'], stunned: false };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const guard = newState.players.find(p => p.id === 'A1')!;
+      expect(isGuardCancelledByDefensive(newState, guard)).toBe(true);
+    });
+  });
+
+  describe('Integration avec calculateOffensiveAssists', () => {
+    it('un Guard marque par 2 adversaires dont 1 avec Defensive ne fournit PAS d\'assist', () => {
+      // Scenario :
+      //  - A1 attaque B1 (cible)
+      //  - A2 est l'assistant potentiel : a Guard, adjacent a B1, marque par B2 (autre adversaire que B1)
+      //  - B2 a Defensive et est adjacent a A2 -> annule Guard de A2
+      //  - Resultat : A2 ne fournit plus d'assist (marque par B2 sans Guard)
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 7, skills: [] };
+          if (p.id === 'A2')
+            return { ...p, pos: { x: 11, y: 8 }, stunned: false, pm: 6, skills: ['guard'] };
+          if (p.id === 'B1') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 12, y: 8 }, stunned: false, pm: 6, skills: ['defensive'] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+
+      const attacker = newState.players.find(p => p.id === 'A1')!;
+      const target = newState.players.find(p => p.id === 'B1')!;
+      const assists = calculateOffensiveAssists(newState, attacker, target);
+      expect(assists).toBe(0);
+    });
+
+    it('un Guard marque par 2 adversaires SANS Defensive fournit 1 assist (regle standard)', () => {
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 7, skills: [] };
+          if (p.id === 'A2')
+            return { ...p, pos: { x: 11, y: 8 }, stunned: false, pm: 6, skills: ['guard'] };
+          if (p.id === 'B1') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 12, y: 8 }, stunned: false, pm: 6, skills: [] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+
+      const attacker = newState.players.find(p => p.id === 'A1')!;
+      const target = newState.players.find(p => p.id === 'B1')!;
+      const assists = calculateOffensiveAssists(newState, attacker, target);
+      expect(assists).toBe(1);
+    });
+
+    it("Defensive ne s'applique pas pendant le tour de l'equipe Defensive", () => {
+      // Memes positions que le scenario "Guard annule" mais c'est le tour de B
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'B',
+        players: state.players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 7, skills: [] };
+          if (p.id === 'A2')
+            return { ...p, pos: { x: 11, y: 8 }, stunned: false, pm: 6, skills: ['guard'] };
+          if (p.id === 'B1') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 12, y: 8 }, stunned: false, pm: 6, skills: ['defensive'] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const attacker = newState.players.find(p => p.id === 'A1')!;
+      const target = newState.players.find(p => p.id === 'B1')!;
+      // Guard est encore actif -> A2 fournit 1 assist malgre B2
+      const assists = calculateOffensiveAssists(newState, attacker, target);
+      expect(assists).toBe(1);
+    });
+
+    it("Defensive n'affecte PAS les assists defensifs (regle BB2020 — tour adverse uniquement)", () => {
+      // Scenario symetrique pour les defensive assists :
+      //  - B1 est la cible, B2 est l'assistant defensif avec Guard marque par A2+attaquant
+      //  - A2 a Defensive mais c'est le tour de l'equipe A (l'attaquant)
+      //  - Regle : Defensive ne s'applique qu'au tour adverse. Ici B est l'equipe
+      //    adverse au joueur Defensive A2 -> Defensive s'applique bien.
+      //  - Cependant, la regle BB2020 annule le Guard uniquement pour les
+      //    assists offensifs (le tour adverse = tour de l'attaquant).
+      //  - Defensive n'affecte pas les defensive assists : Guard de B2 reste actif.
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 7, skills: [] };
+          if (p.id === 'A2')
+            return { ...p, pos: { x: 9, y: 8 }, stunned: false, pm: 6, skills: ['defensive'] };
+          if (p.id === 'B1') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 10, y: 8 }, stunned: false, pm: 6, skills: ['guard'] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const attacker = newState.players.find(p => p.id === 'A1')!;
+      const target = newState.players.find(p => p.id === 'B1')!;
+      // B2 Guard marque par A1 et A2 : Guard lui permet de fournir assist defensif
+      const defAssists = calculateDefensiveAssists(newState, attacker, target);
+      expect(defAssists).toBe(1);
+    });
+
+    it('assist sans Guard ni Defensive marque par autre adversaire = 0', () => {
+      // Sanity check : pas de Guard, assistant marque par autre que la cible
+      const newState: GameState = {
+        ...state,
+        currentPlayer: 'A',
+        players: state.players.map(p => {
+          if (p.id === 'A1') return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 7, skills: [] };
+          if (p.id === 'A2')
+            return { ...p, pos: { x: 11, y: 8 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B1') return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+          if (p.id === 'B2')
+            return { ...p, pos: { x: 12, y: 8 }, stunned: false, pm: 6, skills: [] };
+          return { ...p, pos: { x: 0, y: 0 } };
+        }),
+      };
+      const attacker = newState.players.find(p => p.id === 'A1')!;
+      const target = newState.players.find(p => p.id === 'B1')!;
+      const assists = calculateOffensiveAssists(newState, attacker, target);
+      expect(assists).toBe(0);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/defensive.ts
+++ b/packages/game-engine/src/mechanics/defensive.ts
@@ -1,0 +1,66 @@
+/**
+ * Defensive (BB3 Season 2/3 — Agility).
+ *
+ * Pendant le tour d'equipe de l'adversaire UNIQUEMENT, tous les joueurs
+ * adverses Marques (adjacents) par ce joueur ne peuvent pas utiliser le skill
+ * Guard pour fournir des assists offensifs. Ne s'applique pas pendant le
+ * propre tour du joueur Defensive (la regle BB2020 est explicite :
+ * "mais pas pendant votre propre tour d'equipe").
+ *
+ * Le joueur Defensive doit etre debout (pas stunned) pour appliquer l'effet :
+ * un joueur stunned ne fournit plus de zone de tacle et ne marque donc plus
+ * ses adversaires adjacents.
+ *
+ * Utilisateurs principaux (5 equipes prioritaires) :
+ *  - Dwarf Blocker + Dwarf Blocker Lineman (Nains)
+ *  - Jaguar Warrior Blocker (Hommes-Lezards)
+ *
+ * Cable dans `blocking.ts` via `calculateOffensiveAssists` : quand un
+ * assistant offensif potentiel possede Guard, on verifie si ce Guard est
+ * annule par un adversaire Defensive adjacent ; si oui, le Guard ne
+ * s'applique plus et l'assistant est soumis a la regle standard (pas
+ * d'assist s'il est marque par un adversaire autre que la cible).
+ */
+
+import type { GameState, Player } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { isAdjacent } from './movement';
+
+/**
+ * Retourne vrai si le joueur possede le skill Defensive.
+ * Accepte les variantes de slug : `defensive`, `Defensive`.
+ */
+export function hasDefensive(player: Player): boolean {
+  return hasSkill(player, 'defensive');
+}
+
+/**
+ * Determine si le Guard d'un joueur est annule par un adversaire Defensive.
+ *
+ * Conditions (regle BB2020) :
+ *  - C'est le tour d'equipe du joueur Guard (donc le tour adverse du joueur
+ *    Defensive). Defensive ne s'applique jamais pendant le propre tour du
+ *    joueur Defensive.
+ *  - Un joueur adverse (par rapport a `guardPlayer`) possede Defensive, est
+ *    debout (non stunned) et est adjacent a `guardPlayer` (marque donc le
+ *    joueur Guard).
+ */
+export function isGuardCancelledByDefensive(
+  state: GameState,
+  guardPlayer: Player,
+): boolean {
+  // Defensive ne s'applique que pendant le tour adverse du joueur Defensive.
+  // Le joueur Defensive est sur l'equipe adverse a `guardPlayer`, donc le
+  // tour adverse du Defensive == tour de l'equipe de `guardPlayer`.
+  if (state.currentPlayer !== guardPlayer.team) return false;
+
+  for (const other of state.players) {
+    if (other.id === guardPlayer.id) continue;
+    if (other.team === guardPlayer.team) continue;
+    if (other.stunned) continue;
+    if (!isAdjacent(other.pos, guardPlayer.pos)) continue;
+    if (hasDefensive(other)) return true;
+  }
+
+  return false;
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -182,6 +182,18 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'guard'),
 });
 
+// DEFENSIVE
+// Effet cable dans `mechanics/defensive.ts` + `mechanics/blocking.ts`
+// (annulation du Guard des adversaires marques par le joueur Defensive
+// pendant le tour adverse, pour le calcul des assists offensifs).
+// L'entree ici sert pour la decouverte UI et la documentation.
+registerSkill({
+  slug: 'defensive',
+  triggers: ['on-block-defender'],
+  description: "Pendant le tour adverse uniquement, tous les joueurs adverses marques par ce joueur ne peuvent pas utiliser le skill Guard.",
+  canApply: (ctx) => hasSkill(ctx.player, 'defensive'),
+});
+
 // MIGHTY BLOW (+1)
 registerSkill({
   slug: 'mighty-blow',


### PR DESCRIPTION
## Résumé

Implémentation du skill **Defensive** (BB3 S2/S3 — Agility).

Règle : pendant le tour d'équipe de l'adversaire uniquement, tous les joueurs adverses marqués (adjacents) par un joueur Defensive ne peuvent plus utiliser le skill **Guard** pour fournir des assists offensifs. Un joueur Defensive stunné perd sa zone de tâcle et ne déclenche pas l'effet.

### Changements

- **`packages/game-engine/src/mechanics/defensive.ts`** (nouveau) — `hasDefensive()` + `isGuardCancelledByDefensive(state, guard)` : vérifie que c'est le tour du joueur Guard et qu'un adversaire Defensive non-stunné lui est adjacent.
- **`packages/game-engine/src/mechanics/blocking.ts`** — `calculateOffensiveAssists` : le Guard d'un assistant est considéré actif uniquement s'il n'est pas annulé par un Defensive adverse.
- **`packages/game-engine/src/skills/skill-registry.ts`** — enregistre le skill `defensive` (trigger `on-block-defender`) pour la découverte UI et la documentation.
- **`packages/game-engine/src/mechanics/defensive.test.ts`** (nouveau) — 13 tests unitaires et d'intégration.

### Tâche roadmap

- Sprint 14 — tâche **P2.2** : `Implementer defensive (progression universelle)` cochée dans [`TODO.md`](../blob/claude/upbeat-mayer-4mxGy/TODO.md).

### Utilisateurs principaux (5 équipes prioritaires)

- Dwarf Blocker + Dwarf Blocker Lineman (Nains)
- Jaguar Warrior Blocker (Hommes-Lézards)
- Skill de progression universelle disponible au level-up.

## Plan de test

- [x] `pnpm test defensive.test` — 14 tests passent
- [x] `pnpm test` (game-engine) — **3814 tests passent**, aucune régression
- [x] `pnpm lint` — 0 error (warnings pré-existants inchangés)
- [x] `pnpm typecheck` — OK sur tous les packages
- [x] `pnpm --filter @bb/game-engine build` — OK
