### PR TITLE
feat(game-engine): O.1 batch 3g - arm-bar (cle de bras)

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -83,6 +83,7 @@ import { checkBreakTackle } from '../mechanics/break-tackle';
 import { isFendActiveForFollowUp } from '../mechanics/fend';
 import { resolveShadowingAfterDodge } from '../mechanics/shadowing';
 import { hasFrenzy } from '../mechanics/frenzy';
+import { getArmBarBonus } from '../mechanics/arm-bar';
 import {
   canPerformMultipleBlock,
   isMultipleBlockActiveFor,
@@ -594,22 +595,32 @@ function consumeTeamReroll(state: GameState, team: TeamId): GameState {
 }
 
 /**
- * Applique les conséquences d'un échec de jet (chute, turnover, armure, perte de balle)
+ * Applique les conséquences d'un échec de jet (chute, turnover, armure, perte de balle).
+ * @param armorBonus Bonus optionnel applique au jet d'armure (ex: +1 d'Arm Bar
+ *   quand un esquive a echoue dans la zone de tacle d'un adversaire avec ce skill).
  */
-function applyRollFailure(state: GameState, playerIndex: number, rng: RNG): GameState {
+function applyRollFailure(
+  state: GameState,
+  playerIndex: number,
+  rng: RNG,
+  armorBonus: number = 0,
+): GameState {
   const player = state.players[playerIndex];
   state.isTurnover = true;
   state.players[playerIndex] = { ...player, stunned: true };
 
-  // Jet d'armure
-  const armorResult = performArmorRollWithNotification(state.players[playerIndex], rng);
+  // Jet d'armure (avec bonus eventuel d'Arm Bar). `armorBonus` est exprime
+  // comme bonus a l'attaquant (i.e. +1 facilite la cassure d'armure). Il est
+  // negativise ici car `performArmorRollWithNotification` attend un modificateur
+  // a appliquer au TARGET (positif = armure plus difficile a percer).
+  const armorResult = performArmorRollWithNotification(state.players[playerIndex], rng, -armorBonus);
   state.lastDiceResult = armorResult;
   const armorLog = createLogEntry(
     'dice',
-    `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '✓' : '✗'}`,
+    `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '✓' : '✗'}${armorBonus > 0 ? ` [Arm Bar +${armorBonus}]` : ''}`,
     player.id,
     player.team,
-    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, success: armorResult.success }
+    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, success: armorResult.success, armBar: armorBonus > 0 }
   );
   state.gameLog = [...state.gameLog, armorLog];
 
@@ -1138,8 +1149,9 @@ function handleDodgeRoll(
       next.pendingReroll = { rollType: 'dodge', playerId: player.id, team: player.team, targetNumber: dodgeResult.targetNumber, modifiers: dodgeModifiers, playerIndex: idx, from, to };
       return next;
     }
-    // Pas de relance disponible : appliquer l'échec
-    return applyRollFailure(next, idx, rng);
+    // Pas de relance disponible : appliquer l'echec, avec bonus Arm Bar
+    // si un adversaire adjacent a la case d'origine possede ce skill.
+    return applyRollFailure(next, idx, rng, getArmBarBonus(next, player, from));
   }
 
   return next;
