### PR TITLE
feat: tutoriel interactif (Sprint 15 · N.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -270,7 +270,7 @@
 
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
-| N.1 | Tutoriel interactif (match guide, scripts pas a pas) | Engagement | [ ] |
+| N.1 | Tutoriel interactif (match guide, scripts pas a pas) | Engagement | [x] |
 | N.2 | Mode simplifie pour debutants (leverager `SIMPLIFIED_RULES`) | Engagement | [ ] |
 | N.3 | IA adversaire — evaluation heuristique basique (eval position + coup) | Engagement | [ ] |
 | N.4 | Mode pratique contre IA (3 niveaux de difficulte) | Engagement | [ ] |

--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -35,6 +35,11 @@ export default function Footer() {
                   {t.play?.playOnline || "Jouer en ligne"}
                 </a>
               </li>
+              <li>
+                <a href="/tutoriel" className="hover:text-nuffle-gold hover:underline transition-colors">
+                  {t.footer.tutorial}
+                </a>
+              </li>
             </ul>
           </div>
           <div>

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -83,6 +83,7 @@ export const translations = {
       items: "élément",
       itemsPlural: "éléments",
       compulsory: "Obligatoire",
+      tutorial: "Tutoriel interactif",
     },
     // Star Players page
     starPlayers: {
@@ -496,6 +497,7 @@ export const translations = {
       items: "item",
       itemsPlural: "items",
       compulsory: "Compulsory",
+      tutorial: "Interactive tutorial",
     },
     // Star Players page
     starPlayers: {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -25,6 +25,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${BASE_URL}/tutoriel`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/tutoriel/mon-premier-match`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
       url: `${BASE_URL}/legal/mentions-legales`,
       lastModified: new Date(),
       changeFrequency: 'monthly',

--- a/apps/web/app/tutoriel/[slug]/page.tsx
+++ b/apps/web/app/tutoriel/[slug]/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  advanceTutorialProgress,
+  createTutorialProgress,
+  findTutorialScript,
+  getCurrentStep,
+  getProgressRatio,
+  goBackTutorialProgress,
+  isTutorialComplete,
+  restartTutorialProgress,
+  type TutorialProgress,
+  type TutorialScript,
+  type TutorialStep,
+} from "@bb/game-engine";
+import { useLanguage } from "../../contexts/LanguageContext";
+
+const STORAGE_PREFIX = "nuffle.tutorial.progress.";
+
+function getLocalizedStepText(
+  step: TutorialStep,
+  key: "title" | "body" | "tip",
+  lang: "fr" | "en",
+): string {
+  if (key === "title") return lang === "fr" ? step.titleFr : step.titleEn;
+  if (key === "body") return lang === "fr" ? step.bodyFr : step.bodyEn;
+  return lang === "fr" ? step.tipFr ?? "" : step.tipEn ?? "";
+}
+
+function loadStoredProgress(slug: string): TutorialProgress | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(`${STORAGE_PREFIX}${slug}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "slug" in parsed &&
+      (parsed as TutorialProgress).slug === slug &&
+      typeof (parsed as TutorialProgress).currentStepIndex === "number"
+    ) {
+      return parsed as TutorialProgress;
+    }
+  } catch {
+    // Corrupted payload; discard.
+  }
+  return null;
+}
+
+function persistProgress(progress: TutorialProgress): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      `${STORAGE_PREFIX}${progress.slug}`,
+      JSON.stringify(progress),
+    );
+  } catch {
+    // Storage full or unavailable — ignore.
+  }
+}
+
+export default function TutorielRunnerPage() {
+  const { language } = useLanguage();
+  const params = useParams<{ slug: string }>();
+  const router = useRouter();
+  const slug = params?.slug;
+  const script = useMemo<TutorialScript | undefined>(
+    () => (typeof slug === "string" ? findTutorialScript(slug) : undefined),
+    [slug],
+  );
+
+  const [progress, setProgress] = useState<TutorialProgress | null>(null);
+
+  useEffect(() => {
+    if (!script) return;
+    const stored = loadStoredProgress(script.slug);
+    setProgress(stored ?? createTutorialProgress(script));
+  }, [script]);
+
+  useEffect(() => {
+    if (progress) {
+      persistProgress(progress);
+    }
+  }, [progress]);
+
+  const step = useMemo<TutorialStep | undefined>(() => {
+    if (!script || !progress) return undefined;
+    return getCurrentStep(progress, script);
+  }, [progress, script]);
+
+  const ratio = useMemo(() => {
+    if (!script || !progress) return 0;
+    return getProgressRatio(progress, script);
+  }, [progress, script]);
+
+  const onNext = useCallback(() => {
+    if (!script || !progress) return;
+    setProgress(advanceTutorialProgress(progress, script));
+  }, [progress, script]);
+
+  const onPrev = useCallback(() => {
+    if (!progress) return;
+    setProgress(goBackTutorialProgress(progress));
+  }, [progress]);
+
+  const onRestart = useCallback(() => {
+    if (!progress) return;
+    setProgress(restartTutorialProgress(progress));
+  }, [progress]);
+
+  if (!script) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4 text-nuffle-anthracite">
+          {language === "fr" ? "Tutoriel introuvable" : "Tutorial not found"}
+        </h1>
+        <p className="text-gray-600 mb-6">
+          {language === "fr"
+            ? "Le tutoriel demande n'existe pas."
+            : "The requested tutorial does not exist."}
+        </p>
+        <button
+          onClick={() => router.push("/tutoriel")}
+          className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-bronze text-white rounded-lg font-semibold text-sm transition-colors"
+        >
+          {language === "fr" ? "Retour aux tutoriels" : "Back to tutorials"}
+        </button>
+      </main>
+    );
+  }
+
+  if (!progress || !step) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-8">
+        <p className="text-gray-500">
+          {language === "fr" ? "Chargement..." : "Loading..."}
+        </p>
+      </main>
+    );
+  }
+
+  const complete = isTutorialComplete(progress);
+  const title = language === "fr" ? script.titleFr : script.titleEn;
+  const stepTitle = getLocalizedStepText(step, "title", language);
+  const stepBody = getLocalizedStepText(step, "body", language);
+  const stepTip = getLocalizedStepText(step, "tip", language);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8">
+      <nav className="text-sm mb-4">
+        <Link href="/tutoriel" className="text-nuffle-bronze hover:underline">
+          &larr; {language === "fr" ? "Tous les tutoriels" : "All tutorials"}
+        </Link>
+      </nav>
+
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-nuffle-anthracite">{title}</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          {language === "fr" ? "Etape" : "Step"}{" "}
+          {Math.min(progress.currentStepIndex + 1, script.steps.length)} /{" "}
+          {script.steps.length}
+        </p>
+        <div
+          className="mt-3 h-2 bg-gray-200 rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(ratio * 100)}
+        >
+          <div
+            className="h-full bg-nuffle-gold transition-all"
+            style={{ width: `${Math.round(ratio * 100)}%` }}
+          />
+        </div>
+      </header>
+
+      <section className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-nuffle-anthracite mb-3">
+          {stepTitle}
+        </h2>
+        <p className="text-gray-700 whitespace-pre-wrap leading-relaxed">
+          {stepBody}
+        </p>
+        {stepTip && (
+          <p className="mt-4 text-sm text-nuffle-bronze bg-amber-50 border border-amber-200 rounded-md p-3">
+            💡 {stepTip}
+          </p>
+        )}
+      </section>
+
+      <div className="flex items-center justify-between mt-6 gap-3 flex-wrap">
+        <button
+          onClick={onPrev}
+          disabled={progress.currentStepIndex === 0}
+          className="px-4 py-2 rounded-lg border border-gray-300 text-nuffle-anthracite hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed text-sm"
+        >
+          {language === "fr" ? "Precedent" : "Previous"}
+        </button>
+        <button
+          onClick={onRestart}
+          className="px-3 py-2 rounded-lg border border-gray-300 text-nuffle-anthracite hover:bg-gray-50 text-sm"
+        >
+          {language === "fr" ? "Recommencer" : "Restart"}
+        </button>
+        {complete ? (
+          <Link
+            href="/tutoriel"
+            className="px-4 py-2 rounded-lg bg-nuffle-gold hover:bg-nuffle-bronze text-white font-semibold text-sm"
+          >
+            {language === "fr" ? "Tutoriel termine" : "Tutorial complete"} ✓
+          </Link>
+        ) : (
+          <button
+            onClick={onNext}
+            className="px-4 py-2 rounded-lg bg-nuffle-gold hover:bg-nuffle-bronze text-white font-semibold text-sm"
+          >
+            {progress.currentStepIndex === script.steps.length - 1
+              ? language === "fr"
+                ? "Terminer"
+                : "Finish"
+              : language === "fr"
+              ? "Suivant"
+              : "Next"}
+          </button>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/tutoriel/page.test.tsx
+++ b/apps/web/app/tutoriel/page.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TutorielListPage from "./page";
+import { LanguageProvider } from "../contexts/LanguageContext";
+
+function renderWithProvider() {
+  return render(
+    <LanguageProvider>
+      <TutorielListPage />
+    </LanguageProvider>,
+  );
+}
+
+describe("TutorielListPage — N.1 interactive tutorial listing", () => {
+  it("renders the page heading", () => {
+    renderWithProvider();
+    expect(screen.getByRole("heading", { level: 1 })).toBeTruthy();
+  });
+
+  it("lists the intro tutorial with a Start link", () => {
+    renderWithProvider();
+    const link = screen.getByRole("link", { name: /commencer/i });
+    expect(link.getAttribute("href")).toBe("/tutoriel/mon-premier-match");
+  });
+
+  it("shows the intro tutorial title", () => {
+    renderWithProvider();
+    expect(screen.getByText(/mon premier match/i)).toBeTruthy();
+  });
+});

--- a/apps/web/app/tutoriel/page.tsx
+++ b/apps/web/app/tutoriel/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+import Link from "next/link";
+import { listTutorialScripts, type TutorialScript } from "@bb/game-engine";
+import { useLanguage } from "../contexts/LanguageContext";
+
+function getLocalizedTitle(script: TutorialScript, lang: "fr" | "en"): string {
+  return lang === "fr" ? script.titleFr : script.titleEn;
+}
+
+function getLocalizedSummary(script: TutorialScript, lang: "fr" | "en"): string {
+  return lang === "fr" ? script.summaryFr : script.summaryEn;
+}
+
+function getLocalizedDifficulty(
+  difficulty: TutorialScript["difficulty"],
+  lang: "fr" | "en",
+): string {
+  if (lang === "fr") {
+    return difficulty === "beginner"
+      ? "Debutant"
+      : difficulty === "intermediate"
+      ? "Intermediaire"
+      : "Avance";
+  }
+  return difficulty === "beginner"
+    ? "Beginner"
+    : difficulty === "intermediate"
+    ? "Intermediate"
+    : "Advanced";
+}
+
+export default function TutorielListPage() {
+  const { language } = useLanguage();
+  const scripts = listTutorialScripts();
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-nuffle-anthracite mb-2">
+          {language === "fr" ? "Tutoriels interactifs" : "Interactive tutorials"}
+        </h1>
+        <p className="text-nuffle-bronze">
+          {language === "fr"
+            ? "Apprenez Nuffle Arena pas a pas. Chaque tutoriel vous guide dans une facette du jeu."
+            : "Learn Nuffle Arena step by step. Each tutorial walks you through a core part of the game."}
+        </p>
+      </header>
+
+      {scripts.length === 0 ? (
+        <p className="text-gray-500">
+          {language === "fr" ? "Aucun tutoriel disponible." : "No tutorial available."}
+        </p>
+      ) : (
+        <ul className="space-y-4">
+          {scripts.map((script) => (
+            <li
+              key={script.slug}
+              className="border border-gray-200 rounded-lg p-5 hover:border-nuffle-gold transition-colors bg-white"
+            >
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-xl font-semibold text-nuffle-anthracite">
+                    {getLocalizedTitle(script, language)}
+                  </h2>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {getLocalizedSummary(script, language)}
+                  </p>
+                  <div className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500">
+                    <span className="inline-flex items-center gap-1">
+                      ⏱ {script.estimatedMinutes} min
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      🎯 {getLocalizedDifficulty(script.difficulty, language)}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      📚 {script.steps.length}{" "}
+                      {language === "fr" ? "etapes" : "steps"}
+                    </span>
+                  </div>
+                </div>
+                <Link
+                  href={`/tutoriel/${script.slug}`}
+                  className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-bronze text-white rounded-lg font-semibold text-sm transition-colors whitespace-nowrap"
+                >
+                  {language === "fr" ? "Commencer" : "Start"}
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -378,3 +378,23 @@ export {
   type ReplayFrame,
   type ReplayTurnPayload,
 } from './core/replay';
+
+// Export du module tutoriel (N.1)
+export {
+  listTutorialScripts,
+  findTutorialScript,
+  createTutorialProgress,
+  advanceTutorialProgress,
+  goBackTutorialProgress,
+  restartTutorialProgress,
+  isTutorialComplete,
+  getCurrentStep,
+  getProgressRatio,
+  MON_PREMIER_MATCH,
+  type TutorialScript,
+  type TutorialStep,
+  type TutorialStepActionKind,
+  type TutorialStepHighlight,
+  type TutorialProgress,
+  type TutorialDifficulty,
+} from './tutorial';

--- a/packages/game-engine/src/tutorial/engine.test.ts
+++ b/packages/game-engine/src/tutorial/engine.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the tutorial engine.
+ * N.1 — Tutoriel interactif (match guide, scripts pas a pas).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  createTutorialProgress,
+  advanceTutorialProgress,
+  goBackTutorialProgress,
+  restartTutorialProgress,
+  isTutorialComplete,
+  getCurrentStep,
+  getProgressRatio,
+  findTutorialScript,
+  listTutorialScripts,
+} from './engine';
+import type { TutorialScript } from './types';
+
+const fixture: TutorialScript = {
+  slug: 'fixture',
+  titleFr: 'Fixture FR',
+  titleEn: 'Fixture EN',
+  summaryFr: 'Resume FR',
+  summaryEn: 'Summary EN',
+  estimatedMinutes: 5,
+  difficulty: 'beginner',
+  steps: [
+    {
+      id: 'step-1',
+      titleFr: 'Etape 1 FR',
+      titleEn: 'Step 1 EN',
+      bodyFr: 'Corps FR',
+      bodyEn: 'Body EN',
+    },
+    {
+      id: 'step-2',
+      titleFr: 'Etape 2 FR',
+      titleEn: 'Step 2 EN',
+      bodyFr: 'Corps FR 2',
+      bodyEn: 'Body EN 2',
+    },
+    {
+      id: 'step-3',
+      titleFr: 'Etape 3 FR',
+      titleEn: 'Step 3 EN',
+      bodyFr: 'Corps FR 3',
+      bodyEn: 'Body EN 3',
+    },
+  ],
+};
+
+describe('Regle: Tutorial Engine', () => {
+  it('createTutorialProgress initialises to the first step', () => {
+    const progress = createTutorialProgress(fixture);
+    expect(progress.slug).toBe('fixture');
+    expect(progress.currentStepIndex).toBe(0);
+    expect(progress.completed).toBe(false);
+  });
+
+  it('advanceTutorialProgress moves to the next step (immutable)', () => {
+    const progress = createTutorialProgress(fixture);
+    const next = advanceTutorialProgress(progress, fixture);
+    expect(progress.currentStepIndex).toBe(0);
+    expect(next.currentStepIndex).toBe(1);
+    expect(next.completed).toBe(false);
+  });
+
+  it('advanceTutorialProgress marks completed on the final step', () => {
+    const at2 = { ...createTutorialProgress(fixture), currentStepIndex: 2 };
+    const after = advanceTutorialProgress(at2, fixture);
+    expect(after.currentStepIndex).toBe(2);
+    expect(after.completed).toBe(true);
+  });
+
+  it('advanceTutorialProgress is a no-op once completed', () => {
+    const done = { ...createTutorialProgress(fixture), currentStepIndex: 2, completed: true };
+    const after = advanceTutorialProgress(done, fixture);
+    expect(after).toEqual(done);
+  });
+
+  it('goBackTutorialProgress moves to the previous step', () => {
+    const at1 = { ...createTutorialProgress(fixture), currentStepIndex: 1 };
+    const back = goBackTutorialProgress(at1);
+    expect(back.currentStepIndex).toBe(0);
+  });
+
+  it('goBackTutorialProgress clamps at zero', () => {
+    const progress = createTutorialProgress(fixture);
+    const back = goBackTutorialProgress(progress);
+    expect(back.currentStepIndex).toBe(0);
+  });
+
+  it('goBackTutorialProgress clears the completed flag', () => {
+    const done = { ...createTutorialProgress(fixture), currentStepIndex: 2, completed: true };
+    const back = goBackTutorialProgress(done);
+    expect(back.completed).toBe(false);
+    expect(back.currentStepIndex).toBe(1);
+  });
+
+  it('restartTutorialProgress returns a fresh progress', () => {
+    const done = { ...createTutorialProgress(fixture), currentStepIndex: 2, completed: true };
+    const fresh = restartTutorialProgress(done);
+    expect(fresh.currentStepIndex).toBe(0);
+    expect(fresh.completed).toBe(false);
+    expect(fresh.slug).toBe('fixture');
+  });
+
+  it('isTutorialComplete returns true only when completed flag is true', () => {
+    const progress = createTutorialProgress(fixture);
+    expect(isTutorialComplete(progress)).toBe(false);
+    const done = { ...progress, currentStepIndex: 2, completed: true };
+    expect(isTutorialComplete(done)).toBe(true);
+  });
+
+  it('getCurrentStep returns the step at the current index', () => {
+    const progress = createTutorialProgress(fixture);
+    expect(getCurrentStep(progress, fixture)?.id).toBe('step-1');
+    const at2 = { ...progress, currentStepIndex: 2 };
+    expect(getCurrentStep(at2, fixture)?.id).toBe('step-3');
+  });
+
+  it('getCurrentStep returns undefined for out-of-range indices', () => {
+    const progress = { ...createTutorialProgress(fixture), currentStepIndex: 99 };
+    expect(getCurrentStep(progress, fixture)).toBeUndefined();
+  });
+
+  it('getProgressRatio reflects the position within the script', () => {
+    expect(getProgressRatio({ ...createTutorialProgress(fixture), currentStepIndex: 0 }, fixture)).toBeCloseTo(1 / 3);
+    expect(getProgressRatio({ ...createTutorialProgress(fixture), currentStepIndex: 2 }, fixture)).toBeCloseTo(2 / 3);
+    expect(getProgressRatio({ ...createTutorialProgress(fixture), currentStepIndex: 2, completed: true }, fixture)).toBe(1);
+  });
+
+  it('findTutorialScript returns the intro script by slug', () => {
+    const script = findTutorialScript('mon-premier-match');
+    expect(script).toBeDefined();
+    expect(script?.slug).toBe('mon-premier-match');
+    expect(script?.steps.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('findTutorialScript returns undefined for an unknown slug', () => {
+    expect(findTutorialScript('ghost-slug')).toBeUndefined();
+  });
+
+  it('listTutorialScripts returns at least the intro script', () => {
+    const scripts = listTutorialScripts();
+    expect(scripts.length).toBeGreaterThanOrEqual(1);
+    expect(scripts.some((s) => s.slug === 'mon-premier-match')).toBe(true);
+  });
+
+  it('every registered tutorial script has unique step ids', () => {
+    for (const script of listTutorialScripts()) {
+      const ids = script.steps.map((s) => s.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it('every registered tutorial step has bilingual content', () => {
+    for (const script of listTutorialScripts()) {
+      for (const step of script.steps) {
+        expect(step.titleFr.length).toBeGreaterThan(0);
+        expect(step.titleEn.length).toBeGreaterThan(0);
+        expect(step.bodyFr.length).toBeGreaterThan(0);
+        expect(step.bodyEn.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/game-engine/src/tutorial/engine.ts
+++ b/packages/game-engine/src/tutorial/engine.ts
@@ -1,0 +1,97 @@
+/**
+ * Moteur du tutoriel interactif.
+ * Gestion du progres pas a pas, navigation avant/arriere et registre de scripts.
+ * N.1 — Tutoriel interactif (match guide, scripts pas a pas).
+ */
+import type { TutorialProgress, TutorialScript, TutorialStep } from './types';
+import { MON_PREMIER_MATCH } from './scripts/intro';
+
+const REGISTRY: readonly TutorialScript[] = Object.freeze([MON_PREMIER_MATCH]);
+
+export function listTutorialScripts(): readonly TutorialScript[] {
+  return REGISTRY;
+}
+
+export function findTutorialScript(slug: string): TutorialScript | undefined {
+  return REGISTRY.find((script) => script.slug === slug);
+}
+
+export function createTutorialProgress(script: TutorialScript): TutorialProgress {
+  return {
+    slug: script.slug,
+    currentStepIndex: 0,
+    completed: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function getCurrentStep(
+  progress: TutorialProgress,
+  script: TutorialScript
+): TutorialStep | undefined {
+  if (progress.currentStepIndex < 0 || progress.currentStepIndex >= script.steps.length) {
+    return undefined;
+  }
+  return script.steps[progress.currentStepIndex];
+}
+
+export function advanceTutorialProgress(
+  progress: TutorialProgress,
+  script: TutorialScript
+): TutorialProgress {
+  if (progress.completed) {
+    return progress;
+  }
+  const lastIndex = script.steps.length - 1;
+  if (progress.currentStepIndex >= lastIndex) {
+    return {
+      ...progress,
+      currentStepIndex: lastIndex,
+      completed: true,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+  return {
+    ...progress,
+    currentStepIndex: progress.currentStepIndex + 1,
+    completed: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function goBackTutorialProgress(progress: TutorialProgress): TutorialProgress {
+  const nextIndex = Math.max(0, progress.currentStepIndex - 1);
+  return {
+    ...progress,
+    currentStepIndex: nextIndex,
+    completed: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function restartTutorialProgress(progress: TutorialProgress): TutorialProgress {
+  return {
+    ...progress,
+    currentStepIndex: 0,
+    completed: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function isTutorialComplete(progress: TutorialProgress): boolean {
+  return progress.completed === true;
+}
+
+export function getProgressRatio(
+  progress: TutorialProgress,
+  script: TutorialScript
+): number {
+  if (script.steps.length === 0) {
+    return 0;
+  }
+  if (progress.completed) {
+    return 1;
+  }
+  const stepsDone = Math.min(progress.currentStepIndex + 1, script.steps.length - 1);
+  return stepsDone / script.steps.length;
+}

--- a/packages/game-engine/src/tutorial/index.ts
+++ b/packages/game-engine/src/tutorial/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Barrel pour le module tutoriel.
+ */
+export * from './types';
+export * from './engine';
+export { MON_PREMIER_MATCH } from './scripts/intro';

--- a/packages/game-engine/src/tutorial/scripts/intro.ts
+++ b/packages/game-engine/src/tutorial/scripts/intro.ts
@@ -1,0 +1,142 @@
+/**
+ * Premier tutoriel : "Mon premier match".
+ * Initie le debutant au plateau, au mouvement, au blocage et au touchdown.
+ */
+import type { TutorialScript } from '../types';
+
+export const MON_PREMIER_MATCH: TutorialScript = {
+  slug: 'mon-premier-match',
+  titleFr: 'Mon premier match',
+  titleEn: 'My first match',
+  summaryFr:
+    "Decouvrez les bases de Nuffle Arena : plateau, mouvement, blocage, passe et touchdown en moins de dix minutes.",
+  summaryEn:
+    'Learn the basics of Nuffle Arena: board, movement, blocking, passing and touchdowns in under ten minutes.',
+  estimatedMinutes: 8,
+  difficulty: 'beginner',
+  nextSlugs: ['regles-allegees'],
+  steps: [
+    {
+      id: 'welcome',
+      titleFr: 'Bienvenue dans Nuffle Arena',
+      titleEn: 'Welcome to Nuffle Arena',
+      bodyFr:
+        "Nuffle Arena est un jeu de football fantastique au tour par tour. Chaque equipe tente de marquer des touchdowns en franchissant la ligne d'en-but adverse. Ce tutoriel vous accompagne pas a pas, sans risquer de perdre votre equipe.",
+      bodyEn:
+        'Nuffle Arena is a turn-based fantasy football game. Each team tries to score touchdowns by crossing the opposing end zone. This tutorial guides you step by step, with no risk to your team.',
+      action: 'info',
+      imageKey: 'tutorial/welcome',
+    },
+    {
+      id: 'board',
+      titleFr: 'Le plateau 26 x 15',
+      titleEn: 'The 26 x 15 pitch',
+      bodyFr:
+        "Le terrain mesure 26 cases de long pour 15 de large. Les deux zones bleues de chaque cote sont les en-but : y deposer le ballon avec un joueur debout marque un touchdown.",
+      bodyEn:
+        'The pitch is 26 squares long and 15 wide. The blue zones on each side are the end zones: taking the ball there with a standing player scores a touchdown.',
+      action: 'info',
+      highlights: [
+        { kind: 'cell', cell: { x: 0, y: 7 } },
+        { kind: 'cell', cell: { x: 25, y: 7 } },
+      ],
+      imageKey: 'tutorial/board',
+    },
+    {
+      id: 'turn',
+      titleFr: 'Le tour de jeu',
+      titleEn: 'The turn',
+      bodyFr:
+        "A chaque tour, vous pouvez bouger chacun de vos joueurs une fois et realiser une seule action speciale (blitz, passe, faute). Un jet rate provoque un turnover : votre tour s'arrete immediatement.",
+      bodyEn:
+        'Each turn you may move each of your players once and perform a single special action (blitz, pass, foul). A failed roll triggers a turnover: your turn ends immediately.',
+      action: 'info',
+      tipFr: 'Astuce : commencez par les actions les plus sures pour eviter un turnover precoce.',
+      tipEn: 'Tip: start with the safest actions to avoid an early turnover.',
+    },
+    {
+      id: 'move',
+      titleFr: 'Deplacer un joueur',
+      titleEn: 'Move a player',
+      bodyFr:
+        "Selectionnez un joueur pour afficher ses cases de mouvement vertes. Chaque case coute 1 point de MA (Movement Allowance). Sortir de la zone de tacle d'un adversaire declenche un jet d'esquive.",
+      bodyEn:
+        "Select a player to reveal their green movement squares. Each square costs 1 MA (Movement Allowance). Leaving an opponent's tackle zone triggers a dodge roll.",
+      action: 'move-player',
+      highlights: [{ kind: 'hud', target: 'selected-player' }],
+      imageKey: 'tutorial/move',
+    },
+    {
+      id: 'block',
+      titleFr: 'Bloquer un adversaire',
+      titleEn: 'Block an opponent',
+      bodyFr:
+        "Un joueur debout peut bloquer un adversaire debout en case adjacente. Le nombre de des (1 a 3) depend des forces et des assistances. Le joueur le plus faible choisit parmi les des si vous etes moins fort.",
+      bodyEn:
+        'A standing player can block an adjacent standing opponent. The number of dice (1 to 3) depends on strengths and assists. The weaker player picks the die if you are outmatched.',
+      action: 'block-player',
+      highlights: [{ kind: 'dice', target: 'block-dice' }],
+      imageKey: 'tutorial/block',
+      tipFr: 'Les des de blocage ne sont pas des D6 : chaque face represente un resultat specifique.',
+      tipEn: 'Block dice are not D6: each face represents a specific outcome.',
+    },
+    {
+      id: 'pickup',
+      titleFr: 'Ramasser le ballon',
+      titleEn: 'Pick up the ball',
+      bodyFr:
+        "Deplacez un joueur sur la case du ballon pour declencher un jet de ramassage base sur son AG. L'echec est un turnover, pensez a depenser une relance si besoin.",
+      bodyEn:
+        "Move a player onto the ball's square to trigger a pickup roll based on AG. A failure is a turnover; spend a re-roll if needed.",
+      action: 'pickup-ball',
+      highlights: [{ kind: 'info-panel', target: 'ball-carrier' }],
+      imageKey: 'tutorial/pickup',
+    },
+    {
+      id: 'pass',
+      titleFr: 'Passer le ballon',
+      titleEn: 'Pass the ball',
+      bodyFr:
+        "Une passe est une action speciale : un seul joueur peut la tenter par tour. Portee courte, longue ou tres longue, plus la distance est grande plus le jet est difficile.",
+      bodyEn:
+        'A pass is a special action: only one player per turn can attempt it. Range is short, long, or very long — the farther you throw, the harder the roll.',
+      action: 'pass-ball',
+      highlights: [{ kind: 'hud', target: 'pass-button' }],
+      imageKey: 'tutorial/pass',
+    },
+    {
+      id: 'touchdown',
+      titleFr: 'Marquer un touchdown',
+      titleEn: 'Score a touchdown',
+      bodyFr:
+        "Deposez un joueur debout avec le ballon dans l'en-but adverse pour marquer un touchdown. La partie repart ensuite sur un nouveau kickoff.",
+      bodyEn:
+        "Place a standing player carrying the ball in the opposing end zone to score a touchdown. The game then restarts with a new kickoff.",
+      action: 'score-touchdown',
+      highlights: [{ kind: 'cell', cell: { x: 25, y: 7 } }],
+      imageKey: 'tutorial/touchdown',
+    },
+    {
+      id: 'end-turn',
+      titleFr: 'Terminer son tour',
+      titleEn: 'End your turn',
+      bodyFr:
+        "Cliquez sur 'Fin de tour' pour passer la main. L'adversaire joue alors son tour. Une partie dure deux mi-temps de huit tours chacune (ou six en mode allege).",
+      bodyEn:
+        "Click 'End turn' to hand the game over. Your opponent then plays their turn. A match lasts two halves of eight turns each (six in simplified mode).",
+      action: 'end-turn',
+      highlights: [{ kind: 'hud', target: 'end-turn-button' }],
+      imageKey: 'tutorial/end-turn',
+    },
+    {
+      id: 'next-steps',
+      titleFr: 'Prochaines etapes',
+      titleEn: 'Next steps',
+      bodyFr:
+        "Vous connaissez l'essentiel ! Continuez avec le mode regles allegees pour pratiquer sans competences, puis affrontez l'IA avant un match en ligne classe.",
+      bodyEn:
+        'You know the essentials! Continue with the simplified rules mode to practice without skills, then challenge the AI before a ranked online match.',
+      action: 'info',
+    },
+  ],
+};

--- a/packages/game-engine/src/tutorial/types.ts
+++ b/packages/game-engine/src/tutorial/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Types du tutoriel interactif.
+ * N.1 — Tutoriel interactif (match guide, scripts pas a pas).
+ */
+
+export type TutorialDifficulty = 'beginner' | 'intermediate' | 'advanced';
+
+export type TutorialStepActionKind =
+  | 'info'
+  | 'move-player'
+  | 'block-player'
+  | 'pass-ball'
+  | 'pickup-ball'
+  | 'score-touchdown'
+  | 'end-turn';
+
+export interface TutorialStepHighlight {
+  /** Identifiant logique de la zone mise en avant par la UI (board-cell, HUD, dugout, etc.). */
+  kind: 'cell' | 'hud' | 'dugout' | 'dice' | 'info-panel';
+  /** Coordonnees sur le plateau (optionnel selon kind). */
+  cell?: { x: number; y: number };
+  /** Cible generique (ex: id CSS, data-testid). */
+  target?: string;
+}
+
+export interface TutorialStep {
+  id: string;
+  titleFr: string;
+  titleEn: string;
+  bodyFr: string;
+  bodyEn: string;
+  /** Action attendue du joueur (info par defaut : on passe a l'etape suivante avec le bouton). */
+  action?: TutorialStepActionKind;
+  /** Cellules ou elements de UI a mettre en evidence durant cette etape. */
+  highlights?: TutorialStepHighlight[];
+  /** Cle d'image (asset) illustrant l'etape. */
+  imageKey?: string;
+  /** Notes complementaires affichees comme infobulle. */
+  tipFr?: string;
+  tipEn?: string;
+}
+
+export interface TutorialScript {
+  slug: string;
+  titleFr: string;
+  titleEn: string;
+  summaryFr: string;
+  summaryEn: string;
+  /** Duree estimee pour completer le tutoriel, en minutes. */
+  estimatedMinutes: number;
+  difficulty: TutorialDifficulty;
+  steps: TutorialStep[];
+  /** Slugs d'autres tutoriels recommandes apres celui-ci. */
+  nextSlugs?: string[];
+}
+
+export interface TutorialProgress {
+  slug: string;
+  currentStepIndex: number;
+  completed: boolean;
+  /** Horodatage ISO de la derniere mise a jour (facultatif pour la persistance). */
+  updatedAt?: string;
+}


### PR DESCRIPTION
## Resume

- Nouveau module `packages/game-engine/src/tutorial` : types, moteur immuable (advance/goBack/restart/progressRatio), registre de scripts et barrel exporte depuis `@bb/game-engine`.
- Premier script `mon-premier-match` (10 etapes bilingues FR/EN) couvrant plateau, tour, mouvement, blocage, ramassage, passe, touchdown et fin de tour.
- Pages web `/tutoriel` (liste) et `/tutoriel/[slug]` (runner) avec barre de progression, navigation precedent/suivant/recommencer et persistance du progres en localStorage.
- Lien footer `Tutoriel interactif` (FR/EN) + ajout au sitemap.

## Tache roadmap

Sprint 15, tache `N.1 — Tutoriel interactif (match guide, scripts pas a pas)` cochee dans `TODO.md`.

## Plan de test

- [x] `packages/game-engine` — 17 tests unitaires pour le moteur de tutoriel (types, immuabilite, progression, registre).
- [x] `apps/web` — smoke test React Testing Library sur la page `/tutoriel`.
- [x] `pnpm typecheck` pour les 4 packages (`game-engine`, `ui`, `server`, `web`).
- [x] `pnpm lint` (0 erreur).
- [ ] `pnpm test` full suite (server/integration long — en cours de verification locale).
- [ ] Verification UI manuelle : parcours liste → runner → progression localStorage → fin de tutoriel.
