### PR TITLE
refactor: standardize ApiResponse&lt;T&gt; envelope with helpers (O.6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -351,7 +351,7 @@
 | O.3 | Verification differences regles S3 | Contenu | [x] |
 | O.4 | Expansion E2E tests (couverture cible 80%) | Qualite | [x] |
 | O.5 | Optimisation taille GameState (separer gameLog) | Perf | [x] |
-| O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [ ] |
+| O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [x] |
 | O.7 | Optimiser queries DB (pagination, select) | Perf | [ ] |
 | O.8 | Cosmetiques (logos equipe, generateur noms) | Engagement | [ ] |
 | O.9 | Features communautaires (match of the week, Discord) | Engagement | [ ] |

--- a/apps/server/src/routes/feature-flags.ts
+++ b/apps/server/src/routes/feature-flags.ts
@@ -19,6 +19,7 @@ import {
   addUserOverride,
   removeUserOverride,
 } from "../services/featureFlags";
+import { sendSuccess, sendError } from "../utils/api-response";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Erreur serveur";
@@ -34,18 +35,16 @@ userFeatureFlagsRouter.use(authUser);
 
 userFeatureFlagsRouter.get("/me", async (req: AuthenticatedRequest, res) => {
   if (!req.user?.id) {
-    return res.status(401).json({ success: false, error: "Non authentifié" });
+    return sendError(res, "Non authentifié", 401);
   }
   try {
     const keys = await listEnabledKeysForUser(req.user.id, {
       roles: req.user.roles,
     });
-    return res.json({ success: true, data: keys });
+    return sendSuccess(res, keys);
   } catch (error: unknown) {
     console.error("[featureFlags] /me error:", error);
-    return res
-      .status(500)
-      .json({ success: false, error: errorMessage(error) });
+    return sendError(res, errorMessage(error));
   }
 });
 
@@ -60,12 +59,10 @@ adminFeatureFlagsRouter.use(authUser, adminOnly);
 adminFeatureFlagsRouter.get("/", async (_req, res) => {
   try {
     const flags = await listAll();
-    return res.json({ success: true, data: flags });
+    return sendSuccess(res, flags);
   } catch (error: unknown) {
     console.error("[featureFlags] GET / error:", error);
-    return res
-      .status(500)
-      .json({ success: false, error: errorMessage(error) });
+    return sendError(res, errorMessage(error));
   }
 });
 
@@ -81,17 +78,13 @@ adminFeatureFlagsRouter.post(
       };
       const existing = await prisma.featureFlag.findUnique({ where: { key } });
       if (existing) {
-        return res
-          .status(409)
-          .json({ success: false, error: "Une flag avec cette clé existe déjà" });
+        return sendError(res, "Une flag avec cette clé existe déjà", 409);
       }
       const flag = await createFlag({ key, description, enabled });
-      return res.status(201).json({ success: true, data: flag });
+      return sendSuccess(res, flag, 201);
     } catch (error: unknown) {
       console.error("[featureFlags] POST / error:", error);
-      return res
-        .status(500)
-        .json({ success: false, error: errorMessage(error) });
+      return sendError(res, errorMessage(error));
     }
   },
 );
@@ -103,17 +96,13 @@ adminFeatureFlagsRouter.patch(
     try {
       const existing = await findById(req.params.id);
       if (!existing) {
-        return res
-          .status(404)
-          .json({ success: false, error: "Feature flag introuvable" });
+        return sendError(res, "Feature flag introuvable", 404);
       }
       const flag = await updateFlag(req.params.id, req.body);
-      return res.json({ success: true, data: flag });
+      return sendSuccess(res, flag);
     } catch (error: unknown) {
       console.error("[featureFlags] PATCH /:id error:", error);
-      return res
-        .status(500)
-        .json({ success: false, error: errorMessage(error) });
+      return sendError(res, errorMessage(error));
     }
   },
 );
