### PR TITLE
feat(league): L.9 enforce allowedRosters restriction in service layer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -301,7 +301,7 @@
 | L.6 | Page detail ligue (calendrier, classement, matchs) | Frontend | [x] |
 | L.7 | Integration match online -> ligue (resultats auto) | Backend | [x] |
 | L.8 | ELO saisonnier avec reset et placements | Backend | [x] |
-| L.9 | Ligue demarrage : "Open 5 Teams" limite aux 5 equipes prioritaires | Backend | [ ] |
+| L.9 | Ligue demarrage : "Open 5 Teams" limite aux 5 equipes prioritaires | Backend | [x] |
 
 ### Sprint 18-19 — Parite Mobile (~10 jours, ex-Sprint 16-17)
 

--- a/apps/server/src/routes/league.test.ts
+++ b/apps/server/src/routes/league.test.ts
@@ -364,7 +364,10 @@ describe("Route: POST /leagues/seasons/:seasonId/join", () => {
     expect(mockService.addParticipant).not.toHaveBeenCalled();
   });
 
-  it("rejects teams whose roster is not allowed", async () => {
+  it("rejects teams whose roster is not allowed (domain error from service)", async () => {
+    // L.9 — la verification allowedRosters est deleguee au service.
+    // Le handler se contente de convertir l'erreur metier en reponse 400
+    // via `domainError`.
     mockPrisma.team.findUnique.mockResolvedValue({
       id: "team-1",
       ownerId: "user-1",
@@ -374,6 +377,9 @@ describe("Route: POST /leagues/seasons/:seasonId/join", () => {
       id: "season-1",
       league: { allowedRosters: JSON.stringify(["skaven", "dwarf"]) },
     });
+    mockService.addParticipant.mockRejectedValue(
+      new Error("Roster chaos non autorise sur cette saison (autorises: skaven, dwarf)"),
+    );
     const req = createReq({
       params: { seasonId: "season-1" },
       body: { teamId: "team-1" },

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -214,17 +214,8 @@ export async function handleJoinSeason(
     return;
   }
 
-  const allowed = parseAllowedRosters(
-    (season as { league: { allowedRosters: string | null } }).league
-      .allowedRosters,
-  );
-  if (allowed && !allowed.includes((team as { roster: string }).roster)) {
-    res.status(400).json({
-      error: `Roster ${(team as { roster: string }).roster} non autorise (autorises: ${allowed.join(", ")})`,
-    });
-    return;
-  }
-
+  // L.9 — la restriction allowedRosters est enforcee dans `addParticipant`
+  // (source de verite metier). Le domainError ci-dessous convertit en 400.
   try {
     const participant = await addParticipant({ seasonId, teamId: body.teamId });
     res.status(201).json(participant);

--- a/apps/server/src/services/league.test.ts
+++ b/apps/server/src/services/league.test.ts
@@ -389,6 +389,118 @@ describe("Rule: League service", () => {
         data: expect.objectContaining({ seasonElo: 1234 }),
       });
     });
+
+    it("L.9 — rejects a team whose roster is not in the league allowedRosters", async () => {
+      // Ligue "Open 5 Teams" : restreinte aux 5 rosters prioritaires.
+      // Toute equipe d'un autre roster doit etre refusee cote service,
+      // meme si un caller bypasse les verifications HTTP.
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+        league: {
+          maxParticipants: 16,
+          allowedRosters: JSON.stringify([
+            "skaven",
+            "gnome",
+            "lizardmen",
+            "dwarf",
+            "imperial_nobility",
+          ]),
+        },
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: teamId,
+        roster: "chaos_chosen",
+      });
+
+      await expect(addParticipant({ seasonId, teamId })).rejects.toThrow(
+        /roster|autorise/i,
+      );
+      expect(mockPrisma.leagueParticipant.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.leagueParticipant.create).not.toHaveBeenCalled();
+    });
+
+    it("L.9 — accepts a team whose roster is part of the allowedRosters", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+        league: {
+          maxParticipants: 16,
+          allowedRosters: JSON.stringify([
+            "skaven",
+            "gnome",
+            "lizardmen",
+            "dwarf",
+            "imperial_nobility",
+          ]),
+        },
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: teamId,
+        roster: "skaven",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue(null);
+      mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+      mockPrisma.leagueParticipant.create.mockImplementation(
+        async (args: { data: { seasonId: string; teamId: string } }) => ({
+          id: "participant-skaven",
+          ...args.data,
+        }),
+      );
+
+      const result = await addParticipant({ seasonId, teamId });
+
+      expect(result).toMatchObject({ teamId });
+      expect(mockPrisma.leagueParticipant.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("L.9 — accepts any roster when allowedRosters is null (open league)", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+        league: { maxParticipants: 16, allowedRosters: null },
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: teamId,
+        roster: "chaos_chosen",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue(null);
+      mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+      mockPrisma.leagueParticipant.create.mockImplementation(
+        async (args: { data: { seasonId: string; teamId: string } }) => ({
+          id: "participant-chaos",
+          ...args.data,
+        }),
+      );
+
+      await addParticipant({ seasonId, teamId });
+
+      expect(mockPrisma.leagueParticipant.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("L.9 — falls back to open league when allowedRosters JSON is malformed", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+        league: { maxParticipants: 16, allowedRosters: "not-json" },
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: teamId,
+        roster: "chaos_chosen",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue(null);
+      mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+      mockPrisma.leagueParticipant.create.mockImplementation(
+        async (args: { data: { seasonId: string; teamId: string } }) => ({
+          id: "participant-fallback",
+          ...args.data,
+        }),
+      );
+
+      await addParticipant({ seasonId, teamId });
+
+      expect(mockPrisma.leagueParticipant.create).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("createRound", () => {

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -170,7 +170,9 @@ export async function createSeason(input: CreateSeasonInput) {
 export async function addParticipant(input: AddParticipantInput) {
   const season = await prisma.leagueSeason.findUnique({
     where: { id: input.seasonId },
-    include: { league: { select: { maxParticipants: true } } },
+    include: {
+      league: { select: { maxParticipants: true, allowedRosters: true } },
+    },
   });
   if (!season) {
     throw new Error(`Saison introuvable: ${input.seasonId}`);
@@ -187,6 +189,21 @@ export async function addParticipant(input: AddParticipantInput) {
   });
   if (!team) {
     throw new Error(`Equipe introuvable: ${input.teamId}`);
+  }
+
+  // L.9 — invariant metier de la ligue "Open 5 Teams" : une saison peut
+  // restreindre les rosters autorises. On enforce la restriction ici
+  // (source de verite) pour que les seeders, scripts admin et le handler
+  // HTTP beneficient tous de la meme garantie.
+  const allowed = parseAllowedRosters(
+    (season as { league: { allowedRosters: string | null } }).league
+      .allowedRosters ?? null,
+  );
+  const teamRoster = (team as { roster?: string }).roster;
+  if (allowed && teamRoster && !allowed.includes(teamRoster)) {
+    throw new Error(
+      `Roster ${teamRoster} non autorise sur cette saison (autorises: ${allowed.join(", ")})`,
+    );
   }
 
   const existing = await prisma.leagueParticipant.findUnique({


### PR DESCRIPTION
## Resume

- Deplace l'enforcement de `allowedRosters` du handler HTTP vers le service `addParticipant` (source de verite metier).
- Garantit la restriction "Open 5 Teams -> 5 rosters prioritaires" pour tous les callers (seeders, scripts admin, jobs futurs), pas seulement `POST /leagues/seasons/:id/join`.
- Le handler `handleJoinSeason` ne duplique plus la regle : il delegue au service et convertit l'erreur metier en 400 via `domainError`.

## Tache roadmap

- **Sprint 17**, tache **L.9** — "Ligue demarrage : 'Open 5 Teams' limite aux 5 equipes prioritaires" (Backend).
- Case cochee dans `TODO.md`.

## Plan de test

- [x] 4 nouveaux tests unitaires dans `apps/server/src/services/league.test.ts` :
  - rejette un roster hors `allowedRosters`
  - accepte un roster present dans la liste
  - accepte n'importe quel roster quand `allowedRosters` est `null` (ligue ouverte)
  - retombe sur "ligue ouverte" si le JSON `allowedRosters` est malforme
- [x] Test existant de la route `POST .../join` mis a jour pour mocker `addParticipant` levant l'erreur domaine (plus de double check).
- [x] Suite serveur : 549/549 tests verts.
- [x] `pnpm typecheck` (server) : OK.
- [x] `pnpm lint` : aucune regression (0 warnings sur les fichiers touches).
- [x] Seeder `seedDefaultLeagues` (L.2) deja en place et idempotent : cree la ligue "Open 5 Teams" en status `draft` avec les 5 rosters prioritaires — aucune modif necessaire.
- [ ] Build `@bb/web` non verifiable ici (echec local cause par `next/font` ne parvenant pas a fetch Google Fonts en sandbox, sans rapport avec le changement backend).
