### PR TITLE
feat(game-engine): O.1 batch 3u — final niche skills registry (closes O.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -340,7 +340,7 @@
 | K.12 | Implementer `ball-and-chain` — Goblin Fanatic | Regle | [x] |
 | K.13 | Implementer `bombardier` — Goblin Bomma | Regle | [x] |
 | O.2 | Star player special rules restantes (~30, hors 5 equipes) | Contenu | [x] |
-| O.1 | ~39 skills niche restants (batch 3) | Contenu | [ ] |
+| O.1 | ~39 skills niche restants (batch 3) | Contenu | [x] |
 
 ### Sprint 22+ — Polish final & communaute
 

--- a/packages/game-engine/src/skills/batch-3u-registry.test.ts
+++ b/packages/game-engine/src/skills/batch-3u-registry.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+  getSkillsForTrigger,
+} from './skill-registry';
+
+/**
+ * O.1 batch 3u — Registre de decouverte UI pour les dernieres regles
+ * speciales Star Player + competences Scelerate S3 niche presentes dans
+ * le catalogue mais absentes du `skill-registry`. Ce batch cloture la
+ * sous-tache O.1 (batch 3) en couvrant les 6 derniers skills non
+ * enregistres.
+ *
+ * Skills couverts :
+ *  - `bullseye`      -> Trait S3 Force : lors d'un Lancer de Coequipier
+ *                       avec un Lancer Superbe, le joueur lance ne
+ *                       Valdingue pas et atterrit sur la case ciblee.
+ *  - `casse-os`      -> Trait Star : une fois par match, +1 en Force
+ *                       lors d'une Action de Blocage.
+ *  - `coup-sauvage`  -> Trait Star : une fois par partie, peut relancer
+ *                       n'importe quel nombre de des de Blocage.
+ *  - `la-baliste`    -> Trait Star : une fois par match, peut relancer
+ *                       un jet de Passe (Passe ou Lancer de Coequipier) rate.
+ *  - `lord-of-chaos` -> Trait Star : l'equipe gagne +1 Relance d'Equipe
+ *                       pour la premiere mi-temps.
+ *  - `fatal-flight`  -> Scelerate S3 : Lancer de Coequipier — si le
+ *                       joueur lance atterrit ou rebondit sur une case
+ *                       occupee et plaque l'adversaire, +1 Armure/Blessure
+ *                       et SPP d'Elimination le cas echeant.
+ *
+ * Conformement aux batches 3g-3t, ce batch ajoute uniquement des entrees
+ * de decouverte et n'expose AUCUN `getModifiers` : les mecaniques
+ * associees (annulation valdingue TTM, bonus ponctuel Force, relance
+ * dice-pool, relance passe, +1 Relance d'Equipe initiale, bonus
+ * armure/blessure conditionnel post-TTM) sont resolues dans les
+ * handlers dedies. Dupliquer les modificateurs ici creerait un
+ * double-comptage.
+ */
+
+type BatchTrigger =
+  | 'on-pass'
+  | 'on-block-attacker'
+  | 'on-kickoff'
+  | 'on-armor';
+
+interface BatchSkill {
+  readonly slug: string;
+  readonly trigger: BatchTrigger;
+}
+
+const BATCH_SKILLS: readonly BatchSkill[] = [
+  { slug: 'bullseye', trigger: 'on-pass' },
+  { slug: 'casse-os', trigger: 'on-block-attacker' },
+  { slug: 'coup-sauvage', trigger: 'on-block-attacker' },
+  { slug: 'la-baliste', trigger: 'on-pass' },
+  { slug: 'lord-of-chaos', trigger: 'on-kickoff' },
+  { slug: 'fatal-flight', trigger: 'on-armor' },
+];
+
+describe('O.1 batch 3u — skill-registry discovery entries', () => {
+  describe('getSkillEffect', () => {
+    for (const { slug, trigger } of BATCH_SKILLS) {
+      it(`trouve le skill "${slug}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect, `registry entry missing for ${slug}`).toBeDefined();
+        expect(effect!.slug).toBe(slug);
+      });
+
+      it(`le skill "${slug}" declare le trigger "${trigger}"`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.triggers).toContain(trigger);
+      });
+
+      it(`le skill "${slug}" a une description non vide`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.description.length).toBeGreaterThan(0);
+      });
+
+      it(`le skill "${slug}" declare canApply`, () => {
+        const effect = getSkillEffect(slug);
+        expect(typeof effect!.canApply).toBe('function');
+      });
+
+      it(`le skill "${slug}" n'expose pas getModifiers (evite double-comptage)`, () => {
+        const effect = getSkillEffect(slug);
+        expect(effect!.getModifiers).toBeUndefined();
+      });
+    }
+  });
+
+  describe('getAllRegisteredSkills', () => {
+    it('inclut les 6 skills du batch 3u', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      for (const { slug } of BATCH_SKILLS) {
+        expect(slugs, `missing slug ${slug}`).toContain(slug);
+      }
+    });
+  });
+
+  describe('getSkillsForTrigger', () => {
+    it('on-pass inclut bullseye et la-baliste', () => {
+      const slugs = getSkillsForTrigger('on-pass').map((e) => e.slug);
+      expect(slugs).toContain('bullseye');
+      expect(slugs).toContain('la-baliste');
+    });
+
+    it('on-block-attacker inclut casse-os et coup-sauvage', () => {
+      const slugs = getSkillsForTrigger('on-block-attacker').map((e) => e.slug);
+      expect(slugs).toContain('casse-os');
+      expect(slugs).toContain('coup-sauvage');
+    });
+
+    it('on-kickoff inclut lord-of-chaos', () => {
+      const slugs = getSkillsForTrigger('on-kickoff').map((e) => e.slug);
+      expect(slugs).toContain('lord-of-chaos');
+    });
+
+    it('on-armor inclut fatal-flight', () => {
+      const slugs = getSkillsForTrigger('on-armor').map((e) => e.slug);
+      expect(slugs).toContain('fatal-flight');
+    });
+  });
+
+  describe('canApply : strict sur le slug', () => {
+    const basePlayer = {
+      id: 'p1',
+      team: 'A' as const,
+      pos: { x: 0, y: 0 },
+      name: 'T',
+      number: 1,
+      position: 'Lineman',
+      ma: 6,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [] as string[],
+      pm: 6,
+      state: 'active' as const,
+    };
+    const baseCtx = { player: basePlayer, state: {} as any };
+
+    for (const { slug } of BATCH_SKILLS) {
+      it(`"${slug}" : canApply = false sans le skill`, () => {
+        const effect = getSkillEffect(slug)!;
+        expect(effect.canApply(baseCtx as any)).toBe(false);
+      });
+
+      it(`"${slug}" : canApply = true avec le skill canonique`, () => {
+        const effect = getSkillEffect(slug)!;
+        const ctx = {
+          ...baseCtx,
+          player: { ...basePlayer, skills: [slug] },
+        };
+        expect(effect.canApply(ctx as any)).toBe(true);
+      });
+    }
+
+    it('"casse-os" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('casse-os')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['casse_os'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"coup-sauvage" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('coup-sauvage')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['coup_sauvage'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"la-baliste" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('la-baliste')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['la_baliste'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"lord-of-chaos" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('lord-of-chaos')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['lord_of_chaos'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('"fatal-flight" : canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('fatal-flight')!;
+      const ctx = {
+        ...baseCtx,
+        player: { ...basePlayer, skills: ['fatal_flight'] },
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1611,3 +1611,93 @@ registerSkill({
   description: "Avant le jet d'Armure apres avoir ete Plaque, ce joueur peut jeter un D6 : sur 4+ son arme sabotee explose, Plaquant aussi l'adversaire et KO automatique pour lui. Necessite Arme Secrete.",
   canApply: (ctx) => hasSkill(ctx.player, 'saboteur'),
 });
+
+// ─── BULLSEYE (O.1 batch 3u) ────────────────────────────────────────────────
+// Bullseye (Dans le Mille) est un trait Season 3 Force : lors d'une Action
+// de Lancer de Coequipier, si le resultat du lancer est un Lancer Superbe,
+// le joueur lance ne Valdingue pas et atterrit sur la case ciblee.
+// L'annulation du Valdingue post-TTM sur Lancer Superbe est geree par le
+// Throw Team-Mate handler dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'une
+// regle speciale de resolution TTM, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'bullseye',
+  triggers: ['on-pass'],
+  description: "Lors d'un Lancer de Coequipier avec Lancer Superbe, le joueur lance ne Valdingue pas et atterrit sur la case ciblee.",
+  canApply: (ctx) => hasSkill(ctx.player, 'bullseye'),
+});
+
+// ─── CASSE-OS (O.1 batch 3u) ────────────────────────────────────────────────
+// Casse-Os (Bone Breaker) est une regle speciale Star Player : une fois
+// par match, ce joueur ajoute +1 en Force lors d'une Action de Blocage.
+// Le bonus ponctuel de Force est gere par le blocking handler dedie via
+// un flag per-match ; l'entree du registre sert a la decouverte UI. On
+// n'expose PAS de getModifiers : il s'agit d'un bonus opt-in une fois
+// par match, pas d'un modificateur de jet permanent.
+registerSkill({
+  slug: 'casse-os',
+  triggers: ['on-block-attacker'],
+  description: "Une fois par match, +1 en Force lors d'une Action de Blocage.",
+  canApply: (ctx) => hasSkill(ctx.player, 'casse-os') || hasSkill(ctx.player, 'casse_os'),
+});
+
+// ─── COUP SAUVAGE (O.1 batch 3u) ────────────────────────────────────────────
+// Coup Sauvage (Savage Blow) est une regle speciale Star Player : une fois
+// par partie, ce joueur peut relancer n'importe quel nombre de des de
+// Blocage qu'il vient de lancer. La relance du pool de des est geree par
+// le blocking handler dedie via un flag per-match ; l'entree du registre
+// sert a la decouverte UI. On n'expose PAS de getModifiers : il s'agit
+// d'une relance opt-in une fois par partie, pas d'un modificateur de
+// jet.
+registerSkill({
+  slug: 'coup-sauvage',
+  triggers: ['on-block-attacker'],
+  description: "Une fois par partie, ce joueur peut relancer n'importe quel nombre de des de Blocage qu'il vient de lancer.",
+  canApply: (ctx) => hasSkill(ctx.player, 'coup-sauvage') || hasSkill(ctx.player, 'coup_sauvage'),
+});
+
+// ─── LA BALISTE (O.1 batch 3u) ──────────────────────────────────────────────
+// La Baliste (The Ballista) est une regle speciale Star Player : une fois
+// par match, ce joueur peut relancer un jet de Passe rate (Passe ou Lancer
+// de Coequipier). La relance ponctuelle est geree par le pass/TTM handler
+// dedie via un flag per-match ; l'entree du registre sert a la decouverte
+// UI. On n'expose PAS de getModifiers : il s'agit d'une relance opt-in
+// une fois par match, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'la-baliste',
+  triggers: ['on-pass'],
+  description: "Une fois par match, ce joueur peut relancer un jet de Passe rate (Passe ou Lancer de Coequipier).",
+  canApply: (ctx) => hasSkill(ctx.player, 'la-baliste') || hasSkill(ctx.player, 'la_baliste'),
+});
+
+// ─── LORD OF CHAOS (O.1 batch 3u) ───────────────────────────────────────────
+// Lord of Chaos (Seigneur du Chaos) est une regle speciale Star Player
+// d'equipe : l'equipe de ce joueur gagne +1 Relance d'Equipe pour la
+// premiere mi-temps. Le bonus de setup kickoff est applique par le pre-
+// match sequence resolver dedie ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : il s'agit d'un bonus
+// de setup de ressource equipe, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'lord-of-chaos',
+  triggers: ['on-kickoff'],
+  description: "L'equipe de ce joueur gagne +1 Relance d'Equipe pour la premiere mi-temps.",
+  canApply: (ctx) => hasSkill(ctx.player, 'lord-of-chaos') || hasSkill(ctx.player, 'lord_of_chaos'),
+});
+
+// ─── FATAL FLIGHT (O.1 batch 3u) ────────────────────────────────────────────
+// Fatal Flight (Vol Fatal) est une competence Scelerate Season 3 : lors
+// d'un Lancer de Coequipier, si le joueur lance atterrit ou rebondit sur
+// une case occupee et plaque l'adversaire, il peut appliquer +1 au jet
+// d'Armure ou au jet de Blessure ; si l'adversaire subit une Elimination,
+// le joueur gagne les PSP correspondants. Le bonus armure/blessure
+// conditionnel post-TTM et l'octroi de SPP sont geres par le TTM
+// handler + SPP manager dedies ; l'entree du registre sert a la
+// decouverte UI. On n'expose PAS de getModifiers : le bonus est
+// conditionne par l'atterrissage sur case occupee suite a un TTM, pas
+// applicable inconditionnellement via collectModifiers.
+registerSkill({
+  slug: 'fatal-flight',
+  triggers: ['on-armor'],
+  description: "Lors d'un Lancer de Coequipier, si le joueur lance atterrit ou rebondit sur une case occupee et plaque l'adversaire, +1 au jet d'Armure ou de Blessure ; sur Elimination, gagne les PSP correspondants.",
+  canApply: (ctx) => hasSkill(ctx.player, 'fatal-flight') || hasSkill(ctx.player, 'fatal_flight'),
+});