@@ -122,17 +111,13 @@ adminFeatureFlagsRouter.delete("/:id", async (req, res) => {
   try {
     const existing = await findById(req.params.id);
     if (!existing) {
-      return res
-        .status(404)
-        .json({ success: false, error: "Feature flag introuvable" });
+      return sendError(res, "Feature flag introuvable", 404);
     }
     await deleteFlag(req.params.id);
-    return res.json({ success: true, data: { id: req.params.id } });
+    return sendSuccess(res, { id: req.params.id });
   } catch (error: unknown) {
     console.error("[featureFlags] DELETE /:id error:", error);
-    return res
-      .status(500)
-      .json({ success: false, error: errorMessage(error) });
+    return sendError(res, errorMessage(error));
   }
 });
 
@@ -140,17 +125,13 @@ adminFeatureFlagsRouter.get("/:id/users", async (req, res) => {
   try {
     const existing = await findById(req.params.id);
     if (!existing) {
-      return res
-        .status(404)
-        .json({ success: false, error: "Feature flag introuvable" });
+      return sendError(res, "Feature flag introuvable", 404);
     }
     const users = await listUsersForFlag(req.params.id);
-    return res.json({ success: true, data: users });
+    return sendSuccess(res, users);
   } catch (error: unknown) {
     console.error("[featureFlags] GET /:id/users error:", error);
-    return res
-      .status(500)
-      .json({ success: false, error: errorMessage(error) });
+    return sendError(res, errorMessage(error));
   }
 });
 
@@ -161,24 +142,18 @@ adminFeatureFlagsRouter.post(
     try {
       const flag = await findById(req.params.id);
       if (!flag) {
-        return res
-          .status(404)
-          .json({ success: false, error: "Feature flag introuvable" });
+        return sendError(res, "Feature flag introuvable", 404);
       }
       const { userId } = req.body as { userId: string };
       const user = await prisma.user.findUnique({ where: { id: userId } });
       if (!user) {
-        return res
-          .status(404)
-          .json({ success: false, error: "Utilisateur introuvable" });
+        return sendError(res, "Utilisateur introuvable", 404);
       }
       await addUserOverride(req.params.id, userId);
-      return res.status(201).json({ success: true, data: { userId } });
+      return sendSuccess(res, { userId }, 201);
     } catch (error: unknown) {
       console.error("[featureFlags] POST /:id/users error:", error);
-      return res
-        .status(500)
-        .json({ success: false, error: errorMessage(error) });
+      return sendError(res, errorMessage(error));
     }
   },
 );
@@ -187,16 +162,12 @@ adminFeatureFlagsRouter.delete("/:id/users/:userId", async (req, res) => {
   try {
     const flag = await findById(req.params.id);
     if (!flag) {
-      return res
-        .status(404)
-        .json({ success: false, error: "Feature flag introuvable" });
+      return sendError(res, "Feature flag introuvable", 404);
     }
     await removeUserOverride(req.params.id, req.params.userId);
-    return res.json({ success: true, data: { userId: req.params.userId } });
+    return sendSuccess(res, { userId: req.params.userId });
   } catch (error: unknown) {
     console.error("[featureFlags] DELETE /:id/users/:userId error:", error);
-    return res
-      .status(500)
-      .json({ success: false, error: errorMessage(error) });
+    return sendError(res, errorMessage(error));
   }
 });

