### PR TITLE
feat(mobile): M.9 push notifications natives via Expo

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -317,7 +317,7 @@
 | M.6 | Ecran leaderboard | Mobile | [x] |
 | M.7 | Ecran replay de match | Mobile | [x] |
 | M.8 | Ecrans cups/ligues | Mobile | [x] |
-| M.9 | Push notifications natives (Expo Notifications) | Mobile | [ ] |
+| M.9 | Push notifications natives (Expo Notifications) | Mobile | [x] |
 | M.10 | Details joueur et progression | Mobile | [ ] |
 | M.11 | Catalogue Star Players mobile | Mobile | [ ] |
 | M.12 | Profil et settings mobile | Mobile | [ ] |

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -5,6 +5,18 @@
     "scheme": "nuffle-arena",
     "version": "0.1.0",
     "orientation": "portrait",
-    "sdkVersion": "51.0.0"
+    "sdkVersion": "51.0.0",
+    "notification": {
+      "iosDisplayInForeground": true,
+      "androidMode": "default"
+    },
+    "plugins": [
+      [
+        "expo-notifications",
+        {
+          "color": "#ffffff"
+        }
+      ]
+    ]
   }
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,11 +1,32 @@
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
+import { useCallback } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { AuthProvider } from "../lib/auth-context";
+import { AuthProvider, useAuth } from "../lib/auth-context";
+import { useExpoPushRegistration } from "../lib/use-expo-push";
+
+function PushRegistration() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const handleNavigate = useCallback(
+    (path: string) => {
+      // expo-router accepts relative/absolute paths; cast only because the
+      // generic signature expects a typed route union.
+      router.push(path as never);
+    },
+    [router],
+  );
+  useExpoPushRegistration({
+    enabled: user !== null,
+    onNavigate: handleNavigate,
+  });
+  return null;
+}
 
 export default function Layout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AuthProvider>
+        <PushRegistration />
         <Stack>
           <Stack.Screen name="index" options={{ title: "Nuffle Arena" }} />
           <Stack.Screen name="lobby" options={{ title: "Mes matchs" }} />

