### PR TITLE
feat(game-engine): K.13 implementer bombardier (Goblin Bomma)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -338,7 +338,7 @@
 | K.10 | Implementer `multiple-block` — Ogres | Regle | [x] |
 | K.11 | Implementer `hail-mary-pass` + `safe-pass` | Regle | [x] |
 | K.12 | Implementer `ball-and-chain` — Goblin Fanatic | Regle | [x] |
-| K.13 | Implementer `bombardier` — Goblin Bomma | Regle | [ ] |
+| K.13 | Implementer `bombardier` — Goblin Bomma | Regle | [x] |
 | O.2 | Star player special rules restantes (~30, hors 5 equipes) | Contenu | [ ] |
 | O.1 | ~39 skills niche restants (batch 3) | Contenu | [ ] |
 

--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -76,6 +76,7 @@ import { canProjectileVomit, executeProjectileVomit } from '../mechanics/project
 import { canStab, executeStab } from '../mechanics/stab';
 import { canChainsaw, executeChainsaw } from '../mechanics/chainsaw';
 import { canBallAndChain, executeBallAndChain } from '../mechanics/ball-and-chain';
+import { canBombThrow, executeBombThrow } from '../mechanics/bombardier';
 import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import { checkDauntless } from '../mechanics/dauntless';
 import { checkBreakTackle } from '../mechanics/break-tackle';
