### PR TITLE
feat: IA — evaluation heuristique position + coup (N.3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -272,7 +272,7 @@
 |---|-------|------|--------|
 | N.1 | Tutoriel interactif (match guide, scripts pas a pas) | Engagement | [x] |
 | N.2 | Mode simplifie pour debutants (leverager `SIMPLIFIED_RULES`) | Engagement | [x] |
-| N.3 | IA adversaire — evaluation heuristique basique (eval position + coup) | Engagement | [ ] |
+| N.3 | IA adversaire — evaluation heuristique basique (eval position + coup) | Engagement | [x] |
 | N.4 | Mode pratique contre IA (3 niveaux de difficulte) | Engagement | [ ] |
 | N.4b | IA contrainte aux 5 equipes prioritaires dans un premier temps | Engagement | [ ] |
 

--- a/packages/game-engine/src/ai/evaluator.test.ts
+++ b/packages/game-engine/src/ai/evaluator.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import type { GameState, Player, Move } from '../core/types';
+import { evaluatePosition, scoreMove, pickBestMove, EVAL_WEIGHTS } from './evaluator';
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Lineman',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: [],
+    pm: 6,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function baseState(players: Player[], overrides: Partial<GameState> = {}): GameState {
+  const state = setup();
+  return { ...state, players, ...overrides };
+}
+
+describe('IA: evaluatePosition', () => {
+  it('retourne un objet avec total et breakdown detailles', () => {
+    const a = makePlayer({ id: 'a1', team: 'A', pos: { x: 10, y: 7 } });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 15, y: 7 } });
+    const state = baseState([a, b]);
+
+    const evaluation = evaluatePosition(state, 'A');
+
+    expect(evaluation).toHaveProperty('total');
+    expect(evaluation).toHaveProperty('breakdown');
+    expect(typeof evaluation.total).toBe('number');
+    expect(evaluation.breakdown).toHaveProperty('score');
+    expect(evaluation.breakdown).toHaveProperty('possession');
+    expect(evaluation.breakdown).toHaveProperty('ballProgress');
+    expect(evaluation.breakdown).toHaveProperty('playerCount');
+    expect(evaluation.breakdown).toHaveProperty('carrierSafety');
+    expect(evaluation.breakdown).toHaveProperty('attrition');
+  });
+
+  it('le score de TD domine toutes les autres considerations', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const b = makePlayer({ id: 'b1', team: 'B' });
+    const equal = baseState([a, b]);
+    const winning = { ...equal, score: { teamA: 2, teamB: 0 } };
+
+    const equalEval = evaluatePosition(equal, 'A');
+    const winningEval = evaluatePosition(winning, 'A');
+
+    expect(winningEval.total - equalEval.total).toBe(EVAL_WEIGHTS.TOUCHDOWN * 2);
+    expect(winningEval.breakdown.score).toBe(EVAL_WEIGHTS.TOUCHDOWN * 2);
+  });
+
+  it('inverse le score selon la perspective de l equipe', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const b = makePlayer({ id: 'b1', team: 'B' });
+    const state = baseState([a, b], { score: { teamA: 1, teamB: 0 } });
+
+    const evalA = evaluatePosition(state, 'A');
+    const evalB = evaluatePosition(state, 'B');
+
+    expect(evalA.breakdown.score).toBeGreaterThan(0);
+    expect(evalB.breakdown.score).toBeLessThan(0);
+    expect(evalA.breakdown.score).toBe(-evalB.breakdown.score);
+  });
+
+  it('attribue un bonus de possession de balle', () => {
+    const carrier = makePlayer({ id: 'a1', team: 'A', hasBall: true });
+    const b = makePlayer({ id: 'b1', team: 'B' });
+    const withBall = baseState([carrier, b], { ball: carrier.pos });
+
+    const none = makePlayer({ id: 'a2', team: 'A' });
+    const withoutBall = baseState([none, b]);
+
+    const withEval = evaluatePosition(withBall, 'A');
+    const withoutEval = evaluatePosition(withoutBall, 'A');
+
+    expect(withEval.breakdown.possession).toBeGreaterThan(withoutEval.breakdown.possession);
+  });
+
+  it('valorise l avance du porteur vers la endzone adverse', () => {
+    const nearOwn = makePlayer({ id: 'a1', team: 'A', pos: { x: 2, y: 7 }, hasBall: true });
+    const nearOpp = makePlayer({ id: 'a1', team: 'A', pos: { x: 23, y: 7 }, hasBall: true });
+    const b = makePlayer({ id: 'b1', team: 'B' });
+    const deepState = baseState([nearOwn, b], { ball: nearOwn.pos });
+    const advancedState = baseState([nearOpp, b], { ball: nearOpp.pos });
+
+    expect(
+      evaluatePosition(advancedState, 'A').breakdown.ballProgress,
+    ).toBeGreaterThan(evaluatePosition(deepState, 'A').breakdown.ballProgress);
+  });
+
+  it('penalise les joueurs blesses et valorise les blessures adverses', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const b1 = makePlayer({ id: 'b1', team: 'B' });
+    const b2 = makePlayer({ id: 'b2', team: 'B', state: 'casualty' });
+    const state = baseState([a, b1, b2]);
+
+    const evaluation = evaluatePosition(state, 'A');
+    expect(evaluation.breakdown.attrition).toBeGreaterThan(0);
+  });
+
+  it('pays zero for ended matches without score', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const state = baseState([a], { gamePhase: 'ended' });
+
+    const evaluation = evaluatePosition(state, 'A');
+    expect(evaluation.total).toBe(0);
+  });
+});
+
+describe('IA: scoreMove', () => {
+  it('retourne un score fini pour END_TURN', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const b = makePlayer({ id: 'b1', team: 'B' });
+    const state = baseState([a, b]);
+
+    const score = scoreMove(state, { type: 'END_TURN' }, 'A');
+    expect(Number.isFinite(score)).toBe(true);
+  });
+
+  it('prefere un MOVE qui avance le porteur vers l endzone adverse', () => {
+    const carrier = makePlayer({
+      id: 'a1',
+      team: 'A',
+      pos: { x: 10, y: 7 },
+      hasBall: true,
+      pm: 6,
+    });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 20, y: 7 } });
+    const state = baseState([carrier, b], { ball: carrier.pos });
+
+    const forward: Move = { type: 'MOVE', playerId: 'a1', to: { x: 11, y: 7 } };
+    const backward: Move = { type: 'MOVE', playerId: 'a1', to: { x: 9, y: 7 } };
+
+    expect(scoreMove(state, forward, 'A')).toBeGreaterThan(scoreMove(state, backward, 'A'));
+  });
+
+  it('donne un score positif a un BLOCK avec avantage de force', () => {
+    const strong = makePlayer({ id: 'a1', team: 'A', pos: { x: 5, y: 5 }, st: 5 });
+    const weak = makePlayer({ id: 'b1', team: 'B', pos: { x: 6, y: 5 }, st: 2 });
+    const state = baseState([strong, weak]);
+
+    const score = scoreMove(state, { type: 'BLOCK', playerId: 'a1', targetId: 'b1' }, 'A');
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it('penalise un BLOCK avec desavantage de force', () => {
+    const weak = makePlayer({ id: 'a1', team: 'A', pos: { x: 5, y: 5 }, st: 2 });
+    const strong = makePlayer({ id: 'b1', team: 'B', pos: { x: 6, y: 5 }, st: 5 });
+    const state = baseState([weak, strong]);
+
+    const strongBlock: Move = { type: 'BLOCK', playerId: 'a1', targetId: 'b1' };
+    const safe: Move = { type: 'END_TURN' };
+
+    expect(scoreMove(state, strongBlock, 'A')).toBeLessThan(scoreMove(state, safe, 'A'));
+  });
+
+  it('valorise une passe vers un coequipier plus avance', () => {
+    const passer = makePlayer({
+      id: 'a1',
+      team: 'A',
+      pos: { x: 8, y: 7 },
+      hasBall: true,
+    });
+    const receiver = makePlayer({ id: 'a2', team: 'A', pos: { x: 14, y: 7 } });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 20, y: 7 } });
+    const state = baseState([passer, receiver, b], { ball: passer.pos });
+
+    const pass: Move = { type: 'PASS', playerId: 'a1', targetId: 'a2' };
+    const end: Move = { type: 'END_TURN' };
+
+    expect(scoreMove(state, pass, 'A')).toBeGreaterThan(scoreMove(state, end, 'A'));
+  });
+});
+
+describe('IA: pickBestMove', () => {
+  it('retourne null si aucun mouvement legal', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const state = baseState([a], { gamePhase: 'ended' });
+    expect(pickBestMove(state, 'A')).toBeNull();
+  });
+
+  it('retourne un mouvement legal lorsque des options existent', () => {
+    const carrier = makePlayer({
+      id: 'a1',
+      team: 'A',
+      pos: { x: 10, y: 7 },
+      hasBall: true,
+      pm: 6,
+    });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 20, y: 7 } });
+    const state = baseState([carrier, b], { ball: carrier.pos });
+
+    const move = pickBestMove(state, 'A');
+    expect(move).not.toBeNull();
+  });
+
+  it('choisit un mouvement en avant plutot qu en arriere quand c est la meilleure option', () => {
+    const carrier = makePlayer({
+      id: 'a1',
+      team: 'A',
+      pos: { x: 10, y: 7 },
+      hasBall: true,
+      pm: 6,
+    });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 22, y: 14 } });
+    const state = baseState([carrier, b], { ball: carrier.pos });
+
+    const move = pickBestMove(state, 'A');
+    expect(move).not.toBeNull();
+    if (move && move.type === 'MOVE') {
+      expect(move.to.x).toBeGreaterThanOrEqual(carrier.pos.x);
+    }
+  });
+
+  it('est deterministe (meme etat => meme choix)', () => {
+    const carrier = makePlayer({
+      id: 'a1',
+      team: 'A',
+      pos: { x: 10, y: 7 },
+      hasBall: true,
+      pm: 6,
+    });
+    const b = makePlayer({ id: 'b1', team: 'B', pos: { x: 20, y: 7 } });
+    const state = baseState([carrier, b], { ball: carrier.pos });
+
+    const m1 = pickBestMove(state, 'A');
+    const m2 = pickBestMove(state, 'A');
+    expect(m1).toEqual(m2);
+  });
+});

