### PR TITLE
feat(game-engine): K.11 hail-mary legal moves + tests complementaires

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -253,7 +253,7 @@ export function getLegalMoves(state: GameState): Move[] {
       );
       for (const target of teammates) {
         const range = getPassRange(p.pos, target.pos);
-        if (range && canAttemptPassForRange(p, range)) {
+        if (canAttemptPassForRange(p, range)) {
           moves.push({ type: 'PASS', playerId: p.id, targetId: target.id });
         }
       }

--- a/packages/game-engine/src/mechanics/hail-mary-pass.test.ts
+++ b/packages/game-engine/src/mechanics/hail-mary-pass.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../index';
+import type { GameState, RNG, Player } from '../core/types';
+import { canAttemptPassForRange, getPassRange, executePass } from './passing';
+
+/**
+ * Regle : Hail Mary Pass (Passe Desesperee) — Blood Bowl 2020 / BB3
+ *
+ * "Quand ce joueur effectue une action de Passe, la case cible peut etre n'importe
+ *  ou sur le terrain et la regle de portee n'a pas besoin d'etre utilisee. Une
+ *  passe desesperee n'est jamais precise, peu importe le resultat du test de
+ *  Capacite de Passe."
+ *
+ * Notes d'implementation :
+ *  - Le passeur avec Hail Mary Pass peut cibler au-dela de la portee normale
+ *    (plus de 13 cases, hors categorie quick/short/long/bomb).
+ *  - Meme si le jet de Capacite de Passe reussit, la passe n'est jamais precise :
+ *    le ballon rebondit depuis la case cible (pas de jet de reception direct).
+ *  - Sur echec du jet de passe, comportement standard : turnover + rebond.
+ *  - Les interceptions s'appliquent normalement.
+ */
+
+function makeRNGFromValues(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+/** rollD6 = floor(rng() * 6) + 1. Pour obtenir V, renvoyer (V - 1)/6 + 0.01 */
+function d6(value: number): number {
+  return (value - 1) / 6 + 0.01;
+}
+
+/** getRandomDirection lit rng() puis multiplie par 8. Pour un index I (0..7), renvoyer I/8 + 0.001 */
+function scatter(index: number): number {
+  return index / 8 + 0.001;
+}
+
+function createHMPState(): GameState {
+  const state = setup();
+  // Passer A1 at (2,7) with hail-mary-pass. Target A2 very far at (24,7) (distance 22).
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 2, y: 7 }, name: 'Orc Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 4, av: 9,
+      skills: ['hail-mary-pass'],
+      pm: 6, hasBall: true, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 24, y: 7 }, name: 'Orc Catcher', number: 2,
+      position: 'Catcher', ma: 7, st: 3, ag: 3, pa: 5, av: 8, skills: [],
+      pm: 7, hasBall: false, state: 'active',
+    },
+    {
+      id: 'B1', team: 'B', pos: { x: 20, y: 0 }, name: 'Defender', number: 1,
+      position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: [],
+      pm: 6, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = { x: 2, y: 7 };
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamBlitzCount = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 3, teamB: 3 };
+  state.isTurnover = false;
+  return state;
+}
+
+function getPlayer(state: GameState, id: string): Player {
+  const p = state.players.find(pl => pl.id === id);
+  if (!p) throw new Error(`Player ${id} not found`);
+  return p;
+}
+
+describe('Regle: Hail Mary Pass', () => {
+  it('autorise une passe au-dela de la portee Long Bomb (>13 cases)', () => {
+    const state = createHMPState();
+    const passer = getPlayer(state, 'A1');
+    // Distance 22 : normalement hors de toute categorie (null).
+    expect(getPassRange(passer.pos, getPlayer(state, 'A2').pos)).toBeNull();
+    expect(canAttemptPassForRange(passer, null)).toBe(true);
+  });
+
+  it('refuse la passe ultra-longue pour un joueur sans le skill', () => {
+    const state = createHMPState();
+    const passer = { ...getPlayer(state, 'A1'), skills: [] };
+    expect(canAttemptPassForRange(passer, null)).toBe(false);
+  });
+
+  it('sur jet de passe reussi, le ballon rebondit depuis la cible (jamais precise)', () => {
+    const state = createHMPState();
+    const passer = getPlayer(state, 'A1');
+    const target = getPlayer(state, 'A2');
+    // rng : [pass roll = 6] puis [scatter direction index 0]
+    const rng = makeRNGFromValues([d6(6), scatter(0)]);
+
+    const next = executePass(state, passer, target, rng);
+
+    // Le passeur n'a plus le ballon
+    expect(getPlayer(next, 'A1').hasBall).toBe(false);
+    // La cible ne l'a pas recu (jamais precise = pas de catch direct)
+    expect(getPlayer(next, 'A2').hasBall).toBe(false);
+    // Le ballon est sur le terrain (positionne et rebondissant)
+    expect(next.ball).toBeDefined();
+    // Succes de passe : pas de turnover
+    expect(next.isTurnover).toBe(false);
+    // Log qui mentionne l'imprecision
+    const logText = next.gameLog.map(l => l.message).join('\n');
+    expect(logText).toMatch(/impr[eé]cis|Hail Mary|desesp[eé]r/i);
+  });
+
+  it('sur jet de passe rate, turnover standard', () => {
+    const state = createHMPState();
+    const passer = getPlayer(state, 'A1');
+    const target = getPlayer(state, 'A2');
+    // pa=4, aucune TZ => targetNumber=4, roll 1 => echec
+    const rng = makeRNGFromValues([d6(1), scatter(0)]);
+
+    const next = executePass(state, passer, target, rng);
+
+    expect(getPlayer(next, 'A1').hasBall).toBe(false);
+    expect(getPlayer(next, 'A2').hasBall).toBe(false);
+    expect(next.isTurnover).toBe(true);
+  });
+});