--- a/apps/mobile/lib/expo-push.test.ts
+++ b/apps/mobile/lib/expo-push.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  isExpoPushToken,
+  buildSubscribePayload,
+  parseNotificationData,
+  resolveNavigationRoute,
+  EXPO_PUSH_API,
+  type NotificationData,
+} from "./expo-push";
+
+describe("isExpoPushToken", () => {
+  it("accepts ExponentPushToken format", () => {
+    expect(isExpoPushToken("ExponentPushToken[abc123xyz]")).toBe(true);
+  });
+
+  it("accepts ExpoPushToken format (shorter prefix)", () => {
+    expect(isExpoPushToken("ExpoPushToken[abc123xyz]")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isExpoPushToken("")).toBe(false);
+  });
+
+  it("rejects plain random string", () => {
+    expect(isExpoPushToken("random-token-abc")).toBe(false);
+  });
+
+  it("rejects tokens without closing bracket", () => {
+    expect(isExpoPushToken("ExponentPushToken[abc")).toBe(false);
+  });
+
+  it("rejects tokens with empty payload", () => {
+    expect(isExpoPushToken("ExponentPushToken[]")).toBe(false);
+  });
+
+  it("rejects web-push endpoint URLs", () => {
+    expect(isExpoPushToken("https://push.example.com/sub/abc")).toBe(false);
+  });
+});
+
+describe("buildSubscribePayload", () => {
+  it("normalises platform to ios/android/web", () => {
+    expect(
+      buildSubscribePayload("ExponentPushToken[abc]", "ios").platform,
+    ).toBe("ios");
+    expect(
+      buildSubscribePayload("ExponentPushToken[abc]", "android").platform,
+    ).toBe("android");
+    expect(
+      buildSubscribePayload("ExponentPushToken[abc]", "web").platform,
+    ).toBe("web");
+  });
+
+  it("defaults unknown platforms to 'unknown'", () => {
+    expect(
+      buildSubscribePayload("ExponentPushToken[abc]", "symbian").platform,
+    ).toBe("unknown");
+  });
+
+  it("keeps the token verbatim", () => {
+    const payload = buildSubscribePayload("ExponentPushToken[abc]", "ios");
+    expect(payload.token).toBe("ExponentPushToken[abc]");
+  });
+});
+
+describe("parseNotificationData", () => {
+  it("extracts a turn notification from {kind, matchId}", () => {
+    const data: NotificationData = parseNotificationData({
+      kind: "turn",
+      matchId: "match-abc",
+    });
+    expect(data.kind).toBe("turn");
+    expect(data.matchId).toBe("match-abc");
+  });
+
+  it("extracts a matchFound notification", () => {
+    const data = parseNotificationData({
+      kind: "matchFound",
+      matchId: "match-xyz",
+    });
+    expect(data.kind).toBe("matchFound");
+    expect(data.matchId).toBe("match-xyz");
+  });
+
+  it("falls back to 'unknown' for malformed payloads", () => {
+    expect(parseNotificationData(null).kind).toBe("unknown");
+    expect(parseNotificationData(undefined).kind).toBe("unknown");
+    expect(parseNotificationData(42).kind).toBe("unknown");
+    expect(parseNotificationData({}).kind).toBe("unknown");
+  });
+
+  it("preserves the url when provided", () => {
+    const data = parseNotificationData({
+      kind: "turn",
+      matchId: "m1",
+      url: "/play/m1",
+    });
+    expect(data.url).toBe("/play/m1");
+  });
+
+  it("ignores unknown 'kind' values and marks them unknown", () => {
+    const data = parseNotificationData({ kind: "explosion", matchId: "m1" });
+    expect(data.kind).toBe("unknown");
+  });
+
+  it("rejects non-string matchId", () => {
+    const data = parseNotificationData({ kind: "turn", matchId: 42 });
+    expect(data.matchId).toBeUndefined();
+  });
+});
+
+describe("resolveNavigationRoute", () => {
+  it("maps turn notifications to /play/[id]", () => {
+    expect(
+      resolveNavigationRoute({ kind: "turn", matchId: "abc" }),
+    ).toBe("/play/abc");
+  });
+
+  it("maps matchFound notifications to /play/[id]", () => {
+    expect(
+      resolveNavigationRoute({ kind: "matchFound", matchId: "abc" }),
+    ).toBe("/play/abc");
+  });
+
+  it("prefers an explicit url when valid", () => {
+    expect(
+      resolveNavigationRoute({
+        kind: "turn",
+        matchId: "abc",
+        url: "/replay/abc",
+      }),
+    ).toBe("/replay/abc");
+  });
+
+  it("rejects external URLs to prevent open-redirect", () => {
+    expect(
+      resolveNavigationRoute({
+        kind: "turn",
+        matchId: "abc",
+        url: "https://evil.example.com/phish",
+      }),
+    ).toBe("/play/abc");
+  });
+
+  it("returns null when no matchId and no url (unknown)", () => {
+    expect(resolveNavigationRoute({ kind: "unknown" })).toBeNull();
+  });
+
+  it("returns null if matchId contains path separators", () => {
+    expect(
+      resolveNavigationRoute({ kind: "turn", matchId: "abc/../etc" }),
+    ).toBeNull();
+  });
+});
+
+describe("EXPO_PUSH_API", () => {
+  it("points at the official Expo push endpoint", () => {
+    expect(EXPO_PUSH_API).toBe("https://exp.host/--/api/v2/push/send");
+  });
+});

