### PR TITLE
feat(game-engine): O.1 batch 3t — star player + scelerate S3 traits registry (6 skills)

### DIFF
--- a/packages/game-engine/src/skills/batch-3t-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3t-registry.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3t — Registre de decouverte UI pour regles speciales Star
+ * Player + competences Scelerate Season 3 presentes dans le catalogue
+ * mais absentes du `skill-registry`.
+ *
+ * Skills couverts :
+ *  - `stakes`               -> Trait Star : pieux benis, +1 Armure contre
+ *                              Khemri / Necromantique / Mort-Vivant /
+ *                              Vampire lors d'une attaque de Poignard.
+ *  - `solitary-aggressor`   -> Scelerate S3 : relance Armure ratee quand
+ *                              l'Agression est effectuee sans Soutien
+ *                              Offensif ou Defensif.
+ *  - `lightning-aggression` -> Scelerate S3 : l'activation ne prend pas
+ *                              fin apres une Action d'Agression ; peut
+ *                              continuer son mouvement restant.
+ *  - `boot-to-the-head`     -> Scelerate S3 : peut fournir Soutien
+ *                              Offensif pour l'Agression d'un coequipier,
+ *                              quel que soit le nombre de joueurs adverses
+ *                              qui le Marquent.
+ *  - `violent-innovator`    -> Scelerate S3 : gagne les PSP d'Elimination
+ *                              meme quand l'elimination est infligee via
+ *                              une Action Speciale.
+ *  - `saboteur`             -> Scelerate S3 : apres avoir ete Plaque,
+ *                              peut faire exploser son arme sabotee
+ *                              (D6 4+) pour Plaquer aussi l'adversaire.
+ *
+ * Conformement aux batches 3g-3s, ce batch ajoute uniquement des entrees
+ * de decouverte et n'expose AUCUN `getModifiers` : les mecaniques
+ * associees (bonus armure conditionnel au roster adverse, relance opt-in
+ * conditionnelle, prolongation d'activation, soutien special, comptage
+ * SPP, D6 explosion d'arme) sont resolues dans les handlers dedies.
+ * Dupliquer les modificateurs ici creerait un double-comptage.
+ */
+
+type BatchTrigger = 'on-armor' | 'on-foul' | 'on-injury';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'stakes', trigger: 'on-armor' },
+  { slug: 'solitary-aggressor', trigger: 'on-foul' },
+  { slug: 'lightning-aggression', trigger: 'on-foul' },
+  { slug: 'boot-to-the-head', trigger: 'on-foul' },
+  { slug: 'violent-innovator', trigger: 'on-injury' },
+  { slug: 'saboteur', trigger: 'on-armor' },
+];
+
+describe('O.1 batch 3t — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 6 skills du batch 3t', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-armor inclut stakes et saboteur', () => {
+      const slugs = getSkillsForTrigger('on-armor').map((e) => e.slug);
+      expect(slugs).toContain('stakes');
+      expect(slugs).toContain('saboteur');
+    });
+
+    it('on-foul inclut solitary-aggressor, lightning-aggression, boot-to-the-head', () => {
+      const slugs = getSkillsForTrigger('on-foul').map((e) => e.slug);
+      expect(slugs).toContain('solitary-aggressor');
+      expect(slugs).toContain('lightning-aggression');
+      expect(slugs).toContain('boot-to-the-head');
+    });
+
+    it('on-injury inclut violent-innovator', () => {
+      const slugs = getSkillsForTrigger('on-injury').map((e) => e.slug);
+      expect(slugs).toContain('violent-innovator');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"solitary-aggressor" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('solitary-aggressor')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['solitary_aggressor'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"lightning-aggression" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('lightning-aggression')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['lightning_aggression'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"boot-to-the-head" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('boot-to-the-head')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['boot_to_the_head'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"violent-innovator" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('violent-innovator')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['violent_innovator'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1508,3 +1508,106 @@ registerSkill({
   description: "Un Lancer de Coequipier rate effectue par ce joueur ne cause pas de turnover.",
   canApply: (ctx) => hasSkill(ctx.player, 'reliable'),
 });
+
+// ─── STAKES (O.1 batch 3t) ──────────────────────────────────────────────────
+// Stakes (Pieux) est une regle speciale Star Player : lors d'une attaque de
+// Poignard (Stab) contre un joueur Khemri, Necromantique, Mort-Vivant ou
+// Vampire, ce joueur ajoute +1 au jet d'Armure. Le bonus conditionnel au
+// roster adverse est gere par l'armor handler dedie (verification du
+// type d'equipe via le roster metadata) ; l'entree du registre sert a
+// la decouverte UI. On n'expose PAS de getModifiers : le bonus est
+// conditionne par le type de roster adverse, pas applicable
+// inconditionnellement via collectModifiers.
+registerSkill({
+  slug: 'stakes',
+  triggers: ['on-armor'],
+  description: "+1 au jet d'Armure lors d'une attaque de Poignard contre un joueur Khemri, Necromantique, Mort-Vivant ou Vampire.",
+  canApply: (ctx) => hasSkill(ctx.player, 'stakes'),
+});
+
+// ─── SOLITARY AGGRESSOR (O.1 batch 3t) ──────────────────────────────────────
+// Solitary Aggressor (Agresseur Solitaire) est une competence Scelerate
+// Season 3 : quand ce joueur effectue une Action d'Agression sans Soutien
+// Offensif ni Defensif, il peut relancer un Jet d'Armure rate. La
+// relance conditionnelle (verification absence de soutiens) est geree
+// par le foul handler dedie ; l'entree du registre sert a la decouverte
+// UI. On n'expose PAS de getModifiers : il s'agit d'une relance opt-in,
+// pas d'un modificateur de jet.
+registerSkill({
+  slug: 'solitary-aggressor',
+  triggers: ['on-foul'],
+  description: "Quand ce joueur effectue une Agression sans Soutien Offensif ou Defensif, il peut relancer un Jet d'Armure rate.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'solitary-aggressor') ||
+    hasSkill(ctx.player, 'solitary_aggressor'),
+});
+
+// ─── LIGHTNING AGGRESSION (O.1 batch 3t) ────────────────────────────────────
+// Lightning Aggression (Agression Eclair) est une competence Scelerate
+// Season 3 : l'Activation de ce joueur ne prend pas fin apres qu'il a
+// effectue une Action d'Agression et il peut continuer son Action de
+// Mouvement avec son mouvement restant. La prolongation d'activation
+// post-Agression est geree par le foul handler dedie ; l'entree du
+// registre sert a la decouverte UI. On n'expose PAS de getModifiers :
+// il s'agit d'une regle de flow d'activation, pas d'un modificateur de
+// jet.
+registerSkill({
+  slug: 'lightning-aggression',
+  triggers: ['on-foul'],
+  description: "L'Activation de ce joueur ne prend pas fin apres une Action d'Agression ; il peut continuer son Action de Mouvement avec son mouvement restant.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'lightning-aggression') ||
+    hasSkill(ctx.player, 'lightning_aggression'),
+});
+
+// ─── BOOT TO THE HEAD (O.1 batch 3t) ────────────────────────────────────────
+// Boot to the Head (Coup de Crampons) est une competence Scelerate Season 3
+// : ce joueur peut fournir un Soutien Offensif quand un coequipier effectue
+// une Action d'Agression, quel que soit le nombre de joueurs adverses qui
+// le Marquent. L'override du comptage de soutien sur Agression est gere
+// par le foul-assist resolver dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une regle
+// d'eligibilite au soutien, pas d'un modificateur de jet applique via
+// collectModifiers.
+registerSkill({
+  slug: 'boot-to-the-head',
+  triggers: ['on-foul'],
+  description: "Ce joueur peut fournir un Soutien Offensif pour une Agression d'un coequipier, quel que soit le nombre de joueurs adverses qui le Marquent.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'boot-to-the-head') ||
+    hasSkill(ctx.player, 'boot_to_the_head'),
+});
+
+// ─── VIOLENT INNOVATOR (O.1 batch 3t) ───────────────────────────────────────
+// Violent Innovator (Innovateur Violent) est une competence Scelerate
+// Season 3 : si un adversaire subit une Elimination suite a une Action
+// Speciale effectuee par ce joueur, ce joueur gagne les PSP
+// correspondants. L'octroi de SPP post-Elimination sur Action Speciale
+// est gere par le SPP manager dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'un
+// ajustement de comptage SPP, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'violent-innovator',
+  triggers: ['on-injury'],
+  description: "Si un adversaire subit une Elimination suite a une Action Speciale effectuee par ce joueur, celui-ci gagne les PSP correspondants.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'violent-innovator') ||
+    hasSkill(ctx.player, 'violent_innovator'),
+});
+
+// ─── SABOTEUR (O.1 batch 3t) ────────────────────────────────────────────────
+// Saboteur est une competence Scelerate Season 3 reservee aux Armes
+// Secretes : quand ce joueur est Plaque suite a l'Action de Blocage d'un
+// adversaire, avant le jet d'Armure, il peut lancer un D6. Sur 1-3, rien
+// ne se passe et le jet d'Armure suit ; sur 4+, l'arme sabotee explose,
+// Plaque aussi l'adversaire (sans Turnover sauf si porteur de Ballon)
+// et ce joueur est automatiquement KO. La resolution du D6 d'explosion
+// est geree par le saboteur handler dedie ; l'entree du registre sert a
+// la decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une
+// action alternative pre-armure, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'saboteur',
+  triggers: ['on-armor'],
+  description: "Avant le jet d'Armure apres avoir ete Plaque, ce joueur peut jeter un D6 : sur 4+ son arme sabotee explose, Plaquant aussi l'adversaire et KO automatique pour lui. Necessite Arme Secrete.",
+  canApply: (ctx) => hasSkill(ctx.player, 'saboteur'),
+});


### PR DESCRIPTION
## Resume

Enregistre 6 regles speciales Star Player + competences Scelerate Season 3 niche dans le `skill-registry` (O.1 batch 3t) pour activer leur decouverte UI :

- `stakes`               — +1 Armure contre Khemri/Necro/Mort-Vivant/Vampire (`on-armor`)
- `solitary-aggressor`   — relance Armure ratee si Agression sans Soutien (`on-foul`)
- `lightning-aggression` — activation continue apres Agression (`on-foul`)
- `boot-to-the-head`     — Soutien Offensif d'Agression illimite par marqueurs (`on-foul`)
- `violent-innovator`    — PSP d'Elimination sur Action Speciale (`on-injury`)
- `saboteur`             — D6 4+ explosion d'arme sabotee post-Plaquage (`on-armor`)

Conformement au pattern des batches 3g-3s, aucune entree n'expose `getModifiers` pour eviter le double-comptage avec les handlers dedies (armor handler conditionnel au roster adverse, foul handler, foul-assist resolver, SPP manager, saboteur handler). Chaque entree reconnait la variante underscore du slug quand applicable (`solitary_aggressor`, `lightning_aggression`, `boot_to_the_head`, `violent_innovator`).

## Tache roadmap

Sprint 20-21 — `O.1` (~39 skills niche restants, batch 3). Ce PR porte le progres : 122 → 128 skills enregistres ; il reste 6 skills non enregistres a couvrir dans un batch ulterieur (`bullseye`, `casse-os`, `coup-sauvage`, `la-baliste`, `lord-of-chaos`, `fatal-flight`).

## Plan de test

- [x] `pnpm test` : 4605 tests OK (dont les 50 tests batch-3t)
- [x] `pnpm lint` : 0 erreurs (warnings pre-existants uniquement)
- [x] `pnpm typecheck` : OK
- [x] `pnpm build` : OK
- [x] Chaque skill verifie : declaration dans registry, trigger correct, description non vide, `canApply` strict sur slug, `getModifiers` non expose
- [x] Variantes underscore couvertes : `solitary_aggressor`, `lightning_aggression`, `boot_to_the_head`, `violent_innovator`
- [x] Accessors : presence dans `getAllRegisteredSkills()` et `getSkillsForTrigger(trigger)`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_