### PR TITLE
feat(ai): three-level AI difficulty for practice mode (N.4)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -273,7 +273,7 @@
 | N.1 | Tutoriel interactif (match guide, scripts pas a pas) | Engagement | [x] |
 | N.2 | Mode simplifie pour debutants (leverager `SIMPLIFIED_RULES`) | Engagement | [x] |
 | N.3 | IA adversaire — evaluation heuristique basique (eval position + coup) | Engagement | [x] |
-| N.4 | Mode pratique contre IA (3 niveaux de difficulte) | Engagement | [ ] |
+| N.4 | Mode pratique contre IA (3 niveaux de difficulte) | Engagement | [x] |
 | N.4b | IA contrainte aux 5 equipes prioritaires dans un premier temps | Engagement | [ ] |
 
 ### Sprint 16 — Social & retention (~5 jours, ex-Sprint 19 remonte)

--- a/packages/game-engine/src/ai/difficulty.test.ts
+++ b/packages/game-engine/src/ai/difficulty.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { makeRNG } from '../utils/rng';
+import type { GameState, Move, Player, RNG } from '../core/types';
+import { pickBestMove } from './evaluator';
+import {
+  AI_DIFFICULTY_LEVELS,
+  AI_DIFFICULTY_PROFILES,
+  DEFAULT_AI_DIFFICULTY,
+  getAIDifficultyProfile,
+  listAIDifficulties,
+  pickAIMove,
+  scoreMoveForDifficulty,
+} from './difficulty';
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'Lineman',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: [],
+    pm: 6,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+function baseState(players: Player[], overrides: Partial<GameState> = {}): GameState {
+  const state = setup();
+  return { ...state, players, ...overrides };
+}
+
+function blockAdvantageState(): GameState {
+  const strong = makePlayer({ id: 'a1', team: 'A', pos: { x: 5, y: 5 }, st: 5 });
+  const weak = makePlayer({ id: 'b1', team: 'B', pos: { x: 6, y: 5 }, st: 2 });
+  return baseState([strong, weak]);
+}
+
+function carrierAdvancedState(): GameState {
+  const carrier = makePlayer({
+    id: 'a1', team: 'A', pos: { x: 10, y: 7 }, hasBall: true, pm: 6,
+  });
+  const defender = makePlayer({ id: 'b1', team: 'B', pos: { x: 22, y: 14 } });
+  return baseState([carrier, defender], { ball: carrier.pos });
+}
+
+describe('IA difficulty: profiles registry', () => {
+  it('expose les trois niveaux de difficulte', () => {
+    expect(AI_DIFFICULTY_LEVELS).toEqual(['easy', 'medium', 'hard']);
+    expect(listAIDifficulties()).toEqual(['easy', 'medium', 'hard']);
+  });
+
+  it('expose un niveau par defaut (medium)', () => {
+    expect(DEFAULT_AI_DIFFICULTY).toBe('medium');
+  });
+
+  it('chaque niveau a un profil coherent', () => {
+    for (const level of AI_DIFFICULTY_LEVELS) {
+      const profile = getAIDifficultyProfile(level);
+      expect(profile.slug).toBe(level);
+      expect(profile.noise).toBeGreaterThanOrEqual(0);
+      expect(profile.blunderRate).toBeGreaterThanOrEqual(0);
+      expect(profile.blunderRate).toBeLessThanOrEqual(1);
+      expect(profile.timidityRate).toBeGreaterThanOrEqual(0);
+      expect(profile.timidityRate).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('le profil durcit a mesure que le niveau augmente', () => {
+    const easy = AI_DIFFICULTY_PROFILES.easy;
+    const medium = AI_DIFFICULTY_PROFILES.medium;
+    const hard = AI_DIFFICULTY_PROFILES.hard;
+
+    expect(hard.noise).toBeLessThan(medium.noise);
+    expect(medium.noise).toBeLessThan(easy.noise);
+
+    expect(hard.blunderRate).toBeLessThanOrEqual(medium.blunderRate);
+    expect(medium.blunderRate).toBeLessThanOrEqual(easy.blunderRate);
+
+    expect(hard.timidityRate).toBeLessThanOrEqual(medium.timidityRate);
+    expect(medium.timidityRate).toBeLessThanOrEqual(easy.timidityRate);
+
+    expect(hard.noise).toBe(0);
+    expect(hard.blunderRate).toBe(0);
+    expect(hard.timidityRate).toBe(0);
+  });
+});
+
+describe('IA difficulty: pickAIMove — contrats generaux', () => {
+  it('retourne null si aucun coup legal', () => {
+    const a = makePlayer({ id: 'a1', team: 'A' });
+    const state = baseState([a], { gamePhase: 'ended' });
+    for (const difficulty of AI_DIFFICULTY_LEVELS) {
+      expect(pickAIMove(state, 'A', { difficulty })).toBeNull();
+    }
+  });
+
+  it('retourne toujours un coup present dans les coups legaux', () => {
+    const state = carrierAdvancedState();
+    for (const difficulty of AI_DIFFICULTY_LEVELS) {
+      const rng = makeRNG(`ai-${difficulty}-legal`);
+      const move = pickAIMove(state, 'A', { difficulty, rng });
+      expect(move).not.toBeNull();
+    }
+  });
+
+  it('hard est equivalent a pickBestMove', () => {
+    const state = blockAdvantageState();
+    const reference = pickBestMove(state, 'A');
+    const chosen = pickAIMove(state, 'A', { difficulty: 'hard' });
+    expect(chosen).toEqual(reference);
+  });
+
+  it('hard ne consomme pas de RNG (deterministe sans RNG)', () => {
+    const state = carrierAdvancedState();
+    const a = pickAIMove(state, 'A', { difficulty: 'hard' });
+    const b = pickAIMove(state, 'A', { difficulty: 'hard' });
+    expect(a).toEqual(b);
+  });
+
+  it('utilise medium par defaut quand difficulty est omis', () => {
+    const state = blockAdvantageState();
+    const rng: RNG = makeRNG('default-level');
+    const withoutLevel = pickAIMove(state, 'A', { rng });
+    const rngRef: RNG = makeRNG('default-level');
+    const withMedium = pickAIMove(state, 'A', { difficulty: 'medium', rng: rngRef });
+    expect(withoutLevel).toEqual(withMedium);
+  });
+
+  it('meme seed RNG => meme choix (reproductibilite)', () => {
+    const state = carrierAdvancedState();
+    for (const difficulty of AI_DIFFICULTY_LEVELS) {
+      const m1 = pickAIMove(state, 'A', { difficulty, rng: makeRNG('repeat') });
+      const m2 = pickAIMove(state, 'A', { difficulty, rng: makeRNG('repeat') });
+      expect(m1).toEqual(m2);
+    }
+  });
+});
+
+describe('IA difficulty: differences de comportement', () => {
+  it('easy peut produire des choix differents avec des seeds differents', () => {
+    const state = carrierAdvancedState();
+    const choices = new Set<string>();
+    for (let i = 0; i < 30; i++) {
+      const move = pickAIMove(state, 'A', {
+        difficulty: 'easy',
+        rng: makeRNG(`easy-seed-${i}`),
+      });
+      choices.add(JSON.stringify(move));
+    }
+    expect(choices.size).toBeGreaterThan(1);
+  });
+
+  it('hard choisit toujours un BLOCK avantageux face a un END_TURN', () => {
+    const state = blockAdvantageState();
+    const move = pickAIMove(state, 'A', { difficulty: 'hard' });
+    expect(move).not.toBeNull();
+    expect(move?.type).toBe('BLOCK');
+  });
+
+  it('easy privilegie globalement davantage END_TURN que hard', () => {
+    const state = blockAdvantageState();
+    let easyEndTurns = 0;
+    let hardEndTurns = 0;
+    for (let i = 0; i < 50; i++) {
+      const easyMove = pickAIMove(state, 'A', {
+        difficulty: 'easy',
+        rng: makeRNG(`compare-easy-${i}`),
+      });
+      const hardMove = pickAIMove(state, 'A', { difficulty: 'hard' });
+      if (easyMove?.type === 'END_TURN') easyEndTurns++;
+      if (hardMove?.type === 'END_TURN') hardEndTurns++;
+    }
+    expect(easyEndTurns).toBeGreaterThan(hardEndTurns);
+  });
+});
+
+describe('IA difficulty: scoreMoveForDifficulty', () => {
+  it('hard donne exactement le meme score que scoreMove (sans RNG)', () => {
+    const state = blockAdvantageState();
+    const move: Move = { type: 'BLOCK', playerId: 'a1', targetId: 'b1' };
+    const hard = scoreMoveForDifficulty(state, move, 'A', 'hard');
+    // Sur hard, sans bruit ni biais, le score doit rester > 0 (block favorable)
+    expect(hard).toBeGreaterThan(0);
+    // Et etre deterministe (meme appel, meme valeur)
+    expect(scoreMoveForDifficulty(state, move, 'A', 'hard')).toBe(hard);
+  });
+
+  it('easy applique un biais moyen positif en faveur d END_TURN', () => {
+    const state = blockAdvantageState();
+    const endTurn: Move = { type: 'END_TURN' };
+    const hardScore = scoreMoveForDifficulty(state, endTurn, 'A', 'hard');
+    let total = 0;
+    const samples = 40;
+    for (let i = 0; i < samples; i++) {
+      total += scoreMoveForDifficulty(state, endTurn, 'A', 'easy', makeRNG(`bias-${i}`));
+    }
+    const averageEasy = total / samples;
+    expect(averageEasy).toBeGreaterThan(hardScore);
+  });
+
+  it('scoreMoveForDifficulty reste un nombre fini pour tous les niveaux', () => {
+    const state = blockAdvantageState();
+    const move: Move = { type: 'BLOCK', playerId: 'a1', targetId: 'b1' };
+    for (const difficulty of AI_DIFFICULTY_LEVELS) {
+      const rng = makeRNG(`finite-${difficulty}`);
+      const score = scoreMoveForDifficulty(state, move, 'A', difficulty, rng);
+      expect(Number.isFinite(score)).toBe(true);
+    }
+  });
+});
+
+describe('IA difficulty: boucle de tour (integration)', () => {
+  it('peut jouer une sequence complete sans planter et termine sur END_TURN', async () => {
+    const { applyMove } = await import('../actions/actions');
+    let state = blockAdvantageState();
+    let safety = 0;
+    let lastMove: Move | null = null;
+    const rng = makeRNG('turn-loop');
+    while (safety < 50) {
+      const move = pickAIMove(state, 'A', { difficulty: 'medium', rng });
+      if (!move) break;
+      lastMove = move;
+      if (move.type === 'END_TURN') break;
+      state = applyMove(state, move, rng);
+      safety++;
+    }
+    expect(safety).toBeLessThan(50);
+    expect(lastMove).not.toBeNull();
+  });
+});
+
+describe('IA difficulty: qualite relative (hard > easy en moyenne)', () => {
+  it('sur des etats varies, hard privilegie plus souvent des coups de score positif', () => {
+    const scenarios: GameState[] = [
+      blockAdvantageState(),
+      carrierAdvancedState(),
+    ];
+
+    let easyPositive = 0;
+    let hardPositive = 0;
+
+    for (let s = 0; s < scenarios.length; s++) {
+      for (let i = 0; i < 20; i++) {
+        const easyMove = pickAIMove(scenarios[s], 'A', {
+          difficulty: 'easy',
+          rng: makeRNG(`quality-easy-${s}-${i}`),
+        });
+        const hardMove = pickAIMove(scenarios[s], 'A', { difficulty: 'hard' });
+        if (easyMove && easyMove.type !== 'END_TURN') easyPositive++;
+        if (hardMove && hardMove.type !== 'END_TURN') hardPositive++;
+      }
+    }
+
+    // Sur 40 tirages, hard doit proposer plus d'actions concretes que easy
+    expect(hardPositive).toBeGreaterThan(easyPositive);
+  });
+});

--- a/packages/game-engine/src/ai/difficulty.ts
+++ b/packages/game-engine/src/ai/difficulty.ts
@@ -1,0 +1,179 @@
+/**
+ * N.4 — Mode pratique contre IA : trois niveaux de difficulte.
+ *
+ * Fournit :
+ *  - `AI_DIFFICULTY_LEVELS` et `AI_DIFFICULTY_PROFILES` : catalogue des niveaux.
+ *  - `pickAIMove`                 : selection de coup pondere par le niveau.
+ *  - `scoreMoveForDifficulty`     : score heuristique augmente des biais de niveau.
+ *
+ * Chaque niveau applique un profil d'imperfections sur les scores heuristiques
+ * produits par `scoreMove` : bruit additif, biais pro-END_TURN, evitement des
+ * actions agressives (timidite). `hard` est strictement identique a
+ * `pickBestMove` (profil neutre et deterministe).
+ */
+
+import type { GameState, Move, RNG, TeamId } from '../core/types';
+import { getLegalMoves } from '../actions/actions';
+import { makeRNG } from '../utils/rng';
+import { pickBestMove, scoreMove } from './evaluator';
+
+export type AIDifficulty = 'easy' | 'medium' | 'hard';
+
+export const AI_DIFFICULTY_LEVELS: readonly AIDifficulty[] = Object.freeze([
+  'easy',
+  'medium',
+  'hard',
+] as const);
+
+export const DEFAULT_AI_DIFFICULTY: AIDifficulty = 'medium';
+
+export interface AIDifficultyProfile {
+  readonly slug: AIDifficulty;
+  /** Amplitude du bruit additif applique aux scores heuristiques. */
+  readonly noise: number;
+  /** Probabilite (0..1) de choisir au hasard parmi les coups les mieux scores. */
+  readonly blunderRate: number;
+  /** Probabilite (0..1) d'ecarter un coup agressif (BLOCK/BLITZ/FOUL/PASS). */
+  readonly timidityRate: number;
+  /** Bonus additif sur le score d'END_TURN (pro-termine rapidement le tour). */
+  readonly endTurnBias: number;
+}
+
+const AGGRESSIVE_MOVE_TYPES: ReadonlySet<Move['type']> = new Set([
+  'BLOCK',
+  'BLITZ',
+  'FOUL',
+  'PASS',
+]);
+
+export const AI_DIFFICULTY_PROFILES: Readonly<Record<AIDifficulty, AIDifficultyProfile>> = Object.freeze({
+  easy: Object.freeze({
+    slug: 'easy',
+    noise: 80,
+    blunderRate: 0.35,
+    timidityRate: 0.35,
+    endTurnBias: 40,
+  }),
+  medium: Object.freeze({
+    slug: 'medium',
+    noise: 20,
+    blunderRate: 0.1,
+    timidityRate: 0.05,
+    endTurnBias: 5,
+  }),
+  hard: Object.freeze({
+    slug: 'hard',
+    noise: 0,
+    blunderRate: 0,
+    timidityRate: 0,
+    endTurnBias: 0,
+  }),
+});
+
+export function getAIDifficultyProfile(difficulty: AIDifficulty): AIDifficultyProfile {
+  return AI_DIFFICULTY_PROFILES[difficulty];
+}
+
+export function listAIDifficulties(): readonly AIDifficulty[] {
+  return AI_DIFFICULTY_LEVELS;
+}
+
+/**
+ * Score heuristique augmente des biais propres au niveau de difficulte.
+ * `hard` retourne exactement `scoreMove` (profil neutre, deterministe).
+ */
+export function scoreMoveForDifficulty(
+  state: GameState,
+  move: Move,
+  team: TeamId,
+  difficulty: AIDifficulty,
+  rng?: RNG,
+): number {
+  const base = scoreMove(state, move, team);
+  const profile = getAIDifficultyProfile(difficulty);
+  let score = base;
+  if (move.type === 'END_TURN') {
+    score += profile.endTurnBias;
+  }
+  if (profile.noise > 0 && rng) {
+    score += (rng() * 2 - 1) * profile.noise;
+  }
+  return score;
+}
+
+export interface PickAIMoveOptions {
+  difficulty?: AIDifficulty;
+  rng?: RNG;
+}
+
+/**
+ * Selectionne le prochain coup pour `team` selon le niveau de difficulte.
+ * `hard` delegue a `pickBestMove` (strictement optimal et deterministe).
+ * `easy`/`medium` appliquent bruit, timidite et blunders pondenes par `rng`.
+ * Si `rng` est omis sur un niveau non-`hard`, un RNG deterministe fixe est utilise
+ * afin de garantir la reproductibilite (les choix restent stables appel apres appel).
+ */
+export function pickAIMove(
+  state: GameState,
+  team: TeamId,
+  options: PickAIMoveOptions = {},
+): Move | null {
+  const difficulty = options.difficulty ?? DEFAULT_AI_DIFFICULTY;
+
+  if (difficulty === 'hard') {
+    return pickBestMove(state, team);
+  }
+
+  const legal = getLegalMoves(state);
+  if (legal.length === 0) return null;
+
+  const rng: RNG = options.rng ?? makeRNG(`ai-default-${difficulty}`);
+  const profile = getAIDifficultyProfile(difficulty);
+
+  const filtered = filterTimidMoves(legal, profile.timidityRate, rng);
+  const pool = filtered.length > 0 ? filtered : legal;
+
+  const scored = pool.map(candidate => ({
+    move: candidate,
+    score: scoreMoveForDifficulty(state, candidate, team, difficulty, rng),
+  }));
+
+  const sorted = sortByScoreDescStable(scored);
+
+  if (profile.blunderRate > 0 && rng() < profile.blunderRate && sorted.length > 1) {
+    const topCount = Math.max(2, Math.ceil(sorted.length * 0.4));
+    const topSlice = sorted.slice(0, topCount);
+    const pickIndex = Math.min(topSlice.length - 1, Math.floor(rng() * topSlice.length));
+    return topSlice[pickIndex].move;
+  }
+
+  return sorted[0].move;
+}
+
+function filterTimidMoves(
+  moves: readonly Move[],
+  timidityRate: number,
+  rng: RNG,
+): Move[] {
+  if (timidityRate <= 0) return [...moves];
+  const kept: Move[] = [];
+  for (const move of moves) {
+    if (AGGRESSIVE_MOVE_TYPES.has(move.type) && rng() < timidityRate) {
+      continue;
+    }
+    kept.push(move);
+  }
+  return kept;
+}
+
+interface ScoredMove { readonly move: Move; readonly score: number; }
+
+function sortByScoreDescStable(scored: readonly ScoredMove[]): ScoredMove[] {
+  return scored
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      if (b.entry.score !== a.entry.score) return b.entry.score - a.entry.score;
+      return a.index - b.index;
+    })
+    .map(({ entry }) => entry);
+}

--- a/packages/game-engine/src/ai/index.ts
+++ b/packages/game-engine/src/ai/index.ts
@@ -1,7 +1,8 @@
 /**
  * Barrel du module IA adversaire (N.3+).
  * Regroupe les utilitaires d'evaluation heuristique utilises par l'IA
- * (evaluer une position, scorer un coup, choisir le meilleur coup).
+ * (evaluer une position, scorer un coup, choisir le meilleur coup) ainsi que
+ * les profils de difficulte (N.4 — mode pratique contre IA).
  */
 export {
   evaluatePosition,
@@ -10,3 +11,14 @@ export {
   EVAL_WEIGHTS,
 } from './evaluator';
 export type { EvaluationBreakdown, PositionEvaluation } from './evaluator';
+
+export {
+  AI_DIFFICULTY_LEVELS,
+  AI_DIFFICULTY_PROFILES,
+  DEFAULT_AI_DIFFICULTY,
+  getAIDifficultyProfile,
+  listAIDifficulties,
+  pickAIMove,
+  scoreMoveForDifficulty,
+} from './difficulty';
+export type { AIDifficulty, AIDifficultyProfile, PickAIMoveOptions } from './difficulty';

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -383,14 +383,27 @@ export {
   type ReplayTurnPayload,
 } from './core/replay';
 
-// Export du module IA adversaire (N.3)
+// Export du module IA adversaire (N.3) + profils de difficulte (N.4)
 export {
   evaluatePosition,
   scoreMove,
   pickBestMove,
   EVAL_WEIGHTS,
+  AI_DIFFICULTY_LEVELS,
+  AI_DIFFICULTY_PROFILES,
+  DEFAULT_AI_DIFFICULTY,
+  getAIDifficultyProfile,
+  listAIDifficulties,
+  pickAIMove,
+  scoreMoveForDifficulty,
 } from './ai';
-export type { EvaluationBreakdown, PositionEvaluation } from './ai';
+export type {
+  EvaluationBreakdown,
+  PositionEvaluation,
+  AIDifficulty,
+  AIDifficultyProfile,
+  PickAIMoveOptions,
+} from './ai';
 
 // Export du module tutoriel (N.1)
 export {


### PR DESCRIPTION
## Resume

- Ajoute un systeme de difficulte a 3 niveaux (`easy`, `medium`, `hard`) pour l'IA adversaire construit sur `pickBestMove` existant (N.3)
- `hard` : identique a `pickBestMove` (strict optimum, deterministe). `medium` : bruit leger + blunders rares + timidite faible (defaut). `easy` : bruit fort, blunders frequents, biais pro-END_TURN et evitement des actions agressives
- Expose `pickAIMove(state, team, { difficulty, rng })`, `scoreMoveForDifficulty`, `AI_DIFFICULTY_PROFILES`, `DEFAULT_AI_DIFFICULTY` via le barrel `@bb/game-engine`

## Tache roadmap

Sprint 15, tache N.4 — Mode pratique contre IA (3 niveaux de difficulte).

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` — 3989 tests (dont 18 nouveaux sur `difficulty.test.ts`)
- [x] `pnpm --filter @bb/game-engine lint` — 0 erreur, pas de nouveau warning
- [x] `pnpm --filter @bb/game-engine typecheck`
- [x] `pnpm --filter @bb/game-engine build`
- [x] `pnpm typecheck` (monorepo) — 4/4 succes
- [ ] Integration UI mode pratique + constraint 5 equipes (suivi dans la tache N.4b)