--- a/apps/mobile/lib/expo-push.ts
+++ b/apps/mobile/lib/expo-push.ts
@@ -1,0 +1,99 @@
+// Pure helpers for Expo Push Notifications.
+// Kept free of expo-notifications imports so they can be unit-tested in Node.
+
+export const EXPO_PUSH_API = "https://exp.host/--/api/v2/push/send";
+
+export type NotificationKind = "turn" | "matchFound" | "unknown";
+
+export type Platform = "ios" | "android" | "web" | "unknown";
+
+export interface NotificationData {
+  kind: NotificationKind;
+  matchId?: string;
+  url?: string;
+}
+
+export interface ExpoSubscribePayload {
+  token: string;
+  platform: Platform;
+}
+
+const EXPO_TOKEN_RE = /^(?:Exponent|Expo)PushToken\[[^\]]+\]$/;
+
+export function isExpoPushToken(token: string): boolean {
+  if (!token) return false;
+  return EXPO_TOKEN_RE.test(token);
+}
+
+const KNOWN_PLATFORMS: readonly Platform[] = ["ios", "android", "web"] as const;
+
+function normalisePlatform(raw: string): Platform {
+  return (KNOWN_PLATFORMS as readonly string[]).includes(raw)
+    ? (raw as Platform)
+    : "unknown";
+}
+
+export function buildSubscribePayload(
+  token: string,
+  platform: string,
+): ExpoSubscribePayload {
+  return {
+    token,
+    platform: normalisePlatform(platform),
+  };
+}
+
+const VALID_KINDS: readonly NotificationKind[] = [
+  "turn",
+  "matchFound",
+] as const;
+
+function isValidKind(value: unknown): value is "turn" | "matchFound" {
+  return (
+    typeof value === "string" &&
+    (VALID_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function extractString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function parseNotificationData(raw: unknown): NotificationData {
+  if (!raw || typeof raw !== "object") {
+    return { kind: "unknown" };
+  }
+  const obj = raw as Record<string, unknown>;
+  const kind: NotificationKind = isValidKind(obj.kind) ? obj.kind : "unknown";
+  const matchId = extractString(obj.matchId);
+  const url = extractString(obj.url);
+  return { kind, matchId, url };
+}
+
+// Allow only relative paths that cannot escape the app (no scheme, no parent
+// traversal, no protocol-relative URL). This prevents push payloads from
+// redirecting users to arbitrary hosts when tapped.
+function isSafeInternalPath(url: string): boolean {
+  if (!url.startsWith("/")) return false;
+  if (url.startsWith("//")) return false;
+  if (url.includes("..")) return false;
+  return true;
+}
+
+function isSafeMatchId(matchId: string): boolean {
+  return !matchId.includes("/") && !matchId.includes("..");
+}
+
+export function resolveNavigationRoute(
+  data: NotificationData,
+): string | null {
+  if (data.url && isSafeInternalPath(data.url)) {
+    return data.url;
+  }
+  if (data.matchId && isSafeMatchId(data.matchId)) {
+    if (data.kind === "turn" || data.kind === "matchFound") {
+      return `/play/${data.matchId}`;
+    }
+  }
+  return null;
+}

--- a/apps/mobile/lib/use-expo-push.ts
+++ b/apps/mobile/lib/use-expo-push.ts
@@ -1,0 +1,116 @@
+// React hook wiring expo-notifications with the server push API.
+// The pure/testable helpers live in ./expo-push.ts; this file contains the
+// platform glue that depends on native modules and cannot run under vitest.
+
+import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
+import * as Notifications from "expo-notifications";
+import { apiPost } from "./api";
+import {
+  isExpoPushToken,
+  parseNotificationData,
+  resolveNavigationRoute,
+} from "./expo-push";
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+async function ensureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== "android") return;
+  await Notifications.setNotificationChannelAsync("default", {
+    name: "default",
+    importance: Notifications.AndroidImportance.HIGH,
+    vibrationPattern: [0, 250, 250, 250],
+  });
+}
+
+async function requestPermissions(): Promise<boolean> {
+  const existing = await Notifications.getPermissionsAsync();
+  if (existing.status === "granted") return true;
+  const requested = await Notifications.requestPermissionsAsync();
+  return requested.status === "granted";
+}
+
+async function getTokenOrNull(): Promise<string | null> {
+  try {
+    const res = await Notifications.getExpoPushTokenAsync();
+    return isExpoPushToken(res.data) ? res.data : null;
+  } catch {
+    return null;
+  }
+}
+
+type PlatformOption = "ios" | "android" | "web";
+
+function currentPlatform(): PlatformOption {
+  if (Platform.OS === "ios") return "ios";
+  if (Platform.OS === "android") return "android";
+  return "web";
+}
+
+export interface ExpoPushRegistrationOptions {
+  enabled: boolean;
+  onNavigate?: (path: string) => void;
+}
+
+export function useExpoPushRegistration({
+  enabled,
+  onNavigate,
+}: ExpoPushRegistrationOptions): void {
+  const tokenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (Platform.OS === "web") return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        await ensureAndroidChannel();
+        const granted = await requestPermissions();
+        if (!granted || cancelled) return;
+        const token = await getTokenOrNull();
+        if (!token || cancelled) return;
+        tokenRef.current = token;
+        await apiPost("/push/expo-subscribe", {
+          token,
+          platform: currentPlatform(),
+        });
+      } catch {
+        // Registration is best-effort; silently ignore failures.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!onNavigate) return;
+    const sub = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        const data = parseNotificationData(
+          response.notification.request.content.data,
+        );
+        const route = resolveNavigationRoute(data);
+        if (route) onNavigate(route);
+      },
+    );
+    return () => sub.remove();
+  }, [onNavigate]);
+}
+
+export async function unregisterExpoPush(token: string): Promise<void> {
+  try {
+    await apiPost("/push/expo-unsubscribe", { token });
+  } catch {
+    // Ignore — best effort
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@bb/game-engine": "workspace:*",
     "expo": "^51.0.28",
+    "expo-notifications": "~0.28.19",
     "expo-router": "^3.4.8",
     "expo-secure-store": "~13.0.2",
     "react": "18.3.1",

--- a/apps/server/src/routes/push.ts
+++ b/apps/server/src/routes/push.ts
@@ -5,11 +5,16 @@ import {
   pushSubscribeSchema,
   pushUnsubscribeSchema,
   pushPreferencesSchema,
+  expoPushSubscribeSchema,
+  expoPushUnsubscribeSchema,
 } from "../schemas/push.schemas";
 import {
   addSubscription,
   removeSubscription,
   getVapidPublicKey,
+  addExpoSubscription,
+  removeExpoSubscription,
+  type ExpoPlatform,
 } from "../services/push-notifications";
 import {
   getNotificationPreferences,
@@ -98,6 +103,47 @@ router.put(
     } catch {
       return res.status(500).json({ error: "Erreur serveur" });
     }
+  },
+);
+
+/**
+ * POST /push/expo-subscribe
+ * Register an Expo push token (mobile device) for the authenticated user.
+ * Body: { token: "ExponentPushToken[...]", platform: "ios" | "android" | "web" }
+ */
+router.post(
+  "/expo-subscribe",
+  authUser,
+  validate(expoPushSubscribeSchema),
+  (req: AuthenticatedRequest, res) => {
+    const { token, platform } = req.body as {
+      token: string;
+      platform: ExpoPlatform;
+    };
+    const ok = addExpoSubscription(req.user!.id, { token, platform });
+    if (!ok) {
+      return res.status(400).json({ error: "Token Expo invalide" });
+    }
+    return res.json({ ok: true });
+  },
+);
+
+/**
+ * POST /push/expo-unsubscribe
+ * Remove an Expo push token for the authenticated user.
+ * Body: { token: "ExponentPushToken[...]" }
+ */
+router.post(
+  "/expo-unsubscribe",
+  authUser,
+  validate(expoPushUnsubscribeSchema),
+  (req: AuthenticatedRequest, res) => {
+    const { token } = req.body as { token: string };
+    const removed = removeExpoSubscription(req.user!.id, token);
+    if (!removed) {
+      return res.status(404).json({ error: "Abonnement non trouve" });
+    }
+    return res.json({ ok: true });
   },
 );
 

--- a/apps/server/src/schemas/push.schemas.ts
+++ b/apps/server/src/schemas/push.schemas.ts
@@ -17,3 +17,25 @@ export const pushPreferencesSchema = z.object({
   turnNotification: z.boolean().optional(),
   matchFoundNotification: z.boolean().optional(),
 });
+
+// Expo Push tokens follow the `ExponentPushToken[...]` / `ExpoPushToken[...]`
+// format. We validate the exact shape to reject arbitrary strings and
+// protect the in-memory store from garbage values.
+export const expoPushSubscribeSchema = z.object({
+  token: z
+    .string()
+    .regex(
+      /^(?:Exponent|Expo)PushToken\[[^\]]+\]$/,
+      "token Expo invalide",
+    ),
+  platform: z.enum(["ios", "android", "web"]),
+});
+
+export const expoPushUnsubscribeSchema = z.object({
+  token: z
+    .string()
+    .regex(
+      /^(?:Exponent|Expo)PushToken\[[^\]]+\]$/,
+      "token Expo invalide",
+    ),
+});

