### PR TITLE
test(e2e-api): O.4 — add feature-flags.spec.ts (expansion E2E)

### DIFF
--- a/tests/e2e-api/specs/feature-flags.spec.ts
+++ b/tests/e2e-api/specs/feature-flags.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { get, rawGet, resetDb } from "../helpers/api";
+import { seedAndLogin } from "../helpers/factories";
+
+/**
+ * Spec /api/feature-flags/me (O.4 expansion E2E).
+ *
+ * La route `GET /api/feature-flags/me` expose la liste des feature
+ * flags actuellement actifs pour l'utilisateur authentifie. Le service
+ * `listEnabledKeysForUser` retourne :
+ *
+ *  - tous les flags quand `FEATURE_FLAGS_FORCE_ENABLED=true` (setup
+ *    e2e-api met ce flag par defaut, donc le test runner voit
+ *    l'ensemble des flags declares) ;
+ *  - sinon la combinaison flags globalement actives + overrides
+ *    utilisateur.
+ *
+ * Ce spec valide :
+ *
+ *  - refus sans token (401) — middleware `authUser` poste en premier ;
+ *  - reponse 200 + enveloppe `{ success: true, data: string[] }` avec
+ *    token valide ;
+ *  - le data est trie alphabetiquement (contrat de la fonction
+ *    `listEnabledKeysForUser`) ;
+ *  - le meme user vu deux fois renvoie la meme liste (stabilite sans
+ *    effet de bord).
+ */
+
+interface FeatureFlagsResponse {
+  success: boolean;
+  data: string[];
+  error?: string;
+}
+
+describe("E2E API — /api/feature-flags/me", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("GET /api/feature-flags/me sans token -> 401", async () => {
+    const res = await rawGet("/api/feature-flags/me", null);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/feature-flags/me avec token -> 200 + `{ success, data: string[] }`", async () => {
+    const { token } = await seedAndLogin(
+      "flags-a@e2e.test",
+      "password-flags",
+      "FlagsUser",
+    );
+    const json = await get<FeatureFlagsResponse>(
+      "/api/feature-flags/me",
+      token,
+    );
+    expect(json.success).toBe(true);
+    expect(Array.isArray(json.data)).toBe(true);
+    // Chaque entree est une cle string non vide.
+    for (const key of json.data) {
+      expect(typeof key).toBe("string");
+      expect(key.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("le tableau data est trie alphabetiquement", async () => {
+    const { token } = await seedAndLogin(
+      "flags-b@e2e.test",
+      "password-flags",
+      "FlagsSortCheck",
+    );
+    const json = await get<FeatureFlagsResponse>(
+      "/api/feature-flags/me",
+      token,
+    );
+    const sorted = [...json.data].sort();
+    expect(json.data).toEqual(sorted);
+  });
+
+  it("deux appels consecutifs renvoient la meme liste (stabilite)", async () => {
+    const { token } = await seedAndLogin(
+      "flags-c@e2e.test",
+      "password-flags",
+      "FlagsStability",
+    );
+    const first = await get<FeatureFlagsResponse>(
+      "/api/feature-flags/me",
+      token,
+    );
+    const second = await get<FeatureFlagsResponse>(
+      "/api/feature-flags/me",
+      token,
+    );
+    expect(second.data).toEqual(first.data);
+  });
+
+  it("GET /api/feature-flags/me avec token invalide -> 401", async () => {
+    const res = await rawGet(
+      "/api/feature-flags/me",
+      "invalid.jwt.token",
+    );
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Resume

Ajoute un spec E2E API pour la route `GET /api/feature-flags/me` qui n'etait pas couverte. Progression incrementale vers l'objectif **O.4** (expansion E2E tests, cible 80% coverage) du Sprint 22+.

Couverture :

- `GET /api/feature-flags/me` sans token -> 401 (middleware `authUser`)
- `GET /api/feature-flags/me` avec token valide -> 200 + `{ success, data: string[] }` ; chaque entree est une cle string non vide
- Le tableau `data` est trie alphabetiquement (contrat du service `listEnabledKeysForUser`)
- Deux appels consecutifs renvoient la meme liste (stabilite, pas d'effet de bord sur la lecture)
- Token invalide (`invalid.jwt.token`) -> 401

Le setup e2e-api met `FEATURE_FLAGS_FORCE_ENABLED=true`, donc le service renvoie l'ensemble des flags declares pour le user test (pas d'effet de bord requis sur la table `FeatureFlag`).

## Tache roadmap

Sprint 22+ — `O.4` (Expansion E2E tests, couverture cible 80%). Progres incremental (3e PR) :
- +1 spec E2E API (13 → 14 fichiers)
- +5 tests E2E API (77 → 82 tests)
- Route `GET /api/feature-flags/me` desormais couverte (auth gate + contract + stabilite)

## Plan de test

- [x] `pnpm test` (dans `tests/e2e-api`) : 82 tests OK (dont les 5 nouveaux de `feature-flags.spec.ts`)
- [x] 401 sans token + 401 token invalide
- [x] 200 + enveloppe `{ success, data: string[] }`
- [x] Tri alphabetique verifie
- [x] Stabilite (2 appels identiques)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrxjmaGF3aA8B6Emck1Gnp)_