### PR TITLE
feat(admin): page d'avancement lisant roadmap et sprints

### DIFF
--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -64,6 +64,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
                 Administration
               </div>
               {navItem("/admin", "Aperçu", "📊")}
+              {navItem("/admin/progress", "Avancement", "🗺️")}
               {navItem("/admin/users", "Utilisateurs", "👥")}
               {navItem("/admin/teams", "Équipes", "⚽")}
               {navItem("/admin/matches", "Parties", "🎮")}

--- a/apps/web/app/admin/progress/page.tsx
+++ b/apps/web/app/admin/progress/page.tsx
@@ -1,0 +1,344 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  ProgressReport,
+  ProgressSource,
+  ProgressTask,
+  ProgressTotals,
+  TaskStatus,
+} from "./progress-parser";
+
+type StatusFilter = "all" | TaskStatus;
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  done: "Terminé",
+  in_progress: "En cours",
+  pending: "À faire",
+};
+
+const STATUS_COLOR: Record<TaskStatus, string> = {
+  done: "bg-green-100 text-green-800 border-green-200",
+  in_progress: "bg-amber-100 text-amber-800 border-amber-200",
+  pending: "bg-gray-100 text-gray-700 border-gray-200",
+};
+
+function barColor(percent: number): string {
+  if (percent >= 80) return "bg-green-500";
+  if (percent >= 50) return "bg-blue-500";
+  if (percent >= 20) return "bg-amber-500";
+  return "bg-gray-400";
+}
+
+function ProgressBar({ totals }: { totals: ProgressTotals }) {
+  if (totals.total === 0) {
+    return <div className="text-xs text-gray-500">Aucune tâche</div>;
+  }
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs text-gray-600">
+        <span>
+          {totals.done} / {totals.total} tâches
+        </span>
+        <span className="font-semibold text-gray-800">{totals.percent}%</span>
+      </div>
+      <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          className={`h-2 transition-all duration-500 ${barColor(totals.percent)}`}
+          style={{ width: `${totals.percent}%` }}
+          role="progressbar"
+          aria-valuenow={totals.percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+      <div className="flex flex-wrap gap-3 text-xs text-gray-500">
+        <span>✅ {totals.done} terminées</span>
+        {totals.inProgress > 0 && <span>🚧 {totals.inProgress} en cours</span>}
+        <span>⏳ {totals.pending} à faire</span>
+      </div>
+    </div>
+  );
+}
+
+function filterTasks(tasks: ProgressTask[], filter: StatusFilter): ProgressTask[] {
+  if (filter === "all") return tasks;
+  return tasks.filter((t) => t.status === filter);
+}
+
+function SectionCard({
+  section,
+  filter,
+}: {
+  section: ProgressReport["sources"][number]["sections"][number];
+  filter: StatusFilter;
+}) {
+  const visibleTasks = filterTasks(section.tasks, filter);
+  if (visibleTasks.length === 0) return null;
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <h4 className="text-base font-semibold text-gray-900">{section.title}</h4>
+        <span className="text-xs font-medium text-gray-600 shrink-0">
+          {section.totals.done}/{section.totals.total} · {section.totals.percent}%
+        </span>
+      </div>
+      <div className="mb-3">
+        <div className="w-full bg-gray-100 rounded-full h-1.5 overflow-hidden">
+          <div
+            className={`h-1.5 ${barColor(section.totals.percent)}`}
+            style={{ width: `${section.totals.percent}%` }}
+          />
+        </div>
+      </div>
+      <ul className="divide-y divide-gray-100">
+        {visibleTasks.map((task, index) => (
+          <li
+            key={`${task.id}-${index}`}
+            className="flex items-start gap-3 py-2 text-sm"
+          >
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border shrink-0 ${STATUS_COLOR[task.status]}`}
+            >
+              {STATUS_LABEL[task.status]}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-baseline gap-2">
+                <span className="font-mono text-xs text-gray-500 shrink-0">
+                  {task.id}
+                </span>
+                <span className="text-gray-900">{task.text}</span>
+                {task.tag && (
+                  <span className="text-xs text-blue-700 bg-blue-50 px-1.5 py-0.5 rounded">
+                    {task.tag}
+                  </span>
+                )}
+              </div>
+              {task.detail && (
+                <div className="text-xs text-gray-500 mt-0.5">{task.detail}</div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SourceBlock({
+  source,
+  filter,
+  expanded,
+  onToggle,
+}: {
+  source: ProgressSource;
+  filter: StatusFilter;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <section className="bg-gradient-to-br from-white to-gray-50 rounded-xl shadow-md border border-gray-200 overflow-hidden">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full text-left p-5 hover:bg-gray-50 transition-colors"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <h3 className="text-lg font-heading font-semibold text-nuffle-anthracite">
+              {source.title}
+            </h3>
+            <p className="text-xs text-gray-500 font-mono mt-0.5">{source.path}</p>
+          </div>
+          <span className="text-gray-400 text-xl shrink-0" aria-hidden="true">
+            {expanded ? "▾" : "▸"}
+          </span>
+        </div>
+        <div className="mt-3">
+          <ProgressBar totals={source.totals} />
+        </div>
+      </button>
+      {expanded && source.sections.length > 0 && (
+        <div className="border-t border-gray-200 bg-gray-50/50 p-4 space-y-3">
+          {source.sections.map((section) => (
+            <SectionCard
+              key={section.title}
+              section={section}
+              filter={filter}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default function AdminProgressPage() {
+  const [report, setReport] = useState<ProgressReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<StatusFilter>("all");
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const loadReport = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem("auth_token");
+      const response = await fetch("/api/admin/progress", {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error || `Erreur ${response.status}`);
+      }
+      const data: ProgressReport = await response.json();
+      setReport(data);
+      // Expand the first source by default
+      if (data.sources.length > 0) {
+        setExpanded({ [data.sources[0].id]: true });
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadReport();
+  }, []);
+
+  const toggleSource = (id: string) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const expandAll = () => {
+    if (!report) return;
+    const next: Record<string, boolean> = {};
+    for (const s of report.sources) next[s.id] = true;
+    setExpanded(next);
+  };
+
+  const collapseAll = () => setExpanded({});
+
+  const generatedAt = useMemo(() => {
+    if (!report) return null;
+    try {
+      return new Date(report.generatedAt).toLocaleString("fr-FR");
+    } catch {
+      return report.generatedAt;
+    }
+  }, [report]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-nuffle-gold mb-4"></div>
+          <p className="text-gray-600">Lecture des fichiers de roadmap…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+            🗺️ Avancement
+          </h1>
+          <p className="text-sm text-gray-600">
+            Agrégation des fichiers de roadmap et de sprints
+            {generatedAt && <> · généré le {generatedAt}</>}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={loadReport}
+          className="px-4 py-2 bg-nuffle-gold text-white rounded-lg text-sm font-medium hover:bg-nuffle-gold/90 shadow-sm transition-colors"
+        >
+          🔄 Rafraîchir
+        </button>
+      </div>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 flex items-center gap-2">
+          <span aria-hidden="true">⚠️</span>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {report && (
+        <>
+          <section className="bg-white rounded-xl shadow-md border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-xl font-heading font-semibold text-nuffle-anthracite">
+                📊 Avancement global
+              </h2>
+              <span className="text-2xl font-bold text-nuffle-gold">
+                {report.totals.percent}%
+              </span>
+            </div>
+            <ProgressBar totals={report.totals} />
+          </section>
+
+          <section className="flex flex-wrap items-center gap-3">
+            <div className="flex flex-wrap gap-2">
+              {(["all", "pending", "in_progress", "done"] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFilter(value)}
+                  className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                    filter === value
+                      ? "bg-nuffle-anthracite text-white border-nuffle-anthracite"
+                      : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+                  }`}
+                >
+                  {value === "all" ? "Toutes" : STATUS_LABEL[value]}
+                </button>
+              ))}
+            </div>
+            <div className="ml-auto flex gap-2">
+              <button
+                type="button"
+                onClick={expandAll}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-gray-200 text-gray-700 hover:bg-gray-50"
+              >
+                Tout déplier
+              </button>
+              <button
+                type="button"
+                onClick={collapseAll}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-gray-200 text-gray-700 hover:bg-gray-50"
+              >
+                Tout replier
+              </button>
+            </div>
+          </section>
+
+          <div className="space-y-4">
+            {report.sources.length === 0 ? (
+              <div className="p-6 bg-white rounded-xl border border-gray-200 text-center text-gray-500">
+                Aucun fichier de roadmap trouvé.
+              </div>
+            ) : (
+              report.sources.map((source) => (
+                <SourceBlock
+                  key={source.id}
+                  source={source}
+                  filter={filter}
+                  expanded={Boolean(expanded[source.id])}
+                  onToggle={() => toggleSource(source.id)}
+                />
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/admin/progress/progress-parser.test.ts
+++ b/apps/web/app/admin/progress/progress-parser.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMarkdown,
+  summariseReport,
+  summariseSource,
+} from "./progress-parser";
+
+describe("progress-parser", () => {
+  it("parses a simple GFM table with status column", () => {
+    const md = `# Phases
+
+## Phase A
+
+| #   | Task          | Gain | Diff   | Statut | Detail |
+|-----|---------------|------|--------|--------|--------|
+| A.1 | Implement WS  | Fort | Facile | [x]    | done   |
+| A.2 | Broadcast     | Fort | Moyen  | [ ]    | todo   |
+| A.3 | Partial       | Fort | Moyen  | [~]    | wip    |
+`;
+
+    const sections = parseMarkdown(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBe("Phase A");
+    expect(sections[0].tasks).toHaveLength(3);
+
+    const [t1, t2, t3] = sections[0].tasks;
+    expect(t1).toMatchObject({ id: "A.1", text: "Implement WS", status: "done" });
+    expect(t2).toMatchObject({ id: "A.2", status: "pending" });
+    expect(t3).toMatchObject({ id: "A.3", status: "in_progress" });
+
+    expect(sections[0].totals).toEqual({
+      total: 3,
+      done: 1,
+      inProgress: 1,
+      pending: 1,
+      percent: 33,
+    });
+  });
+
+  it("parses checkbox lists outside tables", () => {
+    const md = `## Sprint 2
+
+Checklist:
+
+- [ ] 2.1 — Task alpha
+- [x] 2.2 — Task beta
+- [~] 2.3 — Task gamma
+`;
+
+    const sections = parseMarkdown(md);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBe("Sprint 2");
+    expect(sections[0].tasks.map((t) => t.id)).toEqual(["2.1", "2.2", "2.3"]);
+    expect(sections[0].totals.done).toBe(1);
+    expect(sections[0].totals.pending).toBe(1);
+    expect(sections[0].totals.inProgress).toBe(1);
+    expect(sections[0].totals.percent).toBe(33);
+  });
+
+  it("groups tasks by ## or ### headings and ignores other content", () => {
+    const md = `# Top
+
+## Section One
+
+Intro paragraph (should be ignored).
+
+| # | Task | Statut |
+|---|------|--------|
+| 1 | one  | [x]    |
+
+## Section Two
+
+- [ ] 2.1 — two
+- [x] 2.2 — three
+
+### Subsection
+
+- [x] 2.3 — four
+`;
+
+    const sections = parseMarkdown(md);
+    expect(sections.map((s) => s.title)).toEqual([
+      "Section One",
+      "Section Two",
+      "Subsection",
+    ]);
+    expect(sections[0].totals.total).toBe(1);
+    expect(sections[1].totals.total).toBe(2);
+    expect(sections[2].totals.total).toBe(1);
+  });
+
+  it("summarises a source and a report", () => {
+    const md = `## A
+
+- [x] one
+- [ ] two
+
+## B
+
+- [x] three
+`;
+    const sections = parseMarkdown(md);
+    const source = summariseSource("t", "Test", "test.md", sections);
+    expect(source.totals).toEqual({
+      total: 3,
+      done: 2,
+      inProgress: 0,
+      pending: 1,
+      percent: 67,
+    });
+
+    const report = summariseReport([source]);
+    expect(report.sources).toHaveLength(1);
+    expect(report.totals.total).toBe(3);
+    expect(report.totals.done).toBe(2);
+    expect(typeof report.generatedAt).toBe("string");
+  });
+
+  it("ignores table rows without a status cell", () => {
+    const md = `## Overview
+
+| Sprint | Focus | Status |
+|--------|-------|--------|
+| 1      | A     | Done   |
+| 2      | B     | Pending|
+`;
+    const sections = parseMarkdown(md);
+    expect(sections).toHaveLength(0);
+  });
+
+  it("treats the first non-empty cell after the id as task text", () => {
+    const md = `## Sprint
+
+| B0.1 | Brancher le registry | Fort | Moyen | [ ] | Debloque 38 skills |
+`;
+    const sections = parseMarkdown(md);
+    expect(sections[0].tasks[0]).toMatchObject({
+      id: "B0.1",
+      text: "Brancher le registry",
+      status: "pending",
+      detail: "Debloque 38 skills",
+    });
+  });
+});

--- a/apps/web/app/admin/progress/progress-parser.ts
+++ b/apps/web/app/admin/progress/progress-parser.ts
@@ -1,0 +1,212 @@
+export type TaskStatus = "done" | "in_progress" | "pending";
+
+export interface ProgressTask {
+  id: string;
+  text: string;
+  status: TaskStatus;
+  tag?: string;
+  detail?: string;
+}
+
+export interface ProgressSection {
+  title: string;
+  tasks: ProgressTask[];
+  totals: ProgressTotals;
+}
+
+export interface ProgressTotals {
+  total: number;
+  done: number;
+  inProgress: number;
+  pending: number;
+  percent: number;
+}
+
+export interface ProgressSource {
+  id: string;
+  title: string;
+  path: string;
+  sections: ProgressSection[];
+  totals: ProgressTotals;
+}
+
+export interface ProgressReport {
+  sources: ProgressSource[];
+  totals: ProgressTotals;
+  generatedAt: string;
+}
+
+const STATUS_MAP: Record<string, TaskStatus> = {
+  x: "done",
+  X: "done",
+  "~": "in_progress",
+  " ": "pending",
+  "": "pending",
+};
+
+function statusFromChar(ch: string): TaskStatus {
+  return STATUS_MAP[ch] ?? "pending";
+}
+
+function emptyTotals(): ProgressTotals {
+  return { total: 0, done: 0, inProgress: 0, pending: 0, percent: 0 };
+}
+
+function addToTotals(totals: ProgressTotals, status: TaskStatus): ProgressTotals {
+  const next: ProgressTotals = {
+    total: totals.total + 1,
+    done: totals.done + (status === "done" ? 1 : 0),
+    inProgress: totals.inProgress + (status === "in_progress" ? 1 : 0),
+    pending: totals.pending + (status === "pending" ? 1 : 0),
+    percent: 0,
+  };
+  next.percent = next.total === 0 ? 0 : Math.round((next.done / next.total) * 100);
+  return next;
+}
+
+function mergeTotals(a: ProgressTotals, b: ProgressTotals): ProgressTotals {
+  const total = a.total + b.total;
+  const done = a.done + b.done;
+  return {
+    total,
+    done,
+    inProgress: a.inProgress + b.inProgress,
+    pending: a.pending + b.pending,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+  };
+}
+
+const TABLE_ROW_STATUS_RE = /\[( |x|X|~)\]/;
+const CHECKBOX_LINE_RE = /^\s*-\s*\[( |x|X|~)\]\s*(.+?)\s*$/;
+const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
+
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|")) return [];
+  const inner = trimmed.replace(/^\|/, "").replace(/\|$/, "");
+  return inner.split("|").map((cell) => cell.trim());
+}
+
+function isTableSeparator(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|")) return false;
+  return /^\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?$/.test(trimmed);
+}
+
+function parseTableRowTask(cells: string[]): ProgressTask | null {
+  const statusCellIndex = cells.findIndex((c) => TABLE_ROW_STATUS_RE.test(c));
+  if (statusCellIndex === -1) return null;
+  const statusMatch = cells[statusCellIndex].match(TABLE_ROW_STATUS_RE);
+  if (!statusMatch) return null;
+  const status = statusFromChar(statusMatch[1]);
+
+  const id = cells[0] || "";
+  const textCells = cells.slice(1, statusCellIndex).filter((c) => c.length > 0);
+  const text = textCells[0] || cells[1] || id || "(sans titre)";
+  const tag = textCells.length > 1 ? textCells[textCells.length - 1] : undefined;
+  const detail = cells.slice(statusCellIndex + 1).join(" | ").trim() || undefined;
+
+  return {
+    id: id || text.slice(0, 40),
+    text,
+    status,
+    tag,
+    detail: detail && detail.length > 0 ? detail : undefined,
+  };
+}
+
+function parseCheckboxLine(line: string): ProgressTask | null {
+  const m = line.match(CHECKBOX_LINE_RE);
+  if (!m) return null;
+  const status = statusFromChar(m[1]);
+  const text = m[2];
+  const idMatch = text.match(/^([A-Z0-9]+(?:\.[A-Z0-9]+)*)\s*[—–-]\s*(.+)$/);
+  if (idMatch) {
+    return { id: idMatch[1], text: idMatch[2], status };
+  }
+  return { id: text.slice(0, 40), text, status };
+}
+
+/**
+ * Parse a markdown document with sections (##/###) that contain either
+ * GFM tables with a status column ([ ], [x], [~]) or checkbox lists.
+ */
+export function parseMarkdown(content: string): ProgressSection[] {
+  const lines = content.split(/\r?\n/);
+  const sections: ProgressSection[] = [];
+
+  let currentTitle = "Général";
+  let currentTasks: ProgressTask[] = [];
+  let currentTotals = emptyTotals();
+
+  const flush = () => {
+    if (currentTasks.length > 0) {
+      sections.push({
+        title: currentTitle,
+        tasks: currentTasks,
+        totals: currentTotals,
+      });
+    }
+    currentTasks = [];
+    currentTotals = emptyTotals();
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      const level = heading[1].length;
+      if (level === 2 || level === 3) {
+        flush();
+        currentTitle = heading[2];
+      }
+      continue;
+    }
+
+    if (line.trim().startsWith("|")) {
+      if (isTableSeparator(line)) continue;
+      const cells = splitTableRow(line);
+      if (cells.length === 0) continue;
+      const task = parseTableRowTask(cells);
+      if (task) {
+        currentTasks.push(task);
+        currentTotals = addToTotals(currentTotals, task.status);
+      }
+      continue;
+    }
+
+    const cb = parseCheckboxLine(line);
+    if (cb) {
+      currentTasks.push(cb);
+      currentTotals = addToTotals(currentTotals, cb.status);
+    }
+  }
+
+  flush();
+  return sections;
+}
+
+export function summariseSource(
+  id: string,
+  title: string,
+  path: string,
+  sections: ProgressSection[],
+): ProgressSource {
+  const totals = sections.reduce<ProgressTotals>(
+    (acc, section) => mergeTotals(acc, section.totals),
+    emptyTotals(),
+  );
+  return { id, title, path, sections, totals };
+}
+
+export function summariseReport(sources: ProgressSource[]): ProgressReport {
+  const totals = sources.reduce<ProgressTotals>(
+    (acc, source) => mergeTotals(acc, source.totals),
+    emptyTotals(),
+  );
+  return {
+    sources,
+    totals,
+    generatedAt: new Date().toISOString(),
+  };
+}

--- a/apps/web/app/api/admin/progress/route.ts
+++ b/apps/web/app/api/admin/progress/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { jwtVerify } from "jose";
+import {
+  parseMarkdown,
+  summariseReport,
+  summariseSource,
+  type ProgressSource,
+} from "../../../admin/progress/progress-parser";
+
+export const dynamic = "force-dynamic";
+
+let _cachedSecret: Uint8Array | null = null;
+
+function getJwtSecret(): Uint8Array {
+  if (_cachedSecret) return _cachedSecret;
+  const raw = process.env.JWT_SECRET;
+  if (!raw && process.env.NODE_ENV === "production") {
+    throw new Error(
+      'FATAL: Missing required environment variable "JWT_SECRET".',
+    );
+  }
+  _cachedSecret = new TextEncoder().encode(raw || "dev-secret-change-me");
+  return _cachedSecret;
+}
+
+async function verifyAdmin(request: NextRequest): Promise<boolean> {
+  const token =
+    request.cookies.get("auth_token")?.value ||
+    request.headers.get("authorization")?.replace("Bearer ", "");
+  if (!token) return false;
+  try {
+    const { payload } = await jwtVerify(token, getJwtSecret());
+    const roles = Array.isArray(payload.roles)
+      ? (payload.roles as string[])
+      : payload.role
+        ? [payload.role as string]
+        : [];
+    return roles.includes("admin");
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the repository root by walking up from `process.cwd()` until we find
+ * a `pnpm-workspace.yaml` file. Falls back to `process.cwd()` if not found.
+ */
+async function resolveRepoRoot(): Promise<string> {
+  let dir = process.cwd();
+  for (let i = 0; i < 6; i++) {
+    if (await fileExists(path.join(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd();
+}
+
+interface SourceConfig {
+  id: string;
+  title: string;
+  relPath: string;
+  description?: string;
+}
+
+const SOURCE_CONFIGS: SourceConfig[] = [
+  {
+    id: "todo",
+    title: "TODO — Sprints",
+    relPath: "TODO.md",
+    description: "Backlog priorisé par sprints et phases",
+  },
+  {
+    id: "phases",
+    title: "Roadmap — Phases détaillées",
+    relPath: "docs/roadmap/phases.md",
+    description: "Toutes les tâches par phase (A à O)",
+  },
+  {
+    id: "sprint-0",
+    title: "Sprint 0 — Bugfixes & sécurité",
+    relPath: "docs/roadmap/sprint-0.md",
+    description: "Bugs critiques et failles de sécurité",
+  },
+  {
+    id: "sprint-2",
+    title: "Sprint 2 — Game engine",
+    relPath: "docs/sprints/SPRINT-2-game-engine-stabilization.md",
+  },
+  {
+    id: "sprint-3",
+    title: "Sprint 3 — Frontend",
+    relPath: "docs/sprints/SPRINT-3-frontend-stabilization.md",
+  },
+  {
+    id: "sprint-4",
+    title: "Sprint 4 — Server & sécurité",
+    relPath: "docs/sprints/SPRINT-4-server-security.md",
+  },
+  {
+    id: "sprint-5",
+    title: "Sprint 5 — Tests & dette",
+    relPath: "docs/sprints/SPRINT-5-test-infrastructure.md",
+  },
+  {
+    id: "sprint-6",
+    title: "Sprint 6 — Badges (foundation)",
+    relPath: "docs/sprints/SPRINT-6-badges-foundation.md",
+  },
+  {
+    id: "sprint-7",
+    title: "Sprint 7 — Badges (match & cup)",
+    relPath: "docs/sprints/SPRINT-7-badges-match-cup-triggers.md",
+  },
+];
+
+async function loadSource(
+  root: string,
+  config: SourceConfig,
+): Promise<ProgressSource | null> {
+  const full = path.join(root, config.relPath);
+  if (!(await fileExists(full))) return null;
+  const content = await fs.readFile(full, "utf-8");
+  const sections = parseMarkdown(content);
+  const source = summariseSource(config.id, config.title, config.relPath, sections);
+  return source;
+}
+
+export async function GET(request: NextRequest) {
+  const isAdmin = await verifyAdmin(request);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const root = await resolveRepoRoot();
+    const sources: ProgressSource[] = [];
+    for (const cfg of SOURCE_CONFIGS) {
+      const source = await loadSource(root, cfg);
+      if (source) sources.push(source);
+    }
+    const report = summariseReport(sources);
+    return NextResponse.json(report);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Erreur serveur";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- Nouvelle page admin **`/admin/progress`** qui agrège l'état d'avancement depuis `TODO.md`, `docs/roadmap/phases.md`, `docs/roadmap/sprint-0.md` et `docs/sprints/SPRINT-*.md`.
- Parseur markdown pur (tables GFM avec colonne `[ ]`/`[x]`/`[~]` et listes de cases à cocher), groupé par sections `##`/`###`.
- API route admin-only (`/api/admin/progress`) qui lit les fichiers côté serveur et renvoie le rapport agrégé (vérif JWT via `jose`, `force-dynamic`).
- UI avec barre globale, barres par source et par section, filtres par statut (Toutes / À faire / En cours / Terminé) et boutons déplier/replier.
- Lien **🗺️ Avancement** ajouté dans la sidebar admin.

## Fichiers

- `apps/web/app/admin/progress/progress-parser.ts` — parseur pur (testable)
- `apps/web/app/admin/progress/progress-parser.test.ts` — 6 tests unitaires
- `apps/web/app/admin/progress/page.tsx` — page React client
- `apps/web/app/api/admin/progress/route.ts` — API route Next.js
- `apps/web/app/admin/layout.tsx` — entrée nav

## Test plan

- [x] `pnpm vitest run` → 244/244 verts (dont 6 nouveaux tests parseur)
- [x] `pnpm next build` → build OK, `/admin/progress` et `/api/admin/progress` compilent
- [x] Smoke test parseur sur fichiers réels (TODO 170 tâches · 85% · phases 144 · 8% · sprint-2 13 · 0%)
- [ ] Vérifier la page à la main en dev (`pnpm dev`, login admin → `/admin/progress`)
- [ ] Vérifier la 401 sur `/api/admin/progress` sans rôle admin

## Notes

Le parseur supporte les formats déjà présents dans le repo (tables GFM avec colonne statut, checkboxes Markdown). Aucun fichier n'est modifié en écriture — lecture seule.