--- a/apps/server/src/services/expo-push-notifications.test.ts
+++ b/apps/server/src/services/expo-push-notifications.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock web-push before importing (same as push-notifications.test.ts so the
+// shared module state remains consistent).
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn().mockResolvedValue({ statusCode: 201 }),
+    generateVAPIDKeys: vi.fn().mockReturnValue({
+      publicKey: "test-public-key",
+      privateKey: "test-private-key",
+    }),
+  },
+}));
+
+vi.mock("./notification-preferences", () => ({
+  shouldSendNotification: vi.fn().mockResolvedValue(true),
+  NotificationType: { Turn: "turn", MatchFound: "matchFound" },
+}));
+
+import {
+  addExpoSubscription,
+  removeExpoSubscription,
+  getExpoSubscriptions,
+  clearExpoSubscriptions,
+  sendExpoPushToUser,
+  sendTurnPush,
+  sendMatchFoundPush,
+  clearSubscriptions,
+} from "./push-notifications";
+
+describe("Expo push notifications", () => {
+  const userId = "user-123";
+  const expoToken = "ExponentPushToken[abc123xyz]";
+
+  beforeEach(() => {
+    clearSubscriptions();
+    clearExpoSubscriptions();
+    vi.clearAllMocks();
+  });
+
+  describe("addExpoSubscription", () => {
+    it("stores an Expo push token for a user", () => {
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+      expect(getExpoSubscriptions(userId)).toHaveLength(1);
+      expect(getExpoSubscriptions(userId)[0]).toEqual({
+        token: expoToken,
+        platform: "ios",
+      });
+    });
+
+    it("keeps multiple tokens for the same user (multiple devices)", () => {
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+      addExpoSubscription(userId, {
+        token: "ExponentPushToken[second]",
+        platform: "android",
+      });
+      expect(getExpoSubscriptions(userId)).toHaveLength(2);
+    });
+
+    it("replaces entries with the same token (re-register)", () => {
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+      addExpoSubscription(userId, { token: expoToken, platform: "android" });
+      const subs = getExpoSubscriptions(userId);
+      expect(subs).toHaveLength(1);
+      expect(subs[0].platform).toBe("android");
+    });
+
+    it("rejects malformed tokens (returns false)", () => {
+      const ok = addExpoSubscription(userId, {
+        token: "not-a-token",
+        platform: "ios",
+      });
+      expect(ok).toBe(false);
+      expect(getExpoSubscriptions(userId)).toHaveLength(0);
+    });
+  });
+
+  describe("removeExpoSubscription", () => {
+    it("removes a stored Expo token", () => {
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+      expect(removeExpoSubscription(userId, expoToken)).toBe(true);
+      expect(getExpoSubscriptions(userId)).toHaveLength(0);
+    });
+
+    it("returns false when the token is unknown", () => {
+      expect(
+        removeExpoSubscription(userId, "ExponentPushToken[missing]"),
+      ).toBe(false);
+    });
+  });
+
+  describe("sendExpoPushToUser", () => {
+    it("returns sent=0/failed=0 when user has no Expo subscriptions", async () => {
+      const result = await sendExpoPushToUser(userId, {
+        title: "Test",
+        body: "No subs",
+      });
+      expect(result).toEqual({ sent: 0, failed: 0 });
+    });
+
+    it("POSTs to the Expo push API for each token", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: { status: "ok", id: "receipt-1" } }),
+            { status: 200 },
+          ),
+        );
+
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+
+      const result = await sendExpoPushToUser(userId, {
+        title: "Nuffle Arena",
+        body: "C'est votre tour !",
+        url: "/play/match-abc",
+      });
+
+      expect(result.sent).toBe(1);
+      expect(result.failed).toBe(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const call = fetchMock.mock.calls[0];
+      expect(call[0]).toBe("https://exp.host/--/api/v2/push/send");
+      expect(call[1]?.method).toBe("POST");
+      const headers = call[1]?.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect(headers["Accept"]).toBe("application/json");
+      const body = JSON.parse((call[1]?.body as string) ?? "{}");
+      expect(body.to).toBe(expoToken);
+      expect(body.title).toBe("Nuffle Arena");
+      expect(body.body).toBe("C'est votre tour !");
+      expect(body.data?.url).toBe("/play/match-abc");
+      expect(body.sound).toBe("default");
+      fetchMock.mockRestore();
+    });
+
+    it("removes the token on DeviceNotRegistered error", async () => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: {
+              status: "error",
+              message:
+                '"ExponentPushToken[abc123xyz]" is not a registered push notification recipient',
+              details: { error: "DeviceNotRegistered" },
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+
+      const result = await sendExpoPushToUser(userId, {
+        title: "Test",
+        body: "Expired",
+      });
+
+      expect(result.sent).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(getExpoSubscriptions(userId)).toHaveLength(0);
+      fetchMock.mockRestore();
+    });
+
+    it("keeps the token on transient network errors", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("network down"));
+
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+
+      const result = await sendExpoPushToUser(userId, {
+        title: "Test",
+        body: "Network",
+      });
+
+      expect(result.sent).toBe(0);
+      expect(result.failed).toBe(1);
+      expect(getExpoSubscriptions(userId)).toHaveLength(1);
+      fetchMock.mockRestore();
+    });
+  });
+
+  describe("sendTurnPush / sendMatchFoundPush with Expo tokens", () => {
+    it("sendTurnPush also sends to Expo subscriptions", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: { status: "ok", id: "r1" } }),
+            { status: 200 },
+          ),
+        );
+      addExpoSubscription(userId, { token: expoToken, platform: "android" });
+
+      sendTurnPush(userId, "match-xyz");
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(fetchMock).toHaveBeenCalled();
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0][1]?.body as string) ?? "{}",
+      );
+      expect(body.to).toBe(expoToken);
+      expect(body.data).toMatchObject({
+        kind: "turn",
+        matchId: "match-xyz",
+        url: "/play/match-xyz",
+      });
+      fetchMock.mockRestore();
+    });
+
+    it("sendMatchFoundPush also sends to Expo subscriptions", async () => {
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: { status: "ok", id: "r1" } }),
+            { status: 200 },
+          ),
+        );
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+
+      sendMatchFoundPush(userId, "match-found-1");
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(fetchMock).toHaveBeenCalled();
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0][1]?.body as string) ?? "{}",
+      );
+      expect(body.to).toBe(expoToken);
+      expect(body.data).toMatchObject({
+        kind: "matchFound",
+        matchId: "match-found-1",
+      });
+      fetchMock.mockRestore();
+    });
+
+    it("preference gating applies to Expo pushes too", async () => {
+      const { shouldSendNotification } = await import(
+        "./notification-preferences"
+      );
+      vi.mocked(shouldSendNotification).mockResolvedValueOnce(false);
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      addExpoSubscription(userId, { token: expoToken, platform: "ios" });
+
+      sendTurnPush(userId, "match-gated");
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      fetchMock.mockRestore();
+    });
+  });
+});

