### PR TITLE
feat(game-engine): O.1 batch 3r — breathe-fire + clearance + pile-on + provocation + surefoot + trickster

### DIFF
--- a/packages/game-engine/src/skills/batch-3r-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3r-registry.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3r — Registre de decouverte UI pour skills niche presents
+ * sur les rosters Season 3 mais absents du `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `breathe-fire`  -> Trait S3 : une fois par activation, au lieu d'un Bloc,
+ *                       peut effectuer une action Speciale Souffle de Feu
+ *                       (Slann Kroxigor, Black Orc Trained Troll variantes).
+ *  - `clearance`     -> Competence Scelerate S3 : action Speciale de Degagement
+ *                       utilisant le gabarit de renvois (1 par tour, peut
+ *                       bouger avant, pas de Turnover ballon au sol).
+ *  - `pile-on`       -> Trait BB2020 S3 : apres un bloc reussi, valdingue
+ *                       possible + relance du jet d'atterrissage rate (Goblin
+ *                       Fanatic variantes, Halfling Hefty).
+ *  - `provocation`   -> Competence Scelerate S3 : quand ce joueur est Repousse
+ *                       suite a un blocage contre lui, il peut forcer le
+ *                       joueur adverse a Poursuivre (sauf si enracine).
+ *  - `surefoot`      -> General S3 : chaque fois que ce joueur est cense etre
+ *                       Plaque ou Chute, un D6 sur 6 l'empeche de tomber et
+ *                       n'interrompt pas son activation.
+ *  - `trickster`     -> Trait S3 : avant de determiner les des de bloc, le
+ *                       defenseur peut etre replace sur n'importe quelle case
+ *                       inoccupee adjacente au joueur attaquant.
+ *
+ * Conformement aux batches 3g-3q, ce batch ajoute uniquement des entrees de
+ * decouverte et n'expose AUCUN `getModifiers` : les mecaniques associees
+ * (action speciale alt-bloc, action de degagement, valdingue / relance
+ * d'agilite, interdiction de poursuite, esquive passive de Chute,
+ * re-placement defensif pre-bloc) sont resolues ou le seront dans des
+ * batches dedies. Dupliquer les modificateurs ici creerait un
+ * double-comptage.
+ */
+
+type BatchTrigger =
+  | 'on-activation'
+  | 'on-injury'
+  | 'on-block-result'
+  | 'on-movement'
+  | 'on-block-defender';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'breathe-fire', trigger: 'on-activation' },
+  { slug: 'clearance', trigger: 'on-activation' },
+  { slug: 'pile-on', trigger: 'on-injury' },
+  { slug: 'provocation', trigger: 'on-block-result' },
+  { slug: 'surefoot', trigger: 'on-movement' },
+  { slug: 'trickster', trigger: 'on-block-defender' },
+];
+
+describe('O.1 batch 3r — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 6 skills du batch 3r', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-activation inclut breathe-fire et clearance', () => {
+      const slugs = getSkillsForTrigger('on-activation').map((e) => e.slug);
+      expect(slugs).toContain('breathe-fire');
+      expect(slugs).toContain('clearance');
+    });
+
+    it('on-injury inclut pile-on', () => {
+      const slugs = getSkillsForTrigger('on-injury').map((e) => e.slug);
+      expect(slugs).toContain('pile-on');
+    });
+
+    it('on-block-result inclut provocation', () => {
+      const slugs = getSkillsForTrigger('on-block-result').map((e) => e.slug);
+      expect(slugs).toContain('provocation');
+    });
+
+    it('on-movement inclut surefoot', () => {
+      const slugs = getSkillsForTrigger('on-movement').map((e) => e.slug);
+      expect(slugs).toContain('surefoot');
+    });
+
+    it('on-block-defender inclut trickster', () => {
+      const slugs = getSkillsForTrigger('on-block-defender').map((e) => e.slug);
+      expect(slugs).toContain('trickster');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"breathe-fire" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('breathe-fire')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['breathe_fire'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"pile-on" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('pile-on')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['pile_on'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1329,3 +1329,96 @@ registerSkill({
   description: "A la fin du tour d'equipe adverse, lancez un D6 pour chaque coequipier a Terre et non-Etourdi dans les trois cases d'un joueur Debout avec ce trait ; sur un succes, le coequipier est immediatement releve.",
   canApply: (ctx) => hasSkill(ctx.player, 'pick-me-up') || hasSkill(ctx.player, 'pick_me_up'),
 });
+
+// ─── BREATHE FIRE (O.1 batch 3r) ────────────────────────────────────────────
+// Breathe Fire (Souffle Ardent) est un trait Season 3 (Slann Kroxigor,
+// variantes Black Orc Trained Troll) : une fois par activation, au lieu
+// d'effectuer une action de Bloc, ce joueur peut effectuer une action
+// Speciale Souffle de Feu (template conique, jet d'armure sur tout joueur
+// touche). Le dispatch d'action et le template de zone sont geres par le
+// handler d'action speciale dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il ne s'agit pas d'un
+// modificateur de jet mais d'une action alternative.
+registerSkill({
+  slug: 'breathe-fire',
+  triggers: ['on-activation'],
+  description: "Une fois par activation, au lieu d'effectuer une action de Bloc, ce joueur peut effectuer une action Speciale Souffle de Feu.",
+  canApply: (ctx) => hasSkill(ctx.player, 'breathe-fire') || hasSkill(ctx.player, 'breathe_fire'),
+});
+
+// ─── CLEARANCE (O.1 batch 3r) ───────────────────────────────────────────────
+// Clearance (Degagement) est une competence Scelerate Season 3 : une fois
+// par tour d'equipe, le joueur peut annoncer une action Speciale de
+// Degagement. Il peut effectuer un mouvement d'abord, puis choisir une
+// direction avec le gabarit de renvois (D6 direction + D6 cases) ; pas de
+// Turnover si le ballon est au sol. Le dispatch d'action est gere par le
+// handler d'action speciale dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une action
+// alternative, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'clearance',
+  triggers: ['on-activation'],
+  description: "Une fois par tour, ce joueur peut annoncer une action Speciale de Degagement. Il peut bouger d'abord, puis utiliser le Gabarit de Renvois (D6 direction + D6 cases). Pas de Turnover si le ballon est au sol.",
+  canApply: (ctx) => hasSkill(ctx.player, 'clearance'),
+});
+
+// ─── PILE-ON (O.1 batch 3r) ─────────────────────────────────────────────────
+// Pile On (Pique) est un trait (BB2020 S3) : apres un bloc reussi qui met
+// l'adversaire a Terre, ce joueur peut choisir de Valdinguer sur lui au lieu
+// de rester debout, offrant un bonus au jet d'armure/blessure via le handler
+// dedie ; ce trait permet egalement de relancer un jet d'agilite
+// d'atterrissage rate. Les deux effets sont resolus respectivement dans
+// l'injury handler et dans le landing handler ; l'entree du registre sert a
+// la decouverte UI. On n'expose PAS de getModifiers pour eviter un
+// double-comptage sur l'injury/landing.
+registerSkill({
+  slug: 'pile-on',
+  triggers: ['on-injury'],
+  description: "Apres un bloc reussi, ce joueur peut choisir de Valdinguer sur l'adversaire a Terre pour des degats supplementaires. Permet egalement de relancer un jet d'agilite d'atterrissage rate.",
+  canApply: (ctx) => hasSkill(ctx.player, 'pile-on') || hasSkill(ctx.player, 'pile_on'),
+});
+
+// ─── PROVOCATION (O.1 batch 3r) ─────────────────────────────────────────────
+// Provocation est une competence Scelerate Season 3 : quand ce joueur est
+// Repousse suite a un blocage contre lui, il peut forcer le joueur adverse
+// a Poursuivre (sauf si l'adverse est Enracine). L'effet est applique par
+// le resolveur de push-back / follow-up ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une
+// contrainte sur la decision de suivre, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'provocation',
+  triggers: ['on-block-result'],
+  description: "Quand ce joueur est Repousse suite a un blocage contre lui, il peut forcer le joueur adverse a Poursuivre (sauf si enracine).",
+  canApply: (ctx) => hasSkill(ctx.player, 'provocation'),
+});
+
+// ─── SUREFOOT (O.1 batch 3r) ────────────────────────────────────────────────
+// Surefoot (Appuis Surs) est une competence General Season 3 : chaque fois
+// que ce joueur est cense etre Plaque ou Chuter (esquive, GFI, bloc, etc.),
+// jetez un D6 ; sur un 6, il n'est pas Plaque / ne Chute pas. Si cela se
+// produit pendant son activation, il peut continuer normalement sans
+// Turnover. Le jet d'evitement est gere par les handlers de mouvement /
+// bloc dedies ; l'entree du registre sert a la decouverte UI. On n'expose
+// PAS de getModifiers pour eviter un double-comptage sur le jet passif.
+registerSkill({
+  slug: 'surefoot',
+  triggers: ['on-movement'],
+  description: "Chaque fois que ce joueur est cense etre Plaque ou Chuter, jetez un D6. Sur un 6, il n'est pas Plaque / ne Chute pas. Pendant son activation, il peut continuer normalement sans Turnover.",
+  canApply: (ctx) => hasSkill(ctx.player, 'surefoot'),
+});
+
+// ─── TRICKSTER (O.1 batch 3r) ───────────────────────────────────────────────
+// Trickster (Farceur) est un trait Season 3 : avant de determiner combien
+// de des sont lances lors d'un bloc (ou d'une action speciale qui remplace
+// un bloc) cible sur ce joueur, il peut etre retire du terrain et replace
+// sur n'importe quelle case inoccupee adjacente au joueur effectuant le
+// bloc. Le re-placement pre-bloc est gere par le pre-processor d'action de
+// bloc ; l'entree du registre sert a la decouverte UI. On n'expose PAS de
+// getModifiers : il ne s'agit pas d'un modificateur de jet mais d'un
+// re-placement defensif.
+registerSkill({
+  slug: 'trickster',
+  triggers: ['on-block-defender'],
+  description: "Avant de determiner les des de bloc, ce joueur peut etre retire du terrain et replace sur n'importe quelle case inoccupee adjacente au joueur effectuant le bloc.",
+  canApply: (ctx) => hasSkill(ctx.player, 'trickster'),
+});


### PR DESCRIPTION
## Resume

Ajoute 6 entrees de decouverte UI au `skill-registry` pour les traits et competences **Season 3** presents sur les rosters mais jusqu'ici absents du registre :

| Slug | Trigger | Categorie / Equipes concernees |
|---|---|---|
| `breathe-fire` | `on-activation` | Trait S3 (Slann Kroxigor, Black Orc Trained Troll) |
| `clearance` | `on-activation` | Scelerate S3 (gabarit de renvois, 1/tour) |
| `pile-on` | `on-injury` | Trait BB2020 S3 (Goblin Fanatic, Halfling Hefty) |
| `provocation` | `on-block-result` | Scelerate S3 (force la poursuite adverse) |
| `surefoot` | `on-movement` | General S3 (D6 sur 6 = pas de Chute) |
| `trickster` | `on-block-defender` | Trait S3 (re-placement defensif pre-bloc) |

Conformement aux batches **3g a 3q**, ces entrees sont purement **declaratives** :

- `canApply` strict sur le slug (variantes underscore pour les slugs composes : `breathe_fire`, `pile_on`)
- **aucun `getModifiers` expose** pour eviter un double-comptage avec les handlers de mecaniques dedies (action alt-bloc, action de degagement, valdingue/relance d'agilite, interdiction de poursuite, esquive passive de Chute, re-placement defensif).

## Tache roadmap

Sprint 20-21 — **O.1 : ~39 skills niche restants (batch 3)** (continuation des batches 3f-3q deja mergees, #331 / #332).

## Plan de test

- [x] Tests unitaires `batch-3r-registry.test.ts` : 50 cas couvrant
  - `getSkillEffect(slug)` : presence, slug, trigger, description, `canApply`, absence de `getModifiers`
  - `getAllRegisteredSkills()` : inclusion des 6 skills
  - `getSkillsForTrigger(...)` : mapping trigger -> skill (dont `on-activation` couvrant `breathe-fire` ET `clearance`)
  - `canApply` : faux sans skill, vrai avec slug canonique, vrai avec variante underscore pour les slugs composes
- [x] `pnpm test` (game-engine) : **4504 / 4504 tests verts** (dont les 50 nouveaux)
- [x] `pnpm typecheck` (game-engine) : **OK**
- [x] `pnpm lint` (game-engine) : 0 erreur, warnings coherents avec batches precedents

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoKSoFGRLFWeCQyUqxCtsz)_