### PR TITLE
feat(ai): restrict AI opponent to 5 priority teams (N.4b)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -274,7 +274,7 @@
 | N.2 | Mode simplifie pour debutants (leverager `SIMPLIFIED_RULES`) | Engagement | [x] |
 | N.3 | IA adversaire — evaluation heuristique basique (eval position + coup) | Engagement | [x] |
 | N.4 | Mode pratique contre IA (3 niveaux de difficulte) | Engagement | [x] |
-| N.4b | IA contrainte aux 5 equipes prioritaires dans un premier temps | Engagement | [ ] |
+| N.4b | IA contrainte aux 5 equipes prioritaires dans un premier temps | Engagement | [x] |
 
 ### Sprint 16 — Social & retention (~5 jours, ex-Sprint 19 remonte)
 

--- a/packages/game-engine/src/ai/index.ts
+++ b/packages/game-engine/src/ai/index.ts
@@ -22,3 +22,15 @@ export {
   scoreMoveForDifficulty,
 } from './difficulty';
 export type { AIDifficulty, AIDifficultyProfile, PickAIMoveOptions } from './difficulty';
+
+// N.4b — Whitelist rosters IA adversaire (5 equipes prioritaires)
+export {
+  AI_OPPONENT_ALLOWED_ROSTERS,
+  isAIOpponentRosterAllowed,
+  listAIOpponentAllowedRosters,
+  pickAIOpponentRoster,
+} from './opponent-teams';
+export type {
+  AIOpponentRoster,
+  PickAIOpponentRosterOptions,
+} from './opponent-teams';

