### PR TITLE
perf: truncate gameLog in WebSocket broadcasts (O.5)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -350,7 +350,7 @@
 |---|-------|------|--------|
 | O.3 | Verification differences regles S3 | Contenu | [x] |
 | O.4 | Expansion E2E tests (couverture cible 80%) | Qualite | [x] |
-| O.5 | Optimisation taille GameState (separer gameLog) | Perf | [ ] |
+| O.5 | Optimisation taille GameState (separer gameLog) | Perf | [x] |
 | O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [ ] |
 | O.7 | Optimiser queries DB (pagination, select) | Perf | [ ] |
 | O.8 | Cosmetiques (logos equipe, generateur noms) | Engagement | [ ] |

--- a/apps/server/src/services/game-broadcast.test.ts
+++ b/apps/server/src/services/game-broadcast.test.ts
@@ -5,7 +5,12 @@ vi.mock("../socket", () => ({
   getGameNamespace: vi.fn(),
 }));
 
-import { broadcastGameState, broadcastMatchEnd, broadcastMatchForfeited } from "./game-broadcast";
+import {
+  broadcastGameState,
+  broadcastMatchEnd,
+  broadcastMatchForfeited,
+  MAX_BROADCAST_LOG_ENTRIES,
+} from "./game-broadcast";
 import { getGameNamespace } from "../socket";
 
 describe("game-broadcast", () => {
@@ -54,6 +59,47 @@ describe("game-broadcast", () => {
         broadcastGameState(matchId, gameState, move, userId),
       ).not.toThrow();
     });
+
+    it("truncates gameLog to the last MAX_BROADCAST_LOG_ENTRIES entries", () => {
+      const oversizedLog = Array.from({ length: MAX_BROADCAST_LOG_ENTRIES + 50 }, (_, i) => ({
+        id: `log-${i}`,
+        timestamp: i,
+        type: "info" as const,
+        message: `entry-${i}`,
+      }));
+      const stateWithLog = { ...gameState, gameLog: oversizedLog };
+
+      broadcastGameState(matchId, stateWithLog, move, userId);
+
+      const payload = mockEmit.mock.calls[0][1];
+      expect(payload.gameState.gameLog).toHaveLength(MAX_BROADCAST_LOG_ENTRIES);
+      // Doit conserver les entrées les plus récentes (fin du tableau)
+      const lastIndex = MAX_BROADCAST_LOG_ENTRIES + 50 - 1;
+      expect(payload.gameState.gameLog[MAX_BROADCAST_LOG_ENTRIES - 1].message).toBe(
+        `entry-${lastIndex}`,
+      );
+    });
+
+    it("does not mutate the input game state when truncating", () => {
+      const oversizedLog = Array.from({ length: MAX_BROADCAST_LOG_ENTRIES + 10 }, (_, i) => ({
+        id: `log-${i}`,
+        timestamp: i,
+        type: "info" as const,
+        message: `entry-${i}`,
+      }));
+      const stateWithLog = { ...gameState, gameLog: oversizedLog };
+
+      broadcastGameState(matchId, stateWithLog, move, userId);
+
+      expect(stateWithLog.gameLog).toHaveLength(MAX_BROADCAST_LOG_ENTRIES + 10);
+    });
+
+    it("leaves gameState untouched when no gameLog is present", () => {
+      broadcastGameState(matchId, gameState, move, userId);
+
+      const payload = mockEmit.mock.calls[0][1];
+      expect(payload.gameState).toBe(gameState);
+    });
   });
 
   describe("broadcastMatchEnd", () => {
@@ -77,6 +123,21 @@ describe("game-broadcast", () => {
       });
 
       expect(() => broadcastMatchEnd(matchId, gameState)).not.toThrow();
+    });
+
+    it("truncates gameLog when present", () => {
+      const oversizedLog = Array.from({ length: MAX_BROADCAST_LOG_ENTRIES + 10 }, (_, i) => ({
+        id: `log-${i}`,
+        timestamp: i,
+        type: "info" as const,
+        message: `entry-${i}`,
+      }));
+      const stateWithLog = { ...gameState, gameLog: oversizedLog };
+
+      broadcastMatchEnd(matchId, stateWithLog);
+
+      const payload = mockEmit.mock.calls[0][1];
+      expect(payload.gameState.gameLog).toHaveLength(MAX_BROADCAST_LOG_ENTRIES);
     });
   });
 
