### PR TITLE
docs: add Sprint 6 & 7 specs for badges/titles/rewards system

### DIFF
--- a/docs/sprints/FEATURE-BADGES-TITLES-REWARDS.md
+++ b/docs/sprints/FEATURE-BADGES-TITLES-REWARDS.md
@@ -1,0 +1,128 @@
+# Feature — Badges, Titres & Récompenses
+
+> Source de vérité pour l'implémentation différée du système de badges, titres et récompenses.
+> Plan validé avec l'utilisateur le 2026-04-20.
+
+## Objectif
+
+Ajouter une progression méta-jeu qui reconnaît et met en valeur les actions des utilisateurs :
+- **Badges** — récompenses atomiques débloquées par action/seuil (tutoriel, dons, équipe créée, match joué, ligue créée, ligue terminée, etc.)
+- **Titres** — libellés portés par le coach (Mécène, Champion de la Coupe XXX 2026, Vétéran, Joueur assidu, etc.)
+- **Récompenses** — pour l'instant limitées aux points de profil + effets visuels. Cosmétiques reportés.
+
+## Décisions utilisateur
+
+| Sujet | Décision |
+|---|---|
+| Périmètre première PR | **P1 + P2 ensemble** (foundation + triggers match/cup) |
+| Provider donations | **Ko-fi** (webhook) — intégration réelle en P3, modèle Prisma créé en P1 |
+| Catalogue badges/titres | **Tout le catalogue proposé validé** |
+| Récompenses cosmétiques | **Hors périmètre V1** — revues ultérieurement |
+| Titre actif | **Un seul titre actif à la fois** par utilisateur |
+
+## Sprints
+
+| Sprint | Statut | Contenu |
+|---|---|---|
+| [SPRINT-6](./SPRINT-6-badges-foundation.md) | À implémenter | **P1** — Foundation : schéma Prisma, AchievementService, règles onboarding, endpoints profil |
+| [SPRINT-7](./SPRINT-7-badges-match-cup-triggers.md) | À implémenter | **P2** — Match & Cup triggers : hooks broadcast/forfeit, règles compétitives, titre dynamique champion |
+| SPRINT-8 (à écrire) | Future | **P3** — Intégration Ko-fi webhook + badges donor_* + titre Mécène |
+| SPRINT-9 (à écrire) | Future | **P4** — Tracking tutoriel détaillé + badges onboarding par palier |
+| SPRINT-10 (à écrire) | Future | **P5** — Frontend Web : pages `/me/badges`, `/me/titles`, profil public enrichi, toast unlock |
+| SPRINT-11 (à écrire) | Future | **P6** — Mobile : écran profil + push notification badge |
+| SPRINT-12 (à écrire) | Future | **P7** — Polish : badges secrets, daily streak, animations |
+
+## Modèles Prisma cibles (résumé)
+
+```prisma
+Badge           // catalogue statique (slug unique, category, tier, i18n)
+UserBadge       // débloqué par user (unique [userId, badgeId])
+Title           // catalogue statique (slug, scope static|dynamic, rarity)
+UserTitle       // débloqué par user (isActive bool, label finalisé, context JSON)
+TutorialProgress // par scriptSlug
+Donation        // provider=ko-fi|stripe|manual, amountCents, externalId
+UserStats       // compteurs agrégés dénormalisés
+```
+
+Ajouts au modèle `User` :
+- `badges UserBadge[]`
+- `titles UserTitle[]`
+- `activeTitleId String?`
+- `donations Donation[]`
+- `tutorialProgress TutorialProgress[]`
+- `stats UserStats?`
+- `profilePoints Int @default(0)`
+
+## Architecture logicielle
+
+```
+apps/server/src/services/achievements/
+├── index.ts                # dispatch(trigger, ctx)
+├── triggers.ts             # enum Trigger { TUTORIAL_COMPLETED, MATCH_ENDED, CUP_COMPLETED, ... }
+├── rules/
+│   ├── onboarding.rules.ts # first_team, first_match, profile_complete, tutorial_complete, ...
+│   ├── matches.rules.ts    # matches_played_N, winning_streak_N, flawless_victory, elo_N, ...
+│   ├── cups.rules.ts       # first_cup_created, cup_champion, cup_finisher, ...
+│   ├── social.rules.ts     # social_butterfly, sportsmanship, ...
+│   ├── donations.rules.ts  # donor_first, donor_silver, donor_gold, donor_legend
+│   └── fun.rules.ts        # night_owl, daily_streak_N, birthday_match, ...
+├── badge-grant.ts          # upsert UserBadge (idempotent)
+├── title-grant.ts          # upsert UserTitle + éventuel auto-activate
+├── stats-updater.ts        # incrémente UserStats
+└── notify.ts               # emit socket "user:badge-unlocked" + push notif
+```
+
+### Points d'intégration (call-sites)
+
+| Trigger | Call-site | Sprint |
+|---|---|---|
+| `TEAM_CREATED` | `apps/server/src/routes/team.ts` POST `/teams` | P1 |
+| `PROFILE_UPDATED` | `apps/server/src/routes/user.ts` PUT `/me` | P1 |
+| `TUTORIAL_STEP_COMPLETED` | nouveau POST `/api/me/tutorial-progress` | P1 |
+| `MATCH_ENDED` | `apps/server/src/services/game-broadcast.ts::broadcastMatchEnd` | P2 |
+| `MATCH_FORFEITED` | `apps/server/src/services/forfeit-tracker.ts` | P2 |
+| `CUP_CREATED` | `apps/server/src/routes/cup.ts` POST | P2 |
+| `CUP_COMPLETED` | endpoint cup status → `terminee` | P2 |
+| `DONATION_RECEIVED` | webhook Ko-fi `POST /api/donations/webhook/kofi` | P3 |
+| `LOGIN` | middleware auth (streak) | P7 |
+
+## API cible (résumé)
+
+```
+GET    /api/me/badges            # mes badges + progression
+GET    /api/me/titles            # mes titres + isActive
+PUT    /api/me/title             # body { titleId | null } → active
+GET    /api/users/:id/profile    # public : titre actif + vitrine badges non-hidden
+GET    /api/badges               # catalogue public (sans hidden)
+POST   /api/me/tutorial-progress # { scriptSlug, completed }
+POST   /api/donations/webhook/kofi  # webhook Ko-fi (P3)
+POST   /api/donations/manual     # admin only (P3)
+```
+
+## Catalogue badges validé (tous activés)
+
+**Onboarding (7)** : tutorial_started, tutorial_complete, first_team, roster_collector_bronze/silver/gold, first_match, first_win, profile_complete.
+
+**Compétition (13)** : matches_played_10/50/100/500, winning_streak_3/5/10, flawless_victory, comeback_king, shutout_master, quick_finish, goldsmith, elo_1500/1800/2000, forfeit_zero_50matches.
+
+**Coupes (6)** : first_cup_created, cup_finisher, cup_champion, cup_champion_x5/x10, cup_runner_up, community_organizer.
+
+**Faits du jeu (8)** : nuffle_loved, nuffle_cursed, kaboom, passmaster, interceptor_extraordinaire, mvp_collector, apothecary_hero, legendary_player.
+
+**Soutien & Communauté (6)** : donor_first, donor_silver, donor_gold, donor_legend, social_butterfly, sportsmanship.
+
+**Régularité / Fun (hidden=true, 5)** : night_owl, daily_streak_7/30, early_bird, easter_egg_konami, birthday_match.
+
+## Catalogue titres validé
+
+`rookie`, `veteran`, `assidu`, `mecene`, `grand_mecene`, `pilier`, `champion_cup` (dynamique), `vice_champion_cup` (dynamique), `bug_hunter`, `beta_tester`, `coach_elite`, `legende_vivante`, `taulier_du_terrain`, `nuffle_chosen`, `dev`.
+
+## Risques & invariants
+
+1. **Idempotence** : `@@unique [userId, badgeId]` sur `UserBadge` + `upsert` garantit aucune duplication.
+2. **Migration additive** : aucun risque de perte de données — tous les nouveaux modèles sont optionnels depuis `User`.
+3. **Patreon legacy** : `User.patreon` conservé en l'état (compatibilité), la logique dons s'appuie sur `Donation` + badges donor_*.
+4. **Performance** : `UserStats` évite les `count()` à chaque dispatch ; mises à jour incrémentales.
+5. **Titre actif unique** : à l'activation d'un titre, désactiver les autres dans une transaction Prisma.
+6. **Titre dynamique** : le `label` est figé à l'attribution (indépendant des renames de coupe).
+7. **i18n** : `nameFr/nameEn` suit le pattern existant (Skill, Roster).

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -12,8 +12,16 @@
 | **Sprint 3** | Frontend stabilization | 15 issues | Pending |
 | **Sprint 4** | Server & Security hardening | 14 issues | Pending |
 | **Sprint 5** | Test infrastructure & tech debt | 7 issues | Pending |