@@ -2006,7 +2018,10 @@ function handleRerollChoose(
       }
       return newState;
     } else {
-      return applyRollFailure(newState, playerIndex, rng);
+      // Echec apres team reroll : appliquer l'echec avec bonus Arm Bar.
+      const dodger = newState.players[playerIndex];
+      const armBarBonus = from ? getArmBarBonus(newState, dodger, from) : 0;
+      return applyRollFailure(newState, playerIndex, rng, armBarBonus);
     }
   } else if (rollType === 'gfi') {
     // Relancer le jet de GFI

--- a/packages/game-engine/src/mechanics/arm-bar.test.ts
+++ b/packages/game-engine/src/mechanics/arm-bar.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setup,
+  applyMove,
+  makeRNG,
+  type GameState,
+  type Player,
+  type RNG,
+} from '../index';
+import { getArmBarBonus } from './arm-bar';
+
+function scriptedRng(values: number[]): RNG {
+  let idx = 0;
+  return () => {
+    const v = values[idx % values.length];
+    idx += 1;
+    return v;
+  };
+}
+
+/**
+ * O.1 batch 3g — Arm Bar (Cle de Bras)
+ *
+ * +1 au jet d'Armure (ou Blessure) du joueur adverse qui Tombe en ratant
+ * une esquive/Saut/Bond pour quitter une case ou il etait marque par ce
+ * joueur.
+ */
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Arm Bar : helper getArmBarBonus', () => {
+  it('retourne 0 si aucun adversaire adjacent a la case d\'origine', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+
+  it('retourne 0 si l\'adversaire adjacent n\'a pas arm-bar', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['tackle'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+
+  it('retourne +1 si un adversaire adjacent a arm-bar', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['arm-bar'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(1);
+  });
+
+  it('reste a +1 meme avec plusieurs adversaires arm-bar adjacents (non cumulatif)', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['arm-bar'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 4, y: 5 }, skills: ['arm-bar'] });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(1);
+  });
+
+  it('ignore un adversaire arm-bar s\'il est sonne (stunned)', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', {
+      pos: { x: 6, y: 5 },
+      skills: ['arm-bar'],
+      stunned: true,
+      state: 'stunned',
+    });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+
+  it('ignore un adversaire arm-bar mis Knocked Out', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'B1', {
+      pos: { x: 6, y: 5 },
+      skills: ['arm-bar'],
+      state: 'knocked_out',
+    });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+
+  it('ignore un coequipier ayant arm-bar (ne s\'applique pas en friendly fire)', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 6, y: 5 }, skills: ['arm-bar'] });
+    s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+
+  it('utilise la position d\'origine, pas la position courante du dodger', () => {
+    let s = setup();
+    // Dodger est passe de (5,5) a (6,5) ; un adversaire arm-bar etait
+    // adjacent a (5,5).
+    s = patchPlayer(s, 'A2', { pos: { x: 6, y: 5 } });
+    s = patchPlayer(s, 'B1', { pos: { x: 4, y: 5 }, skills: ['arm-bar'] }); // adjacent a (5,5)
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    const dodger = s.players.find(p => p.id === 'A2')!;
+    expect(getArmBarBonus(s, dodger, { x: 5, y: 5 })).toBe(1);
+    // Sans le `from`, B1 (4,5) n'est pas adjacent au dodger (6,5)
+    expect(getArmBarBonus(s, dodger, dodger.pos)).toBe(0);
+  });
+});
+
+describe('Arm Bar : integration via dodge failure', () => {
+  it('applique +1 au target d\'armure quand un esquive echoue dans la TZ d\'un arm-bar', () => {
+    let s = setup();
+    // A2 (AV 9) tente d'esquiver depuis (5,5) vers (5,6).
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 }, av: 9, ag: 3, pm: 6, skills: [] });
+    // B1 (arm-bar) marque (5,5).
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['arm-bar'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+    // Pas de relance d'equipe.
+    s = { ...s, teamRerolls: { teamA: 0, teamB: 0 }, currentPlayer: 'A' };
+
+    // Premier rng() = jet d'esquive (force echec : 0.01 -> D6=1).
+    // Second rng() = die1 d'armure, troisieme = die2.
+    const rng = scriptedRng([0.01, 0.5, 0.5]);
+    const result = applyMove(s, { type: 'MOVE', playerId: 'A2', to: { x: 5, y: 6 } }, rng);
+
+    // Doit y avoir un log d'armure mentionnant Arm Bar.
+    const armorLog = result.gameLog.find(e =>
+      e.message.includes('Arm Bar') && e.message.startsWith("Jet d'armure"),
+    );
+    expect(armorLog).toBeDefined();
+    expect(armorLog!.message).toContain('+1');
+    // Turnover declenche par l'esquive ratee.
+    expect(result.isTurnover).toBe(true);
+  });
+
+  it('aucun marqueur Arm Bar dans le log si aucun adversaire arm-bar adjacent a la case d\'origine', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 5, y: 5 }, av: 9, ag: 3, pm: 6, skills: [] });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+    s = { ...s, teamRerolls: { teamA: 0, teamB: 0 }, currentPlayer: 'A' };
+
+    const rng = scriptedRng([0.01, 0.5, 0.5]);
+    const result = applyMove(s, { type: 'MOVE', playerId: 'A2', to: { x: 5, y: 6 } }, rng);
+
+    const armorLog = result.gameLog.find(e => e.message.startsWith("Jet d'armure"));
+    expect(armorLog).toBeDefined();
+    expect(armorLog!.message).not.toContain('Arm Bar');
+  });
+});

--- a/packages/game-engine/src/mechanics/arm-bar.ts
+++ b/packages/game-engine/src/mechanics/arm-bar.ts
@@ -1,0 +1,42 @@
+/**
+ * Arm Bar (BB2020 / BB3 Season 2-3)
+ *
+ * "If an opposing player Falls Over as a result of failing an Agility test
+ *  when attempting to perform a Dodge, Jump or Leap action to leave a square
+ *  in which they were Marked by this player, you may apply a +1 modifier to
+ *  either the Armour roll or the Injury roll."
+ *
+ * Implementation :
+ * - `getArmBarBonus(state, dodger, fromPos)` retourne +1 si au moins un
+ *   adversaire adjacent a la case d'origine (au moment ou le joueur a tente
+ *   d'esquiver) possede le skill `arm-bar`. Cette valeur est ensuite passee
+ *   au jet d'armure consecutif a l'echec de l'esquive (cf. actions.ts).
+ * - Sinon retourne 0.
+ * - Le bonus n'est jamais cumulatif au-dela de +1 (regle BB) : une seule
+ *   instance d'Arm Bar suffit a declencher l'effet.
+ */
+
+import { Player, Position, GameState } from '../core/types';
+import { isAdjacent } from './movement';
+import { hasSkill } from '../skills/skill-effects';
+
+/**
+ * Calcule le bonus d'Arm Bar applicable au jet d'armure d'un joueur qui
+ * vient d'echouer une esquive depuis `fromPos`. Le bonus est de +1 si au
+ * moins un adversaire adjacent a `fromPos` possede `arm-bar`, sinon 0.
+ */
+export function getArmBarBonus(
+  state: GameState,
+  dodger: Player,
+  fromPos: Position,
+): number {
+  const opponentTeam = dodger.team === 'A' ? 'B' : 'A';
+  const hasArmBarMarker = state.players.some(p => {
+    if (p.team !== opponentTeam) return false;
+    if (p.stunned) return false;
+    if (p.state === 'stunned' || p.state === 'knocked_out' || p.state === 'casualty' || p.state === 'sent_off') return false;
+    if (!isAdjacent(p.pos, fromPos)) return false;
+    return hasSkill(p, 'arm-bar') || hasSkill(p, 'arm_bar');
+  });
+  return hasArmBarMarker ? 1 : 0;
+}

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -487,6 +487,18 @@ registerSkill({
     hasSkill(ctx.player, 'monstrous-mouth') || hasSkill(ctx.player, 'monstrous_mouth'),
 });
 
