### PR TITLE
feat(game-engine): O.1 batch 3m - bloodlust + always-hungry + secret-weapon registry

### DIFF
--- a/packages/game-engine/src/skills/batch-3m-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3m-registry.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3m — Registre de decouverte UI pour skills niche deja
+ * implementes mecaniquement mais absents du `skill-registry`.
+ *
+ * Les mecaniques correspondantes existent deja :
+ *  - `bloodlust`     -> mechanics/negative-traits.ts (checkBloodlust, cible 4+)
+ *  - `bloodlust-2`   -> mechanics/negative-traits.ts (checkBloodlust, cible 2+)
+ *  - `bloodlust-3`   -> mechanics/negative-traits.ts (checkBloodlust, cible 3+)
+ *  - `always-hungry` -> mechanics/negative-traits.ts (declenche sur Throw Team-Mate)
+ *  - `secret-weapon` -> mechanics/secret-weapons.ts (expulsion fin de drive)
+ *
+ * Sans entree dans le registre, `getSkillEffect(slug)` retournait `undefined`,
+ * ce qui privait l'UI du catalogue (description) et empechait la decouverte
+ * automatique par les composants qui iterent sur `getAllRegisteredSkills()`.
+ *
+ * Conformement au pattern des batchs 3g/3h/3i/3j/3k/3l, ce batch n'ajoute
+ * AUCUNE logique moteur : les effets sont deja resolus par les handlers
+ * dedies. En particulier, on n'expose pas de `getModifiers` pour ces skills
+ * car ils declenchent des jets specifiques (D6 contre cible) plutot que
+ * des modificateurs additionnels sur d'autres jets.
+ */
+
+type BatchTrigger = 'on-activation' | 'on-pass' | 'passive';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'bloodlust', trigger: 'on-activation' },
+  { slug: 'bloodlust-2', trigger: 'on-activation' },
+  { slug: 'bloodlust-3', trigger: 'on-activation' },
+  { slug: 'always-hungry', trigger: 'on-pass' },
+  { slug: 'secret-weapon', trigger: 'passive' },
+];
+
+describe('O.1 batch 3m — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 5 skills du batch 3m', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-activation inclut les 3 variantes bloodlust', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      expect(slugs).toContain('bloodlust');
+      expect(slugs).toContain('bloodlust-2');
+      expect(slugs).toContain('bloodlust-3');
+    });
+
+    it('on-pass inclut always-hungry', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('always-hungry');
+    });
+
+    it('passive inclut secret-weapon', () => {
+      const slugs = getSkillsForTrigger('passive').map((e) => e.slug);
+      expect(slugs).toContain('secret-weapon');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"bloodlust" canApply ne se declenche pas pour les variantes -2/-3 seules', () => {
+      const effect = getSkillEffect('bloodlust')!;
+      const ctxWith2 = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['bloodlust-2'] },
+      };
+      const ctxWith3 = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['bloodlust-3'] },
+      };
+      // Les variantes ont leurs propres entrees registry pour eviter le
+      // double-comptage : la canApply de "bloodlust" ne reagit qu'au slug
+      // canonique.
+      expect(effect.canApply(ctxWith2 as any)).toBe(false);
+      expect(effect.canApply(ctxWith3 as any)).toBe(false);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1071,3 +1071,58 @@ registerSkill({
   description: "Action speciale : jet d'Agilite (2+) contre un adversaire adjacent. Succes = la cible perd sa zone de tacle jusqu'a sa prochaine activation. Echec = fin d'activation (pas de turnover). -1 par zone de tacle adverse hors cible.",
   canApply: (ctx) => hasSkill(ctx.player, 'hypnotic-gaze') || hasSkill(ctx.player, 'hypnotic_gaze'),
 });
