### PR TITLE
feat(game-engine): O.3 — audit S2 vs S3 rules + register running-pass-2025

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -348,7 +348,7 @@
 
 | # | Tache | Type | Statut |
 |---|-------|------|--------|
-| O.3 | Verification differences regles S3 | Contenu | [ ] |
+| O.3 | Verification differences regles S3 | Contenu | [x] |
 | O.4 | Expansion E2E tests (couverture cible 80%) | Qualite | [ ] |
 | O.5 | Optimisation taille GameState (separer gameLog) | Perf | [ ] |
 | O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [ ] |

--- a/packages/game-engine/src/skills/season3-rules-audit.test.ts
+++ b/packages/game-engine/src/skills/season3-rules-audit.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { SKILLS_DEFINITIONS, type SkillDefinition } from './index';
+import {
+  getSkillEffect,
+  getAllRegisteredSkills,
+} from './skill-registry';
+
+/**
+ * O.3 — Verification differences regles S3.
+ *
+ * Cette suite audite la coherence entre le catalogue de skills
+ * (`SKILLS_DEFINITIONS`) et le `skill-registry` pour les skills
+ * Season 3 :
+ *
+ *  - Chaque skill `season3Only: true` DOIT avoir une entree de
+ *    decouverte UI dans le registry (batch 3g-3u a couvert
+ *    l'essentiel ; cette suite garde la propriete comme
+ *    non-regression).
+ *  - Chaque skill `isModified: true` DOIT avoir une entree de
+ *    decouverte UI dans le registry — cela garantit qu'on peut
+ *    differencier la variante S3 d'un skill BB2020 existant
+ *    lorsqu'elle est annotee comme telle dans le catalogue.
+ *  - Chaque slug annote comme S3 dans `SKILLS_DEFINITIONS` DOIT
+ *    pouvoir etre resolu via `getSkillEffect(slug)`.
+ *
+ * Cet audit est un filet de non-regression : si un nouveau skill
+ * S3-only ou modifie-S3 est ajoute sans entree registry, ces
+ * tests echouent avec un message precis.
+ */
+
+const season3Only: readonly SkillDefinition[] = SKILLS_DEFINITIONS.filter(
+  (s) => s.season3Only === true,
+);
+
+const isModified: readonly SkillDefinition[] = SKILLS_DEFINITIONS.filter(
+  (s) => s.isModified === true,
+);
+
+describe('O.3 — S2 vs S3 rules audit', () => {
+  describe('couverture `season3Only` dans le registre', () => {
+    it('le catalogue contient au moins un skill `season3Only`', () => {
+      expect(season3Only.length).toBeGreaterThan(0);
+    });
+
+    for (const def of season3Only) {
+      it(`"${def.slug}" (season3Only) est present dans le registry`, () => {
+        const effect = getSkillEffect(def.slug);
+        expect(
+          effect,
+          `season3Only skill ${def.slug} missing from registry`,
+        ).toBeDefined();
+      });
+    }
+  });
+
+  describe('couverture `isModified` dans le registre', () => {
+    it('le catalogue contient au moins un skill `isModified`', () => {
+      expect(isModified.length).toBeGreaterThan(0);
+    });
+
+    for (const def of isModified) {
+      it(`"${def.slug}" (isModified) est present dans le registry`, () => {
+        const effect = getSkillEffect(def.slug);
+        expect(
+          effect,
+          `isModified skill ${def.slug} missing from registry`,
+        ).toBeDefined();
+      });
+    }
+  });
+
+  describe('coherence globale du catalogue', () => {
+    it('chaque entree registry a un slug unique', () => {
+      const slugs = getAllRegisteredSkills().map((e) => e.slug);
+      expect(new Set(slugs).size).toBe(slugs.length);
+    });
+
+    it('chaque skill `season3Only` est aussi `Category` ou `Trait` significatif', () => {
+      for (const def of season3Only) {
+        expect(
+          def.category.length,
+          `${def.slug} has empty category`,
+        ).toBeGreaterThan(0);
+      }
+    });
+
+    it('aucun skill `season3Only` n\'est dans `running-pass` non suffixe (evite collision avec S2)', () => {
+      // La variante S3 du skill "Running Pass" doit etre `running-pass-2025`
+      // (le slug S2 "running-pass" existe aussi et ne doit PAS etre
+      // flag S3). On verifie que les flags sont bien poses sur les bons
+      // slugs.
+      const s2 = SKILLS_DEFINITIONS.find((s) => s.slug === 'running-pass');
+      const s3 = SKILLS_DEFINITIONS.find((s) => s.slug === 'running-pass-2025');
+      expect(s2, 'running-pass (S2) missing from catalog').toBeDefined();
+      expect(s3, 'running-pass-2025 (S3) missing from catalog').toBeDefined();
+      expect(s2!.season3Only).not.toBe(true);
+      expect(s3!.season3Only).toBe(true);
+      expect(s3!.isModified).toBe(true);
+    });
+  });
+
+  describe('running-pass-2025 : entree dedicee S3', () => {
+    it('le skill est declare dans le registry', () => {
+      const effect = getSkillEffect('running-pass-2025');
+      expect(effect).toBeDefined();
+      expect(effect!.slug).toBe('running-pass-2025');
+    });
+
+    it('le skill expose le trigger `on-pass`', () => {
+      const effect = getSkillEffect('running-pass-2025');
+      expect(effect!.triggers).toContain('on-pass');
+    });
+
+    it('le skill a une description non vide', () => {
+      const effect = getSkillEffect('running-pass-2025');
+      expect(effect!.description.length).toBeGreaterThan(0);
+    });
+
+    it('canApply est strict sur le slug (false sans le skill)', () => {
+      const effect = getSkillEffect('running-pass-2025')!;
+      const ctx = {
+        player: {
+          id: 'p1',
+          team: 'A' as const,
+          pos: { x: 0, y: 0 },
+          name: 'T',
+          number: 1,
+          position: 'Thrower',
+          ma: 6,
+          st: 3,
+          ag: 3,
+          pa: 3,
+          av: 9,
+          skills: [] as string[],
+          pm: 6,
+          state: 'active' as const,
+        },
+        state: {} as any,
+      };
+      expect(effect.canApply(ctx as any)).toBe(false);
+    });
+
+    it('canApply est true avec le slug canonique', () => {
+      const effect = getSkillEffect('running-pass-2025')!;
+      const ctx = {
+        player: {
+          id: 'p1',
+          team: 'A' as const,
+          pos: { x: 0, y: 0 },
+          name: 'T',
+          number: 1,
+          position: 'Thrower',
+          ma: 6,
+          st: 3,
+          ag: 3,
+          pa: 3,
+          av: 9,
+          skills: ['running-pass-2025'] as string[],
+          pm: 6,
+          state: 'active' as const,
+        },
+        state: {} as any,
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it('canApply reconnait aussi la variante underscore', () => {
+      const effect = getSkillEffect('running-pass-2025')!;
+      const ctx = {
+        player: {
+          id: 'p1',
+          team: 'A' as const,
+          pos: { x: 0, y: 0 },
+          name: 'T',
+          number: 1,
+          position: 'Thrower',
+          ma: 6,
+          st: 3,
+          ag: 3,
+          pa: 3,
+          av: 9,
+          skills: ['running_pass_2025'] as string[],
+          pm: 6,
+          state: 'active' as const,
+        },
+        state: {} as any,
+      };
+      expect(effect.canApply(ctx as any)).toBe(true);
+    });
+
+    it("n'expose pas getModifiers (evite double-comptage avec running-pass S2)", () => {
+      const effect = getSkillEffect('running-pass-2025');
+      expect(effect!.getModifiers).toBeUndefined();
+    });
+  });
+});

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -1701,3 +1701,24 @@ registerSkill({
   description: "Lors d'un Lancer de Coequipier, si le joueur lance atterrit ou rebondit sur une case occupee et plaque l'adversaire, +1 au jet d'Armure ou de Blessure ; sur Elimination, gagne les PSP correspondants.",
   canApply: (ctx) => hasSkill(ctx.player, 'fatal-flight') || hasSkill(ctx.player, 'fatal_flight'),
 });
+
+// ─── RUNNING PASS 2025 (O.3 S3 audit) ───────────────────────────────────────
+// Running Pass 2025 (Transmission dans la course) est la variante Season 3
+// modifiee du skill `running-pass` : si ce joueur effectue une Action de
+// Passe qui est une Passe Rapide ou une Action de Transmission, son
+// activation ne prend pas fin et il peut continuer son Action de Mouvement
+// avec son mouvement restant. La difference avec la version S2 est la
+// portee etendue (Passe Rapide + Transmission, vs. Transmission seule en
+// S2). La prolongation d'activation post-passe est geree par le pass
+// handler dedie et conditionne la version appliquee selon le flag
+// `season3Only` du catalogue. L'entree du registre sert a la decouverte
+// UI et a la discrimination S2/S3. On n'expose PAS de getModifiers : il
+// s'agit d'une regle de flow d'activation, pas d'un modificateur de jet.
+registerSkill({
+  slug: 'running-pass-2025',
+  triggers: ['on-pass'],
+  description: "Season 3 : si ce joueur effectue une Action de Passe qui est une Passe Rapide ou une Action de Transmission, son activation ne prend pas fin et il peut continuer son Action de Mouvement.",
+  canApply: (ctx) =>
+    hasSkill(ctx.player, 'running-pass-2025') ||
+    hasSkill(ctx.player, 'running_pass_2025'),
+});


### PR DESCRIPTION
## Resume

Cloture la sous-tache **O.3** (Verification differences regles S3) via :

1. **Audit automatise** (filet de non-regression CI) qui verifie la coherence entre le catalogue `SKILLS_DEFINITIONS` et le `skill-registry` :
   - Tout skill `season3Only: true` (21 slugs) doit etre resolvable via `getSkillEffect`
   - Tout skill `isModified: true` (33 slugs) doit etre resolvable via `getSkillEffect`
   - Les flags S3 sont poses sur le bon slug (ex. `running-pass` S2 non flag, `running-pass-2025` S3 flag)

2. **Enregistrement de `running-pass-2025`** — variante Season 3 modifiee de Running Pass (portee etendue aux Passes Rapides en plus des Transmissions). Avant ce PR, c'etait le seul skill `season3Only`/`isModified` du catalogue absent du registry.

Conformement au pattern des batches 3g-3u, l'entree `running-pass-2025` n'expose pas `getModifiers` : la prolongation d'activation post-passe est geree par le pass handler dedie. La variante S2 `running-pass` reste enregistree a part.

## Tache roadmap

Sprint 22+ — **cloture O.3** (Verification differences regles S3).
- Progres : 134 → 135 skills enregistres
- Tous les slugs `season3Only` et `isModified` du catalogue sont desormais resolvables via `getSkillEffect`
- TODO.md : `O.3` passe a `[x]`

## Plan de test

- [x] `pnpm test` : 4723 tests OK (dont 66 nouveaux dans `season3-rules-audit.test.ts`)
- [x] `pnpm lint` : 0 erreurs
- [x] `pnpm typecheck` : OK
- [x] `pnpm build` : OK
- [x] Audit complet : 21 `season3Only` skills + 33 `isModified` skills + 4 coherence globale
- [x] `running-pass-2025` TDD : declaration registry, trigger `on-pass`, description, `canApply` strict, variante underscore, `getModifiers` non expose


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_