### PR TITLE
feat(game-engine): O.1 batch 3o - drunkard + timmm-ber + fumblerooskie

### DIFF
--- a/packages/game-engine/src/skills/batch-3o-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3o-registry.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3o — Registre de decouverte UI pour skills niche deja
+ * presents sur les rosters Season 3 (Treeman Halfling, Norse Lineman,
+ * Elven Union Lineman) mais absents du `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `drunkard`       -> -1 au jet de Foncer (Norse Lineman, Bertha Bigfist...)
+ *  - `timmm-ber`      -> bonus pour se relever si MA<=2 + allies adjacents
+ *                        (Treeman Halfling / roster Halfling)
+ *  - `fumblerooskie`  -> action speciale : lacher le ballon dans une case
+ *                        quittee pendant un mouvement (Elven Union Lineman)
+ *
+ * Conformement aux batches 3g-3n, ce batch ajoute uniquement des entrees de
+ * decouverte et n'expose AUCUN `getModifiers` : les mecaniques associees
+ * (GFI, relevement, action speciale Fumblerooskie) sont deja resolues par
+ * des handlers dedies ou le seront dans un batch ulterieur. Dupliquer les
+ * modificateurs ici creerait un double-comptage.
+ */
+
+type BatchTrigger = 'on-gfi' | 'on-activation' | 'on-movement';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'drunkard', trigger: 'on-gfi' },
+  { slug: 'timmm-ber', trigger: 'on-activation' },
+  { slug: 'fumblerooskie', trigger: 'on-movement' },
+];
+
+describe('O.1 batch 3o — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3o', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-gfi inclut drunkard', () => {
+      const slugs = getSkillsForTrigger('on-gfi').map((e) => e.slug);
+      expect(slugs).toContain('drunkard');
+    });
+
+    it('on-activation inclut timmm-ber', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      expect(slugs).toContain('timmm-ber');
+    });
+
+    it('on-movement inclut fumblerooskie', () => {
+      const slugs = getSkillsForTrigger('on-movement').map((e) => e.slug);
+      expect(slugs).toContain('fumblerooskie');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"timmm-ber" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('timmm-ber')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['timmm_ber'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1168,3 +1168,43 @@ registerSkill({
   description: "Une fois par tour d'equipe, en plus d'un autre joueur effectuant une Passe ou un Lancer d'Equipier, un seul joueur avec ce trait peut effectuer l'action speciale 'Kick Team-Mate'.",
   canApply: (ctx) => hasSkill(ctx.player, 'kick-team-mate') || hasSkill(ctx.player, 'kick_team_mate'),
 });
+
+// ─── DRUNKARD (O.1 batch 3o) ────────────────────────────────────────────────
+// Drunkard (Poivrot) impose -1 au jet de Foncer (GFI) du joueur. Le
+// modificateur reel est applique par la logique de mouvement (GFI handler) ;
+// l'entree du registre sert a la decouverte UI et a la documentation. On
+// n'expose PAS de getModifiers ici pour eviter le double-comptage avec
+// l'implementation existante du GFI.
+registerSkill({
+  slug: 'drunkard',
+  triggers: ['on-gfi'],
+  description: "Ce joueur subit un modificateur de -1 au jet de de lorsqu'il tente de Foncer (GFI).",
+  canApply: (ctx) => hasSkill(ctx.player, 'drunkard'),
+});
+
+// ─── TIMMM-BER! (O.1 batch 3o) ──────────────────────────────────────────────
+// Timmm-ber! est un trait de relevement pour les joueurs a tres faible
+// mobilite (MA <= 2, typiquement les Treemen). Quand ce joueur tente de se
+// relever, il beneficie d'un modificateur +1 par coequipier Debout adjacent
+// et en position ouverte. Un 1 naturel reste un echec quel que soit le
+// nombre d'aidants. La mecanique de relevement dediee lit directement le
+// skill sur le joueur ; l'entree du registre sert a la decouverte UI.
+registerSkill({
+  slug: 'timmm-ber',
+  triggers: ['on-activation'],
+  description: "Si ce joueur a une Allocation de Mouvement de 2 ou moins, il applique +1 au jet pour se relever par coequipier Debout adjacent en position ouverte. Un 1 naturel reste un echec.",
+  canApply: (ctx) => hasSkill(ctx.player, 'timmm-ber') || hasSkill(ctx.player, 'timmm_ber'),
+});
+
+// ─── FUMBLEROOSKIE (O.1 batch 3o) ───────────────────────────────────────────
+// Fumblerooskie est une action volontaire : pendant un mouvement ou un Blitz
+// alors qu'il est en possession du ballon, ce joueur peut choisir de "lacher"
+// le ballon dans n'importe quelle case quittee pendant son mouvement. Le
+// ballon ne rebondit pas. La mecanique est geree par un handler d'action
+// dedie ; l'entree du registre sert a la decouverte UI et a la documentation.
+registerSkill({
+  slug: 'fumblerooskie',
+  triggers: ['on-movement'],
+  description: "Pendant un mouvement ou un Blitz en possession du ballon, ce joueur peut lacher le ballon dans n'importe quelle case qu'il quitte. Le ballon ne rebondit pas.",
+  canApply: (ctx) => hasSkill(ctx.player, 'fumblerooskie'),
+});


### PR DESCRIPTION
## Résumé

Batch 3o de la tâche **O.1 — skills niche restants**. Poursuit la stratégie des batchs 3g-3n : ajoute des **entrées de découverte UI** pour 3 skills déjà présents sur les rosters Season 3 mais absents du `skill-registry`, sans introduire de `getModifiers` (pour éviter le double-comptage avec les handlers dédiés).

- `drunkard` (trigger `on-gfi`) — -1 au Foncer (Norse Lineman, Bertha Bigfist)
- `timmm-ber` (trigger `on-activation`) — bonus de relèvement MA≤2 + alliés adjacents (Treeman Halfling, roster Halfling)
- `fumblerooskie` (trigger `on-movement`) — action spéciale lâche-ballon pendant le mouvement (Elven Union Lineman)

## Tâche roadmap

Sprint 20-21, tâche **O.1** (`TODO.md`). Tâche incrémentale, toujours `[ ]` après ce batch (d'autres skills niche restants).

## Fichiers touchés

- `packages/game-engine/src/skills/skill-registry.ts` (+40 lignes) — 3 appels `registerSkill`
- `packages/game-engine/src/skills/batch-3o-registry.test.ts` (nouveau, 141 lignes) — 26 tests

## Plan de test

- [x] `pnpm test src/skills/batch-3o-registry` — 26/26 GREEN (RED confirmé avant impl)
- [x] `pnpm test` — 4384/4384 tests game-engine OK (aucune régression)
- [x] `pnpm typecheck` — OK
- [x] `pnpm lint` — 0 errors (warnings pré-existants inchangés)
- [x] `pnpm --filter=@bb/game-engine build` — OK
- [ ] Build `@bb/web` non vérifié (Google Fonts bloquées en sandbox, hors scope)

## Pattern respecté

Conforme aux batchs 3g-3n :
- Pas de `getModifiers` → évite le double-comptage avec les handlers dédiés (GFI, relèvement, action spéciale Fumblerooskie).
- `canApply` strict sur le slug canonique + variantes underscore si applicable.
- Descriptions en français, commentaires explicatifs au-dessus de chaque `registerSkill`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F1uscDH9tHx8adCmRyim6W)_