### PR TITLE
Gate AI training feature behind feature flag

### DIFF
--- a/apps/server/src/routes/local-match.ts
+++ b/apps/server/src/routes/local-match.ts
@@ -31,6 +31,8 @@ import { persistPlayerDeaths } from "../services/player-death";
 import { persistPermanentInjuries } from "../services/permanent-injuries";
 import { getLinemanStats } from "../services/journeymen";
 import { validate, validateQuery } from "../middleware/validate";
+import { requireFeatureFlag } from "../middleware/requireFeatureFlag";
+import { AI_TRAINING_FLAG } from "../services/featureFlags";
 import {
   localMatchListQuerySchema,
   createLocalMatchSchema,
@@ -1570,13 +1572,19 @@ router.post("/share/:token/validate", authUser, validate(validateShareTokenSchem
 // ─────────────────────────────────────────────────────────────────────────────
 
 // GET /local-match/ai/opponents — liste la whitelist des rosters IA (N.4b).
-router.get("/ai/opponents", authUser, async (_req: AuthenticatedRequest, res) => {
-  res.json({ rosters: listAIOpponentAllowedRosters() });
-});
+router.get(
+  "/ai/opponents",
+  requireFeatureFlag(AI_TRAINING_FLAG),
+  authUser,
+  async (_req: AuthenticatedRequest, res) => {
+    res.json({ rosters: listAIOpponentAllowedRosters() });
+  },
+);
 
 // POST /local-match/practice — cree un match pratique contre IA.
 router.post(
   "/practice",
+  requireFeatureFlag(AI_TRAINING_FLAG),
   authUser,
   validate(createPracticeMatchSchema),
   async (req: AuthenticatedRequest, res) => {
@@ -1632,6 +1640,7 @@ router.post(
 // Ne mute pas l'etat cote serveur : le client applique le coup puis persiste via PUT /state.
 router.post(
   "/:id/ai-next-move",
+  requireFeatureFlag(AI_TRAINING_FLAG),
   authUser,
   validate(aiNextMoveSchema),
   async (req: AuthenticatedRequest, res) => {

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -17,7 +17,7 @@ import {
   SEASON_3_RENAMED_SKILLS 
 } from "./static-skills-data-s3";
 import { UNKNOWN_USER_ID } from "./utils/user-constants";
-import { ONLINE_PLAY_FLAG } from "./services/featureFlags";
+import { ONLINE_PLAY_FLAG, AI_TRAINING_FLAG } from "./services/featureFlags";
 import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
 
 async function main() {
@@ -977,6 +977,41 @@ async function main() {
     });
     console.log(
       `   ✅ Override '${ONLINE_PLAY_FLAG}' ajouté pour user@example.com`,
+    );
+  }
+
+  // "ai_training" : gate la fonctionnalité "Entrainement contre l'IA"
+  // (création d'un match pratique solo + calcul du coup IA).
+  // Par défaut désactivé globalement ; FEATURE_FLAGS_FORCE_ENABLED=true (CI)
+  // et le rôle admin court-circuitent ce flag. Un override est ajouté pour
+  // user@example.com afin de faciliter les tests manuels.
+  const aiTrainingFlag = await prisma.featureFlag.upsert({
+    where: { key: AI_TRAINING_FLAG },
+    update: {
+      description:
+        "Active l'entrainement contre l'IA (match pratique solo + coups IA).",
+    },
+    create: {
+      key: AI_TRAINING_FLAG,
+      description:
+        "Active l'entrainement contre l'IA (match pratique solo + coups IA).",
+      enabled: false,
+    },
+  });
+  console.log(
+    `   ✅ Flag '${AI_TRAINING_FLAG}' ${aiTrainingFlag.enabled ? "actif" : "inactif (override admin/user)"}`,
+  );
+
+  if (testUser) {
+    await prisma.featureFlagUser.upsert({
+      where: {
+        flagId_userId: { flagId: aiTrainingFlag.id, userId: testUser.id },
+      },
+      create: { flagId: aiTrainingFlag.id, userId: testUser.id },
+      update: {},
+    });
+    console.log(
+      `   ✅ Override '${AI_TRAINING_FLAG}' ajouté pour user@example.com`,
     );
   }
 

--- a/apps/server/src/services/featureFlags.test.ts
+++ b/apps/server/src/services/featureFlags.test.ts
@@ -30,6 +30,7 @@ import {
   removeUserOverride,
   invalidateFeatureFlagsCache,
   ONLINE_PLAY_FLAG,
+  AI_TRAINING_FLAG,
 } from "./featureFlags";
 
 const mockPrisma = prisma as any;
@@ -320,6 +321,12 @@ describe("featureFlags service", () => {
   describe("ONLINE_PLAY_FLAG constant", () => {
     it('exports the canonical "online_play" key', () => {
       expect(ONLINE_PLAY_FLAG).toBe("online_play");
+    });
+  });
+
+  describe("AI_TRAINING_FLAG constant", () => {
+    it('exports the canonical "ai_training" key', () => {
+      expect(AI_TRAINING_FLAG).toBe("ai_training");
     });
   });
 });

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -17,6 +17,12 @@ import { hasRole } from "../utils/roles";
  */
 export const ONLINE_PLAY_FLAG = "online_play" as const;
 
+/**
+ * Clé du flag qui gate la fonctionnalité "Entrainement contre l'IA"
+ * (POST /local-match/practice et POST /local-match/:id/ai-next-move).
+ */
+export const AI_TRAINING_FLAG = "ai_training" as const;
+
 export interface FeatureFlagDTO {
   id: string;
   key: string;

--- a/apps/web/app/lib/featureFlagKeys.ts
+++ b/apps/web/app/lib/featureFlagKeys.ts
@@ -5,3 +5,4 @@
  * À garder synchronisé manuellement avec le backend.
  */
 export const ONLINE_PLAY_FLAG = "online_play" as const;
+export const AI_TRAINING_FLAG = "ai_training" as const;

--- a/apps/web/app/play/page.test.tsx
+++ b/apps/web/app/play/page.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import PlayPage from "./page";
 import { LanguageProvider } from "../contexts/LanguageContext";
+import { FeatureFlagProvider } from "../contexts/FeatureFlagContext";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -21,10 +22,19 @@ vi.mock("./hooks/useMatchmakingSocket", () => ({
   useMatchmakingSocket: vi.fn(),
 }));
 
+vi.mock("../lib/featureFlags", () => ({
+  fetchMyFlags: vi.fn(),
+}));
+
+import { fetchMyFlags } from "../lib/featureFlags";
+const mockedFetchMyFlags = fetchMyFlags as unknown as ReturnType<typeof vi.fn>;
+
 function renderWithProvider() {
   return render(
     <LanguageProvider>
-      <PlayPage />
+      <FeatureFlagProvider>
+        <PlayPage />
+      </FeatureFlagProvider>
     </LanguageProvider>,
   );
 }
@@ -68,6 +78,7 @@ describe("PlayPage — ELO display in lobby", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorageMock.getItem.mockReturnValue("fake-token");
+    mockedFetchMyFlags.mockResolvedValue([]);
   });
 
   it("displays opponent ELO rating in match cards", async () => {
@@ -99,5 +110,50 @@ describe("PlayPage — ELO display in lobby", () => {
 
     // Opponent ELO should be displayed
     expect(screen.getByText("1180")).toBeTruthy();
+  });
+});
+
+describe("PlayPage — ai_training feature flag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue("fake-token");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/auth/me")) return Promise.resolve(mockAuthResponse);
+      if (url.includes("/my-matches"))
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ matches: [] }),
+        });
+      if (url.includes("/team/mine"))
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockTeamsData),
+        });
+      if (url.includes("/matchmaking/status"))
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockQueueData),
+        });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  it("hides the 'Entrainement contre l'IA' card when the flag is inactive", async () => {
+    mockedFetchMyFlags.mockResolvedValue([]);
+    renderWithProvider();
+    // Wait for the create-match card (always rendered) to appear, then
+    // assert the practice card is absent.
+    await waitFor(() =>
+      expect(screen.getByTestId("create-match-button")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("practice-ai-card")).toBeNull();
+  });
+
+  it("shows the 'Entrainement contre l'IA' card when the flag is active", async () => {
+    mockedFetchMyFlags.mockResolvedValue(["ai_training"]);
+    renderWithProvider();
+    await waitFor(() =>
+      expect(screen.getByTestId("practice-ai-card")).toBeTruthy(),
+    );
   });
 });

