### PR TITLE
feat(game-engine): O.1 batch 3j - on-the-ball + throw-team-mate + dump-off registry entries

### DIFF
--- a/packages/game-engine/src/skills/batch-3j-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3j-registry.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3j — Registre de decouverte UI pour skills niche deja
+ * implementes mecaniquement mais absents du `skill-registry`.
+ *
+ * Les mecaniques correspondantes existent deja :
+ *  - `on-the-ball`     -> mechanics/on-the-ball.ts
+ *  - `throw-team-mate` -> mechanics/throw-team-mate.ts
+ *  - `dump-off`        -> mechanics/dump-off.ts
+ *
+ * Sans entree dans le registre, `getSkillEffect(slug)` retournait `undefined`,
+ * ce qui privait l'UI du catalogue (description) et empechait la decouverte
+ * automatique par les composants qui iterent sur `getAllRegisteredSkills()`.
+ *
+ * Conformement au pattern des batchs 3g (cloud-burster/titchy), 3h
+ * (mighty-blow-1/2, dirty-player-2) et 3i (leap, stab, projectile-vomit),
+ * ce batch n'ajoute AUCUNE logique moteur : les effets sont deja resolus
+ * par les handlers dedies.
+ */
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: 'on-pass' | 'on-block-defender';
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'on-the-ball', trigger: 'on-pass' },
+  { slug: 'throw-team-mate', trigger: 'on-pass' },
+  { slug: 'dump-off', trigger: 'on-block-defender' },
+];
+
+describe('O.1 batch 3j — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3j', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-pass inclut on-the-ball et throw-team-mate', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('on-the-ball');
+      expect(slugs).toContain('throw-team-mate');
+    });
+
+    it('on-block-defender inclut dump-off', () => {
+      const slugs = getSkillsForTrigger('on-block-defender').map((e) => e.slug);
+      expect(slugs).toContain('dump-off');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -922,3 +922,42 @@ registerSkill({
   description: "Action speciale remplacant un Blocage : jet D6 contre une cible adjacente. Sur 2+, la cible est mise a terre et subit un jet d'armure. Sur 1, l'activation se termine sans turnover.",
   canApply: (ctx) => hasSkill(ctx.player, 'projectile-vomit') || hasSkill(ctx.player, 'projectile_vomit'),
 });
+
+// ─── ON THE BALL (O.1 batch 3j) ─────────────────────────────────────────────
+// On the Ball est une reaction defensive declenchee lors d'une action de Passe
+// adverse : le joueur possedant ce skill peut se deplacer jusqu'a 3 cases avant
+// que le jet de Passe soit effectue, une fois par tour d'equipe. Resolution
+// dans `mechanics/on-the-ball.ts` (`executeOnTheBallMove`, `canUseOnTheBall`,
+// tracking via `state.usedOnTheBallThisTurn`). L'entree du registre sert a la
+// decouverte UI et a la documentation.
+registerSkill({
+  slug: 'on-the-ball',
+  triggers: ['on-pass'],
+  description: "Une fois par tour d'equipe, lorsque l'adversaire declare une action de Passe, ce joueur peut se deplacer jusqu'a 3 cases avant le jet de Passe, en terminant adjacent ou sur la case cible.",
+  canApply: (ctx) => hasSkill(ctx.player, 'on-the-ball') || hasSkill(ctx.player, 'on_the_ball'),
+});
+
+// ─── THROW TEAM-MATE (O.1 batch 3j) ─────────────────────────────────────────
+// Throw Team-Mate permet a un joueur (Big Guy, Ogre, Treeman, etc.) de lancer
+// un coequipier Right Stuff sur une case cible. Implementation dans
+// `mechanics/throw-team-mate.ts` (action THROW_TEAM_MATE dispatchee via
+// actions.ts). L'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'throw-team-mate',
+  triggers: ['on-pass'],
+  description: "Action speciale : lance un coequipier possedant Right Stuff vers une case cible. Utilise les regles de portee et de deviation des passes ; la cible effectue un jet d'armure a l'atterrissage.",
+  canApply: (ctx) => hasSkill(ctx.player, 'throw-team-mate') || hasSkill(ctx.player, 'throw_team_mate'),
+});
+
+// ─── DUMP-OFF (O.1 batch 3j) ────────────────────────────────────────────────
+// Dump-off est une reaction defensive : quand ce joueur porteur du ballon est
+// cible d'un Blocage/Blitz, il peut immediatement effectuer une Passe Rapide
+// avant la resolution du bloc, interrompant l'activation de l'attaquant.
+// Resolution dans `mechanics/dump-off.ts` (`canDumpOff`, `executeDumpOff`).
+// L'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'dump-off',
+  triggers: ['on-block-defender'],
+  description: "Quand ce joueur porteur du ballon est cible d'un Blocage/Blitz, il peut effectuer immediatement une Passe Rapide avant la resolution du bloc. Pas de turnover si la passe rate.",
+  canApply: (ctx) => hasSkill(ctx.player, 'dump-off') || hasSkill(ctx.player, 'dump_off'),
+});