--- a/packages/game-engine/src/ai/opponent-teams.test.ts
+++ b/packages/game-engine/src/ai/opponent-teams.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { makeRNG } from '../utils/rng';
+import {
+  PRIORITY_TEAM_ROSTERS,
+  type PriorityTeamRoster,
+} from '../rosters/priority-teams';
+import {
+  AI_OPPONENT_ALLOWED_ROSTERS,
+  isAIOpponentRosterAllowed,
+  listAIOpponentAllowedRosters,
+  pickAIOpponentRoster,
+  type AIOpponentRoster,
+} from './opponent-teams';
+
+/**
+ * N.4b — IA contrainte aux 5 equipes prioritaires dans un premier temps.
+ *
+ * La liste d'equipes jouables par l'IA est un sous-ensemble strict des rosters
+ * disponibles : seules les 5 equipes du MVP (Skaven, Gnomes, Hommes-Lezards,
+ * Nains, Noblesse Imperiale) peuvent etre affectees a un adversaire controle
+ * par l'IA. Tout contournement doit echouer fermement pour preserver l'UX du
+ * mode pratique (N.4).
+ */
+describe('N.4b — whitelist rosters IA adversaire', () => {
+  describe('AI_OPPONENT_ALLOWED_ROSTERS', () => {
+    it('contient exactement les 5 equipes prioritaires', () => {
+      expect(AI_OPPONENT_ALLOWED_ROSTERS).toHaveLength(5);
+      expect([...AI_OPPONENT_ALLOWED_ROSTERS].sort()).toEqual(
+        [...PRIORITY_TEAM_ROSTERS].sort(),
+      );
+    });
+
+    it('reste aligne sur PRIORITY_TEAM_ROSTERS (meme ordre roadmap)', () => {
+      expect(AI_OPPONENT_ALLOWED_ROSTERS).toEqual(PRIORITY_TEAM_ROSTERS);
+    });
+
+    it('est gele (immutabilite au runtime)', () => {
+      expect(Object.isFrozen(AI_OPPONENT_ALLOWED_ROSTERS)).toBe(true);
+    });
+
+    it('listAIOpponentAllowedRosters retourne la meme liste', () => {
+      expect(listAIOpponentAllowedRosters()).toBe(AI_OPPONENT_ALLOWED_ROSTERS);
+    });
+  });
+
+  describe('isAIOpponentRosterAllowed', () => {
+    it.each(PRIORITY_TEAM_ROSTERS)(
+      'autorise le roster prioritaire "%s"',
+      slug => {
+        expect(isAIOpponentRosterAllowed(slug)).toBe(true);
+      },
+    );
+
+    it.each([
+      'orc',
+      'chaos_renegade',
+      'nurgle',
+      'vampire',
+      'goblin',
+      'wood_elf',
+      'amazon',
+      'human',
+      'norse',
+      'undead',
+      'underworld',
+      'ogre',
+      'halfling',
+      'khorne',
+      'unknown-team',
+      '',
+      'SKAVEN',
+      'Skaven',
+    ])('rejette le roster non prioritaire "%s"', slug => {
+      expect(isAIOpponentRosterAllowed(slug)).toBe(false);
+    });
+
+    it('sert de type guard pour PriorityTeamRoster', () => {
+      const slug: string = 'skaven';
+      if (isAIOpponentRosterAllowed(slug)) {
+        const typed: AIOpponentRoster = slug;
+        expect(typed).toBe('skaven');
+      } else {
+        throw new Error('skaven doit etre autorise');
+      }
+    });
+  });
+
+  describe('pickAIOpponentRoster', () => {
+    it('retourne toujours un roster autorise (sans RNG)', () => {
+      const chosen = pickAIOpponentRoster();
+      expect(chosen).not.toBeNull();
+      expect(isAIOpponentRosterAllowed(chosen as string)).toBe(true);
+    });
+
+    it('retourne toujours un roster autorise avec RNG seede', () => {
+      for (let i = 0; i < 20; i++) {
+        const rng = makeRNG(`pick-${i}`);
+        const chosen = pickAIOpponentRoster({ rng });
+        expect(chosen).not.toBeNull();
+        expect(isAIOpponentRosterAllowed(chosen as string)).toBe(true);
+      }
+    });
+
+    it('meme seed => meme choix (reproductibilite)', () => {
+      const a = pickAIOpponentRoster({ rng: makeRNG('seed-abc') });
+      const b = pickAIOpponentRoster({ rng: makeRNG('seed-abc') });
+      expect(a).toEqual(b);
+    });
+
+    it('seeds differents produisent au moins deux choix distincts sur 50 tirages', () => {
+      const choices = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        const roster = pickAIOpponentRoster({ rng: makeRNG(`diverse-${i}`) });
+        if (roster) choices.add(roster);
+      }
+      expect(choices.size).toBeGreaterThan(1);
+    });
+
+    it('respecte le parametre exclude', () => {
+      const excluded: PriorityTeamRoster = 'skaven';
+      for (let i = 0; i < 30; i++) {
+        const rng = makeRNG(`exclude-${i}`);
+        const chosen = pickAIOpponentRoster({ rng, exclude: [excluded] });
+        expect(chosen).not.toBeNull();
+        expect(chosen).not.toBe(excluded);
+        expect(isAIOpponentRosterAllowed(chosen as string)).toBe(true);
+      }
+    });
+
+    it('ignore les exclusions hors whitelist sans effet de bord', () => {
+      const chosen = pickAIOpponentRoster({
+        rng: makeRNG('ignore-unknown'),
+        exclude: ['unknown-team', 'orc', ''],
+      });
+      expect(chosen).not.toBeNull();
+      expect(isAIOpponentRosterAllowed(chosen as string)).toBe(true);
+    });
+
+    it('retourne null quand toutes les equipes sont exclues', () => {
+      const chosen = pickAIOpponentRoster({
+        rng: makeRNG('all-excluded'),
+        exclude: PRIORITY_TEAM_ROSTERS,
+      });
+      expect(chosen).toBeNull();
+    });
+
+    it('permet d enchainer 2 tirages sans duplicate via exclude', () => {
+      const rng = makeRNG('chain');
+      const first = pickAIOpponentRoster({ rng });
+      expect(first).not.toBeNull();
+      const second = pickAIOpponentRoster({
+        rng,
+        exclude: first ? [first] : [],
+      });
+      expect(second).not.toBeNull();
+      expect(second).not.toBe(first);
+    });
+  });
+});

