### PR TITLE
feat(mobile): M.4 popups natifs Block/Push/FollowUp/Reroll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -312,7 +312,7 @@
 | M.1 | Ecrans gestion d'equipe (creer, editer, voir) | Mobile | [x] |
 | M.2 | Ecran queue matchmaking | Mobile | [x] |
 | M.3 | Integration WebSocket complete | Mobile | [x] |
-| M.4 | Popups block/push/followup/reroll natifs | Mobile | [ ] |
+| M.4 | Popups block/push/followup/reroll natifs | Mobile | [x] |
 | M.5 | Chat in-game mobile | Mobile | [ ] |
 | M.6 | Ecran leaderboard | Mobile | [ ] |
 | M.7 | Ecran replay de match | Mobile | [ ] |

--- a/apps/mobile/app/play/[id].tsx
+++ b/apps/mobile/app/play/[id].tsx
@@ -17,6 +17,7 @@ import {
   type Move,
 } from "@bb/game-engine";
 import PixiBoardNative from "../../../../packages/ui/src/board/PixiBoard.native";
+import MatchPopups from "../../components/popups/MatchPopups";
 
 function normalizeState(state: any): GameState {
   if (!state) return state;
@@ -376,6 +377,12 @@ export default function PlayScreen() {
           Tap un joueur pour voir ses cases jouables. Double-tap pour annuler.
         </Text>
       </View>
+
+      <MatchPopups
+        state={state}
+        isMyTurn={isMyTurn}
+        submitMove={submitMove}
+      />
     </View>
   );
 }

--- a/apps/mobile/components/popups/BlockChoicePopup.tsx
+++ b/apps/mobile/components/popups/BlockChoicePopup.tsx
@@ -1,0 +1,152 @@
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+
+export type BlockResult =
+  | "PLAYER_DOWN"
+  | "BOTH_DOWN"
+  | "PUSH_BACK"
+  | "STUMBLE"
+  | "POW";
+
+interface BlockChoicePopupProps {
+  visible: boolean;
+  attackerName: string;
+  defenderName: string;
+  chooser: "attacker" | "defender";
+  options: BlockResult[];
+  onChoose: (result: BlockResult) => void;
+  onClose: () => void;
+}
+
+const RESULT_LABELS: Record<BlockResult, string> = {
+  PLAYER_DOWN: "Attaquant à terre",
+  BOTH_DOWN: "Deux à terre",
+  PUSH_BACK: "Repoussé",
+  STUMBLE: "Trébuche",
+  POW: "POW !",
+};
+
+export default function BlockChoicePopup({
+  visible,
+  attackerName,
+  defenderName,
+  chooser,
+  options,
+  onChoose,
+  onClose,
+}: BlockChoicePopupProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Choix du dé de blocage</Text>
+          <Text style={styles.subtitle}>
+            {chooser === "attacker"
+              ? `${attackerName} choisit`
+              : `${defenderName} choisit`}
+          </Text>
+
+          <View style={styles.grid}>
+            {options.map((opt) => (
+              <Pressable
+                key={opt}
+                onPress={() => onChoose(opt)}
+                style={({ pressed }) => [
+                  styles.optionButton,
+                  pressed && styles.optionButtonPressed,
+                ]}
+                accessibilityLabel={`Choisir ${RESULT_LABELS[opt]}`}
+              >
+                <Text style={styles.optionLabel}>{RESULT_LABELS[opt]}</Text>
+              </Pressable>
+            ))}
+          </View>
+
+          <Pressable
+            onPress={onClose}
+            style={styles.cancelButton}
+            accessibilityLabel="Annuler"
+          >
+            <Text style={styles.cancelText}>Annuler</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 20,
+    width: "100%",
+    maxWidth: 380,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    color: "#111827",
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 10,
+    marginBottom: 20,
+  },
+  optionButton: {
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    backgroundColor: "#F9FAFB",
+    minWidth: 100,
+    alignItems: "center",
+  },
+  optionButtonPressed: {
+    backgroundColor: "#E5E7EB",
+  },
+  optionLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  cancelButton: {
+    alignSelf: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 6,
+  },
+  cancelText: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#374151",
+  },
+});