--- a/packages/game-engine/src/mechanics/safe-pass.test.ts
+++ b/packages/game-engine/src/mechanics/safe-pass.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { setup } from '../index';
+import type { GameState, RNG, Player } from '../core/types';
+import { executePass } from './passing';
+
+/**
+ * Regle : Safe Pass (Passe Assuree) — Blood Bowl 2020 / BB3
+ *
+ * "Si ce joueur echoue une action de Passe, le ballon n'est pas lache, ne rebondit
+ *  pas depuis la case qu'occupe ce joueur, et aucun Renversement n'est cause. Au
+ *  lieu de cela, ce joueur garde possession du ballon et son activation se termine."
+ *
+ * Notes d'implementation :
+ *  - Uniquement sur echec du jet de Capacite de Passe (pas sur echec de reception,
+ *    ni sur interception).
+ *  - Le passeur conserve le ballon (hasBall = true).
+ *  - Pas de turnover (isTurnover reste false).
+ *  - Pas de rebond (state.ball reste undefined, car attache au passeur).
+ */
+
+function makeRNGFromValues(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+function d6(value: number): number {
+  return (value - 1) / 6 + 0.01;
+}
+
+function createSafePassState(skills: string[] = ['safe-pass']): GameState {
+  const state = setup();
+  // Passer A1 a (5,7), cible A2 a (8,7) (distance 3 = Quick).
+  state.players = [
+    {
+      id: 'A1', team: 'A', pos: { x: 5, y: 7 }, name: 'Elf Thrower', number: 1,
+      position: 'Thrower', ma: 6, st: 3, ag: 3, pa: 3, av: 8,
+      skills,
+      pm: 6, hasBall: true, state: 'active',
+    },
+    {
+      id: 'A2', team: 'A', pos: { x: 8, y: 7 }, name: 'Elf Catcher', number: 2,
+      position: 'Catcher', ma: 8, st: 2, ag: 3, pa: 4, av: 7, skills: [],
+      pm: 8, hasBall: false, state: 'active',
+    },
+  ];
+  state.ball = { x: 5, y: 7 };
+  state.currentPlayer = 'A';
+  state.playerActions = {};
+  state.teamBlitzCount = {};
+  state.teamFoulCount = {};
+  state.teamRerolls = { teamA: 3, teamB: 3 };
+  state.isTurnover = false;
+  return state;
+}
+
+function getPlayer(state: GameState, id: string): Player {
+  const p = state.players.find(pl => pl.id === id);
+  if (!p) throw new Error(`Player ${id} not found`);
+  return p;
+}
+
+describe('Regle: Safe Pass', () => {
+  it('sur jet de passe rate, le passeur garde le ballon et aucun turnover', () => {
+    const state = createSafePassState(['safe-pass']);
+    const passer = getPlayer(state, 'A1');
+    const target = getPlayer(state, 'A2');
+    // pa=3, portee quick (+1) => targetNumber = 3-1 = 2. Roll 1 => echec.
+    const rng = makeRNGFromValues([d6(1)]);
+
+    const next = executePass(state, passer, target, rng);
+
+    expect(getPlayer(next, 'A1').hasBall).toBe(true);
+    expect(getPlayer(next, 'A2').hasBall).toBe(false);
+    expect(next.isTurnover).toBe(false);
+    expect(next.ball).toBeUndefined();
+
+    const logText = next.gameLog.map(l => l.message).join('\n');
+    expect(logText).toMatch(/Safe Pass|Passe Assur[eé]e/i);
+  });
+
+  it("sans le skill, une passe ratee provoque un turnover", () => {
+    const state = createSafePassState([]);
+    const passer = getPlayer(state, 'A1');
+    const target = getPlayer(state, 'A2');
+    const rng = makeRNGFromValues([d6(1), 0.001, 0.001]);
+
+    const next = executePass(state, passer, target, rng);
+
+    expect(getPlayer(next, 'A1').hasBall).toBe(false);
+    expect(next.isTurnover).toBe(true);
+  });
+
+  it("sur passe reussie, le skill n'intervient pas (flux standard)", () => {
+    const state = createSafePassState(['safe-pass']);
+    const passer = getPlayer(state, 'A1');
+    const target = getPlayer(state, 'A2');
+    // pa=3, quick(+1) => target 2. Roll 6 => succes. Catch ag=3 => target 3. Roll 6 => succes.
+    const rng = makeRNGFromValues([d6(6), d6(6)]);
+
+    const next = executePass(state, passer, target, rng);
+
+    expect(getPlayer(next, 'A1').hasBall).toBe(false);
+    expect(getPlayer(next, 'A2').hasBall).toBe(true);
+    expect(next.isTurnover).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resume

Remplace #308 (redondante avec #307 deja mergee) en ne conservant que les apports reels :

- **Fix `getLegalMoves`** : supprime le guard `range && ...` pour que les cibles Hail Mary (distance > 13, `range === null`) soient bien proposees quand le passeur possede le skill. Sans ce fix, l'IA et l'UI cote serveur ne generaient jamais de coup `PASS` Hail Mary.
- **Tests complementaires** : deux nouveaux fichiers qui couvrent les memes comportements que `hail-mary-safe-pass.test.ts` deja present, avec des scenarios additionnels (portee 22 cases, garde de possession sur echec Safe Pass, etc.).

### Fichiers

- `packages/game-engine/src/actions/actions.ts` — retrait du guard `range && ...` dans `getLegalMoves`.
- `packages/game-engine/src/mechanics/hail-mary-pass.test.ts` — 4 tests.
- `packages/game-engine/src/mechanics/safe-pass.test.ts` — 3 tests.

## Plan de test

- [x] `pnpm -F @bb/game-engine typecheck` — OK
- [x] `pnpm -F @bb/game-engine test` — 4190 tests passants (138 fichiers)
- [x] `pnpm -F @bb/game-engine lint` — 0 erreur
- [x] Scenarios couverts par les tests :
  - HMP autorise la cible a 22 cases (> 13)
  - HMP + succes → ballon au sol, pas de turnover
  - HMP + echec → turnover standard
  - Safe Pass + echec → passeur garde le ballon, pas de turnover, pas de rebond
  - Sans Safe Pass, echec → turnover + rebond
  - Safe Pass + succes → flux standard

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1esp7fxmbFiUQS2LZkoFA)_