### PR TITLE
feat(social): N.8 badges Maitre par equipe prioritaire

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -285,7 +285,7 @@
 | N.5 | Systeme d'amis (ajout, invitation, statut en ligne) | Social | [x] |
 | N.6 | Historique de matchs avec stats de carriere (par equipe, par joueur) | Social | [x] |
 | N.7 | Systeme d'achievements (succes) | Social | [x] |
-| N.8 | Badges "Maitre" par equipe prioritaire (gagner X matchs avec chaque) | Social | [ ] |
+| N.8 | Badges "Maitre" par equipe prioritaire (gagner X matchs avec chaque) | Social | [x] |
 
 ### Sprint 17 — Infrastructure Competitive : ligues (~8 jours, ex-Sprint 14)
 

--- a/apps/server/src/services/achievements.test.ts
+++ b/apps/server/src/services/achievements.test.ts
@@ -37,6 +37,7 @@ const baseStats = (
   casualties: 0,
   friendsCount: 0,
   rostersPlayed: new Set<string>(),
+  winsByRoster: new Map<string, number>(),
   ...overrides,
 });
 
@@ -118,6 +119,79 @@ describe("Rule: evaluateAchievements", () => {
   });
 });
 
+describe("Rule: Master roster badges (N.8)", () => {
+  const PRIORITY = [
+    "skaven",
+    "lizardmen",
+    "dwarf",
+    "gnome",
+    "imperial_nobility",
+  ];
+
+  it("exposes a 'master-<roster>' achievement for each priority team", () => {
+    for (const roster of PRIORITY) {
+      const ach = ACHIEVEMENTS_CATALOG.find((a) => a.slug === `master-${roster}`);
+      expect(ach, `missing master-${roster}`).toBeDefined();
+      expect(ach!.category).toBe("rosters");
+    }
+  });
+
+  it("each master badge requires exactly 5 wins with the roster", () => {
+    for (const roster of PRIORITY) {
+      const ach = ACHIEVEMENTS_CATALOG.find((a) => a.slug === `master-${roster}`)!;
+      expect(
+        ach.predicate(
+          baseStats({ winsByRoster: new Map([[roster, 4]]) }),
+        ),
+      ).toBe(false);
+      expect(
+        ach.predicate(
+          baseStats({ winsByRoster: new Map([[roster, 5]]) }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("master badge is scoped to its own roster (no cross-counting)", () => {
+    const masterSkaven = ACHIEVEMENTS_CATALOG.find(
+      (a) => a.slug === "master-skaven",
+    )!;
+    expect(
+      masterSkaven.predicate(
+        baseStats({ winsByRoster: new Map([["dwarf", 100]]) }),
+      ),
+    ).toBe(false);
+    expect(
+      masterSkaven.predicate(
+        baseStats({
+          winsByRoster: new Map([
+            ["skaven", 5],
+            ["dwarf", 0],
+          ]),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("renames the legacy 'roster-<roster>' badges to 'Pioneer' semantics", () => {
+    const pioneer = ACHIEVEMENTS_CATALOG.find((a) => a.slug === "roster-skaven")!;
+    expect(pioneer.nameFr.toLowerCase()).toContain("pionnier");
+    expect(pioneer.nameEn.toLowerCase()).toContain("pioneer");
+    expect(pioneer.predicate(baseStats({ rostersPlayed: new Set(["skaven"]) }))).toBe(
+      true,
+    );
+  });
+
+  it("evaluateAchievements unlocks master badge when wins threshold reached", () => {
+    const result = evaluateAchievements(
+      baseStats({ winsByRoster: new Map([["skaven", 5]]) }),
+      new Set<string>(),
+    );
+    expect(result).toContain("master-skaven");
+    expect(result).not.toContain("master-dwarf");
+  });
+});
+
 describe("unlockAchievements", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -167,6 +241,56 @@ describe("getUserAchievements (lazy evaluation)", () => {
     const matches10 = result.achievements.find((a) => a.slug === "matches-10");
     expect(matches10?.unlocked).toBe(false);
     expect(matches10?.unlockedAt).toBeNull();
+  });
+
+  it("computes winsByRoster per roster for master badges (N.8)", async () => {
+    mockPrisma.userAchievement.findMany.mockResolvedValue([]);
+    const buildSelection = (
+      selId: string,
+      roster: string,
+      myScore: number,
+      oppScore: number,
+    ) => ({
+      id: selId,
+      userId: "user-1",
+      teamRef: { roster },
+      match: {
+        id: `m-${selId}`,
+        status: "ended",
+        turns: [
+          {
+            payload: {
+              gameState: {
+                score: { teamA: myScore, teamB: oppScore },
+                players: [],
+                matchStats: {},
+              },
+            },
+          },
+        ],
+        teamSelections: [
+          { id: selId, userId: "user-1" },
+          { id: `opp-${selId}`, userId: "user-x" },
+        ],
+      },
+    });
+    // 3 wins with skaven, 1 loss with skaven, 2 wins with dwarf
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      buildSelection("s1", "skaven", 2, 0),
+      buildSelection("s2", "skaven", 3, 1),
+      buildSelection("s3", "skaven", 4, 1),
+      buildSelection("s4", "skaven", 0, 2),
+      buildSelection("s5", "dwarf", 1, 0),
+      buildSelection("s6", "dwarf", 2, 1),
+    ]);
+    mockPrisma.friendship.count.mockResolvedValue(0);
+    mockPrisma.userAchievement.createMany.mockResolvedValue({ count: 0 });
+
+    const result = await getUserAchievements("user-1");
+
+    const winsByRoster = result.stats.winsByRoster ?? {};
+    expect(winsByRoster.skaven).toBe(3);
+    expect(winsByRoster.dwarf).toBe(2);
   });
 
   it("unlocks new achievements on first read when stats suffice", async () => {

--- a/apps/server/src/services/achievements.ts
+++ b/apps/server/src/services/achievements.ts
@@ -33,6 +33,7 @@ export interface UserAchievementStats {
   casualties: number;
   friendsCount: number;
   rostersPlayed: Set<string>;
+  winsByRoster: Map<string, number>;
 }
 
 export interface AchievementDefinition {
@@ -59,8 +60,9 @@ export interface AchievementView {
 }
 
 export interface UserAchievementsResult {
-  stats: Omit<UserAchievementStats, "rostersPlayed"> & {
+  stats: Omit<UserAchievementStats, "rostersPlayed" | "winsByRoster"> & {
     rostersPlayed: string[];
+    winsByRoster: Record<string, number>;
   };
   achievements: AchievementView[];
 }
@@ -94,13 +96,23 @@ const MILESTONE_CASUALTIES: Array<[string, number, string, string, string]> = [
   ["cas-100", 100, "Boucher", "Butcher", "Infliger 100 sorties"],
 ];
 
+/**
+ * Priority rosters (Sprint 13/14 MVP scope): each gets two achievements —
+ *  - `roster-<slug>` (Pionnier/Pioneer) : play one match with the team
+ *  - `master-<slug>` (Maître/Master) : win N.8-threshold matches with the team
+ *
+ * Tuple : [roster slug, FR team name, EN team name]
+ */
 const PRIORITY_ROSTERS: Array<[string, string, string]> = [
-  ["skaven", "Maître des Skavens", "Skaven master"],
-  ["lizardmen", "Maître des Hommes-Lézards", "Lizardmen master"],
-  ["dwarf", "Maître des Nains", "Dwarf master"],
-  ["gnome", "Maître des Gnomes", "Gnome master"],
-  ["imperial_nobility", "Maître de la Noblesse Impériale", "Imperial Nobility master"],
+  ["skaven", "Skavens", "Skaven"],
+  ["lizardmen", "Hommes-Lézards", "Lizardmen"],
+  ["dwarf", "Nains", "Dwarf"],
+  ["gnome", "Gnomes", "Gnome"],
+  ["imperial_nobility", "Noblesse Impériale", "Imperial Nobility"],
 ];
+
+/** Minimum wins with a priority roster required to earn its Master badge. */
+export const MASTER_ROSTER_WINS_THRESHOLD = 5;
 
 function buildCatalog(): AchievementDefinition[] {
   const catalog: AchievementDefinition[] = [];
@@ -181,13 +193,24 @@ function buildCatalog(): AchievementDefinition[] {
   for (const [roster, nameFr, nameEn] of PRIORITY_ROSTERS) {
     catalog.push({
       slug: `roster-${roster}`,
-      nameFr,
-      nameEn,
+      nameFr: `Pionnier des ${nameFr}`,
+      nameEn: `${nameEn} pioneer`,
       descriptionFr: `Jouer un match avec l'équipe ${nameFr}`,
       descriptionEn: `Play a match with the ${nameEn} team`,
       category: "rosters",
       icon: "⚔️",
       predicate: (s) => s.rostersPlayed.has(roster),
+    });
+    catalog.push({
+      slug: `master-${roster}`,
+      nameFr: `Maître des ${nameFr}`,
+      nameEn: `${nameEn} master`,
+      descriptionFr: `Gagner ${MASTER_ROSTER_WINS_THRESHOLD} matchs avec l'équipe ${nameFr}`,
+      descriptionEn: `Win ${MASTER_ROSTER_WINS_THRESHOLD} matches with the ${nameEn} team`,
+      category: "rosters",
+      icon: "👑",
+      predicate: (s) =>
+        (s.winsByRoster.get(roster) ?? 0) >= MASTER_ROSTER_WINS_THRESHOLD,
     });
   }
 
@@ -297,6 +320,7 @@ export async function computeUserStats(
   let touchdowns = 0;
   let casualties = 0;
   const rostersPlayed = new Set<string>();
+  const winsByRoster = new Map<string, number>();
 
   for (const sel of selections) {
     if (!sel.match || sel.match.status !== "ended") continue;
@@ -317,8 +341,12 @@ export async function computeUserStats(
       teamSide === "A" ? gs.score?.teamB ?? 0 : gs.score?.teamA ?? 0;
 
     touchdowns += myScore;
-    if (myScore > oppScore) wins += 1;
-    else if (myScore < oppScore) losses += 1;
+    if (myScore > oppScore) {
+      wins += 1;
+      if (roster) {
+        winsByRoster.set(roster, (winsByRoster.get(roster) ?? 0) + 1);
+      }
+    } else if (myScore < oppScore) losses += 1;
     else draws += 1;
 
     const players = gs.players ?? [];
@@ -347,6 +375,7 @@ export async function computeUserStats(
     casualties,
     friendsCount,
     rostersPlayed,
+    winsByRoster,
   };
 }
 
@@ -404,6 +433,7 @@ export async function getUserAchievements(
       casualties: stats.casualties,
       friendsCount: stats.friendsCount,
       rostersPlayed: Array.from(stats.rostersPlayed),
+      winsByRoster: Object.fromEntries(stats.winsByRoster),
     },
     achievements,
   };

--- a/apps/web/app/me/achievements/page.tsx
+++ b/apps/web/app/me/achievements/page.tsx
@@ -25,6 +25,7 @@ interface StatsSummary {
   casualties: number;
   friendsCount: number;
   rostersPlayed: string[];
+  winsByRoster?: Record<string, number>;
 }
 
 interface AchievementsResponse {


### PR DESCRIPTION
## Resume

- Ajoute un achievement `master-<roster>` ("Maitre des <equipe>", icone 👑) qui se debloque apres **5 victoires** avec chacune des 5 equipes prioritaires (Skaven, Hommes-Lezards, Nains, Gnomes, Noblesse Imperiale).
- Nouveau champ `winsByRoster: Map<string, number>` dans `UserAchievementStats`, calcule dans `computeUserStats` a partir des matches `ended` et du score final.
- Renomme les achievements `roster-<roster>` existants en "Pionnier des <equipe>" pour refleter leur vrai predicat (jouer 1 match), liberant le label "Maitre" pour le nouvel achievement.
- Seuil centralise : `MASTER_ROSTER_WINS_THRESHOLD = 5`.

## Tache roadmap

Sprint 16 — N.8 : Badges "Maitre" par equipe prioritaire (gagner X matchs avec chaque).

## Plan de test

- [x] `pnpm --filter=@bb/server test` → 420/420 tests passent (18 tests sur `achievements.test.ts`, dont 6 nouveaux pour N.8).
- [x] `pnpm --filter=web test` → 222/222 tests passent (UI achievements inchangee fonctionnellement).
- [x] `pnpm --filter=@bb/game-engine test` → 4025/4025 tests passent.
- [x] `pnpm --filter=@bb/server typecheck` → OK.
- [ ] Verification manuelle : jouer 5 victoires avec les Skavens et verifier que le badge "Maitre des Skavens" apparait sur `/me/achievements`.
- [ ] Verification : le badge "Pionnier des Skavens" reste debloque apres le 1er match joue.
