### PR TITLE
test(e2e-api): O.4 — add achievements + leagues specs (expansion E2E)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -137,6 +137,36 @@ if (process.env.TEST_SQLITE === "1") {
         (prisma as any).$executeRawUnsafe('DELETE FROM "_MatchToUser"'),
       );
       await safe("match", () => prisma.match.deleteMany({}));
+      // League hierarchy: participants/rounds cascade from seasons; seasons
+      // and leagues must be removed before users (creatorId is RESTRICT).
+      await safe("leagueRound", () =>
+        (prisma as any).leagueRound?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      await safe("leagueParticipant", () =>
+        (prisma as any).leagueParticipant?.deleteMany?.({}) ??
+        Promise.resolve(),
+      );
+      await safe("leagueSeason", () =>
+        (prisma as any).leagueSeason?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      await safe("league", () =>
+        (prisma as any).league?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      // Cup hierarchy (creator is RESTRICT vs User).
+      await safe("cupParticipant", () =>
+        (prisma as any).cupParticipant?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      await safe("cup", () =>
+        (prisma as any).cup?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      // UserAchievement + Friendship cascade on User, but deleting explicitly
+      // avoids surprises if cascade rules change.
+      await safe("userAchievement", () =>
+        (prisma as any).userAchievement?.deleteMany?.({}) ?? Promise.resolve(),
+      );
+      await safe("friendship", () =>
+        (prisma as any).friendship?.deleteMany?.({}) ?? Promise.resolve(),
+      );
       await safe("teamPlayer", () => prisma.teamPlayer.deleteMany({}));
       await safe("team", () => prisma.team.deleteMany({}));
       await safe("user", () => prisma.user.deleteMany({}));

--- a/tests/e2e-api/specs/achievements.spec.ts
+++ b/tests/e2e-api/specs/achievements.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { rawGet, get, resetDb } from "../helpers/api";
+import { seedAndLogin } from "../helpers/factories";
+
+/**
+ * Spec /achievements (route authentifiee, O.4 expansion E2E).
+ *
+ * La route `/achievements` renvoie le catalogue complet des succes avec le
+ * statut verrouille/deverouille pour l'utilisateur courant. Les succes sont
+ * calcules lazy a chaque appel (stats agregees sur matches / amities /
+ * rosters joues) — voir apps/server/src/services/achievements.ts.
+ *
+ * On valide :
+ *  - 401 sans token (authUser middleware)
+ *  - 200 + enveloppe `{ success, data: { stats, achievements } }` avec token
+ *  - toutes les achievements sont `unlocked=false` pour un utilisateur neuf
+ *  - les stats agregees sont a 0 pour un utilisateur neuf
+ *  - chaque achievement contient les champs i18n attendus (fr/en)
+ *  - le catalogue contient au moins "first-match" (jalon bas)
+ */
+interface AchievementView {
+  slug: string;
+  nameFr: string;
+  nameEn: string;
+  descriptionFr: string;
+  descriptionEn: string;
+  category: string;
+  icon: string;
+  unlocked: boolean;
+  unlockedAt: string | null;
+}
+
+interface AchievementStats {
+  matchesPlayed: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  touchdowns: number;
+  casualties: number;
+  friendsCount: number;
+  rostersPlayed: string[];
+  winsByRoster: Record<string, number>;
+}
+
+interface AchievementsResponse {
+  success: boolean;
+  data: {
+    stats: AchievementStats;
+    achievements: AchievementView[];
+  };
+}
+
+describe("E2E API — /achievements", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("GET /achievements sans token renvoie 401", async () => {
+    const res = await rawGet("/achievements", null);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /achievements avec token renvoie 200 + enveloppe standard", async () => {
+    const { token } = await seedAndLogin("ach@e2e.test", "password-ach", "Ach");
+    const res = await rawGet("/achievements", token);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as AchievementsResponse;
+    expect(json.success).toBe(true);
+    expect(json.data).toHaveProperty("stats");
+    expect(json.data).toHaveProperty("achievements");
+    expect(Array.isArray(json.data.achievements)).toBe(true);
+  });
+
+  it("utilisateur neuf a toutes les achievements verrouillees", async () => {
+    const { token } = await seedAndLogin(
+      "ach2@e2e.test",
+      "password-ach2",
+      "Ach2",
+    );
+    const json = await get<AchievementsResponse>("/achievements", token);
+    expect(json.data.achievements.length).toBeGreaterThan(0);
+    for (const ach of json.data.achievements) {
+      expect(ach.unlocked).toBe(false);
+      expect(ach.unlockedAt).toBeNull();
+    }
+  });
+
+  it("utilisateur neuf a toutes les stats a 0", async () => {
+    const { token } = await seedAndLogin(
+      "ach3@e2e.test",
+      "password-ach3",
+      "Ach3",
+    );
+    const json = await get<AchievementsResponse>("/achievements", token);
+    expect(json.data.stats.matchesPlayed).toBe(0);
+    expect(json.data.stats.wins).toBe(0);
+    expect(json.data.stats.draws).toBe(0);
+    expect(json.data.stats.losses).toBe(0);
+    expect(json.data.stats.touchdowns).toBe(0);
+    expect(json.data.stats.casualties).toBe(0);
+    expect(json.data.stats.friendsCount).toBe(0);
+    expect(json.data.stats.rostersPlayed).toEqual([]);
+    expect(json.data.stats.winsByRoster).toEqual({});
+  });
+
+  it("chaque achievement contient les champs i18n + metadonnees", async () => {
+    const { token } = await seedAndLogin(
+      "ach4@e2e.test",
+      "password-ach4",
+      "Ach4",
+    );
+    const json = await get<AchievementsResponse>("/achievements", token);
+    for (const ach of json.data.achievements) {
+      expect(typeof ach.slug).toBe("string");
+      expect(ach.slug.length).toBeGreaterThan(0);
+      expect(typeof ach.nameFr).toBe("string");
+      expect(typeof ach.nameEn).toBe("string");
+      expect(typeof ach.descriptionFr).toBe("string");
+      expect(typeof ach.descriptionEn).toBe("string");
+      expect(typeof ach.category).toBe("string");
+      expect(typeof ach.icon).toBe("string");
+      expect(typeof ach.unlocked).toBe("boolean");
+    }
+  });
+
+  it("catalogue contient le jalon 'first-match'", async () => {
+    const { token } = await seedAndLogin(
+      "ach5@e2e.test",
+      "password-ach5",
+      "Ach5",
+    );
+    const json = await get<AchievementsResponse>("/achievements", token);
+    const slugs = json.data.achievements.map((a) => a.slug);
+    expect(slugs).toContain("first-match");
+  });
+
+  it("deux utilisateurs neufs isoles : progression independante", async () => {
+    const userA = await seedAndLogin(
+      "achA@e2e.test",
+      "password-achA",
+      "AchA",
+    );
+    const userB = await seedAndLogin(
+      "achB@e2e.test",
+      "password-achB",
+      "AchB",
+    );
+    const jsonA = await get<AchievementsResponse>(
+      "/achievements",
+      userA.token,
+    );
+    const jsonB = await get<AchievementsResponse>(
+      "/achievements",
+      userB.token,
+    );
+    // Deux utilisateurs distincts partagent le meme catalogue mais ont
+    // leur propre statut d'unlock (tous verrouilles ici).
+    expect(jsonA.data.achievements.length).toBe(
+      jsonB.data.achievements.length,
+    );
+    expect(jsonA.data.stats.matchesPlayed).toBe(0);
+    expect(jsonB.data.stats.matchesPlayed).toBe(0);
+  });
+});

--- a/tests/e2e-api/specs/leagues.spec.ts
+++ b/tests/e2e-api/specs/leagues.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { rawGet, rawPost, post, get, resetDb } from "../helpers/api";
+import { seedAndLogin } from "../helpers/factories";
+
+/**
+ * Spec /leagues (Sprint 17, L.3 — expansion E2E O.4).
+ *
+ * Les routes `/leagues` gerent la creation, le listing et le detail des
+ * ligues competitives. Toute la famille est authentifiee (authUser).
+ * On couvre ici :
+ *  - 401 sans token
+ *  - creation d'une ligue minimale (201 + payload attendu)
+ *  - listing (enveloppe `{ leagues: [] }` puis non-vide apres creation)
+ *  - detail par id (404 inconnu, 200 existant)
+ *  - validation Zod sur payload invalide (400)
+ *  - isolement utilisateur : un autre coach voit la ligue publique dans la liste
+ *  - format `allowedRosters` : tableau ou null (parse JSON <-> array)
+ */
+interface League {
+  id: string;
+  creatorId: string;
+  name: string;
+  description: string | null;
+  ruleset: string;
+  isPublic: boolean;
+  maxParticipants: number;
+  allowedRosters: string[] | null;
+  winPoints: number;
+  drawPoints: number;
+  lossPoints: number;
+  forfeitPoints: number;
+}
+
+interface ListResponse {
+  leagues: League[];
+}
+
+interface DetailResponse {
+  league: League;
+}
+
+describe("E2E API — /leagues", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  it("GET /leagues sans token renvoie 401", async () => {
+    const res = await rawGet("/leagues", null);
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /leagues sans token renvoie 401", async () => {
+    const res = await rawPost("/leagues", null, { name: "Ligue de test" });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /leagues avec token et DB vide renvoie { leagues: [] }", async () => {
+    const { token } = await seedAndLogin(
+      "lg1@e2e.test",
+      "password-lg1",
+      "LG1",
+    );
+    const json = await get<ListResponse>("/leagues", token);
+    expect(json).toHaveProperty("leagues");
+    expect(Array.isArray(json.leagues)).toBe(true);
+    expect(json.leagues).toEqual([]);
+  });
+
+  it("POST /leagues cree une ligue avec defaults et la retrouve via GET", async () => {
+    const { token, userId } = await seedAndLogin(
+      "lg2@e2e.test",
+      "password-lg2",
+      "LG2",
+    );
+    const created = await post<League>("/leagues", token, {
+      name: "Ligue E2E",
+      description: "Creee par le spec leagues.spec.ts",
+    });
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe("Ligue E2E");
+    expect(created.creatorId).toBe(userId);
+    // Defaults imposes par le service league.
+    expect(created.ruleset).toBe("season_3");
+    expect(created.isPublic).toBe(true);
+    expect(created.maxParticipants).toBe(16);
+    expect(created.winPoints).toBe(3);
+    expect(created.drawPoints).toBe(1);
+    expect(created.lossPoints).toBe(0);
+    expect(created.forfeitPoints).toBe(-1);
+    // allowedRosters par defaut = null (pas de restriction)
+    expect(created.allowedRosters).toBeNull();
+
+    const list = await get<ListResponse>("/leagues", token);
+    expect(list.leagues.length).toBe(1);
+    expect(list.leagues[0].id).toBe(created.id);
+  });
+
+  it("POST /leagues avec allowedRosters retourne un tableau de slugs", async () => {
+    const { token } = await seedAndLogin(
+      "lg3@e2e.test",
+      "password-lg3",
+      "LG3",
+    );
+    const created = await post<League>("/leagues", token, {
+      name: "Open 5 Teams",
+      allowedRosters: ["skaven", "lizardmen", "dwarves"],
+    });
+    expect(Array.isArray(created.allowedRosters)).toBe(true);
+    expect(created.allowedRosters).toEqual([
+      "skaven",
+      "lizardmen",
+      "dwarves",
+    ]);
+  });
+
+  it("POST /leagues avec payload invalide renvoie 400 (Zod)", async () => {
+    const { token } = await seedAndLogin(
+      "lg4@e2e.test",
+      "password-lg4",
+      "LG4",
+    );
+    // `name` vide -> viole min(1).
+    const res = await rawPost("/leagues", token, { name: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /leagues avec maxParticipants hors bornes renvoie 400", async () => {
+    const { token } = await seedAndLogin(
+      "lg5@e2e.test",
+      "password-lg5",
+      "LG5",
+    );
+    // maxParticipants doit etre entre 2 et 128 (schema Zod).
+    const tooSmall = await rawPost("/leagues", token, {
+      name: "Ligue mini",
+      maxParticipants: 1,
+    });
+    expect(tooSmall.status).toBe(400);
+    const tooLarge = await rawPost("/leagues", token, {
+      name: "Ligue maxi",
+      maxParticipants: 999,
+    });
+    expect(tooLarge.status).toBe(400);
+  });
+
+  it("GET /leagues/:id renvoie 404 pour un id inconnu", async () => {
+    const { token } = await seedAndLogin(
+      "lg6@e2e.test",
+      "password-lg6",
+      "LG6",
+    );
+    const res = await rawGet("/leagues/unknown-league-id", token);
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /leagues/:id retourne la ligue creee", async () => {
+    const { token } = await seedAndLogin(
+      "lg7@e2e.test",
+      "password-lg7",
+      "LG7",
+    );
+    const created = await post<League>("/leagues", token, {
+      name: "Ligue detail",
+      description: "Pour le test /:id",
+    });
+    const detail = await get<DetailResponse>(
+      `/leagues/${created.id}`,
+      token,
+    );
+    expect(detail.league.id).toBe(created.id);
+    expect(detail.league.name).toBe("Ligue detail");
+    expect(detail.league.description).toBe("Pour le test /:id");
+  });
+
+  it("listing par un autre coach contient la ligue publique", async () => {
+    const creator = await seedAndLogin(
+      "lg8a@e2e.test",
+      "password-lg8a",
+      "LG8A",
+    );
+    const viewer = await seedAndLogin(
+      "lg8b@e2e.test",
+      "password-lg8b",
+      "LG8B",
+    );
+    const created = await post<League>("/leagues", creator.token, {
+      name: "Ligue publique",
+      isPublic: true,
+    });
+    const list = await get<ListResponse>(
+      "/leagues?publicOnly=true",
+      viewer.token,
+    );
+    const ids = list.leagues.map((l) => l.id);
+    expect(ids).toContain(created.id);
+  });
+});


### PR DESCRIPTION
## Résumé

Ajoute deux nouveaux specs E2E API pour étendre la couverture des routes authentifiées (O.4, Sprint 22+) :

- **`tests/e2e-api/specs/achievements.spec.ts`** (7 tests) sur `GET /achievements` — auth requise, catalogue complet avec statut lock/unlock, stats agrégées (matches/wins/rosters), i18n fr/en, présence du jalon `first-match`, isolement inter-utilisateurs.
- **`tests/e2e-api/specs/leagues.spec.ts`** (10 tests) sur les routes `/leagues` (L.3, Sprint 17) — auth, création avec defaults, `allowedRosters` ↔ tableau JSON, validation Zod (name vide, maxParticipants hors bornes [2..128]), détail 404/200, listing `publicOnly` visible par un autre coach.
- **`apps/server/src/index.ts`** — étend `/__test/reset` pour purger `league*` / `cup*` / `userAchievement` / `friendship` avant la suppression des users (contrainte `RESTRICT` sur `creatorId`). Toutes les étapes sont wrappées dans `safe()` pour rester rétrocompatibles avec les specs existantes.

## Tâche roadmap

Sprint 22+, tâche O.4 — Expansion E2E tests (couverture cible 80%).

Continue la série de PRs incrémentales déjà établie : career-stats (#344), friends (#343), feature-flags (#342), push-notifications (#341), public-rosters (#340).

## Plan de test

- [x] `pnpm run test` dans `tests/e2e-api/` : **17 fichiers, 105 tests verts** (15 existants + 2 nouveaux)
- [x] `pnpm run test` dans `apps/server/` : **54 fichiers, 648 tests verts** (non-régression)
- [x] `pnpm run typecheck` à la racine : OK
- [x] `pnpm run lint` à la racine : 0 erreur (1015 warnings préexistants)
- [x] Spécifiquement : les specs existants (`public-rosters`, `feature-flags`, `friends`, `career-stats`, `smoke`, etc.) passent après l'extension de `/__test/reset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0133SgFrrano9ULyJWG7GfLa)_