--- a/apps/server/src/services/push-notifications.test.ts
+++ b/apps/server/src/services/push-notifications.test.ts
@@ -27,11 +27,13 @@ import {
   getVapidPublicKey,
   sendTurnPush,
   sendMatchFoundPush,
+  clearExpoSubscriptions,
 } from "./push-notifications";
 
 describe("push-notifications", () => {
   beforeEach(() => {
     clearSubscriptions();
+    clearExpoSubscriptions();
     vi.clearAllMocks();
   });
 
@@ -232,6 +234,11 @@ describe("push-notifications", () => {
         icon: "/images/favicon-optimized.png",
         url: "/play/match-def",
         tag: "match-found-match-def",
+        data: {
+          kind: "matchFound",
+          matchId: "match-def",
+          url: "/play/match-def",
+        },
       });
     });
 

--- a/apps/server/src/services/push-notifications.ts
+++ b/apps/server/src/services/push-notifications.ts
@@ -48,6 +48,26 @@ export interface PushPayload {
   badge?: string;
   url?: string;
   tag?: string;
+  data?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Expo Push (mobile) types
+// ---------------------------------------------------------------------------
+
+export type ExpoPlatform = "ios" | "android" | "web" | "unknown";
+
+export interface ExpoSubscriptionData {
+  token: string;
+  platform: ExpoPlatform;
+}
+
+export const EXPO_PUSH_API = "https://exp.host/--/api/v2/push/send";
+
+const EXPO_TOKEN_RE = /^(?:Exponent|Expo)PushToken\[[^\]]+\]$/;
+
+export function isValidExpoPushToken(token: string): boolean {
+  return !!token && EXPO_TOKEN_RE.test(token);
 }
 
 // ---------------------------------------------------------------------------
