### PR TITLE
feat(mobile): M.10 ecran details joueur et progression

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -318,7 +318,7 @@
 | M.7 | Ecran replay de match | Mobile | [x] |
 | M.8 | Ecrans cups/ligues | Mobile | [x] |
 | M.9 | Push notifications natives (Expo Notifications) | Mobile | [x] |
-| M.10 | Details joueur et progression | Mobile | [ ] |
+| M.10 | Details joueur et progression | Mobile | [x] |
 | M.11 | Catalogue Star Players mobile | Mobile | [ ] |
 | M.12 | Profil et settings mobile | Mobile | [ ] |
 

--- a/apps/mobile/app/player/[teamId]/[playerId].tsx
+++ b/apps/mobile/app/player/[teamId]/[playerId].tsx
@@ -1,0 +1,431 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../../lib/api";
+import { useAuth } from "../../../lib/auth-context";
+import {
+  canAffordAdvancement,
+  computeInjurySummary,
+  computePlayerStatus,
+  formatAdvancementType,
+  formatSpp,
+  formatStatValue,
+  getEffectiveStat,
+  getNextAdvancementOptions,
+  parsePlayerAdvancements,
+  type StatKey,
+  type TeamPlayerWithProgression,
+} from "../../../lib/player-details";
+
+const STATS: Array<{ key: StatKey; label: string }> = [
+  { key: "ma", label: "MA" },
+  { key: "st", label: "ST" },
+  { key: "ag", label: "AG" },
+  { key: "pa", label: "PA" },
+  { key: "av", label: "AV" },
+];
+
+export default function PlayerDetailScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const params = useLocalSearchParams<{ teamId: string; playerId: string }>();
+  const teamId = params.teamId;
+  const playerId = params.playerId;
+
+  const [player, setPlayer] = useState<TeamPlayerWithProgression | null>(null);
+  const [teamName, setTeamName] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPlayer = useCallback(async () => {
+    if (!teamId || !playerId) return;
+    try {
+      const data = await apiGet(`/team/${teamId}`);
+      const team = data?.team;
+      if (!team) {
+        setError("Equipe introuvable");
+        return;
+      }
+      setTeamName(team.name ?? "");
+      const match: TeamPlayerWithProgression | undefined = (
+        team.players ?? []
+      ).find((p: TeamPlayerWithProgression) => p.id === playerId);
+      if (!match) {
+        setError("Joueur introuvable");
+        return;
+      }
+      setPlayer(match);
+      setError(null);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [teamId, playerId, router, logout]);
+
+  useEffect(() => {
+    fetchPlayer().finally(() => setLoading(false));
+  }, [fetchPlayer]);
+
+  const advancements = useMemo(
+    () => (player ? parsePlayerAdvancements(player.advancements) : []),
+    [player],
+  );
+
+  const options = useMemo(
+    () => getNextAdvancementOptions(advancements.length),
+    [advancements.length],
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error || !player) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>{error ?? "Joueur introuvable"}</Text>
+        <Pressable
+          onPress={() => (teamId ? router.replace(`/teams/${teamId}`) : router.back())}
+          style={styles.linkButton}
+        >
+          <Text style={styles.linkButtonText}>Retour a l&apos;equipe</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const injuries = computeInjurySummary(player);
+  const status = computePlayerStatus(player);
+
+  return (
+    <ScrollView
+      style={styles.flex}
+      contentContainerStyle={styles.scrollContent}
+    >
+      <View style={styles.header}>
+        <Text style={styles.playerName}>
+          #{player.number} {player.name}
+        </Text>
+        <Text style={styles.subtitle}>
+          {player.position} — {teamName}
+        </Text>
+        <View style={[styles.badge, statusStyle(status)]}>
+          <Text style={styles.badgeText}>{status}</Text>
+        </View>
+      </View>
+
+      <Section title="Caracteristiques">
+        <View style={styles.statRow}>
+          {STATS.map((s) => {
+            const effective = getEffectiveStat(player, s.key);
+            const base = player[s.key] ?? 0;
+            const reduced = effective !== base;
+            return (
+              <View key={s.key} style={styles.statCell}>
+                <Text style={styles.statLabel}>{s.label}</Text>
+                <Text
+                  style={[styles.statValue, reduced && styles.statReduced]}
+                >
+                  {formatStatValue(s.key, effective)}
+                </Text>
+                {reduced && (
+                  <Text style={styles.statBase}>
+                    base {formatStatValue(s.key, base)}
+                  </Text>
+                )}
+              </View>
+            );
+          })}
+        </View>
+      </Section>
+
+      <Section title="Progression">
+        <InfoRow label="SPP disponibles" value={formatSpp(player.spp)} />
+        <InfoRow
+          label="Matchs joues"
+          value={String(player.matchesPlayed ?? 0)}
+        />
+        <InfoRow
+          label="Touchdowns"
+          value={String(player.totalTouchdowns ?? 0)}
+        />
+        <InfoRow
+          label="Sorties infligees"
+          value={String(player.totalCasualties ?? 0)}
+        />
+        <InfoRow
+          label="Passes reussies"
+          value={String(player.totalCompletions ?? 0)}
+        />
+        <InfoRow
+          label="Interceptions"
+          value={String(player.totalInterceptions ?? 0)}
+        />
+        <InfoRow
+          label="MVP"
+          value={String(player.totalMvpAwards ?? 0)}
+        />
+        <InfoRow
+          label="Avancements pris"
+          value={String(advancements.length)}
+        />
+      </Section>
+
+      <Section title="Competences">
+        {player.skills ? (
+          <Text style={styles.skillsText}>{player.skills}</Text>
+        ) : (
+          <Text style={styles.empty}>Aucune competence acquise</Text>
+        )}
+      </Section>
+
+      <Section title="Avancements acquis">
+        {advancements.length === 0 ? (
+          <Text style={styles.empty}>Aucun avancement pour l&apos;instant</Text>
+        ) : (
+          advancements.map((adv, idx) => (
+            <InfoRow
+              key={`${adv.skillSlug}-${idx}`}
+              label={`${idx + 1}. ${adv.skillSlug}`}
+              value={formatAdvancementType(adv.type)}
+            />
+          ))
+        )}
+      </Section>
+
+      <Section title="Prochain avancement">
+        {player.dead ? (
+          <Text style={styles.empty}>Joueur decede — aucune progression</Text>
+        ) : (
+          options.map((opt) => {
+            const affordable = canAffordAdvancement(player.spp, opt.sppCost);
+            return (
+              <View key={opt.type} style={styles.row}>
+                <Text style={styles.rowLabel}>{opt.label}</Text>
+                <Text
+                  style={[
+                    styles.rowValue,
+                    affordable ? styles.rowAffordable : styles.rowLocked,
+                  ]}
+                >
+                  {opt.sppCost} SPP {affordable ? "✓" : "✗"}
+                </Text>
+              </View>
+            );
+          })
+        )}
+      </Section>
+
+      <Section title="Blessures & statut">
+        {injuries.length === 0 ? (
+          <Text style={styles.empty}>Aucune blessure persistante</Text>
+        ) : (
+          injuries.map((entry, idx) => (
+            <Text key={idx} style={styles.injuryItem}>
+              • {entry}
+            </Text>
+          ))
+        )}
+      </Section>
+
+      <Pressable onPress={() => router.back()} style={styles.backButton}>
+        <Text style={styles.backText}>Retour</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue}>{value}</Text>
+    </View>
+  );
+}
+
+function statusStyle(status: string) {
+  if (status === "Decede") return styles.badgeDead;
+  if (status === "Absent prochain match") return styles.badgeWarn;
+  if (status === "Blesse") return styles.badgeInjured;
+  return styles.badgeOk;
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: "#F9FAFB" },
+  scrollContent: { padding: 16, paddingBottom: 32 },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    backgroundColor: "#F9FAFB",
+  },
+  header: { marginBottom: 16 },
+  playerName: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    marginTop: 2,
+  },
+  badge: {
+    alignSelf: "flex-start",
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    marginTop: 8,
+  },
+  badgeText: {
+    color: "#fff",
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+  badgeOk: { backgroundColor: "#22C55E" },
+  badgeWarn: { backgroundColor: "#F59E0B" },
+  badgeInjured: { backgroundColor: "#EA580C" },
+  badgeDead: { backgroundColor: "#991B1B" },
+  section: {
+    backgroundColor: "#fff",
+    padding: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+  },
+  statRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  statCell: {
+    alignItems: "center",
+    flex: 1,
+    paddingVertical: 4,
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#6B7280",
+    fontWeight: "600",
+    marginBottom: 2,
+  },
+  statValue: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  statReduced: {
+    color: "#B91C1C",
+  },
+  statBase: {
+    fontSize: 10,
+    color: "#9CA3AF",
+    marginTop: 1,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F3F4F6",
+  },
+  rowLabel: {
+    fontSize: 13,
+    color: "#374151",
+  },
+  rowValue: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  rowAffordable: {
+    color: "#047857",
+  },
+  rowLocked: {
+    color: "#9CA3AF",
+  },
+  skillsText: {
+    fontSize: 13,
+    color: "#111827",
+    lineHeight: 18,
+  },
+  empty: {
+    fontSize: 13,
+    color: "#9CA3AF",
+    fontStyle: "italic",
+  },
+  injuryItem: {
+    fontSize: 13,
+    color: "#B91C1C",
+    paddingVertical: 2,
+  },
+  backButton: {
+    paddingVertical: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  backText: {
+    color: "#6B7280",
+    fontSize: 14,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  linkButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  linkButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/teams/[id].tsx
+++ b/apps/mobile/app/teams/[id].tsx
@@ -239,9 +239,27 @@ export default function TeamDetailScreen() {
           {positions.length === 0 ? (
             <Text style={styles.empty}>Aucun joueur recrute</Text>
           ) : (
-            positions.map((p) => (
-              <InfoRow key={p.position} label={p.position} value={`x${p.count}`} />
-            ))
+            <>
+              {positions.map((p) => (
+                <InfoRow
+                  key={p.position}
+                  label={p.position}
+                  value={`x${p.count}`}
+                />
+              ))}
+              {(team.players ?? []).map((p) => (
+                <Pressable
+                  key={p.id}
+                  onPress={() => router.push(`/player/${team.id}/${p.id}`)}
+                  style={styles.row}
+                >
+                  <Text style={styles.rowLabel}>
+                    #{p.number} {p.name}
+                  </Text>
+                  <Text style={styles.rowValue}>{p.position} ›</Text>
+                </Pressable>
+              ))}
+            </>
           )}
         </Section>
 

--- a/apps/mobile/lib/player-details.test.ts
+++ b/apps/mobile/lib/player-details.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePlayerAdvancements,
+  formatSpp,
+  formatStatValue,
+  getEffectiveStat,
+  getNextAdvancementOptions,
+  canAffordAdvancement,
+  computeInjurySummary,
+  computePlayerStatus,
+  formatAdvancementType,
+  type TeamPlayerWithProgression,
+} from "./player-details";
+
+function buildPlayer(
+  overrides: Partial<TeamPlayerWithProgression> = {},
+): TeamPlayerWithProgression {
+  return {
+    id: "p1",
+    name: "Grot",
+    position: "Lineman",
+    number: 1,
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 9,
+    skills: "",
+    spp: 0,
+    totalTouchdowns: 0,
+    totalCasualties: 0,
+    totalCompletions: 0,
+    totalInterceptions: 0,
+    totalMvpAwards: 0,
+    matchesPlayed: 0,
+    nigglingInjuries: 0,
+    maReduction: 0,
+    stReduction: 0,
+    agReduction: 0,
+    paReduction: 0,
+    avReduction: 0,
+    missNextMatch: false,
+    advancements: "[]",
+    dead: false,
+    ...overrides,
+  };
+}
+
+describe("parsePlayerAdvancements", () => {
+  it("returns an empty array for an empty or default string", () => {
+    expect(parsePlayerAdvancements("")).toEqual([]);
+    expect(parsePlayerAdvancements("[]")).toEqual([]);
+  });
+
+  it("parses a valid JSON array of advancements", () => {
+    const raw = JSON.stringify([
+      { skillSlug: "block", type: "primary", isRandom: false, at: 1 },
+      { skillSlug: "dodge", type: "random-secondary", isRandom: true, at: 2 },
+    ]);
+    const parsed = parsePlayerAdvancements(raw);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].skillSlug).toBe("block");
+    expect(parsed[1].type).toBe("random-secondary");
+  });
+
+  it("returns an empty array on invalid JSON", () => {
+    expect(parsePlayerAdvancements("not json")).toEqual([]);
+    expect(parsePlayerAdvancements("{}")).toEqual([]);
+  });
+
+  it("ignores non-array payloads", () => {
+    expect(parsePlayerAdvancements(JSON.stringify({ foo: "bar" }))).toEqual([]);
+  });
+});
+
+describe("formatSpp", () => {
+  it("formats SPP as a simple string", () => {
+    expect(formatSpp(0)).toBe("0 SPP");
+    expect(formatSpp(12)).toBe("12 SPP");
+  });
+
+  it("handles undefined or null as zero", () => {
+    expect(formatSpp(undefined)).toBe("0 SPP");
+    expect(formatSpp(null)).toBe("0 SPP");
+  });
+});
+
+describe("formatStatValue", () => {
+  it("formats PA as /+ (target value) for Blood Bowl stats", () => {
+    expect(formatStatValue("pa", 4)).toBe("4+");
+    expect(formatStatValue("ag", 3)).toBe("3+");
+  });
+
+  it("formats MA/ST/AV as plain numbers", () => {
+    expect(formatStatValue("ma", 6)).toBe("6");
+    expect(formatStatValue("st", 3)).toBe("3");
+    expect(formatStatValue("av", 9)).toBe("9+");
+  });
+
+  it("renders missing PA as '-'", () => {
+    expect(formatStatValue("pa", 0)).toBe("-");
+  });
+});
+
+describe("getEffectiveStat", () => {
+  it("subtracts reductions from the base value", () => {
+    const player = buildPlayer({ ma: 7, maReduction: 2 });
+    expect(getEffectiveStat(player, "ma")).toBe(5);
+  });
+
+  it("floors at 1 when the reduction exceeds the base", () => {
+    const player = buildPlayer({ st: 3, stReduction: 5 });
+    expect(getEffectiveStat(player, "st")).toBe(1);
+  });
+
+  it("returns the base value when no reduction is present", () => {
+    const player = buildPlayer({ av: 9, avReduction: 0 });
+    expect(getEffectiveStat(player, "av")).toBe(9);
+  });
+});
+
+describe("getNextAdvancementOptions", () => {
+  it("returns the 4 advancement types with their SPP costs for a rookie", () => {
+    const options = getNextAdvancementOptions(0);
+    expect(options).toHaveLength(4);
+    const primary = options.find((o) => o.type === "primary");
+    const secondary = options.find((o) => o.type === "secondary");
+    const randomPrimary = options.find((o) => o.type === "random-primary");
+    const randomSecondary = options.find((o) => o.type === "random-secondary");
+    expect(primary?.sppCost).toBe(6);
+    expect(secondary?.sppCost).toBe(12);
+    expect(randomPrimary?.sppCost).toBe(3);
+    expect(randomSecondary?.sppCost).toBe(6);
+  });
+
+  it("increases the cost for later advancements", () => {
+    const options = getNextAdvancementOptions(2);
+    const primary = options.find((o) => o.type === "primary");
+    // 3rd advancement cost for primary = 12
+    expect(primary?.sppCost).toBe(12);
+  });
+
+  it("caps at the 6th advancement cost", () => {
+    const options = getNextAdvancementOptions(10);
+    const primary = options.find((o) => o.type === "primary");
+    expect(primary?.sppCost).toBe(30);
+  });
+});
+
+describe("canAffordAdvancement", () => {
+  it("returns true when SPP >= cost", () => {
+    expect(canAffordAdvancement(6, 6)).toBe(true);
+    expect(canAffordAdvancement(20, 6)).toBe(true);
+  });
+
+  it("returns false when SPP < cost", () => {
+    expect(canAffordAdvancement(5, 6)).toBe(false);
+    expect(canAffordAdvancement(0, 3)).toBe(false);
+  });
+});
+
+describe("computeInjurySummary", () => {
+  it("returns an empty list when the player is healthy", () => {
+    const player = buildPlayer();
+    expect(computeInjurySummary(player)).toEqual([]);
+  });
+
+  it("reports niggling injuries", () => {
+    const player = buildPlayer({ nigglingInjuries: 2 });
+    expect(computeInjurySummary(player)).toEqual([
+      "Blessures persistantes : 2",
+    ]);
+  });
+
+  it("reports stat reductions and miss-next-match", () => {
+    const player = buildPlayer({
+      maReduction: 1,
+      avReduction: 1,
+      missNextMatch: true,
+    });
+    const summary = computeInjurySummary(player);
+    expect(summary).toContain("MA -1");
+    expect(summary).toContain("AV -1");
+    expect(summary).toContain("Absent au prochain match");
+  });
+});
+
+describe("computePlayerStatus", () => {
+  it("returns 'Decede' for a dead player", () => {
+    expect(computePlayerStatus(buildPlayer({ dead: true }))).toBe("Decede");
+  });
+
+  it("returns 'Absent prochain match' when flagged", () => {
+    expect(
+      computePlayerStatus(buildPlayer({ missNextMatch: true })),
+    ).toBe("Absent prochain match");
+  });
+
+  it("returns 'Blesse' when there are persistent injuries", () => {
+    expect(
+      computePlayerStatus(buildPlayer({ nigglingInjuries: 1 })),
+    ).toBe("Blesse");
+  });
+
+  it("returns 'Apte' for a healthy player", () => {
+    expect(computePlayerStatus(buildPlayer())).toBe("Apte");
+  });
+
+  it("prioritises death over other statuses", () => {
+    const player = buildPlayer({
+      dead: true,
+      nigglingInjuries: 3,
+      missNextMatch: true,
+    });
+    expect(computePlayerStatus(player)).toBe("Decede");
+  });
+});
+
+describe("formatAdvancementType", () => {
+  it("returns a French label for each advancement type", () => {
+    expect(formatAdvancementType("primary")).toBe("Primaire");
+    expect(formatAdvancementType("secondary")).toBe("Secondaire");
+    expect(formatAdvancementType("random-primary")).toBe(
+      "Primaire aleatoire",
+    );
+    expect(formatAdvancementType("random-secondary")).toBe(
+      "Secondaire aleatoire",
+    );
+  });
+});

--- a/apps/mobile/lib/player-details.ts
+++ b/apps/mobile/lib/player-details.ts
@@ -1,0 +1,175 @@
+// Pure helpers for the mobile player detail screen (M.10).
+// Network-free so they can be unit-tested in node.
+
+import type { AdvancementType, PlayerAdvancement } from "@bb/game-engine";
+import type { TeamPlayer } from "./teams";
+
+export type { AdvancementType, PlayerAdvancement };
+
+// Mirror of packages/game-engine/src/utils/advancements.ts SPP_COST_TABLE.
+// Inlined locally because mobile's vitest/metro resolve @bb/game-engine as
+// the built package (types only) — runtime values are duplicated to keep the
+// mobile helper dependency-free.
+const SPP_COST_TABLE: Record<AdvancementType, readonly number[]> = {
+  primary: [0, 6, 8, 12, 16, 20, 30],
+  secondary: [0, 12, 14, 18, 22, 26, 40],
+  "random-primary": [0, 3, 4, 6, 8, 10, 15],
+  "random-secondary": [0, 6, 8, 12, 16, 20, 30],
+};
+
+export function getNextAdvancementPspCost(
+  alreadyTaken: number,
+  type: AdvancementType,
+): number {
+  const next = Math.min(Math.max(alreadyTaken + 1, 1), 6);
+  return SPP_COST_TABLE[type][next];
+}
+
+export interface TeamPlayerWithProgression extends TeamPlayer {
+  spp: number;
+  totalTouchdowns: number;
+  totalCasualties: number;
+  totalCompletions: number;
+  totalInterceptions: number;
+  totalMvpAwards: number;
+  matchesPlayed: number;
+  nigglingInjuries: number;
+  maReduction: number;
+  stReduction: number;
+  agReduction: number;
+  paReduction: number;
+  avReduction: number;
+  missNextMatch: boolean;
+  advancements: string;
+  dead: boolean;
+}
+
+export type StatKey = "ma" | "st" | "ag" | "pa" | "av";
+
+export interface AdvancementOption {
+  type: AdvancementType;
+  sppCost: number;
+  label: string;
+}
+
+export function parsePlayerAdvancements(raw: string): PlayerAdvancement[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(
+    (entry): entry is PlayerAdvancement =>
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as PlayerAdvancement).skillSlug === "string" &&
+      typeof (entry as PlayerAdvancement).type === "string",
+  );
+}
+
+export function formatSpp(spp: number | null | undefined): string {
+  const value = spp ?? 0;
+  return `${value} SPP`;
+}
+
+export function formatStatValue(stat: StatKey, value: number): string {
+  if (stat === "pa") {
+    return value > 0 ? `${value}+` : "-";
+  }
+  if (stat === "ag" || stat === "av") {
+    return `${value}+`;
+  }
+  return String(value);
+}
+
+const REDUCTION_KEYS: Record<StatKey, keyof TeamPlayerWithProgression> = {
+  ma: "maReduction",
+  st: "stReduction",
+  ag: "agReduction",
+  pa: "paReduction",
+  av: "avReduction",
+};
+
+export function getEffectiveStat(
+  player: TeamPlayerWithProgression,
+  stat: StatKey,
+): number {
+  const base = player[stat] ?? 0;
+  const reduction = (player[REDUCTION_KEYS[stat]] as number) ?? 0;
+  return Math.max(1, base - reduction);
+}
+
+const ADVANCEMENT_LABELS: Record<AdvancementType, string> = {
+  primary: "Primaire",
+  secondary: "Secondaire",
+  "random-primary": "Primaire aleatoire",
+  "random-secondary": "Secondaire aleatoire",
+};
+
+export function formatAdvancementType(type: AdvancementType): string {
+  return ADVANCEMENT_LABELS[type];
+}
+
+const ORDERED_TYPES: AdvancementType[] = [
+  "primary",
+  "secondary",
+  "random-primary",
+  "random-secondary",
+];
+
+export function getNextAdvancementOptions(
+  advancementsCount: number,
+): AdvancementOption[] {
+  return ORDERED_TYPES.map((type) => ({
+    type,
+    sppCost: getNextAdvancementPspCost(advancementsCount, type),
+    label: ADVANCEMENT_LABELS[type],
+  }));
+}
+
+export function canAffordAdvancement(spp: number, cost: number): boolean {
+  return spp >= cost;
+}
+
+export function computeInjurySummary(
+  player: TeamPlayerWithProgression,
+): string[] {
+  const summary: string[] = [];
+  if (player.nigglingInjuries > 0) {
+    summary.push(`Blessures persistantes : ${player.nigglingInjuries}`);
+  }
+  const reductions: Array<[StatKey, number]> = [
+    ["ma", player.maReduction ?? 0],
+    ["st", player.stReduction ?? 0],
+    ["ag", player.agReduction ?? 0],
+    ["pa", player.paReduction ?? 0],
+    ["av", player.avReduction ?? 0],
+  ];
+  for (const [key, reduction] of reductions) {
+    if (reduction > 0) {
+      summary.push(`${key.toUpperCase()} -${reduction}`);
+    }
+  }
+  if (player.missNextMatch) {
+    summary.push("Absent au prochain match");
+  }
+  return summary;
+}
+
+export type PlayerStatus =
+  | "Decede"
+  | "Absent prochain match"
+  | "Blesse"
+  | "Apte";
+
+export function computePlayerStatus(
+  player: TeamPlayerWithProgression,
+): PlayerStatus {
+  if (player.dead) return "Decede";
+  if (player.missNextMatch) return "Absent prochain match";
+  if ((player.nigglingInjuries ?? 0) > 0) return "Blesse";
+  return "Apte";
+}