@@ -689,7 +690,7 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
   const ACTIVATION_MOVE_TYPES: string[] = [
     'MOVE', 'LEAP', 'DODGE', 'BLOCK', 'MULTI_BLOCK', 'BLITZ', 'PASS', 'HANDOFF',
     'THROW_TEAM_MATE', 'FOUL', 'HYPNOTIC_GAZE', 'PROJECTILE_VOMIT', 'STAB',
-    'CHAINSAW', 'BALL_AND_CHAIN',
+    'CHAINSAW', 'BALL_AND_CHAIN', 'BOMB_THROW',
   ];
   if (ACTIVATION_MOVE_TYPES.includes(move.type) && 'playerId' in move) {
     const playerId = (move as { playerId: string }).playerId;
@@ -766,6 +767,8 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
       return handleChainsaw(activeState, move, rng);
     case 'BALL_AND_CHAIN':
       return handleBallAndChain(activeState, move, rng);
+    case 'BOMB_THROW':
+      return handleBombThrow(activeState, move, rng);
     case 'DUMP_OFF_CHOOSE':
       return handleDumpOffChoose(activeState, move, rng);
     case 'KICKOFF_PERFECT_DEFENCE':
@@ -2652,6 +2655,26 @@ function handleBallAndChain(
 
   let newState = executeBallAndChain(state, move.playerId, rng);
   newState = setPlayerAction(newState, move.playerId, 'MOVE');
+  newState = checkPlayerTurnEnd(newState, move.playerId);
+  return newState;
+}
+
+/**
+ * Gere une action Bomb Throw (Lancer de Bombe) pour un Bombardier.
+ */
+function handleBombThrow(
+  state: GameState,
+  move: { type: 'BOMB_THROW'; playerId: string; target: Position },
+  rng: RNG,
+): GameState {
+  const player = state.players.find(p => p.id === move.playerId);
+  if (!player) return state;
+  if (player.team !== state.currentPlayer) return state;
+  if (hasPlayerActed(state, player.id)) return state;
+  if (!canBombThrow(state, move.playerId, move.target)) return state;
+
+  let newState = executeBombThrow(state, move.playerId, move.target, rng);
+  newState = setPlayerAction(newState, move.playerId, 'BOMB_THROW');
   newState = checkPlayerTurnEnd(newState, move.playerId);
   return newState;
 }

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -359,7 +359,8 @@ export type ActionType =
   | 'PROJECTILE_VOMIT'
   | 'STAB'
   | 'CHAINSAW'
-  | 'BALL_AND_CHAIN';
+  | 'BALL_AND_CHAIN'
+  | 'BOMB_THROW';
 
 export type Move =
   | { type: 'MOVE'; playerId: string; to: Position }
@@ -384,6 +385,7 @@ export type Move =
   | { type: 'STAB'; playerId: string; targetId: string }
   | { type: 'CHAINSAW'; playerId: string; targetId: string }
   | { type: 'BALL_AND_CHAIN'; playerId: string }
+  | { type: 'BOMB_THROW'; playerId: string; target: Position }
   | { type: 'DUMP_OFF_CHOOSE'; passerId: string; receiverId: string | null }
   | { type: 'KICKOFF_PERFECT_DEFENCE'; positions: Array<{ playerId: string; position: Position }> }
   | { type: 'KICKOFF_HIGH_KICK'; playerId: string | null }

--- a/packages/game-engine/src/mechanics/bombardier.test.ts
+++ b/packages/game-engine/src/mechanics/bombardier.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setup, type GameState, type Player, type RNG } from '../index';
+import {
+  hasBombardier,
+  canBombThrow,
+  executeBombThrow,
+  BOMB_ARMOR_BONUS,
+  BOMB_MAX_RANGE,
+} from './bombardier';
+
+/**
+ * Regle: Bombardier (Blood Bowl 2020 / BB3 Season 2/3)
+ *
+ * Resume:
+ * - Remplace l'action de blocage par une action speciale "Lancer de Bombe".
+ * - Cible une case dans la portee Quick ou Short (1-6 cases).
+ * - Jet de D6 contre la PA du Bombardier (modificateurs de portee standard).
+ * - Succes : la bombe atterrit sur la case cible. Tout joueur sur cette case
+ *   fait un jet d'armure a +1 (BOMB_ARMOR_BONUS). Armure percee -> jet de
+ *   blessure.
+ * - Echec (non-fumble) : la bombe devie (D8) d'une case depuis la cible.
+ * - Fumble (jet brut = 1) : la bombe explose sur le lanceur.
+ * - Pas de turnover sur echec (regle officielle BB2020).
+ * - `pm = 0` apres l'action (activation terminee).
+ */
+
+function scriptedRng(values: number[]): RNG {
+  let idx = 0;
+  return () => {
+    const v = values[idx % values.length];
+    idx += 1;
+    return v;
+  };
+}
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Regle: Bombardier', () => {
+  let state: GameState;
+
+  beforeEach(() => {
+    state = setup();
+  });
+
+  describe('hasBombardier', () => {
+    it('retourne false si le joueur n\'a pas le skill', () => {
+      const player = state.players.find(p => p.id === 'A2')!;
+      expect(hasBombardier(player)).toBe(false);
+    });
+
+    it('retourne true si le joueur a bombardier', () => {
+      const player: Player = {
+        ...state.players.find(p => p.id === 'A2')!,
+        skills: ['bombardier'],
+      };
+      expect(hasBombardier(player)).toBe(true);
+    });
+  });
+
+  describe('Constantes', () => {
+    it('BOMB_ARMOR_BONUS vaut +1 (regle BB2020)', () => {
+      expect(BOMB_ARMOR_BONUS).toBe(1);
+    });
+
+    it('BOMB_MAX_RANGE vaut 6 (Quick + Short only)', () => {
+      expect(BOMB_MAX_RANGE).toBe(6);
+    });
+  });
+
+  describe('canBombThrow', () => {
+    it('retourne false sans le skill bombardier', () => {
+      const s = patchPlayer(state, 'A2', { pos: { x: 5, y: 5 } });
+      expect(canBombThrow(s, 'A2', { x: 8, y: 5 })).toBe(false);
+    });
+
+    it('retourne false si le joueur est stunned', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        stunned: true,
+      });
+      expect(canBombThrow(s, 'A2', { x: 8, y: 5 })).toBe(false);
+    });
+
+    it('retourne false si ce n\'est pas le tour de son equipe', () => {
+      const s = patchPlayer(state, 'B1', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      expect(canBombThrow(s, 'B1', { x: 8, y: 5 })).toBe(false);
+    });
+
+    it('retourne false si la cible est hors portee (>6 cases)', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      // 8 cases ecart
+      expect(canBombThrow(s, 'A2', { x: 13, y: 5 })).toBe(false);
+    });
+
+    it('retourne false si la cible est hors du terrain', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      expect(canBombThrow(s, 'A2', { x: -1, y: 5 })).toBe(false);
+    });
+
+    it('retourne false si la cible est la case du lanceur', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      expect(canBombThrow(s, 'A2', { x: 5, y: 5 })).toBe(false);
+    });
+
+    it('retourne true pour une cible en portee Short (5 cases)', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      expect(canBombThrow(s, 'A2', { x: 10, y: 5 })).toBe(true);
+    });
+
+    it('retourne true pour une cible en portee Quick (2 cases)', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      expect(canBombThrow(s, 'A2', { x: 7, y: 5 })).toBe(true);
+    });
+  });
+
+  describe('executeBombThrow - succes', () => {
+    it('la bombe atterrit sur la cible et touche le joueur present', () => {
+      // Bomber en (5,5), cible ennemie B1 en (8,5), PA=3.
+      let s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        pa: 3,
+        pm: 6,
+      });
+      s = patchPlayer(s, 'B1', { pos: { x: 8, y: 5 }, av: 8 });
+      s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+      s = patchPlayer(s, 'B2', { pos: { x: 0, y: 1 } });
+
+      // rng: pass roll = 4 (succes car PA=3 et Short=-0 -> target 3), puis armor dice.
+      // pass D6 -> 4 via 0.55 (floor(0.55*6)+1=4)
+      // armor 2D6 -> 6+5=11 via 0.9, 0.7 (floor(0.9*6)+1=6, floor(0.7*6)+1=5) -> 11 vs 8+1=9 -> percee
+      const rng = scriptedRng([0.55, 0.9, 0.7, 0.5, 0.5]);
+      const result = executeBombThrow(s, 'A2', { x: 8, y: 5 }, rng);
+
+      // L'activation est terminee
+      const bomber = result.players.find(p => p.id === 'A2')!;
+      expect(bomber.pm).toBe(0);
+
+      // Le joueur cible a reellement subi un jet d'armure/blessure : verifier
+      // via le log que la bombe a atteint B1.
+      const logText = result.gameLog.map(e => e.message).join('\n');
+      expect(logText).toMatch(/bombe|Bombe/i);
+    });
+
+    it('la bombe sans cible (case vide) n\'entraine aucun jet d\'armure', () => {
+      let s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        pa: 3,
+        pm: 6,
+      });
+      s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+      s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+      s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+
+      const rng = scriptedRng([0.55, 0.5, 0.5, 0.5, 0.5]);
+      const result = executeBombThrow(s, 'A2', { x: 8, y: 5 }, rng);
+
+      // Aucun jet d'armure enregistre
+      expect(result.lastDiceResult?.type).not.toBe('armor');
+      // Activation terminee
+      expect(result.players.find(p => p.id === 'A2')!.pm).toBe(0);
+    });
+
+    it('n\'entraine pas de turnover sur echec (regle BB2020)', () => {
+      let s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        pa: 6, // tres difficile
+        pm: 6,
+      });
+      s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+      s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+      s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+
+      // pass D6 -> 2 (echec non-fumble car PA=6 target=6)
+      // Ensuite scatter D8 puis eventuel armor (case vide normalement)
+      const rng = scriptedRng([0.2, 0.3, 0.5, 0.5, 0.5, 0.5]);
+      const result = executeBombThrow(s, 'A2', { x: 8, y: 5 }, rng);
+
+      expect(result.isTurnover).toBeFalsy();
+    });
+  });
+
+  describe('executeBombThrow - fumble', () => {
+    it('un jet brut de 1 fait exploser la bombe sur le lanceur', () => {
+      let s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        pa: 3,
+        pm: 6,
+        av: 8,
+      });
+      s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+      s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+      s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+
+      // rng: pass D6 = 1 via 0.01 -> fumble
+      // armor 2D6 = 6+6 = 12 via 0.99, 0.99 -> percee (12 >= 8+1=9)
+      const rng = scriptedRng([0.01, 0.99, 0.99, 0.5, 0.5]);
+      const result = executeBombThrow(s, 'A2', { x: 8, y: 5 }, rng);
+
+      const logText = result.gameLog.map(e => e.message).join('\n');
+      expect(logText).toMatch(/fumble|rate|rebond|lanceur|Bombardier/i);
+      // Activation terminee
+      expect(result.players.find(p => p.id === 'A2')!.pm).toBe(0);
+    });
+  });
+
+  describe('executeBombThrow - invariants', () => {
+    it('ne fait rien si le joueur n\'a pas bombardier', () => {
+      const before = state;
+      const after = executeBombThrow(before, 'A2', { x: 10, y: 7 }, scriptedRng([0.5]));
+      expect(after).toBe(before);
+    });
+
+    it('ne fait rien si la cible est hors portee', () => {
+      const s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+      });
+      const after = executeBombThrow(s, 'A2', { x: 20, y: 5 }, scriptedRng([0.5]));
+      // L'etat reste inchange
+      expect(after).toBe(s);
+    });
+
+    it('ne fait rien si le joueur est introuvable', () => {
+      const before = state;
+      const after = executeBombThrow(before, 'UNKNOWN', { x: 10, y: 7 }, scriptedRng([0.5]));
+      expect(after).toBe(before);
+    });
+  });
+});