--- a/apps/mobile/components/popups/FollowUpChoicePopup.tsx
+++ b/apps/mobile/components/popups/FollowUpChoicePopup.tsx
@@ -1,0 +1,171 @@
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+
+interface FollowUpChoicePopupProps {
+  visible: boolean;
+  attackerName: string;
+  targetName: string;
+  targetNewPosition: { x: number; y: number };
+  onChoose: (followUp: boolean) => void;
+  onClose: () => void;
+}
+
+export default function FollowUpChoicePopup({
+  visible,
+  attackerName,
+  targetName,
+  targetNewPosition,
+  onChoose,
+  onClose,
+}: FollowUpChoicePopupProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Suivi (Follow-up)</Text>
+          <Text style={styles.subtitle}>
+            {attackerName} a repoussé {targetName} vers ({targetNewPosition.x},{" "}
+            {targetNewPosition.y})
+          </Text>
+          <Text style={styles.question}>
+            Voulez-vous que {attackerName} le suive dans la case libérée ?
+          </Text>
+
+          <View style={styles.row}>
+            <Pressable
+              onPress={() => onChoose(true)}
+              style={({ pressed }) => [
+                styles.choiceButton,
+                styles.choiceYes,
+                pressed && styles.pressed,
+              ]}
+              accessibilityLabel="Suivre"
+            >
+              <Text style={styles.choiceIcon}>✓</Text>
+              <Text style={styles.choiceText}>Suivre</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => onChoose(false)}
+              style={({ pressed }) => [
+                styles.choiceButton,
+                styles.choiceNo,
+                pressed && styles.pressed,
+              ]}
+              accessibilityLabel="Ne pas suivre"
+            >
+              <Text style={styles.choiceIcon}>✗</Text>
+              <Text style={styles.choiceText}>Ne pas suivre</Text>
+            </Pressable>
+          </View>
+
+          <Text style={styles.hint}>
+            Le suivi est gratuit et ne consomme pas de points de mouvement
+          </Text>
+
+          <Pressable
+            onPress={onClose}
+            style={styles.cancelButton}
+            accessibilityLabel="Annuler"
+          >
+            <Text style={styles.cancelText}>Annuler</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 20,
+    width: "100%",
+    maxWidth: 380,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    color: "#111827",
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  question: {
+    fontSize: 13,
+    color: "#374151",
+    textAlign: "center",
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+    marginBottom: 16,
+  },
+  choiceButton: {
+    flex: 1,
+    maxWidth: 150,
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  choiceYes: {
+    backgroundColor: "#16A34A",
+  },
+  choiceNo: {
+    backgroundColor: "#DC2626",
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  choiceIcon: {
+    fontSize: 18,
+    color: "#fff",
+    marginBottom: 2,
+  },
+  choiceText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#fff",
+  },
+  hint: {
+    fontSize: 11,
+    color: "#9CA3AF",
+    textAlign: "center",
+    marginBottom: 14,
+  },
+  cancelButton: {
+    alignSelf: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 6,
+  },
+  cancelText: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#374151",
+  },
+});

