### PR TITLE
feat: add L.3 league CRUD API routes (create/join/schedule/standings)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -295,7 +295,7 @@
 |---|-------|------|--------|
 | L.1 | Modeles Prisma League/LeagueSeason/LeagueParticipant/LeagueRound | DB | [x] |
 | L.2 | Migration Prisma + seed data | DB | [x] |
-| L.3 | Routes API CRUD ligue (create, join, schedule, standings) | API | [ ] |
+| L.3 | Routes API CRUD ligue (create, join, schedule, standings) | API | [x] |
 | L.4 | Generateur de calendrier round-robin | Backend | [ ] |
 | L.5 | Page liste des ligues | Frontend | [ ] |
 | L.6 | Page detail ligue (calendrier, classement, matchs) | Frontend | [ ] |

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import pushRoutes from "./routes/push";
 import friendsRoutes from "./routes/friends";
 import careerStatsRoutes from "./routes/career-stats";
 import achievementsRoutes from "./routes/achievements";
+import leagueRoutes from "./routes/league";
 import {
   userFeatureFlagsRouter,
   adminFeatureFlagsRouter,
@@ -92,6 +93,7 @@ app.use("/push", pushRoutes);
 app.use("/friends", friendsRoutes);
 app.use("/career-stats", careerStatsRoutes);
 app.use("/achievements", achievementsRoutes);
+app.use("/leagues", leagueRoutes);
 app.use("/api/feature-flags", userFeatureFlagsRouter);
 app.use("/admin/feature-flags", adminFeatureFlagsRouter);
 

--- a/apps/server/src/routes/league.test.ts
+++ b/apps/server/src/routes/league.test.ts
@@ -1,0 +1,463 @@
+/**
+ * L.3 — Tests des routes API ligue (create / list / get / join /
+ * schedule round / standings / withdraw).
+ *
+ * Les handlers sont unitaires : service et prisma mockes,
+ * req/res faits a la main (comme middleware/authUser.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/league", () => ({
+  createLeague: vi.fn(),
+  createSeason: vi.fn(),
+  addParticipant: vi.fn(),
+  createRound: vi.fn(),
+  listLeagues: vi.fn(),
+  getLeagueById: vi.fn(),
+  getSeasonById: vi.fn(),
+  computeSeasonStandings: vi.fn(),
+  withdrawParticipant: vi.fn(),
+  parseAllowedRosters: vi.fn((raw: string | null) =>
+    raw ? (JSON.parse(raw) as string[]) : null,
+  ),
+}));
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    team: { findUnique: vi.fn() },
+    league: { findUnique: vi.fn() },
+  },
+}));
+
+import type { Request, Response } from "express";
+import {
+  createLeague,
+  createSeason,
+  addParticipant,
+  createRound,
+  listLeagues,
+  getLeagueById,
+  getSeasonById,
+  computeSeasonStandings,
+  withdrawParticipant,
+} from "../services/league";
+import { prisma } from "../prisma";
+import {
+  handleCreateLeague,
+  handleListLeagues,
+  handleGetLeague,
+  handleCreateSeason,
+  handleJoinSeason,
+  handleCreateRound,
+  handleGetStandings,
+  handleLeaveSeason,
+} from "./league";
+import type { AuthenticatedRequest } from "../middleware/authUser";
+
+const mockService = {
+  createLeague: createLeague as ReturnType<typeof vi.fn>,
+  createSeason: createSeason as ReturnType<typeof vi.fn>,
+  addParticipant: addParticipant as ReturnType<typeof vi.fn>,
+  createRound: createRound as ReturnType<typeof vi.fn>,
+  listLeagues: listLeagues as ReturnType<typeof vi.fn>,
+  getLeagueById: getLeagueById as ReturnType<typeof vi.fn>,
+  getSeasonById: getSeasonById as ReturnType<typeof vi.fn>,
+  computeSeasonStandings: computeSeasonStandings as ReturnType<typeof vi.fn>,
+  withdrawParticipant: withdrawParticipant as ReturnType<typeof vi.fn>,
+};
+const mockPrisma = prisma as unknown as {
+  team: { findUnique: ReturnType<typeof vi.fn> };
+  league: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+function createRes() {
+  const res: Partial<Response> & {
+    statusCode?: number;
+    payload?: unknown;
+  } = {};
+  res.status = vi.fn().mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  });
+  res.json = vi.fn().mockImplementation((payload: unknown) => {
+    res.payload = payload;
+    return res as Response;
+  });
+  return res as Response & { statusCode?: number; payload?: unknown };
+}
+
+function createReq(
+  overrides: Partial<AuthenticatedRequest> = {},
+): AuthenticatedRequest {
+  return {
+    body: {},
+    params: {},
+    query: {},
+    user: { id: "user-1", roles: ["user"] },
+    ...overrides,
+  } as AuthenticatedRequest;
+}
+
+describe("Route: POST /leagues (create)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates a league with the authenticated user as creator", async () => {
+    mockService.createLeague.mockResolvedValue({
+      id: "league-1",
+      name: "Open 5 Teams",
+      creatorId: "user-1",
+    });
+
+    const req = createReq({ body: { name: "Open 5 Teams" } });
+    const res = createRes();
+    await handleCreateLeague(req, res);
+
+    expect(mockService.createLeague).toHaveBeenCalledWith(
+      expect.objectContaining({ creatorId: "user-1", name: "Open 5 Teams" }),
+    );
+    expect(res.statusCode).toBe(201);
+    expect(res.payload).toMatchObject({ id: "league-1" });
+  });
+
+  it("passes allowedRosters through to the service", async () => {
+    mockService.createLeague.mockResolvedValue({ id: "league-2" });
+    const req = createReq({
+      body: {
+        name: "Open 5",
+        allowedRosters: ["skaven", "gnomes"],
+        maxParticipants: 8,
+      },
+    });
+    const res = createRes();
+    await handleCreateLeague(req, res);
+    expect(mockService.createLeague).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedRosters: ["skaven", "gnomes"],
+        maxParticipants: 8,
+      }),
+    );
+  });
+
+  it("returns 400 when the service throws a domain error", async () => {
+    mockService.createLeague.mockRejectedValue(new Error("nom obligatoire"));
+    const req = createReq({ body: { name: " " } });
+    const res = createRes();
+    await handleCreateLeague(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toMatchObject({ error: expect.stringMatching(/nom/i) });
+  });
+});
+
+describe("Route: GET /leagues (list)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the list of leagues with publicOnly default", async () => {
+    mockService.listLeagues.mockResolvedValue([
+      { id: "league-1", name: "A", isPublic: true },
+    ]);
+    const req = createReq({ query: {} });
+    const res = createRes();
+    await handleListLeagues(req, res);
+    expect(mockService.listLeagues).toHaveBeenCalledWith(
+      expect.objectContaining({ publicOnly: undefined }),
+    );
+    expect(res.payload).toMatchObject({ leagues: expect.any(Array) });
+  });
+
+  it("forwards query filters to the service (post validateQuery coercion)", async () => {
+    mockService.listLeagues.mockResolvedValue([]);
+    // validateQuery coerces publicOnly from "false" to boolean false before the handler
+    const req = createReq({
+      query: { status: "open", publicOnly: false } as unknown as Record<
+        string,
+        string
+      >,
+    });
+    const res = createRes();
+    await handleListLeagues(req, res);
+    expect(mockService.listLeagues).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "open", publicOnly: false }),
+    );
+  });
+});
+
+describe("Route: GET /leagues/:id", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 404 when the league does not exist", async () => {
+    mockService.getLeagueById.mockResolvedValue(null);
+    const req = createReq({ params: { id: "nope" } });
+    const res = createRes();
+    await handleGetLeague(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns the league details including parsed allowedRosters", async () => {
+    mockService.getLeagueById.mockResolvedValue({
+      id: "league-1",
+      name: "Open",
+      allowedRosters: JSON.stringify(["skaven", "dwarf"]),
+      seasons: [],
+    });
+    const req = createReq({ params: { id: "league-1" } });
+    const res = createRes();
+    await handleGetLeague(req, res);
+    expect(res.payload).toMatchObject({
+      league: expect.objectContaining({
+        id: "league-1",
+        allowedRosters: ["skaven", "dwarf"],
+      }),
+    });
+  });
+});
+
+describe("Route: POST /leagues/:id/seasons (schedule a season)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects non-creator with 403", async () => {
+    mockService.getLeagueById.mockResolvedValue({
+      id: "league-1",
+      creatorId: "someone-else",
+    });
+    const req = createReq({
+      params: { id: "league-1" },
+      body: { name: "Saison 1" },
+    });
+    const res = createRes();
+    await handleCreateSeason(req, res);
+    expect(res.statusCode).toBe(403);
+    expect(mockService.createSeason).not.toHaveBeenCalled();
+  });
+
+  it("lets the creator create a new season", async () => {
+    mockService.getLeagueById.mockResolvedValue({
+      id: "league-1",
+      creatorId: "user-1",
+    });
+    mockService.createSeason.mockResolvedValue({
+      id: "season-1",
+      seasonNumber: 1,
+      name: "Saison 1",
+    });
+    const req = createReq({
+      params: { id: "league-1" },
+      body: { name: "Saison 1" },
+    });
+    const res = createRes();
+    await handleCreateSeason(req, res);
+    expect(mockService.createSeason).toHaveBeenCalledWith(
+      expect.objectContaining({ leagueId: "league-1", name: "Saison 1" }),
+    );
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 404 when the league is not found", async () => {
+    mockService.getLeagueById.mockResolvedValue(null);
+    const req = createReq({
+      params: { id: "unknown" },
+      body: { name: "S1" },
+    });
+    const res = createRes();
+    await handleCreateSeason(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Route: POST /leagues/seasons/:seasonId/join", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requires the team to belong to the authenticated user", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "other-user",
+      roster: "skaven",
+    });
+    mockService.getSeasonById.mockResolvedValue({
+      id: "season-1",
+      league: { allowedRosters: null },
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleJoinSeason(req, res);
+    expect(res.statusCode).toBe(403);
+    expect(mockService.addParticipant).not.toHaveBeenCalled();
+  });
+
+  it("rejects teams whose roster is not allowed", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "user-1",
+      roster: "chaos",
+    });
+    mockService.getSeasonById.mockResolvedValue({
+      id: "season-1",
+      league: { allowedRosters: JSON.stringify(["skaven", "dwarf"]) },
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleJoinSeason(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toMatchObject({
+      error: expect.stringMatching(/roster/i),
+    });
+  });
+
+  it("registers the team when ownership + roster check pass", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "user-1",
+      roster: "skaven",
+    });
+    mockService.getSeasonById.mockResolvedValue({
+      id: "season-1",
+      league: { allowedRosters: null },
+    });
+    mockService.addParticipant.mockResolvedValue({
+      id: "participant-1",
+      seasonId: "season-1",
+      teamId: "team-1",
+      seasonElo: 1000,
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleJoinSeason(req, res);
+    expect(mockService.addParticipant).toHaveBeenCalledWith({
+      seasonId: "season-1",
+      teamId: "team-1",
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("returns 404 when the season is missing", async () => {
+    mockService.getSeasonById.mockResolvedValue(null);
+    const req = createReq({
+      params: { seasonId: "nope" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleJoinSeason(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Route: POST /leagues/seasons/:seasonId/rounds (schedule round)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects non-creator with 403", async () => {
+    mockService.getSeasonById.mockResolvedValue({
+      id: "season-1",
+      league: { creatorId: "someone-else" },
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { roundNumber: 1 },
+    });
+    const res = createRes();
+    await handleCreateRound(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("creates the round when the caller is the creator", async () => {
+    mockService.getSeasonById.mockResolvedValue({
+      id: "season-1",
+      league: { creatorId: "user-1" },
+    });
+    mockService.createRound.mockResolvedValue({
+      id: "round-1",
+      roundNumber: 1,
+      name: "J1",
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { roundNumber: 1, name: "J1" },
+    });
+    const res = createRes();
+    await handleCreateRound(req, res);
+    expect(mockService.createRound).toHaveBeenCalledWith(
+      expect.objectContaining({ seasonId: "season-1", roundNumber: 1 }),
+    );
+    expect(res.statusCode).toBe(201);
+  });
+});
+
+describe("Route: GET /leagues/seasons/:seasonId/standings", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the sorted standings", async () => {
+    mockService.computeSeasonStandings.mockResolvedValue([
+      { teamId: "t1", points: 9, touchdownDifference: 5 },
+      { teamId: "t2", points: 3, touchdownDifference: -2 },
+    ]);
+    const req = createReq({ params: { seasonId: "season-1" } });
+    const res = createRes();
+    await handleGetStandings(req, res);
+    expect(mockService.computeSeasonStandings).toHaveBeenCalledWith("season-1");
+    expect(res.payload).toMatchObject({
+      standings: [
+        expect.objectContaining({ teamId: "t1" }),
+        expect.objectContaining({ teamId: "t2" }),
+      ],
+    });
+  });
+
+  it("returns 404 when the season does not exist", async () => {
+    mockService.computeSeasonStandings.mockRejectedValue(
+      new Error("Saison introuvable: X"),
+    );
+    const req = createReq({ params: { seasonId: "nope" } });
+    const res = createRes();
+    await handleGetStandings(req, res);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("Route: POST /leagues/seasons/:seasonId/leave", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("only allows the team owner to withdraw", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "other-user",
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleLeaveSeason(req, res);
+    expect(res.statusCode).toBe(403);
+    expect(mockService.withdrawParticipant).not.toHaveBeenCalled();
+  });
+
+  it("calls withdrawParticipant for the owner", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "user-1",
+    });
+    mockService.withdrawParticipant.mockResolvedValue({
+      id: "part-1",
+      status: "withdrawn",
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleLeaveSeason(req, res);
+    expect(mockService.withdrawParticipant).toHaveBeenCalledWith({
+      seasonId: "season-1",
+      teamId: "team-1",
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -1,0 +1,314 @@
+/**
+ * L.3 — Routes API ligue (Sprint 17).
+ *
+ * Expose les operations create / list / detail / join / schedule /
+ * standings / withdraw au-dessus du service `services/league.ts`.
+ * La logique metier (bornes, unicite, etats autorises) reste dans le
+ * service — les handlers s'occupent de l'auth, du parse et du format.
+ */
+
+import { Router } from "express";
+import type { Response } from "express";
+import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
+import { validate, validateQuery } from "../middleware/validate";
+import { prisma } from "../prisma";
+import {
+  createLeague,
+  createSeason,
+  addParticipant,
+  createRound,
+  listLeagues,
+  getLeagueById,
+  getSeasonById,
+  computeSeasonStandings,
+  withdrawParticipant,
+  parseAllowedRosters,
+} from "../services/league";
+import {
+  createLeagueSchema,
+  createSeasonSchema,
+  joinSeasonSchema,
+  createRoundSchema,
+  listLeaguesQuerySchema,
+  type CreateLeagueBody,
+  type CreateSeasonBody,
+  type JoinSeasonBody,
+  type CreateRoundBody,
+  type ListLeaguesQuery,
+} from "../schemas/league.schemas";
+
+function requireUserId(req: AuthenticatedRequest, res: Response): string | null {
+  const id = req.user?.id;
+  if (!id) {
+    res.status(401).json({ error: "Non authentifie" });
+    return null;
+  }
+  return id;
+}
+
+function serializeLeague(
+  league: Record<string, unknown> & { allowedRosters?: string | null },
+) {
+  return {
+    ...league,
+    allowedRosters: parseAllowedRosters(
+      (league.allowedRosters as string | null) ?? null,
+    ),
+  };
+}
+
+function domainError(res: Response, e: unknown): void {
+  const message = e instanceof Error ? e.message : "Erreur inconnue";
+  const isMissing = /introuvable|not found/i.test(message);
+  res.status(isMissing ? 404 : 400).json({ error: message });
+}
+
+export async function handleCreateLeague(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as CreateLeagueBody;
+  try {
+    const league = await createLeague({
+      creatorId: userId,
+      name: body.name,
+      description: body.description ?? null,
+      ruleset: body.ruleset,
+      isPublic: body.isPublic,
+      maxParticipants: body.maxParticipants,
+      allowedRosters: body.allowedRosters ?? null,
+      winPoints: body.winPoints,
+      drawPoints: body.drawPoints,
+      lossPoints: body.lossPoints,
+      forfeitPoints: body.forfeitPoints,
+    });
+    res.status(201).json(serializeLeague(league as Record<string, unknown>));
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleListLeagues(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const query = req.query as unknown as ListLeaguesQuery;
+  try {
+    const leagues = await listLeagues({
+      creatorId: query.creatorId,
+      status: query.status,
+      publicOnly: query.publicOnly,
+    });
+    res.status(200).json({
+      leagues: (leagues as Array<Record<string, unknown>>).map(serializeLeague),
+    });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleGetLeague(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const leagueId = req.params.id;
+  const league = await getLeagueById(leagueId);
+  if (!league) {
+    res.status(404).json({ error: "Ligue introuvable" });
+    return;
+  }
+  res.status(200).json({
+    league: serializeLeague(league as unknown as Record<string, unknown>),
+  });
+}
+
+export async function handleCreateSeason(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const leagueId = req.params.id;
+  const league = await getLeagueById(leagueId);
+  if (!league) {
+    res.status(404).json({ error: "Ligue introuvable" });
+    return;
+  }
+  if ((league as { creatorId: string }).creatorId !== userId) {
+    res
+      .status(403)
+      .json({ error: "Seul le createur de la ligue peut creer une saison" });
+    return;
+  }
+  const body = req.body as CreateSeasonBody;
+  try {
+    const season = await createSeason({
+      leagueId,
+      name: body.name,
+      seasonNumber: body.seasonNumber,
+      startDate: body.startDate ?? null,
+      endDate: body.endDate ?? null,
+    });
+    res.status(201).json(season);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleJoinSeason(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  const body = req.body as JoinSeasonBody;
+
+  const season = await getSeasonById(seasonId);
+  if (!season) {
+    res.status(404).json({ error: "Saison introuvable" });
+    return;
+  }
+
+  const team = await prisma.team.findUnique({ where: { id: body.teamId } });
+  if (!team) {
+    res.status(404).json({ error: "Equipe introuvable" });
+    return;
+  }
+  if ((team as { ownerId: string }).ownerId !== userId) {
+    res
+      .status(403)
+      .json({ error: "Vous ne pouvez inscrire que vos propres equipes" });
+    return;
+  }
+
+  const allowed = parseAllowedRosters(
+    (season as { league: { allowedRosters: string | null } }).league
+      .allowedRosters,
+  );
+  if (allowed && !allowed.includes((team as { roster: string }).roster)) {
+    res.status(400).json({
+      error: `Roster ${(team as { roster: string }).roster} non autorise (autorises: ${allowed.join(", ")})`,
+    });
+    return;
+  }
+
+  try {
+    const participant = await addParticipant({ seasonId, teamId: body.teamId });
+    res.status(201).json(participant);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleLeaveSeason(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  const body = req.body as JoinSeasonBody;
+
+  const team = await prisma.team.findUnique({ where: { id: body.teamId } });
+  if (!team) {
+    res.status(404).json({ error: "Equipe introuvable" });
+    return;
+  }
+  if ((team as { ownerId: string }).ownerId !== userId) {
+    res
+      .status(403)
+      .json({ error: "Vous ne pouvez retirer que vos propres equipes" });
+    return;
+  }
+
+  try {
+    const updated = await withdrawParticipant({ seasonId, teamId: body.teamId });
+    res.status(200).json(updated);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleCreateRound(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  const body = req.body as CreateRoundBody;
+
+  const season = await getSeasonById(seasonId);
+  if (!season) {
+    res.status(404).json({ error: "Saison introuvable" });
+    return;
+  }
+  if ((season as { league: { creatorId: string } }).league.creatorId !== userId) {
+    res
+      .status(403)
+      .json({ error: "Seul le createur de la ligue peut planifier" });
+    return;
+  }
+
+  try {
+    const round = await createRound({
+      seasonId,
+      roundNumber: body.roundNumber,
+      name: body.name ?? null,
+      startDate: body.startDate ?? null,
+      endDate: body.endDate ?? null,
+    });
+    res.status(201).json(round);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+export async function handleGetStandings(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const seasonId = req.params.seasonId;
+  try {
+    const standings = await computeSeasonStandings(seasonId);
+    res.status(200).json({ seasonId, standings });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+const router = Router();
+
+router.post("/", authUser, validate(createLeagueSchema), handleCreateLeague);
+router.get("/", authUser, validateQuery(listLeaguesQuerySchema), handleListLeagues);
+router.get("/:id", authUser, handleGetLeague);
+router.post(
+  "/:id/seasons",
+  authUser,
+  validate(createSeasonSchema),
+  handleCreateSeason,
+);
+router.post(
+  "/seasons/:seasonId/join",
+  authUser,
+  validate(joinSeasonSchema),
+  handleJoinSeason,
+);
+router.post(
+  "/seasons/:seasonId/leave",
+  authUser,
+  validate(joinSeasonSchema),
+  handleLeaveSeason,
+);
+router.post(
+  "/seasons/:seasonId/rounds",
+  authUser,
+  validate(createRoundSchema),
+  handleCreateRound,
+);
+router.get("/seasons/:seasonId/standings", authUser, handleGetStandings);
+
+export default router;

--- a/apps/server/src/schemas/league.schemas.ts
+++ b/apps/server/src/schemas/league.schemas.ts
@@ -1,0 +1,70 @@
+/**
+ * L.3 — Zod schemas for league API routes.
+ *
+ * Sprint 17 — infrastructure competitive : ligues.
+ * Garde les routes /leagues alignees avec le service `services/league.ts`.
+ */
+
+import { z } from "zod";
+
+const rosterSlug = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9_-]+$/i, "slug de roster invalide");
+
+export const createLeagueSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Le nom de la ligue est requis")
+    .max(100, "Le nom de la ligue ne peut pas depasser 100 caracteres"),
+  description: z.string().max(500).optional().nullable(),
+  ruleset: z.enum(["season_2", "season_3"]).optional(),
+  isPublic: z.boolean().optional(),
+  maxParticipants: z.number().int().min(2).max(128).optional(),
+  allowedRosters: z.array(rosterSlug).max(64).optional().nullable(),
+  winPoints: z.number().int().min(0).max(10).optional(),
+  drawPoints: z.number().int().min(0).max(10).optional(),
+  lossPoints: z.number().int().min(-10).max(10).optional(),
+  forfeitPoints: z.number().int().min(-10).max(10).optional(),
+});
+
+export const createSeasonSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Le nom de la saison est requis")
+    .max(100, "Le nom de la saison ne peut pas depasser 100 caracteres"),
+  seasonNumber: z.number().int().min(1).optional(),
+  startDate: z.coerce.date().optional().nullable(),
+  endDate: z.coerce.date().optional().nullable(),
+});
+
+export const joinSeasonSchema = z.object({
+  teamId: z.string().min(1, "teamId requis"),
+});
+
+export const createRoundSchema = z.object({
+  roundNumber: z.number().int().min(1, "Numero de journee >= 1"),
+  name: z.string().trim().min(1).max(100).optional().nullable(),
+  startDate: z.coerce.date().optional().nullable(),
+  endDate: z.coerce.date().optional().nullable(),
+});
+
+export const listLeaguesQuerySchema = z.object({
+  creatorId: z.string().optional(),
+  status: z
+    .enum(["draft", "open", "in_progress", "completed", "archived"])
+    .optional(),
+  publicOnly: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+});
+
+export type CreateLeagueBody = z.infer<typeof createLeagueSchema>;
+export type CreateSeasonBody = z.infer<typeof createSeasonSchema>;
+export type JoinSeasonBody = z.infer<typeof joinSeasonSchema>;
+export type CreateRoundBody = z.infer<typeof createRoundSchema>;
+export type ListLeaguesQuery = z.infer<typeof listLeaguesQuerySchema>;

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -262,3 +262,158 @@ export function parseAllowedRosters(raw: string | null): string[] | null {
     return null;
   }
 }
+
+export interface StandingRow {
+  participantId: string;
+  teamId: string;
+  teamName: string;
+  roster: string;
+  ownerId: string;
+  coachName: string | null;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  points: number;
+  touchdownsFor: number;
+  touchdownsAgainst: number;
+  touchdownDifference: number;
+  casualtiesFor: number;
+  casualtiesAgainst: number;
+  seasonElo: number;
+  status: LeagueParticipantStatus;
+}
+
+/**
+ * Classement d'une saison (L.3 standings). Trie selon :
+ *   points DESC → diff TD DESC → TD pour DESC → ELO DESC → nom ASC.
+ * Cette methode lit les compteurs materialises sur `LeagueParticipant`
+ * (mis a jour par L.7 : integration match -> ligue).
+ */
+export async function computeSeasonStandings(
+  seasonId: string,
+): Promise<StandingRow[]> {
+  const season = await prisma.leagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { id: true },
+  });
+  if (!season) {
+    throw new Error(`Saison introuvable: ${seasonId}`);
+  }
+
+  const participants = await prisma.leagueParticipant.findMany({
+    where: { seasonId },
+    include: {
+      team: {
+        select: {
+          id: true,
+          name: true,
+          roster: true,
+          owner: { select: { id: true, coachName: true } },
+        },
+      },
+    },
+  });
+
+  type ParticipantRow = (typeof participants)[number];
+  const rows: StandingRow[] = participants.map((p: ParticipantRow) => ({
+    participantId: p.id,
+    teamId: p.teamId,
+    teamName: p.team.name,
+    roster: p.team.roster,
+    ownerId: p.team.owner.id,
+    coachName: p.team.owner.coachName ?? null,
+    played: p.wins + p.draws + p.losses,
+    wins: p.wins,
+    draws: p.draws,
+    losses: p.losses,
+    points: p.points,
+    touchdownsFor: p.touchdownsFor,
+    touchdownsAgainst: p.touchdownsAgainst,
+    touchdownDifference: p.touchdownsFor - p.touchdownsAgainst,
+    casualtiesFor: p.casualtiesFor,
+    casualtiesAgainst: p.casualtiesAgainst,
+    seasonElo: p.seasonElo,
+    status: p.status as LeagueParticipantStatus,
+  }));
+
+  rows.sort((a, b) => {
+    if (b.points !== a.points) return b.points - a.points;
+    if (b.touchdownDifference !== a.touchdownDifference) {
+      return b.touchdownDifference - a.touchdownDifference;
+    }
+    if (b.touchdownsFor !== a.touchdownsFor) {
+      return b.touchdownsFor - a.touchdownsFor;
+    }
+    if (b.seasonElo !== a.seasonElo) return b.seasonElo - a.seasonElo;
+    return a.teamName.localeCompare(b.teamName);
+  });
+
+  return rows;
+}
+
+export async function getLeagueById(leagueId: string) {
+  return prisma.league.findUnique({
+    where: { id: leagueId },
+    include: {
+      creator: { select: { id: true, coachName: true, email: true } },
+      seasons: { orderBy: { seasonNumber: "asc" } },
+    },
+  });
+}
+
+export async function getSeasonById(seasonId: string) {
+  return prisma.leagueSeason.findUnique({
+    where: { id: seasonId },
+    include: {
+      league: true,
+      rounds: { orderBy: { roundNumber: "asc" } },
+      participants: {
+        include: {
+          team: {
+            select: {
+              id: true,
+              name: true,
+              roster: true,
+              owner: { select: { id: true, coachName: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Withdraw une equipe d'une saison : refuse si la saison est terminee
+ * ou si l'equipe n'est pas inscrite.
+ */
+export async function withdrawParticipant(input: {
+  seasonId: string;
+  teamId: string;
+}) {
+  const season = await prisma.leagueSeason.findUnique({
+    where: { id: input.seasonId },
+    select: { id: true, status: true },
+  });
+  if (!season) {
+    throw new Error(`Saison introuvable: ${input.seasonId}`);
+  }
+  if (season.status === "completed") {
+    throw new Error("Saison terminee : impossible de retirer une equipe");
+  }
+
+  const existing = await prisma.leagueParticipant.findUnique({
+    where: {
+      seasonId_teamId: { seasonId: input.seasonId, teamId: input.teamId },
+    },
+  });
+  if (!existing) {
+    throw new Error("Cette equipe n'est pas inscrite sur la saison");
+  }
+
+  return prisma.leagueParticipant.update({
+    where: { id: existing.id },
+    data: { status: "withdrawn" },
+  });
+}


### PR DESCRIPTION
## Resume

- Expose 8 endpoints `/leagues` au-dessus du service existant (`services/league.ts`) : create, list, detail, create-season, join, leave, schedule-round, standings.
- Etend le service avec `computeSeasonStandings` (tri points DESC -> diff TD -> TD pour -> ELO -> nom), `getLeagueById`, `getSeasonById`, `withdrawParticipant`.
- Ajoute les schemas Zod dedies (`schemas/league.schemas.ts`) et 20 tests unitaires couvrant auth / ownership / allowedRosters / mapping d'erreurs.

## Tache roadmap

Sprint 17 - L.3 `Routes API CRUD ligue (create, join, schedule, standings)`.

## Plan de test

- [x] `pnpm --filter @bb/server test` : 486 tests au vert (dont 20 nouveaux sur les routes ligue + 15 sur le service).
- [x] `pnpm --filter @bb/server typecheck` : propre.
- [ ] Tester manuellement `POST /leagues`, `POST /leagues/:id/seasons`, `POST /leagues/seasons/:seasonId/join`, `GET /leagues/seasons/:seasonId/standings` avec un user authentifie (reservation pour un test d'integration dedie plus tard).
- [ ] Valider que les creators-only checks (`POST /seasons`, `POST /rounds`) renvoient bien 403 pour un user non proprietaire.