+| **Sprint 6** | Badges foundation (P1) | 7 tickets | Pending |
+| **Sprint 7** | Badges match & cup triggers (P2) | 7 tickets | Pending |
 
-**Total: 61 issues identified, 12 fixed.**
+**Total: 75 issues identified, 12 fixed.**
+
+## Feature — Badges, Titres & Récompenses
+
+Sprints 6 & 7 forment la **première PR** de la feature badges/titres/récompenses.
+Voir [FEATURE-BADGES-TITLES-REWARDS.md](./FEATURE-BADGES-TITLES-REWARDS.md) pour le plan global
+et les sprints P3 à P7 à venir (Ko-fi, tutoriel détaillé, frontend, mobile, polish).
 
 ## Sprint 1 — DONE
 
@@ -84,9 +92,35 @@ See [SPRINT-5-test-infrastructure.md](./SPRINT-5-test-infrastructure.md)
 - Regression tests for Sprint 1 fixes
 - Clean up empty scripts and dev notes
 
+## Sprint 6 — Badges Foundation (P1)
+
+See [SPRINT-6-badges-foundation.md](./SPRINT-6-badges-foundation.md)
+
+**Key items:**
+- Migration Prisma (Badge, UserBadge, Title, UserTitle, Donation, UserStats, TutorialProgress)
+- Seed catalogue badges + titres (validé utilisateur)
+- AchievementService (dispatch + grant + notify + idempotence)
+- 5 règles onboarding (first_team, profile_complete, tutorial_started/complete, roster_collector)
+- Endpoints `/api/me/badges`, `/api/me/titles`, `PUT /api/me/title`, `POST /api/me/tutorial-progress`
+- Hooks dans `routes/team.ts` et `routes/user.ts`
+
+## Sprint 7 — Badges Match & Cup Triggers (P2)
+
+See [SPRINT-7-badges-match-cup-triggers.md](./SPRINT-7-badges-match-cup-triggers.md)
+
+**Key items:**
+- Enum Trigger étendu (MATCH_ENDED, MATCH_FORFEITED, CUP_CREATED, CUP_COMPLETED)
+- Hooks dans `game-broadcast.ts`, `forfeit-tracker.ts`, `routes/cup.ts`
+- stats-updater étendu (match + cup)
+- matches.rules.ts (11 règles) + cups.rules.ts (7 règles) + game-facts.rules.ts (8 règles)
+- Titre dynamique `champion_cup` avec label figé à l'attribution
+- Titres `coach_elite`, `legende_vivante`, `taulier_du_terrain`, `veteran`
+- Endpoint `/api/me/badges` enrichi avec progression
+
 ## Priority Order
 
 1. **Sprint 2** — Game engine correctness is the foundation. Fixing state mutation and rule bugs prevents cascading issues.
 2. **Sprint 3** — Frontend stability directly affects user experience. Memory leaks and race conditions cause visible bugs.
 3. **Sprint 4** — Security hardening before production deployment. Required for any public-facing release.
 4. **Sprint 5** — Test infrastructure enables safe future development. Lower urgency but high long-term value.
+5. **Sprints 6 + 7** — New feature (badges/titres). Peut être implémentée en parallèle des sprints de stabilisation. Une seule PR combinant P1+P2.