@@ -90,6 +110,52 @@ export function getSubscriptions(userId: string): PushSubscriptionData[] {
 
 export function clearSubscriptions(): void {
   subscriptions.clear();
+}
+
+// ---------------------------------------------------------------------------
+// In-memory Expo push token store (per user, multiple devices)
+// ---------------------------------------------------------------------------
+
+const expoSubscriptions = new Map<string, ExpoSubscriptionData[]>();
+
+export function addExpoSubscription(
+  userId: string,
+  sub: ExpoSubscriptionData,
+): boolean {
+  if (!isValidExpoPushToken(sub.token)) {
+    return false;
+  }
+  const userSubs = expoSubscriptions.get(userId) ?? [];
+  const filtered = userSubs.filter((s) => s.token !== sub.token);
+  filtered.push(sub);
+  expoSubscriptions.set(userId, filtered);
+  return true;
+}
+
+export function removeExpoSubscription(
+  userId: string,
+  token: string,
+): boolean {
+  const userSubs = expoSubscriptions.get(userId);
+  if (!userSubs) return false;
+  const filtered = userSubs.filter((s) => s.token !== token);
+  if (filtered.length === userSubs.length) return false;
+  if (filtered.length === 0) {
+    expoSubscriptions.delete(userId);
+  } else {
+    expoSubscriptions.set(userId, filtered);
+  }
+  return true;
+}
+
+export function getExpoSubscriptions(
+  userId: string,
+): ExpoSubscriptionData[] {
+  return expoSubscriptions.get(userId) ?? [];
+}
+
+export function clearExpoSubscriptions(): void {
+  expoSubscriptions.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -146,6 +212,97 @@ export function getVapidPublicKey(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Expo Push delivery (native mobile)
+// ---------------------------------------------------------------------------
+
+interface ExpoPushResponse {
+  data?: {
+    status: "ok" | "error";
+    id?: string;
+    message?: string;
+    details?: { error?: string };
+  };
+  errors?: unknown[];
+}
+
+function buildExpoBody(
+  token: string,
+  payload: PushPayload,
+): Record<string, unknown> {
+  const data: Record<string, unknown> = { ...(payload.data ?? {}) };
+  if (payload.url && !("url" in data)) data.url = payload.url;
+  return {
+    to: token,
+    title: payload.title,
+    body: payload.body,
+    data,
+    sound: "default",
+    priority: "high",
+    channelId: "default",
+  };
+}
+
+async function sendToExpo(
+  token: string,
+  payload: PushPayload,
+): Promise<{ ok: boolean; unregistered: boolean }> {
+  try {
+    const res = await fetch(EXPO_PUSH_API, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(buildExpoBody(token, payload)),
+    });
+    if (!res.ok) {
+      return { ok: false, unregistered: false };
+    }
+    const json = (await res.json().catch(() => ({}))) as ExpoPushResponse;
+    if (json.data?.status === "ok") {
+      return { ok: true, unregistered: false };
+    }
+    const errCode = json.data?.details?.error;
+    const unregistered =
+      errCode === "DeviceNotRegistered" || errCode === "InvalidCredentials";
+    return { ok: false, unregistered };
+  } catch {
+    return { ok: false, unregistered: false };
+  }
+}
+
+export async function sendExpoPushToUser(
+  userId: string,
+  payload: PushPayload,
+): Promise<{ sent: number; failed: number }> {
+  const subs = getExpoSubscriptions(userId);
+  if (subs.length === 0) return { sent: 0, failed: 0 };
+
+  let sent = 0;
+  let failed = 0;
+  const tokensToRemove: string[] = [];
+
+  const results = await Promise.all(
+    subs.map((s) => sendToExpo(s.token, payload)),
+  );
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.ok) {
+      sent++;
+    } else {
+      failed++;
+      if (result.unregistered) tokensToRemove.push(subs[i].token);
+    }
+  }
+
+  for (const token of tokensToRemove) {
+    removeExpoSubscription(userId, token);
+  }
+
+  return { sent, failed };
+}
+
+// ---------------------------------------------------------------------------
 // Game-specific push helpers
 // ---------------------------------------------------------------------------
 
