### PR TITLE
perf: pagination + bornes sur queries DB non bornees (O.7)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -352,7 +352,7 @@
 | O.4 | Expansion E2E tests (couverture cible 80%) | Qualite | [x] |
 | O.5 | Optimisation taille GameState (separer gameLog) | Perf | [x] |
 | O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [x] |
-| O.7 | Optimiser queries DB (pagination, select) | Perf | [ ] |
+| O.7 | Optimiser queries DB (pagination, select) | Perf | [x] |
 | O.8 | Cosmetiques (logos equipe, generateur noms) | Engagement | [ ] |
 | O.9 | Features communautaires (match of the week, Discord) | Engagement | [ ] |
 | O.10 | Dashboard analytics personnel et global | Engagement | [ ] |

--- a/apps/server/src/routes/local-match.ts
+++ b/apps/server/src/routes/local-match.ts
@@ -26,6 +26,7 @@ import {
 } from "@bb/game-engine";
 import { randomBytes } from "crypto";
 import { hasRole } from "../utils/roles";
+import { parsePagination, buildApiMeta } from "../utils/pagination";
 import { persistMatchSPP } from "../services/spp-tracking";
 import { persistPlayerDeaths } from "../services/player-death";
 import { persistPermanentInjuries } from "../services/permanent-injuries";
@@ -125,54 +126,62 @@ router.get("/", authUser, validateQuery(localMatchListQuerySchema), async (req: 
       }
     }
     
