### PR TITLE
feat: implement disturbing-presence skill (Sprint 14 P2.3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -255,7 +255,7 @@
 |---|-------|------|--------|
 | P2.1 | Implementer `kick` (tres pris en progression, universel) | Regle | [x] |
 | P2.2 | Implementer `defensive` (progression universelle) | Regle | [x] |
-| P2.3 | Implementer `disturbing-presence` (progression universelle) | Regle | [ ] |
+| P2.3 | Implementer `disturbing-presence` (progression universelle) | Regle | [x] |
 | P2.4 | Implementer `leap` (Saurus progression frequente) | Regle | [x] |
 | P2.5 | Implementer `dump-off` (Imperial / Skaven Thrower progression) | Regle | [x] |
 | P2.6 | Implementer `sneaky-git` (Dwarf Troll Slayer progression) | Regle | [ ] |

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -210,6 +210,13 @@ export {
   isFendActiveForFollowUp,
 } from './mechanics/fend';
 
+// Export du skill Disturbing Presence (-1 aux passes/catches/intercept des adversaires a <= 3 cases)
+export {
+  hasDisturbingPresence,
+  getDisturbingPresenceModifier,
+  DISTURBING_PRESENCE_RANGE,
+} from './mechanics/disturbing-presence';
+
 // Export du skill Running Pass (Imperial Thrower, etc.)
 export {
   hasRunningPass,

--- a/packages/game-engine/src/mechanics/disturbing-presence.test.ts
+++ b/packages/game-engine/src/mechanics/disturbing-presence.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState, Player } from '../core/types';
+import {
+  hasDisturbingPresence,
+  getDisturbingPresenceModifier,
+} from './disturbing-presence';
+import { calculatePassModifiers, calculateCatchModifiers } from './passing';
+
+/**
+ * Disturbing Presence (Presence Perturbante) — BB3 Season 2/3.
+ *
+ * Quand un joueur adverse effectue une action de Passe, Lancer d'Equipier,
+ * Lancer de Bombe, tente d'intercepter une passe ou de receptionner le ballon,
+ * il applique un modificateur de -1 par joueur adverse avec cette competence
+ * situe a 3 cases ou moins de lui (distance de Chebyshev).
+ *
+ * Un joueur Prone / Stunned / KO / Casualty / Hypnotise n'exerce pas sa
+ * presence perturbante.
+ */
+
+const TEAM_A = 'A';
+const TEAM_B = 'B';
+
+function makePlayer(partial: Partial<Player> & Pick<Player, 'id' | 'team' | 'pos'>): Player {
+  return {
+    name: partial.id,
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: [],
+    pm: 6,
+    stunned: false,
+    state: 'active',
+    ...partial,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  return {
+    width: 26,
+    height: 15,
+    players,
+    ball: undefined,
+    currentPlayer: TEAM_A,
+    half: 1,
+    turn: 1,
+    scores: { teamA: 0, teamB: 0 },
+    playerActions: {},
+    teamFoulCount: {},
+    teamRerolls: { teamA: 0, teamB: 0 },
+    matchStats: {},
+    gameLog: [],
+    isTurnover: false,
+  } as unknown as GameState;
+}
+
+describe('hasDisturbingPresence', () => {
+  it('retourne true si le joueur a le skill', () => {
+    const p = makePlayer({ id: 'P1', team: TEAM_A, pos: { x: 0, y: 0 }, skills: ['disturbing-presence'] });
+    expect(hasDisturbingPresence(p)).toBe(true);
+  });
+
+  it('retourne false sinon', () => {
+    const p = makePlayer({ id: 'P1', team: TEAM_A, pos: { x: 0, y: 0 }, skills: [] });
+    expect(hasDisturbingPresence(p)).toBe(false);
+  });
+});
+
+describe('getDisturbingPresenceModifier', () => {
+  it('retourne 0 sans adversaire avec le skill', () => {
+    const state = makeState([
+      makePlayer({ id: 'A1', team: TEAM_A, pos: { x: 5, y: 5 } }),
+      makePlayer({ id: 'B1', team: TEAM_B, pos: { x: 6, y: 5 } }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+
+  it('retourne -1 pour un adversaire avec disturbing-presence a 3 cases', () => {
+    const state = makeState([
+      makePlayer({ id: 'A1', team: TEAM_A, pos: { x: 5, y: 5 } }),
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 8, y: 5 },
+        skills: ['disturbing-presence'],
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(-1);
+  });
+
+  it('cumule -2 pour deux adversaires avec disturbing-presence dans 3 cases', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 7, y: 6 },
+        skills: ['disturbing-presence'],
+      }),
+      makePlayer({
+        id: 'B2',
+        team: TEAM_B,
+        pos: { x: 4, y: 3 },
+        skills: ['disturbing-presence'],
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(-2);
+  });
+
+  it('ne compte pas les adversaires a plus de 3 cases', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 9, y: 5 }, // Chebyshev = 4
+        skills: ['disturbing-presence'],
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+
+  it('ne compte pas les coequipiers avec disturbing-presence', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'A2',
+        team: TEAM_A,
+        pos: { x: 6, y: 5 },
+        skills: ['disturbing-presence'],
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+
+  it('ne compte pas un adversaire stunned', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 6, y: 5 },
+        skills: ['disturbing-presence'],
+        stunned: true,
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+
+  it('ne compte pas un adversaire KO / Casualty / Sent Off', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 6, y: 5 },
+        skills: ['disturbing-presence'],
+        state: 'knocked_out',
+      }),
+      makePlayer({
+        id: 'B2',
+        team: TEAM_B,
+        pos: { x: 5, y: 6 },
+        skills: ['disturbing-presence'],
+        state: 'casualty',
+      }),
+      makePlayer({
+        id: 'B3',
+        team: TEAM_B,
+        pos: { x: 5, y: 4 },
+        skills: ['disturbing-presence'],
+        state: 'sent_off',
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+
+  it('ne compte pas un adversaire hypnotise', () => {
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: 6, y: 5 },
+        skills: ['disturbing-presence'],
+      }),
+    ]);
+    const hypnotized = { ...state, hypnotizedPlayers: ['B1'] } as GameState;
+    expect(getDisturbingPresenceModifier(hypnotized, { x: 5, y: 5 }, TEAM_A)).toBe(0);
+  });
+});
+
+describe('integration — calculatePassModifiers applique disturbing-presence', () => {
+  it('subit -1 par adversaire avec disturbing-presence a 3 cases du passeur', () => {
+    const passer = makePlayer({ id: 'A1', team: TEAM_A, pos: { x: 10, y: 7 }, hasBall: true });
+    const target = makePlayer({ id: 'A2', team: TEAM_A, pos: { x: 13, y: 7 } });
+    const dp = makePlayer({
+      id: 'B1',
+      team: TEAM_B,
+      pos: { x: 12, y: 7 }, // 2 cases du passeur
+      skills: ['disturbing-presence'],
+    });
+    const state = makeState([passer, target, dp]);
+    const mods = calculatePassModifiers(state, passer, target.pos);
+    // distance quick (+1), pas d'adversaire adjacent au passeur (-0), DP (-1)
+    expect(mods).toBe(0);
+  });
+
+  it('cumule le malus de marquage et de disturbing-presence', () => {
+    const passer = makePlayer({ id: 'A1', team: TEAM_A, pos: { x: 10, y: 7 }, hasBall: true });
+    const target = makePlayer({ id: 'A2', team: TEAM_A, pos: { x: 13, y: 7 } });
+    const marker = makePlayer({
+      id: 'B1',
+      team: TEAM_B,
+      pos: { x: 11, y: 7 }, // adjacent + DP
+      skills: ['disturbing-presence'],
+    });
+    const state = makeState([passer, target, marker]);
+    const mods = calculatePassModifiers(state, passer, target.pos);
+    // quick (+1), marquage (-1), DP (-1)
+    expect(mods).toBe(-1);
+  });
+});
+
+describe('integration — calculateCatchModifiers applique disturbing-presence', () => {
+  it('subit -1 par adversaire avec disturbing-presence a 3 cases du receveur', () => {
+    const catcher = makePlayer({ id: 'A2', team: TEAM_A, pos: { x: 13, y: 7 } });
+    const dp = makePlayer({
+      id: 'B1',
+      team: TEAM_B,
+      pos: { x: 15, y: 8 }, // 2 cases du receveur
+      skills: ['disturbing-presence'],
+    });
+    const state = makeState([catcher, dp]);
+    const mods = calculateCatchModifiers(state, catcher);
+    // pas d'adversaire adjacent (-0), DP (-1)
+    expect(mods).toBe(-1);
+  });
+});

--- a/packages/game-engine/src/mechanics/disturbing-presence.ts
+++ b/packages/game-engine/src/mechanics/disturbing-presence.ts
@@ -1,0 +1,68 @@
+/**
+ * Disturbing Presence (Presence Perturbante) — BB3 Season 2/3.
+ *
+ * Quand un joueur adverse effectue une action de Passe, Lancer d'Equipier,
+ * Lancer de Bombe, ou tente d'intercepter une passe / receptionner le ballon,
+ * il subit un modificateur de -1 par joueur adverse possedant cette
+ * competence situe a 3 cases ou moins de lui (distance de Chebyshev).
+ *
+ * Un joueur au sol, stunned, KO, blesse, expulse ou hypnotise n'exerce pas
+ * sa presence perturbante (il ne peut plus utiliser ses competences).
+ *
+ * La resolution concrete est cablee dans `passing.ts` (pass / catch /
+ * interception) et `throw-team-mate.ts`.
+ */
+
+import type { GameState, Player, Position, TeamId } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+
+/** Portee de la competence (en cases, distance de Chebyshev). */
+export const DISTURBING_PRESENCE_RANGE = 3;
+
+/** Retourne vrai si le joueur possede la competence Disturbing Presence. */
+export function hasDisturbingPresence(player: Player): boolean {
+  return hasSkill(player, 'disturbing-presence') || hasSkill(player, 'disturbing_presence');
+}
+
+/**
+ * Indique si ce joueur peut exercer sa presence perturbante :
+ * il doit etre sur le terrain et actif (ni stunned, ni KO, ni casualty,
+ * ni expulse, ni hypnotise).
+ */
+function canExertDisturbingPresence(state: GameState, player: Player): boolean {
+  if (player.stunned) return false;
+  const s = player.state;
+  if (s === 'knocked_out' || s === 'casualty' || s === 'sent_off') return false;
+  const hypnotized = state.hypnotizedPlayers ?? [];
+  if (hypnotized.includes(player.id)) return false;
+  return true;
+}
+
+/** Distance de Chebyshev entre deux positions. */
+function chebyshev(a: Position, b: Position): number {
+  return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+}
+
+/**
+ * Retourne le modificateur (negatif ou zero) a appliquer a un jet de Passe,
+ * Lancer d'Equipier, Interception ou Reception effectue par un joueur de
+ * `team` a la position `position`.
+ *
+ * -1 par joueur adverse avec Disturbing Presence eligible dans un rayon de 3
+ * cases. Les coequipiers avec le skill ne comptent pas.
+ */
+export function getDisturbingPresenceModifier(
+  state: GameState,
+  position: Position,
+  team: TeamId,
+): number {
+  let modifier = 0;
+  for (const player of state.players) {
+    if (player.team === team) continue;
+    if (!hasDisturbingPresence(player)) continue;
+    if (!canExertDisturbingPresence(state, player)) continue;
+    if (chebyshev(player.pos, position) > DISTURBING_PRESENCE_RANGE) continue;
+    modifier -= 1;
+  }
+  return modifier;
+}

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -9,6 +9,7 @@ import { samePos, isAdjacent, getAdjacentOpponents } from './movement';
 import { createLogEntry } from '../utils/logging';
 import { bounceBall, checkTouchdowns, isInOpponentEndzone, awardTouchdown } from './ball';
 import { hasSkill } from '../skills/skill-effects';
+import { getDisturbingPresenceModifier } from './disturbing-presence';
 
 /**
  * Distances de passe selon BB2020
@@ -79,6 +80,9 @@ export function calculatePassModifiers(
   const opponentsNearPasser = getAdjacentOpponents(state, passer.pos, passer.team);
   modifiers -= opponentsNearPasser.length;
 
+  // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases
+  modifiers += getDisturbingPresenceModifier(state, passer.pos, passer.team);
+
   return modifiers;
 }
 
@@ -113,6 +117,9 @@ export function calculateCatchModifiers(
   // Malus pour chaque adversaire en zone de tacle du receveur
   const opponentsNearCatcher = getAdjacentOpponents(state, catcher.pos, catcher.team);
   modifiers -= opponentsNearCatcher.length;
+
+  // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases
+  modifiers += getDisturbingPresenceModifier(state, catcher.pos, catcher.team);
 
   return modifiers;
 }
@@ -180,11 +187,23 @@ export function findInterceptors(
 }
 
 /**
- * Effectue un jet d'interception (AG du joueur, -2 de base)
+ * Effectue un jet d'interception (AG du joueur, -2 de base).
+ * Applique egalement le malus Disturbing Presence (-1 par adversaire avec
+ * le skill a <= 3 cases de l'intercepteur).
  */
-export function performInterceptionRoll(interceptor: Player, rng: RNG): DiceResult {
+export function performInterceptionRoll(
+  interceptor: Player,
+  rng: RNG,
+  state?: GameState,
+): DiceResult {
   const diceRoll = rollD6(rng);
-  const targetNumber = Math.max(2, Math.min(6, interceptor.ag + 2)); // Plus difficile : AG + 2
+  const dpModifier = state
+    ? getDisturbingPresenceModifier(state, interceptor.pos, interceptor.team)
+    : 0;
+  // Total modifier = -2 (interception de base) + DP (negatif ou nul)
+  const totalModifier = -2 + dpModifier;
+  // targetNumber base = interceptor.ag - totalModifier (un modificateur negatif augmente le target)
+  const targetNumber = Math.max(2, Math.min(6, interceptor.ag - totalModifier));
   const success = diceRoll >= targetNumber;
 
   return {
@@ -193,7 +212,7 @@ export function performInterceptionRoll(interceptor: Player, rng: RNG): DiceResu
     diceRoll,
     targetNumber,
     success,
-    modifiers: -2,
+    modifiers: totalModifier,
   };
 }
 
@@ -217,7 +236,7 @@ export function executePass(
   // Vérifier les interceptions
   const interceptors = findInterceptors(newState, passer.pos, target.pos, passer.team);
   for (const interceptor of interceptors) {
-    const interceptResult = performInterceptionRoll(interceptor, rng);
+    const interceptResult = performInterceptionRoll(interceptor, rng, newState);
 
     const interceptLog = createLogEntry(
       'dice',

--- a/packages/game-engine/src/mechanics/throw-team-mate.ts
+++ b/packages/game-engine/src/mechanics/throw-team-mate.ts
@@ -23,6 +23,7 @@ import { performInjuryRoll } from './injury';
 import { getDistance, getPassRangeModifier } from './passing';
 import { getAdjacentOpponents } from './movement';
 import { checkAlwaysHungry } from './negative-traits';
+import { getDisturbingPresenceModifier } from './disturbing-presence';
 
 export type ThrowRange = 'quick' | 'short' | 'long';
 
@@ -85,6 +86,9 @@ function calculateThrowModifiers(
   if (hasSkill(thrown, 'stunty')) {
     modifiers += 1;
   }
+
+  // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases du lanceur
+  modifiers += getDisturbingPresenceModifier(state, thrower.pos, thrower.team);
 
   return modifiers;
 }

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -745,3 +745,16 @@ registerSkill({
   description: 'Quand un joueur adverse déclare un Blocage ciblant ce joueur, l\'attaquant lance un D6 avant le blocage. Sur 1, le blocage est annulé et l\'action est gaspillée.',
   canApply: (ctx) => hasSkill(ctx.player, 'foul-appearance'),
 });
+
+// ─── DISTURBING PRESENCE ───────────────────────────────────────────────────
+// Disturbing Presence est resolue dans `mechanics/disturbing-presence.ts`
+// (`getDisturbingPresenceModifier`) et appliquee dans `passing.ts` (pass,
+// catch, interception) et `throw-team-mate.ts`. Un adversaire avec ce skill
+// situe a <= 3 cases applique -1 au test correspondant. L'entree du registre
+// sert a l'affichage UI et a la documentation du skill.
+registerSkill({
+  slug: 'disturbing-presence',
+  triggers: ['on-pass', 'on-catch'],
+  description: "Quand un adversaire effectue une Passe, un Lancer d'Equipier, une Interception ou une Reception, il subit -1 par joueur avec ce skill a 3 cases ou moins.",
+  canApply: (ctx) => hasSkill(ctx.player, 'disturbing-presence') || hasSkill(ctx.player, 'disturbing_presence'),
+});


### PR DESCRIPTION
## Resume

- Implements **Disturbing Presence** (Presence Perturbante): opposing players within 3 squares (Chebyshev) of a Pass, Catch, Interception, or Throw Team-Mate action apply -1 per player with the skill.
- Prone / stunned / KO / casualty / sent-off / hypnotized players do not exert Disturbing Presence (cannot use skills).
- Wired into `passing.ts` (`calculatePassModifiers`, `calculateCatchModifiers`, `performInterceptionRoll`) and `throw-team-mate.ts` (`calculateThrowModifiers`).

## Tache roadmap

Sprint 14, tache **P2.3 — Implementer `disturbing-presence` (progression universelle)**.

## Plan de test

- [x] 13 nouveaux tests unitaires + integration dans `disturbing-presence.test.ts`
  - `hasDisturbingPresence` (skill detection)
  - `getDisturbingPresenceModifier` : 0 sans adversaire, -1 / -2 a 3 cases, 0 hors portee (4+), ignore coequipiers, ignore stunned/KO/casualty/sent-off, ignore hypnotises
  - Integration `calculatePassModifiers` et `calculateCatchModifiers` (cumul correct avec marquage)
- [x] Tous les tests existants passent (3827/3827)
- [x] `pnpm typecheck` OK
- [x] `pnpm lint` 0 erreur
- [x] `pnpm build` OK

## Fichiers modifies

- **new** `packages/game-engine/src/mechanics/disturbing-presence.ts`
- **new** `packages/game-engine/src/mechanics/disturbing-presence.test.ts`
- `packages/game-engine/src/mechanics/passing.ts` (+DP dans pass, catch, interception)
- `packages/game-engine/src/mechanics/throw-team-mate.ts` (+DP dans jet de lancer)
- `packages/game-engine/src/skills/skill-registry.ts` (entree registre pour decouverte UI)
- `packages/game-engine/src/index.ts` (exports)
- `TODO.md` (P2.3 cochee)
