### PR TITLE
Enable user registration with admin validation workflow

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -131,8 +131,8 @@ if (process.env.TEST_SQLITE === "1") {
     }
   });
 
-  // Seed d'utilisateurs de test (register est désactivé en pré-alpha,
-  // donc on expose un endpoint dédié aux tests E2E).
+  // Seed d'utilisateurs de test : endpoint dédié aux tests E2E qui crée
+  // un compte déjà validé (bypass de la modération admin).
   app.post("/__test/seed-user", async (req, res) => {
     try {
       const { email, password, name } = req.body as {

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -7,6 +7,7 @@ import { normalizeRoles } from "../utils/roles";
 import { validate } from "../middleware/validate";
 import {
   loginSchema,
+  registerSchema,
   updateProfileSchema,
   changePasswordSchema,
 } from "../schemas/auth.schemas";
@@ -14,11 +15,77 @@ import { JWT_SECRET } from "../config";
 
 const router = Router();
 
-// Registration disabled during pre-alpha
-router.post("/register", (_req, res) => {
-  return res.status(403).json({
-    error: "L'inscription est actuellement désactivée. Nuffle Arena est en pré-alpha et sera bientôt disponible à l'inscription.",
-  });
+router.post("/register", validate(registerSchema), async (req, res) => {
+  try {
+    const {
+      email,
+      password,
+      coachName,
+      name,
+      firstName,
+      lastName,
+      dateOfBirth,
+    } = req.body;
+
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ error: "Email déjà utilisé" });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    const created = await prisma.user.create({
+      data: {
+        email,
+        passwordHash,
+        coachName,
+        name: name ?? coachName,
+        firstName: firstName && firstName !== "" ? firstName : null,
+        lastName: lastName && lastName !== "" ? lastName : null,
+        dateOfBirth:
+          dateOfBirth && dateOfBirth !== "" ? new Date(dateOfBirth) : null,
+      },
+    });
+
+    const roles = normalizeRoles((created as any).roles ?? created.role);
+    const primaryRole = roles[0];
+    const publicUser = {
+      id: created.id,
+      email: created.email,
+      name: created.name,
+      coachName: created.coachName,
+      firstName: created.firstName,
+      lastName: created.lastName,
+      dateOfBirth: created.dateOfBirth,
+      role: primaryRole,
+      roles,
+      valid: created.valid,
+      createdAt: created.createdAt,
+    };
+
+    // Si l'inscription nécessite la modération admin (valid=false en prod),
+    // on ne retourne pas de token : le compte devra être validé avant login.
+    if (created.valid === false) {
+      return res.status(201).json({
+        user: publicUser,
+        message:
+          "Votre compte a bien été créé. Il doit être validé par un administrateur avant que vous puissiez vous connecter.",
+      });
+    }
+
+    const token = jwt.sign(
+      { sub: created.id, role: primaryRole, roles },
+      JWT_SECRET,
+      { expiresIn: "7d" },
+    );
+    return res.status(201).json({ user: publicUser, token });
+  } catch (err: any) {
+    if (err?.code === "P2002") {
+      return res.status(409).json({ error: "Email déjà utilisé" });
+    }
+    console.error(err);
+    return res.status(500).json({ error: "Erreur serveur" });
+  }
 });
 
 router.post("/login", validate(loginSchema), async (req, res) => {

--- a/apps/server/src/schemas/auth.schemas.ts
+++ b/apps/server/src/schemas/auth.schemas.ts
@@ -9,7 +9,11 @@ export const registerSchema = z.object({
   name: z.string().optional(),
   firstName: z.string().optional(),
   lastName: z.string().optional(),
-  dateOfBirth: z.string().optional().nullable(),
+  dateOfBirth: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date de naissance invalide (format YYYY-MM-DD)")
+    .optional()
+    .nullable(),
 });
 
 export const loginSchema = z.object({

--- a/apps/server/src/schemas/auth.schemas.ts
+++ b/apps/server/src/schemas/auth.schemas.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email("Email invalide"),
-  password: z.string().min(1, "Mot de passe requis"),
+  password: z
+    .string()
+    .min(8, "Le mot de passe doit contenir au moins 8 caractères"),
   coachName: z.string().min(1, "Nom de coach requis").max(50),
   name: z.string().optional(),
   firstName: z.string().optional(),

--- a/apps/server/src/schemas/zod-schemas.test.ts
+++ b/apps/server/src/schemas/zod-schemas.test.ts
@@ -603,6 +603,12 @@ describe("Auth schemas", () => {
       expect(result.dateOfBirth).toBe("1990-01-01");
     });
 
+    it("rejects a malformed dateOfBirth", () => {
+      expect(() =>
+        registerSchema.parse({ ...validBody, dateOfBirth: "not-a-date" }),
+      ).toThrow();
+    });
+
     it("rejects an invalid email", () => {
       expect(() =>
         registerSchema.parse({ ...validBody, email: "not-an-email" }),

--- a/apps/server/src/schemas/zod-schemas.test.ts
+++ b/apps/server/src/schemas/zod-schemas.test.ts
@@ -9,6 +9,9 @@ import {
   updateMatchStatusSchema,
 } from "./admin.schemas";
 
+// Auth schemas
+import { registerSchema } from "./auth.schemas";
+
 // Admin data schemas
 import {
   createSkillSchema,
@@ -567,6 +570,61 @@ describe("Team schemas", () => {
     it("still requires name, roster, and choices", () => {
       expect(() => buildTeamSchema.parse({ name: "X", roster: "human" })).toThrow();
       expect(() => buildTeamSchema.parse({ name: "", roster: "human", choices: [] })).toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth schemas
+// ---------------------------------------------------------------------------
+
+describe("Auth schemas", () => {
+  describe("registerSchema", () => {
+    const validBody = {
+      email: "coach@example.com",
+      password: "secret12",
+      coachName: "Coach Z",
+    };
+
+    it("accepts a minimal valid body", () => {
+      const result = registerSchema.parse(validBody);
+      expect(result.email).toBe("coach@example.com");
+      expect(result.coachName).toBe("Coach Z");
+    });
+
+    it("accepts optional profile fields", () => {
+      const result = registerSchema.parse({
+        ...validBody,
+        firstName: "Jane",
+        lastName: "Doe",
+        dateOfBirth: "1990-01-01",
+      });
+      expect(result.firstName).toBe("Jane");
+      expect(result.dateOfBirth).toBe("1990-01-01");
+    });
+
+    it("rejects an invalid email", () => {
+      expect(() =>
+        registerSchema.parse({ ...validBody, email: "not-an-email" }),
+      ).toThrow();
+    });
+
+    it("rejects a password shorter than 8 characters", () => {
+      expect(() =>
+        registerSchema.parse({ ...validBody, password: "short" }),
+      ).toThrow();
+    });
+
+    it("rejects an empty coachName", () => {
+      expect(() =>
+        registerSchema.parse({ ...validBody, coachName: "" }),
+      ).toThrow();
+    });
+
+    it("rejects a coachName longer than 50 characters", () => {
+      expect(() =>
+        registerSchema.parse({ ...validBody, coachName: "x".repeat(51) }),
+      ).toThrow();
     });
   });
 });

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -137,8 +137,9 @@ export const translations = {
       login: "Connectez-vous",
       required: "requis",
       error: "Erreur",
-      preAlphaTitle: "Inscription indisponible",
-      preAlphaMessage: "Nuffle Arena est actuellement en pré-alpha. L'inscription sera bientôt disponible. Restez connectés !",
+      pendingValidationTitle: "Compte en attente de validation",
+      pendingValidationMessage:
+        "Votre compte a bien été créé. Un administrateur doit le valider avant que vous puissiez vous connecter.",
     },
     // Teams pages
     teams: {
@@ -563,8 +564,9 @@ export const translations = {
       login: "Log in",
       required: "required",
       error: "Error",
-      preAlphaTitle: "Registration unavailable",
-      preAlphaMessage: "Nuffle Arena is currently in pre-alpha. Registration will be available soon. Stay tuned!",
+      pendingValidationTitle: "Account pending validation",
+      pendingValidationMessage:
+        "Your account has been created. An administrator must validate it before you can log in.",
     },
     // Teams pages
     teams: {

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -140,6 +140,7 @@ export const translations = {
       pendingValidationTitle: "Compte en attente de validation",
       pendingValidationMessage:
         "Votre compte a bien été créé. Un administrateur doit le valider avant que vous puissiez vous connecter.",
+      backToHome: "Retour à l'accueil",
     },
     // Teams pages
     teams: {
@@ -567,6 +568,7 @@ export const translations = {
       pendingValidationTitle: "Account pending validation",
       pendingValidationMessage:
         "Your account has been created. An administrator must validate it before you can log in.",
+      backToHome: "Back to home",
     },
     // Teams pages
     teams: {

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -83,7 +83,10 @@ export default function LoginPage() {
         </button>
       </form>
       <p className="text-xs sm:text-sm mt-4 text-center text-gray-500">
-        {t.register.preAlphaMessage}
+        {t.login.noAccount}{" "}
+        <a className="text-blue-600 hover:underline" href="/register">
+          {t.login.register}
+        </a>
       </p>
       </div>
     </div>

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -68,7 +68,7 @@ export default function RegisterPage() {
             className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm sm:text-base"
             href="/"
           >
-            {t.home.title ? "Retour à l'accueil" : "Home"}
+            {t.register.backToHome}
           </a>
         </div>
       </div>

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -1,23 +1,183 @@
 "use client";
+import { useState } from "react";
+import { apiPost } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
 
 export default function RegisterPage() {
   const { t } = useLanguage();
+  const [email, setEmail] = useState("");
+  const [coachName, setCoachName] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setPending(null);
+    setSubmitting(true);
+    try {
+      const payload: Record<string, unknown> = {
+        email,
+        password,
+        coachName,
+      };
+      if (firstName) payload.firstName = firstName;
+      if (lastName) payload.lastName = lastName;
+      if (dateOfBirth) payload.dateOfBirth = dateOfBirth;
+
+      const response = await apiPost("/auth/register", payload);
+
+      if (response?.token) {
+        localStorage.setItem("auth_token", response.token);
+        document.cookie = `auth_token=${response.token}; path=/; max-age=86400; SameSite=Lax`;
+        window.location.href = "/me";
+        return;
+      }
+
+      // Pas de token = compte créé mais en attente de validation admin
+      setPending(response?.message || t.register.pendingValidationMessage);
+    } catch (err: any) {
+      setError(err?.message || t.register.error);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (pending) {
+    return (
+      <div className="w-full p-4 sm:p-6 flex justify-center min-h-[60vh]">
+        <div className="max-w-md w-full text-center">
+          <h1
+            data-testid="register-pending-title"
+            className="text-xl sm:text-2xl font-bold mb-4"
+          >
+            {t.register.pendingValidationTitle}
+          </h1>
+          <p
+            data-testid="register-pending-message"
+            className="text-gray-600 text-sm sm:text-base mb-6"
+          >
+            {pending}
+          </p>
+          <a
+            className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm sm:text-base"
+            href="/"
+          >
+            {t.home.title ? "Retour à l'accueil" : "Home"}
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full p-4 sm:p-6 flex justify-center min-h-[60vh]">
-      <div className="max-w-md w-full text-center">
-        <div className="mb-6 text-6xl">🚧</div>
-        <h1 className="text-xl sm:text-2xl font-bold mb-4">{t.register.preAlphaTitle}</h1>
-        <p className="text-gray-600 text-sm sm:text-base mb-6">
-          {t.register.preAlphaMessage}
+      <div className="max-w-sm w-full">
+        <h1 className="text-xl sm:text-2xl font-bold mb-4">
+          {t.register.title}
+        </h1>
+        <form onSubmit={onSubmit} className="space-y-3 sm:space-y-4">
+          <div>
+            <input
+              data-testid="register-email"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder={t.register.email}
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+            />
+          </div>
+          <div>
+            <input
+              data-testid="register-coachname"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder={t.register.coachNamePlaceholder}
+              type="text"
+              required
+              maxLength={50}
+              value={coachName}
+              onChange={(e) => setCoachName(e.target.value)}
+              autoComplete="nickname"
+            />
+          </div>
+          <div>
+            <input
+              data-testid="register-firstname"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder={t.register.firstNamePlaceholder}
+              type="text"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              autoComplete="given-name"
+            />
+          </div>
+          <div>
+            <input
+              data-testid="register-lastname"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder={t.register.lastNamePlaceholder}
+              type="text"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              autoComplete="family-name"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">
+              {t.register.dateOfBirth}
+            </label>
+            <input
+              data-testid="register-dob"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              type="date"
+              value={dateOfBirth}
+              onChange={(e) => setDateOfBirth(e.target.value)}
+              autoComplete="bday"
+            />
+          </div>
+          <div>
+            <input
+              data-testid="register-password"
+              className="w-full border border-gray-300 p-2.5 sm:p-3 rounded-lg text-sm sm:text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              placeholder={t.register.passwordPlaceholder}
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+          {error && (
+            <p
+              data-testid="register-error"
+              className="text-red-600 text-xs sm:text-sm"
+            >
+              {error}
+            </p>
+          )}
+          <button
+            data-testid="register-submit"
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-blue-600 text-white py-2.5 sm:py-3 rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm sm:text-base disabled:opacity-60"
+          >
+            {t.register.submit}
+          </button>
+        </form>
+        <p className="text-xs sm:text-sm mt-4 text-center text-gray-500">
+          {t.register.hasAccount}{" "}
+          <a className="text-blue-600 hover:underline" href="/login">
+            {t.register.login}
+          </a>
         </p>
-        <a
-          className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm sm:text-base"
-          href="/login"
-        >
-          {t.login.title}
-        </a>
       </div>
     </div>
   );

--- a/tests/e2e-api/specs/auth.spec.ts
+++ b/tests/e2e-api/specs/auth.spec.ts
@@ -23,15 +23,43 @@ describe("E2E API — auth", () => {
     await resetDb();
   });
 
-  it("POST /auth/register est désactivé en pré-alpha (403)", async () => {
+  it("POST /auth/register crée un compte et retourne un token (SQLite: valid=true)", async () => {
     const res = await rawPost("/auth/register", null, {
       email: "newbie@e2e.test",
       password: "password-x",
       coachName: "Newbie",
     });
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string };
-    expect(typeof body.error).toBe("string");
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      user?: { email?: string; coachName?: string };
+      token?: string;
+    };
+    expect(body.user?.email).toBe("newbie@e2e.test");
+    expect(body.user?.coachName).toBe("Newbie");
+    expect(typeof body.token).toBe("string");
+  });
+
+  it("POST /auth/register refuse un email déjà utilisé (409)", async () => {
+    await rawPost("/auth/register", null, {
+      email: "dup@e2e.test",
+      password: "password-x",
+      coachName: "Dup",
+    });
+    const res = await rawPost("/auth/register", null, {
+      email: "dup@e2e.test",
+      password: "password-x",
+      coachName: "DupAgain",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("POST /auth/register refuse un payload invalide (400)", async () => {
+    const res = await rawPost("/auth/register", null, {
+      email: "not-an-email",
+      password: "short",
+      coachName: "",
+    });
+    expect(res.status).toBe(400);
   });
 
   it("POST /auth/login refuse un payload invalide (400)", async () => {

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -15,11 +15,16 @@ describe("Auth API", () => {
     const reg = await fetch(`${API_BASE}/auth/register`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password, name: "Tester" }),
+      body: JSON.stringify({
+        email,
+        password,
+        coachName: "Tester",
+      }),
     });
     expect(reg.status).toBe(201);
     const regBody: any = await reg.json();
     expect(regBody?.user?.email).toBe(email);
+    // En SQLite (tests), `valid` default = true => token renvoyé
     expect(typeof regBody?.token).toBe("string");
 
     // Login


### PR DESCRIPTION
## Résumé

This PR enables user registration functionality with an admin validation workflow. Previously, registration was disabled during pre-alpha. Now users can register with email, password, coach name, and optional profile fields (first name, last name, date of birth). New accounts require admin validation before users can log in, unless they're created in test mode.

### Key Changes

**Frontend (`apps/web/app/register/page.tsx`)**
- Replaced pre-alpha placeholder with a fully functional registration form
- Added form state management for email, password, coach name, and optional profile fields
- Implemented form submission with API integration
- Added pending validation state display when account requires admin approval
- Integrated with localStorage and cookies for token management
- Added error handling and loading states
- Updated login page to link to registration instead of showing pre-alpha message

**Backend (`apps/server/src/routes/auth.ts`)**
- Implemented `/auth/register` endpoint with full registration logic
- Added email uniqueness validation
- Password hashing with bcrypt
- User creation with optional profile fields
- Conditional token generation based on account validation status
- Returns user data and token on successful registration (if valid=true)
- Returns user data and message on pending validation (if valid=false)

**Validation (`apps/server/src/schemas/auth.schemas.ts`)**
- Enhanced `registerSchema` with stricter validation rules
- Password minimum length: 8 characters
- Coach name: 1-50 characters
- Date of birth: ISO 8601 format validation (YYYY-MM-DD)
- Email format validation
- Optional fields for first name, last name, date of birth

**Translations (`apps/web/app/i18n/translations.ts`)**
- Updated French and English translations
- Replaced pre-alpha messages with validation pending messages
- Added "Back to home" button text

**Tests**
- Added comprehensive unit tests for `registerSchema` covering valid inputs, optional fields, and validation edge cases
- Updated integration test to use correct `coachName` field and verify token generation

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (registerSchema validation tests added)
- [x] Tests e2e (integration test updated)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01N8s1iby1sAceag6NwKHzs9