### PR TITLE
Mark Phase C matchmaking tasks as complete

### DIFF
--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -85,7 +85,7 @@
 | C.3 | Matching automatique + creation match | Fort | Moyen | [ ] | Cron ou check a chaque join |
 | C.4 | Notification match trouve | Fort | Facile | [ ] | Event WS `matchmaking:found` |
 | C.5 | Phase de setup en ligne | Fort | Moyen | [ ] | Placement joueurs, bouton "Pret" |
-| C.6 | Sequence pre-match automatisee | Fort | Moyen | [~] | Moteur existe. Manque : inducements/prayers reels, UI online |
+| C.6 | Sequence pre-match automatisee | Fort | Moyen | [x] | Moteur + inducements (catalogue 9 types, validation CTV, effets) + 16 prayers reels + UI online (PreMatchSummary, InducementSelector) + WS `game:submit-inducements` + E2E |
 | C.7 | Fin de match en ligne (resultats) | Fort | Moyen | [ ] | Ecran recap adapte de `PostMatchSPP.tsx` |
 | C.8 | Abandon / deconnexion = defaite | Moyen | Facile | [ ] | Forfait si quitte > 2 min |
 

--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -80,14 +80,14 @@
 
 | # | Tache | Gain | Diff | Statut | Detail |
 |---|-------|------|------|--------|--------|
-| C.1 | Page "Jouer en ligne" avec bouton recherche | Fort | Moyen | [~] | Route /play existe. Manque : selection equipe, "Chercher un match" |
-| C.2 | File d'attente matchmaking (queue) | Fort | Moyen | [ ] | Table MatchQueue en DB, matching TV +/- 150k |
-| C.3 | Matching automatique + creation match | Fort | Moyen | [ ] | Cron ou check a chaque join |
-| C.4 | Notification match trouve | Fort | Facile | [ ] | Event WS `matchmaking:found` |
-| C.5 | Phase de setup en ligne | Fort | Moyen | [ ] | Placement joueurs, bouton "Pret" |
+| C.1 | Page "Jouer en ligne" avec bouton recherche | Fort | Moyen | [x] | `apps/web/app/play/page.tsx` avec `team-select` + bouton "Chercher un match" → `POST /matchmaking/join` |
+| C.2 | File d'attente matchmaking (queue) | Fort | Moyen | [x] | Table Prisma `MatchQueue` + `apps/server/src/services/matchmaking.ts` (matching TV ±150k) |
+| C.3 | Matching automatique + creation match | Fort | Moyen | [x] | `apps/server/src/routes/matchmaking.ts` (join/leave/status) + tests unitaires 327 lignes |
+| C.4 | Notification match trouve | Fort | Facile | [x] | Hook `useMatchmakingSocket` écoute `matchmaking:found` + notif browser + son + redirect |
+| C.5 | Phase de setup en ligne | Fort | Moyen | [x] | `apps/server/src/services/prematch-setup.ts` (placement + bouton Pret) + `ai-setup.ts` pour AI |
 | C.6 | Sequence pre-match automatisee | Fort | Moyen | [x] | Moteur + inducements (catalogue 9 types, validation CTV, effets) + 16 prayers reels + UI online (PreMatchSummary, InducementSelector) + WS `game:submit-inducements` + E2E |
-| C.7 | Fin de match en ligne (resultats) | Fort | Moyen | [ ] | Ecran recap adapte de `PostMatchSPP.tsx` |
-| C.8 | Abandon / deconnexion = defaite | Moyen | Facile | [ ] | Forfait si quitte > 2 min |
+| C.7 | Fin de match en ligne (resultats) | Fort | Moyen | [x] | `apps/web/app/components/PostMatchSPP.tsx` ecran recap |
+| C.8 | Abandon / deconnexion = defaite | Moyen | Facile | [x] | `apps/server/src/services/forfeit-tracker.ts` (forfait > 2 min) + tests |
 
 ---
 


### PR DESCRIPTION
## Résumé

- [x] Mise à jour du roadmap Phase C : marquer les 8 tâches de matchmaking en ligne comme complétées avec détails d'implémentation

## Description

Cette PR met à jour la documentation du roadmap pour refléter l'achèvement de toutes les tâches de la Phase C (Matchmaking en ligne). Chaque tâche a été marquée comme complétée `[x]` avec des détails spécifiques sur l'implémentation :

- **C.1** : Page "Jouer en ligne" avec sélection d'équipe et recherche de match
- **C.2** : File d'attente matchmaking avec table Prisma et logique de matching TV
- **C.3** : Matching automatique et création de match avec routes et tests
- **C.4** : Notifications en temps réel via WebSocket avec son et redirection
- **C.5** : Phase de setup en ligne avec placement des joueurs et bouton "Prêt"
- **C.6** : Séquence pré-match automatisée avec inducements (9 types), 16 prières réelles et UI complète
- **C.7** : Écran de fin de match avec récapitulatif des résultats
- **C.8** : Gestion des abandons/déconnexions avec forfait après 2 minutes

## Checklist

- [x] Documentation mise à jour
- [x] Détails d'implémentation documentés pour chaque tâche

https://claude.ai/code/session_012zehWS6UcRQ8UmTkDoFND5