### PR TITLE
feat(mobile): M.7 ecran replay de match

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -315,7 +315,7 @@
 | M.4 | Popups block/push/followup/reroll natifs | Mobile | [x] |
 | M.5 | Chat in-game mobile | Mobile | [x] |
 | M.6 | Ecran leaderboard | Mobile | [x] |
-| M.7 | Ecran replay de match | Mobile | [ ] |
+| M.7 | Ecran replay de match | Mobile | [x] |
 | M.8 | Ecrans cups/ligues | Mobile | [ ] |
 | M.9 | Push notifications natives (Expo Notifications) | Mobile | [ ] |
 | M.10 | Details joueur et progression | Mobile | [ ] |

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -9,14 +9,30 @@ export default function Layout() {
         <Stack>
           <Stack.Screen name="index" options={{ title: "Nuffle Arena" }} />
           <Stack.Screen name="lobby" options={{ title: "Mes matchs" }} />
-          <Stack.Screen name="matchmaking" options={{ title: "Chercher un match" }} />
+          <Stack.Screen
+            name="matchmaking"
+            options={{ title: "Chercher un match" }}
+          />
           <Stack.Screen name="leaderboard" options={{ title: "Classement" }} />
           <Stack.Screen name="login" options={{ title: "Connexion" }} />
           <Stack.Screen name="register" options={{ title: "Inscription" }} />
-          <Stack.Screen name="match/[id]" options={{ title: "Historique du match", headerShown: false }} />
+          <Stack.Screen
+            name="match/[id]"
+            options={{ title: "Historique du match", headerShown: false }}
+          />
+          <Stack.Screen
+            name="replay/[id]"
+            options={{ title: "Replay", headerShown: false }}
+          />
           <Stack.Screen name="teams/index" options={{ title: "Mes equipes" }} />
-          <Stack.Screen name="teams/new" options={{ title: "Nouvelle equipe" }} />
-          <Stack.Screen name="teams/[id]" options={{ title: "Detail equipe" }} />
+          <Stack.Screen
+            name="teams/new"
+            options={{ title: "Nouvelle equipe" }}
+          />
+          <Stack.Screen
+            name="teams/[id]"
+            options={{ title: "Detail equipe" }}
+          />
         </Stack>
       </AuthProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/app/lobby.tsx
+++ b/apps/mobile/app/lobby.tsx
@@ -84,11 +84,14 @@ function formatDate(dateStr: string): string {
 function MatchCard({
   match,
   onPress,
+  onReplay,
 }: {
   match: MatchSummary;
   onPress: () => void;
+  onReplay?: () => void;
 }) {
   const isMyTurn = match.isMyTurn && match.status === "active";
+  const isEnded = match.status === "ended";
 
   return (
     <Pressable
@@ -103,9 +106,7 @@ function MatchCard({
               { backgroundColor: getStatusColor(match.status) },
             ]}
           />
-          <Text style={styles.statusText}>
-            {getStatusLabel(match.status)}
-          </Text>
+          <Text style={styles.statusText}>{getStatusLabel(match.status)}</Text>
           {isMyTurn && (
             <View style={styles.myTurnBadge}>
               <Text style={styles.myTurnText}>Votre tour</Text>
@@ -143,6 +144,19 @@ function MatchCard({
           </Text>
         )}
       </View>
+
+      {isEnded && onReplay && (
+        <Pressable
+          onPress={(e) => {
+            e.stopPropagation();
+            onReplay();
+          }}
+          style={styles.replayButton}
+          accessibilityLabel="Voir le replay"
+        >
+          <Text style={styles.replayButtonText}>▶ Voir le replay</Text>
+        </Pressable>
+      )}
     </Pressable>
   );
 }
@@ -166,14 +180,15 @@ export default function LobbyScreen() {
       setMatches(data.matches || []);
       setError(null);
     } catch (err: unknown) {
-      if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
         await logout();
         router.replace("/login");
         return;
       }
-      setError(
-        err instanceof Error ? err.message : "Erreur de chargement",
-      );
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
     }
   }, [router, logout]);
 
@@ -261,6 +276,10 @@ export default function LobbyScreen() {
     }
   }
 
