### PR TITLE
feat(game-engine): O.1 batch 3f - cannoneer + monstrous-mouth

### DIFF
--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -912,10 +912,14 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
   // et la cible porte le ballon, la cible lache la balle lors du PUSH_BACK,
   // meme si elle n'est pas mise au sol. La balle rebondit depuis la case
   // d'origine de la cible.
+  // Monstrous Mouth (O.1 batch 3f) : la cible est immunisee contre Strip Ball.
   const attackerHasStripBall =
     attacker.skills.includes('strip-ball') ||
     attacker.skills.includes('strip_ball');
-  if (attackerHasStripBall && target.hasBall) {
+  const targetHasMonstrousMouth =
+    target.skills.includes('monstrous-mouth') ||
+    target.skills.includes('monstrous_mouth');
+  if (attackerHasStripBall && target.hasBall && !targetHasMonstrousMouth) {
     const stripLog = createLogEntry(
       'action',
       `${attacker.name} utilise Strip Ball : ${target.name} lache le ballon !`,

--- a/packages/game-engine/src/mechanics/cannoneer-monstrous-mouth.test.ts
+++ b/packages/game-engine/src/mechanics/cannoneer-monstrous-mouth.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setup,
+  type GameState,
+  type Player,
+  type RNG,
+} from '../index';
+import {
+  calculatePassModifiers,
+  performCatchRollWithSkill,
+} from './passing';
+
+/**
+ * O.1 batch 3f — Skills niche passe/catch :
+ * - Cannoneer : +1 au jet de passe sur les distances Long (7-10) et Bomb (11-13).
+ *   Complement symetrique d'Accurate (Quick/Short) et Strong Arm (Short/Long/Bomb).
+ * - Monstrous Mouth : relance toute tentative ratee de reception (effet symetrique
+ *   du skill Catch mais disponible uniquement pour les joueurs ayant la mutation).
+ *   Le second effet (Strip Ball ne peut pas etre utilise contre ce joueur) est
+ *   couvert par un autre test (blocking).
+ */
+
+function scriptedRng(values: number[]): RNG {
+  let idx = 0;
+  return () => {
+    const v = values[idx % values.length];
+    idx += 1;
+    return v;
+  };
+}
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+function setupPasser(skills: string[]): { state: GameState; passer: Player } {
+  let s = setup();
+  s = patchPlayer(s, 'A2', { skills, pos: { x: 5, y: 5 }, pa: 3 });
+  // Eloigner les autres joueurs pour eviter TZ/DP parasites.
+  s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+  s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+  s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+  const passer = s.players.find(p => p.id === 'A2')!;
+  return { state: s, passer };
+}
+
+function makeCatcher(skills: string[]): Player {
+  const s = setup();
+  const base = s.players.find(p => p.id === 'A2')!;
+  return { ...base, skills, ag: 3 };
+}
+
+describe('Pass modifier skill: Cannoneer', () => {
+  it('aucun bonus sur une passe Quick (distance 3)', () => {
+    const { state, passer } = setupPasser(['cannoneer']);
+    const mod = calculatePassModifiers(state, passer, { x: 8, y: 5 });
+    // Quick range = +1, Cannoneer inactif (Quick) -> +1
+    expect(mod).toBe(1);
+  });
+
+  it('aucun bonus sur une passe Short (distance 5)', () => {
+    const { state, passer } = setupPasser(['cannoneer']);
+    const mod = calculatePassModifiers(state, passer, { x: 10, y: 5 });
+    // Short range = 0, Cannoneer inactif -> 0
+    expect(mod).toBe(0);
+  });
+
+  it('+1 sur une passe Long (distance 10)', () => {
+    const { state, passer } = setupPasser(['cannoneer']);
+    const mod = calculatePassModifiers(state, passer, { x: 15, y: 5 });
+    // Long range = -1, Cannoneer +1 -> 0
+    expect(mod).toBe(0);
+  });
+
+  it('+1 sur une passe Long Bomb (distance 13)', () => {
+    const { state, passer } = setupPasser(['cannoneer']);
+    const mod = calculatePassModifiers(state, passer, { x: 18, y: 5 });
+    // Long Bomb = -2, Cannoneer +1 -> -1
+    expect(mod).toBe(-1);
+  });
+
+  it('cumul Cannoneer + Strong Arm sur une passe Long (+2 total)', () => {
+    const { state, passer } = setupPasser(['cannoneer', 'strong-arm']);
+    const mod = calculatePassModifiers(state, passer, { x: 15, y: 5 });
+    // Long range = -1, Cannoneer +1, Strong Arm +1 -> +1
+    expect(mod).toBe(1);
+  });
+
+  it('cumul Cannoneer + Strong Arm sur une passe Bomb (+2 total)', () => {
+    const { state, passer } = setupPasser(['cannoneer', 'strong-arm']);
+    const mod = calculatePassModifiers(state, passer, { x: 18, y: 5 });
+    // Long Bomb = -2, Cannoneer +1, Strong Arm +1 -> 0
+    expect(mod).toBe(0);
+  });
+
+  it('Accurate + Cannoneer ne se cumulent jamais (aucune portee commune)', () => {
+    const { state, passer } = setupPasser(['accurate', 'cannoneer']);
+    const short = calculatePassModifiers(state, passer, { x: 10, y: 5 });
+    const long = calculatePassModifiers(state, passer, { x: 15, y: 5 });
+    // Short : Accurate +1, Cannoneer inactif -> +1
+    expect(short).toBe(1);
+    // Long : Accurate inactif, Cannoneer +1, base -1 -> 0
+    expect(long).toBe(0);
+  });
+});
+
+describe('Catch skill: Monstrous Mouth (reroll)', () => {
+  it('relance un jet de reception rate (echec puis reussite)', () => {
+    const catcher = makeCatcher(['monstrous-mouth']);
+    // AG 3 -> target 4+. 1er jet = 1 (echec), 2eme = 5 (reussite).
+    const rng = scriptedRng([0.01, 0.75]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  it('ne relance pas si le premier jet reussit', () => {
+    const catcher = makeCatcher(['monstrous-mouth']);
+    const rng = scriptedRng([0.99, 0.01]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(true);
+  });
+
+  it('ne relance pas sans le skill', () => {
+    const catcher = makeCatcher([]);
+    const rng = scriptedRng([0.01, 0.99]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(false);
+  });
+
+  it('catch + monstrous-mouth : une seule relance (pas deux)', () => {
+    const catcher = makeCatcher(['catch', 'monstrous-mouth']);
+    // Echec, echec, un troisieme jet reussi ne doit pas etre consomme.
+    const rng = scriptedRng([0.01, 0.01, 0.99]);
+    const { result, rerolled } = performCatchRollWithSkill(catcher, rng, 0);
+    expect(rerolled).toBe(true);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -100,6 +100,17 @@ export function calculatePassModifiers(
     modifiers += 1;
   }
 
+  // Cannoneer (O.1 batch 3f) : +1 sur Long et Bomb. Complement symetrique
+  // d'Accurate qui lui couvre Quick et Short.
+  if (
+    range &&
+    (range === 'long' || range === 'bomb') &&
+    (passer.skills.includes('cannoneer') ||
+      passer.skills.includes('Cannoneer'))
+  ) {
+    modifiers += 1;
+  }
+
   // Malus pour chaque adversaire en zone de tacle du passeur.
   // Nerves of Steel (O.1 batch 3) annule ce malus.
   const opponentsNearPasser = getAdjacentOpponents(state, passer.pos, passer.team);
@@ -197,8 +208,15 @@ export function performCatchRollWithSkill(
   if (first.success) {
     return { result: first, rerolled: false };
   }
+  // Catch (relance standard) OU Monstrous Mouth (O.1 batch 3f, mutation qui
+  // permet de relancer toute tentative ratee de reception). Les deux skills
+  // offrent la meme relance personnelle ; les posseder ensemble n'autorise
+  // pas une double relance.
   const hasCatch = catcher.skills.some(s => s.toLowerCase() === 'catch');
-  if (!hasCatch) {
+  const hasMonstrousMouth =
+    catcher.skills.includes('monstrous-mouth') ||
+    catcher.skills.includes('monstrous_mouth');
+  if (!hasCatch && !hasMonstrousMouth) {
     return { result: first, rerolled: false };
   }
   const second = performCatchRoll(catcher, rng, modifiers);

--- a/packages/game-engine/src/mechanics/strip-ball.test.ts
+++ b/packages/game-engine/src/mechanics/strip-ball.test.ts
@@ -126,4 +126,31 @@ describe('Regle: Strip Ball', () => {
     // perte de balle automatique hors skills specifiques).
     expect(carrier.hasBall).toBe(true);
   });
+
+  it('Monstrous Mouth : la cible est immunisee contre Strip Ball (O.1 batch 3f)', () => {
+    let s = setupStripBallScenario();
+    // La cible porte-ballon a Monstrous Mouth -> Strip Ball inapplicable.
+    s = patchPlayer(s, 'B1', { skills: ['monstrous-mouth'] });
+
+    const blockResult: BlockDiceResult = {
+      type: 'block',
+      playerId: 'A2',
+      targetId: 'B1',
+      diceRoll: 3,
+      result: 'PUSH_BACK',
+      offensiveAssists: 0,
+      defensiveAssists: 0,
+      totalStrength: 3,
+      targetStrength: 2,
+    };
+    const rng = makeRNG('monstrous-mouth-vs-strip-ball');
+    const result = resolveBlockResult(s, blockResult, rng);
+
+    const carrier = result.players.find(p => p.id === 'B1')!;
+    // Le porteur garde le ballon malgre le PUSH_BACK + Strip Ball de l'attaquant.
+    expect(carrier.hasBall).toBe(true);
+    const logText = result.gameLog.map(e => e.message).join('\n');
+    // Aucun message Strip Ball ne doit apparaitre (skill non declenche).
+    expect(logText).not.toMatch(/Strip Ball/i);
+  });
 });

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -466,6 +466,27 @@ registerSkill({
   getModifiers: () => ({ passModifier: 1 }),
 });
 
+// CANNONEER (O.1 batch 3f) : +1 au jet de passe sur Long et Bomb.
+// Effectivement resolu par `calculatePassModifiers` dans `mechanics/passing.ts`.
+registerSkill({
+  slug: 'cannoneer',
+  triggers: ['on-pass'],
+  description: '+1 au jet de passe pour les passes Long et Long Bomb.',
+  canApply: (ctx) => hasSkill(ctx.player, 'cannoneer'),
+  getModifiers: () => ({ passModifier: 1 }),
+});
+
+// MONSTROUS MOUTH (O.1 batch 3f) : relance toute tentative ratee de reception
+// (effectuee dans `performCatchRollWithSkill`) et Strip Ball ne peut pas etre
+// utilise contre ce joueur (resolu dans `handlePushBack` de `mechanics/blocking.ts`).
+registerSkill({
+  slug: 'monstrous-mouth',
+  triggers: ['on-catch'],
+  description: 'Relance toute tentative ratee de reception. Strip Ball ne peut pas etre utilise contre ce joueur.',
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'monstrous-mouth') || hasSkill(ctx.player, 'monstrous_mouth'),
+});
+
 // SHADOWING
 // La résolution du suivi (2D6 + MA diff >= 7) est effectuée par
 // `resolveShadowingAfterDodge` dans `mechanics/shadowing.ts`, appelé depuis


### PR DESCRIPTION
## Resume

- **Cannoneer** : +1 au jet de passe sur les distances Long (7-10) et Long Bomb (11-13). Complement symetrique d'Accurate (Quick/Short) ; se cumule avec Strong Arm sur Long et Bomb pour un bonus total de +2.
- **Monstrous Mouth** (mutation) — deux effets :
  1. Relance toute tentative ratee de reception (meme mecanique personnelle que le skill Catch ; posseder les deux n'autorise pas de double relance).
  2. Immunite a Strip Ball : la cible porte-ballon avec ce skill ne lache pas la balle sur un PUSH_BACK par un attaquant equipe de Strip Ball.
- Enregistrement des deux skills dans `skill-registry.ts` pour la decouverte UI et la documentation.

### Fichiers

- `packages/game-engine/src/mechanics/passing.ts` — Cannoneer dans `calculatePassModifiers` ; Monstrous Mouth dans `performCatchRollWithSkill`.
- `packages/game-engine/src/mechanics/blocking.ts` — Monstrous Mouth annule l'effet de Strip Ball dans `handlePushBack`.
- `packages/game-engine/src/skills/skill-registry.ts` — 2 entrees (discovery UI).
- `packages/game-engine/src/mechanics/cannoneer-monstrous-mouth.test.ts` — 11 tests (7 Cannoneer, 4 Monstrous Mouth reroll).
- `packages/game-engine/src/mechanics/strip-ball.test.ts` — 1 test d'immunite Monstrous Mouth.

## Tache roadmap

Sprint 20-21, O.1 (batch 3f) — "~39 skills niche restants". Cette PR couvre 2 skills (cannoneer, monstrous-mouth). La macro-tache O.1 reste ouverte.

## Plan de test

- [x] `pnpm test` (game-engine) : 4158 tests verts, dont 12 nouveaux
- [x] `pnpm lint` : 0 erreurs (warnings preexistants inchanges)
- [x] `pnpm typecheck` (workspace) : 4/4 succes
- [x] `pnpm build` : game-engine + server + ui OK ; l'echec `@bb/web` est du a l'absence de reseau vers Google Fonts (Cinzel Decorative, Inter, Montserrat), strictement environnemental et independant de cette PR.
- [x] Scenarios couverts par les tests :
  - Cannoneer : pas de bonus Quick/Short, +1 sur Long/Bomb, cumul avec Strong Arm sur Long/Bomb (+2), Accurate+Cannoneer ne se cumulent jamais (portees disjointes).
  - Monstrous Mouth reroll : relance sur echec, pas de relance sur reussite, pas de relance sans skill, pas de double relance avec Catch.
  - Monstrous Mouth immunite : cible garde le ballon malgre un PUSH_BACK + Strip Ball attaquant, aucun log Strip Ball emis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtVGDrhhkii3xhZLq47CGF)_