### PR TITLE
feat(game-engine): K.11 implementer hail-mary-pass + safe-pass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -336,7 +336,7 @@
 | K.2 | Implementer `stab` — Vampire / Underworld | Regle | [x] |
 | K.3 | Implementer `chainsaw` — Secret weapons | Regle | [x] |
 | K.10 | Implementer `multiple-block` — Ogres | Regle | [x] |
-| K.11 | Implementer `hail-mary-pass` + `safe-pass` | Regle | [ ] |
+| K.11 | Implementer `hail-mary-pass` + `safe-pass` | Regle | [x] |
 | K.12 | Implementer `ball-and-chain` — Goblin Fanatic | Regle | [ ] |
 | K.13 | Implementer `bombardier` — Goblin Bomma | Regle | [ ] |
 | O.2 | Star player special rules restantes (~30, hors 5 equipes) | Contenu | [ ] |

--- a/packages/game-engine/src/mechanics/hail-mary-safe-pass.test.ts
+++ b/packages/game-engine/src/mechanics/hail-mary-safe-pass.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { setup, applyMove } from '../index';
+import { GameState, RNG, Move } from '../core/types';
+import { canAttemptPassForRange, getPassRange } from './passing';
+
+function makeTestRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const val = values[i % values.length];
+    i++;
+    return val;
+  };
+}
+
+function createHailMaryTestState(): GameState {
+  const state = setup();
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 2, y: 7 }, name: 'Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8,
+      skills: ['hail-mary-pass'],
+      pm: 6, hasBall: true, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 22, y: 7 }, name: 'Receiver', number: 2,
+      position: 'Catcher', ma: 8, st: 2, ag: 4, pa: 5, av: 7, skills: [],
+      pm: 8, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = undefined;
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 0, teamB: 0 };
+  return state;
+}
+
+function createSafePassTestState(): GameState {
+  const state = setup();
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8,
+      skills: ['safe-pass'],
+      pm: 6, hasBall: true, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 14, y: 7 }, name: 'Receiver', number: 2,
+      position: 'Catcher', ma: 8, st: 2, ag: 4, pa: 5, av: 7, skills: [],
+      pm: 8, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = undefined;
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 0, teamB: 0 };
+  return state;
+}
+
+describe('Regle: hail-mary-pass', () => {
+  it('permet une passe au-dela de la portee Long Bomb quand le passeur a le skill', () => {
+    const passer = {
+      id: 'P', team: 'A' as const, pos: { x: 0, y: 0 }, name: 'Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8,
+      skills: ['hail-mary-pass'],
+      pm: 6, hasBall: true, state: 'active' as const,
+    };
+    const range = getPassRange({ x: 0, y: 0 }, { x: 22, y: 7 });
+    expect(range).toBeNull();
+    expect(canAttemptPassForRange(passer, range)).toBe(true);
+  });
+
+  it('refuse la passe hors portee quand le passeur n\'a PAS hail-mary-pass', () => {
+    const passer = {
+      id: 'P', team: 'A' as const, pos: { x: 0, y: 0 }, name: 'Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8, skills: [],
+      pm: 6, hasBall: true, state: 'active' as const,
+    };
+    const range = getPassRange({ x: 0, y: 0 }, { x: 22, y: 7 });
+    expect(canAttemptPassForRange(passer, range)).toBe(false);
+  });
+
+  it('sur un jet de passe reussi, ne donne PAS le ballon au receveur (passe non-precise) et ne cause pas de turnover', () => {
+    const state = createHailMaryTestState();
+    const rng = makeTestRNG([0.95, 0.5, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    const passer = result.players.find(p => p.id === 'A1')!;
+    const receiver = result.players.find(p => p.id === 'A2')!;
+
+    expect(passer.hasBall).toBe(false);
+    expect(receiver.hasBall).toBe(false);
+    expect(result.isTurnover).toBe(false);
+  });
+
+  it('sur un jet de passe rate, provoque un turnover comme une passe normale', () => {
+    const state = createHailMaryTestState();
+    const rng = makeTestRNG([0.01, 0.5, 0.5]);
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.isTurnover).toBe(true);
+  });
+});
+
+describe('Regle: safe-pass', () => {
+  it('sur un jet de passe rate, le passeur garde le ballon et il n\'y a pas de turnover', () => {
+    const state = createSafePassTestState();
+    const rng = makeTestRNG([0.01, 0.5, 0.5]);
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    const passer = result.players.find(p => p.id === 'A1')!;
+    const receiver = result.players.find(p => p.id === 'A2')!;
+
+    expect(passer.hasBall).toBe(true);
+    expect(receiver.hasBall).toBe(false);
+    expect(result.isTurnover).toBe(false);
+    expect(result.ball).toBeUndefined();
+  });
+
+  it('sur une passe reussie, se comporte normalement (receveur recoit le ballon)', () => {
+    const state = createSafePassTestState();
+    const rng = makeTestRNG([0.95, 0.95]);
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    const passer = result.players.find(p => p.id === 'A1')!;
+    const receiver = result.players.find(p => p.id === 'A2')!;
+
+    expect(passer.hasBall).toBe(false);
+    expect(receiver.hasBall).toBe(true);
+    expect(result.isTurnover).toBe(false);
+  });
+
+  it('marque l\'activation du passeur comme PASS (activation terminee apres safe-pass)', () => {
+    const state = createSafePassTestState();
+    const rng = makeTestRNG([0.01]);
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.playerActions['A1']).toBe('PASS');
+  });
+});

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -39,9 +39,13 @@ export function getPassRange(from: Position, to: Position): PassRange | null {
  * Détermine si un joueur peut tenter une passe sur une distance donnée.
  * Les joueurs Stunty ne peuvent pas tenter de passes Long ni Long Bomb :
  * l'action est restreinte aux portées Quick et Short.
+ * Les joueurs avec Hail Mary Pass peuvent viser n'importe quelle case du
+ * terrain (la règle de portée est ignorée, même au-delà de Long Bomb).
  */
 export function canAttemptPassForRange(passer: Player, range: PassRange | null): boolean {
-  if (!range) return false;
+  if (!range) {
+    return hasSkill(passer, 'hail-mary-pass') || hasSkill(passer, 'hail_mary_pass');
+  }
   if (hasSkill(passer, 'stunty') && (range === 'long' || range === 'bomb')) {
     return false;
   }
@@ -288,6 +292,25 @@ export function executePass(
   newState.gameLog = [...newState.gameLog, passLog];
 
   if (!passResult.success) {
+    // Safe Pass : sur echec, le passeur garde le ballon. Pas de turnover,
+    // pas de rebond, l'activation se termine (geree par handlePass via
+    // setPlayerAction + checkPlayerTurnEnd).
+    if (hasSkill(passer, 'safe-pass') || hasSkill(passer, 'safe_pass')) {
+      newState.players = newState.players.map(p =>
+        p.id === passer.id ? { ...p, hasBall: true } : p
+      );
+      newState.ball = undefined;
+      const safePassLog = createLogEntry(
+        'info',
+        `Passe Assuree : ${passer.name} garde possession du ballon.`,
+        passer.id,
+        passer.team,
+        { skill: 'safe-pass' }
+      );
+      newState.gameLog = [...newState.gameLog, safePassLog];
+      return newState;
+    }
+
     // Passe ratée : le ballon dévie depuis la cible
     const failLog = createLogEntry(
       'turnover',
@@ -297,6 +320,23 @@ export function executePass(
     );
     newState.gameLog = [...newState.gameLog, failLog];
     newState.isTurnover = true;
+    newState.ball = { ...target.pos };
+    return bounceBall(newState, rng);
+  }
+
+  // Hail Mary Pass : la passe n'est jamais precise. Meme sur un jet reussi,
+  // le ballon ne va pas directement dans les mains du receveur. Il devie depuis
+  // la case cible, sans turnover (le receveur ou un autre joueur peut tenter
+  // de le rattraper via le rebond).
+  if (hasSkill(passer, 'hail-mary-pass') || hasSkill(passer, 'hail_mary_pass')) {
+    const hmpLog = createLogEntry(
+      'info',
+      `Passe Desesperee : la passe n'est jamais precise, le ballon devie depuis la cible.`,
+      passer.id,
+      passer.team,
+      { skill: 'hail-mary-pass' }
+    );
+    newState.gameLog = [...newState.gameLog, hmpLog];
     newState.ball = { ...target.pos };
     return bounceBall(newState, rng);
   }

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -758,6 +758,32 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'foul-appearance'),
 });
 
+// ─── HAIL MARY PASS ────────────────────────────────────────────────────────
+// Hail Mary Pass est resolu dans `mechanics/passing.ts` :
+//  - `canAttemptPassForRange` permet de viser n'importe quelle case (ignore la
+//    regle de portee, y compris au-dela de Long Bomb).
+//  - `executePass` : sur un jet de passe reussi, la passe n'est jamais precise,
+//    le ballon devie depuis la case cible (pas de catch direct, pas de turnover).
+// L'entree du registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'hail-mary-pass',
+  triggers: ['on-pass'],
+  description: "La case cible de la passe peut etre n'importe ou sur le terrain (la regle de portee est ignoree). La passe n'est jamais precise : meme sur un jet reussi, le ballon devie depuis la cible.",
+  canApply: (ctx) => hasSkill(ctx.player, 'hail-mary-pass') || hasSkill(ctx.player, 'hail_mary_pass'),
+});
+
+// ─── SAFE PASS ─────────────────────────────────────────────────────────────
+// Safe Pass est resolu dans `mechanics/passing.ts#executePass` : sur un jet de
+// passe rate, le passeur garde le ballon, il n'y a pas de turnover ni de rebond,
+// et l'activation du passeur se termine (geree par handlePass). L'entree du
+// registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'safe-pass',
+  triggers: ['on-pass'],
+  description: "Si ce joueur rate une action de Passe, le ballon n'est pas lache, ne rebondit pas depuis la case qu'occupe ce joueur, et aucun Renversement n'est cause. Au lieu de cela, ce joueur garde possession du ballon et son activation se termine.",
+  canApply: (ctx) => hasSkill(ctx.player, 'safe-pass') || hasSkill(ctx.player, 'safe_pass'),
+});
+
 // ─── DISTURBING PRESENCE ───────────────────────────────────────────────────
 // Disturbing Presence est resolue dans `mechanics/disturbing-presence.ts`
 // (`getDisturbingPresenceModifier`) et appliquee dans `passing.ts` (pass,


