### PR TITLE
feat(mobile): M.6 ecran leaderboard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -314,7 +314,7 @@
 | M.3 | Integration WebSocket complete | Mobile | [x] |
 | M.4 | Popups block/push/followup/reroll natifs | Mobile | [x] |
 | M.5 | Chat in-game mobile | Mobile | [x] |
-| M.6 | Ecran leaderboard | Mobile | [ ] |
+| M.6 | Ecran leaderboard | Mobile | [x] |
 | M.7 | Ecran replay de match | Mobile | [ ] |
 | M.8 | Ecrans cups/ligues | Mobile | [ ] |
 | M.9 | Push notifications natives (Expo Notifications) | Mobile | [ ] |

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ export default function Layout() {
           <Stack.Screen name="index" options={{ title: "Nuffle Arena" }} />
           <Stack.Screen name="lobby" options={{ title: "Mes matchs" }} />
           <Stack.Screen name="matchmaking" options={{ title: "Chercher un match" }} />
+          <Stack.Screen name="leaderboard" options={{ title: "Classement" }} />
           <Stack.Screen name="login" options={{ title: "Connexion" }} />
           <Stack.Screen name="register" options={{ title: "Inscription" }} />
           <Stack.Screen name="match/[id]" options={{ title: "Historique du match", headerShown: false }} />

--- a/apps/mobile/app/leaderboard.tsx
+++ b/apps/mobile/app/leaderboard.tsx
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../lib/api";
+import { useAuth } from "../lib/auth-context";
+import {
+  LEADERBOARD_PAGE_SIZE,
+  computeLeaderboardStats,
+  formatEloRating,
+  getCurrentPage,
+  getTotalPages,
+  isFirstPage,
+  isLastPage,
+  parseLeaderboardResponse,
+  type LeaderboardEntry,
+  type LeaderboardMeta,
+} from "../lib/leaderboard";
+
+const EMPTY_META: LeaderboardMeta = {
+  total: 0,
+  limit: LEADERBOARD_PAGE_SIZE,
+  offset: 0,
+};
+
+export default function LeaderboardScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [meta, setMeta] = useState<LeaderboardMeta>(EMPTY_META);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLeaderboard = useCallback(
+    async (nextOffset: number) => {
+      try {
+        const response = await apiGet(
+          `/leaderboard?limit=${LEADERBOARD_PAGE_SIZE}&offset=${nextOffset}`,
+        );
+        const parsed = parseLeaderboardResponse(response);
+        setEntries(parsed.entries);
+        setMeta(parsed.meta);
+        setError(null);
+      } catch (err: unknown) {
+        if (
+          err instanceof ApiError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          await logout();
+          router.replace("/login");
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Erreur de chargement");
+      }
+    },
+    [logout, router],
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    fetchLeaderboard(offset).finally(() => setLoading(false));
+  }, [fetchLeaderboard, offset]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchLeaderboard(offset);
+    setRefreshing(false);
+  }, [fetchLeaderboard, offset]);
+
+  const stats = computeLeaderboardStats(entries);
+  const firstPage = isFirstPage(offset);
+  const lastPage = isLastPage(offset, LEADERBOARD_PAGE_SIZE, meta.total);
+  const currentPage = getCurrentPage(offset, LEADERBOARD_PAGE_SIZE);
+  const totalPages = getTotalPages(meta.total, LEADERBOARD_PAGE_SIZE);
+
+  function goPrev() {
+    if (firstPage) return;
+    setOffset(Math.max(0, offset - LEADERBOARD_PAGE_SIZE));
+  }
+
+  function goNext() {
+    if (lastPage) return;
+    setOffset(offset + LEADERBOARD_PAGE_SIZE);
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Classement ELO</Text>
+      </View>
+
+      <View style={styles.statsRow}>
+        <StatCard label="Joueurs" value={String(meta.total)} testID="stats-total" />
+        <StatCard
+          label="Meilleur"
+          value={formatEloRating(stats.top)}
+          testID="stats-top"
+        />
+        <StatCard
+          label="Moyen"
+          value={formatEloRating(stats.average)}
+          testID="stats-average"
+        />
+      </View>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={entries}
+          keyExtractor={(item) => item.userId}
+          renderItem={({ item }) => <EntryRow entry={item} />}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText}>
+                Aucun coach classe pour l'instant.
+              </Text>
+            </View>
+          }
+          ListFooterComponent={
+            meta.total > LEADERBOARD_PAGE_SIZE ? (
+              <View style={styles.pagination}>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={goPrev}
+                  disabled={firstPage}
+                  style={[
+                    styles.pageButton,
+                    firstPage && styles.pageButtonDisabled,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.pageButtonText,
+                      firstPage && styles.pageButtonTextDisabled,
+                    ]}
+                  >
+                    Precedent
+                  </Text>
+                </Pressable>
+                <Text style={styles.pageIndicator}>
+                  Page {currentPage} / {totalPages}
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={goNext}
+                  disabled={lastPage}
+                  style={[
+                    styles.pageButton,
+                    lastPage && styles.pageButtonDisabled,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.pageButtonText,
+                      lastPage && styles.pageButtonTextDisabled,
+                    ]}
+                  >
+                    Suivant
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  testID,
+}: {
+  label: string;
+  value: string;
+  testID?: string;
+}) {
+  return (
+    <View style={styles.statCard} testID={testID}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function EntryRow({ entry }: { entry: LeaderboardEntry }) {
+  const podium = entry.rank <= 3;
+  return (
+    <View style={[styles.row, podium && styles.rowPodium]}>
+      <View style={[styles.rankBadge, podium && styles.rankBadgePodium]}>
+        <Text
+          style={[styles.rankText, podium && styles.rankTextPodium]}
+          numberOfLines={1}
+        >
+          {entry.rank}
+        </Text>
+      </View>
+      <Text style={styles.coachName} numberOfLines={1}>
+        {entry.coachName}
+      </Text>
+      <Text style={styles.eloText}>{formatEloRating(entry.eloRating)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F9FAFB",
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  statsRow: {
+    flexDirection: "row",
+    paddingHorizontal: 16,
+    gap: 8,
+    marginBottom: 8,
+  },
+  statCard: {
+    flex: 1,
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  statLabel: {
+    fontSize: 12,
+    color: "#6B7280",
+    marginBottom: 4,
+  },
+  statValue: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  listContent: {
+    padding: 16,
+    flexGrow: 1,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  rowPodium: {
+    backgroundColor: "#FEF9C3",
+    borderColor: "#FACC15",
+  },
+  rankBadge: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "#F3F4F6",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 12,
+  },
+  rankBadgePodium: {
+    backgroundColor: "#EAB308",
+  },
+  rankText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  rankTextPodium: {
+    color: "#fff",
+  },
+  coachName: {
+    flex: 1,
+    fontSize: 15,
+    color: "#111827",
+    fontWeight: "500",
+  },
+  eloText: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#111827",
+    fontVariant: ["tabular-nums"],
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#6B7280",
+    fontSize: 15,
+    textAlign: "center",
+  },
+  pagination: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingTop: 4,
+    paddingBottom: 16,
+  },
+  pageButton: {
+    backgroundColor: "#111827",
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+  },
+  pageButtonDisabled: {
+    backgroundColor: "#E5E7EB",
+  },
+  pageButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  pageButtonTextDisabled: {
+    color: "#9CA3AF",
+  },
+  pageIndicator: {
+    fontSize: 13,
+    color: "#4B5563",
+  },
+});

--- a/apps/mobile/app/lobby.tsx
+++ b/apps/mobile/app/lobby.tsx
@@ -274,6 +274,12 @@ export default function LobbyScreen() {
           >
             <Text style={styles.teamsButtonText}>Mes equipes</Text>
           </Pressable>
+          <Pressable
+            onPress={() => router.push("/leaderboard")}
+            style={styles.leaderboardButton}
+          >
+            <Text style={styles.leaderboardButtonText}>Classement</Text>
+          </Pressable>
           <Pressable onPress={handleLogout} style={styles.logoutButton}>
             <Text style={styles.logoutText}>Deconnexion</Text>
           </Pressable>
@@ -456,6 +462,17 @@ const styles = StyleSheet.create({
   },
   teamsButtonText: {
     color: "#1D4ED8",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  leaderboardButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    backgroundColor: "#FEF3C7",
+    borderRadius: 6,
+  },
+  leaderboardButtonText: {
+    color: "#92400E",
     fontSize: 13,
     fontWeight: "600",
   },

--- a/apps/mobile/lib/leaderboard.test.ts
+++ b/apps/mobile/lib/leaderboard.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  LEADERBOARD_PAGE_SIZE,
+  computeLeaderboardStats,
+  formatEloRating,
+  getCurrentPage,
+  getTotalPages,
+  isFirstPage,
+  isLastPage,
+  parseLeaderboardResponse,
+  type LeaderboardEntry,
+} from "./leaderboard";
+
+function makeEntry(
+  overrides: Partial<LeaderboardEntry> = {},
+): LeaderboardEntry {
+  return {
+    rank: 1,
+    userId: "u1",
+    coachName: "Coach",
+    eloRating: 1500,
+    ...overrides,
+  };
+}
+
+describe("computeLeaderboardStats", () => {
+  it("returns zeros for an empty list", () => {
+    expect(computeLeaderboardStats([])).toEqual({ top: 0, average: 0 });
+  });
+
+  it("returns the top rating as the max of entries", () => {
+    const entries = [
+      makeEntry({ eloRating: 1500 }),
+      makeEntry({ eloRating: 1700 }),
+      makeEntry({ eloRating: 1600 }),
+    ];
+    expect(computeLeaderboardStats(entries).top).toBe(1700);
+  });
+
+  it("returns the rounded average rating", () => {
+    const entries = [
+      makeEntry({ eloRating: 1500 }),
+      makeEntry({ eloRating: 1700 }),
+      makeEntry({ eloRating: 1601 }),
+    ];
+    // (1500 + 1700 + 1601) / 3 = 1600.333... → 1600
+    expect(computeLeaderboardStats(entries).average).toBe(1600);
+  });
+
+  it("handles a single entry", () => {
+    const entries = [makeEntry({ eloRating: 1234 })];
+    expect(computeLeaderboardStats(entries)).toEqual({
+      top: 1234,
+      average: 1234,
+    });
+  });
+});
+
+describe("pagination helpers", () => {
+  it("getCurrentPage is 1-indexed from offset 0", () => {
+    expect(getCurrentPage(0, 20)).toBe(1);
+    expect(getCurrentPage(20, 20)).toBe(2);
+    expect(getCurrentPage(40, 20)).toBe(3);
+  });
+
+  it("getCurrentPage rounds down for partial offsets", () => {
+    expect(getCurrentPage(15, 20)).toBe(1);
+    expect(getCurrentPage(25, 20)).toBe(2);
+  });
+
+  it("getTotalPages returns at least 1", () => {
+    expect(getTotalPages(0, 20)).toBe(1);
+    expect(getTotalPages(5, 20)).toBe(1);
+  });
+
+  it("getTotalPages rounds up for partial results", () => {
+    expect(getTotalPages(21, 20)).toBe(2);
+    expect(getTotalPages(40, 20)).toBe(2);
+    expect(getTotalPages(41, 20)).toBe(3);
+  });
+
+  it("isFirstPage is true only when offset is 0", () => {
+    expect(isFirstPage(0)).toBe(true);
+    expect(isFirstPage(1)).toBe(false);
+    expect(isFirstPage(20)).toBe(false);
+  });
+
+  it("isLastPage true when offset + pageSize >= total", () => {
+    expect(isLastPage(0, 20, 10)).toBe(true);
+    expect(isLastPage(0, 20, 20)).toBe(true);
+    expect(isLastPage(0, 20, 21)).toBe(false);
+    expect(isLastPage(20, 20, 40)).toBe(true);
+    expect(isLastPage(20, 20, 41)).toBe(false);
+  });
+});
+
+describe("formatEloRating", () => {
+  it("formats an integer rating as a string", () => {
+    expect(formatEloRating(1500)).toBe("1500");
+  });
+
+  it("floors non-integer ratings", () => {
+    expect(formatEloRating(1500.8)).toBe("1500");
+  });
+});
+
+describe("parseLeaderboardResponse", () => {
+  it("extracts data and meta from a well-formed response", () => {
+    const response = {
+      success: true,
+      data: [
+        { rank: 1, userId: "u1", coachName: "A", eloRating: 1700 },
+        { rank: 2, userId: "u2", coachName: "B", eloRating: 1600 },
+      ],
+      meta: { total: 2, limit: 20, offset: 0 },
+    };
+    const parsed = parseLeaderboardResponse(response);
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries[0].coachName).toBe("A");
+    expect(parsed.meta).toEqual({ total: 2, limit: 20, offset: 0 });
+  });
+
+  it("returns empty entries when data is missing", () => {
+    const response = {
+      success: true,
+      meta: { total: 0, limit: 20, offset: 0 },
+    };
+    const parsed = parseLeaderboardResponse(response);
+    expect(parsed.entries).toEqual([]);
+    expect(parsed.meta.total).toBe(0);
+  });
+
+  it("fills missing meta with safe defaults", () => {
+    const parsed = parseLeaderboardResponse({ data: [] });
+    expect(parsed.meta).toEqual({
+      total: 0,
+      limit: LEADERBOARD_PAGE_SIZE,
+      offset: 0,
+    });
+  });
+
+  it("filters out entries with invalid shape", () => {
+    const response = {
+      data: [
+        { rank: 1, userId: "u1", coachName: "A", eloRating: 1700 },
+        null,
+        { rank: "bad" },
+        { rank: 2, userId: "u2", coachName: "B", eloRating: 1600 },
+      ],
+      meta: { total: 4, limit: 20, offset: 0 },
+    };
+    const parsed = parseLeaderboardResponse(response);
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries.map((e) => e.userId)).toEqual(["u1", "u2"]);
+  });
+});
+
+describe("LEADERBOARD_PAGE_SIZE", () => {
+  it("is a positive integer", () => {
+    expect(Number.isInteger(LEADERBOARD_PAGE_SIZE)).toBe(true);
+    expect(LEADERBOARD_PAGE_SIZE).toBeGreaterThan(0);
+  });
+});

--- a/apps/mobile/lib/leaderboard.ts
+++ b/apps/mobile/lib/leaderboard.ts
@@ -1,0 +1,94 @@
+// Pure helpers for the leaderboard screen.
+// Network-free so they can be unit-tested in node.
+
+export const LEADERBOARD_PAGE_SIZE = 20;
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  coachName: string;
+  eloRating: number;
+}
+
+export interface LeaderboardMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface LeaderboardStats {
+  top: number;
+  average: number;
+}
+
+export function computeLeaderboardStats(
+  entries: ReadonlyArray<LeaderboardEntry>,
+): LeaderboardStats {
+  if (entries.length === 0) {
+    return { top: 0, average: 0 };
+  }
+  const ratings = entries.map((e) => e.eloRating);
+  const top = Math.max(...ratings);
+  const average = Math.round(
+    ratings.reduce((sum, r) => sum + r, 0) / entries.length,
+  );
+  return { top, average };
+}
+
+export function getCurrentPage(offset: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  return Math.floor(offset / pageSize) + 1;
+}
+
+export function getTotalPages(total: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+export function isFirstPage(offset: number): boolean {
+  return offset <= 0;
+}
+
+export function isLastPage(
+  offset: number,
+  pageSize: number,
+  total: number,
+): boolean {
+  return offset + pageSize >= total;
+}
+
+export function formatEloRating(rating: number): string {
+  return String(Math.floor(rating));
+}
+
+function isValidEntry(value: unknown): value is LeaderboardEntry {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.rank === "number" &&
+    typeof v.userId === "string" &&
+    typeof v.coachName === "string" &&
+    typeof v.eloRating === "number"
+  );
+}
+
+export interface ParsedLeaderboard {
+  entries: LeaderboardEntry[];
+  meta: LeaderboardMeta;
+}
+
+export function parseLeaderboardResponse(response: unknown): ParsedLeaderboard {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const rawEntries = Array.isArray(raw.data) ? raw.data : [];
+  const entries = rawEntries.filter(isValidEntry);
+
+  const rawMeta = (raw.meta ?? {}) as Record<string, unknown>;
+  const meta: LeaderboardMeta = {
+    total: typeof rawMeta.total === "number" ? rawMeta.total : 0,
+    limit:
+      typeof rawMeta.limit === "number" ? rawMeta.limit : LEADERBOARD_PAGE_SIZE,
+    offset: typeof rawMeta.offset === "number" ? rawMeta.offset : 0,
+  };
+
+  return { entries, meta };
+}