--- a/packages/game-engine/src/ai/opponent-teams.ts
+++ b/packages/game-engine/src/ai/opponent-teams.ts
@@ -1,0 +1,52 @@
+/**
+ * N.4b — IA contrainte aux 5 equipes prioritaires (Sprint 15).
+ *
+ * L'IA adversaire (mode pratique N.4, tutoriel interactif N.1/N.2) ne peut
+ * etre affectee qu'aux rosters du MVP tant que le contenu n'est pas complete
+ * pour les autres equipes. Ce module expose la whitelist partagee, un garde
+ * d'autorisation et un helper de selection reproductible via RNG seede.
+ *
+ * La whitelist est strictement derivee de `PRIORITY_TEAM_ROSTERS` afin que les
+ * deux sources de verite restent alignees sans duplication.
+ */
+
+import type { RNG } from '../core/types';
+import { makeRNG } from '../utils/rng';
+import {
+  PRIORITY_TEAM_ROSTERS,
+  type PriorityTeamRoster,
+} from '../rosters/priority-teams';
+
+export type AIOpponentRoster = PriorityTeamRoster;
+
+export const AI_OPPONENT_ALLOWED_ROSTERS: readonly AIOpponentRoster[] = Object.freeze(
+  [...PRIORITY_TEAM_ROSTERS],
+);
+
+const ALLOWED_SET: ReadonlySet<string> = new Set<string>(AI_OPPONENT_ALLOWED_ROSTERS);
+
+export function listAIOpponentAllowedRosters(): readonly AIOpponentRoster[] {
+  return AI_OPPONENT_ALLOWED_ROSTERS;
+}
+
+export function isAIOpponentRosterAllowed(slug: string): slug is AIOpponentRoster {
+  return ALLOWED_SET.has(slug);
+}
+
+export interface PickAIOpponentRosterOptions {
+  readonly rng?: RNG;
+  readonly exclude?: readonly string[];
+}
+
+export function pickAIOpponentRoster(
+  options: PickAIOpponentRosterOptions = {},
+): AIOpponentRoster | null {
+  const exclusions = new Set<string>(options.exclude ?? []);
+  const pool = AI_OPPONENT_ALLOWED_ROSTERS.filter(slug => !exclusions.has(slug));
+  if (pool.length === 0) return null;
+
+  const rng: RNG = options.rng ?? makeRNG('ai-opponent-default');
+  const raw = Math.floor(rng() * pool.length);
+  const idx = Math.max(0, Math.min(raw, pool.length - 1));
+  return pool[idx];
+}

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -396,6 +396,10 @@ export {
   listAIDifficulties,
   pickAIMove,
   scoreMoveForDifficulty,
+  AI_OPPONENT_ALLOWED_ROSTERS,
+  isAIOpponentRosterAllowed,
+  listAIOpponentAllowedRosters,
+  pickAIOpponentRoster,
 } from './ai';
 export type {
   EvaluationBreakdown,
@@ -403,6 +407,8 @@ export type {
   AIDifficulty,
   AIDifficultyProfile,
   PickAIMoveOptions,
+  AIOpponentRoster,
+  PickAIOpponentRosterOptions,
 } from './ai';
 
 // Export du module tutoriel (N.1)


### PR DESCRIPTION
## Resume

- Ajoute `packages/game-engine/src/ai/opponent-teams.ts` qui expose `AI_OPPONENT_ALLOWED_ROSTERS` (derive de `PRIORITY_TEAM_ROSTERS`), le type guard `isAIOpponentRosterAllowed`, et le selecteur reproductible `pickAIOpponentRoster` avec RNG seede et parametre `exclude`.
- Reexporte la whitelist et ses helpers depuis `src/ai/index.ts` et le barrel principal `src/index.ts` pour les consommateurs web/mobile et futures UIs du mode pratique (N.4) et tutoriel IA (N.1/N.2).
- Coche la tache N.4b dans `TODO.md` (Sprint 15).

## Tache roadmap

Sprint 15 — N.4b : IA contrainte aux 5 equipes prioritaires dans un premier temps (Skaven, Gnomes, Hommes-Lezards, Nains, Noblesse Imperiale).

## Plan de test

- [x] `pnpm test src/ai/opponent-teams.test.ts` — 36 tests verts (whitelist, type guard, picker RNG, exclude, reproductibilite).
- [x] `pnpm test` (game-engine) — 4025 tests verts, aucune regression.
- [x] `pnpm typecheck` (turbo full) — 4/4 workspaces verts.
- [x] `pnpm build` — `@bb/game-engine` vert. `@bb/web` echoue sur fetch Google Fonts (environnement hors ligne, pre-existant, non lie).
