### PR TITLE
feat(game-engine): O.1 batch 3g - cloud-burster + titchy

### DIFF
--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -223,6 +223,9 @@ export function canBlock(state: GameState, playerId: string, targetId: string): 
   // Les joueurs doivent être d'équipes différentes
   if (player.team === target.team) return false;
 
+  // O.1 batch 3g : un joueur avec Titchy ne peut pas declarer d'action de Blocage.
+  if (player.skills.includes('titchy')) return false;
+
   return true;
 }
 

--- a/packages/game-engine/src/mechanics/cloud-burster-titchy.test.ts
+++ b/packages/game-engine/src/mechanics/cloud-burster-titchy.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setup,
+  type GameState,
+  type Player,
+  type RNG,
+} from '../index';
+import {
+  getAdjacentOpponents,
+  calculateDodgeModifiers,
+  calculatePickupModifiers,
+} from './movement';
+import { canBlock } from './blocking';
+import { executePass } from './passing';
+
+/**
+ * O.1 batch 3g — Skills niche :
+ * - Cloud Burster (passing) : sur une passe Long ou Bomb, le passeur peut
+ *   forcer l'adversaire a relancer une interception reussie (une fois par passe).
+ * - Titchy (trait) : le joueur n'exerce pas de zone de tacle et ne peut pas
+ *   declarer d'action de blocage (les joueurs tres petits comme Gobelins,
+ *   Halflings, Lineman Gnome, Skink, etc.).
+ */
+
+function scriptedRng(values: number[]): RNG {
+  let idx = 0;
+  return () => {
+    const v = values[idx % values.length];
+    idx += 1;
+    return v;
+  };
+}
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Trait: Titchy — pas de zone de tacle', () => {
+  it('un joueur adverse titchy n\'est pas compte comme adjacent (pas de TZ)', () => {
+    let s = setup();
+    // A1 en (5,5), B1 adjacent en (6,5) avec titchy.
+    s = patchPlayer(s, 'A1', { pos: { x: 5, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['titchy'] });
+    // Eloigner les autres pour eviter des TZ parasites.
+    s = patchPlayer(s, 'A2', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    const opponents = getAdjacentOpponents(s, { x: 5, y: 5 }, 'A');
+    expect(opponents).toHaveLength(0);
+  });
+
+  it('un joueur adverse non-titchy exerce toujours sa TZ', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A1', { pos: { x: 5, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'A2', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    const opponents = getAdjacentOpponents(s, { x: 5, y: 5 }, 'A');
+    expect(opponents).toHaveLength(1);
+  });
+
+  it('calculateDodgeModifiers : 0 malus quand la case d\'arrivee a un adversaire titchy adjacent', () => {
+    let s = setup();
+    // A1 dodge de (5,5) vers (6,5). B1 titchy adjacent a la case d\'arrivee.
+    s = patchPlayer(s, 'A1', { pos: { x: 5, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'B1', { pos: { x: 7, y: 5 }, skills: ['titchy'] });
+    s = patchPlayer(s, 'A2', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    const mod = calculateDodgeModifiers(s, { x: 5, y: 5 }, { x: 6, y: 5 }, 'A');
+    // Sans titchy, -1 ; avec titchy sur le marqueur, 0.
+    expect(mod).toBe(0);
+  });
+
+  it('calculatePickupModifiers : 0 malus quand un adversaire adjacent a titchy', () => {
+    let s = setup();
+    // La balle est en (5,5) ; B1 titchy adjacent.
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['titchy'] });
+    s = patchPlayer(s, 'A2', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    const mod = calculatePickupModifiers(s, { x: 5, y: 5 }, 'A');
+    expect(mod).toBe(0);
+  });
+
+  it('titchy ne filtre pas les autres adversaires adjacents', () => {
+    let s = setup();
+    // A1 en (5,5) ; B1 titchy en (6,5), B2 normal en (5,6).
+    s = patchPlayer(s, 'A1', { pos: { x: 5, y: 5 }, skills: [] });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: ['titchy'] });
+    s = patchPlayer(s, 'B2', { pos: { x: 5, y: 6 }, skills: [] });
+    s = patchPlayer(s, 'A2', { pos: { x: 0, y: 0 } });
+
+    const opponents = getAdjacentOpponents(s, { x: 5, y: 5 }, 'A');
+    expect(opponents.map(p => p.id)).toEqual(['B2']);
+  });
+});
+
+describe('Trait: Titchy — ne peut pas effectuer de Block', () => {
+  it('canBlock : un joueur titchy ne peut pas initier un blocage', () => {
+    let s = setup();
+    // A2 adjacent a B1, mais A2 a titchy -> pas de block autorise.
+    s = patchPlayer(s, 'A2', {
+      pos: { x: 10, y: 5 },
+      skills: ['titchy'],
+      pm: 6,
+    });
+    s = patchPlayer(s, 'B1', { pos: { x: 11, y: 5 }, skills: [], pm: 6 });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    expect(canBlock(s, 'A2', 'B1')).toBe(false);
+  });
+
+  it('canBlock : un joueur non-titchy peut toujours bloquer normalement', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { pos: { x: 10, y: 5 }, skills: [], pm: 6 });
+    s = patchPlayer(s, 'B1', { pos: { x: 11, y: 5 }, skills: [], pm: 6 });
+    s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+
+    expect(canBlock(s, 'A2', 'B1')).toBe(true);
+  });
+});
+
+describe('Passing skill: Cloud Burster', () => {
+  function setupInterceptionScenario(passerSkills: string[]): GameState {
+    let s = setup();
+    // A1 passeur en (5,5), A2 cible eloignee (Long range : 10 cases).
+    // B1 intercepteur sur la trajectoire en (10,5).
+    s = patchPlayer(s, 'A1', {
+      pos: { x: 5, y: 5 },
+      skills: passerSkills,
+      hasBall: true,
+      pa: 3,
+    });
+    s = patchPlayer(s, 'A2', {
+      pos: { x: 15, y: 5 },
+      skills: [],
+      ag: 4,
+    });
+    s = patchPlayer(s, 'B1', {
+      pos: { x: 10, y: 5 },
+      skills: [],
+      ag: 3,
+    });
+    // Eloigner pour ne pas influencer la trajectoire.
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    return {
+      ...s,
+      currentPlayer: 'A',
+      ball: undefined,
+    };
+  }
+
+  it('force le reroll d\'une interception reussie sur Long range (succes -> echec)', () => {
+    const s = setupInterceptionScenario(['cloud-burster']);
+    const passer = s.players.find(p => p.id === 'A1')!;
+    const target = s.players.find(p => p.id === 'A2')!;
+    // B1 AG 3, interception = -2 de base -> target AG - (-2) = 5.
+    // 1er jet : 6 (0.95 -> 6) = succes
+    // Reroll force : 2 (0.16 -> 2) = echec
+    // Puis jet de passe A1 PA 3 sur Long (-1) : 6 (0.95) = succes
+    // Puis jet de catch A2 AG 4 : 6 (0.95) = succes
+    const rng = scriptedRng([0.95, 0.16, 0.95, 0.95]);
+    const result = executePass(s, passer, target, rng);
+
+    // Pas de turnover.
+    expect(result.isTurnover).toBeFalsy();
+    // Le receveur a le ballon (passe + catch reussis apres echec de l'interception rerollee).
+    const receiver = result.players.find(p => p.id === 'A2')!;
+    expect(receiver.hasBall).toBe(true);
+    // Log contient une mention Cloud Burster.
+    const logText = result.gameLog.map(e => e.message).join('\n');
+    expect(logText).toMatch(/Cloud Burster/i);
+  });
+
+  it('sans Cloud Burster, une interception reussie n\'est pas rerollee (turnover)', () => {
+    const s = setupInterceptionScenario([]);
+    const passer = s.players.find(p => p.id === 'A1')!;
+    const target = s.players.find(p => p.id === 'A2')!;
+    const rng = scriptedRng([0.95, 0.16, 0.95]);
+    const result = executePass(s, passer, target, rng);
+
+    // L'interception a reussi, turnover.
+    expect(result.isTurnover).toBe(true);
+    const interceptor = result.players.find(p => p.id === 'B1')!;
+    expect(interceptor.hasBall).toBe(true);
+  });
+
+  it('sur Quick range, Cloud Burster n\'a AUCUN effet (pas de reroll)', () => {
+    let s = setup();
+    // Distance 3 = Quick. A1 en (5,5), A2 en (8,5). B1 sur (6,5) ou (7,5).
+    s = patchPlayer(s, 'A1', {
+      pos: { x: 5, y: 5 },
+      skills: ['cloud-burster'],
+      hasBall: true,
+      pa: 3,
+    });
+    s = patchPlayer(s, 'A2', { pos: { x: 8, y: 5 }, skills: [], ag: 4 });
+    s = patchPlayer(s, 'B1', { pos: { x: 6, y: 5 }, skills: [], ag: 3 });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    s = { ...s, currentPlayer: 'A', ball: undefined };
+
+    const passer = s.players.find(p => p.id === 'A1')!;
+    const target = s.players.find(p => p.id === 'A2')!;
+    // Interception (AG 3 -> target 5) 1er jet : 6 (succes) -> pas de reroll CB sur Quick
+    const rng = scriptedRng([0.95, 0.16]);
+    const result = executePass(s, passer, target, rng);
+
+    // L'interception tient -> turnover.
+    expect(result.isTurnover).toBe(true);
+    const interceptor = result.players.find(p => p.id === 'B1')!;
+    expect(interceptor.hasBall).toBe(true);
+    const logText = result.gameLog.map(e => e.message).join('\n');
+    expect(logText).not.toMatch(/Cloud Burster/i);
+  });
+
+  it('Cloud Burster ne declenche pas de reroll si l\'interception echoue directement', () => {
+    const s = setupInterceptionScenario(['cloud-burster']);
+    const passer = s.players.find(p => p.id === 'A1')!;
+    const target = s.players.find(p => p.id === 'A2')!;
+    // Interception rate (1), passe reussie, catch reussi.
+    const rng = scriptedRng([0.0, 0.95, 0.95]);
+    const result = executePass(s, passer, target, rng);
+
+    expect(result.isTurnover).toBeFalsy();
+    const logText = result.gameLog.map(e => e.message).join('\n');
+    expect(logText).not.toMatch(/Cloud Burster/i);
+  });
+
+  it('Cloud Burster sur Bomb range : reroll applique (succes -> echec)', () => {
+    let s = setup();
+    // Distance 13 = Bomb. A1 en (5,5), A2 en (18,5), B1 intercepteur en (12,5).
+    s = patchPlayer(s, 'A1', {
+      pos: { x: 5, y: 5 },
+      skills: ['cloud-burster'],
+      hasBall: true,
+      pa: 3,
+    });
+    s = patchPlayer(s, 'A2', { pos: { x: 18, y: 5 }, skills: [], ag: 4 });
+    s = patchPlayer(s, 'B1', { pos: { x: 12, y: 5 }, skills: [], ag: 4 });
+    s = patchPlayer(s, 'B2', { pos: { x: 25, y: 14 } });
+    s = { ...s, currentPlayer: 'A', ball: undefined };
+
+    const passer = s.players.find(p => p.id === 'A1')!;
+    const target = s.players.find(p => p.id === 'A2')!;
+    // Interception AG 4 -> -2 base = target 6. 1er jet : 6 (succes), reroll : 2 (echec)
+    // puis pass PA 3 sur Bomb (-2) : 6 (succes), catch AG 4 : 6 (succes)
+    const rng = scriptedRng([0.95, 0.16, 0.95, 0.95]);
+    const result = executePass(s, passer, target, rng);
+
+    expect(result.isTurnover).toBeFalsy();
+    const receiver = result.players.find(p => p.id === 'A2')!;
+    expect(receiver.hasBall).toBe(true);
+  });
+});
+
+describe('Registre des skills: batch 3g', () => {
+  it('cloud-burster et titchy sont enregistres dans le skill-registry', async () => {
+    const { getSkillEffect } = await import('../skills/skill-registry');
+    expect(getSkillEffect('cloud-burster')).toBeDefined();
+    expect(getSkillEffect('titchy')).toBeDefined();
+  });
+});

