### PR TITLE
feat(mobile): M.1 écrans gestion d'équipe (liste, création, détail, édition)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -309,7 +309,7 @@
 
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
-| M.1 | Ecrans gestion d'equipe (creer, editer, voir) | Mobile | [ ] |
+| M.1 | Ecrans gestion d'equipe (creer, editer, voir) | Mobile | [x] |
 | M.2 | Ecran queue matchmaking | Mobile | [ ] |
 | M.3 | Integration WebSocket complete | Mobile | [ ] |
 | M.4 | Popups block/push/followup/reroll natifs | Mobile | [ ] |

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -12,6 +12,9 @@ export default function Layout() {
           <Stack.Screen name="login" options={{ title: "Connexion" }} />
           <Stack.Screen name="register" options={{ title: "Inscription" }} />
           <Stack.Screen name="match/[id]" options={{ title: "Historique du match", headerShown: false }} />
+          <Stack.Screen name="teams/index" options={{ title: "Mes equipes" }} />
+          <Stack.Screen name="teams/new" options={{ title: "Nouvelle equipe" }} />
+          <Stack.Screen name="teams/[id]" options={{ title: "Detail equipe" }} />
         </Stack>
       </AuthProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/app/lobby.tsx
+++ b/apps/mobile/app/lobby.tsx
@@ -267,9 +267,17 @@ export default function LobbyScreen() {
         <Text style={styles.title}>
           {user?.coachName ? `Salut, ${user.coachName} !` : "Mes matchs"}
         </Text>
-        <Pressable onPress={handleLogout} style={styles.logoutButton}>
-          <Text style={styles.logoutText}>Deconnexion</Text>
-        </Pressable>
+        <View style={styles.headerActions}>
+          <Pressable
+            onPress={() => router.push("/teams")}
+            style={styles.teamsButton}
+          >
+            <Text style={styles.teamsButtonText}>Mes equipes</Text>
+          </Pressable>
+          <Pressable onPress={handleLogout} style={styles.logoutButton}>
+            <Text style={styles.logoutText}>Deconnexion</Text>
+          </Pressable>
+        </View>
       </View>
 
       {myTurnCount > 0 && (
@@ -426,6 +434,22 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "600",
     color: "#111827",
+  },
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  teamsButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    backgroundColor: "#EFF6FF",
+    borderRadius: 6,
+  },
+  teamsButtonText: {
+    color: "#1D4ED8",
+    fontSize: 13,
+    fontWeight: "600",
   },
   logoutButton: {
     paddingVertical: 6,

--- a/apps/mobile/app/teams/[id].tsx
+++ b/apps/mobile/app/teams/[id].tsx
@@ -1,0 +1,541 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { apiGet, apiPut, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  type TeamDetail,
+  countPlayersByPosition,
+  formatTeamValue,
+  formatGoldShort,
+} from "../../lib/teams";
+
+interface EditableInfo {
+  rerolls: number;
+  cheerleaders: number;
+  assistants: number;
+  apothecary: boolean;
+  dedicatedFans: number;
+}
+
+export default function TeamDetailScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const params = useLocalSearchParams<{ id: string }>();
+  const teamId = params.id;
+  const [team, setTeam] = useState<TeamDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editMode, setEditMode] = useState(false);
+  const [draft, setDraft] = useState<EditableInfo | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchTeam = useCallback(async () => {
+    if (!teamId) return;
+    try {
+      const data = await apiGet(`/team/${teamId}`);
+      setTeam(data.team);
+      setError(null);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [teamId, router, logout]);
+
+  useEffect(() => {
+    fetchTeam().finally(() => setLoading(false));
+  }, [fetchTeam]);
+
+  function startEdit() {
+    if (!team) return;
+    setDraft({
+      rerolls: team.rerolls ?? 0,
+      cheerleaders: team.cheerleaders ?? 0,
+      assistants: team.assistants ?? 0,
+      apothecary: team.apothecary ?? false,
+      dedicatedFans: team.dedicatedFans ?? 1,
+    });
+    setEditMode(true);
+  }
+
+  function cancelEdit() {
+    setEditMode(false);
+    setDraft(null);
+  }
+
+  async function saveEdit() {
+    if (!draft || !teamId) return;
+    setSaving(true);
+    try {
+      await apiPut(`/team/${teamId}/info`, draft);
+      await fetchTeam();
+      setEditMode(false);
+      setDraft(null);
+    } catch (err: unknown) {
+      Alert.alert(
+        "Erreur",
+        err instanceof Error ? err.message : "Impossible de sauvegarder",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error || !team) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>
+          {error || "Equipe introuvable"}
+        </Text>
+        <Pressable onPress={() => router.replace("/teams")} style={styles.linkButton}>
+          <Text style={styles.linkButtonText}>Retour aux equipes</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const positions = countPlayersByPosition(team.players ?? []);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.header}>
+          <Text style={styles.teamName}>{team.name}</Text>
+          <Text style={styles.teamRoster}>
+            {team.roster} • {team.ruleset}
+          </Text>
+        </View>
+
+        <View style={styles.statsRow}>
+          <Stat label="Valeur" value={formatTeamValue(team.currentValue)} />
+          <Stat label="Tresor" value={formatGoldShort(team.treasury ?? 0)} />
+          <Stat label="Joueurs" value={String(team.players?.length ?? 0)} />
+        </View>
+
+        <Section title="Configuration">
+          {editMode && draft ? (
+            <View>
+              <Counter
+                label="Relances"
+                value={draft.rerolls}
+                min={0}
+                max={8}
+                onChange={(v) => setDraft({ ...draft, rerolls: v })}
+              />
+              <Counter
+                label="Pom-pom girls"
+                value={draft.cheerleaders}
+                min={0}
+                max={12}
+                onChange={(v) => setDraft({ ...draft, cheerleaders: v })}
+              />
+              <Counter
+                label="Assistants coach"
+                value={draft.assistants}
+                min={0}
+                max={6}
+                onChange={(v) => setDraft({ ...draft, assistants: v })}
+              />
+              <Counter
+                label="Fans devoues"
+                value={draft.dedicatedFans}
+                min={1}
+                max={6}
+                onChange={(v) => setDraft({ ...draft, dedicatedFans: v })}
+              />
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>Apothicaire</Text>
+                <Pressable
+                  onPress={() =>
+                    setDraft({ ...draft, apothecary: !draft.apothecary })
+                  }
+                  style={[
+                    styles.toggle,
+                    draft.apothecary && styles.toggleOn,
+                  ]}
+                >
+                  <Text style={styles.toggleText}>
+                    {draft.apothecary ? "OUI" : "NON"}
+                  </Text>
+                </Pressable>
+              </View>
+
+              <View style={styles.editActions}>
+                <Pressable
+                  onPress={cancelEdit}
+                  style={[styles.actionButton, styles.cancelButton]}
+                >
+                  <Text style={styles.cancelText}>Annuler</Text>
+                </Pressable>
+                <Pressable
+                  onPress={saveEdit}
+                  style={[styles.actionButton, styles.saveButton]}
+                  disabled={saving}
+                >
+                  {saving ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text style={styles.saveText}>Sauvegarder</Text>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+          ) : (
+            <View>
+              <InfoRow label="Relances" value={String(team.rerolls ?? 0)} />
+              <InfoRow
+                label="Pom-pom girls"
+                value={String(team.cheerleaders ?? 0)}
+              />
+              <InfoRow
+                label="Assistants coach"
+                value={String(team.assistants ?? 0)}
+              />
+              <InfoRow
+                label="Fans devoues"
+                value={String(team.dedicatedFans ?? 1)}
+              />
+              <InfoRow
+                label="Apothicaire"
+                value={team.apothecary ? "Oui" : "Non"}
+              />
+              <Pressable onPress={startEdit} style={styles.editButton}>
+                <Text style={styles.editButtonText}>Editer la configuration</Text>
+              </Pressable>
+            </View>
+          )}
+        </Section>
+
+        <Section title={`Joueurs (${team.players?.length ?? 0})`}>
+          {positions.length === 0 ? (
+            <Text style={styles.empty}>Aucun joueur recrute</Text>
+          ) : (
+            positions.map((p) => (
+              <InfoRow key={p.position} label={p.position} value={`x${p.count}`} />
+            ))
+          )}
+        </Section>
+
+        {team.starPlayers && team.starPlayers.length > 0 && (
+          <Section title={`Star Players (${team.starPlayers.length})`}>
+            {team.starPlayers.map((sp) => (
+              <InfoRow
+                key={sp.id}
+                label={sp.name || sp.slug}
+                value={formatGoldShort(sp.cost)}
+              />
+            ))}
+          </Section>
+        )}
+
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>Retour</Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.stat}>
+      <Text style={styles.statValue}>{value}</Text>
+      <Text style={styles.statLabel}>{label}</Text>
+    </View>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue}>{value}</Text>
+    </View>
+  );
+}
+
+function Counter({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <View style={styles.counter}>
+        <Pressable
+          onPress={() => onChange(Math.max(min, value - 1))}
+          style={[styles.counterButton, value <= min && styles.counterDisabled]}
+          disabled={value <= min}
+        >
+          <Text style={styles.counterButtonText}>-</Text>
+        </Pressable>
+        <TextInput
+          style={styles.counterValue}
+          value={String(value)}
+          onChangeText={(text) => {
+            const n = Number.parseInt(text, 10);
+            if (!Number.isNaN(n)) {
+              onChange(Math.max(min, Math.min(max, n)));
+            } else if (text === "") {
+              onChange(min);
+            }
+          }}
+          keyboardType="numeric"
+        />
+        <Pressable
+          onPress={() => onChange(Math.min(max, value + 1))}
+          style={[styles.counterButton, value >= max && styles.counterDisabled]}
+          disabled={value >= max}
+        >
+          <Text style={styles.counterButtonText}>+</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: "#F9FAFB" },
+  scrollContent: { padding: 16, paddingBottom: 32 },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    backgroundColor: "#F9FAFB",
+  },
+  header: { marginBottom: 16 },
+  teamName: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  teamRoster: {
+    fontSize: 13,
+    color: "#6B7280",
+    marginTop: 2,
+  },
+  statsRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 16,
+  },
+  stat: {
+    flex: 1,
+    backgroundColor: "#fff",
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    alignItems: "center",
+  },
+  statValue: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#6B7280",
+    marginTop: 2,
+  },
+  section: {
+    backgroundColor: "#fff",
+    padding: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F3F4F6",
+  },
+  rowLabel: {
+    fontSize: 13,
+    color: "#374151",
+  },
+  rowValue: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  toggle: {
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 6,
+  },
+  toggleOn: {
+    backgroundColor: "#22C55E",
+  },
+  toggleText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#fff",
+  },
+  counter: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  counterButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 6,
+    backgroundColor: "#2563EB",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  counterDisabled: {
+    backgroundColor: "#9CA3AF",
+  },
+  counterButtonText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  counterValue: {
+    minWidth: 40,
+    textAlign: "center",
+    fontSize: 14,
+    fontWeight: "600",
+    paddingVertical: 4,
+    paddingHorizontal: 6,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    borderRadius: 6,
+    backgroundColor: "#fff",
+  },
+  editButton: {
+    marginTop: 12,
+    backgroundColor: "#EFF6FF",
+    paddingVertical: 10,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  editButtonText: {
+    color: "#1D4ED8",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  editActions: {
+    flexDirection: "row",
+    gap: 8,
+    marginTop: 14,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  cancelButton: {
+    backgroundColor: "#E5E7EB",
+  },
+  saveButton: {
+    backgroundColor: "#2563EB",
+  },
+  cancelText: {
+    color: "#374151",
+    fontWeight: "600",
+  },
+  saveText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  empty: {
+    fontSize: 13,
+    color: "#9CA3AF",
+    fontStyle: "italic",
+  },
+  backButton: {
+    paddingVertical: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  backText: {
+    color: "#6B7280",
+    fontSize: 14,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  linkButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  linkButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/teams/index.tsx
+++ b/apps/mobile/app/teams/index.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  type TeamSummary,
+  summarizeTeamRoster,
+} from "../../lib/teams";
+
+export default function TeamsListScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [teams, setTeams] = useState<TeamSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTeams = useCallback(async () => {
+    try {
+      const data = await apiGet("/team/mine");
+      setTeams(data.teams || []);
+      setError(null);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [router, logout]);
+
+  useEffect(() => {
+    fetchTeams().finally(() => setLoading(false));
+  }, [fetchTeams]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchTeams();
+    setRefreshing(false);
+  }, [fetchTeams]);
+
+  function navigateToTeam(team: TeamSummary) {
+    router.push(`/teams/${team.id}`);
+  }
+
+  function navigateToCreate() {
+    router.push("/teams/new");
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Mes equipes</Text>
+        <Pressable onPress={navigateToCreate} style={styles.createButton}>
+          <Text style={styles.createButtonText}>+ Creer</Text>
+        </Pressable>
+      </View>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={teams}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <Pressable
+              onPress={() => navigateToTeam(item)}
+              style={styles.card}
+            >
+              <Text style={styles.teamName}>{item.name}</Text>
+              <Text style={styles.teamMeta}>{summarizeTeamRoster(item)}</Text>
+              <Text style={styles.teamRuleset}>{item.ruleset}</Text>
+            </Pressable>
+          )}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText}>
+                Aucune equipe pour l'instant.
+              </Text>
+              <Pressable
+                onPress={navigateToCreate}
+                style={styles.emptyCreateButton}
+              >
+                <Text style={styles.emptyCreateText}>Creer ma premiere equipe</Text>
+              </Pressable>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F9FAFB",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  createButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+  },
+  createButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  listContent: {
+    padding: 16,
+    flexGrow: 1,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  teamName: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#111827",
+    marginBottom: 4,
+  },
+  teamMeta: {
+    fontSize: 13,
+    color: "#6B7280",
+  },
+  teamRuleset: {
+    fontSize: 11,
+    color: "#9CA3AF",
+    marginTop: 4,
+    textTransform: "uppercase",
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#6B7280",
+    fontSize: 16,
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  emptyCreateButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 12,
+    paddingHorizontal: 22,
+    borderRadius: 8,
+  },
+  emptyCreateText: {
+    color: "#fff",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/teams/new.tsx
+++ b/apps/mobile/app/teams/new.tsx
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, apiPost, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  type RosterSummary,
+  validateTeamName,
+  validateTeamValue,
+  getTeamValueOptions,
+} from "../../lib/teams";
+
+export default function NewTeamScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [name, setName] = useState("");
+  const [rosters, setRosters] = useState<RosterSummary[]>([]);
+  const [selectedRoster, setSelectedRoster] = useState<string | null>(null);
+  const [teamValue, setTeamValue] = useState<number>(1000);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRosters = useCallback(async () => {
+    try {
+      const data = await apiGet("/api/rosters");
+      setRosters(data.rosters || []);
+      setError(null);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [router, logout]);
+
+  useEffect(() => {
+    fetchRosters().finally(() => setLoading(false));
+  }, [fetchRosters]);
+
+  async function handleSubmit() {
+    const nameCheck = validateTeamName(name);
+    if (nameCheck.valid === false) {
+      Alert.alert("Nom invalide", nameCheck.error);
+      return;
+    }
+    if (!selectedRoster) {
+      Alert.alert("Roster requis", "Choisissez un roster pour votre equipe");
+      return;
+    }
+    const valueCheck = validateTeamValue(teamValue);
+    if (valueCheck.valid === false) {
+      Alert.alert("Budget invalide", valueCheck.error);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const data = await apiPost("/team/create-from-roster", {
+        name: name.trim(),
+        roster: selectedRoster,
+        teamValue,
+      });
+      const newId = data?.team?.id;
+      if (newId) {
+        router.replace(`/teams/${newId}`);
+      } else {
+        router.replace("/teams");
+      }
+    } catch (err: unknown) {
+      Alert.alert(
+        "Erreur",
+        err instanceof Error ? err.message : "Impossible de creer l'equipe",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>Erreur : {error}</Text>
+        <Pressable
+          onPress={() => {
+            setLoading(true);
+            fetchRosters().finally(() => setLoading(false));
+          }}
+          style={styles.retryButton}
+        >
+          <Text style={styles.retryText}>Reessayer</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.label}>Nom de l'equipe</Text>
+        <TextInput
+          style={styles.input}
+          value={name}
+          onChangeText={setName}
+          placeholder="Ex: Reikland Reavers"
+          placeholderTextColor="#9CA3AF"
+          maxLength={100}
+        />
+
+        <Text style={styles.label}>Roster</Text>
+        <View style={styles.rosterGrid}>
+          {rosters.map((roster) => {
+            const selected = selectedRoster === roster.slug;
+            return (
+              <Pressable
+                key={roster.slug}
+                onPress={() => setSelectedRoster(roster.slug)}
+                style={[
+                  styles.rosterCard,
+                  selected && styles.rosterCardSelected,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.rosterName,
+                    selected && styles.rosterNameSelected,
+                  ]}
+                  numberOfLines={2}
+                >
+                  {roster.name}
+                </Text>
+                {roster.tier !== null && roster.tier !== undefined && (
+                  <Text style={styles.rosterMeta}>Tier {roster.tier}</Text>
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Text style={styles.label}>Budget (K po)</Text>
+        <View style={styles.budgetRow}>
+          {getTeamValueOptions().map((value) => {
+            const selected = teamValue === value;
+            return (
+              <Pressable
+                key={value}
+                onPress={() => setTeamValue(value)}
+                style={[
+                  styles.budgetOption,
+                  selected && styles.budgetOptionSelected,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.budgetText,
+                    selected && styles.budgetTextSelected,
+                  ]}
+                >
+                  {value}K
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Pressable
+          style={[styles.submit, submitting && styles.submitDisabled]}
+          onPress={handleSubmit}
+          disabled={submitting}
+        >
+          {submitting ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.submitText}>Creer l'equipe</Text>
+          )}
+        </Pressable>
+
+        <Pressable onPress={() => router.back()} style={styles.cancel}>
+          <Text style={styles.cancelText}>Annuler</Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: "#F9FAFB" },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#374151",
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    backgroundColor: "#fff",
+  },
+  rosterGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  rosterCard: {
+    backgroundColor: "#fff",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    padding: 10,
+    width: "48%",
+    minHeight: 60,
+  },
+  rosterCardSelected: {
+    borderColor: "#2563EB",
+    backgroundColor: "#EFF6FF",
+  },
+  rosterName: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  rosterNameSelected: {
+    color: "#1D4ED8",
+  },
+  rosterMeta: {
+    fontSize: 11,
+    color: "#6B7280",
+    marginTop: 4,
+  },
+  budgetRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  budgetOption: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 6,
+    backgroundColor: "#E5E7EB",
+  },
+  budgetOptionSelected: {
+    backgroundColor: "#2563EB",
+  },
+  budgetText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#374151",
+  },
+  budgetTextSelected: {
+    color: "#fff",
+  },
+  submit: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: "center",
+    marginTop: 24,
+  },
+  submitDisabled: {
+    opacity: 0.5,
+  },
+  submitText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  cancel: {
+    paddingVertical: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  cancelText: {
+    color: "#6B7280",
+    fontSize: 14,
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    backgroundColor: "#F9FAFB",
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -65,6 +65,20 @@ export async function apiPost(path: string, body: unknown) {
   return json;
 }
 
+export async function apiPut(path: string, body: unknown) {
+  const auth = await authHeaders();
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...auth },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new ApiError(json?.error || `Erreur ${res.status}`, res.status);
+  }
+  return json;
+}
+
 export async function apiGet(path: string) {
   const auth = await authHeaders();
   const res = await fetch(`${API_BASE}${path}`, {

--- a/apps/mobile/lib/teams.test.ts
+++ b/apps/mobile/lib/teams.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateTeamName,
+  validateTeamValue,
+  formatTeamValue,
+  formatGoldShort,
+  countPlayersByPosition,
+  summarizeTeamRoster,
+  getTeamValueOptions,
+  TEAM_NAME_MIN,
+  TEAM_NAME_MAX,
+  TEAM_VALUE_MIN,
+  TEAM_VALUE_MAX,
+  type TeamSummary,
+  type TeamPlayer,
+} from "./teams";
+
+describe("validateTeamName", () => {
+  it("accepts a non-empty short name", () => {
+    expect(validateTeamName("Reikland Reavers")).toEqual({ valid: true });
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(validateTeamName("  My Team  ")).toEqual({ valid: true });
+  });
+
+  it("rejects an empty string", () => {
+    const result = validateTeamName("");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toMatch(/requis|vide|nom/i);
+    }
+  });
+
+  it("rejects whitespace-only", () => {
+    const result = validateTeamName("    ");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects names longer than the max", () => {
+    const result = validateTeamName("a".repeat(TEAM_NAME_MAX + 1));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toMatch(/100/);
+    }
+  });
+
+  it("accepts a name exactly at the maximum length", () => {
+    expect(validateTeamName("a".repeat(TEAM_NAME_MAX))).toEqual({ valid: true });
+  });
+
+  it("requires at least the minimum length after trim", () => {
+    expect(TEAM_NAME_MIN).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("validateTeamValue", () => {
+  it("accepts the canonical 1000K po budget", () => {
+    expect(validateTeamValue(1000)).toEqual({ valid: true });
+  });
+
+  it("accepts the lower bound", () => {
+    expect(validateTeamValue(TEAM_VALUE_MIN)).toEqual({ valid: true });
+  });
+
+  it("accepts the upper bound", () => {
+    expect(validateTeamValue(TEAM_VALUE_MAX)).toEqual({ valid: true });
+  });
+
+  it("rejects values below the lower bound", () => {
+    const result = validateTeamValue(TEAM_VALUE_MIN - 1);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects values above the upper bound", () => {
+    const result = validateTeamValue(TEAM_VALUE_MAX + 1);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects non-integer or NaN", () => {
+    expect(validateTeamValue(Number.NaN).valid).toBe(false);
+    expect(validateTeamValue(1500.5).valid).toBe(false);
+  });
+});
+
+describe("formatTeamValue", () => {
+  it("formats whole-thousand values without decimals", () => {
+    // currentValue is in 'pieces d'or' (po), 1000 po = 1K po
+    expect(formatTeamValue(1000)).toBe("1K po");
+    expect(formatTeamValue(1_500_000)).toBe("1500K po");
+  });
+
+  it("formats zero", () => {
+    expect(formatTeamValue(0)).toBe("0K po");
+  });
+
+  it("rounds non-whole-thousand values down to nearest K", () => {
+    expect(formatTeamValue(1499)).toBe("1K po");
+    expect(formatTeamValue(1999)).toBe("1K po");
+  });
+});
+
+describe("formatGoldShort", () => {
+  it("returns short form like 1.5K for 1500 po", () => {
+    expect(formatGoldShort(1500)).toBe("1.5K");
+    expect(formatGoldShort(1000)).toBe("1K");
+    expect(formatGoldShort(0)).toBe("0K");
+  });
+});
+
+describe("countPlayersByPosition", () => {
+  const players: TeamPlayer[] = [
+    { id: "1", name: "A", position: "Lineman", number: 1, ma: 6, st: 3, ag: 3, pa: 4, av: 9, skills: "" },
+    { id: "2", name: "B", position: "Lineman", number: 2, ma: 6, st: 3, ag: 3, pa: 4, av: 9, skills: "" },
+    { id: "3", name: "C", position: "Blitzer", number: 3, ma: 7, st: 3, ag: 3, pa: 4, av: 9, skills: "block" },
+  ];
+
+  it("groups players by position with counts", () => {
+    expect(countPlayersByPosition(players)).toEqual([
+      { position: "Blitzer", count: 1 },
+      { position: "Lineman", count: 2 },
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(countPlayersByPosition([])).toEqual([]);
+  });
+});
+
+describe("summarizeTeamRoster", () => {
+  const team: TeamSummary = {
+    id: "t1",
+    name: "Test",
+    roster: "human",
+    ruleset: "season_2",
+    createdAt: new Date().toISOString(),
+    currentValue: 1_000_000,
+  };
+
+  it("provides a one-line summary string", () => {
+    const out = summarizeTeamRoster(team);
+    expect(out).toContain("human");
+    expect(out).toMatch(/1000K/);
+  });
+
+  it("falls back gracefully when currentValue is missing", () => {
+    const out = summarizeTeamRoster({ ...team, currentValue: undefined });
+    expect(out).toContain("human");
+  });
+});
+
+describe("getTeamValueOptions", () => {
+  it("returns common BB3 budget choices", () => {
+    const options = getTeamValueOptions();
+    expect(options).toContain(1000);
+    expect(options).toContain(1100);
+    expect(options[0]).toBe(TEAM_VALUE_MIN <= 1000 ? 1000 : TEAM_VALUE_MIN);
+    expect(options.every((v) => v >= TEAM_VALUE_MIN && v <= TEAM_VALUE_MAX)).toBe(true);
+    expect([...options].sort((a, b) => a - b)).toEqual(options);
+  });
+});

--- a/apps/mobile/lib/teams.ts
+++ b/apps/mobile/lib/teams.ts
@@ -1,0 +1,133 @@
+// Pure helpers for team management screens.
+// Network-free so they can be unit-tested in node.
+
+export const TEAM_NAME_MIN = 1;
+export const TEAM_NAME_MAX = 100;
+export const TEAM_VALUE_MIN = 100;
+export const TEAM_VALUE_MAX = 2000;
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export interface TeamSummary {
+  id: string;
+  name: string;
+  roster: string;
+  ruleset: string;
+  createdAt: string;
+  currentValue?: number;
+}
+
+export interface TeamPlayer {
+  id: string;
+  name: string;
+  position: string;
+  number: number;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number;
+  av: number;
+  skills: string;
+}
+
+export interface TeamDetail extends TeamSummary {
+  treasury: number;
+  rerolls: number;
+  cheerleaders: number;
+  assistants: number;
+  apothecary: boolean;
+  dedicatedFans: number;
+  teamValue: number;
+  initialBudget: number;
+  players: TeamPlayer[];
+  starPlayers?: Array<{
+    id: string;
+    slug: string;
+    cost: number;
+    name?: string;
+  }>;
+}
+
+export interface RosterSummary {
+  slug: string;
+  name: string;
+  budget: number;
+  tier?: number | null;
+  naf?: boolean | null;
+}
+
+export function validateTeamName(name: string): ValidationResult {
+  const trimmed = name.trim();
+  if (trimmed.length < TEAM_NAME_MIN) {
+    return { valid: false, error: "Le nom de l'equipe est requis" };
+  }
+  if (trimmed.length > TEAM_NAME_MAX) {
+    return {
+      valid: false,
+      error: `Le nom de l'equipe ne peut pas depasser ${TEAM_NAME_MAX} caracteres`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateTeamValue(value: number): ValidationResult {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    return { valid: false, error: "La valeur d'equipe doit etre un entier" };
+  }
+  if (value < TEAM_VALUE_MIN || value > TEAM_VALUE_MAX) {
+    return {
+      valid: false,
+      error: `La valeur d'equipe doit etre entre ${TEAM_VALUE_MIN} et ${TEAM_VALUE_MAX} K po`,
+    };
+  }
+  return { valid: true };
+}
+
+// currentValue is stored as gold pieces (po). Display in thousands (K po).
+export function formatTeamValue(currentValuePo: number | undefined): string {
+  if (currentValuePo === undefined || currentValuePo === null) {
+    return "0K po";
+  }
+  const k = Math.floor(currentValuePo / 1000);
+  return `${k}K po`;
+}
+
+export function formatGoldShort(po: number): string {
+  if (!po) return "0K";
+  const k = po / 1000;
+  if (Number.isInteger(k)) {
+    return `${k}K`;
+  }
+  return `${k.toFixed(1)}K`;
+}
+
+export interface PositionCount {
+  position: string;
+  count: number;
+}
+
+export function countPlayersByPosition(players: TeamPlayer[]): PositionCount[] {
+  const map = new Map<string, number>();
+  for (const p of players) {
+    map.set(p.position, (map.get(p.position) ?? 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([position, count]) => ({ position, count }))
+    .sort((a, b) => a.position.localeCompare(b.position));
+}
+
+export function summarizeTeamRoster(team: TeamSummary): string {
+  const value = formatTeamValue(team.currentValue);
+  return `${team.roster} • ${value}`;
+}
+
+// Common BB3 budget choices, restricted to the supported range.
+const BUDGET_CHOICES = [1000, 1100, 1200, 1300, 1500, 1800, 2000];
+
+export function getTeamValueOptions(): number[] {
+  return BUDGET_CHOICES.filter(
+    (v) => v >= TEAM_VALUE_MIN && v <= TEAM_VALUE_MAX,
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "dev": "expo start -c"
+    "dev": "expo start -c",
+    "test": "vitest run"
   },
   "dependencies": {
     "@bb/game-engine": "workspace:*",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "typescript": "^5.5.4",
-    "@types/react": "^18.3.5"
+    "@types/react": "^18.3.5",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    passWithNoTests: true,
+    root: resolve(__dirname),
+    include: ["lib/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.18.0)(jsdom@23.2.0)(terser@5.43.1)
 
   apps/server:
     dependencies:


### PR DESCRIPTION
## Résumé

Première brique de la parité mobile (Sprint 18-19, tâche M.1) : trois écrans
React Native pour gérer ses équipes depuis l'app Expo.

- **`/teams`** — liste des équipes via `GET /team/mine`, pull-to-refresh, état
  vide avec CTA création.
- **`/teams/new`** — sélection d'un roster (`GET /api/rosters`), nom + budget
  K po, création via `POST /team/create-from-roster`.
- **`/teams/[id]`** — détail (joueurs groupés par position, valeur, trésor,
  star players) + mode édition pour rerolls/cheerleaders/assistants/apothicaire/
  fans (`PUT /team/:id/info`).

Bouton **« Mes équipes »** ajouté dans le header du lobby pour la nav.

## Approche TDD

- `apps/mobile/lib/teams.ts` extrait la logique pure (validation nom/budget,
  formatage K po, comptage par position).
- `apps/mobile/lib/teams.test.ts` couvre cette couche avec **22 tests vitest**
  (RED d'abord, GREEN ensuite).
- Vitest ajouté en devDep mobile + `vitest.config.ts` + script `test`.

## Validation

| Vérif | Résultat |
|---|---|
| `pnpm --filter @bb/mobile test` | ✅ 22 / 22 |
| `pnpm --filter @bb/server test` | ✅ 555 / 555 |
| `pnpm --filter @bb/web test` | ✅ 244 / 244 |
| `pnpm --filter @bb/game-engine test` | ✅ 4041 / 4041 |
| `pnpm --filter @bb/ui test` | ✅ 288 / 288 |
| `pnpm lint` | ✅ 4 / 4 (warnings préexistants seulement) |
| `pnpm typecheck` | ✅ 4 / 4 |
| `pnpm build` | ⚠️ web échoue sur `Failed to fetch Montserrat from Google Fonts` (sandbox sans Internet, indépendant de la PR) |
| E2E Playwright | ⚠️ chrome-headless-shell absent du sandbox, indépendant de la PR |

## Tâche roadmap

Sprint 18-19, tâche **M.1 — Écrans gestion d'équipe (créer, éditer, voir)**

## Plan de test

- [ ] Lancer `pnpm --filter @bb/mobile dev` et ouvrir l'app Expo
- [ ] Se connecter, vérifier le bouton « Mes équipes » dans le lobby
- [ ] Liste vide → CTA → création d'une équipe Skaven 1100 K po
- [ ] Vérifier la redirection vers le détail (joueurs, valeur, trésor)
- [ ] Éditer la configuration (rerolls 0→2, apothicaire on, fans 1→3) et sauvegarder
- [ ] Recharger la fiche, vérifier la persistance
- [ ] Pull-to-refresh sur la liste
- [ ] Tester un nom vide, un nom > 100 caractères, un budget hors bornes → alertes

https://claude.ai/code/session_01BbmdvEDCUibFsY6R8ayXGa