--- a/apps/mobile/components/popups/MatchPopups.tsx
+++ b/apps/mobile/components/popups/MatchPopups.tsx
@@ -1,0 +1,94 @@
+import type { GameState, Move, BlockResult } from "@bb/game-engine";
+import BlockChoicePopup from "./BlockChoicePopup";
+import PushChoicePopup from "./PushChoicePopup";
+import FollowUpChoicePopup from "./FollowUpChoicePopup";
+import RerollChoicePopup from "./RerollChoicePopup";
+import {
+  shouldShowBlockPopup,
+  shouldShowPushPopup,
+  shouldShowFollowUpPopup,
+  shouldShowRerollPopup,
+  buildBlockChooseMove,
+  buildPushChooseMove,
+  buildFollowUpChooseMove,
+  buildRerollChooseMove,
+} from "../../lib/block-popups";
+
+interface MatchPopupsProps {
+  state: GameState;
+  isMyTurn: boolean;
+  submitMove: (move: Move) => void;
+}
+
+function playerName(state: GameState, id: string, fallback: string): string {
+  return state.players.find((p) => p.id === id)?.name || fallback;
+}
+
+export default function MatchPopups({
+  state,
+  isMyTurn,
+  submitMove,
+}: MatchPopupsProps) {
+  return (
+    <>
+      {state.pendingBlock && (
+        <BlockChoicePopup
+          visible={shouldShowBlockPopup(state)}
+          attackerName={playerName(state, state.pendingBlock.attackerId, "Attaquant")}
+          defenderName={playerName(state, state.pendingBlock.targetId, "Défenseur")}
+          chooser={state.pendingBlock.chooser}
+          options={state.pendingBlock.options as BlockResult[]}
+          onChoose={(result) =>
+            submitMove(buildBlockChooseMove(state.pendingBlock!, result))
+          }
+          onClose={() => {}}
+        />
+      )}
+
+      {state.pendingPushChoice && (
+        <PushChoicePopup
+          visible={shouldShowPushPopup(state)}
+          attackerName={playerName(state, state.pendingPushChoice.attackerId, "Attaquant")}
+          targetName={playerName(state, state.pendingPushChoice.targetId, "Défenseur")}
+          availableDirections={state.pendingPushChoice.availableDirections}
+          onChoose={(direction) =>
+            submitMove(buildPushChooseMove(state.pendingPushChoice!, direction))
+          }
+          onClose={() => {}}
+        />
+      )}
+
+      {state.pendingFollowUpChoice && (
+        <FollowUpChoicePopup
+          visible={shouldShowFollowUpPopup(state)}
+          attackerName={playerName(state, state.pendingFollowUpChoice.attackerId, "Attaquant")}
+          targetName={playerName(state, state.pendingFollowUpChoice.targetId, "Défenseur")}
+          targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
+          onChoose={(followUp) =>
+            submitMove(
+              buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp),
+            )
+          }
+          onClose={() => {}}
+        />
+      )}
+
+      {state.pendingReroll && isMyTurn && (
+        <RerollChoicePopup
+          visible={shouldShowRerollPopup(state)}
+          rollType={state.pendingReroll.rollType}
+          playerName={playerName(state, state.pendingReroll.playerId, "Joueur")}
+          teamRerollsLeft={
+            state.pendingReroll.team === "A"
+              ? state.teamRerolls?.teamA ?? 0
+              : state.teamRerolls?.teamB ?? 0
+          }
+          onChoose={(useReroll) =>
+            submitMove(buildRerollChooseMove(useReroll))
+          }
+          onClose={() => {}}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/mobile/components/popups/PushChoicePopup.tsx
+++ b/apps/mobile/components/popups/PushChoicePopup.tsx
@@ -1,0 +1,148 @@
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+import { describeDirection } from "../../lib/block-popups";
+
+interface PushDirection {
+  x: number;
+  y: number;
+}
+
+interface PushChoicePopupProps {
+  visible: boolean;
+  attackerName: string;
+  targetName: string;
+  availableDirections: PushDirection[];
+  onChoose: (direction: PushDirection) => void;
+  onClose: () => void;
+}
+
+export default function PushChoicePopup({
+  visible,
+  attackerName,
+  targetName,
+  availableDirections,
+  onChoose,
+  onClose,
+}: PushChoicePopupProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Choix de direction de poussée</Text>
+          <Text style={styles.subtitle}>
+            {attackerName} doit choisir dans quelle direction pousser {targetName}
+          </Text>
+
+          <View style={styles.grid}>
+            {availableDirections.map((direction) => {
+              const { label, arrow } = describeDirection(direction);
+              const key = `${direction.x},${direction.y}`;
+              return (
+                <Pressable
+                  key={key}
+                  onPress={() => onChoose(direction)}
+                  style={({ pressed }) => [
+                    styles.optionButton,
+                    pressed && styles.optionButtonPressed,
+                  ]}
+                  accessibilityLabel={`Pousser vers ${label}`}
+                >
+                  <Text style={styles.arrow}>{arrow}</Text>
+                  <Text style={styles.label}>{label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Pressable
+            onPress={onClose}
+            style={styles.cancelButton}
+            accessibilityLabel="Annuler"
+          >
+            <Text style={styles.cancelText}>Annuler</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 20,
+    width: "100%",
+    maxWidth: 380,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    color: "#111827",
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 10,
+    marginBottom: 20,
+  },
+  optionButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    backgroundColor: "#F9FAFB",
+    alignItems: "center",
+    minWidth: 80,
+  },
+  optionButtonPressed: {
+    backgroundColor: "#E5E7EB",
+  },
+  arrow: {
+    fontSize: 24,
+    marginBottom: 2,
+    color: "#111827",
+  },
+  label: {
+    fontSize: 11,
+    color: "#6B7280",
+  },
+  cancelButton: {
+    alignSelf: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    backgroundColor: "#E5E7EB",
+    borderRadius: 6,
+  },
+  cancelText: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: "#374151",
+  },
+});

--- a/apps/mobile/components/popups/RerollChoicePopup.tsx
+++ b/apps/mobile/components/popups/RerollChoicePopup.tsx
@@ -1,0 +1,143 @@
+import { Modal, View, Text, Pressable, StyleSheet } from "react-native";
+import { rollTypeLabel } from "../../lib/block-popups";
+
+interface RerollChoicePopupProps {
+  visible: boolean;
+  rollType: string;
+  playerName: string;
+  teamRerollsLeft: number;
+  onChoose: (useReroll: boolean) => void;
+  onClose: () => void;
+}
+
+export default function RerollChoicePopup({
+  visible,
+  rollType,
+  playerName,
+  teamRerollsLeft,
+  onChoose,
+  onClose,
+}: RerollChoicePopupProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Relance disponible !</Text>
+          <Text style={styles.subtitle}>
+            {playerName} a raté son jet de{" "}
+            <Text style={styles.rollType}>{rollTypeLabel(rollType)}</Text>
+          </Text>
+          <Text style={styles.rerollsLeft}>
+            Relances restantes : {teamRerollsLeft}
+          </Text>
+
+          <View style={styles.row}>
+            <Pressable
+              onPress={() => onChoose(true)}
+              style={({ pressed }) => [
+                styles.choiceButton,
+                styles.rerollButton,
+                pressed && styles.pressed,
+              ]}
+              accessibilityLabel="Relancer"
+            >
+              <Text style={styles.rerollText}>Relancer</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => onChoose(false)}
+              style={({ pressed }) => [
+                styles.choiceButton,
+                styles.declineButton,
+                pressed && styles.pressed,
+              ]}
+              accessibilityLabel="Refuser"
+            >
+              <Text style={styles.declineText}>Refuser</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 20,
+    width: "100%",
+    maxWidth: 380,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textAlign: "center",
+    color: "#111827",
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    textAlign: "center",
+    marginBottom: 4,
+  },
+  rollType: {
+    fontWeight: "700",
+    color: "#111827",
+  },
+  rerollsLeft: {
+    fontSize: 12,
+    color: "#9CA3AF",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+  },
+  choiceButton: {
+    flex: 1,
+    maxWidth: 150,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  rerollButton: {
+    backgroundColor: "#F97316",
+  },
+  declineButton: {
+    backgroundColor: "#E5E7EB",
+  },
+  pressed: {
+    opacity: 0.8,
+  },
+  rerollText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#fff",
+  },
+  declineText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#374151",
+  },
+});