### PR DESCRIPTION
## Resume
- Nouvel ecran mobile `/player/[teamId]/[playerId]` affichant la fiche detaillee d'un joueur : caracteristiques effectives (avec reductions de blessure visualisees), statut (apte/blesse/absent/decede), stats de carriere (SPP, TD, sorties, passes, interceptions, MVP), competences, avancements acquis, options du prochain avancement (primaire/secondaire + aleatoires) avec cout SPP et indicateur d'eligibilite, et blessures persistantes.
- Helpers purs `apps/mobile/lib/player-details.ts` couverts par **26 tests unitaires** (parse des avancements, format SPP, stat effective, cout du prochain avancement, statut joueur, resume des blessures).
- La liste des joueurs sur la fiche d'equipe (`/teams/[id]`) devient cliquable et ouvre la fiche detaillee.

## Tache roadmap
Sprint 18-19, tache **M.10 — Details joueur et progression**.

## Plan de test
- [x] `pnpm --filter @bb/mobile test` — 229 tests passent (dont 26 nouveaux sur `player-details`)
- [x] `pnpm typecheck` — OK
- [x] `pnpm lint` — OK (0 errors)
- [ ] Verifier manuellement en simulateur Expo : navigation depuis `/teams/[id]` → `/player/[teamId]/[playerId]`, affichage des stats, reductions de caracteristique, prochain avancement, indicateurs d'eligibilite SPP
- [ ] Verifier le cas joueur decede (section Prochain avancement masquee)
- [ ] Verifier le cas joueur avec blessures persistantes (badge `Blesse`, liste detaillee)

## Notes
- `SPP_COST_TABLE` est duplique localement dans `lib/player-details.ts` (miroir de `packages/game-engine/src/utils/advancements.ts`) car la resolution `@bb/game-engine` cote mobile fonctionne en types seuls au runtime vitest/metro.
- Les types `AdvancementType` et `PlayerAdvancement` restent importes depuis `@bb/game-engine` pour rester alignes avec la logique serveur.