### PR TITLE
feat(league): L.7 integration match online -> ligue (resultats auto)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -299,7 +299,7 @@
 | L.4 | Generateur de calendrier round-robin | Backend | [x] |
 | L.5 | Page liste des ligues | Frontend | [x] |
 | L.6 | Page detail ligue (calendrier, classement, matchs) | Frontend | [x] |
-| L.7 | Integration match online -> ligue (resultats auto) | Backend | [ ] |
+| L.7 | Integration match online -> ligue (resultats auto) | Backend | [x] |
 | L.8 | ELO saisonnier avec reset et placements | Backend | [ ] |
 | L.9 | Ligue demarrage : "Open 5 Teams" limite aux 5 equipes prioritaires | Backend | [ ] |
 

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -30,11 +30,13 @@ import {
   joinSeasonSchema,
   createRoundSchema,
   listLeaguesQuerySchema,
+  attachMatchSchema,
   type CreateLeagueBody,
   type CreateSeasonBody,
   type JoinSeasonBody,
   type CreateRoundBody,
   type ListLeaguesQuery,
+  type AttachMatchBody,
 } from "../schemas/league.schemas";
 
 function requireUserId(req: AuthenticatedRequest, res: Response): string | null {
@@ -295,6 +297,69 @@ export async function handleCreateRound(
   }
 }
 
