### PR TITLE
feat(league): L.4 round-robin schedule generator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -296,7 +296,7 @@
 | L.1 | Modeles Prisma League/LeagueSeason/LeagueParticipant/LeagueRound | DB | [x] |
 | L.2 | Migration Prisma + seed data | DB | [x] |
 | L.3 | Routes API CRUD ligue (create, join, schedule, standings) | API | [x] |
-| L.4 | Generateur de calendrier round-robin | Backend | [ ] |
+| L.4 | Generateur de calendrier round-robin | Backend | [x] |
 | L.5 | Page liste des ligues | Frontend | [ ] |
 | L.6 | Page detail ligue (calendrier, classement, matchs) | Frontend | [ ] |
 | L.7 | Integration match online -> ligue (resultats auto) | Backend | [ ] |

--- a/apps/server/src/services/league-schedule.test.ts
+++ b/apps/server/src/services/league-schedule.test.ts
@@ -1,0 +1,274 @@
+/**
+ * L.4 — Tests du generateur de calendrier round-robin (Sprint 17).
+ *
+ * Fonction pure, aucune dependance Prisma.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateRoundRobin,
+  type RoundRobinRound,
+} from "./league-schedule";
+
+function pairSignature(home: string, away: string): string {
+  return [home, away].sort().join("|");
+}
+
+function allPairs(rounds: readonly RoundRobinRound[]): string[] {
+  return rounds.flatMap((r) =>
+    r.pairings.map((p) => pairSignature(p.home, p.away)),
+  );
+}
+
+function countAppearancesPerTeam(
+  rounds: readonly RoundRobinRound[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const round of rounds) {
+    for (const pairing of round.pairings) {
+      counts.set(pairing.home, (counts.get(pairing.home) ?? 0) + 1);
+      counts.set(pairing.away, (counts.get(pairing.away) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+describe("Rule: League round-robin schedule", () => {
+  describe("input validation", () => {
+    it("rejects fewer than 2 participants", () => {
+      expect(() =>
+        generateRoundRobin({ participantIds: [] }),
+      ).toThrow(/deux|two|participants/i);
+      expect(() =>
+        generateRoundRobin({ participantIds: ["solo"] }),
+      ).toThrow(/deux|two|participants/i);
+    });
+
+    it("rejects duplicate participant ids", () => {
+      expect(() =>
+        generateRoundRobin({ participantIds: ["a", "b", "a"] }),
+      ).toThrow(/unique|duplicate|doublon/i);
+    });
+  });
+
+  describe("even participant count (single round-robin)", () => {
+    it("produces N-1 rounds with N/2 pairings each for 2 teams", () => {
+      const rounds = generateRoundRobin({ participantIds: ["a", "b"] });
+
+      expect(rounds).toHaveLength(1);
+      expect(rounds[0].roundNumber).toBe(1);
+      expect(rounds[0].pairings).toHaveLength(1);
+      expect(rounds[0].bye).toBeNull();
+      expect(pairSignature(rounds[0].pairings[0].home, rounds[0].pairings[0].away))
+        .toBe("a|b");
+    });
+
+    it("produces 3 rounds of 2 pairings for 4 teams", () => {
+      const rounds = generateRoundRobin({
+        participantIds: ["a", "b", "c", "d"],
+      });
+
+      expect(rounds).toHaveLength(3);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(2);
+        expect(round.bye).toBeNull();
+      }
+      expect(rounds.map((r) => r.roundNumber)).toEqual([1, 2, 3]);
+    });
+
+    it("has every pair of teams meet exactly once for 6 teams", () => {
+      const teams = ["a", "b", "c", "d", "e", "f"];
+      const rounds = generateRoundRobin({ participantIds: teams });
+
+      expect(rounds).toHaveLength(5);
+
+      const pairs = allPairs(rounds);
+      const expectedPairCount = (teams.length * (teams.length - 1)) / 2;
+      expect(pairs).toHaveLength(expectedPairCount);
+      expect(new Set(pairs).size).toBe(expectedPairCount);
+    });
+
+    it("each team plays exactly once per round", () => {
+      const teams = ["a", "b", "c", "d", "e", "f"];
+      const rounds = generateRoundRobin({ participantIds: teams });
+
+      for (const round of rounds) {
+        const teamsThisRound = new Set<string>();
+        for (const pairing of round.pairings) {
+          expect(teamsThisRound.has(pairing.home)).toBe(false);
+          expect(teamsThisRound.has(pairing.away)).toBe(false);
+          teamsThisRound.add(pairing.home);
+          teamsThisRound.add(pairing.away);
+        }
+        expect(teamsThisRound.size).toBe(teams.length);
+      }
+    });
+  });
+
+  describe("odd participant count (bye handling)", () => {
+    it("produces N rounds with one bye per round for 3 teams", () => {
+      const rounds = generateRoundRobin({
+        participantIds: ["a", "b", "c"],
+      });
+
+      expect(rounds).toHaveLength(3);
+      for (const round of rounds) {
+        expect(round.pairings).toHaveLength(1);
+        expect(round.bye).not.toBeNull();
+      }
+
+      const byes = rounds.map((r) => r.bye).sort();
+      expect(byes).toEqual(["a", "b", "c"]);
+    });
+
+    it("each team plays N-1 matches and has exactly 1 bye for 5 teams", () => {
+      const teams = ["a", "b", "c", "d", "e"];
+      const rounds = generateRoundRobin({ participantIds: teams });
+
+      expect(rounds).toHaveLength(5);
+
+      const counts = countAppearancesPerTeam(rounds);
+      for (const team of teams) {
+        expect(counts.get(team)).toBe(teams.length - 1);
+      }
+
+      const byes = rounds.map((r) => r.bye);
+      expect(byes.filter((b) => b !== null)).toHaveLength(teams.length);
+      expect(new Set(byes)).toEqual(new Set(teams));
+    });
+
+    it("every pair of teams meets exactly once for 5 teams", () => {
+      const teams = ["a", "b", "c", "d", "e"];
+      const rounds = generateRoundRobin({ participantIds: teams });
+      const pairs = allPairs(rounds);
+      const expected = (teams.length * (teams.length - 1)) / 2;
+      expect(pairs).toHaveLength(expected);
+      expect(new Set(pairs).size).toBe(expected);
+    });
+  });
+
+  describe("determinism", () => {
+    it("returns the same schedule for the same input", () => {
+      const input = { participantIds: ["a", "b", "c", "d"] };
+      const first = generateRoundRobin(input);
+      const second = generateRoundRobin(input);
+      expect(first).toEqual(second);
+    });
+
+    it("input order influences home/away assignment", () => {
+      const a = generateRoundRobin({ participantIds: ["a", "b"] });
+      const b = generateRoundRobin({ participantIds: ["b", "a"] });
+      // same pair, but the canonical pair signature must match
+      expect(pairSignature(a[0].pairings[0].home, a[0].pairings[0].away)).toBe(
+        pairSignature(b[0].pairings[0].home, b[0].pairings[0].away),
+      );
+    });
+  });
+
+  describe("home/away balance", () => {
+    it("double round-robin gives each team exactly (N-1) home and (N-1) away games", () => {
+      const teams = ["a", "b", "c", "d"];
+      const rounds = generateRoundRobin({
+        participantIds: teams,
+        doubleRoundRobin: true,
+      });
+      const homeCounts = new Map<string, number>();
+      const awayCounts = new Map<string, number>();
+      for (const round of rounds) {
+        for (const pairing of round.pairings) {
+          homeCounts.set(
+            pairing.home,
+            (homeCounts.get(pairing.home) ?? 0) + 1,
+          );
+          awayCounts.set(
+            pairing.away,
+            (awayCounts.get(pairing.away) ?? 0) + 1,
+          );
+        }
+      }
+      for (const team of teams) {
+        expect(homeCounts.get(team) ?? 0).toBe(teams.length - 1);
+        expect(awayCounts.get(team) ?? 0).toBe(teams.length - 1);
+      }
+    });
+  });
+
+  describe("double round-robin (home and away)", () => {
+    it("produces 2*(N-1) rounds and meets every pair exactly twice", () => {
+      const teams = ["a", "b", "c", "d"];
+      const rounds = generateRoundRobin({
+        participantIds: teams,
+        doubleRoundRobin: true,
+      });
+
+      expect(rounds).toHaveLength(2 * (teams.length - 1));
+
+      const pairSignatures = rounds.flatMap((r) =>
+        r.pairings.map((p) => pairSignature(p.home, p.away)),
+      );
+      const expected = teams.length * (teams.length - 1);
+      expect(pairSignatures).toHaveLength(expected);
+
+      const perPair = new Map<string, number>();
+      for (const sig of pairSignatures) {
+        perPair.set(sig, (perPair.get(sig) ?? 0) + 1);
+      }
+      for (const count of perPair.values()) {
+        expect(count).toBe(2);
+      }
+    });
+
+    it("reverses home/away in the second half", () => {
+      const teams = ["a", "b", "c", "d"];
+      const rounds = generateRoundRobin({
+        participantIds: teams,
+        doubleRoundRobin: true,
+      });
+
+      const firstLeg = rounds.slice(0, teams.length - 1);
+      const secondLeg = rounds.slice(teams.length - 1);
+
+      for (let i = 0; i < firstLeg.length; i += 1) {
+        const firstPairs = firstLeg[i].pairings.map((p) => `${p.home}-${p.away}`);
+        const secondPairs = secondLeg[i].pairings.map(
+          (p) => `${p.away}-${p.home}`,
+        );
+        expect(new Set(firstPairs)).toEqual(new Set(secondPairs));
+      }
+    });
+
+    it("continues round numbers past the first leg", () => {
+      const teams = ["a", "b", "c", "d"];
+      const rounds = generateRoundRobin({
+        participantIds: teams,
+        doubleRoundRobin: true,
+      });
+      expect(rounds.map((r) => r.roundNumber)).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+  });
+
+  describe("priority teams (use case: Open 5 Teams league)", () => {
+    it("schedules 5 priority teams with exactly one bye per team", () => {
+      const priorityRosters = [
+        "skaven",
+        "gnome",
+        "lizardmen",
+        "dwarf",
+        "imperial_nobility",
+      ];
+      const rounds = generateRoundRobin({ participantIds: priorityRosters });
+
+      expect(rounds).toHaveLength(priorityRosters.length);
+      const byes = rounds.map((r) => r.bye).filter((b): b is string => b !== null);
+      expect(byes).toHaveLength(priorityRosters.length);
+      expect(new Set(byes)).toEqual(new Set(priorityRosters));
+
+      const totalPairings = rounds.reduce(
+        (acc, r) => acc + r.pairings.length,
+        0,
+      );
+      // 5 teams: 10 unique pairs to play
+      expect(totalPairings).toBe(10);
+    });
+  });
+});

--- a/apps/server/src/services/league-schedule.ts
+++ b/apps/server/src/services/league-schedule.ts
@@ -1,0 +1,117 @@
+/**
+ * L.4 — Generateur de calendrier round-robin (Sprint 17).
+ *
+ * Fonction pure qui produit le calendrier d'une saison de ligue pour
+ * une liste de participants. Utilise la "methode des cercles" (tables
+ * de Berger) : on fixe un participant et on fait tourner les autres.
+ *
+ * Contrats :
+ * - Deterministe : meme entree -> meme sortie (ordre des rounds et
+ *   des pairings dans chaque round).
+ * - Pour N participants pairs : N-1 rounds, chaque paire se rencontre
+ *   exactement une fois.
+ * - Pour N participants impairs : on ajoute un marqueur "bye" fantome
+ *   et chaque round libere un participant (1 bye par round, reparti
+ *   sur N rounds).
+ * - Option `doubleRoundRobin` : second tour avec home/away inverses,
+ *   les numeros de round continuent (1..N-1 puis N..2(N-1)).
+ * - L'equilibre home/away suit le standard Berger : au plus
+ *   ceil((N-1)/2) matchs a domicile par equipe en simple round-robin.
+ *
+ * Cette fonction ne touche pas la base de donnees : elle renvoie une
+ * structure serialisable, que le seeder L.2 ou une future route L.5/L.7
+ * peut persister sous forme de LeagueRound + futurs LeagueMatch.
+ */
+
+export interface RoundRobinPairing {
+  readonly home: string;
+  readonly away: string;
+}
+
+export interface RoundRobinRound {
+  readonly roundNumber: number;
+  readonly pairings: readonly RoundRobinPairing[];
+  readonly bye: string | null;
+}
+
+export interface GenerateRoundRobinInput {
+  readonly participantIds: readonly string[];
+  readonly doubleRoundRobin?: boolean;
+}
+
+const BYE_MARKER = "__bye__";
+
+export function generateRoundRobin(
+  input: GenerateRoundRobinInput,
+): RoundRobinRound[] {
+  const { participantIds, doubleRoundRobin = false } = input;
+
+  if (participantIds.length < 2) {
+    throw new Error(
+      "Au moins deux participants requis pour generer un calendrier round-robin",
+    );
+  }
+
+  const unique = new Set(participantIds);
+  if (unique.size !== participantIds.length) {
+    throw new Error(
+      "Les identifiants de participants doivent etre uniques (doublon detecte)",
+    );
+  }
+
+  const working: string[] = [...participantIds];
+  if (working.length % 2 === 1) {
+    working.push(BYE_MARKER);
+  }
+
+  const n = working.length;
+  const half = n / 2;
+  const roundsCount = n - 1;
+
+  const fixed = working[0];
+  const rotating: string[] = working.slice(1);
+
+  const firstLeg: RoundRobinRound[] = [];
+
+  for (let r = 0; r < roundsCount; r += 1) {
+    const lineup: string[] = [fixed, ...rotating];
+    const pairings: RoundRobinPairing[] = [];
+    let bye: string | null = null;
+
+    for (let i = 0; i < half; i += 1) {
+      const a = lineup[i];
+      const b = lineup[n - 1 - i];
+
+      if (a === BYE_MARKER) {
+        bye = b;
+        continue;
+      }
+      if (b === BYE_MARKER) {
+        bye = a;
+        continue;
+      }
+
+      // Berger balancing: top slot alternates home/away per round,
+      // other slots follow the round parity + their position.
+      const swap = i === 0 ? r % 2 === 1 : (r + i) % 2 === 0;
+      pairings.push(swap ? { home: b, away: a } : { home: a, away: b });
+    }
+
+    firstLeg.push({ roundNumber: r + 1, pairings, bye });
+
+    // Rotate: last element moves to the front.
+    rotating.unshift(rotating.pop() as string);
+  }
+
+  if (!doubleRoundRobin) {
+    return firstLeg;
+  }
+
+  const secondLeg: RoundRobinRound[] = firstLeg.map((round, idx) => ({
+    roundNumber: roundsCount + idx + 1,
+    pairings: round.pairings.map((p) => ({ home: p.away, away: p.home })),
+    bye: round.bye,
+  }));
+
+  return [...firstLeg, ...secondLeg];
+}


