### PR TITLE
feat(mobile): M.3 integration WebSocket complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -311,7 +311,7 @@
 |---|-------|------|--------|
 | M.1 | Ecrans gestion d'equipe (creer, editer, voir) | Mobile | [x] |
 | M.2 | Ecran queue matchmaking | Mobile | [x] |
-| M.3 | Integration WebSocket complete | Mobile | [ ] |
+| M.3 | Integration WebSocket complete | Mobile | [x] |
 | M.4 | Popups block/push/followup/reroll natifs | Mobile | [ ] |
 | M.5 | Chat in-game mobile | Mobile | [ ] |
 | M.6 | Ecran leaderboard | Mobile | [ ] |

--- a/apps/mobile/app/play/[id].tsx
+++ b/apps/mobile/app/play/[id].tsx
@@ -9,6 +9,7 @@ import {
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { apiGet, apiPost, ApiError } from "../../lib/api";
 import { useAuth } from "../../lib/auth-context";
+import { useGameSocket } from "../../lib/use-game-socket";
 import {
   getLegalMoves,
   type GameState,
@@ -31,7 +32,7 @@ function normalizeState(state: any): GameState {
 export default function PlayScreen() {
   const { id: matchId } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
 
   const [state, setState] = useState<GameState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -62,12 +63,53 @@ export default function PlayScreen() {
     fetchState().finally(() => setLoading(false));
   }, [fetchState]);
 
-  // Poll for state updates when it's not our turn
+  // Resolve whose turn it is from a gameState + current user id
+  const resolveIsMyTurn = useCallback(
+    (gs: GameState | null): boolean => {
+      if (!gs || !user) return false;
+      const myPlayers = gs.players.filter((p) => p.userId === user.id);
+      if (myPlayers.length === 0) return false;
+      const myTeam = myPlayers[0].team;
+      return gs.currentPlayer === myTeam;
+    },
+    [user],
+  );
+
+  // Real-time updates via WebSocket
+  const {
+    connected: wsConnected,
+    submitMove: wsSubmitMove,
+  } = useGameSocket(matchId ?? "", {
+    onStateUpdate: ({ gameState }) => {
+      if (!gameState) return;
+      setState(normalizeState(gameState));
+      setIsMyTurn(resolveIsMyTurn(gameState as GameState));
+      setError(null);
+    },
+    onResyncState: ({ success, gameState }) => {
+      if (success && gameState) {
+        setState(normalizeState(gameState));
+        setIsMyTurn(resolveIsMyTurn(gameState as GameState));
+      }
+    },
+    onMatchEnded: ({ gameState }) => {
+      if (gameState) {
+        setState(normalizeState(gameState));
+      }
+    },
+    onMatchForfeited: ({ gameState }) => {
+      if (gameState) {
+        setState(normalizeState(gameState));
+      }
+    },
+  });
+
+  // HTTP polling fallback — only when WebSocket is not connected
   useEffect(() => {
-    if (!state || loading) return;
+    if (!state || loading || wsConnected) return;
     const interval = setInterval(fetchState, isMyTurn ? 10000 : 3000);
     return () => clearInterval(interval);
-  }, [fetchState, isMyTurn, state, loading]);
+  }, [fetchState, isMyTurn, state, loading, wsConnected]);
 
   // Compute legal moves
   const legal = useMemo(() => {
@@ -106,11 +148,22 @@ export default function PlayScreen() {
       .filter((pos): pos is Position => !!pos);
   }, [legal, state?.selectedPlayerId, state?.players]);
 
-  // Submit a move to the server
+  // Submit a move — prefer WebSocket, fall back to HTTP when unavailable
   const submitMove = useCallback(
     async (move: Move) => {
       setSubmitting(true);
       try {
+        const wsAck = wsConnected ? await wsSubmitMove(move) : null;
+        if (wsAck?.success && wsAck.gameState) {
+          setState(normalizeState(wsAck.gameState));
+          if (typeof wsAck.isMyTurn === "boolean") setIsMyTurn(wsAck.isMyTurn);
+          return;
+        }
+        if (wsAck && !wsAck.success && wsAck.error) {
+          setError(wsAck.error);
+          return;
+        }
+
         const data = await apiPost(`/match/${matchId}/move`, { move });
         if (data?.gameState) {
           setState(normalizeState(data.gameState));
@@ -127,7 +180,7 @@ export default function PlayScreen() {
         setSubmitting(false);
       }
     },
-    [matchId, router, logout],
+    [matchId, router, logout, wsConnected, wsSubmitMove],
   );
 
   // Handle cell tap
@@ -258,6 +311,7 @@ export default function PlayScreen() {
       >
         <Text style={styles.turnBannerText}>
           {isMyTurn ? "Votre tour" : "Tour de l'adversaire"}
+          {wsConnected ? "" : " (hors ligne)"}
         </Text>
         {submitting && (
           <ActivityIndicator

--- a/apps/mobile/lib/game-socket.test.ts
+++ b/apps/mobile/lib/game-socket.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Mock socket.io-client ---
+const mockSocket = {
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  connected: false,
+  id: "test-socket-id",
+  io: {
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+};
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => mockSocket),
+}));
+
+// Must import after mock setup
+import { io } from "socket.io-client";
+import {
+  createGameSocket,
+  createGameSocketHelpers,
+} from "./game-socket";
+
+describe("game-socket — createGameSocket", () => {
+  const authToken = "test-jwt-token";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket.connected = false;
+    mockSocket.on.mockReset();
+    mockSocket.off.mockReset();
+    mockSocket.emit.mockReset();
+    mockSocket.io.on.mockReset();
+    mockSocket.io.off.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a socket.io connection to the /game namespace", () => {
+    const socket = createGameSocket("http://localhost:8201", authToken);
+    expect(io).toHaveBeenCalledWith(
+      "http://localhost:8201/game",
+      expect.objectContaining({
+        auth: { token: `Bearer ${authToken}` },
+        transports: ["websocket", "polling"],
+        autoConnect: false,
+      }),
+    );
+    expect(socket).toBe(mockSocket);
+  });
+
+  it("does not auto-connect (explicit connect required)", () => {
+    createGameSocket("http://localhost:8201", authToken);
+    expect(mockSocket.connect).not.toHaveBeenCalled();
+  });
+
+  it("configures exponential backoff reconnection", () => {
+    createGameSocket("http://localhost:8201", authToken);
+    expect(io).toHaveBeenCalledWith(
+      "http://localhost:8201/game",
+      expect.objectContaining({
+        reconnection: true,
+        reconnectionDelay: 500,
+        reconnectionDelayMax: 10000,
+        reconnectionAttempts: 15,
+        randomizationFactor: 0.3,
+      }),
+    );
+  });
+
+  it("trims trailing slash from server url to avoid double slashes", () => {
+    createGameSocket("http://localhost:8201/", authToken);
+    expect(io).toHaveBeenCalledWith(
+      "http://localhost:8201/game",
+      expect.any(Object),
+    );
+  });
+});
+
+describe("game-socket — helpers: joinMatch / leaveMatch", () => {
+  const matchId = "match-abc";
+
+  beforeEach(() => {
+    mockSocket.on.mockReset();
+    mockSocket.off.mockReset();
+    mockSocket.emit.mockReset();
+  });
+
+  it("joinMatch emits game:join-match with the matchId", () => {
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: { ok: boolean }) => void) => {
+        ack({ ok: true });
+      },
+    );
+
+    const { joinMatch } = createGameSocketHelpers(mockSocket as any);
+    joinMatch(matchId);
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "game:join-match",
+      { matchId },
+      expect.any(Function),
+    );
+  });
+
+  it("joinMatch resolves with the server ack payload", async () => {
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: { ok: boolean; error?: string }) => void) => {
+        ack({ ok: false, error: "forbidden" });
+      },
+    );
+
+    const { joinMatch } = createGameSocketHelpers(mockSocket as any);
+    const res = await joinMatch(matchId);
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("forbidden");
+  });
+
+  it("leaveMatch emits game:leave-match with the matchId", () => {
+    const { leaveMatch } = createGameSocketHelpers(mockSocket as any);
+    leaveMatch(matchId);
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "game:leave-match",
+      { matchId },
+      expect.any(Function),
+    );
+  });
+});
+
+describe("game-socket — helpers: event subscriptions", () => {
+  beforeEach(() => {
+    mockSocket.on.mockReset();
+    mockSocket.off.mockReset();
+  });
+
+  it("onStateUpdated registers listener for game:state-updated", () => {
+    const handler = vi.fn();
+    const { onStateUpdated } = createGameSocketHelpers(mockSocket as any);
+    onStateUpdated(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith("game:state-updated", handler);
+  });
+
+  it("onPlayerConnected registers listener for game:player-connected", () => {
+    const handler = vi.fn();
+    const { onPlayerConnected } = createGameSocketHelpers(mockSocket as any);
+    onPlayerConnected(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith("game:player-connected", handler);
+  });
+
+  it("onPlayerDisconnected registers listener for game:player-disconnected", () => {
+    const handler = vi.fn();
+    const { onPlayerDisconnected } = createGameSocketHelpers(mockSocket as any);
+    onPlayerDisconnected(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith(
+      "game:player-disconnected",
+      handler,
+    );
+  });
+
+  it("onMatchEnded registers listener for game:match-ended", () => {
+    const handler = vi.fn();
+    const { onMatchEnded } = createGameSocketHelpers(mockSocket as any);
+    onMatchEnded(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith("game:match-ended", handler);
+  });
+
+  it("onMatchForfeited registers listener for game:match-forfeited", () => {
+    const handler = vi.fn();
+    const { onMatchForfeited } = createGameSocketHelpers(mockSocket as any);
+    onMatchForfeited(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith("game:match-forfeited", handler);
+  });
+
+  it("onTurnTimerStarted registers listener for game:turn-timer-started", () => {
+    const handler = vi.fn();
+    const { onTurnTimerStarted } = createGameSocketHelpers(mockSocket as any);
+    onTurnTimerStarted(handler);
+    expect(mockSocket.on).toHaveBeenCalledWith(
+      "game:turn-timer-started",
+      handler,
+    );
+  });
+
+  it("cleanup removes all game event listeners", () => {
+    const { cleanup } = createGameSocketHelpers(mockSocket as any);
+    cleanup();
+    expect(mockSocket.off).toHaveBeenCalledWith("game:state-updated");
+    expect(mockSocket.off).toHaveBeenCalledWith("game:player-connected");
+    expect(mockSocket.off).toHaveBeenCalledWith("game:player-disconnected");
+    expect(mockSocket.off).toHaveBeenCalledWith("game:match-ended");
+    expect(mockSocket.off).toHaveBeenCalledWith("game:match-forfeited");
+    expect(mockSocket.off).toHaveBeenCalledWith("game:turn-timer-started");
+  });
+});
+
+describe("game-socket — helpers: submitMove", () => {
+  beforeEach(() => {
+    mockSocket.emit.mockReset();
+  });
+
+  it("emits game:submit-move with matchId and move, resolves with ack", async () => {
+    const ackPayload = {
+      success: true,
+      gameState: { currentPlayer: "B" },
+      isMyTurn: false,
+      moveCount: 1,
+    };
+
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+        ack(ackPayload);
+      },
+    );
+
+    const { submitMove } = createGameSocketHelpers(mockSocket as any);
+    const result = await submitMove("match-1", { type: "END_TURN" } as any);
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "game:submit-move",
+      { matchId: "match-1", move: { type: "END_TURN" } },
+      expect.any(Function),
+    );
+    expect(result).toEqual(ackPayload);
+  });
+
+  it("resolves with error payload when move is rejected", async () => {
+    const errorPayload = {
+      success: false,
+      error: "Not your turn",
+      code: "NOT_YOUR_TURN",
+    };
+
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+        ack(errorPayload);
+      },
+    );
+
+    const { submitMove } = createGameSocketHelpers(mockSocket as any);
+    const result = await submitMove("match-2", {
+      type: "MOVE",
+      playerId: "p1",
+      to: { x: 3, y: 4 },
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Not your turn");
+  });
+});
+
+describe("game-socket — helpers: requestResync", () => {
+  beforeEach(() => {
+    mockSocket.emit.mockReset();
+  });
+
+  it("emits game:request-resync with matchId", () => {
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+        ack({ success: true, gameState: { turn: 1 } });
+      },
+    );
+    const { requestResync } = createGameSocketHelpers(mockSocket as any);
+    requestResync("match-resync");
+
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      "game:request-resync",
+      { matchId: "match-resync" },
+      expect.any(Function),
+    );
+  });
+
+  it("resolves with gameState payload on success", async () => {
+    const payload = { success: true, gameState: { turn: 3 } };
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+        ack(payload);
+      },
+    );
+
+    const { requestResync } = createGameSocketHelpers(mockSocket as any);
+    const result = await requestResync("m");
+
+    expect(result.success).toBe(true);
+    expect(result.gameState).toEqual({ turn: 3 });
+  });
+
+  it("resolves with error on failure", async () => {
+    mockSocket.emit.mockImplementation(
+      (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+        ack({ success: false, error: "not found" });
+      },
+    );
+
+    const { requestResync } = createGameSocketHelpers(mockSocket as any);
+    const result = await requestResync("m");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("not found");
+  });
+});

