### PR TITLE
feat(game-engine): O.1 batch 3i - leap + stab + projectile-vomit registry entries

### DIFF
--- a/packages/game-engine/src/skills/batch-3i-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3i-registry.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3i — Registre de decouverte UI pour skills niche deja
+ * implementes mecaniquement mais absents du `skill-registry`.
+ *
+ * Les mecaniques correspondantes existent deja :
+ *  - `leap`           -> mechanics/leap.ts
+ *  - `stab`           -> mechanics/stab.ts
+ *  - `projectile-vomit` -> mechanics/projectile-vomit.ts
+ *
+ * Sans entree dans le registre, `getSkillEffect(slug)` retournait `undefined`,
+ * ce qui privait l'UI du catalogue (description) et empechait la decouverte
+ * automatique par les composants qui iterent sur `getAllRegisteredSkills()`.
+ */
+
+const BATCH_SKILLS = ['leap', 'stab', 'projectile-vomit'] as const;
+
+describe('O.1 batch 3i — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const slug of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare un trigger on-activation`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain('on-activation');
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3i', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const slug of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger("on-activation")', () => {
+    it('inclut les 3 skills du batch 3i', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      for (const slug of BATCH_SKILLS) {
+        expect(slugs, `missing ${slug} in on-activation trigger`).toContain(slug);
+      }
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const baseCtx = {
+      player: {
+        id: 'p1',
+        team: 'A' as const,
+        pos: { x: 0, y: 0 },
+        name: 'T',
+        number: 1,
+        position: 'Lineman',
+        ma: 6,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: [] as string[],
+        pm: 6,
+        state: 'active' as const,
+      },
+      state: {} as any,
+    };
+
+    for (const slug of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...baseCtx.player, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -886,3 +886,39 @@ registerSkill({
   description: "Quand un adversaire effectue une Passe, un Lancer d'Equipier, une Interception ou une Reception, il subit -1 par joueur avec ce skill a 3 cases ou moins.",
   canApply: (ctx) => hasSkill(ctx.player, 'disturbing-presence') || hasSkill(ctx.player, 'disturbing_presence'),
 });
+
+// ─── LEAP (O.1 batch 3i) ────────────────────────────────────────────────────
+// Leap (Agility) permet de sauter par-dessus une case adjacente pour arriver
+// a une case a distance Chebyshev 2, avec un jet d'Agilite remplacant l'esquive
+// classique. Resolution dans `mechanics/leap.ts` (`executeLeap`, `canLeap`).
+// L'entree du registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'leap',
+  triggers: ['on-activation'],
+  description: "Pendant son mouvement, le joueur peut sauter par-dessus une case adjacente (2 cases de mouvement) avec un jet d'Agilite. Pas de jet d'Esquive requis pour quitter les zones de tacle.",
+  canApply: (ctx) => hasSkill(ctx.player, 'leap') || hasSkill(ctx.player, 'pogo-stick'),
+});
+
+// ─── STAB (O.1 batch 3i) ────────────────────────────────────────────────────
+// Stab remplace une action de Blocage : jet d'armure direct (sans dés de bloc
+// ni assistance) contre une cible adjacente debout. Mighty Blow s'applique a
+// l'armure. Resolution dans `mechanics/stab.ts` (`executeStab`, `canStab`).
+// L'entree du registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'stab',
+  triggers: ['on-activation'],
+  description: "Action speciale remplacant un Blocage : jet d'armure direct contre une cible adjacente. Pas de des de bloc, pas d'assistance, pas de turnover ; l'activation se termine apres le Stab.",
+  canApply: (ctx) => hasSkill(ctx.player, 'stab'),
+});
+
+// ─── PROJECTILE VOMIT (O.1 batch 3i) ────────────────────────────────────────
+// Projectile Vomit (trait de mutation) remplace une action de Blocage : jet
+// D6 (2+ = succes) contre une cible adjacente ; succes = cible mise a terre
+// suivie d'un jet d'armure (Mighty Blow s'applique). Echec termine l'activation
+// sans turnover. Resolution dans `mechanics/projectile-vomit.ts`.
+registerSkill({
+  slug: 'projectile-vomit',
+  triggers: ['on-activation'],
+  description: "Action speciale remplacant un Blocage : jet D6 contre une cible adjacente. Sur 2+, la cible est mise a terre et subit un jet d'armure. Sur 1, l'activation se termine sans turnover.",
+  canApply: (ctx) => hasSkill(ctx.player, 'projectile-vomit') || hasSkill(ctx.player, 'projectile_vomit'),
+});


