### PR TITLE
Add Discord community link to footer

### DIFF
--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -74,6 +74,23 @@ export default function Footer() {
                 </a>
               </li>
             </ul>
+            <h3 className="font-heading font-semibold text-nuffle-anthracite mb-3 mt-6">{t.footer.community}</h3>
+            <ul className="text-sm text-nuffle-anthracite/80 space-y-1 font-body">
+              <li>
+                <a
+                  href="https://discord.gg/5epQQ9Kf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-nuffle-gold hover:underline transition-colors inline-flex items-center gap-1.5"
+                  aria-label={t.footer.joinDiscord}
+                >
+                  <svg className="w-4 h-4 text-[#5865F2]" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20.317 4.369A19.791 19.791 0 0 0 16.558 3.2a.075.075 0 0 0-.079.037 13.77 13.77 0 0 0-.608 1.25 18.28 18.28 0 0 0-5.487 0 12.66 12.66 0 0 0-.617-1.25.077.077 0 0 0-.079-.037 19.736 19.736 0 0 0-3.76 1.169.07.07 0 0 0-.032.027C2.533 8.045 1.68 11.61 2.099 15.132a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.075.075 0 0 0-.041-.104 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.075.075 0 0 1 .078-.01c3.927 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.128 12.3 12.3 0 0 1-1.873.891.076.076 0 0 0-.04.105c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.029 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-4.073-.838-7.608-3.548-10.736a.06.06 0 0 0-.031-.028zM8.02 12.99c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                  </svg>
+                  {t.footer.joinDiscord}
+                </a>
+              </li>
+            </ul>
             <h3 className="font-heading font-semibold text-nuffle-anthracite mb-3 mt-6">{t.footer.legal}</h3>
             <ul className="text-sm text-nuffle-anthracite/80 space-y-1 font-body">
               <li>

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -85,6 +85,8 @@ export const translations = {
       itemsPlural: "éléments",
       compulsory: "Obligatoire",
       tutorial: "Tutoriel interactif",
+      community: "Communauté",
+      joinDiscord: "Rejoindre le Discord",
     },
     // Star Players page
     starPlayers: {
@@ -581,6 +583,8 @@ export const translations = {
       itemsPlural: "items",
       compulsory: "Compulsory",
       tutorial: "Interactive tutorial",
+      community: "Community",
+      joinDiscord: "Join our Discord",
     },
     // Star Players page
     starPlayers: {

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -165,6 +165,47 @@
       to { transform: rotate(360deg); }
     }
 
+    .discord-section {
+      margin-top: 2rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid rgba(203, 161, 53, 0.2);
+    }
+
+    .discord-message {
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: rgba(233, 226, 208, 0.85);
+      margin-bottom: 1rem;
+    }
+
+    .discord-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.75rem 1.5rem;
+      background: #5865F2;
+      color: #FFFFFF;
+      text-decoration: none;
+      border-radius: 0.5rem;
+      font-family: 'Montserrat', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 4px 12px rgba(88, 101, 242, 0.3);
+    }
+
+    .discord-button:hover {
+      background: #4752C4;
+      transform: translateY(-1px);
+      box-shadow: 0 6px 16px rgba(88, 101, 242, 0.45);
+    }
+
+    .discord-button svg {
+      width: 20px;
+      height: 20px;
+      fill: currentColor;
+    }
+
     .footer {
       position: relative;
       z-index: 1;
@@ -222,6 +263,24 @@
       <div class="status">
         <span class="spinner"></span>
         Mise a jour en cours...
+      </div>
+
+      <div class="discord-section">
+        <p class="discord-message">
+          En attendant la reprise du match, rejoignez les coachs sur Discord pour echanger et rester informe !
+        </p>
+        <a
+          href="https://discord.gg/5epQQ9Kf"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="discord-button"
+          aria-label="Rejoindre le Discord de Nuffle Arena"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M20.317 4.369A19.791 19.791 0 0 0 16.558 3.2a.075.075 0 0 0-.079.037 13.77 13.77 0 0 0-.608 1.25 18.28 18.28 0 0 0-5.487 0 12.66 12.66 0 0 0-.617-1.25.077.077 0 0 0-.079-.037 19.736 19.736 0 0 0-3.76 1.169.07.07 0 0 0-.032.027C2.533 8.045 1.68 11.61 2.099 15.132a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.075.075 0 0 0-.041-.104 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.075.075 0 0 1 .078-.01c3.927 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.128 12.3 12.3 0 0 1-1.873.891.076.076 0 0 0-.04.105c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.029 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-4.073-.838-7.608-3.548-10.736a.06.06 0 0 0-.031-.028zM8.02 12.99c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+          </svg>
+          Rejoindre le Discord
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Résumé

- [x] Ajouter un lien vers le serveur Discord dans le pied de page avec une nouvelle section "Communauté"

## Description

Cette PR ajoute une nouvelle section "Communauté" dans le pied de page avec un lien vers le serveur Discord. Le lien inclut :
- Une icône Discord stylisée avec la couleur officielle (#5865F2)
- Un texte localisé en français et anglais
- Les styles cohérents avec le reste du pied de page (hover effects, transitions)
- Les attributs d'accessibilité appropriés (aria-label, rel="noopener noreferrer")

Les traductions ont été ajoutées pour les deux langues supportées :
- FR: "Communauté" / "Rejoindre le Discord"
- EN: "Community" / "Join our Discord"

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires - N/A (changement UI simple)
- [x] Tests e2e - N/A (changement UI simple)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01WX3pGRzT9oGrGb6E924K8M