### PR TITLE
feat(mobile): M.8 ecrans cups et ligues

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -316,7 +316,7 @@
 | M.5 | Chat in-game mobile | Mobile | [x] |
 | M.6 | Ecran leaderboard | Mobile | [x] |
 | M.7 | Ecran replay de match | Mobile | [x] |
-| M.8 | Ecrans cups/ligues | Mobile | [ ] |
+| M.8 | Ecrans cups/ligues | Mobile | [x] |
 | M.9 | Push notifications natives (Expo Notifications) | Mobile | [ ] |
 | M.10 | Details joueur et progression | Mobile | [ ] |
 | M.11 | Catalogue Star Players mobile | Mobile | [ ] |

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -33,6 +33,20 @@ export default function Layout() {
             name="teams/[id]"
             options={{ title: "Detail equipe" }}
           />
+          <Stack.Screen name="cups/index" options={{ title: "Coupes" }} />
+          <Stack.Screen
+            name="cups/archived"
+            options={{ title: "Coupes archivees" }}
+          />
+          <Stack.Screen
+            name="cups/[id]"
+            options={{ title: "Detail coupe" }}
+          />
+          <Stack.Screen name="leagues/index" options={{ title: "Ligues" }} />
+          <Stack.Screen
+            name="leagues/[id]"
+            options={{ title: "Detail ligue" }}
+          />
         </Stack>
       </AuthProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/app/cups/[id].tsx
+++ b/apps/mobile/app/cups/[id].tsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  formatCupStatusLabel,
+  parseCupDetailResponse,
+  type CupDetail,
+} from "../../lib/cups";
+
+export default function CupDetailScreen() {
+  const params = useLocalSearchParams<{ id: string }>();
+  const cupId = typeof params.id === "string" ? params.id : "";
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [cup, setCup] = useState<CupDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCup = useCallback(async () => {
+    if (!cupId) return;
+    try {
+      setError(null);
+      const response = await apiGet(`/cup/${cupId}`);
+      const parsed = parseCupDetailResponse(response);
+      if (!parsed) {
+        throw new Error("Coupe introuvable");
+      }
+      setCup(parsed);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [cupId, logout, router]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchCup().finally(() => setLoading(false));
+  }, [fetchCup]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchCup();
+    setRefreshing(false);
+  }, [fetchCup]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error || !cup) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>{error ?? "Coupe introuvable"}</Text>
+        <Pressable onPress={onRefresh} style={styles.retryButton}>
+          <Text style={styles.retryText}>Reessayer</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    >
+      <View style={styles.headerBlock}>
+        <Text style={styles.title} testID="cup-title">
+          {cup.name}
+        </Text>
+        <View style={styles.badgeRow}>
+          <Text style={styles.badge}>{formatCupStatusLabel(cup.status)}</Text>
+          <Text style={styles.badgeSecondary}>
+            {cup.isPublic ? "Publique" : "Privee"}
+          </Text>
+          <Text style={styles.badgeSecondary}>{cup.ruleset}</Text>
+        </View>
+        <Text style={styles.metaText}>
+          Cree par {cup.creator.coachName || cup.creator.email || "—"}
+        </Text>
+      </View>
+
+      <Section title="Participants" testID="cup-participants">
+        {cup.participants.length === 0 ? (
+          <Text style={styles.mutedText}>Aucun participant pour l'instant.</Text>
+        ) : (
+          cup.participants.map((p) => (
+            <View key={p.id} style={styles.row} testID={`cup-participant-${p.id}`}>
+              <Text style={styles.rowMain}>{p.name}</Text>
+              <Text style={styles.rowSub}>
+                {p.roster} — {p.owner.coachName || p.owner.email || "—"}
+              </Text>
+            </View>
+          ))
+        )}
+      </Section>
+
+      <Section title="Classement" testID="cup-standings">
+        {cup.standings.length === 0 ? (
+          <Text style={styles.mutedText}>Aucun match termine.</Text>
+        ) : (
+          <View>
+            <View style={[styles.standingRow, styles.standingHeader]}>
+              <Text style={styles.standingCellTeam}>Equipe</Text>
+              <Text style={styles.standingCell}>V</Text>
+              <Text style={styles.standingCell}>N</Text>
+              <Text style={styles.standingCell}>D</Text>
+              <Text style={styles.standingCellPts}>Pts</Text>
+            </View>
+            {cup.standings.map((row) => {
+              const participant = cup.participants.find((p) => p.id === row.teamId);
+              return (
+                <View
+                  key={row.teamId}
+                  style={styles.standingRow}
+                  testID={`cup-standing-${row.teamId}`}
+                >
+                  <Text style={styles.standingCellTeam} numberOfLines={1}>
+                    {participant?.name ?? row.teamId}
+                  </Text>
+                  <Text style={styles.standingCell}>{row.wins}</Text>
+                  <Text style={styles.standingCell}>{row.draws}</Text>
+                  <Text style={styles.standingCell}>{row.losses}</Text>
+                  <Text style={styles.standingCellPts}>{row.points}</Text>
+                </View>
+              );
+            })}
+          </View>
+        )}
+      </Section>
+
+      <Section title="Matchs" testID="cup-matches">
+        {cup.matches.length === 0 ? (
+          <Text style={styles.mutedText}>Aucun match joue.</Text>
+        ) : (
+          cup.matches.map((m) => (
+            <View key={m.id} style={styles.row}>
+              <Text style={styles.rowMain}>Match {m.id.slice(0, 8)}</Text>
+              <Text style={styles.rowSub}>{m.status}</Text>
+            </View>
+          ))
+        )}
+      </Section>
+    </ScrollView>
+  );
+}
+
+function Section({
+  title,
+  children,
+  testID,
+}: {
+  title: string;
+  children: React.ReactNode;
+  testID?: string;
+}) {
+  return (
+    <View style={styles.section} testID={testID}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  content: { padding: 16, paddingBottom: 32 },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    backgroundColor: "#F9FAFB",
+  },
+  headerBlock: { marginBottom: 16 },
+  title: { fontSize: 22, fontWeight: "700", color: "#111827", marginBottom: 6 },
+  badgeRow: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginBottom: 6 },
+  badge: {
+    fontSize: 12,
+    color: "#1F2937",
+    backgroundColor: "#FEF3C7",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  badgeSecondary: {
+    fontSize: 12,
+    color: "#374151",
+    backgroundColor: "#E5E7EB",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  metaText: { fontSize: 12, color: "#6B7280" },
+  section: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    padding: 14,
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 10,
+    textTransform: "uppercase",
+  },
+  row: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E5E7EB",
+  },
+  rowMain: { fontSize: 14, fontWeight: "500", color: "#111827" },
+  rowSub: { fontSize: 12, color: "#6B7280", marginTop: 2 },
+  mutedText: { fontSize: 13, color: "#6B7280" },
+  errorText: { color: "#DC2626", fontSize: 14, marginBottom: 12, textAlign: "center" },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  standingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E5E7EB",
+  },
+  standingHeader: { borderBottomColor: "#9CA3AF" },
+  standingCellTeam: { flex: 1, fontSize: 13, color: "#111827" },
+  standingCell: {
+    width: 28,
+    textAlign: "center",
+    fontSize: 13,
+    color: "#374151",
+    fontVariant: ["tabular-nums"],
+  },
+  standingCellPts: {
+    width: 40,
+    textAlign: "right",
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#111827",
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/apps/mobile/app/cups/archived.tsx
+++ b/apps/mobile/app/cups/archived.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  formatCupStatusLabel,
+  parseCupListResponse,
+  sortCupsByRecent,
+  type Cup,
+} from "../../lib/cups";
+
+export default function ArchivedCupsScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [cups, setCups] = useState<Cup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCups = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await apiGet("/cup/archived");
+      setCups(sortCupsByRecent(parseCupListResponse(response)));
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [logout, router]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchCups().finally(() => setLoading(false));
+  }, [fetchCups]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchCups();
+    setRefreshing(false);
+  }, [fetchCups]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Coupes archivees</Text>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={cups}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <Pressable
+              style={styles.card}
+              onPress={() => router.push(`/cups/${item.id}`)}
+              testID={`archived-cup-${item.id}`}
+            >
+              <Text style={styles.cardTitle} numberOfLines={1}>
+                {item.name}
+              </Text>
+              <Text style={styles.cardStatus}>
+                {formatCupStatusLabel(item.status)}
+              </Text>
+            </Pressable>
+          )}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText}>
+                Aucune coupe archivee.
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#111827",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  listContent: { padding: 16, flexGrow: 1 },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  cardTitle: { flex: 1, fontSize: 14, color: "#111827", fontWeight: "500" },
+  cardStatus: {
+    fontSize: 12,
+    color: "#1F2937",
+    backgroundColor: "#E5E7EB",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
+  errorText: { color: "#DC2626", fontSize: 14, marginBottom: 12, textAlign: "center" },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  emptyText: { color: "#6B7280", fontSize: 15, textAlign: "center" },
+});