--- a/apps/mobile/lib/block-popups.test.ts
+++ b/apps/mobile/lib/block-popups.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldShowBlockPopup,
+  shouldShowPushPopup,
+  shouldShowFollowUpPopup,
+  shouldShowRerollPopup,
+  buildBlockChooseMove,
+  buildPushChooseMove,
+  buildFollowUpChooseMove,
+  buildRerollChooseMove,
+  computeBlockTargets,
+  describeDirection,
+  rollTypeLabel,
+} from "./block-popups";
+import type { GameState, Position, Move, BlockResult } from "@bb/game-engine";
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    width: 26,
+    height: 15,
+    players: [],
+    ball: undefined,
+    currentPlayer: "A",
+    turn: 1,
+    half: 1,
+    selectedPlayerId: null,
+    isTurnover: false,
+    playerActions: {},
+    teamBlitzCount: {},
+    teamFoulCount: {},
+    matchStats: {},
+    gamePhase: "playing" as const,
+    score: { teamA: 0, teamB: 0 },
+    dugouts: {
+      teamA: { reserves: [], knocked: [], injured: [], dead: [] },
+      teamB: { reserves: [], knocked: [], injured: [], dead: [] },
+    },
+    gameLog: [],
+    teamRerolls: { teamA: 3, teamB: 3 },
+    rerollUsedThisTurn: false,
+    teamNames: { teamA: "Team A", teamB: "Team B" },
+    ...overrides,
+  } as GameState;
+}
+
+describe("shouldShowBlockPopup", () => {
+  it("returns true when pendingBlock exists", () => {
+    const state = makeState({
+      pendingBlock: {
+        attackerId: "a1",
+        targetId: "b1",
+        options: ["POW", "STUMBLE"] as BlockResult[],
+        chooser: "attacker",
+        offensiveAssists: 0,
+        defensiveAssists: 0,
+        totalStrength: 4,
+        targetStrength: 3,
+      },
+    });
+    expect(shouldShowBlockPopup(state)).toBe(true);
+  });
+
+  it("returns false when no pendingBlock", () => {
+    expect(shouldShowBlockPopup(makeState())).toBe(false);
+  });
+});
+
+describe("shouldShowPushPopup", () => {
+  it("returns true when pendingPushChoice exists", () => {
+    const state = makeState({
+      pendingPushChoice: {
+        attackerId: "a1",
+        targetId: "b1",
+        availableDirections: [{ x: 1, y: 0 }],
+        blockResult: "POW" as BlockResult,
+        offensiveAssists: 0,
+        defensiveAssists: 0,
+        totalStrength: 4,
+        targetStrength: 3,
+      },
+    });
+    expect(shouldShowPushPopup(state)).toBe(true);
+  });
+
+  it("returns false when no pendingPushChoice", () => {
+    expect(shouldShowPushPopup(makeState())).toBe(false);
+  });
+});
+
+describe("shouldShowFollowUpPopup", () => {
+  it("returns true when pendingFollowUpChoice exists", () => {
+    const state = makeState({
+      pendingFollowUpChoice: {
+        attackerId: "a1",
+        targetId: "b1",
+        targetNewPosition: { x: 11, y: 8 },
+        targetOldPosition: { x: 10, y: 8 },
+      },
+    });
+    expect(shouldShowFollowUpPopup(state)).toBe(true);
+  });
+
+  it("returns false when no pendingFollowUpChoice", () => {
+    expect(shouldShowFollowUpPopup(makeState())).toBe(false);
+  });
+});
+
+describe("shouldShowRerollPopup", () => {
+  it("returns true when pendingReroll exists", () => {
+    const state = makeState({
+      pendingReroll: {
+        rollType: "dodge",
+        playerId: "a1",
+        team: "A",
+        targetNumber: 3,
+        modifiers: 0,
+        playerIndex: 0,
+        from: { x: 5, y: 5 },
+        to: { x: 6, y: 5 },
+      },
+    });
+    expect(shouldShowRerollPopup(state)).toBe(true);
+  });
+
+  it("returns false when no pendingReroll", () => {
+    expect(shouldShowRerollPopup(makeState())).toBe(false);
+  });
+});
+
+describe("buildBlockChooseMove", () => {
+  it("builds a BLOCK_CHOOSE move from pendingBlock and chosen result", () => {
+    const pending = {
+      attackerId: "a1",
+      targetId: "b1",
+      options: ["POW", "STUMBLE"] as BlockResult[],
+      chooser: "attacker" as const,
+      offensiveAssists: 0,
+      defensiveAssists: 0,
+      totalStrength: 4,
+      targetStrength: 3,
+    };
+    expect(buildBlockChooseMove(pending, "POW")).toEqual({
+      type: "BLOCK_CHOOSE",
+      playerId: "a1",
+      targetId: "b1",
+      result: "POW",
+    });
+  });
+});
+
+describe("buildPushChooseMove", () => {
+  it("builds a PUSH_CHOOSE move from pendingPushChoice and direction", () => {
+    const pending = {
+      attackerId: "a1",
+      targetId: "b1",
+      availableDirections: [{ x: 1, y: 0 }] as Position[],
+      blockResult: "POW" as BlockResult,
+      offensiveAssists: 0,
+      defensiveAssists: 0,
+      totalStrength: 4,
+      targetStrength: 3,
+    };
+    expect(buildPushChooseMove(pending, { x: 1, y: 0 })).toEqual({
+      type: "PUSH_CHOOSE",
+      playerId: "a1",
+      targetId: "b1",
+      direction: { x: 1, y: 0 },
+    });
+  });
+});
+
+describe("buildFollowUpChooseMove", () => {
+  it("builds FOLLOW_UP_CHOOSE with followUp=true", () => {
+    const pending = {
+      attackerId: "a1",
+      targetId: "b1",
+      targetNewPosition: { x: 11, y: 8 },
+      targetOldPosition: { x: 10, y: 8 },
+    };
+    expect(buildFollowUpChooseMove(pending, true)).toEqual({
+      type: "FOLLOW_UP_CHOOSE",
+      playerId: "a1",
+      targetId: "b1",
+      followUp: true,
+    });
+  });
+
+  it("builds FOLLOW_UP_CHOOSE with followUp=false", () => {
+    const pending = {
+      attackerId: "a1",
+      targetId: "b1",
+      targetNewPosition: { x: 11, y: 8 },
+      targetOldPosition: { x: 10, y: 8 },
+    };
+    expect(buildFollowUpChooseMove(pending, false)).toEqual({
+      type: "FOLLOW_UP_CHOOSE",
+      playerId: "a1",
+      targetId: "b1",
+      followUp: false,
+    });
+  });
+});
+
+describe("buildRerollChooseMove", () => {
+  it("builds REROLL_CHOOSE useReroll=true", () => {
+    expect(buildRerollChooseMove(true)).toEqual({
+      type: "REROLL_CHOOSE",
+      useReroll: true,
+    });
+  });
+
+  it("builds REROLL_CHOOSE useReroll=false", () => {
+    expect(buildRerollChooseMove(false)).toEqual({
+      type: "REROLL_CHOOSE",
+      useReroll: false,
+    });
+  });
+});
+
+describe("computeBlockTargets", () => {
+  it("extracts target positions from BLOCK legal moves for a selected player", () => {
+    const players = [
+      {
+        id: "a1",
+        team: "A" as const,
+        pos: { x: 10, y: 7 },
+        name: "Attacker",
+        ma: 6,
+        st: 3,
+        ag: 3,
+        av: 8,
+        pm: 6,
+        skills: [],
+        status: "active" as const,
+      },
+      {
+        id: "b1",
+        team: "B" as const,
+        pos: { x: 10, y: 8 },
+        name: "Defender",
+        ma: 6,
+        st: 3,
+        ag: 3,
+        av: 8,
+        pm: 6,
+        skills: [],
+        status: "active" as const,
+      },
+      {
+        id: "b2",
+        team: "B" as const,
+        pos: { x: 11, y: 7 },
+        name: "Defender2",
+        ma: 6,
+        st: 3,
+        ag: 3,
+        av: 8,
+        pm: 6,
+        skills: [],
+        status: "active" as const,
+      },
+    ];
+    const legalMoves = [
+      { type: "BLOCK", playerId: "a1", targetId: "b1" },
+      { type: "BLOCK", playerId: "a1", targetId: "b2" },
+      { type: "MOVE", playerId: "a1", to: { x: 9, y: 7 } },
+    ] as Move[];
+
+    expect(computeBlockTargets("a1", legalMoves, players as any)).toEqual([
+      { x: 10, y: 8 },
+      { x: 11, y: 7 },
+    ]);
+  });
+
+  it("returns empty array when no player is selected", () => {
+    expect(computeBlockTargets(null, [], [])).toEqual([]);
+  });
+});
+
+describe("describeDirection", () => {
+  it("returns compass label and arrow for cardinal directions", () => {
+    expect(describeDirection({ x: 0, y: -1 })).toEqual({
+      label: "Nord",
+      arrow: "↑",
+    });
+    expect(describeDirection({ x: 0, y: 1 })).toEqual({
+      label: "Sud",
+      arrow: "↓",
+    });
+    expect(describeDirection({ x: -1, y: 0 })).toEqual({
+      label: "Ouest",
+      arrow: "←",
+    });
+    expect(describeDirection({ x: 1, y: 0 })).toEqual({
+      label: "Est",
+      arrow: "→",
+    });
+  });
+
+  it("returns compass label for diagonal directions", () => {
+    expect(describeDirection({ x: -1, y: -1 })).toEqual({
+      label: "Nord-Ouest",
+      arrow: "↖",
+    });
+    expect(describeDirection({ x: 1, y: -1 })).toEqual({
+      label: "Nord-Est",
+      arrow: "↗",
+    });
+    expect(describeDirection({ x: -1, y: 1 })).toEqual({
+      label: "Sud-Ouest",
+      arrow: "↙",
+    });
+    expect(describeDirection({ x: 1, y: 1 })).toEqual({
+      label: "Sud-Est",
+      arrow: "↘",
+    });
+  });
+
+  it("falls back to coordinate string for unknown directions", () => {
+    expect(describeDirection({ x: 2, y: 3 })).toEqual({
+      label: "(2, 3)",
+      arrow: "?",
+    });
+  });
+});
+
+describe("rollTypeLabel", () => {
+  it("returns French label for known roll types", () => {
+    expect(rollTypeLabel("dodge")).toBe("Esquive");
+    expect(rollTypeLabel("pickup")).toBe("Ramassage");
+    expect(rollTypeLabel("gfi")).toBe("Going For It");
+  });
+
+  it("returns raw value for unknown roll types", () => {
+    expect(rollTypeLabel("unknown")).toBe("unknown");
+  });
+});

