### PR TITLE
Add Authorization header to leaderboard API requests

### DIFF
--- a/apps/web/app/leaderboard/page.test.tsx
+++ b/apps/web/app/leaderboard/page.test.tsx
@@ -220,7 +220,29 @@ describe("LeaderboardPage", () => {
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("/leaderboard?limit=20&offset=0"),
+        expect.any(Object),
       );
     });
+  });
+
+  it("sends Authorization header when an auth token is present (feature flag override)", async () => {
+    localStorageMock.getItem.mockImplementation((key: string) =>
+      key === "auth_token" ? "test-token-123" : null,
+    );
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaderboardData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options).toBeDefined();
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-token-123");
   });
 });

--- a/apps/web/app/leaderboard/page.tsx
+++ b/apps/web/app/leaderboard/page.tsx
@@ -39,8 +39,15 @@ export default function LeaderboardPage() {
       try {
         setLoading(true);
         setError(null);
+        const token =
+          typeof window !== "undefined"
+            ? localStorage.getItem("auth_token")
+            : null;
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
         const response = await fetch(
           `${API_BASE}/leaderboard?limit=${PAGE_SIZE}&offset=${offset}`,
+          { headers },
         );
         if (!response.ok) {
           throw new Error("Erreur lors du chargement du classement");


### PR DESCRIPTION
## Résumé

- [x] Ajouter l'en-tête Authorization aux requêtes API du classement quand un token d'authentification est présent

## Description

Cette PR ajoute le support de l'authentification aux requêtes vers l'API du classement. Lorsqu'un token d'authentification est stocké dans le localStorage, il est maintenant envoyé dans l'en-tête `Authorization` avec le format `Bearer <token>`.

### Changements

- **page.tsx** : Récupération du token depuis le localStorage et ajout de l'en-tête Authorization à la requête fetch du classement
- **page.test.tsx** : Ajout d'un test unitaire vérifiant que l'en-tête Authorization est correctement envoyé quand un token est présent, et mise à jour du test existant pour vérifier les options de la requête

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (test ajouté pour vérifier l'en-tête Authorization)
- [ ] Tests e2e (N/A)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01UhTLGpKgSVGaXXysEntqjM