### PR TITLE
Add inducements selection UI for local matches

### DIFF
--- a/apps/web/app/local-matches/[id]/LocalMatchInducements.test.tsx
+++ b/apps/web/app/local-matches/[id]/LocalMatchInducements.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LocalMatchInducements from "./LocalMatchInducements";
+import type { InducementDefinition, InducementSlug } from "@bb/game-engine";
+
+vi.mock("../../contexts/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: {
+      inducements: {
+        title: "Inducements",
+        pettyCash: "Petty Cash",
+        budget: "Budget",
+        remaining: "Remaining",
+        totalCost: "Total cost",
+        confirm: "Confirm",
+        skip: "Skip",
+        noBudget: "No budget",
+        selectInducements: "Select inducements",
+      },
+      teams: { kpo: "K" },
+    },
+    language: "fr",
+  }),
+}));
+
+vi.mock("../../auth-client", () => ({
+  API_BASE: "http://api.test",
+}));
+
+const CATALOGUE: InducementDefinition[] = [
+  {
+    slug: "extra_team_training" as InducementSlug,
+    displayName: "Extra Team Training",
+    displayNameFr: "Entrainement",
+    baseCost: 100_000,
+    maxQuantity: 4,
+    description: "Extra re-roll",
+  },
+];
+
+const INDUCEMENTS_INFO = {
+  catalogue: CATALOGUE,
+  pettyCash: {
+    teamA: { base: 100_000, treasuryUsed: 0, maxBudget: 100_000 },
+    teamB: { base: 200_000, treasuryUsed: 0, maxBudget: 200_000 },
+  },
+  teamA: {
+    name: "Orcs",
+    roster: "orcs",
+    ctv: 1_000_000,
+    budget: 100_000,
+    hasApothecary: true,
+  },
+  teamB: {
+    name: "Humans",
+    roster: "humans",
+    ctv: 900_000,
+    budget: 200_000,
+    hasApothecary: true,
+  },
+};
+
+describe("LocalMatchInducements", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    vi.stubGlobal("localStorage", {
+      getItem: () => "token-123",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads inducements info on mount and renders both team selectors", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => INDUCEMENTS_INFO,
+    });
+
+    render(
+      <LocalMatchInducements matchId="match-1" onSuccess={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Equipe A/)).toBeDefined();
+      expect(screen.getByText(/Equipe B/)).toBeDefined();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://api.test/local-match/match-1/inducements-info",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+        }),
+      }),
+    );
+  });
+
+  it("submits empty selections when 'Passer' button is clicked", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => INDUCEMENTS_INFO,
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ localMatch: {}, gameState: {} }),
+    });
+
+    const onSuccess = vi.fn();
+    render(
+      <LocalMatchInducements matchId="match-1" onSuccess={onSuccess} />,
+    );
+
+    await waitFor(() => screen.getByText(/Passer/));
+    fireEvent.click(screen.getByText(/Passer/));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toBe("http://api.test/local-match/match-1/inducements");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      selectionA: { items: [] },
+      selectionB: { items: [] },
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("disables 'Valider' button until both teams have confirmed", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => INDUCEMENTS_INFO,
+    });
+
+    render(
+      <LocalMatchInducements matchId="match-1" onSuccess={vi.fn()} />,
+    );
+
+    await waitFor(() => screen.getByText("Valider les inducements"));
+    const validate = screen.getByText(
+      "Valider les inducements",
+    ) as HTMLButtonElement;
+    expect(validate.disabled).toBe(true);
+  });
+
+  it("shows an error when info fetch fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "Pas en phase d'inducements" }),
+    });
+
+    render(
+      <LocalMatchInducements matchId="match-1" onSuccess={vi.fn()} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pas en phase/)).toBeDefined(),
+    );
+    expect(screen.getByText("Reessayer")).toBeDefined();
+  });
+});