@@ -156,15 +313,21 @@ export function getVapidPublicKey(): string {
  */
 export function sendTurnPush(userId: string, matchId: string): void {
   shouldSendNotification(userId, NotificationType.Turn)
-    .then((allowed) => {
+    .then(async (allowed) => {
       if (!allowed) return;
-      return sendPushToUser(userId, {
+      const url = `/play/${matchId}`;
+      const payload: PushPayload = {
         title: "Nuffle Arena",
         body: "C'est votre tour de jouer !",
         icon: "/images/favicon-optimized.png",
-        url: `/play/${matchId}`,
+        url,
         tag: `turn-${matchId}`,
-      });
+        data: { kind: "turn", matchId, url },
+      };
+      await Promise.all([
+        sendPushToUser(userId, payload),
+        sendExpoPushToUser(userId, payload),
+      ]);
     })
     .catch(() => {
       // Push failure is non-blocking
@@ -178,15 +341,21 @@ export function sendTurnPush(userId: string, matchId: string): void {
  */
 export function sendMatchFoundPush(userId: string, matchId: string): void {
   shouldSendNotification(userId, NotificationType.MatchFound)
-    .then((allowed) => {
+    .then(async (allowed) => {
       if (!allowed) return;
-      return sendPushToUser(userId, {
+      const url = `/play/${matchId}`;
+      const payload: PushPayload = {
         title: "Nuffle Arena",
         body: "Un adversaire a ete trouve !",
         icon: "/images/favicon-optimized.png",
-        url: `/play/${matchId}`,
+        url,
         tag: `match-found-${matchId}`,
-      });
+        data: { kind: "matchFound", matchId, url },
+      };
+      await Promise.all([
+        sendPushToUser(userId, payload),
+        sendExpoPushToUser(userId, payload),
+      ]);
     })
     .catch(() => {
       // Push failure is non-blocking

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       expo:
         specifier: ^51.0.28
         version: 51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)
+      expo-notifications:
+        specifier: ~0.28.19
+        version: 0.28.19(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1))
       expo-router:
         specifier: ^3.4.8
         version: 3.5.24(4lt33gfxbfjjwmbzhiuanutprq)
@@ -1584,7 +1587,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -1713,6 +1716,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@inquirer/external-editor@1.0.1':
     resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
@@ -2974,6 +2980,9 @@ packages:
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -3042,6 +3051,9 @@ packages:
 
   babel-preset-expo@11.0.15:
     resolution: {integrity: sha512-rgiMTYwqIPULaO7iZdqyL7aAff9QLOX6OWUtLZBlOrOTreGY1yHah/5+l8MvI6NVc/8Zj5LY4Y5uMSnJIuzTLw==}
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -4024,6 +4036,11 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  expo-application@5.9.1:
+    resolution: {integrity: sha512-uAfLBNZNahnDZLRU41ZFmNSKtetHUT9Ua557/q189ua0AWV7pQjoVAx49E4953feuvqc9swtU3ScZ/hN1XO/FQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@10.0.10:
     resolution: {integrity: sha512-0qoTIihB79k+wGus9wy0JMKq7DdenziVx3iUkGvMAy2azscSgWH6bd2gJ9CGnhC6JRd3qTMFBL0ou/fx7WZl7A==}
     peerDependencies:
@@ -4067,6 +4084,11 @@ packages:
 
   expo-modules-core@1.12.26:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
+
+  expo-notifications@0.28.19:
+    resolution: {integrity: sha512-rKKTnVQQ9XNQyTNwKmI9OlchhVu0XOZfRpImMqPFCJg6IwECM1izdas2SLCbE/GApg2Tw3U5R2fd26OnCtUU/w==}
+    peerDependencies:
+      expo: '*'
 
   expo-router@3.5.24:
     resolution: {integrity: sha512-wFi+PIUrOntF5cgg0PgBMlkxEZlWedIv5dWnPFEzN6Tr3A3bpsqdDLgOEIwvwd+pxn5DLzykTmg9EkQ1pPGspw==}
@@ -4793,6 +4815,10 @@ packages:
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
     engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.3:
@@ -9509,6 +9535,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@ide/backoff@1.0.0': {}
+
   '@inquirer/external-editor@1.0.1(@types/node@22.18.0)':
     dependencies:
       chardet: 2.1.0
@@ -11160,6 +11188,14 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types@0.15.2:
@@ -11252,6 +11288,8 @@ snapshots:
       - '@babel/core'
       - '@babel/preset-env'
       - supports-color
+
+  badgin@1.2.3: {}
 
   balanced-match@1.0.2: {}
 
@@ -12450,6 +12488,10 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  expo-application@5.9.1(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)):
+    dependencies:
+      expo: 51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)
+
   expo-asset@10.0.10(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)):
     dependencies:
       expo: 51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)
@@ -12512,6 +12554,21 @@ snapshots:
   expo-modules-core@1.12.26:
     dependencies:
       invariant: 2.2.4
+
+  expo-notifications@0.28.19(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)):
+    dependencies:
+      '@expo/image-utils': 0.5.1
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1)
+      expo-application: 5.9.1(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1))
+      expo-constants: 16.0.2(expo@51.0.39(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.3.1)(typescript@5.9.2))(react@18.3.1))
+      fs-extra: 9.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   expo-router@3.5.24(4lt33gfxbfjjwmbzhiuanutprq):
     dependencies:
@@ -13350,6 +13407,11 @@ snapshots:
       is-glob: 2.0.1
 
   is-map@2.0.3: {}
+
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
 


### PR DESCRIPTION
## Resume
- Ajoute le support **Expo Notifications** cote mobile (iOS/Android) a cote du web-push existant.
- L'utilisateur authentifie est enregistre automatiquement aupres de l'API Expo Push et recoit "c'est votre tour" / "match trouve". Un tap ouvre le match.
- Le backend envoie desormais en parallele sur web-push ET Expo pour chaque utilisateur ; nettoyage automatique sur `DeviceNotRegistered`.

## Changements principaux
- `apps/mobile/lib/expo-push.ts` : helpers purs (validation du token Expo, parsing de payload, resolution d'URL interne safe).
- `apps/mobile/lib/use-expo-push.ts` : hook React qui demande la permission, recupere le token via `expo-notifications` et l'envoie au backend. Ecoute aussi les taps et route vers `/play/[id]` ou l'URL fournie.
- `apps/mobile/app/_layout.tsx` : wiring dans `AuthProvider`, l'enregistrement ne s'active qu'apres connexion.
- `apps/mobile/app.json` + `apps/mobile/package.json` : plugin Expo Notifications + nouvelle dependance `expo-notifications`.
- `apps/server/src/services/push-notifications.ts` : store in-memory des tokens Expo, `sendExpoPushToUser` via `fetch` direct (`https://exp.host/--/api/v2/push/send`), integration dans `sendTurnPush` / `sendMatchFoundPush`.
- `apps/server/src/routes/push.ts` : `/push/expo-subscribe` et `/push/expo-unsubscribe` (auth + validation Zod).

## Securite
- `resolveNavigationRoute` rejette les URLs externes, protocol-relative, et les `matchId` avec `..` ou `/`.
- Les tokens sont valides cote serveur par regex `^(?:Exponent|Expo)PushToken\[[^\]]+\]$` avant stockage.
- Aucun secret expose ; les notifications passent par l'API publique Expo (pas de cle requise en dev).

## Tache roadmap
Sprint 18-19 — **M.9 Push notifications natives (Expo Notifications)** (cochee dans `TODO.md`).

## Plan de test
- [x] `pnpm --filter @bb/mobile test` — 203 tests passent (dont 23 nouveaux sur `expo-push`)
- [x] `pnpm --filter @bb/server test` — 575 tests passent (dont 13 nouveaux sur Expo push)
- [x] `pnpm typecheck` — server/web/ui/game-engine OK
- [x] `pnpm lint` — 0 errors sur les fichiers nouveaux
- [ ] Verification sur appareil reel : tester la demande de permission iOS/Android, reception du push quand c'est votre tour, tap sur la notification qui ouvre `/play/[id]`
- [ ] Verifier le nettoyage automatique d'un token `DeviceNotRegistered` (reinstaller l'app)

## Note build
Le build `@bb/web` echoue dans l'environnement sandboxe (erreur `SELF_SIGNED_CERT_IN_CHAIN` sur `fonts.googleapis.com`). Preexistant et non lie a cette PR — les builds `@bb/server`, `@bb/ui`, `@bb/game-engine` passent.
