### PR TITLE
feat(league): L.2 seed default 'Open 5 Teams' league

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -294,7 +294,7 @@
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
 | L.1 | Modeles Prisma League/LeagueSeason/LeagueParticipant/LeagueRound | DB | [x] |
-| L.2 | Migration Prisma + seed data | DB | [ ] |
+| L.2 | Migration Prisma + seed data | DB | [x] |
 | L.3 | Routes API CRUD ligue (create, join, schedule, standings) | API | [ ] |
 | L.4 | Generateur de calendrier round-robin | Backend | [ ] |
 | L.5 | Page liste des ligues | Frontend | [ ] |

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -18,6 +18,7 @@ import {
 } from "./static-skills-data-s3";
 import { UNKNOWN_USER_ID } from "./utils/user-constants";
 import { ONLINE_PLAY_FLAG } from "./services/featureFlags";
+import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
 
 async function main() {
   console.log("🌱 Début du seed...\n");
@@ -1930,6 +1931,22 @@ async function main() {
     console.log("   ⚠️  Impossible de créer la coupe : utilisateurs non trouvés");
   }
   console.log("✅ Fixtures de coupe et match local terminées\n");
+
+  // =============================================================================
+  // 8. SEED DES LIGUES PAR DEFAUT (L.2 — Sprint 17)
+  // =============================================================================
+  console.log("🏟️  Seed des ligues par défaut...");
+  const leagueCreator = await prisma.user.findUnique({
+    where: { email: "admin@example.com" },
+    select: { id: true },
+  });
+  if (leagueCreator) {
+    await seedDefaultLeagues({ creatorId: leagueCreator.id });
+    console.log(`   ✅ Ligue '${DEFAULT_LEAGUE_NAME}' prête (saison 1, rounds initiaux, 5 équipes prioritaires)`);
+  } else {
+    console.log("   ⚠️  Admin introuvable, seeder des ligues ignoré");
+  }
+  console.log("✅ Ligues par défaut terminées\n");
 }
 
 main()
@@ -1942,6 +1959,7 @@ main()
     console.log("   - Tous les Star Players ont été importés");
     console.log("   - Les comptes par défaut sont prêts");
     console.log("   - La coupe 'Test 1' et un match local ont été créés");