--- a/packages/game-engine/src/ai/evaluator.ts
+++ b/packages/game-engine/src/ai/evaluator.ts
@@ -1,0 +1,314 @@
+/**
+ * N.3 — Evaluation heuristique basique pour l'IA adversaire.
+ *
+ * Fournit :
+ *  - `evaluatePosition` : score scalaire (perspective equipe) d'un GameState.
+ *  - `scoreMove`        : score estime d'un coup legal pour une equipe.
+ *  - `pickBestMove`     : selectionne le coup legal au score maximal.
+ *
+ * Les heuristiques sont volontairement simples : elles capturent les leviers
+ * de haut niveau (score au tableau, possession, progression, attrition,
+ * protection du porteur) pour produire un adversaire coherent a un niveau
+ * debutant. Des strates plus avancees (simulation multi-coups, apprentissage)
+ * seront ajoutees ulterieurement.
+ */
+
+import type { GameState, Move, Player, Position, TeamId } from '../core/types';
+import { getAdjacentOpponents, isAdjacent } from '../mechanics/movement';
+import { getLegalMoves } from '../actions/actions';
+
+export interface EvaluationBreakdown {
+  score: number;
+  possession: number;
+  ballProgress: number;
+  playerCount: number;
+  carrierSafety: number;
+  attrition: number;
+}
+
+export interface PositionEvaluation {
+  total: number;
+  breakdown: EvaluationBreakdown;
+}
+
+export const EVAL_WEIGHTS = {
+  TOUCHDOWN: 1000,
+  POSSESSION: 300,
+  BALL_PROGRESS_PER_STEP: 15,
+  PLAYER_ACTIVE: 30,
+  PLAYER_STUNNED_PENALTY: 15,
+  PLAYER_KO_PENALTY: 40,
+  PLAYER_CASUALTY_PENALTY: 150,
+  PLAYER_SENT_OFF_PENALTY: 120,
+  CARRIER_PROTECTION_ALLY: 20,
+  CARRIER_TACKLEZONE_PENALTY: 35,
+  CARRIER_IN_ENDZONE_BONUS: 250,
+} as const;
+
+const OPPOSITE: Record<TeamId, TeamId> = { A: 'B', B: 'A' };
+
+function otherTeam(team: TeamId): TeamId {
+  return OPPOSITE[team];
+}
+
+function isActive(player: Player): boolean {
+  return !player.stunned && player.state !== 'casualty'
+    && player.state !== 'knocked_out' && player.state !== 'sent_off';
+}
+
+function teamScore(state: GameState, team: TeamId): number {
+  return team === 'A' ? state.score.teamA : state.score.teamB;
+}
+
+function endzoneX(state: GameState, team: TeamId): number {
+  return team === 'A' ? state.width - 1 : 0;
+}
+
+function distanceToEndzone(state: GameState, pos: Position, team: TeamId): number {
+  return Math.abs(pos.x - endzoneX(state, team));
+}
+
+function findPlayer(state: GameState, playerId: string): Player | undefined {
+  return state.players.find(p => p.id === playerId);
+}
+
+function findBallCarrier(state: GameState): Player | undefined {
+  return state.players.find(p => p.hasBall);
+}
+
+function attritionScore(state: GameState, team: TeamId): number {
+  let score = 0;
+  for (const p of state.players) {
+    const sign = p.team === team ? -1 : 1;
+    if (p.state === 'casualty') {
+      score += sign * EVAL_WEIGHTS.PLAYER_CASUALTY_PENALTY;
+    } else if (p.state === 'sent_off') {
+      score += sign * EVAL_WEIGHTS.PLAYER_SENT_OFF_PENALTY;
+    } else if (p.state === 'knocked_out') {
+      score += sign * EVAL_WEIGHTS.PLAYER_KO_PENALTY;
+    } else if (p.stunned) {
+      score += sign * EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY;
+    }
+  }
+  return score;
+}
+
+function playerCountScore(state: GameState, team: TeamId): number {
+  let score = 0;
+  for (const p of state.players) {
+    if (!isActive(p)) continue;
+    score += (p.team === team ? 1 : -1) * EVAL_WEIGHTS.PLAYER_ACTIVE;
+  }
+  return score;
+}
+
+function carrierSafetyScore(state: GameState, team: TeamId): number {
+  const carrier = findBallCarrier(state);
+  if (!carrier) return 0;
+  const sign = carrier.team === team ? 1 : -1;
+
+  const allies = state.players.filter(
+    p => p.team === carrier.team && p.id !== carrier.id && isActive(p) && isAdjacent(p.pos, carrier.pos),
+  ).length;
+  const opponentsInTz = getAdjacentOpponents(state, carrier.pos, carrier.team).length;
+
+  return sign * (
+    allies * EVAL_WEIGHTS.CARRIER_PROTECTION_ALLY
+    - opponentsInTz * EVAL_WEIGHTS.CARRIER_TACKLEZONE_PENALTY
+  );
+}
+
+function ballProgressScore(state: GameState, team: TeamId): number {
+  const carrier = findBallCarrier(state);
+  if (!carrier) return 0;
+  const sign = carrier.team === team ? 1 : -1;
+  const distance = distanceToEndzone(state, carrier.pos, carrier.team);
+  const progress = (state.width - 1 - distance) * EVAL_WEIGHTS.BALL_PROGRESS_PER_STEP;
+  const endzoneBonus = distance === 0 ? EVAL_WEIGHTS.CARRIER_IN_ENDZONE_BONUS : 0;
+  return sign * (progress + endzoneBonus);
+}
+
+function possessionScore(state: GameState, team: TeamId): number {
+  const carrier = findBallCarrier(state);
+  if (!carrier) return 0;
+  return (carrier.team === team ? 1 : -1) * EVAL_WEIGHTS.POSSESSION;
+}
+
+function scoreDifferenceScore(state: GameState, team: TeamId): number {
+  const diff = teamScore(state, team) - teamScore(state, otherTeam(team));
+  return diff * EVAL_WEIGHTS.TOUCHDOWN;
+}
+
+/**
+ * Score global d'un GameState du point de vue de `team`.
+ * Plus haut = meilleur pour `team`.
+ */
+export function evaluatePosition(state: GameState, team: TeamId): PositionEvaluation {
+  if (state.gamePhase === 'ended'
+      && state.score.teamA === 0 && state.score.teamB === 0) {
+    const zero: EvaluationBreakdown = {
+      score: 0, possession: 0, ballProgress: 0,
+      playerCount: 0, carrierSafety: 0, attrition: 0,
+    };
+    return { total: 0, breakdown: zero };
+  }
+
+  const breakdown: EvaluationBreakdown = {
+    score: scoreDifferenceScore(state, team),
+    possession: possessionScore(state, team),
+    ballProgress: ballProgressScore(state, team),
+    playerCount: playerCountScore(state, team),
+    carrierSafety: carrierSafetyScore(state, team),
+    attrition: attritionScore(state, team),
+  };
+
+  const total = breakdown.score + breakdown.possession + breakdown.ballProgress
+    + breakdown.playerCount + breakdown.carrierSafety + breakdown.attrition;
+
+  return { total, breakdown };
+}
+
+/**
+ * Estimation simple de la probabilite de knockdown de la cible lors d'un
+ * blocage : fonction monotone de la difference de force (incluant les
+ * assistances indirectes via les joueurs adjacents).
+ */
+function estimateBlockKnockdown(state: GameState, attacker: Player, target: Player): number {
+  const atkAssists = state.players.filter(
+    p => p.team === attacker.team && p.id !== attacker.id && isActive(p) && isAdjacent(p.pos, target.pos),
+  ).length;
+  const defAssists = state.players.filter(
+    p => p.team === target.team && p.id !== target.id && isActive(p) && isAdjacent(p.pos, attacker.pos),
+  ).length;
+  const atkStrength = attacker.st + atkAssists;
+  const defStrength = target.st + defAssists;
+
+  if (atkStrength >= 2 * defStrength) return 0.7;
+  if (atkStrength > defStrength) return 0.55;
+  if (atkStrength === defStrength) return 0.33;
+  if (defStrength >= 2 * atkStrength) return 0.08;
+  return 0.18;
+}
+
+function scoreMoveMove(state: GameState, move: Extract<Move, { type: 'MOVE' }>, team: TeamId): number {
+  const player = findPlayer(state, move.playerId);
+  if (!player) return -Infinity;
+
+  const before = evaluatePosition(state, team).total;
+  const simulated: GameState = {
+    ...state,
+    players: state.players.map(p => (p.id === player.id ? { ...p, pos: move.to, pm: Math.max(0, p.pm - 1) } : p)),
+    ball: player.hasBall ? { ...move.to } : state.ball,
+  };
+  const after = evaluatePosition(simulated, team).total;
+  return after - before;
+}
+
+function scoreMoveBlock(state: GameState, move: Extract<Move, { type: 'BLOCK' }>, team: TeamId): number {
+  const attacker = findPlayer(state, move.playerId);
+  const target = findPlayer(state, move.targetId);
+  if (!attacker || !target) return -Infinity;
+
+  const knockdown = estimateBlockKnockdown(state, attacker, target);
+  const knockoutValue = target.team === team
+    ? -EVAL_WEIGHTS.PLAYER_ACTIVE - EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY
+    : EVAL_WEIGHTS.PLAYER_ACTIVE + EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY;
+
+  const possessionSwing = target.hasBall ? EVAL_WEIGHTS.POSSESSION * 0.5 : 0;
+  const selfRisk = knockdown < 0.4 ? -40 : 0;
+  return knockdown * (knockoutValue + possessionSwing) + selfRisk;
+}
+
+function scoreMoveBlitz(state: GameState, move: Extract<Move, { type: 'BLITZ' }>, team: TeamId): number {
+  const attacker = findPlayer(state, move.playerId);
+  const target = findPlayer(state, move.targetId);
+  if (!attacker || !target) return -Infinity;
+
+  const moveDelta = scoreMoveMove(
+    state,
+    { type: 'MOVE', playerId: move.playerId, to: move.to },
+    team,
+  );
+  const simulated: GameState = {
+    ...state,
+    players: state.players.map(p => (p.id === attacker.id ? { ...p, pos: move.to } : p)),
+  };
+  const blockDelta = scoreMoveBlock(simulated, { type: 'BLOCK', playerId: move.playerId, targetId: move.targetId }, team);
+  return moveDelta + blockDelta;
+}
+
+function scoreMovePass(state: GameState, move: Extract<Move, { type: 'PASS' | 'HANDOFF' }>, team: TeamId): number {
+  const passer = findPlayer(state, move.playerId);
+  const receiver = findPlayer(state, move.targetId);
+  if (!passer || !receiver) return -Infinity;
+
+  const simulated: GameState = {
+    ...state,
+    ball: { ...receiver.pos },
+    players: state.players.map(p => {
+      if (p.id === passer.id) return { ...p, hasBall: false };
+      if (p.id === receiver.id) return { ...p, hasBall: true };
+      return p;
+    }),
+  };
+  const delta = evaluatePosition(simulated, team).total - evaluatePosition(state, team).total;
+  const risk = move.type === 'PASS' ? -20 : 0;
+  return delta + risk;
+}
+
+function scoreMoveFoul(state: GameState, move: Extract<Move, { type: 'FOUL' }>, team: TeamId): number {
+  const target = findPlayer(state, move.targetId);
+  if (!target) return -Infinity;
+  if (target.team === team) return -Infinity;
+  const baseValue = target.hasBall ? 90 : 30;
+  return baseValue - 40;
+}
+
+/**
+ * Score heuristique d'un coup (perspective `team`).
+ * Un score plus haut indique un coup juge preferable.
+ */
+export function scoreMove(state: GameState, move: Move, team: TeamId): number {
+  switch (move.type) {
+    case 'END_TURN':
+      return 0;
+    case 'MOVE':
+      return scoreMoveMove(state, move, team);
+    case 'LEAP':
+      return scoreMoveMove(state, { type: 'MOVE', playerId: move.playerId, to: move.to }, team) - 15;
+    case 'BLOCK':
+      return scoreMoveBlock(state, move, team);
+    case 'BLITZ':
+      return scoreMoveBlitz(state, move, team);
+    case 'PASS':
+    case 'HANDOFF':
+      return scoreMovePass(state, move, team);
+    case 'FOUL':
+      return scoreMoveFoul(state, move, team);
+    case 'END_PLAYER_TURN':
+      return -5;
+    default:
+      return -50;
+  }
+}
+
+/**
+ * Retourne le coup legal au meilleur score pour `team` (null si aucun coup).
+ * En cas d'egalite, conserve le premier coup rencontre (ordre stable).
+ */
+export function pickBestMove(state: GameState, team: TeamId): Move | null {
+  const legal = getLegalMoves(state);
+  if (legal.length === 0) return null;
+
+  let bestMove: Move = legal[0];
+  let bestScore = scoreMove(state, bestMove, team);
+  for (let i = 1; i < legal.length; i++) {
+    const candidate = legal[i];
+    const candidateScore = scoreMove(state, candidate, team);
+    if (candidateScore > bestScore) {
+      bestScore = candidateScore;
+      bestMove = candidate;
+    }
+  }
+  return bestMove;
+}

