### PR TITLE
feat(game-engine): O.1 batch 3e - catch + pass personal rerolls

### DIFF
--- a/packages/game-engine/src/mechanics/catch-pass-skill-reroll.test.ts
+++ b/packages/game-engine/src/mechanics/catch-pass-skill-reroll.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { setup, type Player, type RNG } from '../index';
+import { performCatchRollWithSkill, performPassRollWithSkill } from './passing';
+
+/**
+ * O.1 batch 3e — skills de relance personnelle :
+ * - Catch : relance automatique (une fois) d'un jet de reception rate.
+ * - Pass  : relance automatique (une fois) d'un jet de passe rate.
+ */
+
+function scriptedRng(values: number[]): RNG {
+  let idx = 0;
+  return () => {
+    const v = values[idx % values.length];
+    idx += 1;
+    return v;
+  };
+}
+
+function makeCatcher(skills: string[]): Player {
+  const s = setup();
+  return { ...s.players.find(p => p.id === 'A2')!, skills, ag: 3 };
+}
+
+function makePasser(skills: string[]): Player {
+  const s = setup();
+  return { ...s.players.find(p => p.id === 'A2')!, skills, pa: 3 };
+}
+
+describe('Skill: Catch (personal reroll)', () => {
+  it('relance une reception ratee si le receveur a catch', () => {
+    const catcher = makeCatcher(['catch']);
+    // Target ag=3 -> target=3 sans modifier. 1er jet = 1 (echec), 2eme = 5 (succes)
+    const rng = scriptedRng([0.01, 0.8]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  it('ne relance pas si le receveur n\'a pas catch', () => {
+    const catcher = makeCatcher([]);
+    const rng = scriptedRng([0.01, 0.8]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(false);
+  });
+
+  it('ne relance pas si le premier jet est deja reussi', () => {
+    const catcher = makeCatcher(['catch']);
+    const rng = scriptedRng([0.8, 0.01]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('Skill: Pass (personal reroll)', () => {
+  it('relance une passe ratee si le passeur a pass', () => {
+    const passer = makePasser(['pass']);
+    const rng = scriptedRng([0.01, 0.8]);
+    const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  it('ne relance pas si le passeur n\'a pas pass', () => {
+    const passer = makePasser([]);
+    const rng = scriptedRng([0.01, 0.8]);
+    const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(false);
+  });
+
+  it('relance une seule fois (succes apres reroll)', () => {
+    const passer = makePasser(['pass']);
+    // echec -> reroll -> succes
+    const rng = scriptedRng([0.01, 0.9]);
+    const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  it('echec apres reroll reste un echec', () => {
+    const passer = makePasser(['pass']);
+    // echec -> reroll -> echec
+    const rng = scriptedRng([0.01, 0.01]);
+    const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -182,6 +182,50 @@ export function calculateCatchModifiers(
 /**
  * Effectue un jet de réception
  */
+/**
+ * Effectue un jet de reception avec la possibilite d'utiliser le skill `catch`
+ * pour relancer une fois en cas d'echec (sans consommer la relance d'equipe).
+ * BB2020 : "If this player fails to catch a Pass, Pick Up, Intercept or Bounce,
+ * they may re-roll the dice." — implemente ici uniquement sur Catch.
+ */
+export function performCatchRollWithSkill(
+  catcher: Player,
+  rng: RNG,
+  modifiers: number,
+): { result: DiceResult; rerolled: boolean } {
+  const first = performCatchRoll(catcher, rng, modifiers);
+  if (first.success) {
+    return { result: first, rerolled: false };
+  }
+  const hasCatch = catcher.skills.some(s => s.toLowerCase() === 'catch');
+  if (!hasCatch) {
+    return { result: first, rerolled: false };
+  }
+  const second = performCatchRoll(catcher, rng, modifiers);
+  return { result: second, rerolled: true };
+}
+
+/**
+ * Effectue un jet de passe avec la possibilite d'utiliser le skill `pass`
+ * pour relancer une fois en cas d'echec.
+ */
+export function performPassRollWithSkill(
+  passer: Player,
+  rng: RNG,
+  modifiers: number,
+): { result: DiceResult; rerolled: boolean } {
+  const first = performPassRoll(passer, rng, modifiers);
+  if (first.success) {
+    return { result: first, rerolled: false };
+  }
+  const hasPass = passer.skills.some(s => s.toLowerCase() === 'pass');
+  if (!hasPass) {
+    return { result: first, rerolled: false };
+  }
+  const second = performPassRoll(passer, rng, modifiers);
+  return { result: second, rerolled: true };
+}
+
 export function performCatchRoll(catcher: Player, rng: RNG, modifiers: number): DiceResult {
   const diceRoll = rollD6(rng);
   const targetNumber = Math.max(2, Math.min(6, catcher.ag - modifiers));
@@ -327,9 +371,20 @@ export function executePass(
     }
   }
 
-  // Jet de passe
+  // Jet de passe (avec relance `pass` skill si echec et skill present)
   const passModifiers = calculatePassModifiers(newState, passer, target.pos);
-  const passResult = performPassRoll(passer, rng, passModifiers);
+  const passRollOutcome = performPassRollWithSkill(passer, rng, passModifiers);
+  const passResult = passRollOutcome.result;
+  if (passRollOutcome.rerolled) {
+    const rerollLog = createLogEntry(
+      'info',
+      `${passer.name} utilise Pass pour relancer son jet de passe`,
+      passer.id,
+      passer.team,
+      { skill: 'pass' },
+    );
+    newState.gameLog = [...newState.gameLog, rerollLog];
+  }
 
   newState.lastDiceResult = passResult;
 
@@ -413,9 +468,20 @@ export function executePass(
     return bounceBall(newState, rng);
   }
 
-  // Passe réussie : le receveur doit réceptionner
+  // Passe réussie : le receveur doit réceptionner (avec relance `catch` skill)
   const catchModifiers = calculateCatchModifiers(newState, target);
-  const catchResult = performCatchRoll(target, rng, catchModifiers);
+  const catchOutcome = performCatchRollWithSkill(target, rng, catchModifiers);
+  const catchResult = catchOutcome.result;
+  if (catchOutcome.rerolled) {
+    const catchRerollLog = createLogEntry(
+      'info',
+      `${target.name} utilise Catch pour relancer sa reception`,
+      target.id,
+      target.team,
+      { skill: 'catch' },
+    );
+    newState.gameLog = [...newState.gameLog, catchRerollLog];
+  }
 
   const catchLog = createLogEntry(
     'dice',
@@ -515,9 +581,20 @@ export function executeHandoff(
     return bounceBall(newState, rng);
   }
 
-  // Jet de réception pour le receveur
+  // Jet de réception pour le receveur (avec relance `catch` skill)
   const catchModifiers = calculateCatchModifiers(newState, target);
-  const catchResult = performCatchRoll(target, rng, catchModifiers);
+  const catchOutcomeHO = performCatchRollWithSkill(target, rng, catchModifiers);
+  const catchResult = catchOutcomeHO.result;
+  if (catchOutcomeHO.rerolled) {
+    const catchRerollLog = createLogEntry(
+      'info',
+      `${target.name} utilise Catch pour relancer sa reception`,
+      target.id,
+      target.team,
+      { skill: 'catch' },
+    );
+    newState.gameLog = [...newState.gameLog, catchRerollLog];
+  }
 
   newState.lastDiceResult = catchResult;
 


### PR DESCRIPTION
## Resume

Sous-lot E de la tache **O.1 — ~39 skills niche restants (batch 3)**. Branche les skills **Catch** et **Pass** (relances personnelles, non d'equipe) dans le flux de passe.

### Regle BB2020

- **Catch** : relance gratuite d'un jet de reception rate (apres une passe ou un handoff).
- **Pass** : relance gratuite d'un jet de passe rate.

Ces relances ne consomment PAS la relance d'equipe et s'appliquent une seule fois par tentative.

### Implementation

- Nouveaux helpers exports dans `passing.ts` :
  - `performCatchRollWithSkill(catcher, rng, modifiers)`
  - `performPassRollWithSkill(passer, rng, modifiers)`
- `executePass` utilise `performPassRollWithSkill` pour le jet de passe et `performCatchRollWithSkill` pour la reception.
- `executeHandoff` (reception apres handoff) utilise aussi `performCatchRollWithSkill`.
- Log ajoute au gameLog quand la relance est declenchee.

### Fichiers

- `packages/game-engine/src/mechanics/passing.ts` — 2 nouveaux helpers + substitution dans 3 sites d'appel.
- `packages/game-engine/src/mechanics/catch-pass-skill-reroll.test.ts` (nouveau) — 7 tests :
  - Catch : reroll si skill, pas de reroll sans skill, pas de reroll si premier succes
  - Pass : reroll si skill, pas sans, reroll unique (echec-puis-succes / echec-puis-echec)

## Tache roadmap

Sprint 20-21, **O.1** — ~39 skills niche restants (batch 3). Cinquieme sous-lot apres :
- #313 (3a : nerves-of-steel, big-hand, extra-arms)
- #314 (3b : accurate, strong-arm)
- #315 (3c : strip-ball)
- #316 (3d : diving-catch)

## Plan de test

- [x] `pnpm test` — 4146 tests verts (133 fichiers), 7 nouveaux.
- [x] `pnpm typecheck` — OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5eJR3eKJvMhTwXDt2h4aX)_