--- a/docs/sprints/SPRINT-6-badges-foundation.md
+++ b/docs/sprints/SPRINT-6-badges-foundation.md
@@ -1,0 +1,458 @@
+# Sprint 6 — Badges Foundation (P1)
+
+> Phase 1 du système Badges/Titres/Récompenses. Voir [FEATURE-BADGES-TITLES-REWARDS.md](./FEATURE-BADGES-TITLES-REWARDS.md) pour le contexte global.
+> À implémenter **dans la même PR que [SPRINT-7](./SPRINT-7-badges-match-cup-triggers.md)**.
+
+## Objectif
+
+Poser les fondations :
+- Schéma Prisma complet (Badge, UserBadge, Title, UserTitle, Donation, UserStats, TutorialProgress)
+- Seed du catalogue de badges et titres
+- Service `AchievementService` (dispatch + règles + grant + notify)
+- Règles d'onboarding (5 règles minimum)
+- Endpoints profil `/api/me/badges`, `/api/me/titles`, `PUT /api/me/title`, `POST /api/me/tutorial-progress`
+- Intégration dans `routes/team.ts` et `routes/user.ts`
+
+## Tickets
+
+### 6.1 — Migration Prisma : nouveaux modèles
+
+**Fichier :** `prisma/schema.prisma`
+
+**Ajouts :**
+
+```prisma
+model Badge {
+  id            String      @id @default(cuid())
+  slug          String      @unique
+  category      String      // "onboarding" | "social" | "competitive" | "patron" | "veteran" | "fun"
+  tier          String      @default("bronze") // "bronze" | "silver" | "gold" | "platinum" | "legendary"
+  nameFr        String
+  nameEn        String
+  descriptionFr String
+  descriptionEn String
+  iconUrl       String?
+  points        Int         @default(10)
+  hidden        Boolean     @default(false)
+  createdAt     DateTime    @default(now())
+  userBadges    UserBadge[]
+  @@index([category])
+  @@index([hidden])
+}
+
+model UserBadge {
+  id         String   @id @default(cuid())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String
+  badge      Badge    @relation(fields: [badgeId], references: [id], onDelete: Cascade)
+  badgeId    String
+  unlockedAt DateTime @default(now())
+  context    Json?
+  @@unique([userId, badgeId])
+  @@index([userId])
+  @@index([badgeId])
+}
+
+model Title {
+  id         String      @id @default(cuid())
+  slug       String      @unique
+  scope      String      // "static" | "dynamic"
+  nameFr     String
+  nameEn     String
+  rarity     String      @default("common") // "common" | "rare" | "epic" | "legendary"
+  color      String?
+  createdAt  DateTime    @default(now())
+  userTitles UserTitle[]
+}
+
+model UserTitle {
+  id         String   @id @default(cuid())
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     String
+  title      Title    @relation(fields: [titleId], references: [id], onDelete: Cascade)
+  titleId    String
+  label      String
+  context    Json?
+  unlockedAt DateTime @default(now())
+  isActive   Boolean  @default(false)
+  @@unique([userId, titleId, label])
+  @@index([userId])
+  @@index([userId, isActive])
+}
+
+model TutorialProgress {
+  id          String    @id @default(cuid())
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  scriptSlug  String
+  completed   Boolean   @default(false)
+  completedAt DateTime?
+  @@unique([userId, scriptSlug])
+  @@index([userId])
+}
+
+model Donation {
+  id          String   @id @default(cuid())
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  amountCents Int
+  currency    String   @default("EUR")
+  provider    String   // "kofi" | "stripe" | "manual"
+  externalId  String?
+  message     String?
+  createdAt   DateTime @default(now())
+  @@index([userId])
+  @@index([createdAt])
+  @@index([provider, externalId])
+}
+
+model UserStats {
+  id                  String    @id @default(cuid())
+  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId              String    @unique
+  matchesPlayed       Int       @default(0)
+  matchesWon          Int       @default(0)
+  matchesLost         Int       @default(0)
+  matchesDrawn        Int       @default(0)
+  matchesForfeited    Int       @default(0)
+  currentWinStreak    Int       @default(0)
+  bestWinStreak       Int       @default(0)
+  touchdownsScored    Int       @default(0)
+  casualtiesInflicted Int       @default(0)
+  cupsCreated         Int       @default(0)
+  cupsCompleted       Int       @default(0)
+  cupsWon             Int       @default(0)
+  teamsCreated        Int       @default(0)
+  totalDonatedCents   Int       @default(0)
+  loginStreakDays     Int       @default(0)
+  lastLoginAt         DateTime?
+  updatedAt           DateTime  @updatedAt
+}
+```
+
+**Modifs du modèle `User` :**
+
+```prisma
+badges           UserBadge[]
+titles           UserTitle[]
+activeTitleId    String?
+donations        Donation[]
+tutorialProgress TutorialProgress[]
+stats            UserStats?
+profilePoints    Int                @default(0)
+```
+
+**Étapes :**
+1. Ajouter au schema
+2. `pnpm prisma migrate dev --name add_badges_titles_rewards`
+3. `pnpm prisma generate`
+4. `pnpm prisma validate`
+
+**Tests :** aucun (migration structurelle) — vérifier que `pnpm turbo build --filter=server` reste vert.
+
+---
+
+### 6.2 — Seed du catalogue Badge + Title
+
+**Fichiers :**
+- `prisma/seeds/badges.seed.ts` (nouveau)
+- `prisma/seeds/titles.seed.ts` (nouveau)
+- `prisma/seed.ts` (ajouter les appels)
+
+**Contenu badges.seed.ts** (extraits, liste complète dans FEATURE-BADGES-TITLES-REWARDS.md) :
+
+```ts
+export const BADGES = [
+  // Onboarding
+  { slug: "tutorial_started", category: "onboarding", tier: "bronze",
+    nameFr: "Apprenti coach", nameEn: "Apprentice coach",
+    descriptionFr: "Démarrer un tutoriel.", descriptionEn: "Started a tutorial.", points: 5 },
+  { slug: "tutorial_complete", category: "onboarding", tier: "silver",
+    nameFr: "Diplômé du Collège des Coachs", nameEn: "Coaching College Graduate",
+    descriptionFr: "Terminer tous les tutoriels.", descriptionEn: "Complete all tutorials.", points: 25 },
+  { slug: "first_team", category: "onboarding", tier: "bronze",
+    nameFr: "Premier recrutement", nameEn: "First recruitment",
+    descriptionFr: "Créer sa première équipe.", descriptionEn: "Create your first team.", points: 10 },
+  { slug: "first_match", category: "onboarding", tier: "bronze",
+    nameFr: "Baptême du feu", nameEn: "Baptism of fire",
+    descriptionFr: "Jouer son premier match.", descriptionEn: "Play your first match.", points: 10 },
+  { slug: "first_win", category: "onboarding", tier: "silver",
+    nameFr: "Première victoire", nameEn: "First victory",
+    descriptionFr: "Gagner son premier match.", descriptionEn: "Win your first match.", points: 15 },
+  { slug: "profile_complete", category: "onboarding", tier: "bronze",
+    nameFr: "Coach présentable", nameEn: "Presentable coach",
+    descriptionFr: "Profil complété (prénom, nom, date de naissance).",
+    descriptionEn: "Profile filled (first name, last name, date of birth).", points: 5 },
+  { slug: "roster_collector_bronze", category: "onboarding", tier: "bronze",
+    nameFr: "Collectionneur bronze", nameEn: "Bronze collector",
+    descriptionFr: "Posséder 3 rosters différents.", descriptionEn: "Own 3 different rosters.", points: 15 },
+  { slug: "roster_collector_silver", category: "onboarding", tier: "silver",
+    nameFr: "Collectionneur argent", nameEn: "Silver collector",
+    descriptionFr: "Posséder 6 rosters différents.", descriptionEn: "Own 6 different rosters.", points: 30 },
+  { slug: "roster_collector_gold", category: "onboarding", tier: "gold",
+    nameFr: "Collectionneur or", nameEn: "Gold collector",
+    descriptionFr: "Posséder tous les rosters.", descriptionEn: "Own all rosters.", points: 100 },
+  // TODO: ajouter Compétition (13), Coupes (6), Faits du jeu (8), Soutien (6), Fun hidden (5)
+  // Référence exhaustive : FEATURE-BADGES-TITLES-REWARDS.md
+];
+```
+
+**Contenu titles.seed.ts** :
+
+```ts
+export const TITLES = [
+  { slug: "rookie", scope: "static", nameFr: "Recrue", nameEn: "Rookie", rarity: "common", color: "#9ca3af" },
+  { slug: "veteran", scope: "static", nameFr: "Vétéran", nameEn: "Veteran", rarity: "rare", color: "#3b82f6" },
+  { slug: "assidu", scope: "static", nameFr: "Joueur assidu", nameEn: "Regular player", rarity: "common", color: "#14b8a6" },
+  { slug: "mecene", scope: "static", nameFr: "Mécène", nameEn: "Patron", rarity: "rare", color: "#f59e0b" },
+  { slug: "grand_mecene", scope: "static", nameFr: "Grand Mécène", nameEn: "Grand Patron", rarity: "epic", color: "#f97316" },
+  { slug: "pilier", scope: "static", nameFr: "Pilier de Nuffle", nameEn: "Pillar of Nuffle", rarity: "legendary", color: "#eab308" },
+  { slug: "champion_cup", scope: "dynamic",
+    nameFr: "Champion de la {cupName} {year}", nameEn: "Champion of {cupName} {year}",
+    rarity: "epic", color: "#eab308" },
+  { slug: "vice_champion_cup", scope: "dynamic",
+    nameFr: "Vice-champion de la {cupName} {year}", nameEn: "Runner-up of {cupName} {year}",
+    rarity: "rare", color: "#cbd5e1" },
+  { slug: "bug_hunter", scope: "static", nameFr: "Chasseur de bugs", nameEn: "Bug hunter", rarity: "rare", color: "#ef4444" },
+  { slug: "beta_tester", scope: "static", nameFr: "Bêta-testeur", nameEn: "Beta tester", rarity: "rare", color: "#8b5cf6" },
+  { slug: "coach_elite", scope: "static", nameFr: "Coach Élite", nameEn: "Elite Coach", rarity: "epic", color: "#ec4899" },
+  { slug: "legende_vivante", scope: "static", nameFr: "Légende vivante", nameEn: "Living legend", rarity: "legendary", color: "#eab308" },
+  { slug: "taulier_du_terrain", scope: "static", nameFr: "Taulier du terrain", nameEn: "Pitch boss", rarity: "epic", color: "#dc2626" },
+  { slug: "nuffle_chosen", scope: "static", nameFr: "L'Élu de Nuffle", nameEn: "Nuffle's Chosen", rarity: "legendary", color: "#a855f7" },
+  { slug: "dev", scope: "static", nameFr: "Dev de Nuffle Arena", nameEn: "Nuffle Arena Dev", rarity: "legendary", color: "#10b981" },
+];
+```
+
+**Tests :**
+- `tests/integration/seeds/badges-seed.test.ts` : après seed, `prisma.badge.count() === BADGES.length`, idempotence (seed 2x ne duplique pas).
+
+---
+
+### 6.3 — AchievementService : dispatch + grant + notify
+
+**Fichiers à créer :**
+
+```
+apps/server/src/services/achievements/
+├── index.ts
+├── triggers.ts
+├── types.ts
+├── badge-grant.ts
+├── title-grant.ts
+├── stats-updater.ts
+├── notify.ts
+└── rules/
+    └── onboarding.rules.ts
+```
+
+**`triggers.ts`** :
+
+```ts
+export enum Trigger {
+  TEAM_CREATED = "TEAM_CREATED",
+  PROFILE_UPDATED = "PROFILE_UPDATED",
+  TUTORIAL_STEP_COMPLETED = "TUTORIAL_STEP_COMPLETED",
+  // P2 : MATCH_ENDED, MATCH_FORFEITED, CUP_CREATED, CUP_COMPLETED
+  // P3 : DONATION_RECEIVED
+}
+```
+
+**`types.ts`** :
+
+```ts
+export interface AchievementContext {
+  userId: string;
+  [key: string]: unknown;
+}
+
+export interface RuleOutcome {
+  badgesToGrant: { slug: string; context?: unknown }[];
+  titlesToGrant: { slug: string; label: string; context?: unknown; autoActivate?: boolean }[];
+}
+
+export type Rule = (
+  trigger: Trigger,
+  ctx: AchievementContext,
+  prisma: PrismaClient
+) => Promise<RuleOutcome>;
+```
+
+**`index.ts`** (dispatcher, idempotent) :
+
+```ts
+export async function dispatch(
+  trigger: Trigger,
+  ctx: AchievementContext
+): Promise<{ newBadges: UserBadge[]; newTitles: UserTitle[] }> {
+  // 1. Update UserStats incrementally (stats-updater.ts)
+  // 2. Run all rules matching the trigger in parallel
+  // 3. Collect RuleOutcome[]
+  // 4. For each badge slug, call grantBadge() (idempotent upsert)
+  // 5. For each title, call grantTitle()
+  // 6. Notify via notify.ts if new unlocks
+  // 7. Return summary
+}
+```
+
+**`badge-grant.ts`** :
+
+```ts
+export async function grantBadge(
+  userId: string,
+  slug: string,
+  context?: unknown
+): Promise<UserBadge | null> {
+  const badge = await prisma.badge.findUnique({ where: { slug } });
+  if (!badge) throw new Error(`Unknown badge slug: ${slug}`);
+  try {
+    const ub = await prisma.userBadge.create({
+      data: { userId, badgeId: badge.id, context: context ?? undefined },
+    });
+    // Increment profilePoints
+    await prisma.user.update({
+      where: { id: userId },
+      data: { profilePoints: { increment: badge.points } },
+    });
+    return ub;
+  } catch (err) {
+    // Unique constraint violation = already unlocked (idempotent)
+    if (isPrismaUniqueError(err)) return null;
+    throw err;
+  }
+}
+```
+
+**`title-grant.ts`** : similaire + support activation (désactive les autres dans une transaction si `autoActivate`).
+
+**`notify.ts`** :
+
+```ts
+export function notifyUnlocks(userId: string, newBadges: UserBadge[], newTitles: UserTitle[]) {
+  const io = getSocketIO();
+  if (newBadges.length > 0 || newTitles.length > 0) {
+    io.to(`user:${userId}`).emit("user:badge-unlocked", { badges: newBadges, titles: newTitles });
+  }
+  // Push notification (optionnel) : réutiliser push-notifications.ts selon NotificationPreference
+}
+```
+
+**Tests :**
+- `tests/unit/services/achievements/badge-grant.test.ts` — grant idempotent, grant inconnu → erreur, increment profilePoints
+- `tests/unit/services/achievements/title-grant.test.ts` — grant + auto-activate désactive les autres
+- `tests/unit/services/achievements/dispatch.test.ts` — dispatch lance les règles, agrège, notifie
+- `tests/unit/services/achievements/stats-updater.test.ts` — incréments corrects
+
+---
+
+### 6.4 — Règles onboarding (5 minimum)
+
+**Fichier :** `apps/server/src/services/achievements/rules/onboarding.rules.ts`
+
+**Règles à implémenter :**
+
+1. `firstTeamRule` — sur `TEAM_CREATED`, si `stats.teamsCreated === 1` → badge `first_team`.
+2. `profileCompleteRule` — sur `PROFILE_UPDATED`, si `user.firstName && user.lastName && user.dateOfBirth` → badge `profile_complete`.
+3. `tutorialStartedRule` — sur `TUTORIAL_STEP_COMPLETED`, si c'est le premier step complété → badge `tutorial_started`.
+4. `tutorialCompleteRule` — sur `TUTORIAL_STEP_COMPLETED`, si **tous** les scripts disponibles du game-engine (`listTutorialScripts()`) sont `completed=true` → badge `tutorial_complete`.
+5. `rosterCollectorRule` — sur `TEAM_CREATED`, calculer le nombre de rosters distincts (SELECT DISTINCT roster) → badges bronze/silver/gold selon seuils 3/6/all.
+
+**Tests :** `tests/unit/services/achievements/rules/onboarding.rules.test.ts` — un test par règle + cas idempotence (ne ré-attribue pas un badge déjà présent).
+
+---
+
+### 6.5 — Schemas Zod
+
+**Fichier :** `apps/server/src/schemas/badges.schemas.ts`
+
+```ts
+export const tutorialProgressSchema = z.object({
+  scriptSlug: z.string().min(1).max(100),
+  completed: z.boolean(),
+});
+
+export const setActiveTitleSchema = z.object({
+  titleUserId: z.string().cuid().nullable(),
+});
+```
+
+**Tests :** `tests/unit/schemas/badges.schemas.test.ts` — valid/invalid inputs.
+
+---
+
+### 6.6 — Routes API profil
+
+**Fichiers :**
+- `apps/server/src/routes/me-badges.ts` (nouveau)
+- `apps/server/src/routes/me-titles.ts` (nouveau)
+- `apps/server/src/routes/public-badges.ts` (nouveau)
+- `apps/server/src/routes/public-profile.ts` (nouveau ou étendre existant)
+- `apps/server/src/app.ts` (monter les routes)
+
+**Endpoints :**
+
+```
+GET    /api/me/badges
+  → { badges: [{ slug, category, tier, nameFr, nameEn, unlockedAt, context }],
+      progress: [{ slug, current, target, percent }] }
+
+GET    /api/me/titles
+  → { titles: [{ id, slug, label, rarity, color, isActive, unlockedAt }] }
+
+PUT    /api/me/title
+  body: { titleUserId: string | null }
+  → { activeTitleId }
+  (transaction : désactive tous les UserTitle existants, active celui demandé)
+
+POST   /api/me/tutorial-progress
+  body: { scriptSlug, completed }
+  → upsert TutorialProgress + dispatch(TUTORIAL_STEP_COMPLETED)
+
+GET    /api/badges
+  → catalogue public (hidden exclus)
+
+GET    /api/users/:id/profile
+  → { user: { id, coachName, eloRating, activeTitle, badgesVitrine: [6 badges non-hidden] } }
+```
+
+**Tests :** `tests/integration/routes/me-badges.test.ts`, `me-titles.test.ts`, `public-badges.test.ts`, `public-profile.test.ts`.
+
+---
+
+### 6.7 — Intégration dans routes existantes
+
+**Modifications :**
+
+**`apps/server/src/routes/team.ts`** — après création équipe réussie :
+
+```ts
+await dispatch(Trigger.TEAM_CREATED, { userId, teamId: team.id, roster: team.roster });
+```
+
+**`apps/server/src/routes/user.ts`** — après update profil :
+
+```ts
+await dispatch(Trigger.PROFILE_UPDATED, { userId });
+```
+
+**Tests :** étendre `tests/integration/routes/team.test.ts` pour vérifier qu'un badge `first_team` est attribué après création.
+
+---
+
+## Checklist de complétion P1
+
+- [ ] 6.1 Migration Prisma appliquée, `prisma validate` vert
+- [ ] 6.2 Catalogue badges + titres seedé (idempotent)
+- [ ] 6.3 Service `AchievementService` implémenté + tests unit
+- [ ] 6.4 5 règles onboarding implémentées + tests unit
+- [ ] 6.5 Schemas Zod + tests
+- [ ] 6.6 4 routes API + tests integration
+- [ ] 6.7 Hooks dans `routes/team.ts` et `routes/user.ts`
+- [ ] Coverage >= 80% sur `services/achievements/**`
+- [ ] `pnpm turbo build` vert
+- [ ] `pnpm turbo test --filter=server` vert
+- [ ] `pnpm turbo lint` vert
+
+## Dépendances
+
+- **SPRINT-7** dépend de ce sprint (réutilise `dispatch`, `grantBadge`, `grantTitle`, `UserStats`).
+- **Aucune dépendance externe** : Ko-fi webhook reporté en P3.