### PR DESCRIPTION
## Resume

- Nouvel ecran mobile `/leaderboard` (classement ELO) aligne sur l'experience web : cartes de stats (total / meilleur / moyen), podium top 3, pagination `limit/offset` via `GET /leaderboard`.
- Helpers purs testables (`lib/leaderboard.ts`) : stats, pagination, parsing tolerant de la reponse serveur.
- Lien d'acces depuis le header du lobby ("Classement") + `Stack.Screen` dans `_layout.tsx`.

## Tache roadmap

Sprint 18-19 (parite mobile), ligne M.6 — `Ecran leaderboard`. TODO.md mis a jour.

## Plan de test

- [x] Tests unitaires helpers (`apps/mobile/lib/leaderboard.test.ts`) : 17 tests (stats, pagination, parsing)
- [x] `pnpm -F @bb/mobile test` : 115/115 tests verts
- [x] `pnpm -F @bb/server test` : 562/562 tests verts (aucune regression)
- [x] `pnpm -F @bb/game-engine test` : 4050/4050 tests verts
- [x] `pnpm -F @bb/ui test` : 288/288 tests verts
- [x] `pnpm typecheck` : 4 packages verts
- [x] `pnpm lint` : 0 erreur
- [ ] Test visuel sur device/simulateur Expo (a faire par le reviewer)
- [ ] Test avec serveur dev en local : pull-to-refresh + pagination "Suivant/Precedent"
- [ ] Test navigation depuis le lobby via le bouton "Classement"

> Les echecs Playwright `@bb/tests-e2e-ui` et `@bb/web:build` observes en local sont pre-existants et dus a l'environnement (pas d'acces reseau aux Google Fonts, pas de serveur live), non lies a ce PR.
