### PR TITLE
feat(game-engine): O.1 batch 3l - armored-skull + instable + running-pass

### DIFF
--- a/packages/game-engine/src/skills/batch-3l-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3l-registry.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3l — Registre de decouverte UI pour skills niche deja
+ * implementes mecaniquement mais absents du `skill-registry`.
+ *
+ * Les mecaniques correspondantes existent deja :
+ *  - `armored-skull` -> mechanics/injury.ts (modificateur -1 au jet de blessure)
+ *  - `instable`      -> mechanics/negative-traits.ts (interdit Pass/Handoff/TTM)
+ *  - `running-pass`  -> mechanics/running-pass.ts (continue mouvement apres Quick Pass)
+ *
+ * Sans entree dans le registre, `getSkillEffect(slug)` retournait `undefined`,
+ * ce qui privait l'UI du catalogue (description) et empechait la decouverte
+ * automatique par les composants qui iterent sur `getAllRegisteredSkills()`.
+ *
+ * Conformement au pattern des batchs 3g/3h/3i/3j/3k, ce batch n'ajoute AUCUNE
+ * logique moteur : les effets sont deja resolus par les handlers dedies. En
+ * particulier, on n'expose pas de `getModifiers` pour `armored-skull` car le
+ * -1 est deja applique directement dans `performInjuryRoll` ; l'exposer ici
+ * provoquerait un double-comptage via `getInjurySkillModifiers`.
+ */
+
+type BatchTrigger = 'on-injury' | 'passive' | 'on-pass';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+  readonly aliasSlugs?: readonly string[];
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'armored-skull', trigger: 'on-injury' },
+  { slug: 'instable', trigger: 'passive' },
+  {
+    slug: 'running-pass',
+    trigger: 'on-pass',
+    aliasSlugs: ['running_pass', 'running-pass-2025'],
+  },
+];
+
+describe('O.1 batch 3l — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3l', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-injury inclut armored-skull', () => {
+      const slugs = getSkillsForTrigger('on-injury').map((e) => e.slug);
+      expect(slugs).toContain('armored-skull');
+    });
+
+    it('passive inclut instable', () => {
+      const slugs = getSkillsForTrigger('passive').map((e) => e.slug);
+      expect(slugs).toContain('instable');
+    });
+
+    it('on-pass inclut running-pass', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('running-pass');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    for (const { slug, aliasSlugs } of BATCH_SKILLS) {
+      if (!aliasSlugs) continue;
+      for (const alias of aliasSlugs) {
+        it(`"${slug}" : canApply = true avec l'alias "${alias}"`, () => {
+          const effect = getSkillEffect(slug)!;
+          const ctx = {
+            ...baseCtx,
+            player: { ...basePlayer, skills: [alias] },
+          };
+          expect(effect.canApply(ctx as any)).toBe(true);
+        });
+      }
+    }
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1015,6 +1015,49 @@ registerSkill({
   getModifiers: () => ({ strengthModifier: -2 }),
 });
 
+// ─── ARMORED SKULL (O.1 batch 3l) ───────────────────────────────────────────
+// Le modificateur -1 au jet de blessure est applique directement dans
+// `mechanics/injury.ts` (`armoredSkullModifier`), appele par
+// `performInjuryRoll` et `performLastingInjuryRoll`. On n'expose PAS de
+// `getModifiers` ici pour eviter un double-comptage via le flux
+// `skill-bridge.getInjurySkillModifiers` utilise par `blocking.ts`.
+// L'entree du registre sert uniquement a la decouverte UI et a la
+// documentation du skill.
+registerSkill({
+  slug: 'armored-skull',
+  triggers: ['on-injury'],
+  description: "-1 a tout jet de Blessure effectue contre ce joueur. Reduit les chances de KO et de Blessure grave.",
+  canApply: (ctx) => hasSkill(ctx.player, 'armored-skull') || hasSkill(ctx.player, 'armored_skull'),
+});
+
+// ─── INSTABLE (O.1 batch 3l) ────────────────────────────────────────────────
+// Instable interdit les actions Passe, Remise (Hand-Off) et Lancer d'Equipier.
+// La prohibition est appliquee dans `mechanics/negative-traits.ts`
+// (`checkInstableProhibition`) depuis les handlers d'action et depuis
+// `getLegalMoves`. Aucune mecanique registry-driven n'est necessaire ici.
+registerSkill({
+  slug: 'instable',
+  triggers: ['passive'],
+  description: "Ce joueur ne peut pas declarer d'action de Passe, de Transmission (Hand-Off) ni de Lancer d'Equipier. L'action est refusee sans jet et sans turnover.",
+  canApply: (ctx) => hasSkill(ctx.player, 'instable'),
+});
+
+// ─── RUNNING PASS (O.1 batch 3l) ────────────────────────────────────────────
+// Running Pass permet au joueur de continuer son mouvement apres une Passe
+// Rapide reussie (et une Transmission pour la variante `running-pass-2025`).
+// La logique est entierement portee par `mechanics/running-pass.ts` et
+// consommee par `canPlayerContinueMoving` dans `core/game-state.ts`. L'entree
+// ici sert a la decouverte UI (catalogue des skills) et a la documentation.
+registerSkill({
+  slug: 'running-pass',
+  triggers: ['on-pass'],
+  description: "Le joueur peut continuer son mouvement apres une Passe Rapide reussie s'il lui reste du mouvement. Variante Season 3 (`running-pass-2025`) : s'applique egalement aux Transmissions (Hand-Off). Utilisable une fois par tour d'equipe.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'running-pass') ||
+    hasSkill(ctx.player, 'running_pass') ||
+    hasSkill(ctx.player, 'running-pass-2025'),
+});
+
 // ─── HYPNOTIC GAZE (O.1 batch 3k) ───────────────────────────────────────────
 // Hypnotic Gaze est une action speciale remplacant une action standard : le
 // joueur tente un jet d'Agilite (2+) pour priver un adversaire adjacent de sa


### PR DESCRIPTION
## Resume

Ajoute les entries de decouverte UI pour trois skills niche dont la mecanique existe deja mais qui etaient absents du `skill-registry` :

- **armored-skull** -> `mechanics/injury.ts` (modificateur -1 sur jet de blessure)
- **instable** -> `mechanics/negative-traits.ts` (interdit Pass / Hand-Off / TTM)
- **running-pass** -> `mechanics/running-pass.ts` (poursuite de mouvement apres Quick Pass ; couvre aussi `running_pass` et `running-pass-2025`)

Conformement au pattern des batchs 3g/3h/3i/3j/3k, ce batch n'ajoute **aucune** logique moteur. En particulier, `armored-skull` n'expose pas `getModifiers` pour eviter un double-comptage via `skill-bridge.getInjurySkillModifiers` (utilise par `blocking.ts`).

## Tache roadmap

Sprint 20-21, **O.1 — ~39 skills niche restants (batch 3)** — poursuite de la serie de micro-batches (batch **3l**).

## Plan de test

- [x] `batch-3l-registry.test.ts` : 27 nouveaux tests
  - presence dans `getSkillEffect` / `getAllRegisteredSkills` / `getSkillsForTrigger`
  - trigger declare (`on-injury` / `passive` / `on-pass`)
  - description non vide, `canApply` fonctionnel
  - absence de `getModifiers` (garde anti-double-comptage)
  - `canApply` strict (false sans skill, true avec slug canonique ou alias)
- [x] `pnpm test` (143/143 fichiers, 4292/4292 tests)
- [x] `pnpm --filter @bb/game-engine typecheck` (OK)
- [x] `pnpm --filter @bb/game-engine lint` (0 errors ; warnings preexistants)
- [x] `pnpm --filter @bb/game-engine build` (OK)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mnevdq3eHRjrLBMTRtKQo2)_