--- a/apps/server/src/utils/api-response.test.ts
+++ b/apps/server/src/utils/api-response.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests pour l'enveloppe ApiResponse<T> standardisée (tâche O.6).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  apiSuccess,
+  apiError,
+  sendSuccess,
+  sendError,
+  isApiSuccess,
+  isApiError,
+  apiErrorHandler,
+  type ApiResponse,
+} from "./api-response";
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res as { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> };
+}
+
+describe("api-response helpers", () => {
+  describe("apiSuccess", () => {
+    it("retourne une enveloppe success avec data", () => {
+      const r = apiSuccess({ id: "abc" });
+      expect(r).toEqual({ success: true, data: { id: "abc" } });
+    });
+
+    it("supporte les types primitifs", () => {
+      expect(apiSuccess(42)).toEqual({ success: true, data: 42 });
+      expect(apiSuccess("ok")).toEqual({ success: true, data: "ok" });
+      expect(apiSuccess(null)).toEqual({ success: true, data: null });
+    });
+
+    it("inclut meta optionnel pour pagination", () => {
+      const r = apiSuccess([1, 2, 3], { total: 3, page: 1, limit: 10 });
+      expect(r).toEqual({
+        success: true,
+        data: [1, 2, 3],
+        meta: { total: 3, page: 1, limit: 10 },
+      });
+    });
+  });
+
+  describe("apiError", () => {
+    it("retourne une enveloppe error avec message", () => {
+      const r = apiError("Boom");
+      expect(r).toEqual({ success: false, error: "Boom" });
+    });
+  });
+
+  describe("type guards", () => {
+    it("isApiSuccess discrimine correctement", () => {
+      const ok: ApiResponse<number> = apiSuccess(1);
+      const ko: ApiResponse<number> = apiError("nope");
+      expect(isApiSuccess(ok)).toBe(true);
+      expect(isApiSuccess(ko)).toBe(false);
+    });
+
+    it("isApiError discrimine correctement", () => {
+      const ok: ApiResponse<number> = apiSuccess(1);
+      const ko: ApiResponse<number> = apiError("nope");
+      expect(isApiError(ko)).toBe(true);
+      expect(isApiError(ok)).toBe(false);
+    });
+  });
+
+  describe("sendSuccess", () => {
+    it("envoie status 200 par défaut avec l'enveloppe success", () => {
+      const res = mockRes();
+      sendSuccess(res as any, { x: 1 });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { x: 1 } });
+    });
+
+    it("accepte un status custom (ex: 201)", () => {
+      const res = mockRes();
+      sendSuccess(res as any, { id: "new" }, 201);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: { id: "new" } });
+    });
+
+    it("transmet meta quand fourni", () => {
+      const res = mockRes();
+      sendSuccess(res as any, [1], 200, { total: 1, page: 1, limit: 10 });
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: [1],
+        meta: { total: 1, page: 1, limit: 10 },
+      });
+    });
+  });
+
+  describe("sendError", () => {
+    it("envoie status 500 par défaut", () => {
+      const res = mockRes();
+      sendError(res as any, "Erreur serveur");
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: "Erreur serveur" });
+    });
+
+    it("accepte un status custom (ex: 404)", () => {
+      const res = mockRes();
+      sendError(res as any, "Introuvable", 404);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: "Introuvable" });
+    });
+  });
+
+  describe("apiErrorHandler middleware", () => {
+    it("convertit une Error en réponse standardisée 500", () => {
+      const res = mockRes();
+      const next = vi.fn();
+      apiErrorHandler(new Error("Boom"), {} as any, res as any, next as any);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: "Boom" });
+    });
+
+    it("respecte un status attaché à l'erreur (ex: 404)", () => {
+      const res = mockRes();
+      const next = vi.fn();
+      const err = Object.assign(new Error("Not found"), { status: 404 });
+      apiErrorHandler(err, {} as any, res as any, next as any);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: "Not found" });
+    });
+
+    it("renvoie 'Erreur serveur' pour une exception non-Error", () => {
+      const res = mockRes();
+      const next = vi.fn();
+      apiErrorHandler("string error", {} as any, res as any, next as any);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: "Erreur serveur",
+      });
+    });
+
+    it("délègue à next() si headers déjà envoyés", () => {
+      const res = mockRes();
+      (res as any).headersSent = true;
+      const next = vi.fn();
+      const err = new Error("Boom");
+      apiErrorHandler(err, {} as any, res as any, next as any);
+      expect(next).toHaveBeenCalledWith(err);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/utils/api-response.ts
+++ b/apps/server/src/utils/api-response.ts
@@ -1,0 +1,107 @@
+/**
+ * Enveloppe `ApiResponse<T>` standardisée pour toutes les routes API
+ * (tâche O.6 — Sprint 22+).
+ *
+ * Format unique :
+ *   succès : `{ success: true, data: T, meta?: { total, page, limit } }`
+ *   erreur : `{ success: false, error: string }`
+ *
+ * Utiliser `sendSuccess` / `sendError` plutôt que de construire l'objet
+ * manuellement, et brancher `apiErrorHandler` en bout de chaîne Express
+ * pour convertir automatiquement les `throw` en réponses standardisées.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+
+export interface ApiSuccess<T> {
+  success: true;
+  data: T;
+  meta?: ApiMeta;
+}
+
+export interface ApiError {
+  success: false;
+  error: string;
+}
+
+export interface ApiMeta {
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type ApiResponse<T> = ApiSuccess<T> | ApiError;
+
+/** Construit une réponse de succès. */
+export function apiSuccess<T>(data: T, meta?: ApiMeta): ApiSuccess<T> {
+  if (meta) return { success: true, data, meta };
+  return { success: true, data };
+}
+
+/** Construit une réponse d'erreur. */
+export function apiError(message: string): ApiError {
+  return { success: false, error: message };
+}
+
+/** Type guard : vrai si la réponse est un succès. */
+export function isApiSuccess<T>(r: ApiResponse<T>): r is ApiSuccess<T> {
+  return r.success === true;
+}
+
+/** Type guard : vrai si la réponse est une erreur. */
+export function isApiError<T>(r: ApiResponse<T>): r is ApiError {
+  return r.success === false;
+}
+
+/** Envoie une réponse de succès via Express. Status par défaut : 200. */
+export function sendSuccess<T>(
+  res: Response,
+  data: T,
+  status: number = 200,
+  meta?: ApiMeta,
+): Response {
+  return res.status(status).json(apiSuccess(data, meta));
+}
+
+/** Envoie une réponse d'erreur via Express. Status par défaut : 500. */
+export function sendError(
+  res: Response,
+  message: string,
+  status: number = 500,
+): Response {
+  return res.status(status).json(apiError(message));
+}
+
+/**
+ * Middleware de gestion d'erreur Express. À placer en dernier dans la chaîne :
+ *
+ *   app.use(apiErrorHandler);
+ *
+ * Tout `throw new Error(...)` (ou `next(err)`) est converti en
+ * `ApiResponse<never>` au format standardisé. Si l'erreur porte un champ
+ * `status` (number), il est utilisé comme code HTTP.
+ */
+export function apiErrorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+
+  let message = "Erreur serveur";
+  let status = 500;
+
+  if (err instanceof Error) {
+    message = err.message || message;
+    const errStatus = (err as { status?: unknown }).status;
+    if (typeof errStatus === "number" && errStatus >= 100 && errStatus < 600) {
+      status = errStatus;
+    }
+  }
+
+  sendError(res, message, status);
+}


### PR DESCRIPTION
## Resume

- Nouvelle utility `apps/server/src/utils/api-response.ts` : type discriminé `ApiResponse<T>`, builders `apiSuccess` / `apiError`, type guards, helpers Express `sendSuccess` / `sendError` et middleware `apiErrorHandler`.
- Migration des routes feature-flags (user + admin) vers les nouveaux helpers comme exemplar — format de la réponse identique (zéro changement contractuel pour les clients).
- Le standard suit `.claude/rules/common/patterns.md` : `{ success, data?, error?, meta? }`. Les autres routes pourront migrer progressivement.

## Tache roadmap

Sprint 22+, tache **O.6** — Standardiser error handling (`ApiResponse<T>`).

## Plan de test

- [x] `pnpm --filter @bb/server test` (668 tests, +15 helpers ApiResponse)
- [x] `pnpm --filter @bb/server typecheck`
- [x] Vérification visuelle : les routes feature-flags renvoient toujours le même format JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRqH22b6p1uoCiB86xratQ)_