### PR TITLE
Fix AI system user roles field to use array instead of JSON string

### DIFF
--- a/apps/server/src/services/ai-practice.test.ts
+++ b/apps/server/src/services/ai-practice.test.ts
@@ -90,6 +90,16 @@ describe("ensureAISystemUser", () => {
     expect(result.id).toBe("ai-new");
     expect(prisma.user.upsert).toHaveBeenCalledOnce();
   });
+
+  it("passe le champ roles sous forme de tableau (String[] Prisma)", async () => {
+    const prisma = makePrismaMock();
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.user.upsert.mockResolvedValue({ id: "ai-new" });
+    await ensureAISystemUser(prisma as any);
+    const upsertArgs = prisma.user.upsert.mock.calls[0][0];
+    expect(Array.isArray(upsertArgs.create.roles)).toBe(true);
+    expect(upsertArgs.create.roles).toEqual(["ai"]);
+  });
 });
 
 describe("spawnAITeam", () => {

--- a/apps/server/src/services/ai-practice.ts
+++ b/apps/server/src/services/ai-practice.ts
@@ -80,7 +80,7 @@ export async function ensureAISystemUser(prisma: PrismaLike): Promise<{ id: stri
       name: AI_SYSTEM_COACH_NAME,
       coachName: AI_SYSTEM_COACH_NAME,
       role: "ai",
-      roles: JSON.stringify(["ai"]),
+      roles: ["ai"],
     },
   });
   return { id: user.id };


### PR DESCRIPTION
## Résumé

- [x] Fix the `roles` field in `ensureAISystemUser` to pass an array directly instead of a JSON stringified value, matching Prisma's expected `String[]` type

## Description

The `ensureAISystemUser` function was incorrectly passing the `roles` field as a JSON stringified value (`JSON.stringify(["ai"])`) when creating the AI system user. This has been corrected to pass the array directly (`["ai"]`), which aligns with the Prisma schema's `String[]` type definition.

A corresponding test has been added to verify that the `roles` field is passed as an array to the Prisma upsert call.

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (added test case for roles array validation)
- [ ] Tests e2e (N/A)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01CCqxtmtBoBNk4sHDFRYCAW