### PR TITLE
feat(game-engine): O.1 batch 3s — star player traits registry (6 skills)

### DIFF
--- a/packages/game-engine/src/skills/batch-3s-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3s-registry.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3s — Registre de decouverte UI pour regles speciales de
+ * star players presentes dans le catalogue mais absentes du
+ * `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `blind-rage`             -> Trait Star : peut relancer le D6 pour
+ *                                Intrepide (Dauntless).
+ *  - `slayer`                 -> Trait Star : peut relancer les jets
+ *                                d'Intrepide (Dauntless) rates.
+ *  - `consummate-professional`-> Trait Star : une fois par match, peut
+ *                                relancer n'importe quel de.
+ *  - `crushing-blow`          -> Trait Star : une fois par match, +1 au
+ *                                jet d'armure apres un blocage reussi.
+ *  - `pirouette`              -> Trait Star : une fois par tour, +1 au
+ *                                jet d'esquive.
+ *  - `reliable`               -> Trait Star : un Lancer de Coequipier rate
+ *                                ne cause pas de turnover.
+ *
+ * Conformement aux batches 3g-3r, ce batch ajoute uniquement des entrees
+ * de decouverte et n'expose AUCUN `getModifiers` : les mecaniques
+ * associees (relance passive, bonus ponctuel par match / par tour,
+ * annulation de turnover TTM) sont resolues dans les handlers dedies
+ * (dauntless handler, reroll manager, TTM handler). Dupliquer les
+ * modificateurs ici creerait un double-comptage.
+ */
+
+type BatchTrigger =
+  | 'on-block-attacker'
+  | 'on-armor'
+  | 'on-dodge'
+  | 'on-pass'
+  | 'passive';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'blind-rage', trigger: 'on-block-attacker' },
+  { slug: 'slayer', trigger: 'on-block-attacker' },
+  { slug: 'consummate-professional', trigger: 'passive' },
+  { slug: 'crushing-blow', trigger: 'on-armor' },
+  { slug: 'pirouette', trigger: 'on-dodge' },
+  { slug: 'reliable', trigger: 'on-pass' },
+];
+
+describe('O.1 batch 3s — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 6 skills du batch 3s', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-block-attacker inclut blind-rage et slayer', () => {
+      const slugs = getSkillsForTrigger('on-block-attacker').map((e) => e.slug);
+      expect(slugs).toContain('blind-rage');
+      expect(slugs).toContain('slayer');
+    });
+
+    it('passive inclut consummate-professional', () => {
+      const slugs = getSkillsForTrigger('passive').map((e) => e.slug);
+      expect(slugs).toContain('consummate-professional');
+    });
+
+    it('on-armor inclut crushing-blow', () => {
+      const slugs = getSkillsForTrigger('on-armor').map((e) => e.slug);
+      expect(slugs).toContain('crushing-blow');
+    });
+
+    it('on-dodge inclut pirouette', () => {
+      const slugs = getSkillsForTrigger('on-dodge').map((e) => e.slug);
+      expect(slugs).toContain('pirouette');
+    });
+
+    it('on-pass inclut reliable', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('reliable');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"blind-rage" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('blind-rage')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['blind_rage'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"crushing-blow" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('crushing-blow')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['crushing_blow'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"consummate-professional" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('consummate-professional')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['consummate_professional'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1422,3 +1422,89 @@ registerSkill({
   description: "Avant de determiner les des de bloc, ce joueur peut etre retire du terrain et replace sur n'importe quelle case inoccupee adjacente au joueur effectuant le bloc.",
   canApply: (ctx) => hasSkill(ctx.player, 'trickster'),
 });
+
+// ─── BLIND RAGE (O.1 batch 3s) ──────────────────────────────────────────────
+// Blind Rage (Rage Aveugle) est une regle speciale Star Player : quand ce
+// joueur echoue a un jet d'Intrepide (Dauntless), il peut relancer le D6.
+// La relance conditionnelle est geree par le handler Dauntless dedie ;
+// l'entree du registre sert a la decouverte UI. On n'expose PAS de
+// getModifiers : il s'agit d'une relance opt-in, pas d'un modificateur
+// de jet.
+registerSkill({
+  slug: 'blind-rage',
+  triggers: ['on-block-attacker'],
+  description: "Peut relancer le D6 pour Intrepide (Dauntless) quand ce joueur rate le jet.",
+  canApply: (ctx) => hasSkill(ctx.player, 'blind-rage') || hasSkill(ctx.player, 'blind_rage'),
+});
+
+// ─── SLAYER (O.1 batch 3s) ──────────────────────────────────────────────────
+// Slayer (Tueur) est une regle speciale Star Player : chaque jet
+// d'Intrepide (Dauntless) rate peut etre relance. La relance est geree
+// par le handler Dauntless dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une
+// relance opt-in, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'slayer',
+  triggers: ['on-block-attacker'],
+  description: "Peut relancer les jets d'Intrepide (Dauntless) rates.",
+  canApply: (ctx) => hasSkill(ctx.player, 'slayer'),
+});
+
+// ─── CONSUMMATE PROFESSIONAL (O.1 batch 3s) ─────────────────────────────────
+// Consummate Professional (Professionnel Accompli) est une regle speciale
+// Star Player : une fois par match, ce joueur peut relancer n'importe
+// quel de qu'il vient de lancer. La relance est consommee via le
+// reroll manager dedie ; l'entree du registre sert a la decouverte UI.
+// On n'expose PAS de getModifiers : il s'agit d'une relance ponctuelle
+// gerée par un pool par-match, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'consummate-professional',
+  triggers: ['passive'],
+  description: "Une fois par match, ce joueur peut relancer n'importe quel de qu'il vient de lancer.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'consummate-professional') ||
+    hasSkill(ctx.player, 'consummate_professional'),
+});
+
+// ─── CRUSHING BLOW (O.1 batch 3s) ───────────────────────────────────────────
+// Crushing Blow (Coup Devastateur) est une regle speciale Star Player :
+// une fois par match, apres un blocage reussi, ce joueur peut ajouter
+// +1 au jet d'armure inflige a l'adversaire. Le bonus ponctuel est
+// gere par l'armor handler dedie via un flag per-match ; l'entree du
+// registre sert a la decouverte UI. On n'expose PAS de getModifiers :
+// il s'agit d'un bonus opt-in une fois par match, pas d'un modificateur
+// de jet permanent.
+registerSkill({
+  slug: 'crushing-blow',
+  triggers: ['on-armor'],
+  description: "Une fois par match, +1 au jet d'armure apres un blocage reussi.",
+  canApply: (ctx) => hasSkill(ctx.player, 'crushing-blow') || hasSkill(ctx.player, 'crushing_blow'),
+});
+
+// ─── PIROUETTE (O.1 batch 3s) ───────────────────────────────────────────────
+// Pirouette est une regle speciale Star Player : une fois par tour,
+// ce joueur peut ajouter +1 a un jet d'esquive. Le bonus ponctuel est
+// gere par le dodge handler dedie via un flag per-turn ; l'entree du
+// registre sert a la decouverte UI. On n'expose PAS de getModifiers :
+// il s'agit d'un bonus opt-in une fois par tour, pas d'un modificateur
+// de jet permanent.
+registerSkill({
+  slug: 'pirouette',
+  triggers: ['on-dodge'],
+  description: "Une fois par tour, +1 au jet d'esquive.",
+  canApply: (ctx) => hasSkill(ctx.player, 'pirouette'),
+});
+
+// ─── RELIABLE (O.1 batch 3s) ────────────────────────────────────────────────
+// Reliable (Fiable) est une regle speciale Star Player : un Lancer de
+// Coequipier rate effectue par ce joueur ne cause pas de Turnover.
+// L'annulation du Turnover est geree par le Throw Team-Mate handler
+// dedie ; l'entree du registre sert a la decouverte UI. On n'expose
+// PAS de getModifiers : il s'agit d'une contrainte sur la resolution
+// du turnover, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'reliable',
+  triggers: ['on-pass'],
+  description: "Un Lancer de Coequipier rate effectue par ce joueur ne cause pas de turnover.",
+  canApply: (ctx) => hasSkill(ctx.player, 'reliable'),
+});


### PR DESCRIPTION
## Resume

Enregistre 6 regles speciales Star Players niche dans le `skill-registry` (O.1 batch 3s) pour activer leur decouverte UI et completer le catalogue d'effets :

- `blind-rage`              — relance D6 Intrepide (`on-block-attacker`)
- `slayer`                  — relance jet Intrepide rate (`on-block-attacker`)
- `consummate-professional` — relance any die une fois par match (`passive`)
- `crushing-blow`           — +1 armure une fois par match (`on-armor`)
- `pirouette`               — +1 esquive une fois par tour (`on-dodge`)
- `reliable`                — TTM rate ne Turnover pas (`on-pass`)

Conformement au pattern des batches 3g-3r, aucune entree n'expose `getModifiers` pour eviter le double-comptage avec les handlers dedies (dauntless, reroll manager, armor handler, dodge handler, throw team-mate handler) qui resolvent deja ces mecaniques. Chaque entree reconnait la variante underscore du slug quand applicable (`blind_rage`, `crushing_blow`, `consummate_professional`).

## Tache roadmap

Sprint 20-21 — `O.1` (~39 skills niche restants, batch 3). Ce PR porte le progres : 116 → 122 skills enregistres ; il reste 12 skills non enregistres a couvrir dans des batches ulterieurs.

## Plan de test

- [x] `pnpm test` : 4555 tests OK (dont les 51 tests batch-3s)
- [x] `pnpm lint` : 0 erreurs (warnings pre-existants uniquement)
- [x] `pnpm typecheck` : OK
- [x] `pnpm build` : OK
- [x] Chaque skill verifie : declaration dans registry, trigger correct, description non vide, `canApply` strict sur slug, `getModifiers` non expose
- [x] Variantes underscore couvertes : `blind_rage`, `crushing_blow`, `consummate_professional`
- [x] Accessors : presence dans `getAllRegisteredSkills()` et `getSkillsForTrigger(trigger)`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_