--- a/docs/sprints/SPRINT-7-badges-match-cup-triggers.md
+++ b/docs/sprints/SPRINT-7-badges-match-cup-triggers.md
@@ -1,0 +1,292 @@
+# Sprint 7 — Badges Match & Cup Triggers (P2)
+
+> Phase 2 du système Badges/Titres/Récompenses. Dépend de [SPRINT-6](./SPRINT-6-badges-foundation.md).
+> À implémenter **dans la même PR** que SPRINT-6.
+
+## Objectif
+
+Brancher le système de badges sur les événements de match et de coupe :
+- Hook dans `game-broadcast.ts::broadcastMatchEnd`
+- Hook dans `forfeit-tracker.ts`
+- Hook dans routes `cup.ts` (création + fin de coupe)
+- Règles compétitives et coupes
+- Titre dynamique `champion_cup` avec interpolation du nom/année
+
+## Tickets
+
+### 7.1 — Triggers & hooks backend
+
+**Fichier :** `apps/server/src/services/achievements/triggers.ts`
+
+Ajouter :
+
+```ts
+export enum Trigger {
+  // ... P1
+  MATCH_ENDED = "MATCH_ENDED",
+  MATCH_FORFEITED = "MATCH_FORFEITED",
+  CUP_CREATED = "CUP_CREATED",
+  CUP_COMPLETED = "CUP_COMPLETED",
+}
+```
+
+**Call-sites :**
+
+#### `apps/server/src/services/game-broadcast.ts::broadcastMatchEnd`
+
+Après broadcast, pour **chaque participant** (2 joueurs normalement) :
+
+```ts
+await dispatch(Trigger.MATCH_ENDED, {
+  userId,
+  matchId,
+  won: boolean,          // victoire
+  drawn: boolean,
+  lost: boolean,
+  touchdownsScored: number,
+  touchdownsConceded: number,
+  casualtiesInflicted: number,
+  halfOfVictory: 1 | 2,  // pour quick_finish
+  maxScoreGapBeforeComeback: number, // pour comeback_king
+  finalElo: number,
+});
+```
+
+#### `apps/server/src/services/forfeit-tracker.ts`
+
+Quand un forfait est enregistré :
+
+```ts
+await dispatch(Trigger.MATCH_FORFEITED, { userId, matchId });
+```
+
+#### `apps/server/src/routes/cup.ts`
+
+Après création d'une Cup :
+
+```ts
+await dispatch(Trigger.CUP_CREATED, { userId: creatorId, cupId });
+```
+
+Après transition statut `terminee` (endpoint qui gère la fin de coupe) — pour **tous les participants** :
+
+```ts
+await dispatch(Trigger.CUP_COMPLETED, {
+  userId,
+  cupId,
+  cupName: cup.name,
+  year: new Date().getFullYear(),
+  finalRank: 1 | 2 | 3 | ..., // position finale
+  totalParticipants: number,
+});
+```
+
+**Tests :** `tests/integration/services/game-broadcast-achievements.test.ts` — vérifie que `dispatch` est appelé avec le bon contexte. Idem pour `forfeit-tracker` et `cup` routes.
+
+---
+
+### 7.2 — stats-updater : extensions match & cup
+
+**Fichier :** `apps/server/src/services/achievements/stats-updater.ts`
+
+Extensions requises :
+
+- Sur `MATCH_ENDED` :
+  - `matchesPlayed += 1`
+  - Si `won` : `matchesWon += 1`, `currentWinStreak += 1`, `bestWinStreak = max(bestWinStreak, currentWinStreak)`
+  - Si `lost` ou `drawn` : `currentWinStreak = 0`
+  - `touchdownsScored += ctx.touchdownsScored`
+  - `casualtiesInflicted += ctx.casualtiesInflicted`
+- Sur `MATCH_FORFEITED` : `matchesForfeited += 1`, `currentWinStreak = 0`
+- Sur `CUP_CREATED` : `cupsCreated += 1`
+- Sur `CUP_COMPLETED` : `cupsCompleted += 1`, si `finalRank === 1` : `cupsWon += 1`
+
+**Tests :** `tests/unit/services/achievements/stats-updater-match-cup.test.ts`.
+
+---
+
+### 7.3 — Règles compétitives (matches.rules.ts)
+
+**Fichier :** `apps/server/src/services/achievements/rules/matches.rules.ts`
+
+**Règles :**
+
+| Règle | Badge | Trigger | Condition |
+|---|---|---|---|
+| `firstMatchRule` | `first_match` | MATCH_ENDED | `stats.matchesPlayed === 1` |
+| `firstWinRule` | `first_win` | MATCH_ENDED | `won && stats.matchesWon === 1` |
+| `matchesPlayedMilestoneRule` | `matches_played_10/50/100/500` | MATCH_ENDED | seuils |
+| `winningStreakRule` | `winning_streak_3/5/10` | MATCH_ENDED | `stats.currentWinStreak >= N` |
+| `flawlessVictoryRule` | `flawless_victory` | MATCH_ENDED | `won && ctx.touchdownsConceded === 0` |
+| `comebackKingRule` | `comeback_king` | MATCH_ENDED | `won && ctx.maxScoreGapBeforeComeback >= 2` |
+| `shutoutMasterRule` | `shutout_master` | MATCH_ENDED | compter 5 matchs gagnés sans encaisser (requête Prisma sur Match history) |
+| `quickFinishRule` | `quick_finish` | MATCH_ENDED | `won && ctx.halfOfVictory === 1 && ctx.touchdownsScored === 4` |
+| `eloMilestoneRule` | `elo_1500/1800/2000` | MATCH_ENDED | `ctx.finalElo >= N` |
+| `forfeitZeroRule` | `forfeit_zero_50matches` | MATCH_ENDED | `stats.matchesPlayed >= 50 && stats.matchesForfeited === 0` |
+| `goldsmithRule` | `goldsmith` | MATCH_ENDED | cumul trésoreries distribuées >= 1_000_000 (requête sur Team history) |
+
+**Tests :** `tests/unit/services/achievements/rules/matches.rules.test.ts` — un test par règle + idempotence.
+
+---
+
+### 7.4 — Règles coupes (cups.rules.ts)
+
+**Fichier :** `apps/server/src/services/achievements/rules/cups.rules.ts`
+
+**Règles :**
+
+| Règle | Badge/Titre | Trigger | Condition |
+|---|---|---|---|
+| `firstCupCreatedRule` | badge `first_cup_created` | CUP_CREATED | `stats.cupsCreated === 1` |
+| `communityOrganizerRule` | badge `community_organizer` | CUP_CREATED | `stats.cupsCreated >= 5` |
+| `cupFinisherRule` | badge `cup_finisher` | CUP_COMPLETED | toujours |
+| `cupChampionRule` | badge `cup_champion` + titre dynamique `champion_cup` | CUP_COMPLETED | `ctx.finalRank === 1` |
+| `cupChampionX5Rule` | badge `cup_champion_x5` | CUP_COMPLETED | `stats.cupsWon >= 5` |
+| `cupChampionX10Rule` | badge `cup_champion_x10` | CUP_COMPLETED | `stats.cupsWon >= 10` |
+| `cupRunnerUpRule` | badge `cup_runner_up` + titre dynamique `vice_champion_cup` | CUP_COMPLETED | `ctx.finalRank === 2` |
+
+**Titre dynamique (champion) — construction du label :**
+
+```ts
+const title = await prisma.title.findUnique({ where: { slug: "champion_cup" } });
+const label = title.nameFr
+  .replace("{cupName}", ctx.cupName)
+  .replace("{year}", String(ctx.year));
+// ex: "Champion de la Coupe d'Hiver 2026"
+
+await grantTitle(userId, "champion_cup", label, {
+  context: { cupId: ctx.cupId, cupName: ctx.cupName, year: ctx.year },
+  autoActivate: false, // l'utilisateur choisira via PUT /api/me/title
+});
+```
+
+**Tests :** `tests/unit/services/achievements/rules/cups.rules.test.ts`.
+
+---
+
+### 7.5 — Règles "faits du jeu" (game-facts.rules.ts)
+
+**Fichier :** `apps/server/src/services/achievements/rules/game-facts.rules.ts`
+
+Règles dépendant d'événements intra-match (à collecter dans `ctx`) :
+
+| Règle | Badge | Trigger | Condition |
+|---|---|---|---|
+| `kaboomRule` | `kaboom` | MATCH_ENDED | `ctx.casualtiesInflictedThisMatch >= 5` |
+| `passmasterRule` | `passmaster` | MATCH_ENDED | cumul passes longues réussies >= 10 (requête) |
+| `interceptorRule` | `interceptor_extraordinaire` | MATCH_ENDED | cumul interceptions >= 5 |
+| `mvpCollectorRule` | `mvp_collector` | MATCH_ENDED | cumul `totalMvpAwards` sur TeamPlayer du user >= 25 |
+| `apothecaryHeroRule` | `apothecary_hero` | MATCH_ENDED | cumul apothécaire-saves >= 10 (nécessite tracking dédié) |
+| `legendaryPlayerRule` | `legendary_player` | MATCH_ENDED | existe un `TeamPlayer` du user avec `spp >= 51` |
+| `nuffleLovedRule` | `nuffle_loved` (hidden) | MATCH_ENDED | ctx détection 6 double-skull évités |
+| `nuffleCursedRule` | `nuffle_cursed` (hidden) | MATCH_ENDED | ctx détection 3 "1" sur dés cruciaux dans le match |
+
+**Collecte de contexte** : nécessitera une extension dans `game-engine` pour remonter un résumé d'événements par match. Dans `broadcastMatchEnd`, passer à `dispatch` :
+
+```ts
+{
+  ...
+  casualtiesInflictedThisMatch: number,
+  longPassesCompleted: number,
+  interceptionsThisMatch: number,
+  apothecarySaves: number,
+  doubleSkullsAvoided: number,
+  criticalOnesRolled: number,
+}
+```
+
+**Si la collecte de certains sous-événements n'est pas triviale** (`apothecarySaves`, `doubleSkullsAvoided`), les marquer comme **TODO** dans le sprint : implémenter les règles avec fallback `0` et créer un ticket follow-up pour enrichir le résumé d'événements.
+
+**Tests :** `tests/unit/services/achievements/rules/game-facts.rules.test.ts`.
+
+---
+
+### 7.6 — Titre "coach_elite" sur ELO
+
+**Fichier :** `apps/server/src/services/achievements/rules/matches.rules.ts`
+
+Règle supplémentaire :
+
+```ts
+coachEliteTitleRule:
+  on MATCH_ENDED,
+  if ctx.finalElo >= 1800:
+    grantTitle(userId, "coach_elite", "Coach Élite", { autoActivate: false });
+```
+
+Et `legende_vivante` titre :
+
+```ts
+legendeVivanteTitleRule:
+  on MATCH_ENDED,
+  if stats.matchesPlayed >= 500:
+    grantTitle(userId, "legende_vivante", "Légende vivante", { autoActivate: false });
+```
+
+Et `taulier_du_terrain` titre :
+
+```ts
+taulierRule:
+  on MATCH_ENDED,
+  if stats.matchesWon >= 100:
+    grantTitle(userId, "taulier_du_terrain", "Taulier du terrain", { autoActivate: false });
+```
+
+Et `veteran` titre :
+
+```ts
+veteranRule:
+  on MATCH_ENDED,
+  if stats.matchesPlayed >= 100:
+    grantTitle(userId, "veteran", "Vétéran", { autoActivate: false });
+```
+
+**Tests :** couvrir dans `matches.rules.test.ts`.
+
+---
+
+### 7.7 — Route enrichie : GET /api/me/badges avec progression
+
+**Fichier :** `apps/server/src/routes/me-badges.ts`
+
+Étendre la réponse pour inclure la progression sur badges non-débloqués (pour affichage UI "83% → matches_played_100") :
+
+```ts
+progress: [
+  { slug: "matches_played_100", current: 83, target: 100, percent: 83 },
+  { slug: "winning_streak_10", current: 4, target: 10, percent: 40 },
+  ...
+]
+```
+
+Calculs basés sur `UserStats`.
+
+**Tests :** `tests/integration/routes/me-badges-progress.test.ts`.
+
+---
+
+## Checklist de complétion P2
+
+- [ ] 7.1 Enum `Trigger` étendu, hooks dans `game-broadcast.ts`, `forfeit-tracker.ts`, `routes/cup.ts`
+- [ ] 7.2 `stats-updater.ts` étendu (match + cup) + tests
+- [ ] 7.3 `matches.rules.ts` (11 règles) + tests
+- [ ] 7.4 `cups.rules.ts` (7 règles) + tests + titre dynamique `champion_cup` fonctionnel
+- [ ] 7.5 `game-facts.rules.ts` (8 règles) + tests (fallback `0` si contexte absent, avec TODO)
+- [ ] 7.6 Titres `coach_elite`, `legende_vivante`, `taulier_du_terrain`, `veteran` branchés
+- [ ] 7.7 Endpoint `/api/me/badges` retourne la progression
+- [ ] Coverage >= 80% sur `services/achievements/**`
+- [ ] `pnpm turbo build` vert
+- [ ] `pnpm turbo test` vert
+- [ ] Test E2E minimal : jouer un match → badge `first_match` débloqué (via Playwright ou test integration bout-en-bout)
+
+## Dépendances & ordre
+
+1. **SPRINT-6 doit être complété** (service `dispatch`, `grantBadge`, `grantTitle`, `UserStats`, seed catalogue).
+2. Les règles 7.5 game-facts nécessitent parfois des sous-données non triviales — implémenter avec fallback et marquer TODO.
+3. **Toutes les règles P2 doivent être idempotentes** : un match re-broadcasté 2x ne doit pas créer de doublons.
+
+## Points d'attention
+
+- **Transactions** : la mise à jour `UserStats` et le grant de badges doivent être dans la même transaction Prisma quand le stat `UserStats.N` est la condition d'un badge, sinon race condition possible.
+- **Cup finalRank** : la logique de classement existe déjà dans `apps/server/src/services/cup-ranking.ts` (à confirmer lors de l'implémentation). Réutiliser, ne pas dupliquer.
+- **Shutout / Goldsmith** : nécessitent des requêtes d'historique — limiter à la fenêtre des 5 derniers matchs / total cumulé du user, avec index approprié.


### PR DESCRIPTION
## Résumé

Ajout de la documentation complète pour les Sprints 6 et 7 du système Badges/Titres/Récompenses :
- **SPRINT-6** (P1) : fondations du système (schéma Prisma, seed catalogue, AchievementService, règles onboarding, endpoints API profil)
- **SPRINT-7** (P2) : intégration des triggers match/coupe (hooks broadcast/forfeit, règles compétitives, titres dynamiques)
- **FEATURE-BADGES-TITLES-REWARDS.md** : document de référence global avec architecture, décisions utilisateur, catalogue complet

Ces documents servent de source de vérité pour l'implémentation et incluent :
- Tickets détaillés avec fichiers, code snippets et tests attendus
- Checklists de complétion
- Points d'attention (transactions, idempotence, performance)
- Dépendances entre sprints

## Checklist

- [x] Documentation structurée et complète
- [x] Références croisées entre documents
- [x] Checklists de complétion pour chaque sprint
- [x] Exemples de code et schémas Prisma
- [x] Tests unitaires et intégration spécifiés
- [x] README.md mis à jour avec liens et résumés

## Notes

- Les Sprints 6 et 7 doivent être implémentés dans la **même PR** (dépendance étroite)
- Les Sprints 8-12 (P3-P7) sont documentés dans FEATURE-BADGES-TITLES-REWARDS.md mais à spécifier ultérieurement
- Aucun changement de code source — documentation uniquement

https://claude.ai/code/session_017sovjHj2Zea4JYF5R12hu2