### PR TITLE
feat(game-engine): O.1 batch 3a - nerves-of-steel, big-hand, extra-arms

### DIFF
--- a/packages/game-engine/src/mechanics/movement.ts
+++ b/packages/game-engine/src/mechanics/movement.ts
@@ -147,13 +147,28 @@ export function calculateDodgeModifiers(
 export function calculatePickupModifiers(
   state: GameState,
   ballPosition: Position,
-  team: TeamId
+  team: TeamId,
+  picker?: Player
 ): number {
   let modifiers = 0;
 
-  // Malus pour chaque adversaire qui marque la case où se trouve la balle
+  // Malus pour chaque adversaire qui marque la case où se trouve la balle.
+  // Big Hand (O.1 batch 3) annule ce malus de zones de tacle.
   const opponentsAtBall = getAdjacentOpponents(state, ballPosition, team);
-  modifiers -= opponentsAtBall.length; // -1 par adversaire adjacent à la balle
+  const hasBigHand =
+    picker !== undefined &&
+    (picker.skills.includes('big-hand') || picker.skills.includes('big_hand'));
+  if (!hasBigHand) {
+    modifiers -= opponentsAtBall.length;
+  }
+
+  // Extra Arms (O.1 batch 3) : +1 au jet de ramassage.
+  if (
+    picker !== undefined &&
+    (picker.skills.includes('extra-arms') || picker.skills.includes('extra_arms'))
+  ) {
+    modifiers += 1;
+  }
 
   return modifiers;
 }

--- a/packages/game-engine/src/mechanics/niche-modifier-skills.test.ts
+++ b/packages/game-engine/src/mechanics/niche-modifier-skills.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { setup, type GameState, type Player } from '../index';
+import {
+  calculatePassModifiers,
+  calculateCatchModifiers,
+} from './passing';
+import { calculatePickupModifiers } from './movement';
+
+/**
+ * O.1 batch 3 — Skills modificateurs de jets (niche mais a fort impact local) :
+ * - Nerves of Steel : ignore les malus de zones de tacle sur pass et catch.
+ * - Big Hand : ignore le malus de zones de tacle sur le jet de ramassage.
+ * - Extra Arms : +1 aux jets de reception et de ramassage.
+ */
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Niche skills: Nerves of Steel', () => {
+  it('annule le malus TZ sur le jet de passe', () => {
+    let s = setup();
+    // A2 a le passeur, entoure par B1 et B2 (2 TZ).
+    s = patchPlayer(s, 'A2', {
+      skills: ['nerves-of-steel'],
+      pos: { x: 5, y: 5 },
+      pa: 3,
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const passer = s.players.find(p => p.id === 'A2')!;
+    const target = { x: 10, y: 5 }; // distance 5 -> Short range (+0)
+    const modWithSkill = calculatePassModifiers(s, passer, target);
+
+    const passerNoSkill: Player = { ...passer, skills: [] };
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const modNoSkill = calculatePassModifiers(stateNoSkill, passerNoSkill, target);
+
+    // Avec Nerves of Steel : les TZ sont ignorees.
+    expect(modWithSkill).toBeGreaterThan(modNoSkill);
+    expect(modWithSkill).toBe(0); // Short range, pas de TZ pris en compte
+    expect(modNoSkill).toBe(-2); // Short range (0) - 2 TZ = -2
+  });
+
+  it('annule le malus TZ sur le jet de reception', () => {
+    let s = setup();
+    // A2 receveur entoure de 2 adversaires.
+    s = patchPlayer(s, 'A2', {
+      skills: ['nerves-of-steel'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const catcher = s.players.find(p => p.id === 'A2')!;
+    const modWithSkill = calculateCatchModifiers(s, catcher);
+
+    const catcherNoSkill: Player = { ...catcher, skills: [] };
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const modNoSkill = calculateCatchModifiers(stateNoSkill, catcherNoSkill);
+
+    expect(modWithSkill).toBe(0);
+    expect(modNoSkill).toBe(-2);
+  });
+
+  it('ne modifie pas les autres malus (Disturbing Presence)', () => {
+    let s = setup();
+    // Pas d'adversaires TZ, mais 1 adversaire avec Disturbing Presence a 2 cases.
+    s = patchPlayer(s, 'A2', {
+      skills: ['nerves-of-steel'],
+      pos: { x: 5, y: 5 },
+      pa: 3,
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 7, y: 5 }, skills: ['disturbing-presence'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const passer = s.players.find(p => p.id === 'A2')!;
+    const mod = calculatePassModifiers(s, passer, { x: 10, y: 5 });
+    // Nerves ne modifie pas le malus DP : -1 DP attendu + 0 (Short) = -1
+    expect(mod).toBe(-1);
+  });
+});
+
+describe('Niche skills: Big Hand', () => {
+  it('annule le malus TZ sur le jet de ramassage', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['big-hand'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const modWithSkill = calculatePickupModifiers(s, { x: 5, y: 5 }, 'A', s.players.find(p => p.id === 'A2'));
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const modNoSkill = calculatePickupModifiers(stateNoSkill, { x: 5, y: 5 }, 'A', stateNoSkill.players.find(p => p.id === 'A2'));
+
+    expect(modWithSkill).toBe(0);
+    expect(modNoSkill).toBe(-2);
+  });
+});
+
+describe('Niche skills: Extra Arms', () => {
+  it('+1 au jet de ramassage', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['extra-arms'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 1 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const withSkill = calculatePickupModifiers(s, { x: 5, y: 5 }, 'A', s.players.find(p => p.id === 'A2'));
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const noSkill = calculatePickupModifiers(stateNoSkill, { x: 5, y: 5 }, 'A', stateNoSkill.players.find(p => p.id === 'A2'));
+
+    expect(withSkill - noSkill).toBe(1);
+  });
+
+  it('+1 au jet de reception', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['extra-arms'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 1 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const catcher = s.players.find(p => p.id === 'A2')!;
+    const withSkill = calculateCatchModifiers(s, catcher);
+
+    const catcherNoSkill: Player = { ...catcher, skills: [] };
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const noSkill = calculateCatchModifiers(stateNoSkill, catcherNoSkill);
+
+    expect(withSkill - noSkill).toBe(1);
+  });
+
+  it('cumul Big Hand + Extra Arms : +1 et TZ ignore', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['big-hand', 'extra-arms'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const mod = calculatePickupModifiers(s, { x: 5, y: 5 }, 'A', s.players.find(p => p.id === 'A2'));
+    // Sans skill : -2 (2 TZ). Avec Big Hand : 0 TZ. Avec Extra Arms : +1. Total = +1.
+    expect(mod).toBe(1);
+  });
+});

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -80,9 +80,15 @@ export function calculatePassModifiers(
     modifiers += getPassRangeModifier(range);
   }
 
-  // Malus pour chaque adversaire en zone de tacle du passeur
+  // Malus pour chaque adversaire en zone de tacle du passeur.
+  // Nerves of Steel (O.1 batch 3) annule ce malus.
   const opponentsNearPasser = getAdjacentOpponents(state, passer.pos, passer.team);
-  modifiers -= opponentsNearPasser.length;
+  const hasNervesOfSteel =
+    passer.skills.includes('nerves-of-steel') ||
+    passer.skills.includes('nerves_of_steel');
+  if (!hasNervesOfSteel) {
+    modifiers -= opponentsNearPasser.length;
+  }
 
   // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases
   modifiers += getDisturbingPresenceModifier(state, passer.pos, passer.team);
@@ -118,9 +124,23 @@ export function calculateCatchModifiers(
 ): number {
   let modifiers = 0;
 
-  // Malus pour chaque adversaire en zone de tacle du receveur
+  // Malus pour chaque adversaire en zone de tacle du receveur.
+  // Nerves of Steel (O.1 batch 3) annule ce malus.
   const opponentsNearCatcher = getAdjacentOpponents(state, catcher.pos, catcher.team);
-  modifiers -= opponentsNearCatcher.length;
+  const hasNervesOfSteel =
+    catcher.skills.includes('nerves-of-steel') ||
+    catcher.skills.includes('nerves_of_steel');
+  if (!hasNervesOfSteel) {
+    modifiers -= opponentsNearCatcher.length;
+  }
+
+  // Extra Arms (O.1 batch 3) : +1 au jet de reception.
+  if (
+    catcher.skills.includes('extra-arms') ||
+    catcher.skills.includes('extra_arms')
+  ) {
+    modifiers += 1;
+  }
 
   // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases
   modifiers += getDisturbingPresenceModifier(state, catcher.pos, catcher.team);


### PR DESCRIPTION
## Resume

Sous-lot de la tache **O.1 — ~39 skills niche restants (batch 3)**. Implemente mecaniquement 3 skills "modificateurs de jets" qui etaient enregistres dans `skill-registry` mais non cables dans les fonctions de calcul des modificateurs.

- **Nerves of Steel** — annule le malus de zones de tacle adverses sur les jets de **Passe** et de **Reception**. Ne modifie PAS les autres malus (Disturbing Presence, Range), conforme BB2020.
- **Big Hand** — annule le malus de zones de tacle adverses sur le jet de **Ramassage** de balle.
- **Extra Arms** — +1 aux jets de **Reception** et de **Ramassage** (cumulable avec Big Hand).

### Fichiers

- `packages/game-engine/src/mechanics/passing.ts` — `calculatePassModifiers` et `calculateCatchModifiers` : verifient Nerves of Steel avant de soustraire le malus TZ ; Extra Arms ajoute +1 en catch.
- `packages/game-engine/src/mechanics/movement.ts` — `calculatePickupModifiers` accepte desormais un parametre optionnel `picker: Player` pour pouvoir lire les skills du ramasseur et appliquer Big Hand + Extra Arms.
- `packages/game-engine/src/mechanics/niche-modifier-skills.test.ts` (nouveau) — 7 tests couvrant chaque regle.

## Tache roadmap

Sprint 20-21, **O.1** — ~39 skills niche restants (batch 3).

> **Scoping** : cette PR traite un sous-lot de 3 skills. Les autres skills du batch suivront dans des PRs ulterieures (ex: strip-ball, pile-on, safe-pair-of-hands, pass-block, etc.). L'entree TODO reste non-cochee puisque la majorite des skills niche restent a faire.

## Plan de test

- [x] `pnpm test` — 4122 tests verts (129 fichiers), 7 nouveaux tests ajoutes.
- [x] `pnpm typecheck` — OK (tous packages).
- [x] Scenarios couverts par les tests :
  - Nerves of Steel annule 2 TZ sur pass (-2 -> 0) a Short range
  - Nerves of Steel annule 2 TZ sur catch (-2 -> 0)
  - Nerves of Steel ne modifie PAS Disturbing Presence (-1 conserve)
  - Big Hand annule 2 TZ sur pickup (-2 -> 0)
  - Extra Arms +1 au pickup (sans TZ)
  - Extra Arms +1 au catch (sans TZ)
  - Cumul Big Hand + Extra Arms : TZ ignore + 1 = +1 (2 TZ adverses)

## Note technique

Nettoyage aussi de fichiers `.js` obsoletes dans `packages/game-engine/src/` (non trackes par git, generes par une ancienne compilation TSC). Ils etaient charges a la place des `.ts` par Node et empechaient les edits TypeScript d'etre pris en compte par vitest. Ils etaient deja dans `.gitignore` de facto.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5eJR3eKJvMhTwXDt2h4aX)_