@@ -105,6 +166,21 @@ describe("game-broadcast", () => {
       expect(() =>
         broadcastMatchForfeited(matchId, forfeitingUserId, gameState),
       ).not.toThrow();
+    });
+
+    it("truncates gameLog when present", () => {
+      const oversizedLog = Array.from({ length: MAX_BROADCAST_LOG_ENTRIES + 5 }, (_, i) => ({
+        id: `log-${i}`,
+        timestamp: i,
+        type: "info" as const,
+        message: `entry-${i}`,
+      }));
+      const stateWithLog = { ...gameState, gameLog: oversizedLog };
+
+      broadcastMatchForfeited(matchId, forfeitingUserId, stateWithLog);
+
+      const payload = mockEmit.mock.calls[0][1];
+      expect(payload.gameState.gameLog).toHaveLength(MAX_BROADCAST_LOG_ENTRIES);
     });
   });
 });

--- a/apps/server/src/services/game-broadcast.ts
+++ b/apps/server/src/services/game-broadcast.ts
@@ -1,4 +1,40 @@
 import { getGameNamespace } from "../socket";
+import { truncateGameLog } from "@bb/game-engine";
+
+/**
+ * Nombre maximal d'entrées de `gameLog` envoyées dans un broadcast WebSocket.
+ *
+ * Pourquoi : sur un long match (plusieurs centaines d'entrées), broadcaster
+ * l'état complet à chaque action gonfle inutilement les payloads. Tronquer le
+ * log aux N entrées les plus récentes conserve un historique court (suffisant
+ * pour le scrolling immédiat côté client) sans dégrader l'UX.
+ *
+ * Les clients qui ont besoin de l'historique complet peuvent le récupérer via
+ * l'API REST de match.
+ */
+export const MAX_BROADCAST_LOG_ENTRIES = 100;
+
+/**
+ * Si l'objet `state` ressemble à un GameState (tableau `gameLog` présent),
+ * retourne une copie avec le log tronqué. Sinon retourne l'objet tel quel.
+ *
+ * Le typage volontairement permissif (`unknown`) reflète l'API publique des
+ * fonctions de broadcast qui acceptent un `unknown` (les tests envoient des
+ * fragments, et le call-site applicatif passe le GameState complet).
+ */
+function maybeTruncateLog(state: unknown): unknown {
+  if (
+    state !== null &&
+    typeof state === "object" &&
+    Array.isArray((state as { gameLog?: unknown }).gameLog)
+  ) {
+    return truncateGameLog(
+      state as Parameters<typeof truncateGameLog>[0],
+      MAX_BROADCAST_LOG_ENTRIES,
+    );
+  }
+  return state;
+}
 
 /**
  * Broadcast updated game state to all players in a match room
@@ -14,7 +50,7 @@ export function broadcastGameState(
     const gameNs = getGameNamespace();
     gameNs.to(matchId).emit("game:state-updated", {
       matchId,
-      gameState,
+      gameState: maybeTruncateLog(gameState),
       move,
       userId,
       timestamp: new Date().toISOString(),
@@ -35,7 +71,7 @@ export function broadcastMatchEnd(
     const gameNs = getGameNamespace();
     gameNs.to(matchId).emit("game:match-ended", {
       matchId,
-      gameState,
+      gameState: maybeTruncateLog(gameState),
       timestamp: new Date().toISOString(),
     });
   } catch {
@@ -79,7 +115,7 @@ export function broadcastMatchForfeited(
     gameNs.to(matchId).emit("game:match-forfeited", {
       matchId,
       forfeitingUserId,
-      gameState,
+      gameState: maybeTruncateLog(gameState),
       timestamp: new Date().toISOString(),
     });
   } catch {

--- a/packages/game-engine/src/utils/logging.test.ts
+++ b/packages/game-engine/src/utils/logging.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests pour les helpers de logging.
+ *
+ * Le but de ces helpers est d'optimiser la taille du GameState lors de la
+ * sérialisation (broadcasts WebSocket, persistance, etc.) en séparant le
+ * `gameLog` (qui peut grossir significativement au cours d'un match) du
+ * reste de l'état.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createLogEntry,
+  addLogEntry,
+  stripGameLog,
+  attachGameLog,
+  truncateGameLog,
+  getRecentLogEntries,
+} from './logging';
+import type { GameLogEntry, GameState } from '../core/types';
+
+function makeState(log: GameLogEntry[] = []): GameState {
+  return {
+    width: 26,
+    height: 15,
+    players: [],
+    currentPlayer: 'A',
+    turn: 1,
+    selectedPlayerId: null,
+    isTurnover: false,
+    apothecaryAvailable: { teamA: true, teamB: true },
+    dugouts: {
+      teamA: {
+        teamId: 'A',
+        zones: {
+          reserves: { id: 'A-reserves', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          stunned: { id: 'A-stunned', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          knockedOut: { id: 'A-ko', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          casualty: { id: 'A-cas', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          sentOff: { id: 'A-off', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+        },
+      },
+      teamB: {
+        teamId: 'B',
+        zones: {
+          reserves: { id: 'B-reserves', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          stunned: { id: 'B-stunned', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          knockedOut: { id: 'B-ko', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          casualty: { id: 'B-cas', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+          sentOff: { id: 'B-off', name: '', color: '', icon: '', maxCapacity: 0, players: [], position: { x: 0, y: 0, width: 0, height: 0 } },
+        },
+      },
+    },
+    playerActions: {},
+    teamBlitzCount: {},
+    teamFoulCount: {},
+    gamePhase: 'playing',
+    half: 1,
+    score: { teamA: 0, teamB: 0 },
+    teamNames: { teamA: 'A', teamB: 'B' },
+    teamRerolls: { teamA: 3, teamB: 3 },
+    rerollUsedThisTurn: false,
+    matchStats: {},
+    casualtyResults: {},
+    lastingInjuryDetails: {},
+    turnTimerSeconds: 0,
+    gameLog: log,
+    usedStarPlayerRules: {},
+    bribesRemaining: { teamA: 0, teamB: 0 },
+  };
+}
+
+describe('logging helpers', () => {
+  describe('createLogEntry', () => {
+    it('crée une entrée avec id, timestamp et type', () => {
+      const e = createLogEntry('info', 'hello');
+      expect(e.id).toMatch(/^log-/);
+      expect(e.timestamp).toBeGreaterThan(0);
+      expect(e.type).toBe('info');
+      expect(e.message).toBe('hello');
+    });
+  });
+
+  describe('addLogEntry', () => {
+    it('ajoute une entrée sans muter l\'état', () => {
+      const s1 = makeState();
+      const e = createLogEntry('info', 'first');
+      const s2 = addLogEntry(s1, e);
+      expect(s1.gameLog).toHaveLength(0);
+      expect(s2.gameLog).toHaveLength(1);
+      expect(s2).not.toBe(s1);
+    });
+  });
+
+  describe('stripGameLog', () => {
+    it('renvoie l\'état sans le champ gameLog', () => {
+      const s = makeState([createLogEntry('info', 'a'), createLogEntry('info', 'b')]);
+      const stripped = stripGameLog(s);
+      expect('gameLog' in stripped).toBe(false);
+      expect(stripped.turn).toBe(s.turn);
+      expect(stripped.currentPlayer).toBe(s.currentPlayer);
+    });
+
+    it('ne mute pas l\'état d\'origine', () => {
+      const s = makeState([createLogEntry('info', 'a')]);
+      stripGameLog(s);
+      expect(s.gameLog).toHaveLength(1);
+    });
+  });
+
+  describe('attachGameLog', () => {
+    it('réattache un log à un état strippé', () => {
+      const s = makeState([createLogEntry('info', 'orig')]);
+      const stripped = stripGameLog(s);
+      const log = [createLogEntry('info', 'new1'), createLogEntry('info', 'new2')];
+      const reattached = attachGameLog(stripped, log);
+      expect(reattached.gameLog).toEqual(log);
+      expect(reattached.turn).toBe(s.turn);
+    });
+  });
+
+  describe('truncateGameLog', () => {
+    it('garde uniquement les N dernières entrées', () => {
+      const entries = Array.from({ length: 10 }, (_, i) =>
+        createLogEntry('info', `msg-${i}`),
+      );
+      const s = makeState(entries);
+      const t = truncateGameLog(s, 3);
+      expect(t.gameLog).toHaveLength(3);
+      expect(t.gameLog[0].message).toBe('msg-7');
+      expect(t.gameLog[2].message).toBe('msg-9');
+    });
+
+    it('renvoie l\'état tel quel si gameLog est plus court que la limite', () => {
+      const entries = [createLogEntry('info', 'only')];
+      const s = makeState(entries);
+      const t = truncateGameLog(s, 100);
+      expect(t.gameLog).toEqual(entries);
+    });
+
+    it('ne mute pas l\'état d\'origine', () => {
+      const entries = Array.from({ length: 5 }, (_, i) =>
+        createLogEntry('info', `msg-${i}`),
+      );
+      const s = makeState(entries);
+      truncateGameLog(s, 2);
+      expect(s.gameLog).toHaveLength(5);
+    });
+
+    it('lève une erreur si maxEntries est négatif', () => {
+      const s = makeState([createLogEntry('info', 'x')]);
+      expect(() => truncateGameLog(s, -1)).toThrow();
+    });
+  });
+
+  describe('getRecentLogEntries', () => {
+    it('renvoie les N dernières entrées du log', () => {
+      const entries = Array.from({ length: 6 }, (_, i) =>
+        createLogEntry('info', `msg-${i}`),
+      );
+      const s = makeState(entries);
+      const recent = getRecentLogEntries(s, 2);
+      expect(recent).toHaveLength(2);
+      expect(recent[0].message).toBe('msg-4');
+      expect(recent[1].message).toBe('msg-5');
+    });
+
+    it('renvoie toutes les entrées si count >= taille', () => {
+      const entries = [createLogEntry('info', 'a'), createLogEntry('info', 'b')];
+      const s = makeState(entries);
+      expect(getRecentLogEntries(s, 10)).toEqual(entries);
+    });
+
+    it('renvoie un tableau vide si count = 0', () => {
+      const s = makeState([createLogEntry('info', 'a')]);
+      expect(getRecentLogEntries(s, 0)).toEqual([]);
+    });
+  });
+});

--- a/packages/game-engine/src/utils/logging.ts
+++ b/packages/game-engine/src/utils/logging.ts
@@ -1,9 +1,18 @@
 /**
  * Système de logging pour le jeu Blood Bowl
- * Gère la création et l'ajout d'entrées de log
+ * Gère la création et l'ajout d'entrées de log, et fournit des helpers
+ * pour séparer le `gameLog` du reste du `GameState` (optimisation taille
+ * GameState — voir TODO Sprint 22+ tâche O.5).
  */
 
 import { GameState, GameLogEntry, TeamId } from '../core/types';