--- a/apps/web/app/local-matches/[id]/LocalMatchInducements.tsx
+++ b/apps/web/app/local-matches/[id]/LocalMatchInducements.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { API_BASE } from "../../auth-client";
+import InducementSelector from "../../components/InducementSelector";
+import type {
+  InducementDefinition,
+  InducementSelection,
+} from "@bb/game-engine";
+
+interface TeamInducementInfo {
+  name: string;
+  roster: string;
+  ctv: number;
+  budget: number;
+  hasApothecary: boolean;
+}
+
+interface InducementsInfo {
+  catalogue: InducementDefinition[];
+  pettyCash: {
+    teamA: { base: number; treasuryUsed: number; maxBudget: number };
+    teamB: { base: number; treasuryUsed: number; maxBudget: number };
+  };
+  teamA: TeamInducementInfo;
+  teamB: TeamInducementInfo;
+}
+
+interface LocalMatchInducementsProps {
+  matchId: string;
+  onSuccess: () => Promise<void> | void;
+}
+
+export default function LocalMatchInducements({
+  matchId,
+  onSuccess,
+}: LocalMatchInducementsProps) {
+  const [info, setInfo] = useState<InducementsInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [selectionA, setSelectionA] = useState<InducementSelection | null>(null);
+  const [selectionB, setSelectionB] = useState<InducementSelection | null>(null);
+
+  const authHeader = useCallback((): Record<string, string> => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }, []);
+
+  const loadInfo = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${API_BASE}/local-match/${matchId}/inducements-info`,
+        { headers: authHeader() },
+      );
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({}));
+        throw new Error(payload?.error || `Erreur ${res.status}`);
+      }
+      const data = (await res.json()) as InducementsInfo;
+      setInfo(data);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Erreur inconnue";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [matchId, authHeader]);
+
+  useEffect(() => {
+    loadInfo();
+  }, [loadInfo]);
+
+  const submit = useCallback(
+    async (a: InducementSelection, b: InducementSelection) => {
+      setSubmitting(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `${API_BASE}/local-match/${matchId}/inducements`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...authHeader(),
+            },
+            body: JSON.stringify({ selectionA: a, selectionB: b }),
+          },
+        );
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          throw new Error(payload?.error || `Erreur ${res.status}`);
+        }
+        await onSuccess();
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Erreur inconnue";
+        setError(message);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [matchId, authHeader, onSuccess],
+  );
+
+  const handleConfirmA = useCallback((s: InducementSelection) => {
+    setSelectionA(s);
+  }, []);
+
+  const handleSkipA = useCallback(() => {
+    setSelectionA({ items: [] });
+  }, []);
+
+  const handleConfirmB = useCallback((s: InducementSelection) => {
+    setSelectionB(s);
+  }, []);
+
+  const handleSkipB = useCallback(() => {
+    setSelectionB({ items: [] });
+  }, []);
+
+  const handleValidate = useCallback(() => {
+    if (!selectionA || !selectionB) return;
+    submit(selectionA, selectionB);
+  }, [selectionA, selectionB, submit]);
+
+  const handleSkipAll = useCallback(() => {
+    submit({ items: [] }, { items: [] });
+  }, [submit]);
+
+  if (loading) {
+    return (
+      <div className="bg-white border border-gray-200 rounded-lg p-6 text-center">
+        <p className="text-nuffle-anthracite">Chargement des inducements...</p>
+      </div>
+    );
+  }
+
+  if (error && !info) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+        <p className="text-red-700 font-semibold">Erreur</p>
+        <p className="text-red-600 text-sm mt-2">{error}</p>
+        <button
+          onClick={loadInfo}
+          className="mt-4 px-4 py-2 bg-nuffle-gold text-nuffle-anthracite rounded font-semibold hover:bg-nuffle-bronze transition-colors"
+        >
+          Reessayer
+        </button>
+      </div>
+    );
+  }
+
+  if (!info) return null;
+
+  const bothReady = selectionA !== null && selectionB !== null;
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div className="bg-purple-50 border-2 border-purple-300 rounded-xl p-4 sm:p-6 shadow-md">
+        <h2 className="text-xl sm:text-2xl font-bold text-nuffle-anthracite mb-2">
+          Phase d&apos;inducements
+        </h2>
+        <p className="text-sm text-gray-700">
+          Selectionnez les inducements pour chaque equipe. En partie locale,
+          chaque phase doit etre validee manuellement. Confirmez la selection
+          de chaque equipe, puis validez pour passer a la phase suivante.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded p-3 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
+        <div className="flex flex-col items-stretch">
+          <div className="mb-2 text-sm font-semibold text-nuffle-anthracite">
+            Equipe A —{" "}
+            {selectionA !== null ? (
+              <span className="text-emerald-700">Selection confirmee</span>
+            ) : (
+              <span className="text-gray-500">En cours de selection</span>
+            )}
+          </div>
+          {selectionA !== null ? (
+            <div className="rounded border bg-emerald-50 border-emerald-300 p-4 text-sm">
+              <div className="font-semibold text-emerald-700">
+                {info.teamA.name}
+              </div>
+              <div className="text-emerald-600 mt-1">
+                {selectionA.items.length === 0
+                  ? "Aucun inducement"
+                  : `${selectionA.items.length} inducement(s) selectionne(s)`}
+              </div>
+              <button
+                onClick={() => setSelectionA(null)}
+                disabled={submitting}
+                className="mt-3 text-xs text-emerald-800 underline disabled:opacity-50"
+              >
+                Modifier
+              </button>
+            </div>
+          ) : (
+            <InducementSelector
+              catalogue={info.catalogue}
+              budget={info.teamA.budget}
+              pettyCash={info.pettyCash.teamA.maxBudget}
+              teamName={info.teamA.name}
+              disabled={submitting}
+              onConfirm={handleConfirmA}
+              onSkip={handleSkipA}
+            />
+          )}
+        </div>
+
+        <div className="flex flex-col items-stretch">
+          <div className="mb-2 text-sm font-semibold text-nuffle-anthracite">
+            Equipe B —{" "}
+            {selectionB !== null ? (
+              <span className="text-emerald-700">Selection confirmee</span>
+            ) : (
+              <span className="text-gray-500">En cours de selection</span>
+            )}
+          </div>
+          {selectionB !== null ? (
+            <div className="rounded border bg-emerald-50 border-emerald-300 p-4 text-sm">
+              <div className="font-semibold text-emerald-700">
+                {info.teamB.name}
+              </div>
+              <div className="text-emerald-600 mt-1">
+                {selectionB.items.length === 0
+                  ? "Aucun inducement"
+                  : `${selectionB.items.length} inducement(s) selectionne(s)`}
+              </div>
+              <button
+                onClick={() => setSelectionB(null)}
+                disabled={submitting}
+                className="mt-3 text-xs text-emerald-800 underline disabled:opacity-50"
+              >
+                Modifier
+              </button>
+            </div>
+          ) : (
+            <InducementSelector
+              catalogue={info.catalogue}
+              budget={info.teamB.budget}
+              pettyCash={info.pettyCash.teamB.maxBudget}
+              teamName={info.teamB.name}
+              disabled={submitting}
+              onConfirm={handleConfirmB}
+              onSkip={handleSkipB}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 justify-end">
+        <button
+          onClick={handleSkipAll}
+          disabled={submitting}
+          className="px-4 py-2 bg-gray-200 text-gray-700 rounded font-semibold hover:bg-gray-300 transition-colors disabled:opacity-50"
+        >
+          Passer (aucun inducement)
+        </button>
+        <button
+          onClick={handleValidate}
+          disabled={submitting || !bothReady}
+          className="px-6 py-2 bg-gradient-to-r from-nuffle-gold to-nuffle-bronze text-nuffle-anthracite rounded font-bold hover:from-nuffle-bronze hover:to-nuffle-gold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? "Validation..." : "Valider les inducements"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/local-matches/[id]/page.tsx
+++ b/apps/web/app/local-matches/[id]/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { API_BASE } from "../../auth-client";
 import LocalMatchActions from "./LocalMatchActions";
+import LocalMatchInducements from "./LocalMatchInducements";
 import LocalMatchSummary from "./LocalMatchSummary";
 import PostMatchSPP from "./PostMatchSPP";
 import type { TeamId } from "@bb/game-engine";
@@ -704,8 +705,13 @@ export default function LocalMatchPage() {
                   </div>
                 )}
                 
-                {/* Afficher un bouton pour continuer si on est en phase setup */}
-                {localMatch.gameState.preMatch.phase === 'setup' ? (
+                {/* Phase d'inducements : saisie manuelle pour les matchs locaux */}
+                {localMatch.gameState.preMatch.phase === 'inducements' ? (
+                  <LocalMatchInducements
+                    matchId={matchId}
+                    onSuccess={loadLocalMatch}
+                  />
+                ) : localMatch.gameState.preMatch.phase === 'setup' ? (
                   <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
                     <h3 className="text-xl font-semibold text-nuffle-anthracite mb-4">
                       Phase de placement des joueurs
@@ -730,7 +736,7 @@ export default function LocalMatchPage() {
                       Phase actuelle: <strong>{localMatch.gameState.preMatch.phase}</strong>
                     </p>
                     <p className="text-sm text-yellow-700 mt-2">
-                      La séquence d'avant-match est en cours. Les phases suivantes (joueurs de passage, incitations, prières, etc.) seront traitées automatiquement.
+                      La séquence d'avant-match est en cours.
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Résumé

- [x] Ajouter une interface de sélection des inducements pour les matchs locaux
- [x] Permettre à chaque équipe de confirmer sa sélection d'inducements avant validation
- [x] Ajouter des tests unitaires pour le composant

## Description

Ajoute un nouveau composant `LocalMatchInducements` qui gère la phase d'inducements pour les matchs locaux. Ce composant :

- Charge les informations d'inducements disponibles (catalogue, budgets, infos équipes)
- Affiche deux sélecteurs d'inducements côte à côte (un par équipe)
- Permet à chaque équipe de confirmer sa sélection ou de passer
- Valide les deux sélections avant de soumettre au serveur
- Gère les erreurs de chargement et de soumission avec retry

Le composant est intégré dans la page de match local et s'affiche quand `gameState.preMatch.phase === 'inducements'`.

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (170 lignes de tests couvrant les cas principaux)
- [x] Changeset ajouté

https://claude.ai/code/session_01NPm5RxH9Fy8zJ4S16Fu85i