### PR TITLE
Fix AI stuck in kickoff ball placement step

### DIFF
--- a/apps/server/src/routes/match.ts
+++ b/apps/server/src/routes/match.ts
@@ -20,6 +20,7 @@ import {
 import { createOnlinePracticeMatch } from "../services/practice-match";
 import { scheduleAILoop } from "../services/ai-loop";
 import { runAISetupIfNeeded } from "../services/ai-setup";
+import { runAIKickoffIfNeeded } from "../services/ai-kickoff";
 import type { AIDifficulty } from "@bb/game-engine";
 import { getSpectatorCount } from "../game-spectator";
 import { MATCH_SECRET } from "../config";
@@ -931,6 +932,20 @@ router.post(
           gameState.currentPlayer === postMatch.aiTeamSide
         ) {
           scheduleAILoop(matchId);
+        }
+        // Si l'IA est l'equipe qui frappe, placer immediatement le ballon pour
+        // eviter que le match reste bloque sur l'etape `place-ball` du kickoff.
+        if (
+          postMatch?.aiOpponent &&
+          postMatch.aiTeamSide &&
+          gameState.preMatch?.phase === 'kickoff-sequence' &&
+          gameState.preMatch?.kickoffStep === 'place-ball' &&
+          gameState.preMatch?.kickingTeam === postMatch.aiTeamSide
+        ) {
+          const kickoffReport = await runAIKickoffIfNeeded(matchId, prisma as any);
+          if (kickoffReport.ran && kickoffReport.gameState) {
+            gameState = kickoffReport.gameState;
+          }
         }
       }
 

