### PR TITLE
feat(game-engine): O.1 batch 3n - pogo-stick + swarming + kick-team-mate

### DIFF
--- a/packages/game-engine/src/skills/batch-3n-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3n-registry.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3n — Registre de decouverte UI pour skills niche deja
+ * presents sur les rosters Season 3 mais absents du `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `pogo-stick`      -> mechanics/leap.ts (meme mecanique que Leap + 1 au jet)
+ *  - `swarming`        -> regle de placement (depassement 11 joueurs autorise)
+ *  - `kick-team-mate`  -> action speciale alternative a Throw Team-Mate
+ *
+ * Ces skills sont actuellement refuses par `getSkillEffect(slug)`, ce qui
+ * masque leur description dans le catalogue UI et les exclut des
+ * iterations sur `getAllRegisteredSkills()`. Conformement aux batches
+ * 3g-3m, ce batch ajoute uniquement des entrees de decouverte et n'expose
+ * AUCUN `getModifiers` : les mecaniques associees (leap, setup, action
+ * speciale) sont deja resolues par des handlers dedies ou des regles de
+ * placement, et dupliquer les modificateurs creerait un double-comptage.
+ */
+
+type BatchTrigger = 'on-setup' | 'on-movement' | 'on-activation' | 'passive';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'pogo-stick', trigger: 'on-movement' },
+  { slug: 'swarming', trigger: 'on-setup' },
+  { slug: 'kick-team-mate', trigger: 'on-activation' },
+];
+
+describe('O.1 batch 3n — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3n', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-movement inclut pogo-stick', () => {
+      const slugs = getSkillsForTrigger('on-movement').map((e) => e.slug);
+      expect(slugs).toContain('pogo-stick');
+    });
+
+    it('on-setup inclut swarming', () => {
+      const slugs = getSkillsForTrigger('on-setup').map((e) => e.slug);
+      expect(slugs).toContain('swarming');
+    });
+
+    it('on-activation inclut kick-team-mate', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      expect(slugs).toContain('kick-team-mate');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"pogo-stick" : canApply ne reagit pas au slug "leap" seul', () => {
+      // pogo-stick et leap partagent la meme mecanique (leap.ts), mais
+      // chacun recoit sa propre entree dans le registre pour permettre a
+      // l'UI de differencier les deux et de refleter le +1 bonus du
+      // pogo-stick.
+      const effect = getSkillEffect('pogo-stick')!;
+      const ctxWithLeap = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['leap'] },
+      };
+      expect(effect.canApply(ctxWithLeap as any)).toBe(false);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1126,3 +1126,45 @@ registerSkill({
   description: "A la fin de chaque drive, ce joueur est expulse par l'arbitre (Sent-off). Un pot-de-vin (Bribe) peut etre utilise pour tenter de l'eviter (jet D6 : 2+ = sauve).",
   canApply: (ctx) => hasSkill(ctx.player, 'secret-weapon') || hasSkill(ctx.player, 'secret_weapon'),
 });
+
+// ─── POGO STICK (O.1 batch 3n) ──────────────────────────────────────────────
+// Pogo Stick partage la mecanique de Leap (mechanics/leap.ts) : le joueur peut
+// sauter par-dessus une case adjacente occupee (y compris Debout) et recoit
+// +1 au jet d'Agilite du saut. `canLeap` et `calculateLeapAgilityModifier`
+// lisent directement le skill `pogo-stick` sur le joueur. Le dispatch dans
+// `actions/actions.ts` choisit `pogo-stick` comme label du skill declenche
+// quand il est present. On expose ici une entree dediee pour que l'UI puisse
+// differencier Pogo Stick de Leap et refleter le bonus specifique.
+registerSkill({
+  slug: 'pogo-stick',
+  triggers: ['on-movement'],
+  description: "Le joueur peut sauter par-dessus n'importe quelle case adjacente (libre ou occupee), avec un modificateur +1 sur le jet d'Agilite du saut.",
+  canApply: (ctx) => hasSkill(ctx.player, 'pogo-stick') || hasSkill(ctx.player, 'pogo_stick'),
+});
+
+// ─── SWARMING (O.1 batch 3n) ────────────────────────────────────────────────
+// Swarming est une regle de placement : un joueur portant ce trait peut etre
+// place sur le terrain au debut du match meme si cela depasse le nombre
+// maximum de joueurs autorises (Underworld / Goblin). La logique de placement
+// est geree au niveau des validations de setup ; cette entree de registre
+// sert a la decouverte UI (catalogue et fiche joueur) et ne doit PAS exposer
+// de modificateur d'action en jeu.
+registerSkill({
+  slug: 'swarming',
+  triggers: ['on-setup'],
+  description: "Ce joueur peut etre place sur le terrain au debut du match meme si cela depasse le nombre maximum de joueurs autorises.",
+  canApply: (ctx) => hasSkill(ctx.player, 'swarming'),
+});
+
+// ─── KICK TEAM-MATE (O.1 batch 3n) ──────────────────────────────────────────
+// Kick Team-Mate est une action speciale alternative a Throw Team-Mate : une
+// fois par tour d'equipe, en plus d'un autre joueur effectuant une Passe ou un
+// Lancer d'Equipier, un seul joueur avec ce trait peut effectuer une action
+// "Kick Team-Mate". Le dispatch se fait via les handlers d'action dedies.
+// L'entree du registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'kick-team-mate',
+  triggers: ['on-activation'],
+  description: "Une fois par tour d'equipe, en plus d'un autre joueur effectuant une Passe ou un Lancer d'Equipier, un seul joueur avec ce trait peut effectuer l'action speciale 'Kick Team-Mate'.",
+  canApply: (ctx) => hasSkill(ctx.player, 'kick-team-mate') || hasSkill(ctx.player, 'kick_team_mate'),
+});


### PR DESCRIPTION
## Resume
- Ajoute 3 entrees de decouverte UI dans `skill-registry` pour des skills presents sur les rosters Season 3 mais jusqu'ici absents du registre.
- `pogo-stick` : mecanique deja portee par `mechanics/leap.ts`, l'entree differencie visuellement Pogo Stick de Leap et documente le bonus +1 au jet d'Agilite.
- `swarming` : regle de placement (respectee au niveau des validations d'equipe). Entree de decouverte UI uniquement.
- `kick-team-mate` : action speciale alternative a Throw Team-Mate. Entree de decouverte UI uniquement.
- Meme discipline que les batches 3l/3m : aucun `getModifiers` expose, pour eviter les double-comptages avec les handlers dedies.

## Tache roadmap
- Sprint 20-21 / O.1 — ~39 skills niche restants (batch 3).
- Apres ce batch : 29 skills niche restent a integrer au registre. La case de TODO.md reste `[ ]` tant que la serie n'est pas terminee.

## Plan de test
- [x] `packages/game-engine/src/skills/batch-3n-registry.test.ts` : 26 tests (getSkillEffect, triggers, descriptions, canApply strict, getModifiers absent, iteration par trigger).
- [x] Suite complete game-engine : 4358 tests passes (`pnpm test`).
- [x] `pnpm lint` : 0 erreur (921 warnings preexistants sans regression).
- [x] `pnpm typecheck` : OK.
- [x] `pnpm build` : OK.


---
_Generated by [Claude Code](https://claude.ai/code/session_0187zMojbVJARno5oPXEQZNb)_