### PR DESCRIPTION
## Résumé

Implémente les deux skills de passe manquants du Sprint 20-21 (tâche K.11).

- **`hail-mary-pass`** : le passeur peut viser n'importe quelle case du terrain (la règle de portée est ignorée, y compris au-delà de Long Bomb). Sur un jet réussi, la passe n'est jamais précise : le ballon dévie depuis la case cible (pas de catch direct, pas de turnover). Sur un échec, comportement normal (turnover + rebond).
- **`safe-pass`** : sur un jet de passe raté, le passeur garde le ballon. Pas de turnover, pas de rebond, l'activation du passeur se termine (via le flow `handlePass` existant).

## Changements

- `packages/game-engine/src/mechanics/passing.ts` : `canAttemptPassForRange` autorise la portée `null` si le passeur a `hail-mary-pass`. `executePass` gère les deux nouveaux flows (safe-pass sur échec, hail-mary-pass = inaccurate sur succès).
- `packages/game-engine/src/skills/skill-registry.ts` : ajout des deux entrées pour la découverte UI et la documentation.
- `packages/game-engine/src/mechanics/hail-mary-safe-pass.test.ts` : 7 tests unitaires (portée bypass, succès inaccurate, échec turnover, safe-pass garde possession, safe-pass succès normal, activation marquée).

## Tâche roadmap

Sprint 20-21, tâche K.11.

## Plan de test

- [x] `pnpm --filter @bb/game-engine test hail-mary-safe-pass` — 7/7 OK
- [x] `pnpm --filter @bb/game-engine test` — 4077/4077 OK (aucune régression)
- [x] `pnpm typecheck` — OK (4 packages)
- [x] `pnpm lint` — OK (0 errors)
- [x] `pnpm --filter @bb/game-engine build` — OK
- [ ] Build web non testé (bloqué par Google Fonts non joignables depuis le sandbox, sans rapport avec cette PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGTgZMHtpM7CvxGvJ2UP7R)_