--- a/apps/server/src/services/ai-kickoff.test.ts
+++ b/apps/server/src/services/ai-kickoff.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the server-side AI kickoff automation service.
+ *
+ * Covers the "AI stuck in kickoff ball placement" bug: when the AI is the
+ * kicking team during the `kickoff-sequence` → `place-ball` step, no client
+ * submits on behalf of the AI, so the sequence never advances. The service
+ * must place the ball in the receiving half and transition to
+ * `kick-deviation`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./game-broadcast", () => ({
+  broadcastGameState: vi.fn(),
+}));
+
+import {
+  setupPreMatchWithTeams,
+  startKickoffSequence,
+  type ExtendedGameState,
+  type TeamId,
+} from "@bb/game-engine";
+import { broadcastGameState } from "./game-broadcast";
+import { runAIKickoffIfNeeded } from "./ai-kickoff";
+
+function buildKickoffSequenceState(
+  kickingTeam: TeamId,
+): ExtendedGameState {
+  const mkPlayers = (team: TeamId) =>
+    Array.from({ length: 11 }, (_, i) => ({
+      id: `${team}${i + 1}`,
+      name: `${team}${i + 1}`,
+      position: "Lineman",
+      number: i + 1,
+      ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: "",
+    }));
+
+  const base = setupPreMatchWithTeams(mkPlayers("A"), mkPlayers("B"), "Alpha", "Beta");
+  const receivingTeam: TeamId = kickingTeam === "A" ? "B" : "A";
+
+  const atKickoff: ExtendedGameState = {
+    ...base,
+    preMatch: {
+      ...base.preMatch,
+      phase: "kickoff",
+      kickingTeam,
+      receivingTeam,
+    },
+  };
+
+  return startKickoffSequence(atKickoff);
+}
+
+function makePrismaMock(opts: {
+  match?: any;
+  turns?: any[];
+}) {
+  const turns = opts.turns ?? [];
+  return {
+    match: {
+      findUnique: vi.fn().mockResolvedValue(opts.match),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    turn: {
+      findMany: vi.fn().mockImplementation(async () =>
+        turns.map((t: any, i: number) => ({ number: i + 1, ...t })),
+      ),
+      create: vi.fn().mockImplementation(async ({ data }: any) => {
+        turns.push({ payload: data.payload });
+        return data;
+      }),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runAIKickoffIfNeeded", () => {
+  it("returns not-ai-match when the match has no AI opponent", async () => {
+    const db = makePrismaMock({
+      match: { aiOpponent: false, aiTeamSide: null, aiUserId: null },
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(false);
+    expect(report.reason).toBe("not-ai-match");
+  });
+
+  it("returns no-state when no game state turn exists", async () => {
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "A", aiUserId: "ai" },
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(false);
+    expect(report.reason).toBe("no-state");
+  });
+
+  it("returns not-kickoff-phase when the match is not in kickoff-sequence", async () => {
+    const mkPlayers = (team: TeamId) =>
+      Array.from({ length: 11 }, (_, i) => ({
+        id: `${team}${i + 1}`,
+        name: `${team}${i + 1}`,
+        position: "Lineman",
+        number: i + 1,
+        ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: "",
+      }));
+    const state = setupPreMatchWithTeams(mkPlayers("A"), mkPlayers("B"), "Alpha", "Beta");
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "A", aiUserId: "ai" },
+      turns: [{ payload: { gameState: state } }],
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(false);
+    expect(report.reason).toBe("not-kickoff-phase");
+  });
+
+  it("returns not-ai-kicking when the AI team is not the kicking team", async () => {
+    // AI is B, kicking team is A → receiving team is B → AI receives, human kicks.
+    const state = buildKickoffSequenceState("A");
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "B", aiUserId: "ai" },
+      turns: [{ payload: { gameState: state } }],
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(false);
+    expect(report.reason).toBe("not-ai-kicking");
+  });
+
+  it("places the ball when the AI is the kicking team and advances to kick-deviation", async () => {
+    const state = buildKickoffSequenceState("A");
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "A", aiUserId: "ai" },
+      turns: [{ payload: { gameState: state } }],
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(true);
+    expect(report.reason).toBe("placed");
+    const next = report.gameState!;
+    expect(next.preMatch.phase).toBe("kickoff-sequence");
+    expect(next.preMatch.kickoffStep).toBe("kick-deviation");
+    // Ball must be in the receiving team's half (B → x in [13, 24]).
+    expect(next.preMatch.ballPosition!.x).toBeGreaterThanOrEqual(13);
+    expect(next.preMatch.ballPosition!.x).toBeLessThanOrEqual(24);
+    expect(db.turn.create).toHaveBeenCalled();
+    expect(broadcastGameState).toHaveBeenCalled();
+  });
+
+  it("places the ball when the AI (team B) is the kicking team → receiving A", async () => {
+    const state = buildKickoffSequenceState("B");
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "B", aiUserId: "ai" },
+      turns: [{ payload: { gameState: state } }],
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(true);
+    const next = report.gameState!;
+    expect(next.preMatch.ballPosition!.x).toBeGreaterThanOrEqual(1);
+    expect(next.preMatch.ballPosition!.x).toBeLessThanOrEqual(12);
+  });
+
+  it("is a no-op when the kickoff is already past the place-ball step", async () => {
+    let state = buildKickoffSequenceState("A");
+    state = {
+      ...state,
+      preMatch: { ...state.preMatch, kickoffStep: "kick-deviation" },
+    };
+    const db = makePrismaMock({
+      match: { aiOpponent: true, aiTeamSide: "A", aiUserId: "ai" },
+      turns: [{ payload: { gameState: state } }],
+    });
+    const report = await runAIKickoffIfNeeded("m1", db as any);
+    expect(report.ran).toBe(false);
+    expect(report.reason).toBe("not-place-ball-step");
+  });
+});