--- a/apps/mobile/lib/block-popups.ts
+++ b/apps/mobile/lib/block-popups.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure helper functions for Block/Push/FollowUp/Reroll popup logic in online matches.
+ * Mirrors apps/web/app/play/[id]/hooks/useBlockPopups.ts so mobile and web share
+ * the same move-building contract.
+ */
+import type {
+  GameState,
+  Move,
+  Position,
+  Player,
+  BlockResult,
+} from "@bb/game-engine";
+
+export function shouldShowBlockPopup(state: GameState): boolean {
+  return !!state.pendingBlock;
+}
+
+export function shouldShowPushPopup(state: GameState): boolean {
+  return !!state.pendingPushChoice;
+}
+
+export function shouldShowFollowUpPopup(state: GameState): boolean {
+  return !!state.pendingFollowUpChoice;
+}
+
+export function shouldShowRerollPopup(state: GameState): boolean {
+  return !!state.pendingReroll;
+}
+
+export function buildBlockChooseMove(
+  pending: NonNullable<GameState["pendingBlock"]>,
+  result: BlockResult,
+): Move {
+  return {
+    type: "BLOCK_CHOOSE",
+    playerId: pending.attackerId,
+    targetId: pending.targetId,
+    result,
+  } as Move;
+}
+
+export function buildPushChooseMove(
+  pending: NonNullable<GameState["pendingPushChoice"]>,
+  direction: Position,
+): Move {
+  return {
+    type: "PUSH_CHOOSE",
+    playerId: pending.attackerId,
+    targetId: pending.targetId,
+    direction,
+  } as Move;
+}
+
+export function buildFollowUpChooseMove(
+  pending: NonNullable<GameState["pendingFollowUpChoice"]>,
+  followUp: boolean,
+): Move {
+  return {
+    type: "FOLLOW_UP_CHOOSE",
+    playerId: pending.attackerId,
+    targetId: pending.targetId,
+    followUp,
+  } as Move;
+}
+
+export function buildRerollChooseMove(useReroll: boolean): Move {
+  return { type: "REROLL_CHOOSE", useReroll } as Move;
+}
+
+export function computeBlockTargets(
+  selectedPlayerId: string | null,
+  legalMoves: Move[],
+  players: Player[],
+): Position[] {
+  if (!selectedPlayerId) return [];
+  return legalMoves
+    .filter(
+      (m): m is Extract<Move, { type: "BLOCK" }> =>
+        m.type === "BLOCK" && (m as { playerId: string }).playerId === selectedPlayerId,
+    )
+    .map((m) => {
+      const target = players.find(
+        (p) => p.id === (m as { targetId: string }).targetId,
+      );
+      return target ? target.pos : null;
+    })
+    .filter((pos): pos is Position => pos !== null);
+}
+
+export interface DirectionInfo {
+  label: string;
+  arrow: string;
+}
+
+export function describeDirection(dir: Position): DirectionInfo {
+  if (dir.x === 0 && dir.y === -1) return { label: "Nord", arrow: "↑" };
+  if (dir.x === 0 && dir.y === 1) return { label: "Sud", arrow: "↓" };
+  if (dir.x === -1 && dir.y === 0) return { label: "Ouest", arrow: "←" };
+  if (dir.x === 1 && dir.y === 0) return { label: "Est", arrow: "→" };
+  if (dir.x === -1 && dir.y === -1) return { label: "Nord-Ouest", arrow: "↖" };
+  if (dir.x === 1 && dir.y === -1) return { label: "Nord-Est", arrow: "↗" };
+  if (dir.x === -1 && dir.y === 1) return { label: "Sud-Ouest", arrow: "↙" };
+  if (dir.x === 1 && dir.y === 1) return { label: "Sud-Est", arrow: "↘" };
+  return { label: `(${dir.x}, ${dir.y})`, arrow: "?" };
+}
+
+const rollTypeLabels: Record<string, string> = {
+  dodge: "Esquive",
+  pickup: "Ramassage",
+  gfi: "Going For It",
+};
+
+export function rollTypeLabel(rollType: string): string {
+  return rollTypeLabels[rollType] ?? rollType;
+}