--- a/packages/game-engine/src/mechanics/bombardier.ts
+++ b/packages/game-engine/src/mechanics/bombardier.ts
@@ -1,0 +1,219 @@
+/**
+ * Mecanique de Bombardier (Bomb Throw) pour Blood Bowl — BB3 Season 2/3 /
+ * Blood Bowl 2020.
+ *
+ * Resume:
+ * - Un joueur avec `bombardier` peut effectuer une action speciale "Lancer de
+ *   Bombe" a la place d'un blocage.
+ * - La cible est une case du terrain dans la portee Quick ou Short (1 a 6
+ *   cases Chebyshev). Long / Long Bomb non autorises.
+ * - Jet de D6 contre la PA du lanceur, modifie par la portee (Quick +1,
+ *   Short 0).
+ * - Fumble (jet brut = 1) : la bombe explose sur la case du Bombardier
+ *   lui-meme. Armor roll +1 sur le Bombardier, puis jet de blessure si
+ *   percee.
+ * - Echec non-fumble : la bombe devie d'une case dans une direction aleatoire
+ *   (D8) depuis la cible, puis explose sur la case atteinte.
+ * - Succes : la bombe explose directement sur la case cible.
+ * - Impact : tout joueur sur la case finale subit un jet d'armure avec
+ *   modificateur +1 (BOMB_ARMOR_BONUS). Armure percee -> jet de blessure.
+ * - Pas de turnover (regle officielle BB2020).
+ * - `pm = 0` apres l'action.
+ *
+ * Utilisateur principal : Goblin Bomma + Star Players bombardier.
+ */
+
+import type { GameState, Player, Position, RNG, DiceResult } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import { rollD6, performArmorRoll } from '../utils/dice';
+import { performInjuryRoll } from './injury';
+import { getRandomDirection } from './ball';
+import { inBounds } from './movement';
+import { createLogEntry } from '../utils/logging';
+import { getPassRange, getPassRangeModifier } from './passing';
+
+export const BOMB_ARMOR_BONUS = 1;
+export const BOMB_MAX_RANGE = 6; // Quick (1-3) + Short (4-6)
+
+/** Predicat : le joueur possede le trait Bombardier. */
+export function hasBombardier(player: Player): boolean {
+  return hasSkill(player, 'bombardier');
+}
+
+/** Verifie qu'une case cible est valide pour un Lancer de Bombe. */
+export function canBombThrow(
+  state: GameState,
+  playerId: string,
+  target: Position,
+): boolean {
+  const player = state.players.find(p => p.id === playerId);
+  if (!player) return false;
+  if (!hasBombardier(player)) return false;
+  if (player.stunned) return false;
+  if (player.state !== undefined && player.state !== 'active') return false;
+  if (player.team !== state.currentPlayer) return false;
+  if (!inBounds(state, target)) return false;
+  if (target.x === player.pos.x && target.y === player.pos.y) return false;
+
+  const dx = Math.abs(target.x - player.pos.x);
+  const dy = Math.abs(target.y - player.pos.y);
+  const distance = Math.max(dx, dy);
+  if (distance === 0 || distance > BOMB_MAX_RANGE) return false;
+
+  return true;
+}
+
+/** Clamp une position aux limites du terrain. */
+function clampToBoard(state: GameState, pos: Position): Position {
+  return {
+    x: Math.max(0, Math.min(state.width - 1, pos.x)),
+    y: Math.max(0, Math.min(state.height - 1, pos.y)),
+  };
+}
+
+/** Applique les degats d'une explosion sur la case indiquee. */
+function applyBombImpact(
+  state: GameState,
+  attackerId: string,
+  impactPos: Position,
+  rng: RNG,
+): GameState {
+  const victim = state.players.find(
+    p => p.pos.x === impactPos.x && p.pos.y === impactPos.y,
+  );
+  let newState = state;
+
+  const explosionLog = createLogEntry(
+    'action',
+    `La bombe explose en (${impactPos.x}, ${impactPos.y}) !`,
+    attackerId,
+    newState.players.find(p => p.id === attackerId)?.team,
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, explosionLog] };
+
+  if (!victim) return newState;
+
+  const armorResult = performArmorRoll(victim, rng, -BOMB_ARMOR_BONUS);
+  newState = { ...newState, lastDiceResult: armorResult };
+
+  const armorLog = createLogEntry(
+    'dice',
+    `Jet d'armure de ${victim.name} (bombe +${BOMB_ARMOR_BONUS}): ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '(tient)' : '(percee)'}`,
+    victim.id,
+    victim.team,
+    {
+      diceRoll: armorResult.diceRoll,
+      targetNumber: armorResult.targetNumber,
+      bombBonus: BOMB_ARMOR_BONUS,
+    },
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, armorLog] };
+
+  if (!armorResult.success) {
+    const currentVictim = newState.players.find(p => p.id === victim.id);
+    if (currentVictim) {
+      newState = performInjuryRoll(newState, currentVictim, rng, 0, attackerId);
+    }
+  }
+
+  return newState;
+}
+
+/** Termine l'activation du lanceur (pm = 0). */
+function endActivation(state: GameState, playerId: string): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === playerId ? { ...p, pm: 0 } : p)),
+  };
+}
+
+/**
+ * Execute un Lancer de Bombe.
+ */
+export function executeBombThrow(
+  state: GameState,
+  playerId: string,
+  target: Position,
+  rng: RNG,
+): GameState {
+  if (!canBombThrow(state, playerId, target)) return state;
+
+  const bomber = state.players.find(p => p.id === playerId);
+  if (!bomber) return state;
+
+  let newState: GameState = {
+    ...state,
+    gameLog: [
+      ...state.gameLog,
+      createLogEntry(
+        'action',
+        `${bomber.name} lance une bombe vers (${target.x}, ${target.y}) !`,
+        bomber.id,
+        bomber.team,
+        { skill: 'bombardier', target: { ...target } },
+      ),
+    ],
+  };
+
+  // Jet de lancement : D6 contre la PA, modifie par la portee.
+  const range = getPassRange(bomber.pos, target); // 'quick' | 'short' (valide)
+  const rangeModifier = range ? getPassRangeModifier(range) : 0;
+  const diceRoll = rollD6(rng);
+  const modifiers = rangeModifier;
+  // target = max(2, min(6, PA - modifiers))
+  const targetNumber = Math.max(2, Math.min(6, bomber.pa - modifiers));
+  const fumble = diceRoll === 1;
+  const success = !fumble && diceRoll >= targetNumber;
+
+  const throwResult: DiceResult = {
+    type: 'pass',
+    playerId: bomber.id,
+    diceRoll,
+    targetNumber,
+    success,
+    modifiers,
+  };
+  newState = { ...newState, lastDiceResult: throwResult };
+
+  const throwLog = createLogEntry(
+    'dice',
+    `Lancer de Bombe: ${diceRoll}/${targetNumber} ${success ? '✓' : fumble ? 'FUMBLE !' : '✗'}`,
+    bomber.id,
+    bomber.team,
+    { diceRoll, targetNumber, modifiers, fumble },
+  );
+  newState = { ...newState, gameLog: [...newState.gameLog, throwLog] };
+
+  let impactPos: Position;
+  if (fumble) {
+    // La bombe explose sur le lanceur.
+    const fumbleLog = createLogEntry(
+      'action',
+      `Fumble ! La bombe retombe sur ${bomber.name} !`,
+      bomber.id,
+      bomber.team,
+    );
+    newState = { ...newState, gameLog: [...newState.gameLog, fumbleLog] };
+    impactPos = { ...bomber.pos };
+  } else if (!success) {
+    // Deviation : D8 scatter depuis la cible.
+    const dir = getRandomDirection(rng);
+    const scattered: Position = {
+      x: target.x + dir.x,
+      y: target.y + dir.y,
+    };
+    impactPos = clampToBoard(newState, scattered);
+    const scatterLog = createLogEntry(
+      'info',
+      `La bombe devie vers (${impactPos.x}, ${impactPos.y}).`,
+      bomber.id,
+      bomber.team,
+    );
+    newState = { ...newState, gameLog: [...newState.gameLog, scatterLog] };
+  } else {
+    impactPos = { ...target };
+  }
+
+  newState = applyBombImpact(newState, bomber.id, impactPos, rng);
+  return endActivation(newState, playerId);
+}

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -1042,6 +1042,7 @@ export function logInstablePrevention(
     STAB: 'de poignard',
     CHAINSAW: 'de tronconneuse',
     BALL_AND_CHAIN: 'de chaine et boulet',
+    BOMB_THROW: 'de lancer de bombe',
   };
   const label = actionLabels[actionType] ?? '';
   const message = label

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -658,6 +658,17 @@ registerSkill({
   canApply: (ctx) => hasSkill(ctx.player, 'animal-savagery'),
 });
 