### PR DESCRIPTION
## Resume

Enregistre les 6 derniers skills niche dans le `skill-registry`, cloturant la sous-tache **O.1** du Sprint 20-21. Tous les skills du catalogue `SKILLS_DEFINITIONS` disposent desormais d'une entree de decouverte UI dans le registry.

- `bullseye`      — Lancer Superbe : le joueur lance ne Valdingue pas (`on-pass`)
- `casse-os`      — 1×/match +1 Force lors d'une Action de Blocage (`on-block-attacker`)
- `coup-sauvage`  — 1×/match relance n'importe quel nombre de des de Bloc (`on-block-attacker`)
- `la-baliste`    — 1×/match relance un jet de Passe rate (`on-pass`)
- `lord-of-chaos` — +1 Relance d'Equipe pour la premiere mi-temps (`on-kickoff`)
- `fatal-flight`  — TTM : +1 Armure/Blessure sur atterrissage plaquant (`on-armor`)

Conformement au pattern des batches 3g-3t, aucune entree n'expose `getModifiers` pour eviter le double-comptage avec les handlers dedies (TTM handler, blocking handler, pass/TTM handler, pre-match sequence resolver, SPP manager). Chaque entree reconnait la variante underscore du slug quand applicable (`casse_os`, `coup_sauvage`, `la_baliste`, `lord_of_chaos`, `fatal_flight`).

## Tache roadmap

Sprint 20-21 — **cloture O.1** (~39 skills niche restants, batch 3). 
- Progres : 128 → 134 skills enregistres
- TODO.md : `O.1` passe a `[x]`
- Tous les slugs presents dans `SKILLS_DEFINITIONS` sont desormais reconnus par `getSkillEffect`

## Plan de test

- [x] `pnpm test` : 4657 tests OK (dont les 52 tests batch-3u)
- [x] `pnpm lint` : 0 erreurs (warnings pre-existants uniquement)
- [x] `pnpm typecheck` : OK
- [x] `pnpm build` : OK
- [x] Chaque skill verifie : declaration dans registry, trigger correct, description non vide, `canApply` strict sur slug, `getModifiers` non expose
- [x] Variantes underscore couvertes : `casse_os`, `coup_sauvage`, `la_baliste`, `lord_of_chaos`, `fatal_flight`
- [x] Accessors : presence dans `getAllRegisteredSkills()` et `getSkillsForTrigger(trigger)`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_