--- a/apps/web/app/play/page.tsx
+++ b/apps/web/app/play/page.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState, useCallback } from "react";
 import { API_BASE } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useMatchmakingSocket } from "./hooks/useMatchmakingSocket";
+import { useFeatureFlag } from "../hooks/useFeatureFlag";
+import { AI_TRAINING_FLAG } from "../lib/featureFlagKeys";
 
 interface MatchSummary {
   id: string;
@@ -108,6 +110,7 @@ function formatTV(tv: number): string {
 
 export default function PlayPage() {
   const { t, language: lang } = useLanguage();
+  const aiTrainingEnabled = useFeatureFlag(AI_TRAINING_FLAG);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [matchIdInput, setMatchIdInput] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -540,7 +543,8 @@ export default function PlayPage() {
         </div>
       </div>
 
-      {/* Practice vs AI Card (N.4) */}
+      {/* Practice vs AI Card (N.4) — gated behind the `ai_training` feature flag */}
+      {aiTrainingEnabled && (
       <div className="max-w-3xl mx-auto">
         <div
           data-testid="practice-ai-card"
@@ -650,6 +654,7 @@ export default function PlayPage() {
           </div>
         </div>
       </div>
+      )}
 
       {/* Create / Join Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto">


### PR DESCRIPTION
## Résumé

Implement feature flag gating for the AI training functionality (practice matches against AI). This adds the `ai_training` feature flag to control access to:
- The practice vs AI card on the Play page
- The `/local-match/practice` endpoint (create practice match)
- The `/local-match/ai/opponents` endpoint (list AI rosters)
- The `/local-match/:id/ai-next-move` endpoint (compute AI moves)

The flag is disabled by default globally but can be overridden per-user or enabled via admin/CI settings. A test user override is seeded for manual testing.

## Changes

**Backend:**
- Added `AI_TRAINING_FLAG` constant to `featureFlags.ts`
- Protected three AI-related endpoints with `requireFeatureFlag` middleware
- Seeded the `ai_training` flag (disabled by default) with test user override in `seed.ts`
- Added unit test for the new flag constant

**Frontend:**
- Added `AI_TRAINING_FLAG` constant to `featureFlagKeys.ts`
- Wrapped the practice vs AI card in conditional rendering based on `useFeatureFlag` hook
- Updated test suite to mock `fetchMyFlags` and added tests verifying the card visibility based on flag state
- Wrapped `PlayPage` with `FeatureFlagProvider` in tests

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (added feature flag tests for card visibility)
- [x] Changeset ajouté (if applicable)

https://claude.ai/code/session_01NFVTsAMX8ttC2CsxFVHMQv