### PR TITLE
feat(game-engine): O.1 batch 3k - chainsaw + multiple-block + hypnotic-gaze

### DIFF
--- a/packages/game-engine/src/skills/batch-3k-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3k-registry.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3k — Registre de decouverte UI pour skills niche deja
+ * implementes mecaniquement mais absents du `skill-registry`.
+ *
+ * Les mecaniques correspondantes existent deja :
+ *  - `chainsaw`        -> mechanics/chainsaw.ts
+ *  - `multiple-block`  -> mechanics/multiple-block.ts
+ *  - `hypnotic-gaze`   -> mechanics/hypnotic-gaze.ts
+ *
+ * Sans entree dans le registre, `getSkillEffect(slug)` retournait `undefined`,
+ * ce qui privait l'UI du catalogue (description) et empechait la decouverte
+ * automatique par les composants qui iterent sur `getAllRegisteredSkills()`.
+ *
+ * Conformement au pattern des batchs 3g/3h/3i/3j, ce batch n'ajoute AUCUNE
+ * logique moteur : les effets sont deja resolus par les handlers dedies.
+ */
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: 'on-activation' | 'on-block-attacker';
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'chainsaw', trigger: 'on-activation' },
+  { slug: 'multiple-block', trigger: 'on-block-attacker' },
+  { slug: 'hypnotic-gaze', trigger: 'on-activation' },
+];
+
+describe('O.1 batch 3k — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3k', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-activation inclut chainsaw et hypnotic-gaze', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      expect(slugs).toContain('chainsaw');
+      expect(slugs).toContain('hypnotic-gaze');
+    });
+
+    it('on-block-attacker inclut multiple-block', () => {
+      const slugs = getSkillsForTrigger('on-block-attacker').map((e) => e.slug);
+      expect(slugs).toContain('multiple-block');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -961,3 +961,46 @@ registerSkill({
   description: "Quand ce joueur porteur du ballon est cible d'un Blocage/Blitz, il peut effectuer immediatement une Passe Rapide avant la resolution du bloc. Pas de turnover si la passe rate.",
   canApply: (ctx) => hasSkill(ctx.player, 'dump-off') || hasSkill(ctx.player, 'dump_off'),
 });
+
+// ─── CHAINSAW (O.1 batch 3k) ────────────────────────────────────────────────
+// Chainsaw (Secret Weapon) remplace une action de Blocage : jet d'armure
+// direct contre une cible adjacente debout avec un modificateur +3. Mighty
+// Blow ne s'applique pas. Un double 1 naturel fait exploser la tronconneuse
+// sur son porteur. Resolution dans `mechanics/chainsaw.ts` (`executeChainsaw`,
+// `canUseChainsaw`). L'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'chainsaw',
+  triggers: ['on-activation'],
+  description: "Arme Secrete. Action speciale remplacant un Blocage : jet d'armure direct (+3) contre une cible adjacente debout. Mighty Blow ne s'applique pas. Double 1 naturel = la tronconneuse explose sur le porteur.",
+  canApply: (ctx) => hasSkill(ctx.player, 'chainsaw'),
+});
+
+// ─── MULTIPLE BLOCK (O.1 batch 3k) ──────────────────────────────────────────
+// Multiple Block permet, une fois par tour d'equipe, de declarer une action de
+// Blocage ciblant simultanement deux adversaires adjacents avec un malus de
+// -2 ST applique a chacun des deux blocs. Resolution dans
+// `mechanics/multiple-block.ts` (`canPerformMultipleBlock`,
+// `findMultipleBlockTargets`, etc.) avec tracking via
+// `state.usedMultipleBlockThisTurn` et `state.pendingMultipleBlock`.
+// L'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'multiple-block',
+  triggers: ['on-block-attacker'],
+  description: "Une fois par tour d'equipe, ce joueur peut effectuer une action de Blocage ciblant deux adversaires adjacents simultanement. Chaque bloc subit un malus de -2 a la Force de l'attaquant.",
+  canApply: (ctx) => hasSkill(ctx.player, 'multiple-block') || hasSkill(ctx.player, 'multiple_block'),
+  getModifiers: () => ({ strengthModifier: -2 }),
+});
+
+// ─── HYPNOTIC GAZE (O.1 batch 3k) ───────────────────────────────────────────
+// Hypnotic Gaze est une action speciale remplacant une action standard : le
+// joueur tente un jet d'Agilite (2+) pour priver un adversaire adjacent de sa
+// zone de tacle jusqu'a sa prochaine activation. -1 par TZ adverse hors cible.
+// Resolution dans `mechanics/hypnotic-gaze.ts` (`canHypnoticGaze`,
+// `performHypnoticGaze`, `calculateGazeModifiers`). L'entree du registre sert
+// a la decouverte UI.
+registerSkill({
+  slug: 'hypnotic-gaze',
+  triggers: ['on-activation'],
+  description: "Action speciale : jet d'Agilite (2+) contre un adversaire adjacent. Succes = la cible perd sa zone de tacle jusqu'a sa prochaine activation. Echec = fin d'activation (pas de turnover). -1 par zone de tacle adverse hors cible.",
+  canApply: (ctx) => hasSkill(ctx.player, 'hypnotic-gaze') || hasSkill(ctx.player, 'hypnotic_gaze'),
+});