--- a/apps/server/src/services/ai-kickoff.ts
+++ b/apps/server/src/services/ai-kickoff.ts
@@ -1,0 +1,142 @@
+/**
+ * Server-side AI kickoff ball placement.
+ *
+ * Fixes the bug where an online practice match hangs on the kickoff
+ * `place-ball` step when the AI is the kicking team: no client submits on
+ * behalf of the AI, so the sequence never advances. This service picks a
+ * legal ball position (centre of the receiving half), applies
+ * `placeKickoffBall`, persists the resulting state, and broadcasts it.
+ *
+ * Idempotent: bails out if the AI is not the kicking team, if the phase is
+ * not `kickoff-sequence`, or if the kickoff step is past `place-ball`.
+ */
+import {
+  pickAIKickoffBallPosition,
+  placeKickoffBall,
+  type ExtendedGameState,
+  type TeamId,
+} from "@bb/game-engine";
+import { prisma } from "../prisma";
+import { broadcastGameState } from "./game-broadcast";
+
+type PrismaLike = {
+  match: {
+    findUnique: (args: any) => Promise<any>;
+    update: (args: any) => Promise<any>;
+  };
+  turn: {
+    findMany: (args: any) => Promise<any[]>;
+    create: (args: any) => Promise<any>;
+  };
+};
+
+export interface RunAIKickoffReport {
+  readonly ran: boolean;
+  readonly reason:
+    | "not-ai-match"
+    | "no-state"
+    | "not-kickoff-phase"
+    | "not-place-ball-step"
+    | "not-ai-kicking"
+    | "invalid-placement"
+    | "placed";
+  readonly gameState?: ExtendedGameState;
+}
+
+export async function runAIKickoffIfNeeded(
+  matchId: string,
+  db: PrismaLike = prisma as any,
+): Promise<RunAIKickoffReport> {
+  const match = await db.match.findUnique({ where: { id: matchId } });
+  if (!match?.aiOpponent || !match.aiTeamSide || !match.aiUserId) {
+    return { ran: false, reason: "not-ai-match" };
+  }
+
+  const aiTeam = match.aiTeamSide as TeamId;
+  const aiUserId = match.aiUserId as string;
+
+  const state = await loadLatestGameState(db, matchId);
+  if (!state) {
+    return { ran: false, reason: "no-state" };
+  }
+
+  if (state.preMatch?.phase !== "kickoff-sequence") {
+    return { ran: false, reason: "not-kickoff-phase" };
+  }
+  if (state.preMatch.kickoffStep !== "place-ball") {
+    return { ran: false, reason: "not-place-ball-step" };
+  }
+  if (state.preMatch.kickingTeam !== aiTeam) {
+    return { ran: false, reason: "not-ai-kicking" };
+  }
+
+  const position = pickAIKickoffBallPosition(state, aiTeam);
+  let nextState = placeKickoffBall(state, position);
+
+  // `placeKickoffBall` returns the input state untouched when the position
+  // is illegal. Guard against regressions in the helper.
+  if (nextState.preMatch.kickoffStep !== "kick-deviation") {
+    return { ran: false, reason: "invalid-placement", gameState: state };
+  }
+
+  // Mirror the human endpoint: expose the ball position for frontend rendering.
+  if (nextState.preMatch.ballPosition) {
+    nextState = {
+      ...nextState,
+      ball: nextState.preMatch.ballPosition,
+    } as ExtendedGameState;
+  }
+
+  await persistAIKickoffTurn(db, matchId, aiUserId, position, nextState);
+  broadcastGameState(
+    matchId,
+    nextState,
+    { type: "place-kickoff-ball" } as any,
+    aiUserId,
+  );
+
+  return { ran: true, reason: "placed", gameState: nextState };
+}
+
+async function loadLatestGameState(
+  db: PrismaLike,
+  matchId: string,
+): Promise<ExtendedGameState | null> {
+  const turns = await db.turn.findMany({
+    where: { matchId },
+    orderBy: { number: "asc" },
+  });
+  const latest = [...turns].reverse().find((t: any) => t.payload?.gameState);
+  if (!latest) return null;
+  const raw = (latest as any).payload.gameState;
+  return typeof raw === "string" ? JSON.parse(raw) : raw;
+}
+
+async function persistAIKickoffTurn(
+  db: PrismaLike,
+  matchId: string,
+  aiUserId: string,
+  position: { x: number; y: number },
+  gameState: ExtendedGameState,
+): Promise<void> {
+  const turns = await db.turn.findMany({
+    where: { matchId },
+    orderBy: { number: "asc" },
+    select: { number: true },
+  });
+  const nextNumber = (turns[turns.length - 1]?.number ?? 0) + 1;
+  await db.turn.create({
+    data: {
+      matchId,
+      number: nextNumber,
+      payload: {
+        type: "place-kickoff-ball",
+        userId: aiUserId,
+        position,
+        gameState,
+        ai: true,
+        timestamp: new Date().toISOString(),
+      } as any,
+    },
+  });
+}

--- a/apps/server/src/services/ai-setup.ts
+++ b/apps/server/src/services/ai-setup.ts
@@ -20,6 +20,7 @@ import {
 } from "@bb/game-engine";
 import { prisma } from "../prisma";
 import { broadcastGameState } from "./game-broadcast";
