### PR TITLE
feat(game-engine): O.1 batch 3h - mighty-blow-1/2 + dirty-player-2

### DIFF
--- a/packages/game-engine/src/skills/mighty-blow-dirty-player-variants.test.ts
+++ b/packages/game-engine/src/skills/mighty-blow-dirty-player-variants.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { setup, type GameState, type Player } from '../index';
+import { collectModifiers, getSkillEffect } from './skill-registry';
+
+/**
+ * O.1 batch 3h — Variantes Mighty Blow (+1 / +2) et Dirty Player (+2).
+ *
+ * Les rosters BB3 utilisent les slugs `mighty-blow-1`, `mighty-blow-2` et
+ * `dirty-player-2`, mais seul `dirty-player-1` (et l'ancien `mighty-blow`
+ * sans suffixe) etait enregistre. Resultat : les Big Guys, le Deathroller
+ * et Morg n Thorg n'avaient AUCUN bonus d'armure / blessure en jeu.
+ *
+ * Ce batch enregistre les 3 slugs manquants pour que les rosters existants
+ * appliquent enfin le bonus correct.
+ */
+
+function patchPlayer(state: GameState, id: string, patch: Partial<Player>): GameState {
+  return {
+    ...state,
+    players: state.players.map(p => (p.id === id ? { ...p, ...patch } : p)),
+  };
+}
+
+describe('Skill registry: mighty-blow-1', () => {
+  it('est enregistre', () => {
+    expect(getSkillEffect('mighty-blow-1')).toBeDefined();
+  });
+
+  it('declare un trigger on-armor', () => {
+    const effect = getSkillEffect('mighty-blow-1')!;
+    expect(effect.triggers).toContain('on-armor');
+  });
+
+  it('applique +1 armorModifier sur on-armor pour un joueur ayant le skill', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['mighty-blow-1'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-armor', { state: s });
+    expect(mods.armorModifier).toBe(1);
+  });
+
+  it('n\'applique aucun bonus pour un joueur sans le skill', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: [] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-armor', { state: s });
+    expect(mods.armorModifier ?? 0).toBe(0);
+  });
+});
+
+describe('Skill registry: mighty-blow-2', () => {
+  it('est enregistre', () => {
+    expect(getSkillEffect('mighty-blow-2')).toBeDefined();
+  });
+
+  it('declare un trigger on-armor', () => {
+    const effect = getSkillEffect('mighty-blow-2')!;
+    expect(effect.triggers).toContain('on-armor');
+  });
+
+  it('applique +2 armorModifier sur on-armor pour un joueur ayant le skill', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['mighty-blow-2'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-armor', { state: s });
+    expect(mods.armorModifier).toBe(2);
+  });
+
+  it('n\'est pas declenche par mighty-blow-1', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['mighty-blow-1'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    // mighty-blow-2 ne doit pas s'activer pour ce joueur (slug different).
+    expect(getSkillEffect('mighty-blow-2')!.canApply({ player, state: s })).toBe(false);
+  });
+});
+
+describe('Skill registry: dirty-player-2', () => {
+  it('est enregistre', () => {
+    expect(getSkillEffect('dirty-player-2')).toBeDefined();
+  });
+
+  it('declare un trigger on-foul', () => {
+    const effect = getSkillEffect('dirty-player-2')!;
+    expect(effect.triggers).toContain('on-foul');
+  });
+
+  it('applique +2 armorModifier sur on-foul pour un joueur ayant le skill', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['dirty-player-2'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-foul', { state: s });
+    expect(mods.armorModifier).toBe(2);
+  });
+
+  it('n\'est pas declenche par dirty-player-1', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['dirty-player-1'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    // dirty-player-2 ne doit pas s'activer pour ce joueur (slug different).
+    expect(getSkillEffect('dirty-player-2')!.canApply({ player, state: s })).toBe(false);
+  });
+});
+
+describe('Skill stacking : un joueur n\'a jamais qu\'une seule variante', () => {
+  it('un joueur avec uniquement mighty-blow-1 obtient +1 (pas +3)', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['mighty-blow-1'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-armor', { state: s });
+    expect(mods.armorModifier).toBe(1);
+  });
+
+  it('un joueur avec uniquement mighty-blow-2 obtient +2', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['mighty-blow-2'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-armor', { state: s });
+    expect(mods.armorModifier).toBe(2);
+  });
+
+  it('un joueur avec uniquement dirty-player-2 obtient +2 sur foul', () => {
+    let s = setup();
+    s = patchPlayer(s, 'A2', { skills: ['dirty-player-2'] });
+    const player = s.players.find(p => p.id === 'A2')!;
+    const mods = collectModifiers(player, 'on-foul', { state: s });
+    expect(mods.armorModifier).toBe(2);
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -203,6 +203,29 @@ registerSkill({
   getModifiers: () => ({ armorModifier: 1 }), // Appliqué au meilleur choix par le moteur
 });
 
+// MIGHTY BLOW (+1) — variante BB3 utilisee dans les rosters
+// (`mighty-blow-1`). Comportement identique a `mighty-blow` mais slug
+// distinct, donc enregistrement separe pour que les rosters existants
+// recoivent enfin le bonus +1 (O.1 batch 3h).
+registerSkill({
+  slug: 'mighty-blow-1',
+  triggers: ['on-armor', 'on-injury'],
+  description: '+1 au jet d\'armure OU au jet de blessure (automatique).',
+  canApply: (ctx) => hasSkill(ctx.player, 'mighty-blow-1') || hasSkill(ctx.player, 'mighty_blow_1'),
+  getModifiers: () => ({ armorModifier: 1 }),
+});
+
+// MIGHTY BLOW (+2) — variante BB3 utilisee par Morg n Thorg et autres
+// stars (`mighty-blow-2`). Bonus de +2 au jet d'armure ou de blessure.
+// (O.1 batch 3h)
+registerSkill({
+  slug: 'mighty-blow-2',
+  triggers: ['on-armor', 'on-injury'],
+  description: '+2 au jet d\'armure OU au jet de blessure (automatique).',
+  canApply: (ctx) => hasSkill(ctx.player, 'mighty-blow-2') || hasSkill(ctx.player, 'mighty_blow_2'),
+  getModifiers: () => ({ armorModifier: 2 }),
+});
+
 // ─── COMPÉTENCES AVANCÉES ────────────────────────────────────────────────
 
 // DAUNTLESS
@@ -255,6 +278,17 @@ registerSkill({
   description: '+1 au jet d\'armure lors d\'une faute.',
   canApply: (ctx) => hasSkill(ctx.player, 'dirty-player-1') || hasSkill(ctx.player, 'dirty_player') || hasSkill(ctx.player, 'dirty player'),
   getModifiers: () => ({ armorModifier: 1 }),
+});
+
+// DIRTY PLAYER (+2) — variante BB3 utilisee notamment par le Dwarf
+// Deathroller (`dirty-player-2`). Bonus de +2 au jet d'armure lors d'une
+// faute. (O.1 batch 3h)
+registerSkill({
+  slug: 'dirty-player-2',
+  triggers: ['on-foul'],
+  description: '+2 au jet d\'armure lors d\'une faute.',
+  canApply: (ctx) => hasSkill(ctx.player, 'dirty-player-2') || hasSkill(ctx.player, 'dirty_player_2'),
+  getModifiers: () => ({ armorModifier: 2 }),
 });
 
 // SNEAKY GIT


### PR DESCRIPTION
## Resume

Bug latent : les rosters BB3 utilisent les slugs `mighty-blow-1`, `mighty-blow-2` et `dirty-player-2` (Big Guys, Deathroller, Morg n Thorg, etc.), mais seuls `mighty-blow` (sans suffixe) et `dirty-player-1` etaient enregistres dans le skill-registry. Resultat : ces joueurs n'avaient **aucun bonus d'armure / blessure en jeu**.

Ce batch enregistre les trois variantes manquantes :
- **`mighty-blow-1`** : +1 a l'armure ou a la blessure (alias BB3 du `mighty-blow` existant) — actif sur `on-armor` / `on-injury`.
- **`mighty-blow-2`** : +2 a l'armure ou a la blessure — utilise par Morg n Thorg et autres stars majeures.
- **`dirty-player-2`** : +2 a l'armure lors d'une faute — utilise par le Dwarf Deathroller.

### Fichiers

- `packages/game-engine/src/skills/skill-registry.ts` — 3 nouvelles entrees (mighty-blow-1, mighty-blow-2, dirty-player-2).
- `packages/game-engine/src/skills/mighty-blow-dirty-player-variants.test.ts` — 15 tests (enregistrement, triggers, getModifiers, exclusion mutuelle des variantes par slug, additivite via collectModifiers).

### Notes techniques

- L'application des modifiers reste geree par les routes existantes :
  - `getMightyBlowBonusFromRegistry` dans `mechanics/blocking.ts` et `mechanics/stab.ts`
  - `getFoulArmorSkillModifiers` dans `mechanics/foul.ts`
- Aucun changement de logique requis : ces helpers utilisent deja `collectModifiers(player, 'on-armor', { state })` qui itere sur tous les skills enregistres.
- Slugs distincts : `mighty-blow-1` ne s'active pas pour un joueur ayant `mighty-blow-2` (et vice-versa) car `hasSkill` fait une comparaison exacte du slug. Pas de risque d'empilement.

## Tache roadmap

Sprint 20-21, O.1 (batch 3h) — "~39 skills niche restants". Ce batch ferme un bug latent qui privait les Big Guys et stars majeurs de leur bonus principal d'armure.

## Plan de test

- [x] `pnpm test` (game-engine) : 4183 tests verts dont 15 nouveaux
- [x] `pnpm typecheck` (workspace) : OK
- [x] `pnpm lint` : 0 erreurs (warnings preexistants inchanges)
- [x] Scenarios couverts par les tests :
  - Chacun des 3 nouveaux skills est enregistre, declare le bon trigger, et applique son armorModifier attendu via `collectModifiers`.
  - Variantes mutuellement exclusives : un joueur avec `mighty-blow-1` n'active pas `mighty-blow-2` (et vice-versa pour dirty-player).
  - Stacking : un joueur avec une seule variante recoit exactement le bonus de cette variante (pas de double comptage).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtVGDrhhkii3xhZLq47CGF)_