+
+// ─── BLOODLUST (3 variantes) (O.1 batch 3m) ─────────────────────────────────
+// Bloodlust est verifie au debut de l'activation par `checkBloodlust` dans
+// `mechanics/negative-traits.ts`. Le jet D6 (+1 si Block/Blitz) doit atteindre
+// la cible de la variante (4+ par defaut, 2+ pour bloodlust-2, 3+ pour
+// bloodlust-3) ; sinon l'activation se termine sans turnover. Chaque variante
+// recoit son propre slug pour eviter le double-comptage et permettre a l'UI
+// d'afficher le bon seuil. L'entree du registre sert a la decouverte UI et a
+// la documentation.
+registerSkill({
+  slug: 'bloodlust',
+  triggers: ['on-activation'],
+  description: "Au debut de l'activation, jet D6 (+1 si Block/Blitz). Sur un resultat inferieur a 4 (ou 1 naturel), l'activation se termine sans turnover ; le Vampire pourrait mordre un Thrall adjacent.",
+  canApply: (ctx) => hasSkill(ctx.player, 'bloodlust'),
+});
+
+registerSkill({
+  slug: 'bloodlust-2',
+  triggers: ['on-activation'],
+  description: "Au debut de l'activation, jet D6 (+1 si Block/Blitz). Sur un resultat inferieur a 2 (ou 1 naturel), l'activation se termine sans turnover ; le Vampire pourrait mordre un Thrall adjacent.",
+  canApply: (ctx) => hasSkill(ctx.player, 'bloodlust-2'),
+});
+
+registerSkill({
+  slug: 'bloodlust-3',
+  triggers: ['on-activation'],
+  description: "Au debut de l'activation, jet D6 (+1 si Block/Blitz). Sur un resultat inferieur a 3 (ou 1 naturel), l'activation se termine sans turnover ; le Vampire pourrait mordre un Thrall adjacent.",
+  canApply: (ctx) => hasSkill(ctx.player, 'bloodlust-3'),
+});
+
+// ─── ALWAYS HUNGRY (O.1 batch 3m) ───────────────────────────────────────────
+// Always Hungry est verifie lors d'une action Throw Team-Mate dans
+// `mechanics/negative-traits.ts` (`checkAlwaysHungry`). Sur un jet D6 = 1 avant
+// le lancer, le porteur tente de manger son coequipier (jet d'echappee) au lieu
+// de le lancer. L'entree du registre sert a la decouverte UI et a la
+// documentation ; aucun modificateur n'est expose ici (le jet est dedie).
+registerSkill({
+  slug: 'always-hungry',
+  triggers: ['on-pass'],
+  description: "Quand ce joueur tente un Lancer d'Equipier, jet D6 (2+). Sur 1, il essaie de manger le coequipier au lieu de le lancer ; ce dernier peut tenter un jet d'echappee.",
+  canApply: (ctx) => hasSkill(ctx.player, 'always-hungry') || hasSkill(ctx.player, 'always_hungry'),
+});
+
+// ─── SECRET WEAPON (O.1 batch 3m) ───────────────────────────────────────────
+// Secret Weapon est resolu en fin de drive par `expelSecretWeapons` dans
+// `mechanics/secret-weapons.ts`. Tout joueur portant ce trait qui a participe
+// au drive est expulse par l'arbitre, sauf si un Bribe (pot-de-vin) reussit
+// (jet D6 : 2+ = sauve, 1 = expulse quand meme). L'entree du registre sert a
+// la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'secret-weapon',
+  triggers: ['passive'],
+  description: "A la fin de chaque drive, ce joueur est expulse par l'arbitre (Sent-off). Un pot-de-vin (Bribe) peut etre utilise pour tenter de l'eviter (jet D6 : 2+ = sauve).",
+  canApply: (ctx) => hasSkill(ctx.player, 'secret-weapon') || hasSkill(ctx.player, 'secret_weapon'),
+});


### PR DESCRIPTION
## Resume

Ajoute les entrees de decouverte UI au `skill-registry` pour 5 skills deja mecaniquement implementes mais absents du registre :

- `bloodlust` (variante 4+) -> `mechanics/negative-traits.ts#checkBloodlust`
- `bloodlust-2` (2+) -> `mechanics/negative-traits.ts#checkBloodlust`
- `bloodlust-3` (3+) -> `mechanics/negative-traits.ts#checkBloodlust`
- `always-hungry` -> `mechanics/negative-traits.ts` (declenche sur Throw Team-Mate)
- `secret-weapon` -> `mechanics/secret-weapons.ts#expelSecretWeapons`

Conformement au pattern des batchs 3g/3h/3i/3j/3k/3l, ce batch n'ajoute **AUCUNE logique moteur** : les effets sont deja resolus par les handlers dedies. Les entrees registry servent uniquement a la decouverte UI (`getSkillEffect`, `getAllRegisteredSkills`, `getSkillsForTrigger`) et a la documentation des skills. `getModifiers` n'est pas expose pour eviter le double-comptage avec les jets dedies.

## Tache roadmap

Sprint 20-21, tache `O.1 — ~39 skills niche restants (batch 3)` (sous-batch 3m).

## Plan de test

- [x] 40 nouveaux tests dans `packages/game-engine/src/skills/batch-3m-registry.test.ts`
  - discovery via `getSkillEffect` (5 skills × 5 assertions)
  - presence dans `getAllRegisteredSkills`
  - presence dans `getSkillsForTrigger` pour `on-activation`, `on-pass`, `passive`
  - `canApply` strict sur le slug (false sans skill, true avec skill canonique)
  - assertion specifique : `bloodlust` ne reagit pas aux variantes -2/-3 seules (anti-double-comptage)
- [x] `pnpm --filter @bb/game-engine test` : 4332/4332 tests passent (144 fichiers)
- [x] `pnpm --filter @bb/game-engine lint` : 0 erreurs (warnings preexistants non lies au changement)
- [x] `pnpm --filter @bb/game-engine typecheck` : OK
- [x] `pnpm --filter @bb/game-engine build` : OK


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdFjK6TjKdJoy51K4WWRqY)_