+import { runAIKickoffIfNeeded } from "./ai-kickoff";
 
 type PrismaLike = {
   match: {
@@ -115,6 +116,19 @@ export async function runAISetupIfNeeded(
 
   if (!ran) {
     return { ran: false, reason: "not-ai-turn", gameState: state };
+  }
+
+  // Si la sequence de kickoff commence et que l'IA est l'equipe qui frappe,
+  // placer immediatement le ballon pour eviter un blocage cote client.
+  if (
+    state.preMatch?.phase === "kickoff-sequence" &&
+    state.preMatch?.kickoffStep === "place-ball" &&
+    state.preMatch?.kickingTeam === aiTeam
+  ) {
+    const kickoffReport = await runAIKickoffIfNeeded(matchId, db);
+    if (kickoffReport.ran && kickoffReport.gameState) {
+      state = kickoffReport.gameState;
+    }
   }
 
   return { ran: true, reason: "placed", gameState: state };

--- a/packages/game-engine/src/ai/index.ts
+++ b/packages/game-engine/src/ai/index.ts
@@ -37,3 +37,7 @@ export type {
 
 // Auto-placement des joueurs IA pendant la phase setup (fix AI stuck in placement)
 export { autoSetupAITeam, buildAISetupPositions } from './setup-placement';
+
+// Auto-placement du ballon de kickoff quand l'IA est l'equipe qui frappe
+// (fix "match bloque en kickoff" quand l'IA kick)
+export { pickAIKickoffBallPosition } from './kickoff-placement';

--- a/packages/game-engine/src/ai/kickoff-placement.test.ts
+++ b/packages/game-engine/src/ai/kickoff-placement.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the AI kickoff ball placement helper.
+ *
+ * When the AI is the kicking team, the match must not hang on the
+ * `place-ball` step of the kickoff sequence. `pickAIKickoffBallPosition`
+ * picks a legal position in the receiving team's half; the returned
+ * position must be accepted by `placeKickoffBall`.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  setupPreMatchWithTeams,
+  startKickoffSequence,
+  placeKickoffBall,
+  type ExtendedGameState,
+} from '../core/game-state';
+import type { TeamId } from '../core/types';
+import { pickAIKickoffBallPosition } from './kickoff-placement';
+
+function buildKickoffState(kickingTeam: TeamId): ExtendedGameState {
+  const mkPlayers = (team: TeamId) =>
+    Array.from({ length: 11 }, (_, i) => ({
+      id: `${team}${i + 1}`,
+      name: `${team}${i + 1}`,
+      position: 'Lineman',
+      number: i + 1,
+      ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: '',
+    }));
+
+  const base = setupPreMatchWithTeams(mkPlayers('A'), mkPlayers('B'), 'Alpha', 'Beta');
+  const receivingTeam: TeamId = kickingTeam === 'A' ? 'B' : 'A';
+
+  const atKickoff: ExtendedGameState = {
+    ...base,
+    preMatch: {
+      ...base.preMatch,
+      phase: 'kickoff',
+      kickingTeam,
+      receivingTeam,
+    },
+  };
+
+  return startKickoffSequence(atKickoff);
+}
+
+describe('pickAIKickoffBallPosition', () => {
+  it('returns a position in the receiving half when AI is team A (kicking)', () => {
+    const state = buildKickoffState('A');
+    const pos = pickAIKickoffBallPosition(state, 'A');
+    // Receiving team is B → x in [13, 24]
+    expect(pos.x).toBeGreaterThanOrEqual(13);
+    expect(pos.x).toBeLessThanOrEqual(24);
+    expect(pos.y).toBeGreaterThanOrEqual(0);
+    expect(pos.y).toBeLessThanOrEqual(14);
+  });
+
+  it('returns a position in the receiving half when AI is team B (kicking)', () => {
+    const state = buildKickoffState('B');
+    const pos = pickAIKickoffBallPosition(state, 'B');
+    // Receiving team is A → x in [1, 12]
+    expect(pos.x).toBeGreaterThanOrEqual(1);
+    expect(pos.x).toBeLessThanOrEqual(12);
+    expect(pos.y).toBeGreaterThanOrEqual(0);
+    expect(pos.y).toBeLessThanOrEqual(14);
+  });
+
+  it('returned position is accepted by placeKickoffBall and advances to kick-deviation', () => {
+    const state = buildKickoffState('A');
+    const pos = pickAIKickoffBallPosition(state, 'A');
+    const next = placeKickoffBall(state, pos);
+    expect(next.preMatch.kickoffStep).toBe('kick-deviation');
+    expect(next.preMatch.ballPosition).toEqual(pos);
+  });
+
+  it('is deterministic (same state, same team → same position)', () => {
+    const state = buildKickoffState('B');
+    const p1 = pickAIKickoffBallPosition(state, 'B');
+    const p2 = pickAIKickoffBallPosition(state, 'B');
+    expect(p1).toEqual(p2);
+  });
+});

--- a/packages/game-engine/src/ai/kickoff-placement.ts
+++ b/packages/game-engine/src/ai/kickoff-placement.ts
@@ -1,0 +1,38 @@
+/**
+ * AI kickoff ball placement — picks a legal ball position during the
+ * `place-ball` step of the kickoff sequence when the AI is the kicking team.
+ *
+ * Fixes the bug where an online practice match would hang on the ball
+ * placement step: no client submits on behalf of the AI, so the kickoff
+ * sequence never advances past `place-ball`.
+ *
+ * Strategy: place the ball in the centre of the receiving team's half.
+ * This is always legal (see `placeKickoffBall` bounds check) and produces
+ * a fair, predictable deviation target.
+ *
+ * Pure function: no side effects, deterministic for a given input.
+ */
+import type { Position, TeamId } from '../core/types';
+import type { ExtendedGameState } from '../core/game-state';
+
+const CENTER_Y = 7;
+const RECEIVER_A_CENTER_X = 7; // receiver A → x in [1, 12]
+const RECEIVER_B_CENTER_X = 18; // receiver B → x in [13, 24]
+
+/**
+ * Pick a legal kickoff ball position for the AI (kicking team).
+ *
+ * The receiving team is derived from `state.preMatch.receivingTeam`; falls
+ * back to the opposite of `aiTeam` if that field is missing. The returned
+ * position is guaranteed to satisfy the bounds enforced by
+ * `placeKickoffBall`.
+ */
+export function pickAIKickoffBallPosition(
+  state: ExtendedGameState,
+  aiTeam: TeamId,
+): Position {
+  const receivingTeam: TeamId =
+    state.preMatch?.receivingTeam ?? (aiTeam === 'A' ? 'B' : 'A');
+  const x = receivingTeam === 'A' ? RECEIVER_A_CENTER_X : RECEIVER_B_CENTER_X;
+  return { x, y: CENTER_Y };
+}

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -402,6 +402,7 @@ export {
   pickAIOpponentRoster,
   autoSetupAITeam,
   buildAISetupPositions,
+  pickAIKickoffBallPosition,
 } from './ai';
 export type {
   EvaluationBreakdown,


### PR DESCRIPTION
## Résumé

Fixes the bug where an online practice match hangs on the kickoff `place-ball` step when the AI is the kicking team. No client submits on behalf of the AI, so the sequence never advances. This PR adds server-side automation to place the ball in the receiving team's half and transition to `kick-deviation`.

### Changes

- **New module**: `pickAIKickoffBallPosition` in `game-engine/src/ai/kickoff-placement.ts`
  - Pure function that picks a legal ball position (centre of receiving team's half)
  - Deterministic and always produces a position accepted by `placeKickoffBall`

- **New service**: `runAIKickoffIfNeeded` in `server/src/services/ai-kickoff.ts`
  - Server-side automation triggered when AI is the kicking team during `place-ball` step
  - Loads latest game state, applies ball placement, persists turn, broadcasts state
  - Idempotent: bails out if conditions aren't met (not AI match, wrong phase, AI not kicking, etc.)

- **Integration points**:
  - `match.ts` route: Calls `runAIKickoffIfNeeded` after setup completion if kickoff sequence begins
  - `ai-setup.ts`: Also triggers kickoff automation if setup transitions directly to kickoff

### Test Coverage

- Added comprehensive unit tests for `pickAIKickoffBallPosition` covering both kicking teams and position validation
- Added integration tests for `runAIKickoffIfNeeded` covering all bail-out conditions and the happy path
- Tests verify ball position is in correct half and state transitions to `kick-deviation`

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (80 lines of tests for placement helper, 176 lines for service)
- [x] Changeset ajouté

https://claude.ai/code/session_013Mvg36PeKNfaAWMTAkSDms