--- a/apps/mobile/app/cups/index.tsx
+++ b/apps/mobile/app/cups/index.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  CUP_STATUSES,
+  filterCupsByStatus,
+  formatCupStatusLabel,
+  parseCupListResponse,
+  sortCupsByRecent,
+  type Cup,
+  type CupStatusFilter,
+} from "../../lib/cups";
+
+const FILTER_OPTIONS: ReadonlyArray<{ value: CupStatusFilter; label: string }> = [
+  { value: "all", label: "Toutes" },
+  ...CUP_STATUSES.map((s) => ({
+    value: s as CupStatusFilter,
+    label: formatCupStatusLabel(s),
+  })),
+];
+
+export default function CupsListScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [cups, setCups] = useState<Cup[]>([]);
+  const [filter, setFilter] = useState<CupStatusFilter>("all");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCups = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await apiGet("/cup");
+      setCups(sortCupsByRecent(parseCupListResponse(response)));
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [logout, router]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchCups().finally(() => setLoading(false));
+  }, [fetchCups]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchCups();
+    setRefreshing(false);
+  }, [fetchCups]);
+
+  const visible = useMemo(() => filterCupsByStatus(cups, filter), [cups, filter]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Coupes</Text>
+        <Pressable
+          onPress={() => router.push("/cups/archived")}
+          style={styles.archivedLink}
+          testID="cups-archived-link"
+        >
+          <Text style={styles.archivedLinkText}>Archivees</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.filters} testID="cups-filters">
+        {FILTER_OPTIONS.map((opt) => {
+          const active = opt.value === filter;
+          return (
+            <Pressable
+              key={opt.value}
+              onPress={() => setFilter(opt.value)}
+              style={[styles.filterChip, active && styles.filterChipActive]}
+              testID={`cups-filter-${opt.value}`}
+            >
+              <Text
+                style={[
+                  styles.filterChipText,
+                  active && styles.filterChipTextActive,
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={visible}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <CupCard cup={item} onPress={() => router.push(`/cups/${item.id}`)} />
+          )}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText} testID="cups-empty">
+                Aucune coupe pour ce filtre.
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+function CupCard({ cup, onPress }: { cup: Cup; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={styles.card}
+      testID={`cup-card-${cup.id}`}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle} numberOfLines={1}>
+          {cup.name}
+        </Text>
+        <Text style={styles.cardStatus}>
+          {formatCupStatusLabel(cup.status)}
+        </Text>
+      </View>
+      <View style={styles.cardMeta}>
+        <Text style={styles.cardMetaText}>
+          {cup.participantCount} participant
+          {cup.participantCount > 1 ? "s" : ""}
+        </Text>
+        <Text style={styles.cardMetaText}>
+          {cup.isPublic ? "Publique" : "Privee"}
+        </Text>
+        <Text style={styles.cardMetaText}>{cup.ruleset}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  title: { fontSize: 20, fontWeight: "700", color: "#111827" },
+  archivedLink: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: "#E5E7EB",
+  },
+  archivedLinkText: { fontSize: 13, color: "#111827", fontWeight: "500" },
+  filters: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  filterChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: "#fff",
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+  },
+  filterChipActive: { backgroundColor: "#111827", borderColor: "#111827" },
+  filterChipText: { fontSize: 13, color: "#374151" },
+  filterChipTextActive: { color: "#fff", fontWeight: "600" },
+  listContent: { padding: 16, flexGrow: 1 },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 6,
+  },
+  cardTitle: { flex: 1, fontSize: 15, fontWeight: "600", color: "#111827" },
+  cardStatus: {
+    fontSize: 12,
+    color: "#1F2937",
+    backgroundColor: "#FEF3C7",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  cardMeta: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
+  cardMetaText: { fontSize: 12, color: "#6B7280" },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  emptyText: { color: "#6B7280", fontSize: 15, textAlign: "center" },
+});