+// ─── BOMBARDIER ─────────────────────────────────────────────────────────────
+// Action speciale "Lancer de Bombe" implementee dans `mechanics/bombardier.ts`,
+// branchee via l'action BOMB_THROW.
+
+registerSkill({
+  slug: 'bombardier',
+  triggers: ['on-activation'],
+  description: 'Action speciale (remplace un blocage) : lance une bombe sur une case en portee Quick/Short. Succes = explosion +1 armure ; fumble = explosion sur le lanceur ; echec = deviation D8.',
+  canApply: (ctx) => hasSkill(ctx.player, 'bombardier'),
+});
+
 // ─── BALL AND CHAIN ─────────────────────────────────────────────────────────
 // Ball and Chain remplace l'action de Mouvement du joueur par un deplacement
 // automatique dans une direction aleatoire (D8). Implementation dans


### PR DESCRIPTION
## Resume

Implemente le trait **Bombardier** (BB3 Season 2/3, Blood Bowl 2020) utilise principalement par le Goblin Bomma.

- Nouvelle action `BOMB_THROW` (remplace le blocage) : le joueur vise une case a 1-6 cases (Quick/Short uniquement).
- Jet de D6 contre la PA modifiee par la portee (Quick +1, Short 0).
- **Succes** : la bombe explose sur la case cible. Jet d'armure +1 (`BOMB_ARMOR_BONUS`) sur le joueur present, suivi d'un jet de blessure si l'armure cede.
- **Fumble (D6 brut = 1)** : la bombe retombe sur le lanceur. Meme logique d'explosion.
- **Echec non-fumble** : deviation d'une case (D8 scatter via `getRandomDirection`) puis explosion.
- Pas de turnover (regle officielle BB2020).
- `pm = 0` apres l'action (activation terminee).