-    const localMatches = await prisma.localMatch.findMany({
-      where: whereClause,
-      include: {
-        creator: {
-          select: {
-            id: true,
-            coachName: true,
-            email: true,
+    const { limit, offset } = parsePagination(
+      req.query as Record<string, unknown>,
+    );
+    const [localMatches, total] = await Promise.all([
+      prisma.localMatch.findMany({
+        where: whereClause,
+        include: {
+          creator: {
+            select: {
+              id: true,
+              coachName: true,
+              email: true,
+            },
           },
-        },
-        teamA: {
-          select: {
-            id: true,
-            name: true,
-            roster: true,
-            owner: {
-              select: {
-                id: true,
-                coachName: true,
+          teamA: {
+            select: {
+              id: true,
+              name: true,
+              roster: true,
+              owner: {
+                select: {
+                  id: true,
+                  coachName: true,
+                },
               },
             },
           },
-        },
-        teamB: {
-          select: {
-            id: true,
-            name: true,
-            roster: true,
-            owner: {
-              select: {
-                id: true,
-                coachName: true,
+          teamB: {
+            select: {
+              id: true,
+              name: true,
+              roster: true,
+              owner: {
+                select: {
+                  id: true,
+                  coachName: true,
+                },
               },
             },
           },
-        },
-        cup: {
-          select: {
-            id: true,
-            name: true,
-            status: true,
+          cup: {
+            select: {
+              id: true,
+              name: true,
+              status: true,
+            },
           },
         },
-      },
-      orderBy: { createdAt: "desc" },
-    });
-    
-    res.json({ localMatches });
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+      }),
+      prisma.localMatch.count({ where: whereClause }),
+    ]);
+
+    res.json({ localMatches, meta: buildApiMeta({ total, limit, offset }) });
   } catch (e: any) {
     console.error("Erreur lors de la récupération des parties offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
@@ -1204,16 +1213,28 @@ router.get("/:id/actions", authUser, async (req: AuthenticatedRequest, res) => {
       return res.status(403).json({ error: "Accès non autorisé" });
     }
     
-    const actions = await prisma.localMatchAction.findMany({
-      where: { matchId: req.params.id },
-      orderBy: [
-        { half: "asc" },
-        { turn: "asc" },
-        { createdAt: "asc" },
-      ],
-    });
-    
-    res.json({ actions });
+    // Pagination : un match peut accumuler des centaines d'actions, on borne
+    // les retours pour éviter une réponse trop lourde (max 1000, défaut 500).
+    const { limit, offset } = parsePagination(
+      req.query as Record<string, unknown>,
+      { defaultLimit: 500, maxLimit: 1000 },
+    );
+    const where = { matchId: req.params.id };
+    const [actions, total] = await Promise.all([
+      prisma.localMatchAction.findMany({
+        where,
+        orderBy: [
+          { half: "asc" },
+          { turn: "asc" },
+          { createdAt: "asc" },
+        ],
+        take: limit,
+        skip: offset,
+      }),
+      prisma.localMatchAction.count({ where }),
+    ]);
+
+    res.json({ actions, meta: buildApiMeta({ total, limit, offset }) });
   } catch (e: any) {
     console.error("Erreur lors de la récupération des actions:", e);
     return res.status(500).json({ error: "Erreur serveur" });

--- a/apps/server/src/routes/team.ts
+++ b/apps/server/src/routes/team.ts
@@ -30,6 +30,7 @@ import {
 } from "../utils/star-player-validation";
 import { getRosterFromDb } from "../utils/roster-helpers";
 import { resolveRuleset, isValidRuleset } from "../utils/ruleset-helpers";
+import { parsePagination, buildApiMeta } from "../utils/pagination";
 import { validate } from "../middleware/validate";
 import {
   createFromRosterSchema,
@@ -232,14 +233,24 @@ router.get("/mine", authUser, async (req: AuthenticatedRequest, res) => {
   const filterRuleset = isValidRuleset(requestedRuleset)
     ? (requestedRuleset as Ruleset)
     : undefined;
-  const teams = await prisma.team.findMany({
-    where: {
-      ownerId: req.user!.id,
-      ...(filterRuleset && { ruleset: filterRuleset }),
-    },
-    select: { id: true, name: true, roster: true, ruleset: true, createdAt: true, currentValue: true },
-  });
-  res.json({ teams });
+  const { limit, offset } = parsePagination(
+    req.query as Record<string, unknown>,
+  );
+  const where = {
+    ownerId: req.user!.id,
+    ...(filterRuleset && { ruleset: filterRuleset }),
+  };
+  const [teams, total] = await Promise.all([
+    prisma.team.findMany({
+      where,
+      select: { id: true, name: true, roster: true, ruleset: true, createdAt: true, currentValue: true },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.team.count({ where }),
+  ]);
+  res.json({ teams, meta: buildApiMeta({ total, limit, offset }) });
 });
 
 router.get("/rosters/:id", authUser, async (req: AuthenticatedRequest, res) => {
@@ -345,7 +356,8 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
     include: { match: true },
   });
 
-  // Statistiques de matchs locaux pour cette équipe
+  // Statistiques de matchs locaux pour cette équipe — bornées pour éviter
+  // une croissance illimitée (cap à 500 derniers matchs, agrégats locaux).
   const localMatches = await prisma.localMatch.findMany({
     where: {
       OR: [{ teamAId: team.id }, { teamBId: team.id }],
@@ -358,6 +370,8 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
       scoreTeamA: true,
       scoreTeamB: true,
     },
+    orderBy: { createdAt: "desc" },
+    take: 500,
   });
 
   let pending = 0;

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -1,16 +1,24 @@
 import { Router } from "express";
 import { prisma } from "../prisma";
 import { authUser, AuthenticatedRequest } from "../middleware/authUser";
+import { parsePagination, buildApiMeta } from "../utils/pagination";
 
 const router = Router();
 
 router.get("/matches", authUser, async (req: AuthenticatedRequest, res) => {
-  const matches = await prisma.match.findMany({
-    where: { players: { some: { id: req.user!.id } } },
-    select: { id: true, status: true, seed: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  res.json({ matches });
+  const { limit, offset } = parsePagination(req.query as Record<string, unknown>);
+  const where = { players: { some: { id: req.user!.id } } };
+  const [matches, total] = await Promise.all([
+    prisma.match.findMany({
+      where,
+      select: { id: true, status: true, seed: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+    }),
+    prisma.match.count({ where }),
+  ]);
+  res.json({ matches, meta: buildApiMeta({ total, limit, offset }) });
 });
 
 export default router;

--- a/apps/server/src/utils/pagination.test.ts
+++ b/apps/server/src/utils/pagination.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests pour `parsePagination` (tâche O.7 — Sprint 22+).
+ *
+ * Vérifie le parsing des paramètres `limit`, `offset`, `page` depuis
+ * `req.query` avec valeurs par défaut, plafonds, et calculs cohérents
+ * (skip/page/limit pour Prisma + meta `ApiMeta`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { parsePagination, buildApiMeta } from "./pagination";
+
+describe("parsePagination", () => {
+  it("retourne les valeurs par défaut quand la query est vide", () => {
+    const r = parsePagination({});
+    expect(r.limit).toBe(50);
+    expect(r.offset).toBe(0);
+    expect(r.page).toBe(1);
+  });
+
+  it("respecte une `limit` valide", () => {
+    const r = parsePagination({ limit: "25" });
+    expect(r.limit).toBe(25);
+  });
+
+  it("plafonne `limit` au max (par défaut 100)", () => {
+    const r = parsePagination({ limit: "5000" });
+    expect(r.limit).toBe(100);
+  });
+
+  it("respecte un `maxLimit` personnalisé", () => {
+    const r = parsePagination({ limit: "750" }, { maxLimit: 500 });
+    expect(r.limit).toBe(500);
+  });
+
+  it("rejette les `limit` invalides et applique le défaut", () => {
+    expect(parsePagination({ limit: "abc" }).limit).toBe(50);
+    expect(parsePagination({ limit: "-3" }).limit).toBe(50);
+    expect(parsePagination({ limit: "0" }).limit).toBe(50);
+  });
+
+  it("respecte un `defaultLimit` personnalisé", () => {
+    const r = parsePagination({}, { defaultLimit: 20 });
+    expect(r.limit).toBe(20);
+  });
+
+  it("respecte un `offset` valide", () => {
+    const r = parsePagination({ offset: "30" });
+    expect(r.offset).toBe(30);
+  });
+
+  it("interprète `page` (1-based) en offset", () => {
+    const r = parsePagination({ page: "3", limit: "20" });
+    expect(r.offset).toBe(40);
+    expect(r.page).toBe(3);
+  });
+
+  it("priorise `offset` sur `page` quand les deux sont fournis", () => {
+    const r = parsePagination({ offset: "15", page: "9", limit: "10" });
+    expect(r.offset).toBe(15);
+  });
+
+  it("clamp `offset` négatif à 0", () => {
+    const r = parsePagination({ offset: "-50" });
+    expect(r.offset).toBe(0);
+  });
+
+  it("clamp `page` < 1 à 1", () => {
+    const r = parsePagination({ page: "0", limit: "10" });
+    expect(r.page).toBe(1);
+    expect(r.offset).toBe(0);
+  });
+
+  it("ignore les valeurs non-string (Express multi-values)", () => {
+    const r = parsePagination({ limit: ["20", "30"] as unknown as string });
+    expect(r.limit).toBe(50);
+  });
+});
+
+describe("buildApiMeta", () => {
+  it("calcule la `page` à partir de `offset` et `limit`", () => {
+    expect(buildApiMeta({ total: 250, limit: 50, offset: 100 })).toEqual({
+      total: 250,
+      limit: 50,
+      page: 3,
+    });
+  });
+
+  it("normalise la première page (offset 0)", () => {
+    expect(buildApiMeta({ total: 7, limit: 10, offset: 0 })).toEqual({
+      total: 7,
+      limit: 10,
+      page: 1,
+    });
+  });
+
+  it("ne descend jamais sous la page 1", () => {
+    expect(buildApiMeta({ total: 5, limit: 10, offset: -10 }).page).toBe(1);
+  });
+
+  it("fonctionne pour total = 0", () => {
+    expect(buildApiMeta({ total: 0, limit: 50, offset: 0 })).toEqual({
+      total: 0,
+      limit: 50,
+      page: 1,
+    });
+  });
+});

--- a/apps/server/src/utils/pagination.ts
+++ b/apps/server/src/utils/pagination.ts
@@ -1,0 +1,87 @@
+/**
+ * Helper de pagination pour les routes Express qui interrogent Prisma
+ * (tâche O.7 — Sprint 22+).
+ *
+ * Parse `limit`, `offset` et `page` depuis `req.query` et renvoie
+ * `{ limit, offset, page }` prêts à être passés à `findMany({ take, skip })`.
+ *
+ * Règles :
+ *   - `limit` est borné entre 1 et `maxLimit` (défaut 100), défaut 50.
+ *   - `offset` ≥ 0, défaut 0. Prioritaire sur `page` si les deux sont fournis.
+ *   - `page` ≥ 1, converti en `offset = (page - 1) * limit`.
+ *   - Toute valeur invalide retombe sur le défaut (parse-friendly).
+ */
+
+const DEFAULT_LIMIT = 50;
+const DEFAULT_MAX_LIMIT = 100;
+
+export interface PaginationOptions {
+  defaultLimit?: number;
+  maxLimit?: number;
+}
+
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+  page: number;
+}
+
+function parsePositiveInt(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+function parseNonNegativeInt(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * Parse les paramètres de pagination depuis une query Express.
+ *
+ * @param query  `req.query` (record de strings, possiblement undefined)
+ * @param opts   `defaultLimit` (def. 50) et `maxLimit` (def. 100)
+ */
+export function parsePagination(
+  query: Record<string, unknown>,
+  opts: PaginationOptions = {},
+): PaginationParams {
+  const defaultLimit = opts.defaultLimit ?? DEFAULT_LIMIT;
+  const maxLimit = opts.maxLimit ?? DEFAULT_MAX_LIMIT;
+
+  const rawLimit = parsePositiveInt(query.limit);
+  const limit = rawLimit === null ? defaultLimit : Math.min(rawLimit, maxLimit);
+
+  const rawOffset = parseNonNegativeInt(query.offset);
+  if (rawOffset !== null) {
+    const offset = rawOffset;
+    const page = Math.max(1, Math.floor(offset / limit) + 1);
+    return { limit, offset, page };
+  }
+
+  const rawPage = parsePositiveInt(query.page);
+  const page = rawPage ?? 1;
+  const offset = (page - 1) * limit;
+  return { limit, offset, page };
+}
+
+/**
+ * Construit une `ApiMeta` (total + page + limit) à partir d'un total
+ * connu et des paramètres de pagination.
+ */
+export function buildApiMeta({
+  total,
+  limit,
+  offset,
+}: {
+  total: number;
+  limit: number;
+  offset: number;
+}): { total: number; limit: number; page: number } {
+  const page = Math.max(1, Math.floor(Math.max(0, offset) / Math.max(1, limit)) + 1);
+  return { total, limit, page };
+}


### PR DESCRIPTION
## Resume

Plusieurs routes Express lisaient des collections potentiellement illimitees sans `take`/`skip`, ce qui degrade les temps de reponse a mesure que la base grossit (matchs, equipes, actions de match local). Cette PR introduit un helper de pagination reutilisable et l'applique aux routes user-facing les plus exposees.

### Changements
- **Nouveau helper** `apps/server/src/utils/pagination.ts` :
  - `parsePagination(query, { defaultLimit, maxLimit })` : parse `limit`/`offset`/`page` depuis `req.query` avec defauts (50) et plafonds (100) configurables.
  - `buildApiMeta({ total, limit, offset })` : produit l'objet `meta` compatible avec `ApiMeta` (O.6).
  - 16 tests unitaires couvrant defauts, plafonds, valeurs invalides, priorite offset > page, clamps.
- **Routes paginees** (auparavant `findMany` non borne) :
  - `GET /users/matches` (apps/server/src/routes/user.ts)
  - `GET /team/mine` (apps/server/src/routes/team.ts)
  - `GET /local-match` listing (apps/server/src/routes/local-match.ts)
  - `GET /local-match/:id/actions` (defaut 500, max 1000 — un match peut accumuler des centaines d'actions)
- **Cap supplementaire** : `GET /team/:id` borne `localMatches` aux 500 derniers (agregats locaux).

### Retrocompatibilite
Les reponses conservent leur cle racine (`matches`, `teams`, `localMatches`, `actions`) ; un champ `meta: { total, page, limit }` est simplement ajoute. Les frontends (`apps/web`, `apps/mobile`) qui destructurent ces cles continuent de fonctionner sans modification.

## Tache roadmap

Sprint 22+, tache **O.7 — Optimiser queries DB (pagination, select)**

## Plan de test

- [x] `pnpm --filter @bb/server test` (684/684 passent, dont 16 nouveaux sur `pagination.test.ts`)
- [x] `pnpm --filter @bb/server typecheck`
- [x] `pnpm -w typecheck` (4/4 packages : ui, server, web, game-engine)
- [ ] Verifier en staging que les frontends affichent toujours la liste de matchs/equipes/actions avec la nouvelle pagination
- [ ] Verifier que le cap `take: 500` sur `/team/:id` n'altere pas les statistiques affichees (les agregats utilisaient deja toute la collection mais 500 matchs locaux par equipe est largement au-dessus de l'usage reel)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_