### PR TITLE
Fill in OVH hosting information in legal mentions

### DIFF
--- a/apps/web/app/legal/mentions-legales/page.tsx
+++ b/apps/web/app/legal/mentions-legales/page.tsx
@@ -63,20 +63,32 @@ export default function MentionsLegalesPage() {
             Conformément à l&apos;article 6-I-2 de la LCEN, les coordonnées de
             l&apos;hébergeur du site sont les suivantes :
           </p>
-          {/* TODO: Remplacer par les informations réelles de l'hébergeur */}
-          <div className="bg-yellow-50 border border-yellow-200 p-4 rounded-lg">
+          <div className="bg-gray-50 p-4 rounded-lg">
             <p className="mb-2">
-              <strong>Hébergeur :</strong> [Nom de l&apos;hébergeur]
+              <strong>Hébergeur :</strong> OVH SAS
             </p>
             <p className="mb-2">
-              <strong>Adresse :</strong> [Adresse du siège social]
+              <strong>Adresse :</strong> 2 rue Kellermann, 59100 Roubaix, France
             </p>
             <p className="mb-2">
-              <strong>Téléphone :</strong> [Numéro de téléphone]
+              <strong>Téléphone :</strong> +33 9 72 10 10 07
             </p>
-            <p className="text-sm text-yellow-700 mt-2 italic">
-              Information à compléter par l&apos;éditeur conformément à l&apos;article
-              6-I-2 de la LCEN.
+            <p className="mb-2">
+              <strong>Site web :</strong>{" "}
+              <a
+                href="https://www.ovhcloud.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-600 hover:text-emerald-700 hover:underline"
+              >
+                www.ovhcloud.com
+              </a>
+            </p>
+            <p className="mb-2">
+              <strong>RCS :</strong> Lille Métropole 424 761 419
+            </p>
+            <p className="mb-2">
+              <strong>Capital social :</strong> 10 174 560 €
             </p>
           </div>
         </section>
@@ -247,7 +259,7 @@ export default function MentionsLegalesPage() {
 
         <section className="mb-8">
           <p className="text-sm text-gray-500 italic">
-            Dernière mise à jour : 16 avril 2026
+            Dernière mise à jour : 21 avril 2026
           </p>
         </section>
       </div>


### PR DESCRIPTION
## Résumé

- [x] Remplacer les informations d'hébergeur par défaut par les données réelles d'OVH SAS
- [x] Mettre à jour la date de dernière modification

## Description

Cette PR complète la section "Hébergeur" de la page mentions légales en remplaçant les placeholders par les informations réelles d'OVH SAS, conformément à l'article 6-I-2 de la LCEN.

### Changements effectués

- **Informations d'hébergeur** : Remplacement des champs vides par les données d'OVH SAS :
  - Nom : OVH SAS
  - Adresse : 2 rue Kellermann, 59100 Roubaix, France
  - Téléphone : +33 9 72 10 10 07
  - Site web : www.ovhcloud.com (lien cliquable)
  - RCS : Lille Métropole 424 761 419
  - Capital social : 10 174 560 €

- **Styling** : Suppression du style d'alerte (fond jaune) au profit d'un style neutre (fond gris)
- **Suppression** : Retrait du message TODO et de l'avertissement de complétude
- **Mise à jour** : Date de dernière modification (16 avril → 21 avril 2026)

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (N/A - changement de contenu statique)
- [x] Tests e2e (N/A - changement de contenu statique)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01BBdCEHZsRkivAgqQL6iaKU