### PR TITLE
feat(game-engine): O.1 batch 3d - diving-catch catch modifier

### DIFF
--- a/packages/game-engine/src/mechanics/diving-catch.test.ts
+++ b/packages/game-engine/src/mechanics/diving-catch.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { setup, type GameState, type Player } from '../index';
+import { calculateCatchModifiers } from './passing';
+
+/**
+ * O.1 batch 3d — Diving Catch (BB2020) :
+ * - +1 au jet de reception.
+ * - (non implemente ici) : peut receptionner un ballon atterrissant sur une
+ *   case adjacente.
+ */
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Pass modifier skills: Diving Catch', () => {
+  it('+1 au jet de reception quand le catcher a diving-catch', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['diving-catch'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const catcher = s.players.find(p => p.id === 'A2')!;
+    const withSkill = calculateCatchModifiers(s, catcher);
+
+    const catcherNoSkill: Player = { ...catcher, skills: [] };
+    const stateNoSkill = patchPlayer(s, 'A2', { skills: [] });
+    const noSkill = calculateCatchModifiers(stateNoSkill, catcherNoSkill);
+
+    expect(withSkill - noSkill).toBe(1);
+  });
+
+  it('le bonus Diving Catch se cumule avec Extra Arms', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['diving-catch', 'extra-arms'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const catcher = s.players.find(p => p.id === 'A2')!;
+    const modBoth = calculateCatchModifiers(s, catcher);
+    // +1 Diving Catch + +1 Extra Arms = +2 (sans TZ, sans DP)
+    expect(modBoth).toBe(2);
+  });
+
+  it('le bonus reste inchange en presence de Nerves of Steel', () => {
+    // Avec Nerves of Steel : TZ ignore. Avec Diving Catch : +1. Avec 2 TZ :
+    // sans les deux skills on aurait -2, avec les deux on a 0 + 1 = +1.
+    let s = setup();
+    s = patchPlayer(s, 'A2', {
+      skills: ['diving-catch', 'nerves-of-steel'],
+      pos: { x: 5, y: 5 },
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+
+    const catcher = s.players.find(p => p.id === 'A2')!;
+    expect(calculateCatchModifiers(s, catcher)).toBe(1);
+  });
+});

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -162,6 +162,17 @@ export function calculateCatchModifiers(
     modifiers += 1;
   }
 
+  // Diving Catch (O.1 batch 3d) : +1 au jet de reception du ballon.
+  // Note : l'effet "peut receptionner sur une case adjacente" n'est pas
+  // encore implemente (deviation/scatter vers une case voisine suite a une
+  // passe ratee).
+  if (
+    catcher.skills.includes('diving-catch') ||
+    catcher.skills.includes('diving_catch')
+  ) {
+    modifiers += 1;
+  }
+
   // Disturbing Presence : -1 par adversaire avec le skill a <= 3 cases
   modifiers += getDisturbingPresenceModifier(state, catcher.pos, catcher.team);
 


### PR DESCRIPTION
## Resume

Sous-lot D de la tache **O.1 — ~39 skills niche restants (batch 3)**. Branche le bonus **+1 au jet de reception** du skill **Diving Catch** dans `calculateCatchModifiers`.

### Regle BB2020 (implementee partiellement)

- **[x]** +1 au jet de reception du ballon.
- **[ ]** Non couvert ici : possibilite de receptionner un ballon atterrissant sur une case adjacente (effet "diving" qui demande un flux reception etendu, a livrer plus tard).

### Cumuls valides par test

- **Diving Catch + Extra Arms** : +2 (deux bonus distincts au jet de reception).
- **Diving Catch + Nerves of Steel** : +1 avec 2 adversaires marquant (Nerves annule les TZ, Diving Catch ajoute +1).

### Fichiers

- `packages/game-engine/src/mechanics/passing.ts` — ajout du bonus Diving Catch dans `calculateCatchModifiers`, apres Extra Arms.
- `packages/game-engine/src/mechanics/diving-catch.test.ts` (nouveau) — 3 tests.

## Tache roadmap

Sprint 20-21, **O.1** — ~39 skills niche restants (batch 3). Quatrieme sous-lot apres :
- #313 (3a : nerves-of-steel, big-hand, extra-arms)
- #314 (3b : accurate, strong-arm)
- #315 (3c : strip-ball)

## Plan de test

- [x] `pnpm test` — 4139 tests verts (132 fichiers), 3 nouveaux.
- [x] `pnpm typecheck` — OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5eJR3eKJvMhTwXDt2h4aX)_