--- a/apps/mobile/app/leagues/[id].tsx
+++ b/apps/mobile/app/leagues/[id].tsx
@@ -1,0 +1,467 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  formatLeagueRulesetLabel,
+  formatLeagueSeasonStatusLabel,
+  formatLeagueStatusLabel,
+  parseLeagueDetailResponse,
+  parseSeasonDetailResponse,
+  parseStandingsResponse,
+  type LeagueDetail,
+  type LeagueSeasonDetail,
+  type StandingRow,
+} from "../../lib/leagues";
+
+export default function LeagueDetailScreen() {
+  const params = useLocalSearchParams<{ id: string }>();
+  const leagueId = typeof params.id === "string" ? params.id : "";
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [league, setLeague] = useState<LeagueDetail | null>(null);
+  const [selectedSeasonId, setSelectedSeasonId] = useState<string | null>(null);
+  const [season, setSeason] = useState<LeagueSeasonDetail | null>(null);
+  const [standings, setStandings] = useState<StandingRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [seasonLoading, setSeasonLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [seasonError, setSeasonError] = useState<string | null>(null);
+
+  const handleAuthError = useCallback(
+    async (err: unknown): Promise<boolean> => {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return true;
+      }
+      return false;
+    },
+    [logout, router],
+  );
+
+  const fetchLeague = useCallback(async () => {
+    if (!leagueId) return;
+    try {
+      setError(null);
+      const response = await apiGet(`/league/${leagueId}`);
+      const parsed = parseLeagueDetailResponse(response);
+      if (!parsed) throw new Error("Ligue introuvable");
+      setLeague(parsed);
+      setSelectedSeasonId((prev) => {
+        if (prev) return prev;
+        if (parsed.seasons.length === 0) return null;
+        return parsed.seasons[parsed.seasons.length - 1].id;
+      });
+    } catch (err: unknown) {
+      if (await handleAuthError(err)) return;
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [leagueId, handleAuthError]);
+
+  const fetchSeason = useCallback(
+    async (seasonId: string) => {
+      try {
+        setSeasonLoading(true);
+        setSeasonError(null);
+        const [seasonRes, standingsRes] = await Promise.all([
+          apiGet(`/league/seasons/${seasonId}`),
+          apiGet(`/league/seasons/${seasonId}/standings`),
+        ]);
+        setSeason(parseSeasonDetailResponse(seasonRes));
+        setStandings(parseStandingsResponse(standingsRes));
+      } catch (err: unknown) {
+        if (await handleAuthError(err)) return;
+        setSeason(null);
+        setStandings([]);
+        setSeasonError(
+          err instanceof Error ? err.message : "Erreur de chargement",
+        );
+      } finally {
+        setSeasonLoading(false);
+      }
+    },
+    [handleAuthError],
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    fetchLeague().finally(() => setLoading(false));
+  }, [fetchLeague]);
+
+  useEffect(() => {
+    if (!selectedSeasonId) {
+      setSeason(null);
+      setStandings([]);
+      return;
+    }
+    fetchSeason(selectedSeasonId);
+  }, [selectedSeasonId, fetchSeason]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchLeague();
+    if (selectedSeasonId) {
+      await fetchSeason(selectedSeasonId);
+    }
+    setRefreshing(false);
+  }, [fetchLeague, fetchSeason, selectedSeasonId]);
+
+  const participantsById = useMemo(() => {
+    const map = new Map<string, string>();
+    if (season) {
+      for (const p of season.participants) {
+        map.set(p.team.id, p.team.name);
+      }
+    }
+    return map;
+  }, [season]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error || !league) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>{error ?? "Ligue introuvable"}</Text>
+        <Pressable onPress={onRefresh} style={styles.retryButton}>
+          <Text style={styles.retryText}>Reessayer</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    >
+      <View style={styles.headerBlock}>
+        <Text style={styles.title} testID="league-title">
+          {league.name}
+        </Text>
+        <View style={styles.badgeRow}>
+          <Text style={styles.badge}>
+            {formatLeagueStatusLabel(league.status)}
+          </Text>
+          <Text style={styles.badgeSecondary}>
+            {formatLeagueRulesetLabel(league.ruleset)}
+          </Text>
+          <Text style={styles.badgeSecondary}>
+            {league.isPublic ? "Publique" : "Privee"}
+          </Text>
+        </View>
+        {league.description ? (
+          <Text style={styles.description}>{league.description}</Text>
+        ) : null}
+        <Text style={styles.metaText}>
+          {`Createur: ${league.creator.coachName || league.creator.email || "—"} • Max ${league.maxParticipants} equipes`}
+        </Text>
+      </View>
+
+      <View style={styles.scoringCard}>
+        <Text style={styles.sectionTitle}>Bareme</Text>
+        <View style={styles.scoringRow}>
+          <ScoreCell label="Victoire" value={league.winPoints} />
+          <ScoreCell label="Nul" value={league.drawPoints} />
+          <ScoreCell label="Defaite" value={league.lossPoints} />
+          <ScoreCell label="Forfait" value={league.forfeitPoints} />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Saisons</Text>
+        {league.seasons.length === 0 ? (
+          <Text style={styles.mutedText} testID="league-no-seasons">
+            Aucune saison pour l'instant.
+          </Text>
+        ) : (
+          <View style={styles.seasonTabs} testID="league-seasons-tabs">
+            {league.seasons.map((s) => {
+              const active = s.id === selectedSeasonId;
+              return (
+                <Pressable
+                  key={s.id}
+                  onPress={() => setSelectedSeasonId(s.id)}
+                  style={[styles.seasonTab, active && styles.seasonTabActive]}
+                  testID={`season-tab-${s.id}`}
+                >
+                  <Text
+                    style={[
+                      styles.seasonTabText,
+                      active && styles.seasonTabTextActive,
+                    ]}
+                  >
+                    S{s.seasonNumber} — {s.name}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.seasonTabSubtext,
+                      active && styles.seasonTabTextActive,
+                    ]}
+                  >
+                    {formatLeagueSeasonStatusLabel(s.status)}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </View>
+
+      {selectedSeasonId ? (
+        <>
+          {seasonLoading ? (
+            <View style={styles.seasonLoading}>
+              <ActivityIndicator size="small" color="#2563EB" />
+            </View>
+          ) : null}
+          {seasonError ? (
+            <Text style={styles.errorText}>Erreur : {seasonError}</Text>
+          ) : null}
+
+          {season ? (
+            <>
+              <View style={styles.section} testID="season-rounds">
+                <Text style={styles.sectionTitle}>Journees</Text>
+                {season.rounds.length === 0 ? (
+                  <Text style={styles.mutedText}>
+                    Aucune journee planifiee.
+                  </Text>
+                ) : (
+                  season.rounds.map((r) => (
+                    <View
+                      key={r.id}
+                      style={styles.row}
+                      testID={`season-round-${r.id}`}
+                    >
+                      <Text style={styles.rowMain}>
+                        Journee {r.roundNumber}
+                        {r.name ? ` — ${r.name}` : ""}
+                      </Text>
+                      <Text style={styles.rowSub}>{r.status}</Text>
+                    </View>
+                  ))
+                )}
+              </View>
+
+              <View style={styles.section} testID="season-standings">
+                <Text style={styles.sectionTitle}>Classement</Text>
+                {standings.length === 0 ? (
+                  <Text style={styles.mutedText}>
+                    Aucun match comptabilise.
+                  </Text>
+                ) : (
+                  <View>
+                    <View style={[styles.standingRow, styles.standingHeader]}>
+                      <Text style={styles.standingCellTeam}>Equipe</Text>
+                      <Text style={styles.standingCell}>V</Text>
+                      <Text style={styles.standingCell}>N</Text>
+                      <Text style={styles.standingCell}>D</Text>
+                      <Text style={styles.standingCellPts}>Pts</Text>
+                    </View>
+                    {standings.map((row) => (
+                      <View
+                        key={row.teamId}
+                        style={styles.standingRow}
+                        testID={`season-standing-${row.teamId}`}
+                      >
+                        <Text style={styles.standingCellTeam} numberOfLines={1}>
+                          {row.teamName ??
+                            participantsById.get(row.teamId) ??
+                            row.teamId}
+                        </Text>
+                        <Text style={styles.standingCell}>{row.wins}</Text>
+                        <Text style={styles.standingCell}>{row.draws}</Text>
+                        <Text style={styles.standingCell}>{row.losses}</Text>
+                        <Text style={styles.standingCellPts}>{row.points}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+
+              <View style={styles.section} testID="season-participants">
+                <Text style={styles.sectionTitle}>Participants</Text>
+                {season.participants.length === 0 ? (
+                  <Text style={styles.mutedText}>
+                    Aucun participant pour cette saison.
+                  </Text>
+                ) : (
+                  season.participants.map((p) => (
+                    <View
+                      key={p.id}
+                      style={styles.row}
+                      testID={`season-participant-${p.id}`}
+                    >
+                      <Text style={styles.rowMain}>{p.team.name}</Text>
+                      <Text style={styles.rowSub}>
+                        {p.team.roster} •{" "}
+                        {p.team.owner.coachName ?? "—"} • ELO {p.seasonElo}
+                      </Text>
+                    </View>
+                  ))
+                )}
+              </View>
+            </>
+          ) : null}
+        </>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+function ScoreCell({ label, value }: { label: string; value: number }) {
+  return (
+    <View style={styles.scoreCell}>
+      <Text style={styles.scoreLabel}>{label}</Text>
+      <Text style={styles.scoreValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  content: { padding: 16, paddingBottom: 32 },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    backgroundColor: "#F9FAFB",
+  },
+  headerBlock: { marginBottom: 16 },
+  title: { fontSize: 22, fontWeight: "700", color: "#111827", marginBottom: 6 },
+  badgeRow: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginBottom: 6 },
+  badge: {
+    fontSize: 12,
+    color: "#1F2937",
+    backgroundColor: "#FEF3C7",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  badgeSecondary: {
+    fontSize: 12,
+    color: "#374151",
+    backgroundColor: "#E5E7EB",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  description: { fontSize: 13, color: "#374151", marginVertical: 4 },
+  metaText: { fontSize: 12, color: "#6B7280" },
+  scoringCard: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    padding: 12,
+    marginBottom: 12,
+  },
+  scoringRow: { flexDirection: "row", justifyContent: "space-between", gap: 8 },
+  scoreCell: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 6,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 6,
+  },
+  scoreLabel: { fontSize: 11, color: "#6B7280", marginBottom: 2 },
+  scoreValue: { fontSize: 15, fontWeight: "700", color: "#111827" },
+  section: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    padding: 14,
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 10,
+    textTransform: "uppercase",
+  },
+  seasonTabs: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  seasonTab: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    backgroundColor: "#fff",
+  },
+  seasonTabActive: { backgroundColor: "#111827", borderColor: "#111827" },
+  seasonTabText: { fontSize: 13, fontWeight: "500", color: "#111827" },
+  seasonTabSubtext: { fontSize: 11, color: "#6B7280", marginTop: 2 },
+  seasonTabTextActive: { color: "#fff" },
+  seasonLoading: { padding: 12, alignItems: "center" },
+  row: {
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E5E7EB",
+  },
+  rowMain: { fontSize: 14, fontWeight: "500", color: "#111827" },
+  rowSub: { fontSize: 12, color: "#6B7280", marginTop: 2 },
+  mutedText: { fontSize: 13, color: "#6B7280" },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  standingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E5E7EB",
+  },
+  standingHeader: { borderBottomColor: "#9CA3AF" },
+  standingCellTeam: { flex: 1, fontSize: 13, color: "#111827" },
+  standingCell: {
+    width: 28,
+    textAlign: "center",
+    fontSize: 13,
+    color: "#374151",
+    fontVariant: ["tabular-nums"],
+  },
+  standingCellPts: {
+    width: 40,
+    textAlign: "right",
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#111827",
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/apps/mobile/app/leagues/index.tsx
+++ b/apps/mobile/app/leagues/index.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  LEAGUE_STATUSES,
+  filterLeaguesByStatus,
+  formatLeagueRulesetLabel,
+  formatLeagueStatusLabel,
+  parseLeagueListResponse,
+  type League,
+  type LeagueStatusFilter,
+} from "../../lib/leagues";
+
+const FILTER_OPTIONS: ReadonlyArray<{ value: LeagueStatusFilter; label: string }> = [
+  { value: "all", label: "Toutes" },
+  ...LEAGUE_STATUSES.map((s) => ({
+    value: s as LeagueStatusFilter,
+    label: formatLeagueStatusLabel(s),
+  })),
+];
+
+export default function LeaguesListScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [leagues, setLeagues] = useState<League[]>([]);
+  const [filter, setFilter] = useState<LeagueStatusFilter>("all");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchLeagues = useCallback(async () => {
+    try {
+      setError(null);
+      const path =
+        filter === "all" ? "/league" : `/league?status=${encodeURIComponent(filter)}`;
+      const response = await apiGet(path);
+      setLeagues(parseLeagueListResponse(response));
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [filter, logout, router]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchLeagues().finally(() => setLoading(false));
+  }, [fetchLeagues]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchLeagues();
+    setRefreshing(false);
+  }, [fetchLeagues]);
+
+  // Local filter mirrors the server-side filter for safety and test determinism.
+  const visible = useMemo(
+    () => filterLeaguesByStatus(leagues, filter),
+    [leagues, filter],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Ligues</Text>
+
+      <View style={styles.filters} testID="leagues-filters">
+        {FILTER_OPTIONS.map((opt) => {
+          const active = opt.value === filter;
+          return (
+            <Pressable
+              key={opt.value}
+              onPress={() => setFilter(opt.value)}
+              style={[styles.filterChip, active && styles.filterChipActive]}
+              testID={`leagues-filter-${opt.value}`}
+            >
+              <Text
+                style={[
+                  styles.filterChipText,
+                  active && styles.filterChipTextActive,
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={visible}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <LeagueCard
+              league={item}
+              onPress={() => router.push(`/leagues/${item.id}`)}
+            />
+          )}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText} testID="leagues-empty">
+                Aucune ligue pour ce filtre.
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+function LeagueCard({
+  league,
+  onPress,
+}: {
+  league: League;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={styles.card}
+      testID={`league-card-${league.id}`}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle} numberOfLines={1}>
+          {league.name}
+        </Text>
+        <Text style={styles.cardStatus}>
+          {formatLeagueStatusLabel(league.status)}
+        </Text>
+      </View>
+      {league.description ? (
+        <Text style={styles.cardDescription} numberOfLines={2}>
+          {league.description}
+        </Text>
+      ) : null}
+      <View style={styles.cardMeta}>
+        <Text style={styles.cardMetaText}>
+          {formatLeagueRulesetLabel(league.ruleset)}
+        </Text>
+        <Text style={styles.cardMetaText}>
+          Max {league.maxParticipants} equipes
+        </Text>
+        <Text style={styles.cardMetaText}>
+          {league.isPublic ? "Publique" : "Privee"}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#F9FAFB" },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#111827",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  filters: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  filterChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: "#fff",
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+  },
+  filterChipActive: { backgroundColor: "#111827", borderColor: "#111827" },
+  filterChipText: { fontSize: 13, color: "#374151" },
+  filterChipTextActive: { color: "#fff", fontWeight: "600" },
+  listContent: { padding: 16, flexGrow: 1 },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 6,
+    gap: 8,
+  },
+  cardTitle: { flex: 1, fontSize: 15, fontWeight: "600", color: "#111827" },
+  cardStatus: {
+    fontSize: 12,
+    color: "#1F2937",
+    backgroundColor: "#FEF3C7",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+  },
+  cardDescription: { fontSize: 13, color: "#4B5563", marginBottom: 6 },
+  cardMeta: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
+  cardMetaText: { fontSize: 12, color: "#6B7280" },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
+  errorText: { color: "#DC2626", fontSize: 14, marginBottom: 12, textAlign: "center" },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  emptyText: { color: "#6B7280", fontSize: 15, textAlign: "center" },
+});

--- a/apps/mobile/app/lobby.tsx
+++ b/apps/mobile/app/lobby.tsx
@@ -324,6 +324,22 @@ export default function LobbyScreen() {
       </View>
       <View style={styles.actionRow}>
         <Pressable
+          style={styles.cupsButton}
+          onPress={() => router.push("/cups")}
+          testID="lobby-cups-button"
+        >
+          <Text style={styles.actionButtonText}>Coupes</Text>
+        </Pressable>
+        <Pressable
+          style={styles.leaguesButton}
+          onPress={() => router.push("/leagues")}
+          testID="lobby-leagues-button"
+        >
+          <Text style={styles.actionButtonText}>Ligues</Text>
+        </Pressable>
+      </View>
+      <View style={styles.actionRow}>
+        <Pressable
           style={[styles.createButton, createLoading && styles.buttonDisabled]}
           onPress={handleCreate}
           disabled={createLoading}
@@ -545,6 +561,20 @@ const styles = StyleSheet.create({
   joinButton: {
     flex: 1,
     backgroundColor: "#7C3AED",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  cupsButton: {
+    flex: 1,
+    backgroundColor: "#B45309",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  leaguesButton: {
+    flex: 1,
+    backgroundColor: "#0E7490",
     paddingVertical: 12,
     borderRadius: 8,
     alignItems: "center",

--- a/apps/mobile/lib/cups.test.ts
+++ b/apps/mobile/lib/cups.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import {
+  CUP_STATUSES,
+  filterCupsByStatus,
+  formatCupStatusLabel,
+  isValidCupStatus,
+  parseCupDetailResponse,
+  parseCupListResponse,
+  sortCupsByRecent,
+  type Cup,
+  type CupStatus,
+} from "./cups";
+
+function makeCup(overrides: Partial<Cup> = {}): Cup {
+  return {
+    id: "c1",
+    name: "Coupe Test",
+    ruleset: "season_3",
+    status: "ouverte",
+    isPublic: true,
+    creatorId: "u1",
+    creator: { id: "u1", coachName: "Alice", email: "alice@test" },
+    participantCount: 2,
+    participants: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("CUP_STATUSES", () => {
+  it("lists the four cup statuses in display order", () => {
+    expect(CUP_STATUSES).toEqual([
+      "ouverte",
+      "en_cours",
+      "terminee",
+      "archivee",
+    ]);
+  });
+});
+
+describe("isValidCupStatus", () => {
+  it("accepts the known statuses", () => {
+    expect(isValidCupStatus("ouverte")).toBe(true);
+    expect(isValidCupStatus("en_cours")).toBe(true);
+    expect(isValidCupStatus("terminee")).toBe(true);
+    expect(isValidCupStatus("archivee")).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(isValidCupStatus("draft")).toBe(false);
+    expect(isValidCupStatus("")).toBe(false);
+    expect(isValidCupStatus(42)).toBe(false);
+    expect(isValidCupStatus(null)).toBe(false);
+  });
+});
+
+describe("formatCupStatusLabel", () => {
+  it("returns French labels for known statuses", () => {
+    expect(formatCupStatusLabel("ouverte")).toBe("Ouverte");
+    expect(formatCupStatusLabel("en_cours")).toBe("En cours");
+    expect(formatCupStatusLabel("terminee")).toBe("Terminee");
+    expect(formatCupStatusLabel("archivee")).toBe("Archivee");
+  });
+
+  it("echoes unknown status values as-is", () => {
+    expect(formatCupStatusLabel("unknown")).toBe("unknown");
+  });
+});
+
+describe("parseCupListResponse", () => {
+  it("returns an empty list when cups is missing", () => {
+    expect(parseCupListResponse({})).toEqual([]);
+    expect(parseCupListResponse(null)).toEqual([]);
+    expect(parseCupListResponse(undefined)).toEqual([]);
+  });
+
+  it("extracts the cups array from the response envelope", () => {
+    const cups = parseCupListResponse({
+      cups: [
+        {
+          id: "c1",
+          name: "Coupe A",
+          ruleset: "season_3",
+          status: "ouverte",
+          isPublic: true,
+          creatorId: "u1",
+          creator: { id: "u1", coachName: "Alice", email: "alice@test" },
+          participantCount: 4,
+          participants: [],
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-02T00:00:00Z",
+        },
+      ],
+    });
+    expect(cups).toHaveLength(1);
+    expect(cups[0].name).toBe("Coupe A");
+    expect(cups[0].participantCount).toBe(4);
+  });
+
+  it("fills missing optional fields with safe defaults", () => {
+    const cups = parseCupListResponse({
+      cups: [
+        {
+          id: "c1",
+          name: "Partielle",
+          ruleset: "season_2",
+          status: "en_cours",
+          creatorId: "u1",
+        },
+      ],
+    });
+    expect(cups).toHaveLength(1);
+    expect(cups[0].isPublic).toBe(false);
+    expect(cups[0].participantCount).toBe(0);
+    expect(cups[0].participants).toEqual([]);
+    expect(cups[0].creator).toEqual({
+      id: "u1",
+      coachName: "",
+      email: "",
+    });
+  });
+
+  it("filters out entries without an id", () => {
+    const cups = parseCupListResponse({
+      cups: [
+        { name: "Sans id" },
+        null,
+        { id: "ok", name: "OK", ruleset: "season_3", status: "ouverte" },
+      ],
+    });
+    expect(cups).toHaveLength(1);
+    expect(cups[0].id).toBe("ok");
+  });
+});
+
+describe("filterCupsByStatus", () => {
+  const cups = [
+    makeCup({ id: "c1", status: "ouverte" }),
+    makeCup({ id: "c2", status: "en_cours" }),
+    makeCup({ id: "c3", status: "terminee" }),
+    makeCup({ id: "c4", status: "archivee" }),
+  ];
+
+  it("returns all cups when filter is 'all'", () => {
+    expect(filterCupsByStatus(cups, "all")).toHaveLength(4);
+  });
+
+  it("filters to the requested status", () => {
+    expect(filterCupsByStatus(cups, "en_cours").map((c) => c.id)).toEqual([
+      "c2",
+    ]);
+  });
+
+  it("returns an empty list when none match", () => {
+    const noArchives = cups.filter((c) => c.status !== "archivee");
+    expect(filterCupsByStatus(noArchives, "archivee")).toEqual([]);
+  });
+});
+
+describe("sortCupsByRecent", () => {
+  it("sorts cups by updatedAt descending", () => {
+    const sorted = sortCupsByRecent([
+      makeCup({ id: "old", updatedAt: "2026-01-01T00:00:00Z" }),
+      makeCup({ id: "new", updatedAt: "2026-03-01T00:00:00Z" }),
+      makeCup({ id: "mid", updatedAt: "2026-02-01T00:00:00Z" }),
+    ]);
+    expect(sorted.map((c) => c.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      makeCup({ id: "a", updatedAt: "2026-01-01T00:00:00Z" }),
+      makeCup({ id: "b", updatedAt: "2026-02-01T00:00:00Z" }),
+    ];
+    const originalOrder = input.map((c) => c.id);
+    sortCupsByRecent(input);
+    expect(input.map((c) => c.id)).toEqual(originalOrder);
+  });
+
+  it("handles cups with identical updatedAt values deterministically", () => {
+    const same = "2026-01-01T00:00:00Z";
+    const sorted = sortCupsByRecent([
+      makeCup({ id: "a", updatedAt: same }),
+      makeCup({ id: "b", updatedAt: same }),
+    ]);
+    expect(sorted).toHaveLength(2);
+  });
+});
+
+describe("parseCupDetailResponse", () => {
+  it("returns null for empty input", () => {
+    expect(parseCupDetailResponse(null)).toBeNull();
+    expect(parseCupDetailResponse({})).toBeNull();
+  });
+
+  it("parses a well-formed cup with standings and matches", () => {
+    const detail = parseCupDetailResponse({
+      id: "c1",
+      name: "Coupe",
+      ruleset: "season_3",
+      status: "en_cours",
+      isPublic: true,
+      creatorId: "u1",
+      creator: { id: "u1", coachName: "Alice", email: "alice@test" },
+      participantCount: 2,
+      participants: [
+        {
+          id: "t1",
+          name: "Team 1",
+          roster: "skaven",
+          ruleset: "season_3",
+          owner: { id: "u1", coachName: "Alice", email: "alice@test" },
+        },
+      ],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      standings: [
+        { teamId: "t1", points: 3, wins: 1, draws: 0, losses: 0 },
+        { teamId: "t2", points: 0, wins: 0, draws: 0, losses: 1 },
+      ],
+      matches: [
+        { id: "m1", status: "completed" },
+      ],
+    });
+    expect(detail).not.toBeNull();
+    expect(detail?.name).toBe("Coupe");
+    expect(detail?.participants).toHaveLength(1);
+    expect(detail?.standings).toHaveLength(2);
+    expect(detail?.matches).toHaveLength(1);
+  });
+
+  it("defaults missing standings and matches to empty arrays", () => {
+    const detail = parseCupDetailResponse({
+      id: "c1",
+      name: "Coupe",
+      ruleset: "season_3",
+      status: "ouverte",
+      creatorId: "u1",
+    });
+    expect(detail?.standings).toEqual([]);
+    expect(detail?.matches).toEqual([]);
+  });
+});
+
+describe("CupStatus type is exhaustive", () => {
+  it("has formatCupStatusLabel covering every CUP_STATUSES entry", () => {
+    for (const status of CUP_STATUSES) {
+      const typed: CupStatus = status;
+      expect(formatCupStatusLabel(typed)).not.toBe("");
+    }
+  });
+});

--- a/apps/mobile/lib/cups.ts
+++ b/apps/mobile/lib/cups.ts
@@ -1,0 +1,207 @@
+// Pure helpers for the cups screens.
+// Network-free so they can be unit-tested in Node.
+
+export const CUP_STATUSES = [
+  "ouverte",
+  "en_cours",
+  "terminee",
+  "archivee",
+] as const;
+
+export type CupStatus = (typeof CUP_STATUSES)[number];
+export type CupStatusFilter = "all" | CupStatus;
+
+export interface CupCreator {
+  id: string;
+  coachName: string;
+  email: string;
+}
+
+export interface CupParticipant {
+  id: string;
+  name: string;
+  roster: string;
+  ruleset: string;
+  owner: CupCreator;
+}
+
+export interface Cup {
+  id: string;
+  name: string;
+  ruleset: string;
+  status: CupStatus | string;
+  isPublic: boolean;
+  creatorId: string;
+  creator: CupCreator;
+  participantCount: number;
+  participants: CupParticipant[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CupStandingRow {
+  teamId: string;
+  points: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  goalsFor?: number;
+  goalsAgainst?: number;
+}
+
+export interface CupMatchSummary {
+  id: string;
+  status: string;
+}
+
+export interface CupDetail extends Cup {
+  standings: CupStandingRow[];
+  matches: CupMatchSummary[];
+}
+
+const STATUS_LABELS: Record<CupStatus, string> = {
+  ouverte: "Ouverte",
+  en_cours: "En cours",
+  terminee: "Terminee",
+  archivee: "Archivee",
+};
+
+export function isValidCupStatus(value: unknown): value is CupStatus {
+  return (
+    typeof value === "string" && (CUP_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function formatCupStatusLabel(status: string): string {
+  if (isValidCupStatus(status)) {
+    return STATUS_LABELS[status];
+  }
+  return status;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function parseCreator(value: unknown): CupCreator {
+  const raw = (value ?? {}) as Record<string, unknown>;
+  return {
+    id: asString(raw.id, ""),
+    coachName: asString(raw.coachName, ""),
+    email: asString(raw.email, ""),
+  };
+}
+
+function parseParticipant(value: unknown): CupParticipant | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  return {
+    id,
+    name: asString(raw.name, ""),
+    roster: asString(raw.roster, ""),
+    ruleset: asString(raw.ruleset, ""),
+    owner: parseCreator(raw.owner),
+  };
+}
+
+function parseCup(value: unknown): Cup | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  const participantsInput = Array.isArray(raw.participants) ? raw.participants : [];
+  const participants = participantsInput
+    .map(parseParticipant)
+    .filter((p): p is CupParticipant => p !== null);
+  const creatorId = asString(raw.creatorId, "");
+  const creator = parseCreator(raw.creator);
+  if (!creator.id && creatorId) {
+    creator.id = creatorId;
+  }
+  return {
+    id,
+    name: asString(raw.name, ""),
+    ruleset: asString(raw.ruleset, ""),
+    status: asString(raw.status, ""),
+    isPublic: asBoolean(raw.isPublic, false),
+    creatorId,
+    creator,
+    participantCount: asNumber(raw.participantCount, 0),
+    participants,
+    createdAt: asString(raw.createdAt, ""),
+    updatedAt: asString(raw.updatedAt, ""),
+  };
+}
+
+export function parseCupListResponse(response: unknown): Cup[] {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const list = Array.isArray(raw.cups) ? raw.cups : [];
+  return list.map(parseCup).filter((c): c is Cup => c !== null);
+}
+
+export function filterCupsByStatus(
+  cups: ReadonlyArray<Cup>,
+  filter: CupStatusFilter,
+): Cup[] {
+  if (filter === "all") return [...cups];
+  return cups.filter((c) => c.status === filter);
+}
+
+export function sortCupsByRecent(cups: ReadonlyArray<Cup>): Cup[] {
+  return [...cups].sort((a, b) => {
+    if (a.updatedAt === b.updatedAt) return 0;
+    return a.updatedAt < b.updatedAt ? 1 : -1;
+  });
+}
+
+function parseStandingRow(value: unknown): CupStandingRow | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const teamId = asString(raw.teamId, "");
+  if (!teamId) return null;
+  return {
+    teamId,
+    points: asNumber(raw.points, 0),
+    wins: asNumber(raw.wins, 0),
+    draws: asNumber(raw.draws, 0),
+    losses: asNumber(raw.losses, 0),
+    goalsFor: asNumber(raw.goalsFor, 0),
+    goalsAgainst: asNumber(raw.goalsAgainst, 0),
+  };
+}
+
+function parseCupMatch(value: unknown): CupMatchSummary | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  return { id, status: asString(raw.status, "") };
+}
+
+export function parseCupDetailResponse(response: unknown): CupDetail | null {
+  if (!response || typeof response !== "object") return null;
+  const cup = parseCup(response);
+  if (!cup) return null;
+  const raw = response as Record<string, unknown>;
+  const standings = Array.isArray(raw.standings) ? raw.standings : [];
+  const matches = Array.isArray(raw.matches) ? raw.matches : [];
+  return {
+    ...cup,
+    standings: standings
+      .map(parseStandingRow)
+      .filter((s): s is CupStandingRow => s !== null),
+    matches: matches
+      .map(parseCupMatch)
+      .filter((m): m is CupMatchSummary => m !== null),
+  };
+}

--- a/apps/mobile/lib/leagues.test.ts
+++ b/apps/mobile/lib/leagues.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from "vitest";
+import {
+  LEAGUE_STATUSES,
+  LEAGUE_SEASON_STATUSES,
+  filterLeaguesByStatus,
+  formatLeagueStatusLabel,
+  formatLeagueSeasonStatusLabel,
+  formatLeagueRulesetLabel,
+  isValidLeagueStatus,
+  parseLeagueListResponse,
+  parseLeagueDetailResponse,
+  parseSeasonDetailResponse,
+  parseStandingsResponse,
+  type League,
+} from "./leagues";
+
+function makeLeague(overrides: Partial<League> = {}): League {
+  return {
+    id: "l1",
+    name: "Ligue Test",
+    description: null,
+    creatorId: "u1",
+    ruleset: "season_3",
+    status: "open",
+    isPublic: true,
+    maxParticipants: 8,
+    allowedRosters: null,
+    winPoints: 3,
+    drawPoints: 1,
+    lossPoints: 0,
+    forfeitPoints: -1,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("LEAGUE_STATUSES", () => {
+  it("lists the five league statuses in canonical order", () => {
+    expect(LEAGUE_STATUSES).toEqual([
+      "draft",
+      "open",
+      "in_progress",
+      "completed",
+      "archived",
+    ]);
+  });
+});
+
+describe("LEAGUE_SEASON_STATUSES", () => {
+  it("lists the four season statuses", () => {
+    expect(LEAGUE_SEASON_STATUSES).toEqual([
+      "draft",
+      "scheduled",
+      "in_progress",
+      "completed",
+    ]);
+  });
+});
+
+describe("isValidLeagueStatus", () => {
+  it("accepts known statuses", () => {
+    expect(isValidLeagueStatus("draft")).toBe(true);
+    expect(isValidLeagueStatus("archived")).toBe(true);
+  });
+
+  it("rejects unknown or non-string values", () => {
+    expect(isValidLeagueStatus("ouverte")).toBe(false);
+    expect(isValidLeagueStatus(1)).toBe(false);
+    expect(isValidLeagueStatus(null)).toBe(false);
+  });
+});
+
+describe("formatLeagueStatusLabel", () => {
+  it("returns French labels for each known status", () => {
+    expect(formatLeagueStatusLabel("draft")).toBe("Brouillon");
+    expect(formatLeagueStatusLabel("open")).toBe("Ouverte");
+    expect(formatLeagueStatusLabel("in_progress")).toBe("En cours");
+    expect(formatLeagueStatusLabel("completed")).toBe("Terminee");
+    expect(formatLeagueStatusLabel("archived")).toBe("Archivee");
+  });
+
+  it("returns the raw value for unknown statuses", () => {
+    expect(formatLeagueStatusLabel("pending")).toBe("pending");
+  });
+});
+
+describe("formatLeagueSeasonStatusLabel", () => {
+  it("returns French labels for each season status", () => {
+    expect(formatLeagueSeasonStatusLabel("draft")).toBe("Brouillon");
+    expect(formatLeagueSeasonStatusLabel("scheduled")).toBe("Planifiee");
+    expect(formatLeagueSeasonStatusLabel("in_progress")).toBe("En cours");
+    expect(formatLeagueSeasonStatusLabel("completed")).toBe("Terminee");
+  });
+});
+
+describe("formatLeagueRulesetLabel", () => {
+  it("maps season_2 and season_3 to human labels", () => {
+    expect(formatLeagueRulesetLabel("season_2")).toBe("Saison 2");
+    expect(formatLeagueRulesetLabel("season_3")).toBe("Saison 3");
+  });
+
+  it("echoes unknown rulesets", () => {
+    expect(formatLeagueRulesetLabel("custom")).toBe("custom");
+  });
+});
+
+describe("parseLeagueListResponse", () => {
+  it("returns an empty list for empty input", () => {
+    expect(parseLeagueListResponse(null)).toEqual([]);
+    expect(parseLeagueListResponse({})).toEqual([]);
+    expect(parseLeagueListResponse({ leagues: "not-array" })).toEqual([]);
+  });
+
+  it("parses a list of leagues with all fields", () => {
+    const leagues = parseLeagueListResponse({
+      leagues: [
+        {
+          id: "l1",
+          name: "Ligue 1",
+          description: "Ma ligue",
+          creatorId: "u1",
+          ruleset: "season_3",
+          status: "open",
+          isPublic: true,
+          maxParticipants: 8,
+          allowedRosters: ["skaven", "dwarves"],
+          winPoints: 3,
+          drawPoints: 1,
+          lossPoints: 0,
+          forfeitPoints: -1,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-02T00:00:00Z",
+        },
+      ],
+    });
+    expect(leagues).toHaveLength(1);
+    expect(leagues[0].name).toBe("Ligue 1");
+    expect(leagues[0].allowedRosters).toEqual(["skaven", "dwarves"]);
+    expect(leagues[0].winPoints).toBe(3);
+  });
+
+  it("fills missing numeric fields with safe defaults", () => {
+    const leagues = parseLeagueListResponse({
+      leagues: [
+        {
+          id: "l1",
+          name: "Ligue minimale",
+          creatorId: "u1",
+          ruleset: "season_3",
+          status: "draft",
+        },
+      ],
+    });
+    expect(leagues[0].maxParticipants).toBe(0);
+    expect(leagues[0].winPoints).toBe(0);
+    expect(leagues[0].description).toBeNull();
+    expect(leagues[0].allowedRosters).toBeNull();
+  });
+
+  it("drops invalid entries silently", () => {
+    const leagues = parseLeagueListResponse({
+      leagues: [
+        null,
+        { name: "Sans id" },
+        {
+          id: "ok",
+          name: "Ligue OK",
+          creatorId: "u1",
+          ruleset: "season_3",
+          status: "open",
+        },
+      ],
+    });
+    expect(leagues).toHaveLength(1);
+    expect(leagues[0].id).toBe("ok");
+  });
+});
+
+describe("filterLeaguesByStatus", () => {
+  const leagues = [
+    makeLeague({ id: "l1", status: "draft" }),
+    makeLeague({ id: "l2", status: "open" }),
+    makeLeague({ id: "l3", status: "in_progress" }),
+    makeLeague({ id: "l4", status: "completed" }),
+    makeLeague({ id: "l5", status: "archived" }),
+  ];
+
+  it("returns all leagues for 'all'", () => {
+    expect(filterLeaguesByStatus(leagues, "all")).toHaveLength(5);
+  });
+
+  it("filters to a specific status", () => {
+    expect(filterLeaguesByStatus(leagues, "in_progress").map((l) => l.id)).toEqual(
+      ["l3"],
+    );
+  });
+
+  it("returns empty when no league matches", () => {
+    const filtered = filterLeaguesByStatus([], "open");
+    expect(filtered).toEqual([]);
+  });
+});
+
+describe("parseLeagueDetailResponse", () => {
+  it("returns null when league is missing", () => {
+    expect(parseLeagueDetailResponse(null)).toBeNull();
+    expect(parseLeagueDetailResponse({})).toBeNull();
+  });
+
+  it("extracts league and seasons", () => {
+    const detail = parseLeagueDetailResponse({
+      league: {
+        id: "l1",
+        name: "Ligue",
+        creatorId: "u1",
+        creator: { id: "u1", coachName: "Alice", email: "alice@test" },
+        ruleset: "season_3",
+        status: "in_progress",
+        isPublic: true,
+        maxParticipants: 8,
+        allowedRosters: null,
+        winPoints: 3,
+        drawPoints: 1,
+        lossPoints: 0,
+        forfeitPoints: -1,
+        description: null,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+        seasons: [
+          {
+            id: "s1",
+            seasonNumber: 1,
+            name: "Saison 1",
+            status: "in_progress",
+            startDate: null,
+            endDate: null,
+          },
+        ],
+      },
+    });
+    expect(detail?.id).toBe("l1");
+    expect(detail?.seasons).toHaveLength(1);
+    expect(detail?.seasons[0].seasonNumber).toBe(1);
+  });
+
+  it("defaults seasons to empty array when missing", () => {
+    const detail = parseLeagueDetailResponse({
+      league: {
+        id: "l1",
+        name: "Ligue sans saisons",
+        creatorId: "u1",
+        ruleset: "season_3",
+        status: "draft",
+      },
+    });
+    expect(detail?.seasons).toEqual([]);
+  });
+});
+
+describe("parseSeasonDetailResponse", () => {
+  it("returns null for empty input", () => {
+    expect(parseSeasonDetailResponse(null)).toBeNull();
+    expect(parseSeasonDetailResponse({})).toBeNull();
+  });
+
+  it("extracts rounds and participants with defaults", () => {
+    const season = parseSeasonDetailResponse({
+      season: {
+        id: "s1",
+        seasonNumber: 1,
+        name: "Saison 1",
+        status: "in_progress",
+        startDate: null,
+        endDate: null,
+        leagueId: "l1",
+        rounds: [
+          { id: "r1", roundNumber: 1, name: null, status: "pending" },
+        ],
+        participants: [
+          {
+            id: "p1",
+            seasonElo: 1500,
+            status: "active",
+            teamId: "t1",
+            team: {
+              id: "t1",
+              name: "Team 1",
+              roster: "skaven",
+              owner: { id: "u1", coachName: "Alice" },
+            },
+          },
+        ],
+      },
+    });
+    expect(season?.rounds).toHaveLength(1);
+    expect(season?.participants).toHaveLength(1);
+    expect(season?.participants[0].team.name).toBe("Team 1");
+  });
+
+  it("defaults rounds and participants to empty arrays", () => {
+    const season = parseSeasonDetailResponse({
+      season: {
+        id: "s1",
+        seasonNumber: 1,
+        name: "Saison 1",
+        status: "draft",
+        leagueId: "l1",
+      },
+    });
+    expect(season?.rounds).toEqual([]);
+    expect(season?.participants).toEqual([]);
+  });
+});
+
+describe("parseStandingsResponse", () => {
+  it("returns an empty list when input is empty", () => {
+    expect(parseStandingsResponse(null)).toEqual([]);
+    expect(parseStandingsResponse({})).toEqual([]);
+  });
+
+  it("extracts standings with numeric coercion and defaults", () => {
+    const standings = parseStandingsResponse({
+      seasonId: "s1",
+      standings: [
+        {
+          teamId: "t1",
+          points: 9,
+          wins: 3,
+          draws: 0,
+          losses: 0,
+          goalsFor: 12,
+          goalsAgainst: 3,
+        },
+        { teamId: "t2", points: 1, wins: 0, draws: 1, losses: 2 },
+      ],
+    });
+    expect(standings).toHaveLength(2);
+    expect(standings[0].teamId).toBe("t1");
+    expect(standings[0].points).toBe(9);
+    expect(standings[1].goalsFor).toBe(0);
+    expect(standings[1].goalsAgainst).toBe(0);
+  });
+
+  it("drops entries missing a teamId", () => {
+    const standings = parseStandingsResponse({
+      standings: [{ points: 3 }, { teamId: "ok", points: 1 }],
+    });
+    expect(standings).toHaveLength(1);
+    expect(standings[0].teamId).toBe("ok");
+  });
+});

--- a/apps/mobile/lib/leagues.ts
+++ b/apps/mobile/lib/leagues.ts
@@ -1,0 +1,353 @@
+// Pure helpers for the leagues screens.
+// Network-free so they can be unit-tested in Node.
+
+export const LEAGUE_STATUSES = [
+  "draft",
+  "open",
+  "in_progress",
+  "completed",
+  "archived",
+] as const;
+
+export const LEAGUE_SEASON_STATUSES = [
+  "draft",
+  "scheduled",
+  "in_progress",
+  "completed",
+] as const;
+
+export type LeagueStatus = (typeof LEAGUE_STATUSES)[number];
+export type LeagueSeasonStatus = (typeof LEAGUE_SEASON_STATUSES)[number];
+export type LeagueStatusFilter = "all" | LeagueStatus;
+
+export interface League {
+  id: string;
+  name: string;
+  description: string | null;
+  creatorId: string;
+  ruleset: string;
+  status: LeagueStatus | string;
+  isPublic: boolean;
+  maxParticipants: number;
+  allowedRosters: string[] | null;
+  winPoints: number;
+  drawPoints: number;
+  lossPoints: number;
+  forfeitPoints: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LeagueCreator {
+  id: string;
+  coachName: string | null;
+  email: string;
+}
+
+export interface LeagueSeasonSummary {
+  id: string;
+  seasonNumber: number;
+  name: string;
+  status: LeagueSeasonStatus | string;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export interface LeagueDetail extends League {
+  creator: LeagueCreator;
+  seasons: LeagueSeasonSummary[];
+}
+
+export interface LeagueRoundDetail {
+  id: string;
+  roundNumber: number;
+  name: string | null;
+  status: string;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export interface LeagueParticipantDetail {
+  id: string;
+  seasonElo: number;
+  status: string;
+  teamId: string;
+  team: {
+    id: string;
+    name: string;
+    roster: string;
+    owner: { id: string; coachName: string | null };
+  };
+}
+
+export interface LeagueSeasonDetail {
+  id: string;
+  seasonNumber: number;
+  name: string;
+  status: LeagueSeasonStatus | string;
+  startDate: string | null;
+  endDate: string | null;
+  leagueId: string;
+  rounds: LeagueRoundDetail[];
+  participants: LeagueParticipantDetail[];
+}
+
+export interface StandingRow {
+  teamId: string;
+  teamName?: string;
+  points: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  goalsFor: number;
+  goalsAgainst: number;
+}
+
+const STATUS_LABELS: Record<LeagueStatus, string> = {
+  draft: "Brouillon",
+  open: "Ouverte",
+  in_progress: "En cours",
+  completed: "Terminee",
+  archived: "Archivee",
+};
+
+const SEASON_STATUS_LABELS: Record<LeagueSeasonStatus, string> = {
+  draft: "Brouillon",
+  scheduled: "Planifiee",
+  in_progress: "En cours",
+  completed: "Terminee",
+};
+
+const RULESET_LABELS: Record<string, string> = {
+  season_2: "Saison 2",
+  season_3: "Saison 3",
+};
+
+export function isValidLeagueStatus(value: unknown): value is LeagueStatus {
+  return (
+    typeof value === "string" &&
+    (LEAGUE_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function isValidLeagueSeasonStatus(
+  value: unknown,
+): value is LeagueSeasonStatus {
+  return (
+    typeof value === "string" &&
+    (LEAGUE_SEASON_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function formatLeagueStatusLabel(status: string): string {
+  if (isValidLeagueStatus(status)) {
+    return STATUS_LABELS[status];
+  }
+  return status;
+}
+
+export function formatLeagueSeasonStatusLabel(status: string): string {
+  if (isValidLeagueSeasonStatus(status)) {
+    return SEASON_STATUS_LABELS[status];
+  }
+  return status;
+}
+
+export function formatLeagueRulesetLabel(ruleset: string): string {
+  return RULESET_LABELS[ruleset] ?? ruleset;
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNullableString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function parseAllowedRosters(value: unknown): string[] | null {
+  if (value === null || value === undefined) return null;
+  if (!Array.isArray(value)) return null;
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+function parseLeague(value: unknown): League | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  return {
+    id,
+    name: asString(raw.name, ""),
+    description: asNullableString(raw.description),
+    creatorId: asString(raw.creatorId, ""),
+    ruleset: asString(raw.ruleset, ""),
+    status: asString(raw.status, ""),
+    isPublic: asBoolean(raw.isPublic, false),
+    maxParticipants: asNumber(raw.maxParticipants, 0),
+    allowedRosters: parseAllowedRosters(raw.allowedRosters),
+    winPoints: asNumber(raw.winPoints, 0),
+    drawPoints: asNumber(raw.drawPoints, 0),
+    lossPoints: asNumber(raw.lossPoints, 0),
+    forfeitPoints: asNumber(raw.forfeitPoints, 0),
+    createdAt: asString(raw.createdAt, ""),
+    updatedAt: asString(raw.updatedAt, ""),
+  };
+}
+
+export function parseLeagueListResponse(response: unknown): League[] {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const list = Array.isArray(raw.leagues) ? raw.leagues : [];
+  return list.map(parseLeague).filter((l): l is League => l !== null);
+}
+
+export function filterLeaguesByStatus(
+  leagues: ReadonlyArray<League>,
+  filter: LeagueStatusFilter,
+): League[] {
+  if (filter === "all") return [...leagues];
+  return leagues.filter((l) => l.status === filter);
+}
+
+function parseCreator(value: unknown): LeagueCreator {
+  const raw = (value ?? {}) as Record<string, unknown>;
+  return {
+    id: asString(raw.id, ""),
+    coachName: asNullableString(raw.coachName),
+    email: asString(raw.email, ""),
+  };
+}
+
+function parseSeasonSummary(value: unknown): LeagueSeasonSummary | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  return {
+    id,
+    seasonNumber: asNumber(raw.seasonNumber, 0),
+    name: asString(raw.name, ""),
+    status: asString(raw.status, ""),
+    startDate: asNullableString(raw.startDate),
+    endDate: asNullableString(raw.endDate),
+  };
+}
+
+export function parseLeagueDetailResponse(
+  response: unknown,
+): LeagueDetail | null {
+  if (!response || typeof response !== "object") return null;
+  const raw = response as Record<string, unknown>;
+  const league = parseLeague(raw.league);
+  if (!league) return null;
+  const leagueRaw = raw.league as Record<string, unknown>;
+  const seasonsInput = Array.isArray(leagueRaw.seasons) ? leagueRaw.seasons : [];
+  return {
+    ...league,
+    creator: parseCreator(leagueRaw.creator),
+    seasons: seasonsInput
+      .map(parseSeasonSummary)
+      .filter((s): s is LeagueSeasonSummary => s !== null),
+  };
+}
+
+function parseRound(value: unknown): LeagueRoundDetail | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  return {
+    id,
+    roundNumber: asNumber(raw.roundNumber, 0),
+    name: asNullableString(raw.name),
+    status: asString(raw.status, ""),
+    startDate: asNullableString(raw.startDate),
+    endDate: asNullableString(raw.endDate),
+  };
+}
+
+function parseParticipant(value: unknown): LeagueParticipantDetail | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = asString(raw.id, "");
+  if (!id) return null;
+  const teamRaw = (raw.team ?? {}) as Record<string, unknown>;
+  const ownerRaw = (teamRaw.owner ?? {}) as Record<string, unknown>;
+  return {
+    id,
+    seasonElo: asNumber(raw.seasonElo, 0),
+    status: asString(raw.status, ""),
+    teamId: asString(raw.teamId, asString(teamRaw.id, "")),
+    team: {
+      id: asString(teamRaw.id, ""),
+      name: asString(teamRaw.name, ""),
+      roster: asString(teamRaw.roster, ""),
+      owner: {
+        id: asString(ownerRaw.id, ""),
+        coachName: asNullableString(ownerRaw.coachName),
+      },
+    },
+  };
+}
+
+export function parseSeasonDetailResponse(
+  response: unknown,
+): LeagueSeasonDetail | null {
+  if (!response || typeof response !== "object") return null;
+  const raw = response as Record<string, unknown>;
+  const seasonRaw = (raw.season ?? null) as Record<string, unknown> | null;
+  if (!seasonRaw) return null;
+  const id = asString(seasonRaw.id, "");
+  if (!id) return null;
+  const roundsInput = Array.isArray(seasonRaw.rounds) ? seasonRaw.rounds : [];
+  const participantsInput = Array.isArray(seasonRaw.participants)
+    ? seasonRaw.participants
+    : [];
+  return {
+    id,
+    seasonNumber: asNumber(seasonRaw.seasonNumber, 0),
+    name: asString(seasonRaw.name, ""),
+    status: asString(seasonRaw.status, ""),
+    startDate: asNullableString(seasonRaw.startDate),
+    endDate: asNullableString(seasonRaw.endDate),
+    leagueId: asString(seasonRaw.leagueId, ""),
+    rounds: roundsInput
+      .map(parseRound)
+      .filter((r): r is LeagueRoundDetail => r !== null),
+    participants: participantsInput
+      .map(parseParticipant)
+      .filter((p): p is LeagueParticipantDetail => p !== null),
+  };
+}
+
+function parseStandingRow(value: unknown): StandingRow | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const teamId = asString(raw.teamId, "");
+  if (!teamId) return null;
+  return {
+    teamId,
+    teamName: typeof raw.teamName === "string" ? raw.teamName : undefined,
+    points: asNumber(raw.points, 0),
+    wins: asNumber(raw.wins, 0),
+    draws: asNumber(raw.draws, 0),
+    losses: asNumber(raw.losses, 0),
+    goalsFor: asNumber(raw.goalsFor, 0),
+    goalsAgainst: asNumber(raw.goalsAgainst, 0),
+  };
+}
+
+export function parseStandingsResponse(response: unknown): StandingRow[] {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const list = Array.isArray(raw.standings) ? raw.standings : [];
+  return list.map(parseStandingRow).filter((s): s is StandingRow => s !== null);
+}


### PR DESCRIPTION
## Resume

- Ajoute les ecrans mobiles Coupes et Ligues (M.8, Sprint 18-19).
- Helpers purs `lib/cups.ts` et `lib/leagues.ts` avec 44 tests vitest couvrant parsing, filtres et labels.
- Nouveaux ecrans Expo Router : `cups/index`, `cups/archived`, `cups/[id]`, `leagues/index`, `leagues/[id]`.
- Branchement dans `_layout.tsx` et ajout de boutons d'acces depuis le lobby.

## Tache roadmap

Sprint 18-19, tache M.8 — Ecrans cups/ligues (Mobile).

## Plan de test

- [x] `pnpm --filter @bb/mobile test` — 180/180 (dont 44 nouveaux)
- [x] `pnpm --filter @bb/web test` — 254/254 (non touche, regression check)
- [ ] Test manuel sur Expo Go (ecran coupes : liste + filtres + detail + archivees)
- [ ] Test manuel sur Expo Go (ecran ligues : liste + onglets saison + classement)
- [ ] Verifier navigation arriere depuis detail vers liste
- [ ] Verifier l'etat vide quand aucune coupe/ligue

https://claude.ai/code/session_011xAWz3uLnZWBsBRdbbkchK