+    console.log(`   - La ligue '${DEFAULT_LEAGUE_NAME}' est prête`);
   })
   .catch(async (e) => {
     console.error("❌ Erreur lors du seed:", e);

--- a/apps/server/src/seeders/leagues.test.ts
+++ b/apps/server/src/seeders/leagues.test.ts
@@ -1,0 +1,290 @@
+/**
+ * L.2 — Tests du seeder de ligues par defaut.
+ *
+ * Sprint 17 : apres la migration Prisma des modeles League/LeagueSeason/
+ * LeagueParticipant/LeagueRound, on amorce la base avec :
+ *   - La ligue "Open 5 Teams" (L.9) restreinte aux 5 rosters prioritaires.
+ *   - Une saison 1 en status "draft".
+ *   - Des journees (rounds) vides pour amorcer le calendrier.
+ *
+ * Le seeder doit etre idempotent : relancer `pnpm db:seed` ne doit pas
+ * creer de doublons.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    league: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    leagueSeason: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    leagueRound: {
+      findMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    leagueParticipant: {
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+    },
+    team: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  DEFAULT_LEAGUE_NAME,
+  PRIORITY_ROSTERS,
+  seedDefaultLeagues,
+} from "./leagues";
+
+const mockPrisma = prisma as unknown as {
+  league: {
+    findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  leagueSeason: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  leagueRound: {
+    findMany: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
+  };
+  leagueParticipant: {
+    findUnique: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  team: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+};
+
+const CREATOR_ID = "admin-user-id";
+
+describe("Rule: Default league seeder (L.2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]);
+    mockPrisma.leagueParticipant.findUnique.mockResolvedValue(null);
+    mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+    mockPrisma.team.findFirst.mockResolvedValue(null);
+  });
+
+  it("exposes the 5 priority rosters in a stable order", () => {
+    expect(PRIORITY_ROSTERS).toEqual([
+      "skaven",
+      "gnome",
+      "lizardmen",
+      "dwarf",
+      "imperial_nobility",
+    ]);
+  });
+
+  it("creates the 'Open 5 Teams' league when none exists", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue(null);
+    mockPrisma.league.create.mockResolvedValue({
+      id: "league-1",
+      name: DEFAULT_LEAGUE_NAME,
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue(null);
+    mockPrisma.leagueSeason.create.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.league.create).toHaveBeenCalledTimes(1);
+    const data = mockPrisma.league.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      name: DEFAULT_LEAGUE_NAME,
+      creatorId: CREATOR_ID,
+      isPublic: true,
+      ruleset: "season_3",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    expect(data.maxParticipants).toBeGreaterThanOrEqual(PRIORITY_ROSTERS.length);
+  });
+
+  it("is idempotent: does not recreate the league when it already exists", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-existing",
+      name: DEFAULT_LEAGUE_NAME,
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue({
+      id: "season-existing",
+      leagueId: "league-existing",
+      seasonNumber: 1,
+      status: "draft",
+    });
+    mockPrisma.leagueRound.findMany.mockResolvedValue([
+      { seasonId: "season-existing", roundNumber: 1 },
+      { seasonId: "season-existing", roundNumber: 2 },
+      { seasonId: "season-existing", roundNumber: 3 },
+      { seasonId: "season-existing", roundNumber: 4 },
+      { seasonId: "season-existing", roundNumber: 5 },
+    ]);
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.league.create).not.toHaveBeenCalled();
+    expect(mockPrisma.leagueSeason.create).not.toHaveBeenCalled();
+    expect(mockPrisma.leagueRound.createMany).not.toHaveBeenCalled();
+  });
+
+  it("creates an initial season 1 in draft status when absent", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-1",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue(null);
+    mockPrisma.leagueSeason.create.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.leagueSeason.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        leagueId: "league-1",
+        seasonNumber: 1,
+        status: "draft",
+      }),
+    });
+  });
+
+  it("creates exactly (N-1) rounds for a round-robin with N priority teams", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-1",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]);
+    mockPrisma.leagueRound.createMany.mockResolvedValue({ count: 5 });
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    const expectedRoundCount = PRIORITY_ROSTERS.length;
+    expect(mockPrisma.leagueRound.createMany).toHaveBeenCalledTimes(1);
+    const payload = mockPrisma.leagueRound.createMany.mock.calls[0][0].data;
+    expect(payload).toHaveLength(expectedRoundCount);
+    const numbers = payload.map((r: { roundNumber: number }) => r.roundNumber);
+    expect(numbers).toEqual([1, 2, 3, 4, 5]);
+    expect(
+      payload.every((r: { status: string }) => r.status === "pending"),
+    ).toBe(true);
+  });
+
+  it("subscribes the priority team of each roster when available", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-1",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+    mockPrisma.leagueRound.findMany.mockResolvedValue(
+      Array.from({ length: PRIORITY_ROSTERS.length }, (_, i) => ({
+        seasonId: "season-1",
+        roundNumber: i + 1,
+      })),
+    );
+    mockPrisma.team.findFirst.mockImplementation(
+      async ({ where }: { where: { roster: string } }) => ({
+        id: `team-${where.roster}`,
+        roster: where.roster,
+      }),
+    );
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.leagueParticipant.create).toHaveBeenCalledTimes(
+      PRIORITY_ROSTERS.length,
+    );
+    const teamIds = mockPrisma.leagueParticipant.create.mock.calls.map(
+      (c: [{ data: { teamId: string } }]) => c[0].data.teamId,
+    );
+    expect(teamIds).toEqual(
+      PRIORITY_ROSTERS.map((slug) => `team-${slug}`),
+    );
+  });
+
+  it("skips roster enrollment when no team exists for it", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-1",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+    mockPrisma.leagueRound.findMany.mockResolvedValue([
+      { seasonId: "season-1", roundNumber: 1 },
+    ]);
+    mockPrisma.team.findFirst.mockResolvedValue(null);
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.leagueParticipant.create).not.toHaveBeenCalled();
+  });
+
+  it("does not re-enroll a team that is already a participant", async () => {
+    mockPrisma.league.findFirst.mockResolvedValue({
+      id: "league-1",
+      allowedRosters: JSON.stringify(PRIORITY_ROSTERS),
+    });
+    mockPrisma.leagueSeason.findFirst.mockResolvedValue({
+      id: "season-1",
+      leagueId: "league-1",
+      seasonNumber: 1,
+      status: "draft",
+    });
+    mockPrisma.leagueRound.findMany.mockResolvedValue(
+      Array.from({ length: PRIORITY_ROSTERS.length }, (_, i) => ({
+        seasonId: "season-1",
+        roundNumber: i + 1,
+      })),
+    );
+    mockPrisma.team.findFirst.mockImplementation(
+      async ({ where }: { where: { roster: string } }) => ({
+        id: `team-${where.roster}`,
+        roster: where.roster,
+      }),
+    );
+    mockPrisma.leagueParticipant.findUnique.mockResolvedValue({
+      id: "existing-participant",
+    });
+
+    await seedDefaultLeagues({ creatorId: CREATOR_ID });
+
+    expect(mockPrisma.leagueParticipant.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/seeders/leagues.ts
+++ b/apps/server/src/seeders/leagues.ts
@@ -1,0 +1,147 @@
+/**
+ * L.2 — Seeder de ligues par defaut (Sprint 17).
+ *
+ * Amorce la base avec la ligue "Open 5 Teams" decrite dans le backlog
+ * (L.9) : un tournoi pret a lancer restreint aux 5 rosters prioritaires
+ * (Skaven, Gnome, Lizardmen, Dwarf, Imperial Nobility).
+ *
+ * Contrats :
+ * - Idempotent : relancer `pnpm db:seed` ne duplique ni la ligue, ni la
+ *   saison, ni les rounds, ni les inscriptions deja presentes.
+ * - Ne touche pas aux ligues/saisons existantes crees par les
+ *   utilisateurs.
+ * - Si aucune equipe n'existe pour un roster (seed partiel), on ignore
+ *   silencieusement l'inscription plutot que de creer une inscription
+ *   invalide.
+ */
+
+import { prisma } from "../prisma";
+
+export const DEFAULT_LEAGUE_NAME = "Open 5 Teams";
+
+/**
+ * Rosters prioritaires du MVP. L'ordre est volontairement stable : il est
+ * utilise pour generer les inscriptions deterministes (et donc les tests).
+ */
+export const PRIORITY_ROSTERS = [
+  "skaven",
+  "gnome",
+  "lizardmen",
+  "dwarf",
+  "imperial_nobility",
+] as const;
+
+const DEFAULT_INITIAL_ELO = 1000;
+
+export interface SeedDefaultLeaguesInput {
+  creatorId: string;
+}
+
+export async function seedDefaultLeagues(
+  input: SeedDefaultLeaguesInput,
+): Promise<void> {
+  const league = await ensureOpenFiveTeamsLeague(input.creatorId);
+  const season = await ensureInitialSeason(league.id);
+  await ensureRoundRobinRounds(season.id, PRIORITY_ROSTERS.length);
+  await enrollPriorityTeams(season.id);
+}
+
+async function ensureOpenFiveTeamsLeague(creatorId: string) {
+  const existing = await prisma.league.findFirst({
+    where: { name: DEFAULT_LEAGUE_NAME },
+  });
+  if (existing) {
+    return existing;
+  }
+
+  const allowedRostersJson = JSON.stringify([...PRIORITY_ROSTERS]);
+  return prisma.league.create({
+    data: {
+      name: DEFAULT_LEAGUE_NAME,
+      description:
+        "Ligue ouverte restreinte aux 5 rosters prioritaires : Skaven, Gnome, Lizardmen, Dwarf, Imperial Nobility. Calendrier round-robin pret a etre lance par un admin.",
+      creatorId,
+      ruleset: "season_3",
+      status: "draft",
+      isPublic: true,
+      maxParticipants: Math.max(16, PRIORITY_ROSTERS.length),
+      allowedRosters: allowedRostersJson,
+      winPoints: 3,
+      drawPoints: 1,
+      lossPoints: 0,
+      forfeitPoints: -1,
+    },
+  });
+}
+
+async function ensureInitialSeason(leagueId: string) {
+  const existing = await prisma.leagueSeason.findFirst({
+    where: { leagueId, seasonNumber: 1 },
+  });
+  if (existing) {
+    return existing;
+  }
+  return prisma.leagueSeason.create({
+    data: {
+      leagueId,
+      seasonNumber: 1,
+      name: "Saison 1",
+      status: "draft",
+    },
+  });
+}
+
+async function ensureRoundRobinRounds(
+  seasonId: string,
+  participantCount: number,
+): Promise<void> {
+  const roundCount = Math.max(participantCount, 1);
+  const existing = await prisma.leagueRound.findMany({
+    where: { seasonId },
+    select: { roundNumber: true },
+  });
+  const present = new Set(
+    existing.map((r: { roundNumber: number }) => r.roundNumber),
+  );
+  const toCreate: Array<{
+    seasonId: string;
+    roundNumber: number;
+    name: string;
+    status: string;
+  }> = [];
+  for (let n = 1; n <= roundCount; n += 1) {
+    if (present.has(n)) continue;
+    toCreate.push({
+      seasonId,
+      roundNumber: n,
+      name: `Journee ${n}`,
+      status: "pending",
+    });
+  }
+  if (toCreate.length === 0) {
+    return;
+  }
+  await prisma.leagueRound.createMany({ data: toCreate });
+}
+
+async function enrollPriorityTeams(seasonId: string): Promise<void> {
+  for (const roster of PRIORITY_ROSTERS) {
+    const team = await prisma.team.findFirst({
+      where: { roster },
+      orderBy: { createdAt: "asc" },
+    });
+    if (!team) continue;
+    const existing = await prisma.leagueParticipant.findUnique({
+      where: { seasonId_teamId: { seasonId, teamId: team.id } },
+    });
+    if (existing) continue;
+    await prisma.leagueParticipant.create({
+      data: {
+        seasonId,
+        teamId: team.id,
+        seasonElo: DEFAULT_INITIAL_ELO,
+        status: "active",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Résumé

Sprint 17 — tâche **L.2 (Migration Prisma + seed data)** : amorce la base avec la ligue par défaut "Open 5 Teams" (mentionnée dans L.9) au-dessus des modèles L.1 déjà mergés.

- Ajout d'un seeder dédié `apps/server/src/seeders/leagues.ts` idempotent
- Crée la ligue restreinte aux 5 rosters prioritaires (Skaven, Gnome, Lizardmen, Dwarf, Imperial Nobility)
- Crée la saison 1 en `draft`, N rounds squelettes (prêts pour L.4 round-robin), inscrit la première équipe trouvée par roster
- Branché dans `apps/server/src/seed.ts` après les fixtures cup/local-match
- 8 tests unitaires (prisma mocké) couvrant idempotence, valeurs par défaut, et cas d'absence d'équipe

## Tâche roadmap

Sprint 17, tâche **L.2** (cochée dans `TODO.md`).

## Plan de test

- [x] `pnpm vitest run src/seeders/leagues.test.ts` — 8/8 verts
- [x] `pnpm vitest run` (apps/server) — 458/458 verts (aucune régression)
- [x] `pnpm typecheck` sur `@bb/server` — propre
- [ ] `pnpm db:seed` sur une base fraîche pour vérifier l'idempotence bout en bout (à faire manuellement en staging)
- [ ] Relancer `pnpm db:seed` une seconde fois pour confirmer qu'aucun doublon n'apparaît
- [ ] Vérifier via Prisma Studio que la ligue "Open 5 Teams", sa saison 1, ses rounds et ses participants sont bien présents

## Notes

Les erreurs TypeScript préexistantes dans `apps/web/app/local-matches/[id]/PracticeAIPanel.tsx` (merge précédent #262) ne sont pas liées à cette PR — vérifié en stash sur `main`.