### PR DESCRIPTION
## Resume

Ajoute les entrees de decouverte UI/documentation pour trois skills niche deja implementes mecaniquement mais absents du `skill-registry` :

- **Chainsaw** (`mechanics/chainsaw.ts`) : Secret Weapon. Action speciale remplacant un Blocage avec un jet d'armure direct (+3). Mighty Blow ne s'applique pas. Double 1 naturel = la tronconneuse explose sur le porteur.
- **Multiple Block** (`mechanics/multiple-block.ts`) : une fois par tour d'equipe, ce joueur peut effectuer un Blocage ciblant deux adversaires adjacents simultanement. Chaque bloc subit un malus de -2 ST.
- **Hypnotic Gaze** (`mechanics/hypnotic-gaze.ts`) : action speciale. Jet d'Agilite (2+) qui prive la cible de sa zone de tacle jusqu'a sa prochaine activation. -1 par TZ adverse hors cible.

Pattern identique aux batchs 3g/3h/3i/3j : aucune logique moteur ajoutee, les effets sont deja resolus par les handlers dedies. Ce batch rend les skills visibles via `getSkillEffect()` / `getAllRegisteredSkills()` pour le catalogue UI et la decouverte automatique.

### Fichiers

- `packages/game-engine/src/skills/skill-registry.ts` — 3 entrees `registerSkill({...})` (chainsaw, multiple-block, hypnotic-gaze). `multiple-block` expose aussi `getModifiers: () => ({ strengthModifier: -2 })` pour coherence avec les consommateurs du registre.
- `packages/game-engine/src/skills/batch-3k-registry.test.ts` — 21 tests couvrant : presence dans `getSkillEffect`, trigger declare, description non vide, `canApply` strict, inclusion dans `getAllRegisteredSkills` et `getSkillsForTrigger`, predicats `canApply` positif/negatif.

## Tache roadmap

Sprint 20-21, `O.1 — ~39 skills niche restants`, batch 3k.

## Plan de test

- [x] `pnpm --filter '@bb/game-engine' test` — 4252 tests OK (dont 21 nouveaux)
- [x] `pnpm --filter '@bb/game-engine' lint` — 0 errors (warnings preexistants uniquement)
- [x] `pnpm typecheck` monorepo — 4 projets OK (@bb/ui, @bb/game-engine, @bb/server, @bb/web)
- [x] `pnpm --filter '@bb/game-engine' build` — OK
- [x] Scenarios couverts par les tests :
  - `getSkillEffect('chainsaw'|'multiple-block'|'hypnotic-gaze')` renvoie une entree valide
  - Chaque entree declare le trigger attendu (`on-activation` ou `on-block-attacker`)
  - Chaque entree a une description non vide et `canApply` defini
  - `getAllRegisteredSkills()` inclut les 3 nouveaux slugs
  - `getSkillsForTrigger('on-activation')` inclut `chainsaw` et `hypnotic-gaze`
  - `getSkillsForTrigger('on-block-attacker')` inclut `multiple-block`
  - `canApply` renvoie `false` pour un joueur sans le skill et `true` avec


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKzYvHEAhuXisMzzysLrSM)_