### PR TITLE
feat(mobile): M.5 chat in-game mobile

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -313,7 +313,7 @@
 | M.2 | Ecran queue matchmaking | Mobile | [x] |
 | M.3 | Integration WebSocket complete | Mobile | [x] |
 | M.4 | Popups block/push/followup/reroll natifs | Mobile | [x] |
-| M.5 | Chat in-game mobile | Mobile | [ ] |
+| M.5 | Chat in-game mobile | Mobile | [x] |
 | M.6 | Ecran leaderboard | Mobile | [ ] |
 | M.7 | Ecran replay de match | Mobile | [ ] |
 | M.8 | Ecrans cups/ligues | Mobile | [ ] |

--- a/apps/mobile/app/play/[id].tsx
+++ b/apps/mobile/app/play/[id].tsx
@@ -10,6 +10,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { apiGet, apiPost, ApiError } from "../../lib/api";
 import { useAuth } from "../../lib/auth-context";
 import { useGameSocket } from "../../lib/use-game-socket";
+import { useGameChat } from "../../lib/use-game-chat";
 import {
   getLegalMoves,
   type GameState,
@@ -18,6 +19,7 @@ import {
 } from "@bb/game-engine";
 import PixiBoardNative from "../../../../packages/ui/src/board/PixiBoard.native";
 import MatchPopups from "../../components/popups/MatchPopups";
+import GameChat from "../../components/GameChat";
 
 function normalizeState(state: any): GameState {
   if (!state) return state;
@@ -80,6 +82,7 @@ export default function PlayScreen() {
   const {
     connected: wsConnected,
     submitMove: wsSubmitMove,
+    socket: wsSocket,
   } = useGameSocket(matchId ?? "", {
     onStateUpdate: ({ gameState }) => {
       if (!gameState) return;
@@ -103,6 +106,12 @@ export default function PlayScreen() {
         setState(normalizeState(gameState));
       }
     },
+  });
+
+  // In-game chat wired on the same /game socket
+  const { messages: chatMessages, sendMessage: sendChatMessage } = useGameChat({
+    socket: wsSocket,
+    matchId: matchId ?? "",
   });
 
   // HTTP polling fallback — only when WebSocket is not connected
@@ -382,6 +391,12 @@ export default function PlayScreen() {
         state={state}
         isMyTurn={isMyTurn}
         submitMove={submitMove}
+      />
+
+      <GameChat
+        messages={chatMessages}
+        sendMessage={sendChatMessage}
+        currentUserId={user?.id}
       />
     </View>
   );

--- a/apps/mobile/components/GameChat.styles.ts
+++ b/apps/mobile/components/GameChat.styles.ts
@@ -1,0 +1,178 @@
+import { Platform, StyleSheet } from "react-native";
+
+export const gameChatStyles = StyleSheet.create({
+  toggle: {
+    position: "absolute",
+    bottom: 72,
+    left: 16,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: "#4F46E5",
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
+  },
+  toggleIcon: {
+    fontSize: 22,
+  },
+  badge: {
+    position: "absolute",
+    top: -4,
+    right: -4,
+    minWidth: 20,
+    height: 20,
+    paddingHorizontal: 4,
+    borderRadius: 10,
+    backgroundColor: "#EF4444",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  badgeText: {
+    color: "#fff",
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(17, 24, 39, 0.4)",
+    justifyContent: "flex-end",
+  },
+  panel: {
+    backgroundColor: "#fff",
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    maxHeight: "75%",
+    minHeight: 320,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: "#4F46E5",
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+  },
+  headerTitle: {
+    color: "#fff",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  closeButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  closeText: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 32,
+  },
+  emptyText: {
+    color: "#9CA3AF",
+    fontSize: 13,
+  },
+  list: {
+    flexGrow: 0,
+  },
+  listContent: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  messageRow: {
+    marginVertical: 4,
+    maxWidth: "85%",
+  },
+  messageRowMe: {
+    alignSelf: "flex-end",
+    alignItems: "flex-end",
+  },
+  messageRowOther: {
+    alignSelf: "flex-start",
+    alignItems: "flex-start",
+  },
+  bubble: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  bubbleMe: {
+    backgroundColor: "#E0E7FF",
+  },
+  bubbleOther: {
+    backgroundColor: "#F3F4F6",
+  },
+  bubbleText: {
+    fontSize: 13,
+  },
+  bubbleTextMe: {
+    color: "#1E1B4B",
+  },
+  bubbleTextOther: {
+    color: "#1F2937",
+  },
+  timestamp: {
+    fontSize: 10,
+    color: "#9CA3AF",
+    marginTop: 2,
+  },
+  errorBar: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: "#FEE2E2",
+    borderTopWidth: 1,
+    borderTopColor: "#FCA5A5",
+  },
+  errorText: {
+    color: "#B91C1C",
+    fontSize: 12,
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: "#E5E7EB",
+    backgroundColor: "#fff",
+  },
+  input: {
+    flex: 1,
+    fontSize: 14,
+    color: "#111827",
+    paddingHorizontal: 10,
+    paddingVertical: Platform.OS === "ios" ? 8 : 6,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    borderRadius: 8,
+    backgroundColor: "#fff",
+  },
+  sendButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: "#4F46E5",
+    minWidth: 72,
+    alignItems: "center",
+  },
+  sendButtonDisabled: {
+    backgroundColor: "#9CA3AF",
+  },
+  sendText: {
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/components/GameChat.tsx
+++ b/apps/mobile/components/GameChat.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+  type ListRenderItemInfo,
+} from "react-native";
+import type { ChatAck, ChatMessage } from "../lib/game-chat";
+import { MAX_MESSAGE_LENGTH } from "../lib/game-chat";
+import { gameChatStyles as styles } from "./GameChat.styles";
+
+export interface GameChatProps {
+  messages: ChatMessage[];
+  sendMessage: (text: string) => Promise<ChatAck>;
+  currentUserId?: string;
+}
+
+/**
+ * Collapsible in-game chat for mobile.
+ * Toggle button fixed bottom-left; panel opens in a modal with keyboard avoidance.
+ */
+export default function GameChat({
+  messages,
+  sendMessage,
+  currentUserId,
+}: GameChatProps) {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const listRef = useRef<FlatList<ChatMessage> | null>(null);
+  const prevCountRef = useRef(messages.length);
+
+  useEffect(() => {
+    if (!open && messages.length > prevCountRef.current) {
+      setUnreadCount((c) => c + (messages.length - prevCountRef.current));
+    }
+    prevCountRef.current = messages.length;
+  }, [messages.length, open]);
+
+  useEffect(() => {
+    if (open) {
+      setUnreadCount(0);
+      requestAnimationFrame(() => {
+        listRef.current?.scrollToEnd({ animated: true });
+      });
+    }
+  }, [open, messages.length]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || sending) return;
+
+    setSending(true);
+    setError(null);
+
+    const result = await sendMessage(trimmed);
+
+    setSending(false);
+    if (result.ok) {
+      setInput("");
+    } else {
+      setError(result.error ?? "Failed to send");
+    }
+  }, [input, sending, sendMessage]);
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ChatMessage>) => {
+      const isMe = Boolean(currentUserId) && item.userId === currentUserId;
+      return (
+        <View
+          style={[
+            styles.messageRow,
+            isMe ? styles.messageRowMe : styles.messageRowOther,
+          ]}
+          testID={`chat-message-${index}`}
+        >
+          <View
+            style={[styles.bubble, isMe ? styles.bubbleMe : styles.bubbleOther]}
+          >
+            <Text
+              style={[
+                styles.bubbleText,
+                isMe ? styles.bubbleTextMe : styles.bubbleTextOther,
+              ]}
+            >
+              {item.message}
+            </Text>
+          </View>
+          <Text style={styles.timestamp}>
+            {new Date(item.timestamp).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </Text>
+        </View>
+      );
+    },
+    [currentUserId],
+  );
+
+  const keyExtractor = useCallback(
+    (item: ChatMessage, index: number) => `${item.timestamp}-${index}`,
+    [],
+  );
+
+  const inputDisabled = sending || input.trim().length === 0;
+
+  return (
+    <>
+      <Pressable
+        testID="chat-toggle"
+        accessibilityLabel="Ouvrir le chat"
+        onPress={() => setOpen(true)}
+        style={styles.toggle}
+      >
+        <Text style={styles.toggleIcon}>💬</Text>
+        {unreadCount > 0 && (
+          <View style={styles.badge} testID="chat-unread-badge">
+            <Text style={styles.badgeText}>
+              {unreadCount > 9 ? "9+" : String(unreadCount)}
+            </Text>
+          </View>
+        )}
+      </Pressable>
+
+      <Modal
+        visible={open}
+        animationType="slide"
+        transparent
+        onRequestClose={() => setOpen(false)}
+      >
+        <View style={styles.backdrop}>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+            style={styles.panel}
+          >
+            <View style={styles.header}>
+              <Text style={styles.headerTitle}>Chat</Text>
+              <Pressable
+                testID="chat-close"
+                accessibilityLabel="Fermer le chat"
+                onPress={() => setOpen(false)}
+                style={styles.closeButton}
+              >
+                <Text style={styles.closeText}>Fermer</Text>
+              </Pressable>
+            </View>
+
+            {messages.length === 0 ? (
+              <View style={styles.emptyState}>
+                <Text style={styles.emptyText}>
+                  Aucun message. Dites bonjour !
+                </Text>
+              </View>
+            ) : (
+              <FlatList
+                ref={listRef}
+                data={messages}
+                keyExtractor={keyExtractor}
+                renderItem={renderItem}
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+                onContentSizeChange={() =>
+                  listRef.current?.scrollToEnd({ animated: false })
+                }
+                testID="chat-messages"
+              />
+            )}
+
+            {error && (
+              <View style={styles.errorBar}>
+                <Text style={styles.errorText}>{error}</Text>
+              </View>
+            )}
+
+            <View style={styles.inputRow}>
+              <TextInput
+                testID="chat-input"
+                value={input}
+                onChangeText={setInput}
+                placeholder="Message..."
+                placeholderTextColor="#9CA3AF"
+                maxLength={MAX_MESSAGE_LENGTH}
+                editable={!sending}
+                style={styles.input}
+                returnKeyType="send"
+                onSubmitEditing={handleSend}
+                blurOnSubmit={false}
+              />
+              <Pressable
+                testID="chat-send"
+                onPress={handleSend}
+                disabled={inputDisabled}
+                style={[
+                  styles.sendButton,
+                  inputDisabled && styles.sendButtonDisabled,
+                ]}
+              >
+                {sending ? (
+                  <ActivityIndicator size="small" color="#fff" />
+                ) : (
+                  <Text style={styles.sendText}>Envoyer</Text>
+                )}
+              </Pressable>
+            </View>
+          </KeyboardAvoidingView>
+        </View>
+      </Modal>
+    </>
+  );
+}

--- a/apps/mobile/lib/game-chat.test.ts
+++ b/apps/mobile/lib/game-chat.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- Mock socket ---
+const mockSocket = {
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+  connected: true,
+  id: "test-socket-id",
+};
+
+// Must import after mock setup
+import {
+  createGameChatHelpers,
+  MAX_CHAT_MESSAGES,
+  MAX_MESSAGE_LENGTH,
+  appendChatMessage,
+  type ChatMessage,
+} from "./game-chat";
+
+describe("game-chat — createGameChatHelpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket.on.mockReset();
+    mockSocket.off.mockReset();
+    mockSocket.emit.mockReset();
+  });
+
+  describe("sendMessage", () => {
+    it("emits game:chat-message with matchId and trimmed message", () => {
+      mockSocket.emit.mockImplementation(
+        (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+          ack({ ok: true });
+        },
+      );
+
+      const { sendMessage } = createGameChatHelpers(mockSocket as any);
+      sendMessage("match-1", "  Hello!  ");
+
+      expect(mockSocket.emit).toHaveBeenCalledWith(
+        "game:chat-message",
+        { matchId: "match-1", message: "Hello!" },
+        expect.any(Function),
+      );
+    });
+
+    it("resolves with ack payload on success", async () => {
+      mockSocket.emit.mockImplementation(
+        (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+          ack({ ok: true });
+        },
+      );
+
+      const { sendMessage } = createGameChatHelpers(mockSocket as any);
+      const result = await sendMessage("match-1", "Test");
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("resolves with error on server rejection", async () => {
+      mockSocket.emit.mockImplementation(
+        (_event: string, _payload: unknown, ack: (res: unknown) => void) => {
+          ack({ ok: false, error: "Rate limited" });
+        },
+      );
+
+      const { sendMessage } = createGameChatHelpers(mockSocket as any);
+      const result = await sendMessage("match-1", "Spam");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("Rate limited");
+    });
+
+    it("rejects empty/whitespace messages client-side without emitting", async () => {
+      const { sendMessage } = createGameChatHelpers(mockSocket as any);
+      const result = await sendMessage("match-1", "   ");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+
+    it("rejects messages exceeding MAX_MESSAGE_LENGTH", async () => {
+      const { sendMessage } = createGameChatHelpers(mockSocket as any);
+      const result = await sendMessage(
+        "match-1",
+        "x".repeat(MAX_MESSAGE_LENGTH + 1),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("event registration", () => {
+    it("onChatMessage registers listener for game:chat-message", () => {
+      const handler = vi.fn();
+      const { onChatMessage } = createGameChatHelpers(mockSocket as any);
+      onChatMessage(handler);
+
+      expect(mockSocket.on).toHaveBeenCalledWith("game:chat-message", handler);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes chat event listener on cleanup", () => {
+      const { cleanup } = createGameChatHelpers(mockSocket as any);
+      cleanup();
+
+      expect(mockSocket.off).toHaveBeenCalledWith("game:chat-message");
+    });
+  });
+
+  describe("constants", () => {
+    it("MAX_CHAT_MESSAGES is 100", () => {
+      expect(MAX_CHAT_MESSAGES).toBe(100);
+    });
+
+    it("MAX_MESSAGE_LENGTH is 500", () => {
+      expect(MAX_MESSAGE_LENGTH).toBe(500);
+    });
+  });
+});
+
+describe("game-chat — appendChatMessage (rolling buffer)", () => {
+  const baseMsg: ChatMessage = {
+    matchId: "match-1",
+    userId: "user-a",
+    message: "hi",
+    timestamp: "2026-04-22T10:00:00.000Z",
+  };
+
+  it("appends a message to an empty list", () => {
+    const next = appendChatMessage([], baseMsg);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toEqual(baseMsg);
+  });
+
+  it("appends messages preserving order", () => {
+    const a = { ...baseMsg, message: "a" };
+    const b = { ...baseMsg, message: "b" };
+    const next = appendChatMessage([a], b);
+    expect(next.map((m) => m.message)).toEqual(["a", "b"]);
+  });
+
+  it("returns a new array (immutable)", () => {
+    const prev: ChatMessage[] = [];
+    const next = appendChatMessage(prev, baseMsg);
+    expect(next).not.toBe(prev);
+  });
+
+  it("keeps only the last MAX_CHAT_MESSAGES when overflowing", () => {
+    const initial: ChatMessage[] = Array.from(
+      { length: MAX_CHAT_MESSAGES },
+      (_, i) => ({ ...baseMsg, message: `m${i}` }),
+    );
+    const newest = { ...baseMsg, message: "newest" };
+    const next = appendChatMessage(initial, newest);
+
+    expect(next).toHaveLength(MAX_CHAT_MESSAGES);
+    expect(next[next.length - 1]).toEqual(newest);
+    expect(next[0].message).toBe("m1");
+  });
+});

--- a/apps/mobile/lib/game-chat.ts
+++ b/apps/mobile/lib/game-chat.ts
@@ -1,0 +1,82 @@
+// Pure helpers around socket.io-client for the in-game chat channel.
+// Mirrors apps/web useGameChat helpers, but kept React-agnostic so
+// the logic can be unit-tested in Node without React Native.
+
+import type { Socket } from "socket.io-client";
+
+// --- Constants ---
+
+export const MAX_CHAT_MESSAGES = 100;
+export const MAX_MESSAGE_LENGTH = 500;
+
+// --- Types ---
+
+export interface ChatMessage {
+  matchId: string;
+  userId: string;
+  message: string;
+  timestamp: string;
+}
+
+export interface ChatAck {
+  ok: boolean;
+  error?: string;
+}
+
+// --- Helpers ---
+
+/**
+ * Typed helper functions for chat events on a raw socket.
+ * Callers keep hold of the returned object to send, subscribe and cleanup.
+ */
+export function createGameChatHelpers(socket: Socket) {
+  return {
+    sendMessage(matchId: string, message: string): Promise<ChatAck> {
+      const trimmed = message.trim();
+
+      if (!trimmed) {
+        return Promise.resolve({ ok: false, error: "Message cannot be empty" });
+      }
+      if (trimmed.length > MAX_MESSAGE_LENGTH) {
+        return Promise.resolve({
+          ok: false,
+          error: `Message too long (max ${MAX_MESSAGE_LENGTH} characters)`,
+        });
+      }
+
+      return new Promise((resolve) => {
+        socket.emit(
+          "game:chat-message",
+          { matchId, message: trimmed },
+          (response: ChatAck) => {
+            resolve(response);
+          },
+        );
+      });
+    },
+
+    onChatMessage(handler: (data: ChatMessage) => void): void {
+      socket.on("game:chat-message", handler);
+    },
+
+    cleanup(): void {
+      socket.off("game:chat-message");
+    },
+  };
+}
+
+export type GameChatHelpers = ReturnType<typeof createGameChatHelpers>;
+
+/**
+ * Immutable rolling-buffer append: returns a new array with the latest
+ * message at the end, capped to MAX_CHAT_MESSAGES.
+ */
+export function appendChatMessage(
+  prev: ReadonlyArray<ChatMessage>,
+  next: ChatMessage,
+): ChatMessage[] {
+  const appended = [...prev, next];
+  return appended.length > MAX_CHAT_MESSAGES
+    ? appended.slice(appended.length - MAX_CHAT_MESSAGES)
+    : appended;
+}

--- a/apps/mobile/lib/use-game-chat.ts
+++ b/apps/mobile/lib/use-game-chat.ts
@@ -1,0 +1,72 @@
+// React hook that manages the in-game chat channel on the /game namespace.
+// Mirrors apps/web useGameChat, reusing the mobile socket exposed by
+// useGameSocket.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import {
+  appendChatMessage,
+  createGameChatHelpers,
+  type ChatAck,
+  type ChatMessage,
+  type GameChatHelpers,
+} from "./game-chat";
+
+export interface UseGameChatOptions {
+  /** Socket instance from useGameSocket (or null if not connected). */
+  socket: Socket | null;
+  /** The match ID to scope chat messages. */
+  matchId: string;
+}
+
+export interface UseGameChatResult {
+  /** Chat messages received so far (most recent last). */
+  messages: ChatMessage[];
+  /** Send a chat message. Returns the ack payload. */
+  sendMessage: (text: string) => Promise<ChatAck>;
+}
+
+/**
+ * React hook for in-game chat within a match room.
+ *
+ * Listens for chat messages on the provided socket and exposes a
+ * `sendMessage` function. Keeps a rolling buffer of the last
+ * MAX_CHAT_MESSAGES messages.
+ */
+export function useGameChat({
+  socket,
+  matchId,
+}: UseGameChatOptions): UseGameChatResult {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const helpersRef = useRef<GameChatHelpers | null>(null);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const helpers = createGameChatHelpers(socket);
+    helpersRef.current = helpers;
+
+    helpers.onChatMessage((data) => {
+      if (data.matchId !== matchId) return;
+      setMessages((prev) => appendChatMessage(prev, data));
+    });
+
+    return () => {
+      helpers.cleanup();
+      helpersRef.current = null;
+    };
+  }, [socket, matchId]);
+
+  const sendMessage = useCallback(
+    async (text: string): Promise<ChatAck> => {
+      const helpers = helpersRef.current;
+      if (!helpers) {
+        return { ok: false, error: "Not connected" };
+      }
+      return helpers.sendMessage(matchId, text);
+    },
+    [matchId],
+  );
+
+  return { messages, sendMessage };
+}


### PR DESCRIPTION
## Resume

Ajout du chat in-game cote mobile (tache **M.5** du Sprint 18-19 — Parite mobile), aligne sur l'implementation web existante (`apps/web/app/components/GameChat.tsx`, `useGameChat`).

- **`apps/mobile/lib/game-chat.ts`** : helpers typed pour socket.io (`sendMessage`, `onChatMessage`, `cleanup`) + `appendChatMessage` (buffer immuable capped a 100 messages). Validation client (message vide / > 500 chars) avant emit.
- **`apps/mobile/lib/use-game-chat.ts`** : hook React qui s'abonne a `game:chat-message` sur le socket fourni par `useGameSocket`, filtre par `matchId`, expose `messages` et `sendMessage`.
- **`apps/mobile/components/GameChat.tsx`** : panneau collapsible — bouton flottant avec badge non-lus + `Modal` avec `FlatList` et `KeyboardAvoidingView`, bulles de conversation differenciees (me / adversaire), auto-scroll sur nouveaux messages.
- **`apps/mobile/components/GameChat.styles.ts`** : styles extraits pour garder le composant sous 300 lignes.
- **`apps/mobile/app/play/[id].tsx`** : expose `socket` depuis `useGameSocket`, branche `useGameChat` et monte `<GameChat>` a cote des `MatchPopups`.

Le serveur (`apps/server/src/game-chat.ts`) accepte deja l'evenement `game:chat-message` — aucun changement backend necessaire.

## Tache roadmap

Sprint 18-19 (Parite mobile), tache **M.5 — Chat in-game mobile** → `TODO.md` mis a jour.

## Plan de test

- [x] 13 nouveaux tests unitaires (`apps/mobile/lib/game-chat.test.ts`) : emission `game:chat-message`, validation empty/overflow, ack success/error, enregistrement et cleanup des listeners, rolling buffer (immutable, 100 messages max).
- [x] `pnpm --filter @bb/mobile test` → **98 tests OK** (65 existants + 13 nouveaux).
- [x] Typecheck mobile : **zero nouvelle erreur** (baseline 18 erreurs pre-existantes non liees — `@bb/game-engine` resolution workspace).
- [x] `pnpm lint` (turbo) : 0 erreur.
- [x] Tailles : `GameChat.tsx` 219 lignes, `GameChat.styles.ts` 178, `game-chat.ts` 82, `use-game-chat.ts` 72 — tous sous le seuil de 300.
- [ ] QA manuelle : ouvrir un match mobile, envoyer/recevoir des messages, verifier badge non-lus quand panneau ferme, verifier auto-scroll.
