### PR TITLE
fix(admin): inject JWT_SECRET into web container for /api/admin/progress

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,7 @@ services:
       - PORT=3100
       - NEXT_PUBLIC_API_BASE=https://api.nufflearena.fr
       - SERVER_API_BASE=http://server:8201
+      - JWT_SECRET=${JWT_SECRET}
     networks:
       - traefik-network
     labels:


### PR DESCRIPTION
## Problème

La page [/admin/progress](https://nufflearena.fr/admin/progress) affiche systématiquement \`⚠️ Unauthorized\`, même pour un utilisateur admin correctement authentifié.

## Cause racine

Le conteneur \`web\` de \`docker-compose.prod.yml\` ne reçoit pas la variable \`JWT_SECRET\`. Seul \`server\` l'a.

La route [apps/web/app/api/admin/progress/route.ts](apps/web/app/api/admin/progress/route.ts) est la seule route Next.js qui vérifie elle-même la signature JWT via \`jose.jwtVerify\` (les autres routes admin proxy vers Express et lui délèguent l'auth). Côté web, \`process.env.JWT_SECRET\` étant undefined, le fallback \`"dev-secret-change-me"\` est utilisé. Le backend Express signe avec le vrai secret → la vérification côté Next.js échoue → 401.

Le middleware Edge ([middleware.ts](apps/web/middleware.ts)) fait volontairement un simple décode sans vérif de signature, c'est pourquoi la navigation vers la page n'est pas bloquée — seul l'appel fetch échoue.

À noter : \`NODE_ENV=development\` sur le conteneur web en prod a aussi désactivé silencieusement la garde \`FATAL: Missing JWT_SECRET\` qui aurait attrapé ce problème au boot. Passer le web en mode production est un nettoyage séparé (nécessite un vrai \`next build\` + \`next start\`, actuellement on tourne avec \`next dev\`).

## Summary
- Injecte \`JWT_SECRET=\${JWT_SECRET}\` dans les variables d'environnement du service \`web\`

## Test plan
- [ ] Redéployer (\`make deploy\` ou \`docker compose -f docker-compose.prod.yml up -d --force-recreate web\`)
- [ ] Se connecter en tant qu'admin et charger https://nufflearena.fr/admin/progress
- [ ] Vérifier que le rapport s'affiche (plus d'\`Unauthorized\`)
- [ ] Vérifier que les autres routes admin continuent de fonctionner