### PR TITLE
feat(league): L.5 page liste des ligues (frontend)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -297,7 +297,7 @@
 | L.2 | Migration Prisma + seed data | DB | [x] |
 | L.3 | Routes API CRUD ligue (create, join, schedule, standings) | API | [x] |
 | L.4 | Generateur de calendrier round-robin | Backend | [x] |
-| L.5 | Page liste des ligues | Frontend | [ ] |
+| L.5 | Page liste des ligues | Frontend | [x] |
 | L.6 | Page detail ligue (calendrier, classement, matchs) | Frontend | [ ] |
 | L.7 | Integration match online -> ligue (resultats auto) | Backend | [ ] |
 | L.8 | ELO saisonnier avec reset et placements | Backend | [ ] |

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -369,6 +369,25 @@ export const translations = {
       topRating: "Meilleur ELO",
       averageRating: "ELO moyen",
     },
+    // Leagues (Sprint 17 — L.5)
+    leagues: {
+      title: "Ligues",
+      description: "Retrouvez toutes les ligues de Nuffle Arena, inscrivez-vous et suivez les classements saisonniers.",
+      empty: "Aucune ligue pour le moment.",
+      errorLoad: "Erreur lors du chargement des ligues",
+      filterStatus: "Statut",
+      maxParticipants: "Places",
+      visibilityPublic: "Publique",
+      visibilityPrivate: "Privée",
+      allowedRosters: "Rosters autorisés",
+      rulesetSeason2: "Saison 2",
+      rulesetSeason3: "Saison 3",
+      statusDraft: "Brouillon",
+      statusOpen: "Ouverte",
+      statusInProgress: "En cours",
+      statusCompleted: "Terminée",
+      statusArchived: "Archivée",
+    },
     // Inducements (pre-match)
     inducements: {
       title: "Inducements",
@@ -796,6 +815,25 @@ export const translations = {
       totalPlayers: "Ranked players",
       topRating: "Top ELO",
       averageRating: "Average ELO",
+    },
+    // Leagues (Sprint 17 — L.5)
+    leagues: {
+      title: "Leagues",
+      description: "Browse every Nuffle Arena league, join competitions and follow seasonal standings.",
+      empty: "No leagues yet.",
+      errorLoad: "Failed to load leagues",
+      filterStatus: "Status",
+      maxParticipants: "Slots",
+      visibilityPublic: "Public",
+      visibilityPrivate: "Private",
+      allowedRosters: "Allowed rosters",
+      rulesetSeason2: "Season 2",
+      rulesetSeason3: "Season 3",
+      statusDraft: "Draft",
+      statusOpen: "Open",
+      statusInProgress: "In progress",
+      statusCompleted: "Completed",
+      statusArchived: "Archived",
     },
     // Inducements (pre-match)
     inducements: {

--- a/apps/web/app/leagues/layout.tsx
+++ b/apps/web/app/leagues/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+import { OnlinePlayGate } from "../components/OnlinePlayGate";
+
+export default function LeaguesLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <OnlinePlayGate>{children}</OnlinePlayGate>;
+}

--- a/apps/web/app/leagues/page.test.tsx
+++ b/apps/web/app/leagues/page.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LeaguesPage from "./page";
+import { LanguageProvider } from "../contexts/LanguageContext";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const localStorageMock = {
+  getItem: vi.fn<(key: string) => string | null>(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+  length: 0,
+  key: vi.fn(),
+};
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+function renderWithProvider() {
+  return render(
+    <LanguageProvider>
+      <LeaguesPage />
+    </LanguageProvider>,
+  );
+}
+
+const mockLeaguesData = {
+  leagues: [
+    {
+      id: "lg-1",
+      name: "Open 5 Teams",
+      description: "Ligue ouverte aux 5 rosters prioritaires",
+      creatorId: "u1",
+      ruleset: "season_3",
+      status: "open",
+      isPublic: true,
+      maxParticipants: 16,
+      allowedRosters: ["skaven", "gnomes", "lizardmen", "dwarf", "imperial_nobility"],
+      winPoints: 3,
+      drawPoints: 1,
+      lossPoints: 0,
+      forfeitPoints: -1,
+      createdAt: "2026-01-01T10:00:00.000Z",
+      updatedAt: "2026-01-01T10:00:00.000Z",
+    },
+    {
+      id: "lg-2",
+      name: "Casual League",
+      description: null,
+      creatorId: "u2",
+      ruleset: "season_2",
+      status: "draft",
+      isPublic: false,
+      maxParticipants: 8,
+      allowedRosters: null,
+      winPoints: 3,
+      drawPoints: 1,
+      lossPoints: 0,
+      forfeitPoints: -1,
+      createdAt: "2026-02-01T10:00:00.000Z",
+      updatedAt: "2026-02-01T10:00:00.000Z",
+    },
+  ],
+};
+
+describe("LeaguesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue("test-token");
+  });
+
+  it("shows loading state initially", () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    renderWithProvider();
+    expect(screen.getByText(/chargement/i)).toBeTruthy();
+  });
+
+  it("displays the list of leagues after successful fetch", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaguesData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open 5 Teams")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Casual League")).toBeTruthy();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Server error" }),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText(/erreur/i)).toBeTruthy();
+    });
+  });
+
+  it("shows empty state when no leagues are returned", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ leagues: [] }),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("leagues-empty")).toBeTruthy();
+    });
+  });
+
+  it("calls the correct API endpoint with Authorization header", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaguesData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(String(url)).toMatch(/\/league(\?|$)/);
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("filters leagues by status when a status filter is selected", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaguesData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open 5 Teams")).toBeTruthy();
+    });
+
+    const select = screen.getByTestId("leagues-status-filter") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "open" } });
+
+    await waitFor(() => {
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(String(lastCall[0])).toContain("status=open");
+    });
+  });
+
+  it("links each league row to its detail page", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaguesData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open 5 Teams")).toBeTruthy();
+    });
+
+    const links = screen.getAllByRole("link");
+    const detailLink = links.find((a) =>
+      (a as HTMLAnchorElement).href.endsWith("/leagues/lg-1"),
+    );
+    expect(detailLink).toBeTruthy();
+  });
+
+  it("displays participant limit and ruleset for each league", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockLeaguesData),
+    });
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open 5 Teams")).toBeTruthy();
+    });
+
+    // Ruleset labels (Saison 2 / Saison 3) must be visible
+    expect(screen.getAllByText(/saison 3/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/saison 2/i).length).toBeGreaterThanOrEqual(1);
+    // Max participants should be shown
+    expect(screen.getAllByText(/16/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/8/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/app/leagues/page.tsx
+++ b/apps/web/app/leagues/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { API_BASE } from "../auth-client";
+import { useLanguage } from "../contexts/LanguageContext";
+
+type LeagueStatus =
+  | "draft"
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "archived";
+
+interface League {
+  id: string;
+  name: string;
+  description: string | null;
+  creatorId: string;
+  ruleset: string;
+  status: LeagueStatus | string;
+  isPublic: boolean;
+  maxParticipants: number;
+  allowedRosters: string[] | null;
+  winPoints: number;
+  drawPoints: number;
+  lossPoints: number;
+  forfeitPoints: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type StatusFilter = "all" | LeagueStatus;
+
+const STATUS_VALUES: LeagueStatus[] = [
+  "draft",
+  "open",
+  "in_progress",
+  "completed",
+  "archived",
+];
+
+function buildListUrl(status: StatusFilter): string {
+  const params = new URLSearchParams();
+  if (status !== "all") params.set("status", status);
+  const qs = params.toString();
+  return `${API_BASE}/league${qs ? `?${qs}` : ""}`;
+}
+
+export default function LeaguesPage() {
+  const { t } = useLanguage();
+  const [leagues, setLeagues] = useState<League[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchLeagues() {
+      try {
+        setLoading(true);
+        setError(null);
+        const token =
+          typeof window !== "undefined"
+            ? localStorage.getItem("auth_token")
+            : null;
+        const headers: Record<string, string> = {};
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const response = await fetch(buildListUrl(statusFilter), { headers });
+        if (!response.ok) {
+          const body = (await response.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(body.error ?? t.leagues.errorLoad);
+        }
+        const json = (await response.json()) as { leagues: League[] };
+        if (!cancelled) setLeagues(json.leagues);
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : t.leagues.errorLoad);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchLeagues();
+    return () => {
+      cancelled = true;
+    };
+  }, [statusFilter, t.leagues.errorLoad]);
+
+  const rulesetLabels = useMemo<Record<string, string>>(
+    () => ({
+      season_2: t.leagues.rulesetSeason2,
+      season_3: t.leagues.rulesetSeason3,
+    }),
+    [t.leagues.rulesetSeason2, t.leagues.rulesetSeason3],
+  );
+
+  const statusLabels = useMemo<Record<string, string>>(
+    () => ({
+      draft: t.leagues.statusDraft,
+      open: t.leagues.statusOpen,
+      in_progress: t.leagues.statusInProgress,
+      completed: t.leagues.statusCompleted,
+      archived: t.leagues.statusArchived,
+    }),
+    [
+      t.leagues.statusArchived,
+      t.leagues.statusCompleted,
+      t.leagues.statusDraft,
+      t.leagues.statusInProgress,
+      t.leagues.statusOpen,
+    ],
+  );
+
+  if (loading) {
+    return (
+      <div className="w-full p-6">
+        <p>{t.common.loading}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full p-6">
+        <p className="text-red-600">
+          {t.common.error} : {error}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="leagues-page"
+      className="w-full p-4 sm:p-6 space-y-4 sm:space-y-6"
+    >
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold mb-2">
+          {t.leagues.title}
+        </h1>
+        <p className="text-sm sm:text-base text-gray-600">
+          {t.leagues.description}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label
+          htmlFor="leagues-status-filter"
+          className="text-sm font-medium text-gray-700"
+        >
+          {t.leagues.filterStatus}
+        </label>
+        <select
+          id="leagues-status-filter"
+          data-testid="leagues-status-filter"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+          className="border border-gray-300 rounded-md px-3 py-2 text-sm bg-white"
+        >
+          <option value="all">{t.common.all}</option>
+          {STATUS_VALUES.map((s) => (
+            <option key={s} value={s}>
+              {statusLabels[s]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {leagues.length === 0 ? (
+        <div
+          data-testid="leagues-empty"
+          className="text-center py-8 text-gray-500"
+        >
+          {t.leagues.empty}
+        </div>
+      ) : (
+        <ul
+          data-testid="leagues-list"
+          className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4"
+        >
+          {leagues.map((league) => {
+            const ruleset = rulesetLabels[league.ruleset] ?? league.ruleset;
+            const statusLabel =
+              statusLabels[league.status] ?? league.status;
+            return (
+              <li
+                key={league.id}
+                data-testid={`league-item-${league.id}`}
+                className="border border-gray-200 rounded-lg bg-white hover:border-nuffle-gold transition-colors"
+              >
+                <Link
+                  href={`/leagues/${league.id}`}
+                  className="block p-4 space-y-2"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-nuffle-anthracite">
+                      {league.name}
+                    </h2>
+                    <span className="text-xs uppercase tracking-wide bg-nuffle-gold/10 border border-nuffle-gold/30 text-nuffle-bronze px-2 py-0.5 rounded">
+                      {statusLabel}
+                    </span>
+                  </div>
+                  {league.description ? (
+                    <p className="text-sm text-gray-600 line-clamp-2">
+                      {league.description}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-600">
+                    <span>{ruleset}</span>
+                    <span>
+                      {t.leagues.maxParticipants}: {league.maxParticipants}
+                    </span>
+                    <span>
+                      {league.isPublic
+                        ? t.leagues.visibilityPublic
+                        : t.leagues.visibilityPrivate}
+                    </span>
+                    {league.allowedRosters &&
+                    league.allowedRosters.length > 0 ? (
+                      <span>
+                        {t.leagues.allowedRosters}:{" "}
+                        {league.allowedRosters.length}
+                      </span>
+                    ) : null}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Resume

- Ajoute la page `/leagues` (Next.js, App Router) qui liste les ligues via `GET /league`.
- Filtre par statut, gate `OnlinePlayGate`, lien vers `/leagues/[id]`, etats loading/error/empty.
- Traductions FR/EN ajoutees dans `i18n/translations.ts`.

## Tache roadmap

Sprint 17 — L.5 (Page liste des ligues, Frontend)

## Plan de test

- [x] `pnpm test app/leagues/page.test.tsx` (8/8 tests passent)
- [x] `pnpm test` (24 fichiers, 229/229 tests verts)
- [x] `pnpm typecheck`
- [x] `pnpm build` (route `/leagues` generee statiquement)
- [ ] Verifier manuellement `/leagues` sur l'env de staging (rendu loading/empty/list, filtre statut, navigation vers detail)