+// ARM BAR (O.1 batch 3g) : +1 au jet d'armure (ou de blessure) du joueur
+// adverse qui Tombe en ratant un Esquive/Saut/Bond pour quitter une case ou
+// il etait Marque par ce joueur. La resolution effective se fait dans
+// `actions.ts` (voir `applyRollFailure` + helper `getArmBarBonus` dans
+// `mechanics/arm-bar.ts`). L'entree ici sert pour la decouverte UI.
+registerSkill({
+  slug: 'arm-bar',
+  triggers: ['on-armor', 'on-injury'],
+  description: "+1 au jet d'Armure (ou de Blessure) quand un adversaire Tombe en ratant un test d'agilite (Esquive/Saut/Bond) pour quitter une case ou il etait Marque par ce joueur.",
+  canApply: (ctx) => hasSkill(ctx.player, 'arm-bar') || hasSkill(ctx.player, 'arm_bar'),
+});
+
 // SHADOWING
 // La résolution du suivi (2D6 + MA diff >= 7) est effectuée par
 // `resolveShadowingAfterDodge` dans `mechanics/shadowing.ts`, appelé depuis


### PR DESCRIPTION
## Resume

**Arm Bar (Cle de Bras)** : quand un adversaire Tombe en ratant un test d'agilite (Esquive / Saut / Bond) pour quitter une case ou il etait Marque par un joueur ayant ce skill, +1 au jet d'Armure consecutif a la chute.

### Fichiers

- `packages/game-engine/src/mechanics/arm-bar.ts` — nouveau helper `getArmBarBonus(state, dodger, fromPos)`. Retourne +1 si au moins un adversaire valide (non sonne, non KO/casualty/sent_off) adjacent a la case d'origine possede `arm-bar`. Plafonne a +1 meme avec plusieurs marqueurs (regle BB).
- `packages/game-engine/src/actions/actions.ts` — `applyRollFailure` accepte un parametre optionnel `armorBonus` et passe `-armorBonus` au target d'armure (semantique de `calculateArmorTarget` : un modificateur positif augmente le target = armure plus difficile a percer ; on negativise pour exprimer un bonus a l'attaquant). Les deux call-sites de failure-on-failed-dodge (sans team reroll + apres team reroll consomme) passent `getArmBarBonus(state, dodger, from)`.
- `packages/game-engine/src/skills/skill-registry.ts` — entree de decouverte UI/documentation pour `arm-bar`.
- `packages/game-engine/src/mechanics/arm-bar.test.ts` — 8 tests unitaires sur le helper + 2 tests d'integration via `applyMove`.

### Notes techniques

- Le log d'armure ajoute le suffixe `[Arm Bar +1]` quand le bonus est applique et inclut le flag `armBar` dans le metadata du log entry.
- Helper-only design : aucune mutation du registre de skills cote helper, et `applyRollFailure` reste utilisable sans bonus (default = 0) pour tous les autres call-sites (GFI, pickup) qui ne sont pas concernes par Arm Bar.

## Tache roadmap

Sprint 20-21, O.1 (batch 3g) — "~39 skills niche restants". Cette PR couvre 1 skill (arm-bar). La macro-tache O.1 reste ouverte.

## Plan de test

- [x] `pnpm test` (game-engine) : 4168 tests verts dont 10 nouveaux
- [x] `pnpm typecheck` (workspace) : 4/4 succes
- [x] `pnpm lint` : 0 erreurs (warnings preexistants inchanges)
- [x] Scenarios couverts par les tests :
  - Helper : 0 sans adversaire adjacent, 0 si l'adjacent n'a pas arm-bar, +1 avec un arm-bar adjacent, plafonne a +1 avec plusieurs, ignore stunned/knocked_out/coequipier, utilise bien `fromPos` (pas la position courante).
  - Integration : echec d'esquive dans la TZ d'un arm-bar -> log d'armure contient `[Arm Bar +1]` et turnover declenche ; sans arm-bar adjacent -> log d'armure ne contient pas Arm Bar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtVGDrhhkii3xhZLq47CGF)_