### PR TITLE
test(e2e-api): O.4 — add push-notifications.spec.ts (expansion E2E)

### DIFF
--- a/tests/e2e-api/specs/push-notifications.spec.ts
+++ b/tests/e2e-api/specs/push-notifications.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { rawGet, rawPost, resetDb } from "../helpers/api";
+
+/**
+ * Spec /push/* (routes push notifications, O.4 expansion E2E).
+ *
+ * Les routes `/push/*` exposent l'abonnement aux push notifications
+ * (web-push + Expo). Ce spec valide :
+ *
+ *  - `GET /push/vapid-public-key` (no-auth, public) retourne une cle
+ *    VAPID valide. Le serveur genere des cles dev si les env vars
+ *    VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY ne sont pas fournies (cas
+ *    du test runner) — on verifie donc juste que la route renvoie
+ *    200 + une cle non vide.
+ *
+ *  - Les endpoints avec `authUser` (POST /push/subscribe,
+ *    POST /push/unsubscribe, GET /push/preferences, POST
+ *    /push/expo-subscribe, etc.) refusent un appel sans token (401).
+ *    Ces tests 401 ne touchent pas la DB — ils verifient que le
+ *    middleware `authUser` rejette les appels anonymes sur les
+ *    routes sensibles.
+ *
+ * Aucune de ces assertions ne depend du model `NotificationPreference`
+ * (absent du schema sqlite e2e-api), ce qui garde le spec stable dans
+ * l'environnement test in-memory.
+ */
+
+interface VapidKeyResponse {
+  key: string;
+}
+
+describe("E2E API — /push/* (notifications)", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("GET /push/vapid-public-key renvoie 200 + `{ key }` sans auth", async () => {
+    const res = await rawGet("/push/vapid-public-key", null);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as VapidKeyResponse;
+    expect(json).toHaveProperty("key");
+    expect(typeof json.key).toBe("string");
+    // Les cles VAPID sont des P-256 base64url-encoded ~87 chars. Dev
+    // keys auto-generees sont toujours non-vides.
+    expect(json.key.length).toBeGreaterThan(20);
+  });
+
+  it("POST /push/subscribe sans token -> 401", async () => {
+    const res = await rawPost("/push/subscribe", null, {
+      endpoint: "https://example.com/push/endpoint",
+      keys: { p256dh: "dummy", auth: "dummy" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /push/unsubscribe sans token -> 401", async () => {
+    const res = await rawPost("/push/unsubscribe", null, {
+      endpoint: "https://example.com/push/endpoint",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /push/preferences sans token -> 401", async () => {
+    const res = await rawGet("/push/preferences", null);
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /push/expo-subscribe sans token -> 401", async () => {
+    const res = await rawPost("/push/expo-subscribe", null, {
+      token: "ExponentPushToken[dummy]",
+      platform: "ios",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /push/expo-unsubscribe sans token -> 401", async () => {
+    const res = await rawPost("/push/expo-unsubscribe", null, {
+      token: "ExponentPushToken[dummy]",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /push/vapid-public-key est idempotent (2 appels renvoient meme cle)", async () => {
+    const first = (await (await rawGet("/push/vapid-public-key", null)).json()) as VapidKeyResponse;
+    const second = (await (await rawGet("/push/vapid-public-key", null)).json()) as VapidKeyResponse;
+    // Les dev keys generees au boot sont memoizees module-level, donc
+    // stables durant la vie du serveur.
+    expect(second.key).toBe(first.key);
+  });
+});


### PR DESCRIPTION
## Resume

Ajoute un spec E2E API pour les routes `/push/*` (web-push + Expo) qui n'etaient pas couvertes. Progression incrementale vers l'objectif **O.4** (expansion E2E tests, cible 80% coverage) du Sprint 22+.

Couverture :

- `GET /push/vapid-public-key` (public, no-auth) -> 200 + `{ key }` avec cle non-vide (dev mode auto-genere une VAPID keypair valide quand `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` sont absents des env vars, ce qui est le cas du test runner).
- `GET /push/vapid-public-key` est idempotent entre appels (dev keys memoizees module-level).
- Les 5 endpoints avec `authUser` rejettent un appel sans token (401) :
  - `POST /push/subscribe`
  - `POST /push/unsubscribe`
  - `GET /push/preferences`
  - `POST /push/expo-subscribe`
  - `POST /push/expo-unsubscribe`

Les tests 401 ne touchent pas la DB, donc restent stables meme si le model `NotificationPreference` est absent du schema sqlite e2e-api.

## Tache roadmap

Sprint 22+ — `O.4` (Expansion E2E tests, couverture cible 80%). Progres incremental (2e PR) :
- +1 spec E2E API (12 → 13 fichiers)
- +7 tests E2E API (71 → 78 tests)
- Routes `/push/*` desormais couvertes (vapid-public-key + auth gates)

## Plan de test

- [x] `pnpm test` (dans `tests/e2e-api`) : 78 tests OK (dont les 7 nouveaux de `push-notifications.spec.ts`)
- [x] `GET /push/vapid-public-key` : contrat `{ key }`, non vide, idempotent
- [x] Auth gates : 5 endpoints rejettent correctement (401) sans token
- [x] Pas de dependance sur `NotificationPreference` (model absent de sqlite e2e)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_