### PR DESCRIPTION
## Resume

Les mecaniques de **On the Ball**, **Throw Team-Mate** et **Dump-off** etaient deja implementees (`mechanics/on-the-ball.ts`, `mechanics/throw-team-mate.ts`, `mechanics/dump-off.ts`) et branchees dans le flux de jeu (action handlers dedies, helpers `canUseOnTheBall` / `canDumpOff` / `canThrowTeamMate` integres aux resolveurs de passe et de bloc), mais elles etaient absentes du `skill-registry`. Resultat : `getSkillEffect('on-the-ball'|'throw-team-mate'|'dump-off')` retournait `undefined`, ce qui privait le catalogue UI et la documentation de ces 3 skills frequents (Imperial Thrower, Skaven Thrower, Dark Elf Runner, Ogres/Treemen/Rat Ogres, etc.).

Ce batch ajoute 3 entrees "discovery" avec le meme pattern que les batchs precedents :
- **3g** (PR #320, encore ouverte) : titchy, cloud-burster
- **3h** (PR #321, mergee) : mighty-blow-1/2, dirty-player-2
- **3i** (PR #322, mergee) : leap, stab, projectile-vomit
- **3j** (ce PR) : on-the-ball, throw-team-mate, dump-off

Aucun changement de comportement moteur, juste l'enregistrement pour l'UI et la decouverte automatique via `getAllRegisteredSkills()` / `getSkillsForTrigger(...)`.

### Fichiers

- `packages/game-engine/src/skills/skill-registry.ts` — 3 nouvelles entrees :
  - `on-the-ball` -> trigger `on-pass` (reaction defensive avant une passe adverse)
  - `throw-team-mate` -> trigger `on-pass` (action speciale de lancer d'equipier)
  - `dump-off` -> trigger `on-block-defender` (reaction defensive sur bloc)
- `packages/game-engine/src/skills/batch-3j-registry.test.ts` — 21 tests (lookup `getSkillEffect`, trigger specifique par skill, description non vide, `canApply` strict sur le slug, inclusion dans `getSkillsForTrigger('on-pass')` et `('on-block-defender')`).

### Notes techniques

- Les 3 skills acceptent leur slug canonique (`on-the-ball`, `throw-team-mate`, `dump-off`) et la variante underscore (`on_the_ball`, `throw_team_mate`, `dump_off`) pour compatibilite avec d'anciens rosters / donnees legacy.
- Aucun risque de double-declenchement : les effets mecaniques sont deja resolus par les handlers dedies existants ; le registry n'apporte ici que la decouverte. Pas de `getModifiers` ni `modifyBlockResult` declares.

## Tache roadmap

Sprint 20-21, **O.1** — "~39 skills niche restants (batch 3)". Cette PR couvre 3 skills. La macro-tache O.1 reste ouverte (d'autres skills non enregistres restent : `hit-and-run`, `pile-on`, `hate`, `provocation`, `trickster`, etc.).

## Plan de test

- [x] `npx vitest run batch-3j-registry` (depuis `packages/game-engine`) : 21/21 tests OK
- [x] `npx vitest run` (full suite) : 4224 tests OK, 138 fichiers (aucune regression, +21 depuis le run precedent)
- [x] `pnpm --filter '@bb/game-engine' lint` : 0 errors (warnings preexistants inchanges)
- [x] `pnpm typecheck` monorepo : 4/4 projets OK
- [x] `pnpm --filter '@bb/game-engine' build` : OK

### Scenarios couverts par les tests

- `getSkillEffect('on-the-ball'|'throw-team-mate'|'dump-off')` retourne une entree definie
- `on-the-ball` et `throw-team-mate` declarent `on-pass` dans leurs triggers
- `dump-off` declare `on-block-defender` dans ses triggers
- Chaque entree a une description non vide
- `canApply(ctx)` = `false` sans le skill, `true` avec le slug exact
- Les 3 skills apparaissent dans `getAllRegisteredSkills()`
- `on-the-ball` + `throw-team-mate` apparaissent dans `getSkillsForTrigger('on-pass')`
- `dump-off` apparait dans `getSkillsForTrigger('on-block-defender')`

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5iuLipNqnuXRXiCRaSGt9)_