### PR TITLE
feat(P2.7): lister les star players hirables par les 5 equipes prioritaires

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -259,7 +259,7 @@
 | P2.4 | Implementer `leap` (Saurus progression frequente) | Regle | [x] |
 | P2.5 | Implementer `dump-off` (Imperial / Skaven Thrower progression) | Regle | [x] |
 | P2.6 | Implementer `sneaky-git` (Dwarf Troll Slayer progression) | Regle | [x] |
-| P2.7 | Lister les star players hirables par les 5 equipes (flag `hirableBy`) | Contenu | [ ] |
+| P2.7 | Lister les star players hirables par les 5 equipes (flag `hirableBy`) | Contenu | [x] |
 | P2.8 | Ecrire les special rules manquantes de ces star players (~15-25) | Contenu | [ ] |
 | P2.9 | Images + descriptions FR/EN de ces star players | Contenu | [ ] |
 | P2.10 | Tests unitaires sur les special rules star players des 5 equipes | Tests | [ ] |

--- a/packages/game-engine/src/rosters/index.ts
+++ b/packages/game-engine/src/rosters/index.ts
@@ -49,6 +49,13 @@ export {
   type TeamSpriteManifest,
 } from './team-sprites';
 
+// Export des equipes prioritaires (P2.7)
+export {
+  PRIORITY_TEAM_ROSTERS,
+  getStarPlayersHirableByPriorityTeams,
+  type PriorityTeamRoster,
+} from './priority-teams';
+
 // Export des utilitaires Star Players
 export * from './star-players-utils';
 export {

--- a/packages/game-engine/src/rosters/priority-teams.test.ts
+++ b/packages/game-engine/src/rosters/priority-teams.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PRIORITY_TEAM_ROSTERS,
+  getStarPlayersHirableByPriorityTeams,
+  type PriorityTeamRoster,
+} from './priority-teams';
+import { TEAM_ROSTERS_BY_RULESET, DEFAULT_RULESET } from './positions';
+
+/**
+ * P2.7 — Lister les star players hirables par les 5 equipes prioritaires.
+ *
+ * Ces tests figent la liste des star players disponibles pour chaque equipe
+ * du MVP (Skaven, Gnomes, Hommes-Lezards, Nains, Noblesse Imperiale) afin que
+ * les taches de contenu aval (P2.8, P2.9, P2.10) puissent s'appuyer dessus.
+ */
+describe('P2.7 — Star players hirables par equipe prioritaire', () => {
+  describe('PRIORITY_TEAM_ROSTERS', () => {
+    it('contient exactement les 5 equipes du MVP', () => {
+      expect(PRIORITY_TEAM_ROSTERS).toHaveLength(5);
+      expect(PRIORITY_TEAM_ROSTERS).toEqual([
+        'skaven',
+        'gnome',
+        'lizardmen',
+        'dwarf',
+        'imperial_nobility',
+      ]);
+    });
+
+    it('chaque slug correspond a un roster existant dans le ruleset par defaut', () => {
+      const rosters = TEAM_ROSTERS_BY_RULESET[DEFAULT_RULESET];
+      for (const slug of PRIORITY_TEAM_ROSTERS) {
+        expect(rosters[slug]).toBeDefined();
+      }
+    });
+  });
+
+  describe('getStarPlayersHirableByPriorityTeams (season_2)', () => {
+    const map = getStarPlayersHirableByPriorityTeams('season_2');
+
+    it('retourne une entree pour chacune des 5 equipes', () => {
+      const keys = Object.keys(map).sort();
+      expect(keys).toEqual([...PRIORITY_TEAM_ROSTERS].sort());
+    });
+
+    it('chaque equipe a au moins les star players universels ("all")', () => {
+      const universalSlugs = [
+        'helmut_wulf',
+        'morg_n_thorg',
+        'grashnak_blackhoof',
+        'lord_borak',
+      ];
+      for (const roster of PRIORITY_TEAM_ROSTERS) {
+        const slugs = map[roster].map((sp) => sp.slug);
+        for (const universal of universalSlugs) {
+          expect(slugs, `${roster} devrait hirer ${universal}`).toContain(
+            universal,
+          );
+        }
+      }
+    });
+
+    it('Skaven hire les stars Underworld Challenge', () => {
+      const slugs = map.skaven.map((sp) => sp.slug);
+      expect(slugs).toContain('hakflem_skuttlespike');
+      expect(slugs).toContain('glart_smashrip');
+      expect(slugs).toContain('skitter_stab_stab');
+      expect(slugs).toContain('varag_ghoul_chewer');
+      // Ne doit PAS hirer les stars Elven Kingdoms League exclusives
+      expect(slugs).not.toContain('eldril_sidewinder');
+      expect(slugs).not.toContain('roxanna_darknail');
+    });
+
+    it('Hommes-Lezards hire les stars Lustrian Superleague', () => {
+      const slugs = map.lizardmen.map((sp) => sp.slug);
+      expect(slugs).toContain('anqi_panqi');
+      expect(slugs).toContain('boa_konssstriktr');
+      expect(slugs).toContain('mighty_zug');
+      expect(slugs).toContain('zolcath_the_zoat');
+      expect(slugs).not.toContain('hakflem_skuttlespike');
+    });
+
+    it('Nains hirent les stars Old World Classic', () => {
+      const slugs = map.dwarf.map((sp) => sp.slug);
+      expect(slugs).toContain('grim_ironjaw');
+      expect(slugs).toContain('grombrindal');
+      expect(slugs).toContain('barik_farblast');
+      expect(slugs).toContain('deeproot_strongbranch');
+      expect(slugs).not.toContain('hakflem_skuttlespike');
+    });
+
+    it('Noblesse Imperiale hire les stars Old World Classic', () => {
+      const slugs = map.imperial_nobility.map((sp) => sp.slug);
+      expect(slugs).toContain('griff_oberwald');
+      expect(slugs).toContain('grim_ironjaw');
+      expect(slugs).toContain('mighty_zug');
+      expect(slugs).not.toContain('anqi_panqi');
+    });
+
+    it('Gnomes ont acces au moins aux star players "all"', () => {
+      const slugs = map.gnome.map((sp) => sp.slug);
+      expect(slugs.length).toBeGreaterThan(0);
+      expect(slugs).toContain('helmut_wulf');
+      expect(slugs).toContain('morg_n_thorg');
+    });
+
+    it('chaque liste est immuable — un nouvel appel retourne une nouvelle reference', () => {
+      const first = getStarPlayersHirableByPriorityTeams('season_2');
+      const second = getStarPlayersHirableByPriorityTeams('season_2');
+      expect(first).not.toBe(second);
+      expect(first.skaven).not.toBe(second.skaven);
+    });
+  });
+
+  describe('getStarPlayersHirableByPriorityTeams (season_3)', () => {
+    it('inclut la nouvelle eligibilite de Hakflem en Sylvanian Spotlight (S3)', () => {
+      const s3Map = getStarPlayersHirableByPriorityTeams('season_3');
+      const skavenSlugs = s3Map.skaven.map((sp) => sp.slug);
+      // Hakflem reste disponible aux Skavens via underworld_challenge
+      expect(skavenSlugs).toContain('hakflem_skuttlespike');
+    });
+
+    it('fonctionne avec le ruleset par defaut quand omis', () => {
+      const defaultMap = getStarPlayersHirableByPriorityTeams();
+      const s2Map = getStarPlayersHirableByPriorityTeams('season_2');
+      expect(Object.keys(defaultMap)).toEqual(Object.keys(s2Map));
+    });
+  });
+
+  describe('Invariants structurels', () => {
+    it('aucun star player hirable ne doit apparaitre en doublon dans une meme equipe', () => {
+      const map = getStarPlayersHirableByPriorityTeams('season_2');
+      for (const roster of PRIORITY_TEAM_ROSTERS) {
+        const slugs = map[roster].map((sp) => sp.slug);
+        const unique = new Set(slugs);
+        expect(unique.size).toBe(slugs.length);
+      }
+    });
+
+    it('chaque star player retourne expose bien un flag hirableBy non vide', () => {
+      const map = getStarPlayersHirableByPriorityTeams('season_2');
+      for (const roster of PRIORITY_TEAM_ROSTERS) {
+        for (const sp of map[roster]) {
+          expect(sp.hirableBy.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+});

--- a/packages/game-engine/src/rosters/priority-teams.ts
+++ b/packages/game-engine/src/rosters/priority-teams.ts
@@ -1,0 +1,44 @@
+/**
+ * P2.7 — Equipes prioritaires du MVP.
+ *
+ * Les 5 rosters doivent recevoir un contenu complet (skills, star players,
+ * descriptions, images, tests) avant d'etendre le jeu aux autres equipes.
+ * Voir TODO.md, Sprints 13-14.
+ */
+import {
+  getAvailableStarPlayers,
+  type StarPlayerDefinition,
+} from './star-players';
+import { DEFAULT_RULESET, type Ruleset } from './positions';
+
+/**
+ * Slugs des rosters prioritaires (MVP), dans l'ordre roadmap.
+ */
+export const PRIORITY_TEAM_ROSTERS = [
+  'skaven',
+  'gnome',
+  'lizardmen',
+  'dwarf',
+  'imperial_nobility',
+] as const;
+
+export type PriorityTeamRoster = (typeof PRIORITY_TEAM_ROSTERS)[number];
+
+/**
+ * Retourne les star players hirables par chacune des 5 equipes prioritaires.
+ *
+ * Le resultat derive du flag `hirableBy` de chaque star player croise avec les
+ * `regionalRules` du roster prioritaire. Les taches aval (P2.8, P2.9, P2.10)
+ * iterent sur cette structure pour rediger le contenu manquant.
+ *
+ * Chaque invocation retourne des listes neuves : safe pour mutation locale.
+ */
+export function getStarPlayersHirableByPriorityTeams(
+  ruleset: Ruleset = DEFAULT_RULESET,
+): Record<PriorityTeamRoster, StarPlayerDefinition[]> {
+  const result = {} as Record<PriorityTeamRoster, StarPlayerDefinition[]>;
+  for (const roster of PRIORITY_TEAM_ROSTERS) {
+    result[roster] = [...getAvailableStarPlayers(roster, [], ruleset)];
+  }
+  return result;
+}


### PR DESCRIPTION
## Resume

- Ajoute `PRIORITY_TEAM_ROSTERS` (Skaven, Gnomes, Hommes-Lezards, Nains, Noblesse Imperiale) et le helper `getStarPlayersHirableByPriorityTeams(ruleset)` qui derive, pour chacune des 5 equipes MVP, la liste des star players recrutables via le flag `hirableBy` deja present sur `StarPlayerDefinition`.
- Nouveau module dedie `packages/game-engine/src/rosters/priority-teams.ts` (43 lignes) reutilisant `getAvailableStarPlayers` existant — aucune logique dupliquee, aucun impact runtime.
- Re-export via `rosters/index.ts` pour que les apps aval (`@bb/server`, `@bb/web`) et les taches P2.8 / P2.9 / P2.10 (special rules, images, descriptions, tests) puissent consommer la structure.

## Tache roadmap

- Sprint 14, tache **P2.7** — `Lister les star players hirables par les 5 equipes (flag hirableBy)`

## Plan de test

- [x] `priority-teams.test.ts` : 14 assertions figent la liste par equipe + invariants (Skaven ⊃ hakflem/glart, Lizardmen ⊃ anqi/boa, Dwarf ⊃ grombrindal/grim_ironjaw, Noblesse ⊃ griff/grim_ironjaw, Gnomes au moins les stars "all")
- [x] Exclusions verifiees : Skaven ne hire pas eldril/roxanna, Lizardmen ne hire pas hakflem, etc.
- [x] Ruleset season_3 : Hakflem reste disponible aux Skavens via `underworld_challenge`
- [x] Immutabilite : deux invocations retournent des references differentes
- [x] `pnpm test` — 3846 tests passent (dont 14 nouveaux)
- [x] `pnpm typecheck` — clean sur game-engine, server et web
- [x] `pnpm build` — OK
