### PR TITLE
feat(mobile): M.11 catalogue star players

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -319,7 +319,7 @@
 | M.8 | Ecrans cups/ligues | Mobile | [x] |
 | M.9 | Push notifications natives (Expo Notifications) | Mobile | [x] |
 | M.10 | Details joueur et progression | Mobile | [x] |
-| M.11 | Catalogue Star Players mobile | Mobile | [ ] |
+| M.11 | Catalogue Star Players mobile | Mobile | [x] |
 | M.12 | Profil et settings mobile | Mobile | [ ] |
 
 ### Sprint 20-21 — Extension contenu : skills & equipes restantes

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -68,6 +68,14 @@ export default function Layout() {
             name="leagues/[id]"
             options={{ title: "Detail ligue" }}
           />
+          <Stack.Screen
+            name="star-players/index"
+            options={{ title: "Star Players" }}
+          />
+          <Stack.Screen
+            name="star-players/[slug]"
+            options={{ title: "Detail Star Player" }}
+          />
         </Stack>
       </AuthProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/app/lobby.tsx
+++ b/apps/mobile/app/lobby.tsx
@@ -337,6 +337,13 @@ export default function LobbyScreen() {
         >
           <Text style={styles.actionButtonText}>Ligues</Text>
         </Pressable>
+        <Pressable
+          style={styles.starsButton}
+          onPress={() => router.push("/star-players")}
+          testID="lobby-stars-button"
+        >
+          <Text style={styles.actionButtonText}>Stars</Text>
+        </Pressable>
       </View>
       <View style={styles.actionRow}>
         <Pressable
@@ -575,6 +582,13 @@ const styles = StyleSheet.create({
   leaguesButton: {
     flex: 1,
     backgroundColor: "#0E7490",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  starsButton: {
+    flex: 1,
+    backgroundColor: "#D97706",
     paddingVertical: 12,
     borderRadius: 8,
     alignItems: "center",

--- a/apps/mobile/app/star-players/[slug].tsx
+++ b/apps/mobile/app/star-players/[slug].tsx
@@ -1,0 +1,377 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  ActivityIndicator,
+  Pressable,
+  Image,
+  RefreshControl,
+  StyleSheet,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { apiGet, ApiError, API_BASE } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  DEFAULT_RULESET,
+  formatHirableBy,
+  formatStarCost,
+  formatStarStat,
+  getStarSkillList,
+  resolveStarImageUrl,
+  type StarPlayerSummary,
+  type StarRuleset,
+} from "../../lib/star-players";
+
+function parseStarDetailResponse(
+  response: unknown,
+): StarPlayerSummary | null {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const payload = (raw.data ?? raw) as Record<string, unknown>;
+  if (
+    typeof payload.slug !== "string" ||
+    typeof payload.displayName !== "string" ||
+    typeof payload.cost !== "number" ||
+    typeof payload.ma !== "number" ||
+    typeof payload.st !== "number" ||
+    typeof payload.ag !== "number" ||
+    (payload.pa !== null && typeof payload.pa !== "number") ||
+    typeof payload.av !== "number" ||
+    typeof payload.skills !== "string" ||
+    !Array.isArray(payload.hirableBy)
+  ) {
+    return null;
+  }
+  return payload as unknown as StarPlayerSummary;
+}
+
+export default function StarPlayerDetailScreen() {
+  const params = useLocalSearchParams<{ slug: string; ruleset?: string }>();
+  const slug = typeof params.slug === "string" ? params.slug : "";
+  const ruleset: StarRuleset =
+    params.ruleset === "season_2" ? "season_2" : DEFAULT_RULESET;
+
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [player, setPlayer] = useState<StarPlayerSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    if (!slug) return;
+    try {
+      setError(null);
+      const response = await apiGet(
+        `/star-players/${encodeURIComponent(slug)}?ruleset=${ruleset}`,
+      );
+      const parsed = parseStarDetailResponse(response);
+      if (!parsed) {
+        throw new Error("Star Player introuvable");
+      }
+      setPlayer(parsed);
+    } catch (err: unknown) {
+      if (
+        err instanceof ApiError &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        await logout();
+        router.replace("/login");
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Erreur de chargement");
+    }
+  }, [slug, ruleset, logout, router]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchDetail().finally(() => setLoading(false));
+  }, [fetchDetail]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchDetail();
+    setRefreshing(false);
+  }, [fetchDetail]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (error || !player) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>
+          {error ?? "Star Player introuvable"}
+        </Text>
+        <Pressable onPress={onRefresh} style={styles.retryButton}>
+          <Text style={styles.retryText}>Reessayer</Text>
+        </Pressable>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backButtonSecondaryText}>Retour</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const imageUrl = resolveStarImageUrl(player.imageUrl, API_BASE);
+  const skills = getStarSkillList(player.skills);
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.scrollContent}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    >
+      <View style={styles.headerCard}>
+        {imageUrl && (
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.playerImage}
+            resizeMode="contain"
+            accessibilityLabel={`Illustration de ${player.displayName}`}
+          />
+        )}
+        <Text style={styles.playerName}>{player.displayName}</Text>
+        <Text style={styles.playerCost}>{formatStarCost(player.cost)}</Text>
+        {player.isMegaStar && (
+          <View style={styles.megaBadge}>
+            <Text style={styles.megaBadgeText}>Mega Star</Text>
+          </View>
+        )}
+      </View>
+
+      <View style={styles.statsCard}>
+        <Text style={styles.sectionTitle}>Caracteristiques</Text>
+        <View style={styles.statsGrid}>
+          <StatBlock label="MA" value={formatStarStat("ma", player.ma)} />
+          <StatBlock label="ST" value={formatStarStat("st", player.st)} />
+          <StatBlock label="AG" value={formatStarStat("ag", player.ag)} />
+          <StatBlock label="PA" value={formatStarStat("pa", player.pa)} />
+          <StatBlock label="AV" value={formatStarStat("av", player.av)} />
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Competences</Text>
+        {skills.length === 0 ? (
+          <Text style={styles.emptyText}>Aucune competence</Text>
+        ) : (
+          <View style={styles.skillChips}>
+            {skills.map((skill) => (
+              <View key={skill} style={styles.skillChip}>
+                <Text style={styles.skillChipText}>{skill}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Recrutable par</Text>
+        <Text style={styles.bodyText}>{formatHirableBy(player.hirableBy)}</Text>
+      </View>
+
+      {player.specialRule && (
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Regle speciale</Text>
+          <Text style={styles.bodyText}>{player.specialRule}</Text>
+        </View>
+      )}
+
+      <Pressable
+        onPress={() => router.back()}
+        style={styles.backButtonFull}
+        testID="star-detail-back"
+      >
+        <Text style={styles.backButtonText}>Retour au catalogue</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.statBlock}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F9FAFB",
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  headerCard: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 16,
+    alignItems: "center",
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  playerImage: {
+    width: 160,
+    height: 160,
+    borderRadius: 12,
+    marginBottom: 12,
+    backgroundColor: "#F3F4F6",
+  },
+  playerName: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#111827",
+    textAlign: "center",
+  },
+  playerCost: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#D97706",
+    marginTop: 4,
+  },
+  megaBadge: {
+    marginTop: 10,
+    backgroundColor: "#D97706",
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 12,
+  },
+  megaBadgeText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  statsCard: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  statsGrid: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 8,
+  },
+  statBlock: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 10,
+    backgroundColor: "#F3F4F6",
+    borderRadius: 8,
+    marginHorizontal: 2,
+  },
+  statLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "#6B7280",
+    marginBottom: 4,
+  },
+  statValue: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#111827",
+    marginBottom: 8,
+    textTransform: "uppercase",
+  },
+  skillChips: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  skillChip: {
+    backgroundColor: "#EFF6FF",
+    borderRadius: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderWidth: 1,
+    borderColor: "#BFDBFE",
+  },
+  skillChipText: {
+    color: "#1D4ED8",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  bodyText: {
+    color: "#374151",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  emptyText: {
+    color: "#6B7280",
+    fontSize: 13,
+    fontStyle: "italic",
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  backButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  backButtonSecondaryText: {
+    color: "#2563EB",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  backButtonFull: {
+    marginTop: 8,
+    backgroundColor: "#1F2937",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  backButtonText: {
+    color: "#E5E7EB",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/star-players/index.tsx
+++ b/apps/mobile/app/star-players/index.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+  TextInput,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { apiGet, ApiError } from "../../lib/api";
+import { useAuth } from "../../lib/auth-context";
+import {
+  DEFAULT_RULESET,
+  filterStarPlayers,
+  formatHirableBy,
+  formatStarCost,
+  formatStarStat,
+  getStarSkillList,
+  parseStarPlayersResponse,
+  type StarPlayerSummary,
+  type StarRuleset,
+} from "../../lib/star-players";
+
+const RULESET_OPTIONS: { key: StarRuleset; label: string }[] = [
+  { key: "season_3", label: "Saison 3" },
+  { key: "season_2", label: "Saison 2" },
+];
+
+export default function StarPlayersIndexScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [ruleset, setRuleset] = useState<StarRuleset>(DEFAULT_RULESET);
+  const [players, setPlayers] = useState<StarPlayerSummary[]>([]);
+  const [search, setSearch] = useState("");
+  const [megaStarOnly, setMegaStarOnly] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStars = useCallback(
+    async (nextRuleset: StarRuleset) => {
+      try {
+        const response = await apiGet(
+          `/star-players?ruleset=${nextRuleset}`,
+        );
+        setPlayers(parseStarPlayersResponse(response));
+        setError(null);
+      } catch (err: unknown) {
+        if (
+          err instanceof ApiError &&
+          (err.status === 401 || err.status === 403)
+        ) {
+          await logout();
+          router.replace("/login");
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Erreur de chargement");
+      }
+    },
+    [logout, router],
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    fetchStars(ruleset).finally(() => setLoading(false));
+  }, [fetchStars, ruleset]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchStars(ruleset);
+    setRefreshing(false);
+  }, [fetchStars, ruleset]);
+
+  const filtered = useMemo(
+    () => filterStarPlayers(players, { search, megaStarOnly }),
+    [players, search, megaStarOnly],
+  );
+
+  const megaCount = useMemo(
+    () => players.filter((p) => p.isMegaStar).length,
+    [players],
+  );
+
+  function navigateToDetail(player: StarPlayerSummary) {
+    router.push(`/star-players/${player.slug}?ruleset=${ruleset}`);
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Catalogue Star Players</Text>
+        <Text style={styles.subtitle}>
+          {filtered.length} joueur{filtered.length > 1 ? "s" : ""}
+          {filtered.length !== players.length
+            ? ` sur ${players.length}`
+            : ""}
+        </Text>
+      </View>
+
+      <View style={styles.filters}>
+        <View style={styles.rulesetRow}>
+          {RULESET_OPTIONS.map((opt) => (
+            <Pressable
+              key={opt.key}
+              onPress={() => setRuleset(opt.key)}
+              style={[
+                styles.rulesetButton,
+                ruleset === opt.key && styles.rulesetButtonActive,
+              ]}
+              testID={`ruleset-${opt.key}`}
+            >
+              <Text
+                style={[
+                  styles.rulesetText,
+                  ruleset === opt.key && styles.rulesetTextActive,
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Rechercher par nom..."
+          placeholderTextColor="#9CA3AF"
+          value={search}
+          onChangeText={setSearch}
+          autoCapitalize="none"
+          autoCorrect={false}
+          testID="star-search-input"
+        />
+
+        <Pressable
+          onPress={() => setMegaStarOnly((prev) => !prev)}
+          style={[
+            styles.megaToggle,
+            megaStarOnly && styles.megaToggleActive,
+          ]}
+          testID="star-mega-toggle"
+        >
+          <Text
+            style={[
+              styles.megaToggleText,
+              megaStarOnly && styles.megaToggleTextActive,
+            ]}
+          >
+            {megaStarOnly ? "Mega stars uniquement" : `Mega stars (${megaCount})`}
+          </Text>
+        </Pressable>
+      </View>
+
+      {loading && (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#2563EB" />
+        </View>
+      )}
+
+      {error && !loading && (
+        <View style={styles.center}>
+          <Text style={styles.errorText}>Erreur : {error}</Text>
+          <Pressable onPress={onRefresh} style={styles.retryButton}>
+            <Text style={styles.retryText}>Reessayer</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {!loading && !error && (
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.slug}
+          renderItem={({ item }) => (
+            <StarRow
+              player={item}
+              onPress={() => navigateToDetail(item)}
+            />
+          )}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+          ListEmptyComponent={
+            <View style={styles.center}>
+              <Text style={styles.emptyText}>
+                Aucun star player ne correspond aux filtres.
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </View>
+  );
+}
+
+function StarRow({
+  player,
+  onPress,
+}: {
+  player: StarPlayerSummary;
+  onPress: () => void;
+}) {
+  const skills = getStarSkillList(player.skills);
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.row, player.isMegaStar && styles.rowMegaStar]}
+      testID={`star-row-${player.slug}`}
+    >
+      <View style={styles.rowHeader}>
+        <Text style={styles.playerName} numberOfLines={1}>
+          {player.displayName}
+        </Text>
+        <Text style={styles.playerCost}>{formatStarCost(player.cost)}</Text>
+      </View>
+      <View style={styles.statsRow}>
+        <StatChip label="MA" value={formatStarStat("ma", player.ma)} />
+        <StatChip label="ST" value={formatStarStat("st", player.st)} />
+        <StatChip label="AG" value={formatStarStat("ag", player.ag)} />
+        <StatChip label="PA" value={formatStarStat("pa", player.pa)} />
+        <StatChip label="AV" value={formatStarStat("av", player.av)} />
+      </View>
+      {skills.length > 0 && (
+        <Text style={styles.skillsText} numberOfLines={2}>
+          {skills.join(" • ")}
+        </Text>
+      )}
+      <Text style={styles.hirableText} numberOfLines={1}>
+        Recrutable : {formatHirableBy(player.hirableBy)}
+      </Text>
+      {player.isMegaStar && (
+        <View style={styles.megaBadge}>
+          <Text style={styles.megaBadgeText}>Mega Star</Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+function StatChip({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.statChip}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F9FAFB",
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#111827",
+  },
+  subtitle: {
+    fontSize: 13,
+    color: "#6B7280",
+    marginTop: 2,
+  },
+  filters: {
+    paddingHorizontal: 16,
+    marginBottom: 8,
+    gap: 8,
+  },
+  rulesetRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  rulesetButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    backgroundColor: "#E5E7EB",
+  },
+  rulesetButtonActive: {
+    backgroundColor: "#2563EB",
+  },
+  rulesetText: {
+    fontSize: 13,
+    fontWeight: "500",
+    color: "#374151",
+  },
+  rulesetTextActive: {
+    color: "#fff",
+  },
+  searchInput: {
+    borderWidth: 1,
+    borderColor: "#D1D5DB",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    backgroundColor: "#fff",
+  },
+  megaToggle: {
+    alignSelf: "flex-start",
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    backgroundColor: "#FEF3C7",
+    borderWidth: 1,
+    borderColor: "#FDE68A",
+  },
+  megaToggleActive: {
+    backgroundColor: "#D97706",
+    borderColor: "#B45309",
+  },
+  megaToggleText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#92400E",
+  },
+  megaToggleTextActive: {
+    color: "#fff",
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+  },
+  row: {
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  rowMegaStar: {
+    borderColor: "#D97706",
+    backgroundColor: "#FFFBEB",
+  },
+  rowHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  playerName: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#111827",
+    flex: 1,
+    marginRight: 8,
+  },
+  playerCost: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#D97706",
+  },
+  statsRow: {
+    flexDirection: "row",
+    gap: 6,
+    marginBottom: 8,
+  },
+  statChip: {
+    backgroundColor: "#F3F4F6",
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 6,
+    alignItems: "center",
+    minWidth: 44,
+  },
+  statLabel: {
+    fontSize: 10,
+    fontWeight: "600",
+    color: "#6B7280",
+  },
+  statValue: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#111827",
+  },
+  skillsText: {
+    fontSize: 12,
+    color: "#4B5563",
+    marginBottom: 4,
+  },
+  hirableText: {
+    fontSize: 11,
+    color: "#9CA3AF",
+  },
+  megaBadge: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    backgroundColor: "#D97706",
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    borderRadius: 10,
+  },
+  megaBadgeText: {
+    color: "#fff",
+    fontSize: 10,
+    fontWeight: "700",
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  errorText: {
+    color: "#DC2626",
+    fontSize: 14,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: "#2563EB",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#6B7280",
+    fontSize: 15,
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/lib/star-players.test.ts
+++ b/apps/mobile/lib/star-players.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_RULESET,
+  filterStarPlayers,
+  formatHirableBy,
+  formatStarCost,
+  formatStarStat,
+  getStarSkillList,
+  parseStarPlayersResponse,
+  resolveStarImageUrl,
+  type StarPlayerSummary,
+} from "./star-players";
+
+const SAMPLE: StarPlayerSummary = {
+  slug: "akhorne_the_squirrel",
+  displayName: "Akhorne The Squirrel",
+  cost: 80000,
+  ma: 7,
+  st: 1,
+  ag: 2,
+  pa: null,
+  av: 6,
+  skills: "claws,dauntless,dodge",
+  hirableBy: ["all"],
+  specialRule: "Rage aveugle",
+  imageUrl: "/data/Star-Players_files/akhorne.webp",
+  isMegaStar: false,
+};
+
+describe("parseStarPlayersResponse", () => {
+  it("returns empty list when response is not the expected shape", () => {
+    expect(parseStarPlayersResponse(null)).toEqual([]);
+    expect(parseStarPlayersResponse({})).toEqual([]);
+    expect(parseStarPlayersResponse({ success: true })).toEqual([]);
+  });
+
+  it("extracts valid star players from the server envelope", () => {
+    const response = {
+      success: true,
+      count: 1,
+      data: [
+        {
+          slug: "akhorne_the_squirrel",
+          displayName: "Akhorne The Squirrel",
+          cost: 80000,
+          ma: 7,
+          st: 1,
+          ag: 2,
+          pa: null,
+          av: 6,
+          skills: "claws,dauntless,dodge",
+          hirableBy: ["all"],
+          specialRule: "Rage aveugle",
+          imageUrl: "/foo.webp",
+          isMegaStar: false,
+        },
+      ],
+    };
+    const parsed = parseStarPlayersResponse(response);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].slug).toBe("akhorne_the_squirrel");
+    expect(parsed[0].pa).toBeNull();
+  });
+
+  it("deduplicates by slug when the server returns multiple rulesets", () => {
+    const response = {
+      data: [
+        { ...SAMPLE },
+        { ...SAMPLE, cost: 90000 },
+        { ...SAMPLE, slug: "other_star" },
+      ],
+    };
+    const parsed = parseStarPlayersResponse(response);
+    const slugs = parsed.map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    expect(parsed).toHaveLength(2);
+  });
+
+  it("ignores entries with missing mandatory fields", () => {
+    const response = {
+      data: [
+        { slug: "bad", cost: 1 },
+        { ...SAMPLE },
+      ],
+    };
+    expect(parseStarPlayersResponse(response)).toHaveLength(1);
+  });
+});
+
+describe("filterStarPlayers", () => {
+  const players: StarPlayerSummary[] = [
+    { ...SAMPLE },
+    {
+      ...SAMPLE,
+      slug: "griff_oberwald",
+      displayName: "Griff Oberwald",
+      cost: 320000,
+      hirableBy: ["human", "imperial_nobility"],
+      skills: "block,dodge,fend,sprint,sure-feet,sure-hands",
+    },
+    {
+      ...SAMPLE,
+      slug: "morg_n_thorg",
+      displayName: "Morg N Thorg",
+      cost: 430000,
+      skills: "block,frenzy,loner-4,mighty-blow,thick-skull,throw-team-mate",
+      hirableBy: ["all"],
+      isMegaStar: true,
+    },
+  ];
+
+  it("returns everything when no filters are set", () => {
+    expect(filterStarPlayers(players, {})).toEqual(players);
+  });
+
+  it("filters by slug or displayName with case-insensitive search", () => {
+    expect(filterStarPlayers(players, { search: "GRIFF" })).toHaveLength(1);
+    expect(filterStarPlayers(players, { search: "morg" })).toHaveLength(1);
+    expect(filterStarPlayers(players, { search: "akhorn" })).toHaveLength(1);
+  });
+
+  it("filters by max cost (inclusive)", () => {
+    expect(
+      filterStarPlayers(players, { maxCost: 320000 }).map((p) => p.slug),
+    ).toEqual(["akhorne_the_squirrel", "griff_oberwald"]);
+  });
+
+  it("filters by skill slug substring", () => {
+    const frenzied = filterStarPlayers(players, { skill: "frenzy" });
+    expect(frenzied).toHaveLength(1);
+    expect(frenzied[0].slug).toBe("morg_n_thorg");
+  });
+
+  it("filters by hirableBy entry", () => {
+    const forImperial = filterStarPlayers(players, {
+      hirableBy: "imperial_nobility",
+    });
+    expect(forImperial.map((p) => p.slug)).toEqual(["griff_oberwald"]);
+  });
+
+  it("filters by megaStar flag", () => {
+    expect(
+      filterStarPlayers(players, { megaStarOnly: true }).map((p) => p.slug),
+    ).toEqual(["morg_n_thorg"]);
+  });
+
+  it("combines multiple filters", () => {
+    const result = filterStarPlayers(players, {
+      search: "th",
+      maxCost: 500000,
+      skill: "block",
+    });
+    expect(result.map((p) => p.slug)).toEqual(["morg_n_thorg"]);
+  });
+});
+
+describe("formatStarCost", () => {
+  it("displays gold in thousands with a K suffix", () => {
+    expect(formatStarCost(80000)).toBe("80K po");
+    expect(formatStarCost(320000)).toBe("320K po");
+  });
+
+  it("handles zero and undefined gracefully", () => {
+    expect(formatStarCost(0)).toBe("0K po");
+    expect(formatStarCost(undefined)).toBe("0K po");
+  });
+});
+
+describe("formatStarStat", () => {
+  it("returns a dash for null passing stat", () => {
+    expect(formatStarStat("pa", null)).toBe("-");
+  });
+
+  it("appends a plus sign for pa/ag/av when value > 0", () => {
+    expect(formatStarStat("pa", 3)).toBe("3+");
+    expect(formatStarStat("ag", 2)).toBe("2+");
+    expect(formatStarStat("av", 9)).toBe("9+");
+  });
+
+  it("returns raw numeric string for ma/st", () => {
+    expect(formatStarStat("ma", 7)).toBe("7");
+    expect(formatStarStat("st", 4)).toBe("4");
+  });
+});
+
+describe("getStarSkillList", () => {
+  it("splits the comma-separated skills and trims whitespace", () => {
+    expect(getStarSkillList(" block,dodge ,frenzy")).toEqual([
+      "block",
+      "dodge",
+      "frenzy",
+    ]);
+  });
+
+  it("returns empty array for empty or missing input", () => {
+    expect(getStarSkillList("")).toEqual([]);
+    expect(getStarSkillList(undefined)).toEqual([]);
+  });
+});
+
+describe("formatHirableBy", () => {
+  it('returns "Toutes les equipes" for the special "all" entry', () => {
+    expect(formatHirableBy(["all"])).toBe("Toutes les equipes");
+  });
+
+  it("joins multiple roster slugs with a separator", () => {
+    const result = formatHirableBy(["human", "imperial_nobility"]);
+    expect(result).toContain("human");
+    expect(result).toContain("imperial_nobility");
+    expect(result).toContain(",");
+  });
+
+  it("returns a fallback string when empty", () => {
+    expect(formatHirableBy([])).toBe("Aucune equipe");
+  });
+});
+
+describe("resolveStarImageUrl", () => {
+  it("returns null when no URL provided", () => {
+    expect(resolveStarImageUrl(undefined, "https://api.example")).toBeNull();
+    expect(resolveStarImageUrl("", "https://api.example")).toBeNull();
+  });
+
+  it("prefixes server-relative URLs with the API base", () => {
+    expect(
+      resolveStarImageUrl("/data/foo.webp", "https://api.example"),
+    ).toBe("https://api.example/data/foo.webp");
+  });
+
+  it("keeps already absolute URLs unchanged", () => {
+    const abs = "https://cdn.example.com/foo.webp";
+    expect(resolveStarImageUrl(abs, "https://api.example")).toBe(abs);
+  });
+});
+
+describe("DEFAULT_RULESET", () => {
+  it("defaults to season_3", () => {
+    expect(DEFAULT_RULESET).toBe("season_3");
+  });
+});

--- a/apps/mobile/lib/star-players.ts
+++ b/apps/mobile/lib/star-players.ts
@@ -1,0 +1,139 @@
+// Pure helpers for the mobile Star Players catalog (M.11).
+// Network-free so they can be unit-tested in node.
+
+export type StarRuleset = "season_2" | "season_3";
+export const DEFAULT_RULESET: StarRuleset = "season_3";
+
+export interface StarPlayerSummary {
+  slug: string;
+  displayName: string;
+  cost: number;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  skills: string;
+  hirableBy: string[];
+  specialRule?: string;
+  specialRuleEn?: string;
+  imageUrl?: string;
+  isMegaStar?: boolean;
+}
+
+export type StarStatKey = "ma" | "st" | "ag" | "pa" | "av";
+
+export interface StarPlayerFilters {
+  search?: string;
+  maxCost?: number;
+  minCost?: number;
+  skill?: string;
+  hirableBy?: string;
+  megaStarOnly?: boolean;
+}
+
+function isStarSummary(value: unknown): value is StarPlayerSummary {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.slug === "string" &&
+    typeof v.displayName === "string" &&
+    typeof v.cost === "number" &&
+    typeof v.ma === "number" &&
+    typeof v.st === "number" &&
+    typeof v.ag === "number" &&
+    (v.pa === null || typeof v.pa === "number") &&
+    typeof v.av === "number" &&
+    typeof v.skills === "string" &&
+    Array.isArray(v.hirableBy)
+  );
+}
+
+export function parseStarPlayersResponse(
+  response: unknown,
+): StarPlayerSummary[] {
+  const raw = (response ?? {}) as Record<string, unknown>;
+  const rawData = Array.isArray(raw.data) ? raw.data : [];
+  const bySlug = new Map<string, StarPlayerSummary>();
+  for (const entry of rawData) {
+    if (!isStarSummary(entry)) continue;
+    if (!bySlug.has(entry.slug)) {
+      bySlug.set(entry.slug, entry);
+    }
+  }
+  return Array.from(bySlug.values());
+}
+
+export function getStarSkillList(skills: string | undefined): string[] {
+  if (!skills) return [];
+  return skills
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function filterStarPlayers(
+  players: ReadonlyArray<StarPlayerSummary>,
+  filters: StarPlayerFilters,
+): StarPlayerSummary[] {
+  const search = filters.search?.trim().toLowerCase() ?? "";
+  const skill = filters.skill?.trim().toLowerCase() ?? "";
+  const hirable = filters.hirableBy?.trim() ?? "";
+  return players.filter((p) => {
+    if (search) {
+      const haystack = `${p.displayName} ${p.slug}`.toLowerCase();
+      if (!haystack.includes(search)) return false;
+    }
+    if (typeof filters.maxCost === "number" && p.cost > filters.maxCost) {
+      return false;
+    }
+    if (typeof filters.minCost === "number" && p.cost < filters.minCost) {
+      return false;
+    }
+    if (skill) {
+      const skillList = getStarSkillList(p.skills).map((s) => s.toLowerCase());
+      if (!skillList.some((s) => s.includes(skill))) return false;
+    }
+    if (hirable) {
+      if (!p.hirableBy.includes(hirable)) return false;
+    }
+    if (filters.megaStarOnly && !p.isMegaStar) return false;
+    return true;
+  });
+}
+
+export function formatStarCost(cost: number | undefined): string {
+  const value = cost ?? 0;
+  const k = Math.floor(value / 1000);
+  return `${k}K po`;
+}
+
+export function formatStarStat(
+  stat: StarStatKey,
+  value: number | null,
+): string {
+  if (stat === "pa") {
+    if (value === null || value <= 0) return "-";
+    return `${value}+`;
+  }
+  if (stat === "ag" || stat === "av") {
+    return value === null ? "-" : `${value}+`;
+  }
+  return value === null ? "-" : String(value);
+}
+
+export function formatHirableBy(hirableBy: ReadonlyArray<string>): string {
+  if (hirableBy.length === 0) return "Aucune equipe";
+  if (hirableBy.includes("all")) return "Toutes les equipes";
+  return hirableBy.join(", ");
+}
+
+export function resolveStarImageUrl(
+  imageUrl: string | undefined,
+  apiBase: string,
+): string | null {
+  if (!imageUrl) return null;
+  if (/^https?:\/\//i.test(imageUrl)) return imageUrl;
+  if (imageUrl.startsWith("/")) return `${apiBase}${imageUrl}`;
+  return `${apiBase}/${imageUrl}`;
+}


### PR DESCRIPTION
## Resume

- Nouvel ecran mobile `star-players/` : listing (recherche, ruleset S2/S3, filtre Mega Star) + fiche detaillee (stats, competences, regle speciale, image).
- `lib/star-players.ts` : helpers purs (parse, filtre, formatters) testes en node ; re-utilisables entre les deux ecrans.
- Bouton "Stars" ajoute dans le lobby et routes enregistrees dans `_layout.tsx`.

## Tache roadmap

Sprint 18-19, tache **M.11 — Catalogue Star Players mobile**.

## Plan de test

- [x] `pnpm --filter @bb/mobile test` : 254 tests dont 25 nouveaux (`lib/star-players.test.ts`)
- [x] `pnpm typecheck` : 4 packages OK, aucune erreur sur les fichiers modifies
- [x] `pnpm lint` : 0 erreur (799 warnings pre-existants)
- [ ] Validation manuelle dans Expo Go sur un serveur local : acces depuis le lobby -> listing -> detail, switch S2/S3, filtre Mega Star, refresh
- [ ] Test sur ecran iPhone (Safe Area) et Android (status bar)


---
_Generated by [Claude Code](https://claude.ai/code/session_0178RikETk8hzVrky12RgxmL)_