### PR TITLE
Filter leaderboard: exclude unvalidated and AI accounts

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -137,10 +137,12 @@ if (process.env.TEST_SQLITE === "1") {
   // un compte déjà validé (bypass de la modération admin).
   app.post("/__test/seed-user", async (req, res) => {
     try {
-      const { email, password, name } = req.body as {
+      const { email, password, name, role, valid } = req.body as {
         email?: string;
         password?: string;
         name?: string;
+        role?: string;
+        valid?: boolean;
       };
       if (!email || !password) {
         return res
@@ -152,18 +154,25 @@ if (process.env.TEST_SQLITE === "1") {
       const passwordHash = await bcrypt.default.hash(password, 4);
 
       const displayName = name || email.split("@")[0];
-      // Seul le schéma Postgres expose `valid`; on évite de le passer afin que
-      // le même payload fonctionne sur les deux schémas.
+      const effectiveRole = role ?? "user";
+      // `valid` et `roles` sont normalises pour rester compatibles avec les
+      // deux schemas (Postgres: Boolean / String[], SQLite: Boolean / String
+      // JSON). Par defaut un user de test est valide pour que les suites
+      // existantes continuent de passer sans modification.
+      const update: Record<string, unknown> = { passwordHash };
+      if (typeof valid === "boolean") update.valid = valid;
+      if (typeof role === "string") update.role = role;
       const user = await prisma.user.upsert({
         where: { email },
-        update: { passwordHash },
+        update,
         create: {
           email,
           passwordHash,
           name: displayName,
           coachName: displayName,
-          role: "user",
-          roles: JSON.stringify(["user"]),
+          role: effectiveRole,
+          roles: JSON.stringify([effectiveRole]),
+          ...(typeof valid === "boolean" ? { valid } : {}),
         },
       });
 

--- a/apps/server/src/routes/leaderboard.ts
+++ b/apps/server/src/routes/leaderboard.ts
@@ -18,8 +18,17 @@ router.get("/", async (req, res) => {
     );
     const offset = Math.max(0, parseInt(req.query.offset as string, 10) || 0);
 
+    // Exclut les coachs dont le profil n'a pas encore été validé (modération
+    // admin / pré-alpha gate) et les comptes systèmes IA (`role = "ai"`) qui
+    // ne doivent pas apparaître dans le classement humain.
+    const where = {
+      valid: true,
+      role: { not: "ai" },
+    } as const;
+
     const [users, total] = await Promise.all([
       prisma.user.findMany({
+        where,
         select: {
           id: true,
           coachName: true,
@@ -29,7 +38,7 @@ router.get("/", async (req, res) => {
         take: limit,
         skip: offset,
       }),
-      prisma.user.count(),
+      prisma.user.count({ where }),
     ]);
 
     const leaderboard = users.map((user: typeof users[number], index: number) => ({

--- a/tests/e2e-api/helpers/factories.ts
+++ b/tests/e2e-api/helpers/factories.ts
@@ -45,11 +45,12 @@ export async function seedAndLogin(
   email: string,
   password: string,
   name?: string,
+  options: { role?: string; valid?: boolean } = {},
 ): Promise<{ token: string; userId: string }> {
   const seeded = await post<{ id: string; email: string }>(
     "/__test/seed-user",
     null,
-    { email, password, name },
+    { email, password, name, ...options },
   );
   const login = await post<{ token: string; user: { id: string } }>(
     "/auth/login",

--- a/tests/e2e-api/specs/leaderboard.spec.ts
+++ b/tests/e2e-api/specs/leaderboard.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { get, resetDb } from "../helpers/api";
+import { get, post, resetDb } from "../helpers/api";
 import { seedAndLogin } from "../helpers/factories";
 
 interface LeaderboardEntry {
@@ -89,5 +89,37 @@ describe("E2E API — /leaderboard", () => {
     if (res.data.length > 0) {
       expect(res.data[0].rank).toBe(2);
     }
+  });
+
+  it("exclut les profils non validés et les comptes IA du classement", async () => {
+    // Seed direct (sans login car `valid=false` bloque l'authentification).
+    await Promise.all([
+      post("/__test/seed-user", null, {
+        email: "valid@e2e.test",
+        password: "password",
+        name: "ValidCoach",
+      }),
+      post("/__test/seed-user", null, {
+        email: "pending@e2e.test",
+        password: "password",
+        name: "PendingCoach",
+        valid: false,
+      }),
+      post("/__test/seed-user", null, {
+        email: "ai@e2e.test",
+        password: "password",
+        name: "AiCoach",
+        role: "ai",
+      }),
+    ]);
+
+    const res = await get<LeaderboardResponse>("/leaderboard", null);
+    const names = res.data.map((e) => e.coachName);
+    expect(names).toContain("ValidCoach");
+    expect(names).not.toContain("PendingCoach");
+    expect(names).not.toContain("AiCoach");
+    // `meta.total` reflète aussi les filtres pour garder la pagination
+    // cohérente côté client.
+    expect(res.meta.total).toBe(names.length);
   });
 });


### PR DESCRIPTION
## Résumé

- [x] Exclude unvalidated user profiles and AI system accounts from the leaderboard ranking

## Changes

### Leaderboard Filtering
- Updated `/leaderboard` endpoint to filter out users where `valid = false` (pending moderation) and `role = "ai"` (system accounts)
- Applied filters to both the user query and total count to maintain consistent pagination metadata

### Test Seeding Enhancement
- Extended `/__test/seed-user` endpoint to support `role` and `valid` parameters for more flexible test data creation
- Updated `seedAndLogin()` helper to accept optional `role` and `valid` configuration
- Added comprehensive e2e test verifying that only validated non-AI coaches appear in leaderboard results

### Implementation Details
- Filters are applied consistently: `valid: true` and `role: { not: "ai" }`
- Total count reflects applied filters to keep client-side pagination coherent
- Test users default to `valid: true` to maintain backward compatibility with existing test suites
- Schema-agnostic approach ensures compatibility with both Postgres and SQLite backends

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires
- [x] Tests e2e (new test added: "exclut les profils non validés et les comptes IA du classement")
- [x] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_011uXZk1n39jYyhtZYkWdmEK