### PR TITLE
feat: implement sneaky-git skill (Sprint 14 P2.6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -258,7 +258,7 @@
 | P2.3 | Implementer `disturbing-presence` (progression universelle) | Regle | [x] |
 | P2.4 | Implementer `leap` (Saurus progression frequente) | Regle | [x] |
 | P2.5 | Implementer `dump-off` (Imperial / Skaven Thrower progression) | Regle | [x] |
-| P2.6 | Implementer `sneaky-git` (Dwarf Troll Slayer progression) | Regle | [ ] |
+| P2.6 | Implementer `sneaky-git` (Dwarf Troll Slayer progression) | Regle | [x] |
 | P2.7 | Lister les star players hirables par les 5 equipes (flag `hirableBy`) | Contenu | [ ] |
 | P2.8 | Ecrire les special rules manquantes de ces star players (~15-25) | Contenu | [ ] |
 | P2.9 | Images + descriptions FR/EN de ces star players | Contenu | [ ] |

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -14,6 +14,7 @@ import { FULL_RULES } from './rules-config';
 import { expelSecretWeapons } from '../mechanics/secret-weapons';
 import { getWeatherModifiers, applyWeatherDriveEffects } from '../mechanics/weather-effects';
 import { getWeatherCondition, type WeatherType } from './weather-types';
+import { hasSkill } from '../skills/skill-effects';
 
 export type { PreMatchState };
 
@@ -896,11 +897,19 @@ export function canPlayerContinueMoving(state: GameState, playerId: string): boo
   const runningPassActive =
     (state.usedRunningPassThisTurn ?? []).includes(playerId) &&
     (playerAction === 'PASS' || playerAction === 'HANDOFF');
+  // Sneaky Git : l'activation ne se termine pas apres une faute.
+  const sneakyGitFoulContinues =
+    playerAction === 'FOUL' &&
+    (hasSkill(player, 'sneaky-git') || hasSkill(player, 'sneaky_git'));
   return (
     !player.stunned &&
     hasMovement &&
     player.team === state.currentPlayer &&
-    (!hasPlayerActed(state, playerId) || playerAction === 'MOVE' || playerAction === 'BLITZ' || runningPassActive)
+    (!hasPlayerActed(state, playerId) ||
+      playerAction === 'MOVE' ||
+      playerAction === 'BLITZ' ||
+      runningPassActive ||
+      sneakyGitFoulContinues)
   );
 }
 

--- a/packages/game-engine/src/mechanics/foul.test.ts
+++ b/packages/game-engine/src/mechanics/foul.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { setup, applyMove } from '../index';
+import { setup, applyMove, canPlayerContinueMoving } from '../index';
 import { GameState, RNG, Move } from '../core/types';
 import { canFoul, calculateFoulAssists } from './foul';
 
