### PR TITLE
feat: passage du mode alpha au mode beta ouvert à tous

### DIFF
--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -44,6 +44,7 @@ router.post("/register", validate(registerSchema), async (req, res) => {
         lastName: lastName && lastName !== "" ? lastName : null,
         dateOfBirth:
           dateOfBirth && dateOfBirth !== "" ? new Date(dateOfBirth) : null,
+        valid: true,
       },
     });
 
@@ -62,16 +63,6 @@ router.post("/register", validate(registerSchema), async (req, res) => {
       valid: created.valid,
       createdAt: created.createdAt,
     };
-
-    // Si l'inscription nécessite la modération admin (valid=false en prod),
-    // on ne retourne pas de token : le compte devra être validé avant login.
-    if (created.valid === false) {
-      return res.status(201).json({
-        user: publicUser,
-        message:
-          "Votre compte a bien été créé. Il doit être validé par un administrateur avant que vous puissiez vous connecter.",
-      });
-    }
 
     const token = jwt.sign(
       { sub: created.id, role: primaryRole, roles },

--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -35,6 +35,7 @@ export const translations = {
     },
     // Home page
     home: {
+      betaBanner: "Version BÊTA ouverte à tous — vos comptes, équipes et matchs sont désormais conservés.",
       title: "L'arène où le hasard devient divin.",
       description: "Plateforme digitale pour créer et gérer vos équipes Blood Bowl. Construisez vos rosters, recrutez des Star Players légendaires, et exportez vos équipes en PDF.",
       subtitle: "Conformité aux règles officielles Blood Bowl 2025 : 28 rosters disponibles, gestion complète des budgets, trésorerie, et export PDF pour vos parties.",
@@ -533,6 +534,7 @@ export const translations = {
     },
     // Home page
     home: {
+      betaBanner: "BETA version open to everyone — your accounts, teams, and matches are now preserved.",
       title: "The arena where chance becomes divine.",
       description: "Digital platform to create and manage your Blood Bowl teams. Build your rosters, recruit legendary Star Players, and export your teams as PDF.",
       subtitle: "Compliance with official Blood Bowl 2025 rules: 28 available rosters, complete budget management, treasury, and PDF export for your games.",

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -13,14 +13,14 @@ export default function LandingPage() {
     <>
       <HomeStructuredData />
       <div className="min-h-screen">
-      {/* Beta Warning Banner */}
-      <section className="w-full bg-gradient-to-r from-amber-500 via-amber-600 to-amber-500 text-white py-3 px-6 shadow-lg">
+      {/* Beta Launch Banner */}
+      <section className="w-full bg-gradient-to-r from-emerald-600 via-emerald-700 to-emerald-600 text-white py-3 px-6 shadow-lg">
         <div className="max-w-7xl mx-auto flex items-center justify-center gap-2 text-center">
-          <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+          <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
           </svg>
           <p className="font-semibold text-sm md:text-base">
-            <span className="font-bold">Version BETA</span> - Les données sont susceptibles d'être modifiées ou supprimées sans préavis
+            {t.home.betaBanner}
           </p>
         </div>
       </section>


### PR DESCRIPTION
- Remplace le bandeau d'avertissement alpha (données susceptibles
  d'être supprimées) par un bandeau de lancement bêta vert :
  accès ouvert à tous, comptes/équipes/matchs désormais conservés.
- Clés i18n betaBanner ajoutées en FR et EN.
- Suppression de la porte d'approbation admin à l'inscription : les
  nouveaux comptes sont créés avec valid=true et reçoivent leur JWT
  immédiatement. Le soft-delete côté /auth/me et le rejet des comptes
  désactivés au login restent inchangés.