### Fichiers

- `packages/game-engine/src/mechanics/bombardier.ts` (nouveau, ~200 lignes) — logique complete : `hasBombardier`, `canBombThrow`, `executeBombThrow`, helper `applyBombImpact`.
- `packages/game-engine/src/mechanics/bombardier.test.ts` (nouveau) — 19 tests : predicat, constantes, `canBombThrow` (8 cas), succes / case vide / pas de turnover / fumble, invariants.
- `packages/game-engine/src/core/types.ts` — `BOMB_THROW` dans `ActionType` et variant `{ type: 'BOMB_THROW'; playerId; target }` dans `Move`.
- `packages/game-engine/src/actions/actions.ts` — import des helpers, `BOMB_THROW` dans `ACTIVATION_MOVE_TYPES`, case dans le switch, handler `handleBombThrow`.
- `packages/game-engine/src/mechanics/negative-traits.ts` — libelle FR pour `Record<ActionType, string>`.
- `packages/game-engine/src/skills/skill-registry.ts` — enregistrement du skill (trigger `on-activation`, metadata UI).
- `TODO.md` — Sprint 20-21 K.13 coche.

## Tache roadmap

Sprint 20-21, **K.13** — `bombardier` (Goblin Bomma).

## Plan de test

- [x] `pnpm test` — 4115 tests verts (128 fichiers), dont les 19 nouveaux sur `bombardier.test.ts`.
- [x] `pnpm typecheck` — OK (tous packages : game-engine, server, web, ui).
- [x] Scenarios couverts par les tests :
  - Predicat `hasBombardier` (avec / sans skill)
  - Constantes `BOMB_ARMOR_BONUS = 1`, `BOMB_MAX_RANGE = 6`
  - `canBombThrow` : sans skill, stunned, mauvaise equipe, hors portee (>6), hors terrain, case du lanceur, Quick, Short
  - Succes : la bombe atteint la cible, log `bombe`, `pm = 0`
  - Case vide : aucun jet d'armure (`lastDiceResult.type !== 'armor'`)
  - Echec non-fumble : `isTurnover` reste falsy
  - Fumble (D6 = 1) : log `fumble` / `rebond` sur le lanceur
  - Invariants : no-op sans skill, hors portee, joueur inconnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5eJR3eKJvMhTwXDt2h4aX)_