+  function navigateToReplay(match: MatchSummary) {
+    router.push(`/replay/${match.id}`);
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -289,8 +308,8 @@ export default function LobbyScreen() {
       {myTurnCount > 0 && (
         <View style={styles.turnBanner}>
           <Text style={styles.turnBannerText}>
-            {myTurnCount} match{myTurnCount > 1 ? "s" : ""} en attente de
-            votre tour
+            {myTurnCount} match{myTurnCount > 1 ? "s" : ""} en attente de votre
+            tour
           </Text>
         </View>
       )}
@@ -365,7 +384,11 @@ export default function LobbyScreen() {
           data={filtered}
           keyExtractor={(item) => item.id}
           renderItem={({ item }) => (
-            <MatchCard match={item} onPress={() => navigateToMatch(item)} />
+            <MatchCard
+              match={item}
+              onPress={() => navigateToMatch(item)}
+              onReplay={() => navigateToReplay(item)}
+            />
           )}
           contentContainerStyle={styles.listContent}
           refreshControl={
@@ -633,6 +656,19 @@ const styles = StyleSheet.create({
   footerText: {
     fontSize: 11,
     color: "#9CA3AF",
+  },
+  replayButton: {
+    marginTop: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: "#0F172A",
+    borderRadius: 6,
+    alignItems: "center",
+  },
+  replayButtonText: {
+    color: "#93C5FD",
+    fontSize: 13,
+    fontWeight: "600",
   },
   center: {
     flex: 1,

--- a/apps/mobile/app/replay/[id].tsx
+++ b/apps/mobile/app/replay/[id].tsx
@@ -1,0 +1,531 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import {
+  buildReplayFrames,
+  type GameState,
+  type ReplayFrame,
+} from "@bb/game-engine";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  REPLAY_DEFAULT_SPEED_MS,
+  REPLAY_SPEED_OPTIONS,
+  clampFrameIndex,
+  formatMatchDate,
+  formatTeamsTitle,
+  getMoveLabel,
+  nextFrameIndex,
+  parseReplayResponse,
+  prevFrameIndex,
+  type ReplayResponse,
+} from "../../lib/replay";
+import PixiBoardNative from "../../../../packages/ui/src/board/PixiBoard.native";
+
+function normalizeState(state: GameState): GameState {
+  const anyState = state as unknown as Record<string, unknown>;
+  if (!anyState.playerActions) anyState.playerActions = {};
+  if (!anyState.teamBlitzCount) anyState.teamBlitzCount = {};
+  if (!anyState.teamFoulCount) anyState.teamFoulCount = {};
+  if (!anyState.matchStats) anyState.matchStats = {};
+  if (typeof anyState.width !== "number") anyState.width = 26;
+  if (typeof anyState.height !== "number") anyState.height = 15;
+  return state;
+}
+
+export default function ReplayScreen() {
+  const { id: matchId } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  const [replay, setReplay] = useState<ReplayResponse | null>(null);
+  const [frames, setFrames] = useState<ReplayFrame[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState(REPLAY_DEFAULT_SPEED_MS);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const framesRef = useRef<ReplayFrame[]>([]);
+  framesRef.current = frames;
+
+  useEffect(() => {
+    if (!matchId) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const raw = await apiGet(`/match/${matchId}/replay`);
+        if (cancelled) return;
+        const parsed = parseReplayResponse(raw);
+        const built = buildReplayFrames(parsed.turns).map((f) => ({
+          ...f,
+          gameState: normalizeState(f.gameState),
+        }));
+        setReplay(parsed);
+        setFrames(built);
+        setCurrentIndex(0);
+        setError(null);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        if (
+          err instanceof ApiError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          await logout();
+          router.replace("/login");
+          return;
+        }
+        setError(
+          err instanceof Error ? err.message : "Erreur de chargement du replay",
+        );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [matchId, router, logout]);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      setCurrentIndex((prev) => {
+        const len = framesRef.current.length;
+        const next = prev + 1;
+        if (next >= len) {
+          setIsPlaying(false);
+          return prev;
+        }
+        return next;
+      });
+    }, speed);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [isPlaying, speed]);
+
+  const handlePlay = useCallback(() => {
+    if (frames.length === 0) return;
+    if (currentIndex >= frames.length - 1) {
+      setCurrentIndex(0);
+    }
+    setIsPlaying(true);
+  }, [frames.length, currentIndex]);
+
+  const handlePause = useCallback(() => setIsPlaying(false), []);
+
+  const handleStepForward = useCallback(() => {
+    setCurrentIndex((prev) => nextFrameIndex(prev, framesRef.current.length));
+  }, []);
+
+  const handleStepBackward = useCallback(() => {
+    setCurrentIndex((prev) => prevFrameIndex(prev));
+  }, []);
+
+  const handleGoToStart = useCallback(() => setCurrentIndex(0), []);
+
+  const handleGoToEnd = useCallback(() => {
+    setCurrentIndex(
+      (prev) =>
+        clampFrameIndex(
+          framesRef.current.length - 1,
+          framesRef.current.length,
+        ) || prev,
+    );
+  }, []);
+
+  const currentFrame = frames[currentIndex] ?? null;
+  const currentState = currentFrame?.gameState ?? null;
+  const totalFrames = frames.length;
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#2563EB" />
+        <Text style={styles.loadingText}>Chargement du replay...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorTitle}>Erreur</Text>
+        <Text style={styles.errorText}>{error}</Text>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Retour</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (frames.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>Aucune donnee de replay disponible</Text>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Retour</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const teams = replay?.teams ?? { teamA: null, teamB: null };
+  const title = formatTeamsTitle(teams);
+  const dateText = formatMatchDate(replay?.createdAt ?? null);
+  const moveLabel = getMoveLabel(currentFrame?.moveType);
+
+  const score = currentState?.score;
+  const half = currentState?.half;
+  const turn = currentState?.turn;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} style={styles.backLink}>
+          <Text style={styles.backLinkText}>Retour</Text>
+        </Pressable>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {title}
+        </Text>
+        <View style={styles.backLinkSpacer} />
+      </View>
+
+      {dateText.length > 0 && <Text style={styles.dateText}>{dateText}</Text>}
+
+      {score && (
+        <View style={styles.scoreBanner}>
+          <Text style={styles.scoreText}>
+            {score.teamA} - {score.teamB}
+          </Text>
+          {typeof half === "number" && typeof turn === "number" && (
+            <Text style={styles.halfTurn}>
+              Mi-temps {half} • Tour {turn}
+            </Text>
+          )}
+        </View>
+      )}
+
+      <ScrollView
+        style={styles.boardScroll}
+        contentContainerStyle={styles.boardScrollContent}
+        horizontal
+        bouncesZoom
+      >
+        {currentState && <PixiBoardNative state={currentState} cellSize={20} />}
+      </ScrollView>
+
+      <View style={styles.controls}>
+        <View style={styles.transportRow}>
+          <Pressable
+            onPress={handleGoToStart}
+            style={styles.transportButton}
+            accessibilityLabel="Debut"
+          >
+            <Text style={styles.transportIcon}>|◀</Text>
+          </Pressable>
+          <Pressable
+            onPress={handleStepBackward}
+            style={styles.transportButton}
+            accessibilityLabel="Image precedente"
+          >
+            <Text style={styles.transportIcon}>◀</Text>
+          </Pressable>
+          {isPlaying ? (
+            <Pressable
+              onPress={handlePause}
+              style={[styles.transportButton, styles.playButton]}
+              accessibilityLabel="Pause"
+            >
+              <Text style={styles.playIcon}>||</Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={handlePlay}
+              style={[styles.transportButton, styles.playButton]}
+              accessibilityLabel="Lecture"
+            >
+              <Text style={styles.playIcon}>▶</Text>
+            </Pressable>
+          )}
+          <Pressable
+            onPress={handleStepForward}
+            style={styles.transportButton}
+            accessibilityLabel="Image suivante"
+          >
+            <Text style={styles.transportIcon}>▶</Text>
+          </Pressable>
+          <Pressable
+            onPress={handleGoToEnd}
+            style={styles.transportButton}
+            accessibilityLabel="Fin"
+          >
+            <Text style={styles.transportIcon}>▶|</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.progressRow}>
+          <View style={styles.progressBar}>
+            <View
+              style={[
+                styles.progressFill,
+                {
+                  width:
+                    totalFrames > 1
+                      ? `${(currentIndex / (totalFrames - 1)) * 100}%`
+                      : "100%",
+                },
+              ]}
+            />
+          </View>
+          <Text style={styles.progressLabel}>
+            {currentIndex + 1} / {totalFrames}
+          </Text>
+        </View>
+
+        <View style={styles.speedRow}>
+          <Text style={styles.speedLabel}>Vitesse</Text>
+          {REPLAY_SPEED_OPTIONS.map((opt) => {
+            const active = speed === opt.ms;
+            return (
+              <Pressable
+                key={opt.ms}
+                onPress={() => setSpeed(opt.ms)}
+                style={[styles.speedButton, active && styles.speedButtonActive]}
+                accessibilityLabel={`Vitesse ${opt.label}`}
+              >
+                <Text
+                  style={[
+                    styles.speedButtonText,
+                    active && styles.speedButtonTextActive,
+                  ]}
+                >
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {moveLabel.length > 0 && (
+          <Text style={styles.moveLabel}>Action : {moveLabel}</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0F172A",
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    backgroundColor: "#0F172A",
+  },
+  loadingText: {
+    marginTop: 12,
+    color: "#E2E8F0",
+    fontSize: 14,
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#F87171",
+    marginBottom: 8,
+  },
+  errorText: {
+    color: "#FCA5A5",
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  emptyText: {
+    color: "#CBD5F5",
+    fontSize: 15,
+    marginBottom: 16,
+  },
+  backButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    backgroundColor: "#2563EB",
+    borderRadius: 8,
+  },
+  backButtonText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingTop: 48,
+    paddingBottom: 12,
+    gap: 8,
+  },
+  backLink: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    width: 80,
+  },
+  backLinkSpacer: {
+    width: 80,
+  },
+  backLinkText: {
+    color: "#93C5FD",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  headerTitle: {
+    flex: 1,
+    color: "#F8FAFC",
+    fontSize: 15,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  dateText: {
+    color: "#94A3B8",
+    textAlign: "center",
+    fontSize: 12,
+    marginBottom: 8,
+  },
+  scoreBanner: {
+    alignItems: "center",
+    paddingVertical: 10,
+    marginHorizontal: 16,
+    marginBottom: 10,
+    borderRadius: 10,
+    backgroundColor: "#1E293B",
+  },
+  scoreText: {
+    color: "#F8FAFC",
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  halfTurn: {
+    color: "#94A3B8",
+    fontSize: 12,
+    marginTop: 2,
+  },
+  boardScroll: {
+    maxHeight: 320,
+  },
+  boardScrollContent: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  controls: {
+    backgroundColor: "#1E293B",
+    borderTopWidth: 1,
+    borderTopColor: "#334155",
+    padding: 12,
+    gap: 10,
+  },
+  transportRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 8,
+  },
+  transportButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: "#334155",
+    borderRadius: 6,
+    minWidth: 44,
+    alignItems: "center",
+  },
+  playButton: {
+    backgroundColor: "#16A34A",
+  },
+  transportIcon: {
+    color: "#E2E8F0",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  playIcon: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  progressRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  progressBar: {
+    flex: 1,
+    height: 6,
+    backgroundColor: "#334155",
+    borderRadius: 3,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: "#2563EB",
+  },
+  progressLabel: {
+    color: "#CBD5F5",
+    fontSize: 12,
+    minWidth: 56,
+    textAlign: "right",
+  },
+  speedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  speedLabel: {
+    color: "#94A3B8",
+    fontSize: 12,
+    marginRight: 4,
+  },
+  speedButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    backgroundColor: "#334155",
+    borderRadius: 6,
+  },
+  speedButtonActive: {
+    backgroundColor: "#2563EB",
+  },
+  speedButtonText: {
+    color: "#CBD5F5",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  speedButtonTextActive: {
+    color: "#fff",
+  },
+  moveLabel: {
+    color: "#E2E8F0",
+    fontSize: 13,
+  },
+});

--- a/apps/mobile/lib/replay.test.ts
+++ b/apps/mobile/lib/replay.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import {
+  REPLAY_SPEED_OPTIONS,
+  REPLAY_DEFAULT_SPEED_MS,
+  clampFrameIndex,
+  nextFrameIndex,
+  prevFrameIndex,
+  getMoveLabel,
+  formatTeamsTitle,
+  parseReplayResponse,
+  formatMatchDate,
+  type ReplayResponse,
+  type ReplayTeamMeta,
+} from "./replay";
+
+function makeTeam(overrides: Partial<ReplayTeamMeta> = {}): ReplayTeamMeta {
+  return {
+    coachName: "Coach",
+    teamName: "Team",
+    roster: "Human",
+    ...overrides,
+  };
+}
+
+describe("clampFrameIndex", () => {
+  it("returns 0 when the list is empty", () => {
+    expect(clampFrameIndex(5, 0)).toBe(0);
+    expect(clampFrameIndex(-1, 0)).toBe(0);
+  });
+
+  it("clamps to the valid [0, length-1] range", () => {
+    expect(clampFrameIndex(-3, 5)).toBe(0);
+    expect(clampFrameIndex(0, 5)).toBe(0);
+    expect(clampFrameIndex(4, 5)).toBe(4);
+    expect(clampFrameIndex(99, 5)).toBe(4);
+  });
+});
+
+describe("nextFrameIndex", () => {
+  it("advances by one frame", () => {
+    expect(nextFrameIndex(0, 5)).toBe(1);
+    expect(nextFrameIndex(3, 5)).toBe(4);
+  });
+
+  it("does not go past the last frame", () => {
+    expect(nextFrameIndex(4, 5)).toBe(4);
+    expect(nextFrameIndex(0, 0)).toBe(0);
+    expect(nextFrameIndex(0, 1)).toBe(0);
+  });
+});
+
+describe("prevFrameIndex", () => {
+  it("steps back by one frame", () => {
+    expect(prevFrameIndex(2)).toBe(1);
+    expect(prevFrameIndex(1)).toBe(0);
+  });
+
+  it("does not go below 0", () => {
+    expect(prevFrameIndex(0)).toBe(0);
+    expect(prevFrameIndex(-3)).toBe(0);
+  });
+});
+
+describe("REPLAY_SPEED_OPTIONS", () => {
+  it("exposes a list of speed presets with positive ms values", () => {
+    expect(REPLAY_SPEED_OPTIONS.length).toBeGreaterThan(1);
+    for (const opt of REPLAY_SPEED_OPTIONS) {
+      expect(typeof opt.label).toBe("string");
+      expect(opt.label.length).toBeGreaterThan(0);
+      expect(opt.ms).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the default speed value", () => {
+    const defaultOpt = REPLAY_SPEED_OPTIONS.find(
+      (o) => o.ms === REPLAY_DEFAULT_SPEED_MS,
+    );
+    expect(defaultOpt).toBeDefined();
+  });
+});
+
+describe("getMoveLabel", () => {
+  it("maps known move types to French labels", () => {
+    expect(getMoveLabel("move")).toBe("Deplacement");
+    expect(getMoveLabel("block")).toBe("Blocage");
+    expect(getMoveLabel("blitz")).toBe("Blitz");
+    expect(getMoveLabel("pass")).toBe("Passe");
+    expect(getMoveLabel("handoff")).toBe("Transmission");
+    expect(getMoveLabel("foul")).toBe("Agression");
+    expect(getMoveLabel("end-turn")).toBe("Fin de tour");
+  });
+
+  it("returns a fallback label when type is unknown or missing", () => {
+    expect(getMoveLabel(undefined)).toBe("Action");
+    expect(getMoveLabel("")).toBe("Action");
+    expect(getMoveLabel("some-unknown")).toBe("some-unknown");
+  });
+});
+
+describe("formatTeamsTitle", () => {
+  it("formats both teams when present", () => {
+    const title = formatTeamsTitle({
+      teamA: makeTeam({ teamName: "Skavens", coachName: "Rat" }),
+      teamB: makeTeam({ teamName: "Dwarves", coachName: "Hammer" }),
+    });
+    expect(title).toBe("Skavens (Rat) vs Dwarves (Hammer)");
+  });
+
+  it("uses placeholders when a team is missing", () => {
+    const title = formatTeamsTitle({
+      teamA: null,
+      teamB: makeTeam({ teamName: "Dwarves", coachName: "Hammer" }),
+    });
+    expect(title).toBe("Equipe A vs Dwarves (Hammer)");
+  });
+
+  it("omits coach in parentheses when empty", () => {
+    const title = formatTeamsTitle({
+      teamA: makeTeam({ teamName: "Lizards", coachName: "" }),
+      teamB: makeTeam({ teamName: "Gnomes", coachName: "" }),
+    });
+    expect(title).toBe("Lizards vs Gnomes");
+  });
+});
+
+describe("parseReplayResponse", () => {
+  it("extracts turns and teams for a well-formed response", () => {
+    const response = {
+      matchId: "m1",
+      status: "ended",
+      turns: [
+        {
+          type: "gameplay-move",
+          gameState: { turn: 1 },
+          move: { type: "move" },
+          timestamp: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          type: "gameplay-move",
+          gameState: { turn: 2 },
+          move: { type: "block" },
+          timestamp: "2026-01-01T00:00:01.000Z",
+        },
+      ],
+      teams: {
+        teamA: { coachName: "A", teamName: "TeamA", roster: "Skaven" },
+        teamB: { coachName: "B", teamName: "TeamB", roster: "Dwarf" },
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    const parsed = parseReplayResponse(response);
+    expect(parsed.matchId).toBe("m1");
+    expect(parsed.status).toBe("ended");
+    expect(parsed.turns).toHaveLength(2);
+    expect(parsed.turns[0]).toMatchObject({ type: "gameplay-move" });
+    expect(parsed.teams.teamA?.teamName).toBe("TeamA");
+    expect(parsed.teams.teamB?.teamName).toBe("TeamB");
+  });
+
+  it("returns empty turns when the field is missing or not an array", () => {
+    expect(parseReplayResponse({ matchId: "m1", teams: {} }).turns).toEqual([]);
+    expect(
+      parseReplayResponse({ matchId: "m1", turns: "bad", teams: {} }).turns,
+    ).toEqual([]);
+  });
+
+  it("treats null/invalid team metadata as null", () => {
+    const parsed = parseReplayResponse({
+      matchId: "m1",
+      turns: [],
+      teams: {
+        teamA: null,
+        teamB: { coachName: "B", teamName: "T", roster: "R" },
+      },
+    });
+    expect(parsed.teams.teamA).toBeNull();
+    expect(parsed.teams.teamB).toEqual({
+      coachName: "B",
+      teamName: "T",
+      roster: "R",
+    });
+  });
+
+  it("returns safe defaults for an empty response", () => {
+    const parsed = parseReplayResponse({});
+    expect(parsed.matchId).toBe("");
+    expect(parsed.status).toBe("");
+    expect(parsed.turns).toEqual([]);
+    expect(parsed.teams).toEqual({ teamA: null, teamB: null });
+  });
+
+  it("throws a clear error when input is null", () => {
+    expect(() => parseReplayResponse(null)).toThrow();
+  });
+
+  it("filters out turns that are not objects", () => {
+    const response: Partial<ReplayResponse> & { turns: unknown[] } = {
+      matchId: "m1",
+      turns: [
+        { type: "gameplay-move", gameState: { turn: 1 } },
+        null,
+        "bad",
+        42,
+        { type: "gameplay-move", gameState: { turn: 2 } },
+      ],
+      teams: { teamA: null, teamB: null },
+    };
+    const parsed = parseReplayResponse(response);
+    expect(parsed.turns).toHaveLength(2);
+  });
+});
+
+describe("formatMatchDate", () => {
+  it("returns empty string for invalid input", () => {
+    expect(formatMatchDate(null)).toBe("");
+    expect(formatMatchDate(undefined)).toBe("");
+    expect(formatMatchDate("not a date")).toBe("");
+  });
+
+  it("formats a valid ISO date into a human-readable string", () => {
+    const out = formatMatchDate("2026-04-22T10:30:00.000Z");
+    expect(typeof out).toBe("string");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mobile/lib/replay.ts
+++ b/apps/mobile/lib/replay.ts
@@ -1,0 +1,136 @@
+// Pure helpers for the mobile replay screen.
+// Network-free so they can be unit-tested in node.
+
+import type { ReplayTurnPayload } from "@bb/game-engine";
+
+export const REPLAY_DEFAULT_SPEED_MS = 1000;
+
+export interface ReplaySpeedOption {
+  label: string;
+  ms: number;
+}
+
+export const REPLAY_SPEED_OPTIONS: readonly ReplaySpeedOption[] = [
+  { label: "0.5x", ms: 2000 },
+  { label: "1x", ms: 1000 },
+  { label: "2x", ms: 500 },
+  { label: "4x", ms: 250 },
+];
+
+export interface ReplayTeamMeta {
+  coachName: string;
+  teamName: string;
+  roster: string;
+}
+
+export interface ReplayTeamsMeta {
+  teamA: ReplayTeamMeta | null;
+  teamB: ReplayTeamMeta | null;
+}
+
+export interface ReplayResponse {
+  matchId: string;
+  status: string;
+  turns: ReplayTurnPayload[];
+  teams: ReplayTeamsMeta;
+  createdAt?: string;
+}
+
+export function clampFrameIndex(index: number, length: number): number {
+  if (length <= 0) return 0;
+  if (index < 0) return 0;
+  if (index >= length) return length - 1;
+  return index;
+}
+
+export function nextFrameIndex(current: number, length: number): number {
+  if (length <= 0) return 0;
+  const last = length - 1;
+  return current < last ? current + 1 : last;
+}
+
+export function prevFrameIndex(current: number): number {
+  return current > 0 ? current - 1 : 0;
+}
+
+const MOVE_LABELS: Record<string, string> = {
+  move: "Deplacement",
+  block: "Blocage",
+  blitz: "Blitz",
+  pass: "Passe",
+  handoff: "Transmission",
+  foul: "Agression",
+  "end-turn": "Fin de tour",
+  select: "Selection",
+  "choose-block-result": "Choix du bloc",
+  "choose-push-direction": "Choix de poussee",
+  "follow-up": "Poursuite",
+};
+
+export function getMoveLabel(moveType: string | undefined | null): string {
+  if (!moveType) return "Action";
+  return MOVE_LABELS[moveType] ?? moveType;
+}
+
+export function formatTeamsTitle(teams: ReplayTeamsMeta): string {
+  const a = formatSingleTeam(teams.teamA, "Equipe A");
+  const b = formatSingleTeam(teams.teamB, "Equipe B");
+  return `${a} vs ${b}`;
+}
+
+function formatSingleTeam(
+  team: ReplayTeamMeta | null,
+  fallback: string,
+): string {
+  if (!team) return fallback;
+  const name = team.teamName || fallback;
+  const coach = team.coachName?.trim();
+  return coach ? `${name} (${coach})` : name;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseTeamMeta(value: unknown): ReplayTeamMeta | null {
+  if (!isRecord(value)) return null;
+  const coachName = typeof value.coachName === "string" ? value.coachName : "";
+  const teamName = typeof value.teamName === "string" ? value.teamName : "";
+  const roster = typeof value.roster === "string" ? value.roster : "";
+  return { coachName, teamName, roster };
+}
+
+export function parseReplayResponse(response: unknown): ReplayResponse {
+  if (!isRecord(response)) {
+    throw new Error("Invalid replay response");
+  }
+
+  const rawTurns = Array.isArray(response.turns) ? response.turns : [];
+  const turns = rawTurns.filter(isRecord) as ReplayTurnPayload[];
+
+  const rawTeams = isRecord(response.teams) ? response.teams : {};
+  const teams: ReplayTeamsMeta = {
+    teamA: parseTeamMeta(rawTeams.teamA),
+    teamB: parseTeamMeta(rawTeams.teamB),
+  };
+
+  return {
+    matchId: typeof response.matchId === "string" ? response.matchId : "",
+    status: typeof response.status === "string" ? response.status : "",
+    turns,
+    teams,
+    createdAt:
+      typeof response.createdAt === "string" ? response.createdAt : undefined,
+  };
+}
+
+export function formatMatchDate(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
## Resume

- Ajoute un ecran natif de replay des matchs termines dans l'app mobile
- Accessible depuis le lobby via un bouton "Voir le replay" sur les cartes de matchs termines
- Reutilise le meme endpoint serveur `GET /match/:id/replay` que la version web (aucun changement backend)
- Partage la logique de construction des frames avec le web via `buildReplayFrames` (@bb/game-engine)

## Fonctionnement

- L'ecran charge les donnees via `apiGet('/match/:id/replay')` puis construit les frames cote client
- Le plateau est affiche via `PixiBoardNative` en mode lecture seule (pas de `onCellClick`)
- Transport controls : debut, image precedente, play/pause, image suivante, fin
- Barre de progression lineaire + compteur `n / total` + selecteur de vitesse (0.5x, 1x, 2x, 4x)
- Bandeau de score avec mi-temps et tour en cours + label de l'action

## Architecture

- `apps/mobile/lib/replay.ts` — helpers purs (parsing de la reponse API, navigation de frames, formatage), testables en isolation
- `apps/mobile/lib/replay.test.ts` — 21 tests unitaires couvrant parsing, clamp, navigation, formatage
- `apps/mobile/app/replay/[id].tsx` — ecran expo-router avec etat local et interval de lecture
- `apps/mobile/app/_layout.tsx` — enregistrement de la route
- `apps/mobile/app/lobby.tsx` — ajout du bouton "Voir le replay" conditionnel pour matchs `ended`

## Tache roadmap

Sprint 18-19 — Parite Mobile, tache M.7

## Plan de test

- [x] `pnpm --filter @bb/mobile test` — 136 tests (21 nouveaux) passent
- [x] `pnpm --filter @bb/game-engine test` — 4050 tests, aucune regression
- [ ] Smoke test manuel Expo : depuis le lobby, tap sur un match termine → bouton "Voir le replay" → lecture complete
- [ ] Verifier sur iOS et Android que `PixiBoardNative` rend correctement les frames
- [ ] Tester les edge cases : match sans frames, erreur 401/403, erreur serveur
