### PR TITLE
Add safeServerJson wrapper for resilient server-side API calls

### DIFF
--- a/apps/web/app/lib/serverApi.test.ts
+++ b/apps/web/app/lib/serverApi.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { safeServerJson } from "./serverApi";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("safeServerJson", () => {
+  it("returns parsed JSON when the response is OK", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ skills: [{ id: "a" }] }),
+    } as unknown as Response);
+
+    const result = await safeServerJson<{ skills: { id: string }[] }>(
+      "http://server/api/skills",
+    );
+
+    expect(result).toEqual({ skills: [{ id: "a" }] });
+  });
+
+  it("returns null when the response is not OK", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as unknown as Response);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await safeServerJson("http://server/api/skills");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await safeServerJson("http://server/api/skills");
+
+    expect(result).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("returns null when JSON parsing throws", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    } as unknown as Response);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await safeServerJson("http://server/api/skills");
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/app/lib/serverApi.ts
+++ b/apps/web/app/lib/serverApi.ts
@@ -11,3 +11,32 @@ export function getServerApiBase(): string {
     "http://localhost:8201"
   );
 }
+
+/**
+ * SSR/ISR-safe wrapper around `fetch` that returns `null` on any failure
+ * (network error, non-OK status, or JSON parse error) instead of throwing.
+ *
+ * The raw `fetch` call throws `TypeError: fetch failed` when the backend is
+ * unreachable (container not yet listening, DNS hiccup, etc.). Without this
+ * guard the exception propagates out of the Server Component and crashes
+ * page rendering with an "Unhandled Runtime Error" overlay.
+ */
+export async function safeServerJson<T>(
+  url: string,
+  init?: RequestInit,
+): Promise<T | null> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      console.error(
+        `[serverApi] ${url} responded with status ${res.status}`,
+      );
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[serverApi] fetch failed for ${url}: ${message}`);
+    return null;
+  }
+}

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -1,4 +1,4 @@
-import { getServerApiBase } from "../lib/serverApi";
+import { getServerApiBase, safeServerJson } from "../lib/serverApi";
 import SkillsClient, { type Skill } from "./SkillsClient";
 
 // ISR — skill definitions change only with rules edition updates.
@@ -6,13 +6,11 @@ export const revalidate = 3600;
 
 async function fetchSkills(ruleset: string): Promise<Skill[]> {
   const base = getServerApiBase();
-  const res = await fetch(
+  const data = await safeServerJson<{ skills?: Skill[] }>(
     `${base}/api/skills?ruleset=${encodeURIComponent(ruleset)}`,
     { next: { revalidate: 3600 } },
   );
-  if (!res.ok) return [];
-  const data = await res.json();
-  return data.skills || [];
+  return data?.skills || [];
 }
 
 interface SkillsPageProps {

--- a/apps/web/app/teams/[slug]/layout.tsx
+++ b/apps/web/app/teams/[slug]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getServerApiBase } from '../../lib/serverApi';
+import { getServerApiBase, safeServerJson } from '../../lib/serverApi';
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://nufflearena.fr';
 
@@ -7,20 +7,13 @@ export async function generateMetadata({ params }: { params: { slug: string } })
   const { slug } = params;
 
   try {
-    const response = await fetch(`${getServerApiBase()}/api/rosters/${slug}?lang=fr`, {
-      next: { revalidate: 3600 }, // Cache pendant 1 heure
-    });
-    
-    if (!response.ok) {
-      return {
-        title: 'Équipe introuvable',
-        description: 'L\'équipe demandée n\'a pas été trouvée.',
-      };
-    }
-    
-    const data = await response.json();
-    const team = data.roster;
-    
+    const data = await safeServerJson<{ roster?: any }>(
+      `${getServerApiBase()}/api/rosters/${slug}?lang=fr`,
+      { next: { revalidate: 3600 } },
+    );
+
+    const team = data?.roster;
+
     if (!team) {
       return {
         title: 'Équipe introuvable',

--- a/apps/web/app/teams/[slug]/page.tsx
+++ b/apps/web/app/teams/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { DEFAULT_RULESET, type Ruleset } from "@bb/game-engine";
-import { getServerApiBase } from "../../lib/serverApi";
+import { getServerApiBase, safeServerJson } from "../../lib/serverApi";
 import TeamDetailClient from "./TeamDetailClient";
 
 // ISR — roster definitions are reference data that rarely changes.
@@ -16,12 +16,10 @@ async function fetchRoster(
   ruleset: Ruleset,
 ): Promise<{ roster: any; ruleset: Ruleset } | null> {
   const base = getServerApiBase();
-  const res = await fetch(
+  const data = await safeServerJson<{ roster?: any; ruleset?: Ruleset }>(
     `${base}/api/rosters/${encodeURIComponent(slug)}?lang=fr&ruleset=${ruleset}`,
     { next: { revalidate: 3600 } },
   );
-  if (!res.ok) return null;
-  const data = await res.json();
   if (!data?.roster) return null;
   return { roster: data.roster, ruleset: (data.ruleset as Ruleset) || ruleset };
 }

--- a/apps/web/app/teams/page.tsx
+++ b/apps/web/app/teams/page.tsx
@@ -1,4 +1,4 @@
-import { getServerApiBase } from "../lib/serverApi";
+import { getServerApiBase, safeServerJson } from "../lib/serverApi";
 import TeamsListClient, {
   type RosterSummary,
   type Season,
@@ -10,15 +10,11 @@ export const revalidate = 3600;
 
 async function fetchRosters(season: Season): Promise<RosterSummary[]> {
   const base = getServerApiBase();
-  const res = await fetch(
+  const data = await safeServerJson<{ rosters?: any[] }>(
     `${base}/api/rosters?lang=fr&ruleset=${season}`,
     { next: { revalidate: 3600 } },
   );
-  if (!res.ok) {
-    return [];
-  }
-  const data = await res.json();
-  return (data.rosters ?? []).map((roster: any) => ({
+  return (data?.rosters ?? []).map((roster: any) => ({
     slug: roster.slug,
     name: roster.name,
     budget: roster.budget,


### PR DESCRIPTION
## Résumé

- [x] Introduce `safeServerJson` utility function to safely handle server-side API calls in SSR/ISR contexts
- [x] Refactor existing API calls across multiple pages to use the new wrapper
- [x] Add comprehensive unit tests for error handling scenarios

## Description

This PR adds a new `safeServerJson` utility function that wraps `fetch` calls with error handling to prevent Server Component crashes when the backend is unreachable or returns invalid responses.

### Problem
Raw `fetch` calls in Server Components throw `TypeError: fetch failed` when the backend is unavailable (container not yet listening, DNS issues, etc.), causing page rendering to crash with an "Unhandled Runtime Error" overlay. This is particularly problematic in SSR/ISR scenarios.

### Solution
The `safeServerJson` function:
- Returns `null` on any failure (network error, non-OK status, JSON parse error) instead of throwing
- Logs errors to console for debugging
- Provides type-safe generic support for response data
- Supports optional `RequestInit` parameters (e.g., cache revalidation)

### Changes
1. **New utility**: `safeServerJson<T>()` in `apps/web/app/lib/serverApi.ts`
2. **Refactored pages** to use the new wrapper:
   - `apps/web/app/skills/page.tsx`
   - `apps/web/app/teams/page.tsx`
   - `apps/web/app/teams/[slug]/page.tsx`
   - `apps/web/app/teams/[slug]/layout.tsx`
3. **Test coverage**: Added 4 unit tests covering success, HTTP errors, network errors, and JSON parse errors

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (4 new tests in `serverApi.test.ts`)
- [x] Changeset ajouté (if applicable)

https://claude.ai/code/session_01WsFX7vLr4cfAgb6WCXZEwc