@@ -134,5 +134,72 @@ describe('Foul Action', () => {
 
     const fouler = result.players.find(p => p.id === 'A1')!;
     expect(fouler.state).not.toBe('sent_off');
+  });
+});
+
+describe('Regle: Sneaky Git', () => {
+  it('ne declenche pas d\'expulsion sur un doublet naturel au jet d\'armure', () => {
+    const state = createFoulTestState();
+    state.players[0].skills = ['sneaky-git'];
+    // RNG: die1=6, die2=6 => doublet, armor = 12+1 = 13 (broken)
+    const rng = makeTestRNG([0.83, 0.83, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    // Doublet 6-6 : normalement expulse, mais sneaky-git annule l'expulsion
+    expect(fouler.state).not.toBe('sent_off');
+  });
+
+  it('reste expulse sans sneaky-git sur un doublet naturel', () => {
+    const state = createFoulTestState();
+    // pas de skill sneaky-git
+    const rng = makeTestRNG([0.83, 0.83, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+  });
+
+  it('applique le jet de blessure normalement malgre sneaky-git', () => {
+    const state = createFoulTestState();
+    state.players[0].skills = ['sneaky-git'];
+    // die1=6 die2=6 armor brisee, puis injury die1=6, die2=6 => 12 casualty
+    const rng = makeTestRNG([0.83, 0.83, 0.83, 0.83, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const victim = result.players.find(p => p.id === 'B1')!;
+    // La cible a subi le jet de blessure (pas active apres armor brisee + injury 12)
+    expect(victim.state).not.toBe('active');
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).not.toBe('sent_off');
+  });
+
+  it('autorise la poursuite de l\'activation apres une faute', () => {
+    const state = createFoulTestState();
+    state.players[0].skills = ['sneaky-git'];
+    // PM = 6, die1=1 die2=3 (pas de doublet, pas d'expulsion meme sans sneaky-git)
+    const rng = makeTestRNG([0.16, 0.4, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    // Avec sneaky-git, le joueur peut continuer a bouger apres la faute
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(true);
+  });
+
+  it('stoppe l\'activation apres une faute sans sneaky-git', () => {
+    const state = createFoulTestState();
+    const rng = makeTestRNG([0.16, 0.4, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    expect(canPlayerContinueMoving(result, 'A1')).toBe(false);
   });
 });

--- a/packages/game-engine/src/mechanics/foul.ts
+++ b/packages/game-engine/src/mechanics/foul.ts
@@ -8,7 +8,7 @@ import { rollD6 } from '../utils/dice';
 import { isAdjacent, getAdjacentOpponents } from './movement';
 import { createLogEntry } from '../utils/logging';
 import { performInjuryRoll, handleSentOff } from './injury';
-import { getFoulArmorSkillModifiers, getArmorSkillContext } from '../skills/skill-bridge';
+import { getFoulArmorSkillModifiers, getArmorSkillContext, isSneakyGitActive } from '../skills/skill-bridge';
 
 /**
  * Vérifie si un joueur peut faire une faute sur une cible
@@ -114,8 +114,9 @@ export function executeFoul(
     newState = performInjuryRoll(newState, targetPlayer, rng, 0, attacker.id);
   }
 
-  // Expulsion si doublet
-  if (isDoubles) {
+  // Expulsion si doublet, sauf si l'attaquant possede Sneaky Git
+  const sneakyGit = isSneakyGitActive(newState, attacker);
+  if (isDoubles && !sneakyGit) {
     const attackerPlayer = newState.players.find(p => p.id === attacker.id);
     if (attackerPlayer) {
       const expulsionLog = createLogEntry(
@@ -127,6 +128,14 @@ export function executeFoul(
       newState.gameLog = [...newState.gameLog, expulsionLog];
       newState = handleSentOff(newState, attackerPlayer);
     }
+  } else if (isDoubles && sneakyGit) {
+    const sneakyLog = createLogEntry(
+      'action',
+      `Doublet (${die1}-${die2}) ! ${attacker.name} evite l'expulsion grâce à Sneaky Git.`,
+      attacker.id,
+      attacker.team
+    );
+    newState.gameLog = [...newState.gameLog, sneakyLog];
   }
 
   return newState;

--- a/packages/game-engine/src/skills/skill-bridge.ts
+++ b/packages/game-engine/src/skills/skill-bridge.ts
@@ -110,6 +110,15 @@ export function getFoulArmorSkillModifiers(
 }
 
 /**
+ * Indique si un joueur peut ignorer l'expulsion automatique sur un doublet
+ * naturel au jet d'armure d'une faute. Correspond au skill `sneaky-git`.
+ */
+export function isSneakyGitActive(state: GameState, player: Player): boolean {
+  const effect = getSkillEffect('sneaky-git');
+  return effect?.canApply({ player, state }) ?? false;
+}
+
+/**
  * Vérifie si un joueur possède Guard via le skill-registry.
  * Remplace l'appel direct à hasGuard() de skill-effects.
  */

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -257,6 +257,18 @@ registerSkill({
   getModifiers: () => ({ armorModifier: 1 }),
 });
 
+// SNEAKY GIT
+// Effet resolu dans `mechanics/foul.ts` (annulation de l'expulsion sur doublet
+// naturel) et dans `core/game-state.ts#canPlayerContinueMoving` (l'activation
+// se poursuit apres la faute). L'entree du registre sert a la decouverte UI
+// et a la documentation.
+registerSkill({
+  slug: 'sneaky-git',
+  triggers: ['on-foul'],
+  description: "Lors d'une faute, pas d'expulsion sur un doublet naturel au jet d'armure. L'activation du joueur peut se poursuivre apres la faute.",
+  canApply: (ctx) => hasSkill(ctx.player, 'sneaky-git') || hasSkill(ctx.player, 'sneaky_git'),
+});
+
 // PASS
 registerSkill({
   slug: 'pass',


### PR DESCRIPTION
## Resume
- Enregistre `sneaky-git` dans le skill-registry (trigger `on-foul`) et expose un helper `isSneakyGitActive` dans `skill-bridge`.
- Dans `executeFoul`, l'attaquant possedant Sneaky Git n'est plus expulse sur un doublet naturel du jet d'armure ; un log dedie remplace le log d'expulsion.
- Dans `canPlayerContinueMoving`, un joueur avec Sneaky Git peut poursuivre son activation apres une faute (les autres joueurs voient toujours leur activation se terminer).
- 5 tests Vitest ajoutes dans `foul.test.ts` (annulation de l'expulsion, conservation du jet de blessure, poursuite de l'activation, et baseline sans skill).

## Tache roadmap
Sprint 14, P2.6 — Implementer `sneaky-git` (Dwarf Troll Slayer progression). TODO.md coche.

## Plan de test
- [x] `pnpm --filter @bb/game-engine test` → 3832/3832 tests passants (13 dans foul.test.ts)
- [x] `pnpm lint` → 0 erreur (warnings preexistants uniquement)
- [x] `pnpm typecheck` → OK sur les 4 packages
- [x] `pnpm --filter @bb/game-engine build` → OK
- [ ] `pnpm build` web : echec hors sujet (fetch Google Fonts bloque dans le sandbox, pas lie au changement)