--- a/packages/game-engine/src/mechanics/movement.ts
+++ b/packages/game-engine/src/mechanics/movement.ts
@@ -72,7 +72,13 @@ export function getAdjacentOpponents(state: GameState, position: Position, team:
   for (const dir of dirs) {
     const checkPos = { x: position.x + dir.x, y: position.y + dir.y };
     const opponent = state.players.find(
-      p => p.team !== team && p.pos.x === checkPos.x && p.pos.y === checkPos.y && !p.stunned && !hypnotized.includes(p.id)
+      p => p.team !== team
+        && p.pos.x === checkPos.x
+        && p.pos.y === checkPos.y
+        && !p.stunned
+        && !hypnotized.includes(p.id)
+        // O.1 batch 3g : un joueur Titchy n'exerce pas de zone de tacle.
+        && !p.skills.includes('titchy')
     );
     if (opponent) {
       opponents.push(opponent);

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -350,10 +350,19 @@ export function executePass(
   );
   newState.ball = undefined;
 
+  // Cloud Burster (O.1 batch 3g) : sur une passe Long ou Bomb, le passeur peut
+  // forcer le coach adverse a relancer une interception reussie (une fois par
+  // interceptor, sans cumul avec un autre reroll).
+  const passRange = getPassRange(passer.pos, target.pos);
+  const passerHasCloudBurster =
+    hasSkill(passer, 'cloud-burster') || hasSkill(passer, 'cloud_burster');
+  const cloudBursterApplies =
+    passerHasCloudBurster && (passRange === 'long' || passRange === 'bomb');
+
   // Vérifier les interceptions
   const interceptors = findInterceptors(newState, passer.pos, target.pos, passer.team);
   for (const interceptor of interceptors) {
-    const interceptResult = performInterceptionRoll(interceptor, rng, newState);
+    let interceptResult = performInterceptionRoll(interceptor, rng, newState);
 
     const interceptLog = createLogEntry(
       'dice',
@@ -363,6 +372,26 @@ export function executePass(
       { diceRoll: interceptResult.diceRoll, targetNumber: interceptResult.targetNumber }
     );
     newState.gameLog = [...newState.gameLog, interceptLog];
+
+    if (interceptResult.success && cloudBursterApplies) {
+      const cbLog = createLogEntry(
+        'info',
+        `Cloud Burster : ${passer.name} force la relance de l'interception de ${interceptor.name}.`,
+        passer.id,
+        passer.team,
+        { skill: 'cloud-burster' },
+      );
+      newState.gameLog = [...newState.gameLog, cbLog];
+      interceptResult = performInterceptionRoll(interceptor, rng, newState);
+      const rerollLog = createLogEntry(
+        'dice',
+        `Relance d'interception de ${interceptor.name}: ${interceptResult.diceRoll}/${interceptResult.targetNumber} ${interceptResult.success ? '✓' : '✗'}`,
+        interceptor.id,
+        interceptor.team,
+        { diceRoll: interceptResult.diceRoll, targetNumber: interceptResult.targetNumber },
+      );
+      newState.gameLog = [...newState.gameLog, rerollLog];
+    }
 
     if (interceptResult.success) {
       // Interception réussie !

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -487,6 +487,30 @@ registerSkill({
     hasSkill(ctx.player, 'monstrous-mouth') || hasSkill(ctx.player, 'monstrous_mouth'),
 });
 
+// CLOUD BURSTER (O.1 batch 3g) : sur une passe Long ou Bomb, le passeur force
+// le coach adverse a relancer une interception reussie. Resolution dans
+// `mechanics/passing.ts#executePass`. L'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'cloud-burster',
+  triggers: ['on-pass'],
+  description: "Sur une passe Long ou Long Bomb, le passeur peut forcer l'adversaire a relancer une interception reussie.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'cloud-burster') || hasSkill(ctx.player, 'cloud_burster'),
+});
+
+// TITCHY (O.1 batch 3g, trait) : n'exerce pas de zone de tacle et ne peut pas
+// declarer d'action de Blocage. Les autres effets (ignorer les TZ adverses sur
+// ses propres tests d'agilite) relevent des jets ou ce joueur est acteur et
+// seront couverts par un batch ulterieur. Filtrage des TZ dans
+// `mechanics/movement.ts#getAdjacentOpponents`, restriction du Block dans
+// `mechanics/blocking.ts#canBlock`.
+registerSkill({
+  slug: 'titchy',
+  triggers: ['passive'],
+  description: "Ce joueur n'exerce pas de zone de tacle et ne peut pas declarer d'action de Blocage.",
+  canApply: (ctx) => hasSkill(ctx.player, 'titchy'),
+});
+
 // SHADOWING
 // La résolution du suivi (2D6 + MA diff >= 7) est effectuée par
 // `resolveShadowingAfterDodge` dans `mechanics/shadowing.ts`, appelé depuis


### PR DESCRIPTION
## Resume

- **Cloud Burster** (passing) : sur une passe Long ou Long Bomb, le passeur peut forcer le coach adverse a relancer une interception reussie (une fois par interceptor). Integre dans `executePass` via le calcul du range et le nouveau flux de reroll dans la boucle d'interception.
- **Titchy** (trait) :
  - Ce joueur n'exerce pas de zone de tacle — filtrage central dans `getAdjacentOpponents`, donc applique automatiquement aux calculs de Dodge, Pickup, Pass, Catch et a `requiresDodgeRoll`.
  - Ce joueur ne peut pas declarer d'action de Blocage : `canBlock` retourne `false` si le skill est present.
- Enregistrement des deux skills dans `skill-registry` pour la decouverte UI et la documentation.

### Fichiers

- `packages/game-engine/src/mechanics/movement.ts` — `getAdjacentOpponents` ignore desormais les joueurs Titchy.
- `packages/game-engine/src/mechanics/blocking.ts` — `canBlock` refuse les Titchy comme attaquant.
- `packages/game-engine/src/mechanics/passing.ts` — `executePass` applique le reroll Cloud Burster sur Long/Bomb.
- `packages/game-engine/src/skills/skill-registry.ts` — entrees de decouverte UI/documentation pour `cloud-burster` et `titchy`.
- `packages/game-engine/src/mechanics/cloud-burster-titchy.test.ts` — 13 tests (TZ, canBlock, reroll d'interception CB sur Long/Bomb, scenarios negatifs).

## Tache roadmap

Sprint 20-21, O.1 — ~39 skills niche restants, batch 3g.

## Plan de test

- [x] `pnpm test` depuis `packages/game-engine` — 4171 tests OK (dont 13 nouveaux)
- [x] `pnpm --filter '@bb/game-engine' lint` — 0 errors (warnings preexistants uniquement)
- [x] `pnpm typecheck` monorepo — 4 projets OK
- [x] `pnpm --filter '@bb/game-engine' build` — OK
- [x] Scenarios couverts par les tests :
  - Titchy : adversaire adjacent titchy n'est pas compte comme TZ
  - Titchy : dodge/pickup modifiers neutralises quand marqueur adjacent est titchy
  - Titchy : TZ preserve pour les autres adversaires non-titchy
  - Titchy : `canBlock` refuse un attaquant titchy, laisse passer un non-titchy
  - Cloud Burster : Long — interception reussie puis rerollee en echec, pas de turnover
  - Cloud Burster : Bomb — meme flux, reroll applique
  - Cloud Burster : Quick — aucun effet (pas de reroll)
  - Cloud Burster : interception ratee d'emblee — pas de reroll
  - Sans Cloud Burster : interception reussie = turnover direct
  - Registre : `cloud-burster` et `titchy` visibles via `getSkillEffect`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkJACSh7fmLw5zf3Y7smhk)_