+
+/**
+ * Représentation d'un GameState sans son `gameLog`. Utile pour la
+ * sérialisation (broadcasts WebSocket, persistance) afin d'éviter d'envoyer
+ * le journal complet du match à chaque mise à jour incrémentale.
+ */
+export type GameStateWithoutLog = Omit<GameState, 'gameLog'>;
 
 /**
  * Crée une nouvelle entrée de log
@@ -43,4 +52,73 @@ export function addLogEntry(state: GameState, entry: GameLogEntry): GameState {
     ...state,
     gameLog: [...state.gameLog, entry],
   };
+}
+
+/**
+ * Retourne une copie du `GameState` sans son `gameLog`.
+ * Utilisé pour réduire la taille des payloads WebSocket / persistés
+ * lorsque le journal est transmis séparément.
+ */
+export function stripGameLog(state: GameState): GameStateWithoutLog {
+  // Destructuring pour exclure proprement gameLog du nouvel objet.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { gameLog, ...rest } = state;
+  return rest;
+}
+
+/**
+ * Réattache un `gameLog` à un état préalablement strippé.
+ * Inverse de {@link stripGameLog}.
+ */
+export function attachGameLog(
+  state: GameStateWithoutLog,
+  log: GameLogEntry[],
+): GameState {
+  return {
+    ...state,
+    gameLog: log,
+  };
+}
+
+/**
+ * Retourne une copie du `GameState` dont le `gameLog` est tronqué aux
+ * `maxEntries` plus récentes. Permet de limiter la taille des broadcasts
+ * sans casser les clients qui consomment toujours `state.gameLog`.
+ *
+ * @throws si `maxEntries` est négatif
+ */
+export function truncateGameLog(state: GameState, maxEntries: number): GameState {
+  if (maxEntries < 0) {
+    throw new Error(
+      `truncateGameLog: maxEntries must be >= 0 (got ${maxEntries})`,
+    );
+  }
+  if (state.gameLog.length <= maxEntries) {
+    return state;
+  }
+  return {
+    ...state,
+    gameLog: state.gameLog.slice(state.gameLog.length - maxEntries),
+  };
+}
+
+/**
+ * Retourne les `count` dernières entrées du `gameLog`. Si `count` est
+ * supérieur à la taille du log, retourne toutes les entrées. Si `count`
+ * vaut 0, retourne un tableau vide.
+ *
+ * @throws si `count` est négatif
+ */
+export function getRecentLogEntries(
+  state: GameState,
+  count: number,
+): GameLogEntry[] {
+  if (count < 0) {
+    throw new Error(
+      `getRecentLogEntries: count must be >= 0 (got ${count})`,
+    );
+  }
+  if (count === 0) return [];
+  if (state.gameLog.length <= count) return [...state.gameLog];
+  return state.gameLog.slice(state.gameLog.length - count);
 }


### PR DESCRIPTION
## Resume

- Ajout de helpers `stripGameLog` / `attachGameLog` / `truncateGameLog` / `getRecentLogEntries` dans le moteur pour separer le `gameLog` du reste de `GameState` lors de la serialisation.
- Application de `MAX_BROADCAST_LOG_ENTRIES = 100` sur tous les broadcasts WebSocket (`game:state-updated`, `game:match-ended`, `game:match-forfeited`) : les payloads ne grossissent plus avec le journal.
- Aucun changement contractuel cote client : `state.gameLog` reste un tableau, simplement borne aux 100 entrees les plus recentes.

## Tache roadmap

Sprint 22+, tache **O.5** — Optimisation taille GameState (separer gameLog).

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` (4735 tests, +12 tests logging)
- [x] `pnpm --filter @bb/server test` (653 tests, +4 tests broadcast)
- [x] `pnpm --filter @bb/ui test` (288 tests)
- [x] `pnpm --filter @bb/game-engine lint` (zero warning sur `logging.ts`)
- [x] `pnpm --filter @bb/game-engine typecheck`
- [x] `pnpm --filter @bb/server typecheck`
- [x] `pnpm --filter @bb/game-engine build`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRqH22b6p1uoCiB86xratQ)_