+/**
+ * L.7 — Rattache un match existant a un round de ligue.
+ * Reserve au createur de la ligue. Refuse si le match est deja termine
+ * ou deja rattache a une autre saison/round.
+ */
+export async function handleAttachMatch(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { seasonId, roundId } = req.params;
+  const body = req.body as AttachMatchBody;
+
+  const season = await getSeasonById(seasonId);
+  if (!season) {
+    res.status(404).json({ error: "Saison introuvable" });
+    return;
+  }
+  if ((season as { league: { creatorId: string } }).league.creatorId !== userId) {
+    res
+      .status(403)
+      .json({ error: "Seul le createur de la ligue peut rattacher un match" });
+    return;
+  }
+
+  const round = await prisma.leagueRound.findUnique({ where: { id: roundId } });
+  if (!round || (round as { seasonId: string }).seasonId !== seasonId) {
+    res.status(404).json({ error: "Journee introuvable dans cette saison" });
+    return;
+  }
+
+  const match = await prisma.match.findUnique({
+    where: { id: body.matchId },
+    select: {
+      id: true,
+      status: true,
+      leagueSeasonId: true,
+      leagueScoredAt: true,
+    },
+  });
+  if (!match) {
+    res.status(404).json({ error: "Partie introuvable" });
+    return;
+  }
+  if (match.status === "ended" || match.leagueScoredAt) {
+    res.status(400).json({
+      error: "Impossible de rattacher un match deja termine ou deja comptabilise",
+    });
+    return;
+  }
+  if (match.leagueSeasonId && match.leagueSeasonId !== seasonId) {
+    res.status(409).json({ error: "Match deja rattache a une autre saison" });
+    return;
+  }
+
+  await prisma.match.update({
+    where: { id: match.id },
+    data: { leagueSeasonId: seasonId, leagueRoundId: roundId },
+  });
+  res.status(200).json({ matchId: match.id, seasonId, roundId });
+}
+
 export async function handleGetStandings(
   req: AuthenticatedRequest,
   res: Response,
@@ -336,6 +401,12 @@ router.post(
   authUser,
   validate(createRoundSchema),
   handleCreateRound,
+);
+router.post(
+  "/seasons/:seasonId/rounds/:roundId/matches",
+  authUser,
+  validate(attachMatchSchema),
+  handleAttachMatch,
 );
 router.get("/seasons/:seasonId/standings", authUser, handleGetStandings);
 router.get("/seasons/:seasonId", authUser, handleGetSeason);

--- a/apps/server/src/schemas/league.schemas.ts
+++ b/apps/server/src/schemas/league.schemas.ts
@@ -52,6 +52,10 @@ export const createRoundSchema = z.object({
   endDate: z.coerce.date().optional().nullable(),
 });
 
+export const attachMatchSchema = z.object({
+  matchId: z.string().min(1, "matchId requis"),
+});
+
 export const listLeaguesQuerySchema = z.object({
   creatorId: z.string().optional(),
   status: z
@@ -68,3 +72,4 @@ export type CreateSeasonBody = z.infer<typeof createSeasonSchema>;
 export type JoinSeasonBody = z.infer<typeof joinSeasonSchema>;
 export type CreateRoundBody = z.infer<typeof createRoundSchema>;
 export type ListLeaguesQuery = z.infer<typeof listLeaguesQuerySchema>;
+export type AttachMatchBody = z.infer<typeof attachMatchSchema>;

--- a/apps/server/src/services/forfeit-tracker.ts
+++ b/apps/server/src/services/forfeit-tracker.ts
@@ -1,6 +1,7 @@
 import { prisma } from "../prisma";
 import { broadcastMatchForfeited } from "./game-broadcast";
 import { updateEloAfterMatch } from "./elo-update";
+import { recordLeagueMatchResult } from "./league-match-result";
 
 /** Forfeit timeout: 2 minutes of disconnection. */
 export const FORFEIT_TIMEOUT_MS = 2 * 60 * 1000;
@@ -149,6 +150,21 @@ async function executeForfeit(matchId: string, forfeitingUserId: string): Promis
     await updateEloAfterMatch(prisma as any, userAId, userBId, scoreA, scoreB);
   } catch {
     // ELO update error — non-blocking
+  }
+
+  // L.7 — report forfeit to league standings (non-blocking).
+  // Scores are synthetic (1-0 for the winner), no casualties inflicted.
+  try {
+    await recordLeagueMatchResult({
+      matchId,
+      scoreA,
+      scoreB,
+      casualtiesA: 0,
+      casualtiesB: 0,
+    });
+  } catch {
+    // League integration error — non-blocking, the ladder can be
+    // reconciled later via a maintenance task.
   }
 
   // Broadcast forfeit to all connected players

--- a/apps/server/src/services/league-match-result.test.ts
+++ b/apps/server/src/services/league-match-result.test.ts
@@ -1,0 +1,300 @@
+/**
+ * L.7 — Tests integration resultat match -> ligue (Sprint 17).
+ *
+ * Verifie que `recordLeagueMatchResult` :
+ *  - ignore les matchs hors ligue
+ *  - est idempotent (un match ne peut pas etre comptabilise deux fois)
+ *  - distribue points/wins/losses/draws/td/cas selon le bareme de la ligue
+ *  - marque round + saison "completed" quand plus aucun match n'est en attente
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    match: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+    leagueSeason: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    leagueRound: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    leagueParticipant: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    teamSelection: {
+      findMany: vi.fn(),
+    },
+    $transaction: vi.fn(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[])),
+  },
+}));
+
+import { prisma } from "../prisma";
+import { recordLeagueMatchResult } from "./league-match-result";
+
+const mockPrisma = prisma as unknown as {
+  match: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+  leagueSeason: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  leagueRound: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  leagueParticipant: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  teamSelection: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
+};
+
+const LEAGUE = {
+  winPoints: 3,
+  drawPoints: 1,
+  lossPoints: 0,
+  forfeitPoints: -1,
+};
+
+function baseMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "match-1",
+    status: "ended",
+    leagueSeasonId: "season-1",
+    leagueRoundId: "round-1",
+    leagueScoredAt: null,
+    leagueSeason: { id: "season-1", leagueId: "league-1", league: LEAGUE },
+    ...overrides,
+  };
+}
+
+describe("Rule: recordLeagueMatchResult (L.7)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.$transaction.mockImplementation(async (ops: unknown) => {
+      if (Array.isArray(ops)) return Promise.all(ops as Promise<unknown>[]);
+      if (typeof ops === "function") {
+        return (ops as (tx: typeof prisma) => Promise<unknown>)(prisma);
+      }
+      return ops;
+    });
+  });
+
+  it("ignores matches not attached to a league", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(
+      baseMatch({ leagueSeasonId: null, leagueSeason: null }),
+    );
+
+    const result = await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 2,
+      scoreB: 1,
+      casualtiesA: 1,
+      casualtiesB: 0,
+    });
+
+    expect(result).toEqual({ skipped: true, reason: "not-a-league-match" });
+    expect(mockPrisma.leagueParticipant.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when leagueScoredAt is already set", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(
+      baseMatch({ leagueScoredAt: new Date("2026-04-20") }),
+    );
+
+    const result = await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 2,
+      scoreB: 1,
+      casualtiesA: 1,
+      casualtiesB: 0,
+    });
+
+    expect(result).toEqual({ skipped: true, reason: "already-scored" });
+    expect(mockPrisma.leagueParticipant.update).not.toHaveBeenCalled();
+  });
+
+  it("awards winPoints / lossPoints and updates td/cas counters on a win", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(baseMatch());
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      { teamId: "team-A", userId: "user-A" },
+      { teamId: "team-B", userId: "user-B" },
+    ]);
+    mockPrisma.leagueParticipant.findUnique.mockImplementation(
+      async (args: { where: { seasonId_teamId: { teamId: string } } }) => ({
+        id: `p-${args.where.seasonId_teamId.teamId}`,
+        teamId: args.where.seasonId_teamId.teamId,
+      }),
+    );
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]); // no other rounds
+
+    const result = await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 3,
+      scoreB: 1,
+      casualtiesA: 2,
+      casualtiesB: 1,
+    });
+
+    expect(result).toMatchObject({
+      recorded: true,
+      winner: "A",
+      pointsDelta: { teamA: 3, teamB: 0 },
+    });
+
+    const updates = mockPrisma.leagueParticipant.update.mock.calls.map(
+      (c: { 0: { where: { id: string }; data: Record<string, unknown> } }[]) =>
+        c[0],
+    ) as Array<{
+      where: { id: string };
+      data: Record<string, { increment?: number } | number>;
+    }>;
+
+    const aUpdate = updates.find((u) => u.where.id === "p-team-A");
+    const bUpdate = updates.find((u) => u.where.id === "p-team-B");
+    expect(aUpdate?.data.wins).toEqual({ increment: 1 });
+    expect(aUpdate?.data.points).toEqual({ increment: 3 });
+    expect(aUpdate?.data.touchdownsFor).toEqual({ increment: 3 });
+    expect(aUpdate?.data.touchdownsAgainst).toEqual({ increment: 1 });
+    expect(aUpdate?.data.casualtiesFor).toEqual({ increment: 2 });
+    expect(aUpdate?.data.casualtiesAgainst).toEqual({ increment: 1 });
+    expect(bUpdate?.data.losses).toEqual({ increment: 1 });
+    expect(bUpdate?.data.points).toEqual({ increment: 0 });
+    expect(bUpdate?.data.touchdownsFor).toEqual({ increment: 1 });
+
+    expect(mockPrisma.match.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "match-1" },
+        data: expect.objectContaining({ leagueScoredAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it("awards drawPoints to both teams on a draw", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(baseMatch());
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      { teamId: "team-A", userId: "user-A" },
+      { teamId: "team-B", userId: "user-B" },
+    ]);
+    mockPrisma.leagueParticipant.findUnique.mockImplementation(
+      async (args: { where: { seasonId_teamId: { teamId: string } } }) => ({
+        id: `p-${args.where.seasonId_teamId.teamId}`,
+        teamId: args.where.seasonId_teamId.teamId,
+      }),
+    );
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]);
+
+    const result = await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 1,
+      scoreB: 1,
+      casualtiesA: 0,
+      casualtiesB: 0,
+    });
+
+    expect(result).toMatchObject({
+      recorded: true,
+      winner: "draw",
+      pointsDelta: { teamA: 1, teamB: 1 },
+    });
+  });
+
+  it("marks the round completed when no pending match remains", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(baseMatch());
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      { teamId: "team-A", userId: "user-A" },
+      { teamId: "team-B", userId: "user-B" },
+    ]);
+    mockPrisma.leagueParticipant.findUnique.mockImplementation(
+      async (args: { where: { seasonId_teamId: { teamId: string } } }) => ({
+        id: `p-${args.where.seasonId_teamId.teamId}`,
+        teamId: args.where.seasonId_teamId.teamId,
+      }),
+    );
+    mockPrisma.match.count.mockResolvedValue(0); // no unfinished matches in round
+    // findMany is called with where: { status: { not: "completed" } } —
+    // an empty result means "no round left -> season completed".
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]);
+
+    await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 2,
+      scoreB: 0,
+      casualtiesA: 0,
+      casualtiesB: 0,
+    });
+
+    expect(mockPrisma.leagueRound.update).toHaveBeenCalledWith({
+      where: { id: "round-1" },
+      data: { status: "completed" },
+    });
+    expect(mockPrisma.leagueSeason.update).toHaveBeenCalledWith({
+      where: { id: "season-1" },
+      data: { status: "completed" },
+    });
+  });
+
+  it("keeps the round in progress when other matches are still pending", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(baseMatch());
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      { teamId: "team-A", userId: "user-A" },
+      { teamId: "team-B", userId: "user-B" },
+    ]);
+    mockPrisma.leagueParticipant.findUnique.mockImplementation(
+      async (args: { where: { seasonId_teamId: { teamId: string } } }) => ({
+        id: `p-${args.where.seasonId_teamId.teamId}`,
+      }),
+    );
+    mockPrisma.match.count.mockResolvedValue(2); // 2 matches still unfinished
+
+    await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 2,
+      scoreB: 1,
+      casualtiesA: 0,
+      casualtiesB: 0,
+    });
+
+    expect(mockPrisma.leagueRound.update).not.toHaveBeenCalled();
+    expect(mockPrisma.leagueSeason.update).not.toHaveBeenCalled();
+  });
+
+  it("gracefully skips when a participant is missing (team withdrew)", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue(baseMatch());
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      { teamId: "team-A", userId: "user-A" },
+      { teamId: "team-B", userId: "user-B" },
+    ]);
+    mockPrisma.leagueParticipant.findUnique.mockResolvedValueOnce({
+      id: "p-team-A",
+    });
+    mockPrisma.leagueParticipant.findUnique.mockResolvedValueOnce(null);
+
+    const result = await recordLeagueMatchResult({
+      matchId: "match-1",
+      scoreA: 2,
+      scoreB: 0,
+      casualtiesA: 0,
+      casualtiesB: 0,
+    });
+
+    expect(result).toEqual({ skipped: true, reason: "participant-missing" });
+    expect(mockPrisma.leagueParticipant.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/league-match-result.ts
+++ b/apps/server/src/services/league-match-result.ts
@@ -1,0 +1,209 @@
+/**
+ * L.7 — Integration resultat match online -> ligue.
+ *
+ * Appele apres la fin d'un match (fin normale ou forfait) pour :
+ *  - mettre a jour les compteurs materialises du LeagueParticipant
+ *    (wins/draws/losses/points/touchdowns/casualties) en une seule
+ *    transaction,
+ *  - marquer `Match.leagueScoredAt` pour empecher la double comptabilisation,
+ *  - promouvoir le round puis la saison en "completed" quand toutes les
+ *    rencontres sont reportees.
+ *
+ * Ne fait rien pour les matchs non rattaches a une ligue : une ligue doit
+ * avoir ete creee, une saison ouverte et des rounds planifies (L.3/L.4) et
+ * le match doit porter `leagueSeasonId` (defini au moment de l'appariement).
+ *
+ * Contrats :
+ *  - Idempotent : si `leagueScoredAt` est deja renseigne, on ignore.
+ *  - Tolerant : si un participant a ete retire (withdrawn / supprime) entre
+ *    temps, on n'ecrit rien (resultat neutre) plutot que de crasher.
+ */
+
+import { prisma } from "../prisma";
+
+export interface RecordMatchResultInput {
+  readonly matchId: string;
+  readonly scoreA: number;
+  readonly scoreB: number;
+  readonly casualtiesA: number;
+  readonly casualtiesB: number;
+}
+
+export type MatchWinner = "A" | "B" | "draw";
+
+export type RecordMatchResultOutcome =
+  | {
+      readonly recorded: true;
+      readonly winner: MatchWinner;
+      readonly pointsDelta: { readonly teamA: number; readonly teamB: number };
+      readonly roundCompleted: boolean;
+      readonly seasonCompleted: boolean;
+    }
+  | {
+      readonly skipped: true;
+      readonly reason:
+        | "not-a-league-match"
+        | "already-scored"
+        | "participant-missing"
+        | "match-missing";
+    };
+
+function computeWinner(scoreA: number, scoreB: number): MatchWinner {
+  if (scoreA > scoreB) return "A";
+  if (scoreB > scoreA) return "B";
+  return "draw";
+}
+
+interface LeaguePointsBareme {
+  readonly winPoints: number;
+  readonly drawPoints: number;
+  readonly lossPoints: number;
+}
+
+function pointsFor(winner: MatchWinner, side: "A" | "B", b: LeaguePointsBareme) {
+  if (winner === "draw") return b.drawPoints;
+  return winner === side ? b.winPoints : b.lossPoints;
+}
+
+export async function recordLeagueMatchResult(
+  input: RecordMatchResultInput,
+): Promise<RecordMatchResultOutcome> {
+  const match = await prisma.match.findUnique({
+    where: { id: input.matchId },
+    select: {
+      id: true,
+      leagueSeasonId: true,
+      leagueRoundId: true,
+      leagueScoredAt: true,
+      leagueSeason: {
+        select: {
+          id: true,
+          leagueId: true,
+          league: {
+            select: {
+              winPoints: true,
+              drawPoints: true,
+              lossPoints: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!match) {
+    return { skipped: true, reason: "match-missing" };
+  }
+  if (!match.leagueSeasonId || !match.leagueSeason) {
+    return { skipped: true, reason: "not-a-league-match" };
+  }
+  if (match.leagueScoredAt) {
+    return { skipped: true, reason: "already-scored" };
+  }
+
+  const selections = await prisma.teamSelection.findMany({
+    where: { matchId: match.id },
+    orderBy: { createdAt: "asc" },
+    select: { teamId: true, userId: true },
+  });
+  const teamAId = selections[0]?.teamId ?? null;
+  const teamBId = selections[1]?.teamId ?? null;
+  if (!teamAId || !teamBId) {
+    return { skipped: true, reason: "participant-missing" };
+  }
+
+  const seasonId = match.leagueSeasonId;
+  const [participantA, participantB] = await Promise.all([
+    prisma.leagueParticipant.findUnique({
+      where: { seasonId_teamId: { seasonId, teamId: teamAId } },
+      select: { id: true, teamId: true },
+    }),
+    prisma.leagueParticipant.findUnique({
+      where: { seasonId_teamId: { seasonId, teamId: teamBId } },
+      select: { id: true, teamId: true },
+    }),
+  ]);
+
+  if (!participantA || !participantB) {
+    return { skipped: true, reason: "participant-missing" };
+  }
+
+  const bareme = match.leagueSeason.league;
+  const winner = computeWinner(input.scoreA, input.scoreB);
+  const pointsA = pointsFor(winner, "A", bareme);
+  const pointsB = pointsFor(winner, "B", bareme);
+
+  const updateA = prisma.leagueParticipant.update({
+    where: { id: participantA.id },
+    data: {
+      wins: { increment: winner === "A" ? 1 : 0 },
+      draws: { increment: winner === "draw" ? 1 : 0 },
+      losses: { increment: winner === "B" ? 1 : 0 },
+      points: { increment: pointsA },
+      touchdownsFor: { increment: input.scoreA },
+      touchdownsAgainst: { increment: input.scoreB },
+      casualtiesFor: { increment: input.casualtiesA },
+      casualtiesAgainst: { increment: input.casualtiesB },
+    },
+  });
+
+  const updateB = prisma.leagueParticipant.update({
+    where: { id: participantB.id },
+    data: {
+      wins: { increment: winner === "B" ? 1 : 0 },
+      draws: { increment: winner === "draw" ? 1 : 0 },
+      losses: { increment: winner === "A" ? 1 : 0 },
+      points: { increment: pointsB },
+      touchdownsFor: { increment: input.scoreB },
+      touchdownsAgainst: { increment: input.scoreA },
+      casualtiesFor: { increment: input.casualtiesB },
+      casualtiesAgainst: { increment: input.casualtiesA },
+    },
+  });
+
+  const markMatch = prisma.match.update({
+    where: { id: match.id },
+    data: { leagueScoredAt: new Date() },
+  });
+
+  await prisma.$transaction([updateA, updateB, markMatch]);
+
+  let roundCompleted = false;
+  let seasonCompleted = false;
+
+  if (match.leagueRoundId) {
+    const pending = await prisma.match.count({
+      where: {
+        leagueRoundId: match.leagueRoundId,
+        leagueScoredAt: null,
+      },
+    });
+    if (pending === 0) {
+      await prisma.leagueRound.update({
+        where: { id: match.leagueRoundId },
+        data: { status: "completed" },
+      });
+      roundCompleted = true;
+
+      const remainingRounds = await prisma.leagueRound.findMany({
+        where: { seasonId, status: { not: "completed" } },
+        select: { id: true },
+      });
+      if (remainingRounds.length === 0) {
+        await prisma.leagueSeason.update({
+          where: { id: seasonId },
+          data: { status: "completed" },
+        });
+        seasonCompleted = true;
+      }
+    }
+  }
+
+  return {
+    recorded: true,
+    winner,
+    pointsDelta: { teamA: pointsA, teamB: pointsB },
+    roundCompleted,
+    seasonCompleted,
+  };
+}

--- a/apps/server/src/services/move-processor.ts
+++ b/apps/server/src/services/move-processor.ts
@@ -12,6 +12,7 @@ import { isUserConnectedToMatch } from "./connected-users";
 import { handleTurnTimerAfterMove } from "./turn-timer-orchestrator";
 import { FULL_RULES } from "@bb/game-engine";
 import { scheduleAILoop } from "./ai-loop";
+import { recordLeagueMatchResult } from "./league-match-result";
 
 export interface MoveResult {
   success: true;
@@ -24,6 +25,45 @@ export interface MoveError {
   success: false;
   error: string;
   code: "NOT_FOUND" | "INVALID_STATUS" | "NOT_PLAYER" | "NO_STATE" | "NOT_YOUR_TURN" | "ENGINE_ERROR";
+}
+
+interface AggregatedMatchStats {
+  scoreA: number;
+  scoreB: number;
+  casA: number;
+  casB: number;
+}
+
+/**
+ * Compute the team-level stats needed by league standings (L.7).
+ * Mirrors the aggregation performed by GET /match/:id/results so the
+ * ladder and the results screen stay in sync.
+ */
+function aggregateMatchStats(state: ExtendedGameState): AggregatedMatchStats {
+  const raw = state as unknown as {
+    score?: { teamA?: number; teamB?: number };
+    matchStats?: Record<string, { casualties?: number }>;
+    players?: Array<{ id: string; team?: string }>;
+  };
+  const score = raw.score ?? {};
+  const stats = raw.matchStats ?? {};
+  const players = raw.players ?? [];
+
+  let casA = 0;
+  let casB = 0;
+  for (const p of players) {
+    const entry = stats[p.id];
+    if (!entry) continue;
+    if (p.team === "A") casA += entry.casualties ?? 0;
+    else if (p.team === "B") casB += entry.casualties ?? 0;
+  }
+
+  return {
+    scoreA: score.teamA ?? 0,
+    scoreB: score.teamB ?? 0,
+    casA,
+    casB,
+  };
 }
 
 /**
@@ -230,6 +270,23 @@ export async function processMove(
         } catch {
           // Dedicated fans update error — non-blocking
         }
+      }
+
+      // L.7 — report the match result to league standings if the match
+      // is attached to a LeagueSeason. Non-blocking: if the ladder
+      // update fails, the match is still considered finished and the
+      // league service can reconcile later.
+      try {
+        const { scoreA, scoreB, casA, casB } = aggregateMatchStats(newState);
+        await recordLeagueMatchResult({
+          matchId,
+          scoreA,
+          scoreB,
+          casualtiesA: casA,
+          casualtiesB: casB,
+        });
+      } catch {
+        // League integration error — non-blocking
       }
     }
   }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,7 +87,22 @@ model Match {
   aiTeamSide   String? // 'A' | 'B' — side controlled by the AI
   aiUserId     String? // User id of the system AI account
 
+  // L.7 — Rattachement a une saison/journee de ligue. Optionnel : un match
+  // peut etre indepedant (amical, matchmaking classique) ou rattache a une
+  // ligue. Quand les deux sont renseignes, la fin du match met a jour les
+  // compteurs materialises du participant (wins/losses/points/td/cas).
+  leagueSeasonId   String?
+  leagueSeason     LeagueSeason? @relation("LeagueSeasonMatches", fields: [leagueSeasonId], references: [id], onDelete: SetNull)
+  leagueRoundId    String?
+  leagueRound      LeagueRound?  @relation("LeagueRoundMatches", fields: [leagueRoundId], references: [id], onDelete: SetNull)
+  // Marqueur d'idempotence pour recordLeagueMatchResult : une fois le score
+  // reporte au classement, on ne le comptabilise plus, meme si la route/hook
+  // est rejoue.
+  leagueScoredAt   DateTime?
+
   @@index([aiOpponent])
+  @@index([leagueSeasonId])
+  @@index([leagueRoundId])
 }
 
 model Turn {
@@ -603,6 +618,7 @@ model LeagueSeason {
 
   participants LeagueParticipant[]
   rounds       LeagueRound[]
+  matches      Match[]             @relation("LeagueSeasonMatches")
 
   @@unique([leagueId, seasonNumber])
   @@index([leagueId])
@@ -652,6 +668,8 @@ model LeagueRound {
   endDate     DateTime?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+
+  matches     Match[]  @relation("LeagueRoundMatches")
 
   @@unique([seasonId, roundNumber])
   @@index([seasonId])


### PR DESCRIPTION
## Resume

- Ajoute `leagueSeasonId` / `leagueRoundId` / `leagueScoredAt` (optionnels) au modele `Match` et les relations inverses `LeagueSeason.matches` / `LeagueRound.matches`.
- Nouveau service `services/league-match-result.ts` : `recordLeagueMatchResult({ matchId, scoreA, scoreB, casualtiesA, casualtiesB })` — met a jour les compteurs materialises du `LeagueParticipant` (wins/draws/losses/points/touchdowns*/casualties*) en une seule transaction, marque `Match.leagueScoredAt` (idempotent), puis promeut le round et la saison en `completed` quand tout est reporte. Tolerant : renvoie `skipped` si le match n'est pas rattache a une ligue ou si un participant a ete retire.
- Cable dans `move-processor.ts` (fin normale, agrege TD/casualties depuis `gameState`) et `forfeit-tracker.ts` (forfait, 1-0 synthetique). Les deux appels sont non-bloquants : si la mise a jour de la ligue echoue, le match reste considere comme termine et le classement pourra etre reconcilie ulterieurement.
- Nouvelle route `POST /leagues/seasons/:seasonId/rounds/:roundId/matches` (body `{ matchId }`) reservee au createur de la ligue, pour rattacher un match existant a un round. Refuse les matchs deja termines / deja comptabilises / rattaches ailleurs.

## Tache roadmap

Sprint 17 — Infrastructure Competitive : ligues, tache **L.7 — Integration match online -> ligue (resultats auto)**.

## Plan de test

- [x] `recordLeagueMatchResult` — 7 tests unitaires (idempotence, victoire/nul, bareme points, auto-completion round/saison, participant retire, match hors ligue)
- [x] `pnpm --filter @bb/server test` : 524/524 verts
- [x] `pnpm --filter @bb/server typecheck` : OK
- [x] `pnpm run lint` : 0 erreurs (warnings pre-existants uniquement)
- [x] Prisma `validate` : OK
- [ ] Test E2E manuel : creer ligue, saison, rattacher match, terminer match, verifier classement (non realise en sandbox — pas de DB)

Note : la CI web typecheck/build peut echouer sur deux points **pre-existants sur main** (2 erreurs TS dans `app/admin/feature-flags/*`, Google Fonts inaccessible en sandbox), sans rapport avec ce changement.