### PR DESCRIPTION
## Resume

- Implemente les 4 popups natifs React Native pour le match online mobile : `BlockChoicePopup`, `PushChoicePopup`, `FollowUpChoicePopup`, `RerollChoicePopup` (Modal + StyleSheet, sans dependance web).
- Extrait les helpers purs (`shouldShow*`, `build*Move`, `describeDirection`, `rollTypeLabel`) en miroir de `apps/web/.../useBlockPopups.ts` pour garantir un contrat de Move identique web/mobile.
- Cable les popups dans `app/play/[id].tsx` via un wrapper `MatchPopups` — ecoute les champs `pendingBlock`, `pendingPushChoice`, `pendingFollowUpChoice`, `pendingReroll` du `GameState` et envoie les decisions via `submitMove` (WebSocket + fallback HTTP).

## Tache roadmap

Sprint 18-19 — Parite Mobile, tache **M.4** : Popups block/push/followup/reroll natifs.

## Plan de test

- [x] 21 tests unitaires nouveaux sur les helpers (`apps/mobile/lib/block-popups.test.ts`) — tous verts.
- [x] Suite mobile complete : 4 fichiers, 85 tests — tous verts.
- [x] Engine 4050 tests + UI 288 tests inchanges (aucune regression).
- [ ] Validation visuelle Expo a realiser sur appareil (build native requis).
- [ ] Tester le flow complet block → push → follow-up → reroll dans un match multi-joueur reel.

## Notes

- Fichier `app/play/[id].tsx` : 525 → 531 lignes (le bloc popup est isole dans `MatchPopups.tsx` pour limiter la croissance).
- Les composants utilisent uniquement des primitives RN (Modal, View, Text, Pressable, StyleSheet) — aucune dependance Tailwind/web.
- Les tests `@bb/tests-e2e-ui` et `@bb/tests-integration` non executes (Playwright browser manquant dans l'environnement CI, non lie a cette PR).