### PR TITLE
feat(game-engine): O.1 batch 3p - hit-and-run + my-ball + plague-ridden

### DIFF
--- a/packages/game-engine/src/skills/batch-3p-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3p-registry.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3p — Registre de decouverte UI pour skills niche presents
+ * sur les rosters Season 3 mais absents du `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `hit-and-run`   -> Agility skill S3 : mouvement supplementaire apres un
+ *                       Bloc (Vampire Striker, Skaven Gutter Runner Hit Squad)
+ *  - `my-ball`       -> Trait S3 : interdit d'abandonner volontairement le
+ *                       ballon (Halfling Beer Boar)
+ *  - `plague-ridden` -> Trait S3 : remplace une blessure MORT sur un joueur
+ *                       St<=4 par une infection (roster Nurgle, Rotters, Beast
+ *                       of Nurgle, Pestigor)
+ *
+ * Conformement aux batches 3g-3o, ce batch ajoute uniquement des entrees de
+ * decouverte et n'expose AUCUN `getModifiers` : les mecaniques associees
+ * (action speciale post-bloc, restriction de passe, conversion de blessure)
+ * sont deja resolues ou le seront dans un batch dedie. Dupliquer les
+ * modificateurs ici creerait un double-comptage.
+ */
+
+type BatchTrigger = 'on-movement' | 'on-pass' | 'on-injury';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'hit-and-run', trigger: 'on-movement' },
+  { slug: 'my-ball', trigger: 'on-pass' },
+  { slug: 'plague-ridden', trigger: 'on-injury' },
+];
+
+describe('O.1 batch 3p — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 3 skills du batch 3p', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-movement inclut hit-and-run', () => {
+      const slugs = getSkillsForTrigger('on-movement').map((e) => e.slug);
+      expect(slugs).toContain('hit-and-run');
+    });
+
+    it('on-pass inclut my-ball', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('my-ball');
+    });
+
+    it('on-injury inclut plague-ridden', () => {
+      const slugs = getSkillsForTrigger('on-injury').map((e) => e.slug);
+      expect(slugs).toContain('plague-ridden');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"hit-and-run" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('hit-and-run')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['hit_and_run'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"my-ball" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('my-ball')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['my_ball'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"plague-ridden" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('plague-ridden')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['plague_ridden'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1208,3 +1208,50 @@ registerSkill({
   description: "Pendant un mouvement ou un Blitz en possession du ballon, ce joueur peut lacher le ballon dans n'importe quelle case qu'il quitte. Le ballon ne rebondit pas.",
   canApply: (ctx) => hasSkill(ctx.player, 'fumblerooskie'),
 });
+
+// ─── HIT AND RUN (O.1 batch 3p) ─────────────────────────────────────────────
+// Hit and Run est un skill d'Agilite Season 3 : une fois par activation, apres
+// avoir effectue une action de Bloc (ou Blitz), le joueur peut effectuer un
+// mouvement supplementaire. La mecanique de prolongation de mouvement est
+// geree par les handlers d'action dedies ; l'entree du registre sert a la
+// decouverte UI et a la documentation. On n'expose PAS de getModifiers pour
+// eviter un double-comptage avec l'implementation du post-bloc.
+registerSkill({
+  slug: 'hit-and-run',
+  triggers: ['on-movement'],
+  description: "Ce joueur peut effectuer un mouvement apres avoir effectue une action de Blocage.",
+  canApply: (ctx) => hasSkill(ctx.player, 'hit-and-run') || hasSkill(ctx.player, 'hit_and_run'),
+});
+
+// ─── MY BALL (O.1 batch 3p) ─────────────────────────────────────────────────
+// My Ball est un trait Season 3 (Halfling Beer Boar entre autres). Un joueur
+// portant ce trait ne peut pas abandonner volontairement le ballon quand il
+// en est en possession : il ne peut donc pas effectuer d'action de Passe,
+// de Passe a la main, ni utiliser toute autre competence qui lui ferait
+// renoncer a la possession. La restriction est appliquee au niveau du
+// dispatch d'actions ; l'entree du registre sert a la decouverte UI. On
+// n'expose pas de getModifiers : il ne s'agit pas d'un modificateur de jet
+// mais d'une interdiction d'action.
+registerSkill({
+  slug: 'my-ball',
+  triggers: ['on-pass'],
+  description: "Ce joueur ne peut pas abandonner volontairement le ballon : il ne peut pas effectuer de Passe, de Passe a la main, ni utiliser toute competence qui lui ferait renoncer a la possession.",
+  canApply: (ctx) => hasSkill(ctx.player, 'my-ball') || hasSkill(ctx.player, 'my_ball'),
+});
+
+// ─── PLAGUE RIDDEN (O.1 batch 3p) ───────────────────────────────────────────
+// Plague Ridden est un trait Season 3 de l'equipe Nurgle : une fois par
+// match, si un joueur adverse avec ST <= 4 et sans trait Decay / Regeneration
+// / Microbe subit un resultat de Blessure MORT (15-16) suite a un Bloc ou
+// Agression d'un joueur avec ce trait, et qu'il ne peut etre sauve par un
+// apothicaire, le porteur peut choisir d'utiliser Plague Ridden : la victime
+// ne meurt pas, elle est infectee. La logique d'application est geree par le
+// handler de blessure ; l'entree du registre sert a la decouverte UI. On
+// n'expose PAS de getModifiers pour eviter un double-comptage sur l'injury
+// roll.
+registerSkill({
+  slug: 'plague-ridden',
+  triggers: ['on-injury'],
+  description: "Une fois par match, si un joueur adverse avec Force 4 ou moins (sans Decomposition, Regeneration ou Microbe) subit une Blessure MORT suite a un Bloc ou une Agression de ce joueur et ne peut etre sauve par un apothicaire, vous pouvez utiliser ce trait : la victime est infectee au lieu de mourir.",
+  canApply: (ctx) => hasSkill(ctx.player, 'plague-ridden') || hasSkill(ctx.player, 'plague_ridden'),
+});


### PR DESCRIPTION
## Resume

Ajoute trois entrees de decouverte UI dans `skill-registry` pour des skills Season 3 presents sur des rosters mais absents du registre. Conformement aux batches 3i-3o, aucune logique moteur n'est ajoutee : seules des entrees `registerSkill(...)` sans `getModifiers` pour eviter tout double-comptage.

- **`hit-and-run`** (trigger `on-movement`) - mouvement apres un Bloc (Vampire Striker, Skaven Gutter Runner Hit Squad)
- **`my-ball`** (trigger `on-pass`) - interdit d'abandonner volontairement le ballon (Halfling Beer Boar)
- **`plague-ridden`** (trigger `on-injury`) - convertit une MORT en infection (Nurgle Rotters, Beast of Nurgle, Pestigor)

Chaque `canApply` reconnait le slug canonique et sa variante underscore (`hit_and_run`, `my_ball`, `plague_ridden`).

## Tache roadmap

Sprint 20-21, tache **O.1 - ~39 skills niche restants (batch 3)** - batch 3p (progression continue apres 3i-3o).

## Plan de test

- [x] Test dedie `batch-3p-registry.test.ts` : 28 assertions (getSkillEffect, triggers, description non vide, canApply strict sans/avec skill, variantes underscore, getAllRegisteredSkills, getSkillsForTrigger)
- [x] `pnpm test` game-engine : 4412/4412
- [x] `pnpm typecheck` (monorepo) : 4/4 OK
- [x] `pnpm build` game-engine : OK
- [x] `pnpm lint` : 0 erreurs (warnings preexistants uniquement)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hk7S4yLTSpZLHAhtBnZaq4)_