### PR DESCRIPTION
## Resume

Les mecaniques de **Leap**, **Stab** et **Projectile Vomit** etaient deja implementees (`mechanics/leap.ts`, `mechanics/stab.ts`, `mechanics/projectile-vomit.ts`) et branchees dans le flux de jeu (getLegalMoves expose les actions, applyMove dispatche, les tests unitaires mecaniques existent), mais elles etaient absentes du `skill-registry`. Resultat : `getSkillEffect('leap'|'stab'|'projectile-vomit')` retournait `undefined`, ce qui privait le catalogue UI et la documentation de ces 3 skills tres frequents (Skaven Gutter Runner, Dark Elf Assassin, Nurgle Pestigor, Underworld Skaven, Vampire Thrall, etc.).

Ce batch ajoute 3 entrees "discovery" (trigger `on-activation`) avec le meme pattern que les batchs precedents :
- **3g** (PR #320, open) : titchy, cloud-burster
- **3h** (PR #321, merged) : mighty-blow-1/2, dirty-player-2
- **3i** (ce PR) : leap, stab, projectile-vomit

Aucun changement de comportement moteur, juste l'enregistrement pour l'UI et la decouverte automatique via `getAllRegisteredSkills()` / `getSkillsForTrigger('on-activation')`.

### Fichiers

- `packages/game-engine/src/skills/skill-registry.ts` — 3 nouvelles entrees (leap, stab, projectile-vomit), avec alias `pogo-stick` pour `leap` (meme mecanique via `canLeap`) et alias `projectile_vomit` (underscore form) pour compatibilite roster.
- `packages/game-engine/src/skills/batch-3i-registry.test.ts` — 20 tests (lookup `getSkillEffect`, declaration du trigger `on-activation`, description non vide, `canApply` strict sur le slug, inclusion dans `getAllRegisteredSkills()` et `getSkillsForTrigger('on-activation')`).

### Notes techniques

- `leap` reconnait aussi `pogo-stick` cote `canApply` : c'est la meme mecanique (`mechanics/leap.ts#canLeap`) avec un bonus +1 pour pogo-stick.
- Aucun risque de double-declenchement : les effets mecaniques sont deja resolus par le flux existant (action handlers dedies), le registry n'apporte ici que la decouverte. Pas de `getModifiers` ni `modifyBlockResult` declares pour ces 3 skills.

## Tache roadmap

Sprint 20-21, **O.1** — "~39 skills niche restants (batch 3)". Cette PR couvre 3 skills. La macro-tache O.1 reste ouverte (d'autres skills non enregistres restent : `on-the-ball`, `throw-team-mate`, `dump-off`, `hit-and-run`, `pile-on`, etc.).

## Plan de test

- [x] `npx vitest run batch-3i-registry` depuis `packages/game-engine` : 20/20 tests OK
- [x] `npx vitest run` (full suite) : 4203 tests OK, 137 fichiers (aucune regression)
- [x] `pnpm --filter '@bb/game-engine' lint` : 0 errors (warnings preexistants inchanges)
- [x] `pnpm typecheck` monorepo : 4/4 projets OK
- [x] `pnpm --filter '@bb/game-engine' build` : OK

### Scenarios couverts par les tests

- `getSkillEffect('leap'|'stab'|'projectile-vomit')` retourne une entree definie
- Chaque entree declare `on-activation` dans ses triggers
- Chaque entree a une description non vide
- `canApply` est une fonction bien definie
- `canApply(ctx)` = `false` sans le skill, `true` avec le slug exact
- Les 3 skills apparaissent dans `getAllRegisteredSkills()`
- Les 3 skills apparaissent dans `getSkillsForTrigger('on-activation')`

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5iuLipNqnuXRXiCRaSGt9)_