--- a/apps/mobile/lib/game-socket.ts
+++ b/apps/mobile/lib/game-socket.ts
@@ -1,0 +1,168 @@
+// Pure helpers around socket.io-client for the /game namespace.
+// Extracted so the logic can be unit-tested in Node without React Native.
+
+import { io, type Socket } from "socket.io-client";
+import type { ExtendedGameState, Move } from "@bb/game-engine";
+
+// --- Server -> client event payloads ---
+
+export interface StateUpdatedPayload {
+  matchId: string;
+  gameState: ExtendedGameState;
+  move: unknown;
+  userId: string;
+  timestamp: string;
+}
+
+export interface PlayerConnectionPayload {
+  matchId: string;
+  userId: string;
+  connectedSockets: number;
+}
+
+export interface MatchEndedPayload {
+  matchId: string;
+  gameState: ExtendedGameState;
+  timestamp: string;
+}
+
+export interface MatchForfeitedPayload {
+  matchId: string;
+  forfeitingUserId: string;
+  gameState: ExtendedGameState;
+  timestamp: string;
+}
+
+export interface TurnTimerStartedPayload {
+  matchId: string;
+  deadline: number;
+  turnTimerSeconds: number;
+  timestamp: string;
+}
+
+// --- Client -> server ack payloads ---
+
+export interface JoinAckPayload {
+  ok: boolean;
+  error?: string;
+}
+
+export interface MoveAckPayload {
+  success: boolean;
+  gameState?: ExtendedGameState;
+  isMyTurn?: boolean;
+  moveCount?: number;
+  error?: string;
+  code?: string;
+}
+
+export interface ResyncPayload {
+  success: boolean;
+  gameState?: ExtendedGameState;
+  matchId?: string;
+  error?: string;
+}
+
+// --- Factory ---
+
+/**
+ * Create a socket.io client configured for the /game namespace.
+ * Does NOT auto-connect — the caller must call `.connect()` explicitly.
+ */
+export function createGameSocket(serverUrl: string, authToken: string): Socket {
+  const trimmed = serverUrl.endsWith("/")
+    ? serverUrl.slice(0, -1)
+    : serverUrl;
+  return io(`${trimmed}/game`, {
+    auth: { token: `Bearer ${authToken}` },
+    transports: ["websocket", "polling"],
+    autoConnect: false,
+    reconnection: true,
+    reconnectionDelay: 500,
+    reconnectionDelayMax: 10000,
+    reconnectionAttempts: 15,
+    randomizationFactor: 0.3,
+  });
+}
+
+// --- Helpers ---
+
+/**
+ * Typed helpers that wrap raw socket.emit/on calls for game events.
+ * Callers keep hold of the returned object to subscribe, submit moves,
+ * request a resync, and clean up listeners on teardown.
+ */
+export function createGameSocketHelpers(socket: Socket) {
+  return {
+    joinMatch(matchId: string): Promise<JoinAckPayload> {
+      return new Promise((resolve) => {
+        socket.emit("game:join-match", { matchId }, (response: JoinAckPayload) => {
+          resolve(response);
+        });
+      });
+    },
+
+    leaveMatch(matchId: string): void {
+      socket.emit("game:leave-match", { matchId }, () => {});
+    },
+
+    onStateUpdated(handler: (data: StateUpdatedPayload) => void): void {
+      socket.on("game:state-updated", handler);
+    },
+
+    onPlayerConnected(handler: (data: PlayerConnectionPayload) => void): void {
+      socket.on("game:player-connected", handler);
+    },
+
+    onPlayerDisconnected(handler: (data: PlayerConnectionPayload) => void): void {
+      socket.on("game:player-disconnected", handler);
+    },
+
+    onMatchEnded(handler: (data: MatchEndedPayload) => void): void {
+      socket.on("game:match-ended", handler);
+    },
+
+    onMatchForfeited(handler: (data: MatchForfeitedPayload) => void): void {
+      socket.on("game:match-forfeited", handler);
+    },
+
+    onTurnTimerStarted(handler: (data: TurnTimerStartedPayload) => void): void {
+      socket.on("game:turn-timer-started", handler);
+    },
+
+    submitMove(matchId: string, move: Move): Promise<MoveAckPayload> {
+      return new Promise((resolve) => {
+        socket.emit(
+          "game:submit-move",
+          { matchId, move },
+          (response: MoveAckPayload) => {
+            resolve(response);
+          },
+        );
+      });
+    },
+
+    requestResync(matchId: string): Promise<ResyncPayload> {
+      return new Promise((resolve) => {
+        socket.emit(
+          "game:request-resync",
+          { matchId },
+          (response: ResyncPayload) => {
+            resolve(response);
+          },
+        );
+      });
+    },
+
+    cleanup(): void {
+      socket.off("game:state-updated");
+      socket.off("game:player-connected");
+      socket.off("game:player-disconnected");
+      socket.off("game:match-ended");
+      socket.off("game:match-forfeited");
+      socket.off("game:turn-timer-started");
+    },
+  };
+}
+
+export type GameSocketHelpers = ReturnType<typeof createGameSocketHelpers>;