--- a/packages/game-engine/src/ai/index.ts
+++ b/packages/game-engine/src/ai/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Barrel du module IA adversaire (N.3+).
+ * Regroupe les utilitaires d'evaluation heuristique utilises par l'IA
+ * (evaluer une position, scorer un coup, choisir le meilleur coup).
+ */
+export {
+  evaluatePosition,
+  scoreMove,
+  pickBestMove,
+  EVAL_WEIGHTS,
+} from './evaluator';
+export type { EvaluationBreakdown, PositionEvaluation } from './evaluator';

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -383,6 +383,15 @@ export {
   type ReplayTurnPayload,
 } from './core/replay';
 
+// Export du module IA adversaire (N.3)
+export {
+  evaluatePosition,
+  scoreMove,
+  pickBestMove,
+  EVAL_WEIGHTS,
+} from './ai';
+export type { EvaluationBreakdown, PositionEvaluation } from './ai';
+
 // Export du module tutoriel (N.1)
 export {
   listTutorialScripts,


### PR DESCRIPTION
## Resume

Implemente la tache **N.3** (Sprint 15) : IA adversaire — evaluation heuristique basique.

- Nouveau module `packages/game-engine/src/ai/` :
  - `evaluatePosition(state, team)` : score scalaire + breakdown (score, possession, ballProgress, playerCount, carrierSafety, attrition).
  - `scoreMove(state, move, team)` : score heuristique par coup (MOVE, LEAP, BLOCK, BLITZ, PASS, HANDOFF, FOUL, END_TURN, END_PLAYER_TURN).
  - `pickBestMove(state, team)` : choix deterministe du coup legal au meilleur score.
  - `EVAL_WEIGHTS` : poids exportes pour calibration et tests.
- Exports centralises via `packages/game-engine/src/ai/index.ts` + re-export dans `packages/game-engine/src/index.ts`.

Base pour **N.4** (mode pratique contre IA, 3 niveaux de difficulte) : la difficulte pourra moduler le bruit et la profondeur de recherche par-dessus ces heuristiques.

## Tache roadmap

Sprint 15, tache N.3 (cochee dans `TODO.md`).

## Plan de test

- [x] 16 tests unitaires dans `src/ai/evaluator.test.ts`
  - evaluatePosition : breakdown complet, dominance du TD, symetrie equipes, possession, ball progress, attrition, match termine.
  - scoreMove : END_TURN, avance du porteur, avantage/desavantage de force, gain de passe vers receveur avance.
  - pickBestMove : null si legal vide, retour d'un coup legal, preference progression, determinisme.
- [x] Suite complete du package : 3971 tests passent.
- [x] Lint : 0 warning sur `src/ai/`.
- [x] Typecheck `game-engine` : OK.
- [x] Build `game-engine` : OK.

Notes : le build `apps/web` echoue dans le sandbox (Google Fonts inaccessibles) et 3 erreurs `typecheck` preexistent sur `feature-flags` — non liees a cette PR.