### PR DESCRIPTION
## Resume

Sprint 17 — tache **L.4 : Generateur de calendrier round-robin (Backend)**.

- Ajoute `apps/server/src/services/league-schedule.ts`, un generateur pur (sans Prisma) base sur la methode des cercles (Berger) : N-1 rounds pour N participants pairs, N rounds + 1 bye par round pour N impair.
- Supporte un mode `doubleRoundRobin` (aller-retour) qui renvoie 2*(N-1) rounds avec les home/away inverses.
- Deterministe : meme entree -> meme sortie (ordre des rounds et pairings stable), utilisable par L.5/L.6 (UI) et la future L.7 (integration match -> ligue).
- Ajoute 16 tests unitaires couvrant : validation des entrees, cas pair/impair, distribution des byes, unicite des paires, determinisme, home/away mirror du double RR, scenario Open 5 Teams.

L'equilibrage strict home/away (Berger complet) est volontairement hors scope de L.4 : les labels sont produits mais la balance parfaite sera polish si L.7 en a besoin.

## Tache roadmap

Sprint 17, tache **L.4** (cochee dans `TODO.md`).

## Plan de test

- [x] `pnpm test src/services/league-schedule.test.ts` — 16/16 verts
- [x] `pnpm test` (`@bb/server` complet) — 503/503 verts, aucune regression
- [x] `pnpm typecheck` (`@bb/server`) — propre
- [x] `pnpm lint` (`@bb/server`) — propre (warn migration ESLint, pre-existant)
- [ ] Integration avec le seeder L.2 et une route `POST /leagues/seasons/:id/schedule` (a traiter en L.5/L.7)
- [ ] Persistence des pairings dans un futur modele `LeagueMatch` (L.7)

## Notes

Les erreurs TypeScript pre-existantes dans `apps/web/app/local-matches/[id]/PracticeAIPanel.tsx` et `useAIPracticeLoop.test.ts` (cf. PR #267) sont independantes de cette PR — vu sur `main`.