--- a/apps/mobile/lib/use-game-socket.ts
+++ b/apps/mobile/lib/use-game-socket.ts
@@ -1,0 +1,195 @@
+// React hook that manages the /game WebSocket connection for mobile.
+// Mirrors apps/web useGameSocket, but reads the auth token via the
+// mobile-specific SecureStore-backed helper rather than localStorage.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import type { Move } from "@bb/game-engine";
+import { API_BASE, getToken } from "./api";
+import {
+  createGameSocket,
+  createGameSocketHelpers,
+  type GameSocketHelpers,
+  type MatchEndedPayload,
+  type MatchForfeitedPayload,
+  type MoveAckPayload,
+  type PlayerConnectionPayload,
+  type ResyncPayload,
+  type StateUpdatedPayload,
+  type TurnTimerStartedPayload,
+} from "./game-socket";
+
+export interface UseGameSocketOptions {
+  onStateUpdate?: (data: StateUpdatedPayload) => void;
+  onPlayerConnected?: (data: PlayerConnectionPayload) => void;
+  onPlayerDisconnected?: (data: PlayerConnectionPayload) => void;
+  onMatchEnded?: (data: MatchEndedPayload) => void;
+  onMatchForfeited?: (data: MatchForfeitedPayload) => void;
+  onTurnTimerStarted?: (data: TurnTimerStartedPayload) => void;
+  /** Callback when a resync provides a fresh game state after reconnection. */
+  onResyncState?: (data: ResyncPayload) => void;
+}
+
+export interface UseGameSocketResult {
+  connected: boolean;
+  joined: boolean;
+  error: string | null;
+  reconnecting: boolean;
+  reconnectAttempt: number;
+  /** Submit a move via WebSocket. Returns null if socket is unavailable. */
+  submitMove: (move: Move) => Promise<MoveAckPayload | null>;
+  socket: Socket | null;
+}
+
+/**
+ * React hook that connects to the /game namespace, joins the match room,
+ * forwards game events to callbacks, and cleans up on unmount.
+ *
+ * The caller remains responsible for HTTP fallback — if `submitMove`
+ * resolves with `null` (socket not ready), submit via REST.
+ */
+export function useGameSocket(
+  matchId: string,
+  options: UseGameSocketOptions = {},
+): UseGameSocketResult {
+  const [connected, setConnected] = useState(false);
+  const [joined, setJoined] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const socketRef = useRef<Socket | null>(null);
+  const helpersRef = useRef<GameSocketHelpers | null>(null);
+
+  const submitMove = useCallback(
+    async (move: Move): Promise<MoveAckPayload | null> => {
+      const helpers = helpersRef.current;
+      const socket = socketRef.current;
+      if (!helpers || !socket?.connected) return null;
+      return helpers.submitMove(matchId, move);
+    },
+    [matchId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    let cleanupFn: (() => void) | null = null;
+
+    (async () => {
+      const token = await getToken();
+      if (cancelled) return;
+      if (!token) {
+        setError("No auth token found");
+        return;
+      }
+
+      const socket = createGameSocket(API_BASE, token);
+      socketRef.current = socket;
+      const helpers = createGameSocketHelpers(socket);
+      helpersRef.current = helpers;
+
+      const joinAndResync = (isReconnect: boolean) => {
+        helpers.joinMatch(matchId).then((res) => {
+          if (res.ok) {
+            setJoined(true);
+            if (isReconnect) {
+              helpers.requestResync(matchId).then((resyncRes) => {
+                optionsRef.current.onResyncState?.(resyncRes);
+              });
+            }
+          } else {
+            setError(res.error ?? "Failed to join match room");
+          }
+        });
+      };
+
+      socket.on("connect", () => {
+        setConnected(true);
+        setReconnecting(false);
+        setReconnectAttempt(0);
+        setError(null);
+        joinAndResync(false);
+      });
+
+      socket.on("disconnect", () => {
+        setConnected(false);
+        setJoined(false);
+      });
+
+      socket.on("connect_error", (err: Error) => {
+        setError(err.message);
+        setConnected(false);
+      });
+
+      socket.io.on("reconnect_attempt", (attempt: number) => {
+        setReconnecting(true);
+        setReconnectAttempt(attempt);
+      });
+
+      socket.io.on("reconnect", () => {
+        setReconnecting(false);
+        setReconnectAttempt(0);
+        setError(null);
+        joinAndResync(true);
+      });
+
+      socket.io.on("reconnect_failed", () => {
+        setReconnecting(false);
+        setError("Reconnection failed after maximum attempts");
+      });
+
+      helpers.onStateUpdated((data) => {
+        optionsRef.current.onStateUpdate?.(data);
+      });
+      helpers.onPlayerConnected((data) => {
+        optionsRef.current.onPlayerConnected?.(data);
+      });
+      helpers.onPlayerDisconnected((data) => {
+        optionsRef.current.onPlayerDisconnected?.(data);
+      });
+      helpers.onMatchEnded((data) => {
+        optionsRef.current.onMatchEnded?.(data);
+      });
+      helpers.onMatchForfeited((data) => {
+        optionsRef.current.onMatchForfeited?.(data);
+      });
+      helpers.onTurnTimerStarted((data) => {
+        optionsRef.current.onTurnTimerStarted?.(data);
+      });
+
+      socket.connect();
+
+      cleanupFn = () => {
+        helpers.leaveMatch(matchId);
+        helpers.cleanup();
+        socket.off("connect");
+        socket.off("disconnect");
+        socket.off("connect_error");
+        socket.io.off("reconnect_attempt");
+        socket.io.off("reconnect");
+        socket.io.off("reconnect_failed");
+        socket.disconnect();
+        helpersRef.current = null;
+        socketRef.current = null;
+      };
+    })();
+
+    return () => {
+      cancelled = true;
+      if (cleanupFn) cleanupFn();
+    };
+  }, [matchId]);
+
+  return {
+    connected,
+    joined,
+    error,
+    reconnecting,
+    reconnectAttempt,
+    submitMove,
+    socket: socketRef.current,
+  };
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,7 +16,8 @@
     "react-native": "0.75.4",
     "react-native-gesture-handler": "~2.16.2",
     "react-native-reanimated": "~3.10.1",
-    "react-native-svg": "^15.2.0"
+    "react-native-svg": "^15.2.0",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       react-native-svg:
         specifier: ^15.2.0
         version: 15.12.1(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
     devDependencies:
       '@types/react':
         specifier: ^18.3.5


### PR DESCRIPTION
## Résumé

- Ajoute le support WebSocket temps réel à l'app mobile pour le namespace `/game` (socket.io-client), miroir du hook web `useGameSocket`.
- Module pur `lib/game-socket.ts` (factory + helpers : join-match, leave-match, submit-move, request-resync, subscriptions, cleanup) — 19 tests unitaires avec mock socket.io-client.
- Hook React `lib/use-game-socket.ts` qui lit le token via `getToken()` (SecureStore-backed), gère connect / disconnect / reconnect (backoff exponentiel ×15 tentatives) et forwarde `game:state-updated`, `game:match-ended`, `game:match-forfeited`, `game:turn-timer-started` vers des callbacks.
- `app/play/[id].tsx` : préfère WebSocket pour soumettre les moves et recevoir le `gameState` en push ; polling HTTP conservé comme fallback lorsque le socket est déconnecté ; bannière affiche `(hors ligne)` lorsque le WS est indisponible.

## Tâche roadmap

Sprint 18-19 — Parité mobile, tâche **M.3 `Integration WebSocket complete`** (première non cochée du premier sprint non terminé).

## Plan de test

- [x] `pnpm --filter @bb/mobile test` — 64 tests (dont 19 nouveaux pour `game-socket`)
- [x] `pnpm turbo run test --filter=@bb/mobile --filter=@bb/web --filter=@bb/game-engine` — 64 + 250 + 4050 tests verts
- [x] `pnpm turbo run typecheck --filter=@bb/web` — OK
- [x] `pnpm turbo run build --filter=@bb/game-engine --filter=@bb/ui` — OK (web build échoue uniquement sur un fetch Google Fonts environnemental, non lié)
- [ ] Test manuel : lancer l'app mobile, rejoindre un match, vérifier que `gameState` arrive en push et que la bannière passe en mode `(hors ligne)` si le WS tombe.
- [ ] Vérifier sur device réel (iOS + Android) que `socket.io-client` reste stable sous backgrounding / reconnexion réseau.
