### PR TITLE
Add Claude settings with Skill and Monitor permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill",
+      "Monitor"
+    ]
+  }
+}


### PR DESCRIPTION
## Résumé

- [x] But de la PR: Add Claude configuration file with permission settings for Skill and Monitor capabilities

## Description

This PR adds a new `.claude/settings.json` configuration file that defines permission settings for the Claude integration. The configuration explicitly allows the "Skill" and "Monitor" permissions.

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires: N/A (configuration file)
- [x] (si applicable) Tests e2e: N/A (configuration file)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01HRdBL9eQGxhwx7aD9jfrRE