### PR TITLE
feat: generateur de noms d'equipe par roster (O.8a)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -353,7 +353,8 @@
 | O.5 | Optimisation taille GameState (separer gameLog) | Perf | [x] |
 | O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [x] |
 | O.7 | Optimiser queries DB (pagination, select) | Perf | [x] |
-| O.8 | Cosmetiques (logos equipe, generateur noms) | Engagement | [ ] |
+| O.8a | Generateur de noms d'equipe par roster (service + endpoint) | Engagement | [x] |
+| O.8b | Cosmetiques visuels (logos equipe, assets graphiques) | Engagement | [ ] |
 | O.9 | Features communautaires (match of the week, Discord) | Engagement | [ ] |
 | O.10 | Dashboard analytics personnel et global | Engagement | [ ] |
 

--- a/apps/server/src/routes/team.ts
+++ b/apps/server/src/routes/team.ts
@@ -31,6 +31,7 @@ import {
 import { getRosterFromDb } from "../utils/roster-helpers";
 import { resolveRuleset, isValidRuleset } from "../utils/ruleset-helpers";
 import { parsePagination, buildApiMeta } from "../utils/pagination";
+import { generateTeamName } from "../services/team-name-generator";
 import { validate } from "../middleware/validate";
 import {
   createFromRosterSchema,
@@ -206,6 +207,21 @@ function rosterTemplates(roster: AllowedRoster) {
     // Kroxigor optionnel (non inclus par défaut)
   ];
 }
+
+// O.8a — Générateur de noms d'équipe par roster.
+// Public (pas d'auth) : aide à la création d'équipe, sans contenu sensible.
+router.get("/name-generator", (req, res) => {
+  const roster =
+    typeof req.query.roster === "string" && req.query.roster.length > 0
+      ? req.query.roster
+      : "generic";
+  const seed =
+    typeof req.query.seed === "string" && req.query.seed.length > 0
+      ? req.query.seed
+      : undefined;
+  const name = generateTeamName(roster, seed ? { seed } : {});
+  res.json({ name, roster });
+});
 
 router.get("/available", authUser, async (req: AuthenticatedRequest, res) => {
   const requestedRuleset = req.query.ruleset as string | undefined;

--- a/apps/server/src/services/team-name-generator.test.ts
+++ b/apps/server/src/services/team-name-generator.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests pour `generateTeamName` (tâche O.8a — Sprint 22+).
+ *
+ * Le générateur doit :
+ *  - produire une chaîne non vide pour chaque roster reconnu
+ *  - être déterministe à seed constant (testabilité + reproductibilité)
+ *  - utiliser des banques de mots cohérentes avec le thème (skaven →
+ *    vocabulaire vermine, dwarf → vocabulaire forge, etc.)
+ *  - retomber sur un fallback générique pour un roster inconnu plutôt que
+ *    de jeter, pour éviter de casser un appel UI sur un slug récent.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateTeamName,
+  TEAM_NAME_FAMILIES,
+  rosterToFamily,
+} from "./team-name-generator";
+
+describe("generateTeamName", () => {
+  it("retourne une chaîne non vide pour chaque roster supporté", () => {
+    const rosters = [
+      "skaven",
+      "lizardmen",
+      "dwarf",
+      "wood_elf",
+      "dark_elf",
+      "high_elf",
+      "elven_union",
+      "human",
+      "imperial_nobility",
+      "orc",
+      "black_orc",
+      "goblin",
+      "snotling",
+      "halfling",
+      "ogre",
+      "chaos_chosen",
+      "chaos_renegade",
+      "chaos_dwarf",
+      "khorne",
+      "nurgle",
+      "undead",
+      "necromantic_horror",
+      "vampire",
+      "tomb_kings",
+      "amazon",
+      "norse",
+      "underworld",
+      "slann",
+      "gnome",
+      "old_world_alliance",
+    ];
+    for (const roster of rosters) {
+      const name = generateTeamName(roster, { seed: "test-seed-1" });
+      expect(name.length).toBeGreaterThan(0);
+      expect(name).not.toMatch(/undefined|null/);
+    }
+  });
+
+  it("est déterministe pour une seed donnée", () => {
+    const a = generateTeamName("skaven", { seed: "abc" });
+    const b = generateTeamName("skaven", { seed: "abc" });
+    expect(a).toBe(b);
+  });
+
+  it("produit des résultats différents pour des seeds différentes (en général)", () => {
+    const seeds = ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"];
+    const names = seeds.map((s) => generateTeamName("skaven", { seed: s }));
+    const unique = new Set(names);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it("utilise un vocabulaire skaven cohérent", () => {
+    const skavenWords = TEAM_NAME_FAMILIES.skaven.suffixes.join(" ").toLowerCase();
+    expect(skavenWords).toMatch(/rat|vermin|plague|skitter|warp/);
+  });
+
+  it("utilise un vocabulaire dwarf cohérent", () => {
+    const dwarfWords = TEAM_NAME_FAMILIES.dwarf.suffixes.join(" ").toLowerCase();
+    expect(dwarfWords).toMatch(/forge|axe|hammer|beard|hold|stone/);
+  });
+
+  it("retombe sur la famille générique pour un roster inconnu", () => {
+    const name = generateTeamName("unknown_roster", { seed: "x" });
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it("permet d'injecter un RNG personnalisé (testabilité avancée)", () => {
+    const rng = () => 0; // toujours premier élément
+    const name = generateTeamName("skaven", { rng });
+    const firstPrefix = TEAM_NAME_FAMILIES.skaven.prefixes[0];
+    const firstSuffix = TEAM_NAME_FAMILIES.skaven.suffixes[0];
+    expect(name).toBe(`${firstPrefix} ${firstSuffix}`);
+  });
+
+  it("utilise rosterToFamily pour mapper un roster vers sa famille", () => {
+    expect(rosterToFamily("skaven")).toBe("skaven");
+    expect(rosterToFamily("imperial_nobility")).toBe("human");
+    expect(rosterToFamily("black_orc")).toBe("orc");
+    expect(rosterToFamily("necromantic_horror")).toBe("undead");
+    expect(rosterToFamily("khorne")).toBe("chaos");
+    expect(rosterToFamily("unknown_roster")).toBe("generic");
+  });
+
+  it("génère un nom au format `<Préfixe> <Suffixe>` (Title Case)", () => {
+    const name = generateTeamName("skaven", { seed: "fmt" });
+    expect(name).toMatch(/^[A-Z][\p{L}'-]*( [A-Z][\p{L}'-]*)+$/u);
+  });
+});

--- a/apps/server/src/services/team-name-generator.ts
+++ b/apps/server/src/services/team-name-generator.ts
@@ -1,0 +1,473 @@
+/**
+ * Générateur de noms d'équipe Blood Bowl par roster (tâche O.8a — Sprint 22+).
+ *
+ * Approche : chaque roster est mappé sur une "famille" thématique
+ * (ex: imperial_nobility → human, black_orc → orc) qui possède une banque
+ * de préfixes (adjectifs / lieux) et de suffixes (substantifs). Le nom
+ * généré est `${préfixe} ${suffixe}`.
+ *
+ * Les choix sont tirés via un RNG :
+ *   - injectable (`opts.rng`) pour les tests déterministes
+ *   - sinon dérivé d'une seed (`opts.seed`, défaut : aléatoire) via
+ *     `makeRNG` du game-engine — jamais `Math.random()` en code métier.
+ *
+ * Pour un roster inconnu, on retombe sur la famille `generic` (vocabulaire
+ * neutre fantasy) plutôt que de jeter — utile si un nouveau slug arrive.
+ */
+
+import { randomBytes } from "crypto";
+import { makeRNG } from "@bb/game-engine";
+
+export interface NameFamily {
+  prefixes: string[];
+  suffixes: string[];
+}
+
+/** Banques de mots par famille thématique. */
+export const TEAM_NAME_FAMILIES: Record<string, NameFamily> = {
+  skaven: {
+    prefixes: [
+      "Skavenblight",
+      "Clan Pestilens",
+      "Hellpit",
+      "Underempire",
+      "Warp",
+      "Pestilent",
+      "Plague",
+      "Verminous",
+      "Sneaky",
+      "Deathmaster",
+    ],
+    suffixes: [
+      "Rats",
+      "Vermin",
+      "Skitters",
+      "Plague Bringers",
+      "Warpstone Runners",
+      "Gutter Stalkers",
+      "Stormvermin",
+      "Pestilens",
+      "Nightrunners",
+      "Tail-Twitchers",
+    ],
+  },
+
+  lizardmen: {
+    prefixes: [
+      "Hexoatl",
+      "Itza",
+      "Tlaxtlan",
+      "Xlanhuapec",
+      "Sotek",
+      "Spawning",
+      "Sun-Bathed",
+      "Old Ones",
+      "Saurus",
+      "Chameleon",
+    ],
+    suffixes: [
+      "Saurus",
+      "Skinks",
+      "Kroxigors",
+      "Coatls",
+      "Cold Ones",
+      "Temple Guards",
+      "Predators",
+      "Chameleons",
+      "Sun-Heralds",
+      "Spawnings",
+    ],
+  },
+
+  dwarf: {
+    prefixes: [
+      "Karak",
+      "Zhufbar",
+      "Karaz-a-Karak",
+      "Kraka",
+      "Iron",
+      "Stout",
+      "Grumbling",
+      "Throng of",
+      "Beard-Braiders",
+      "Stonebound",
+    ],
+    suffixes: [
+      "Forgehammers",
+      "Axe-Wielders",
+      "Stonebeards",
+      "Hold-Defenders",
+      "Anvil-Smiths",
+      "Slayers",
+      "Longbeards",
+      "Ironbreakers",
+      "Deathrollers",
+      "Gromril Knights",
+    ],
+  },
+
+  elf: {
+    prefixes: [
+      "Athel",
+      "Avelorn",
+      "Naggaroth",
+      "Caledor",
+      "Loren",
+      "Eternal",
+      "Moonlit",
+      "Silver",
+      "Twilight",
+      "Starwood",
+    ],
+    suffixes: [
+      "Wardancers",
+      "Swiftarrows",
+      "Catchers",
+      "Spellweavers",
+      "Treesingers",
+      "Phoenixes",
+      "Silver Helms",
+      "Shadow Blades",
+      "Druchii",
+      "Asur",
+    ],
+  },
+
+  human: {
+    prefixes: [
+      "Reikland",
+      "Altdorf",
+      "Middenheim",
+      "Talabheim",
+      "Nuln",
+      "Empire",
+      "Bretonnian",
+      "Marienburg",
+      "Ostland",
+      "Stirland",
+    ],
+    suffixes: [
+      "Reavers",
+      "Marauders",
+      "Hammers",
+      "Halberdiers",
+      "Crusaders",
+      "Gallants",
+      "Knights",
+      "Sentinels",
+      "Wardens",
+      "Stalwarts",
+    ],
+  },
+
+  orc: {
+    prefixes: [
+      "Da",
+      "Iron",
+      "Bloodied",
+      "Krushers",
+      "Black Crag",
+      "Red Eye",
+      "Bonebreaker",
+      "Skullsplitter",
+      "Choppa",
+      "Waaagh",
+    ],
+    suffixes: [
+      "Boyz",
+      "Krushas",
+      "Stompas",
+      "Choppas",
+      "Black Orcs",
+      "Big 'Uns",
+      "Brawlers",
+      "Skull-Smashers",
+      "Greenskins",
+      "Bonecrushers",
+    ],
+  },
+
+  goblin: {
+    prefixes: [
+      "Sneaky",
+      "Squig-Hopping",
+      "Gitz",
+      "Pointy-Hat",
+      "Bombardier",
+      "Fanatic",
+      "Nasty",
+      "Snotty",
+      "Looney",
+      "Twitchy",
+    ],
+    suffixes: [
+      "Gitz",
+      "Squig Riders",
+      "Looneys",
+      "Pointy Hats",
+      "Bombers",
+      "Fanatics",
+      "Sneaks",
+      "Backstabbers",
+      "Hop-Alongs",
+      "Bandits",
+    ],
+  },
+
+  ogre: {
+    prefixes: [
+      "Iron Guts",
+      "Maneater",
+      "Bull",
+      "Big",
+      "Gut",
+      "Tyrant's",
+      "Mountain",
+      "Smashing",
+      "Bone Breaker",
+      "Mawpit",
+    ],
+    suffixes: [
+      "Maneaters",
+      "Bulls",
+      "Tyrants",
+      "Gutbreakers",
+      "Bonebreakers",
+      "Crushers",
+      "Mountains",
+      "Smashers",
+      "Mawmasters",
+      "Glutters",
+    ],
+  },
+
+  halfling: {
+    prefixes: [
+      "Mootland",
+      "Pie-Eating",
+      "Hayfoot",
+      "Burrow",
+      "Cabbage",
+      "Brewmaster's",
+      "Hill-Folk",
+      "Greenwood",
+      "Tubby",
+      "Stout",
+    ],
+    suffixes: [
+      "Hotpots",
+      "Pie-Slingers",
+      "Tree-Climbers",
+      "Hayfooters",
+      "Burrowers",
+      "Cabbage Tossers",
+      "Brewmasters",
+      "Mootlanders",
+      "Hill-Folk",
+      "Tubbies",
+    ],
+  },
+
+  chaos: {
+    prefixes: [
+      "Doombringer",
+      "Skull-Crusher",
+      "Eternal",
+      "Chaos",
+      "Warp-Touched",
+      "Dark Pact",
+      "Bloodbound",
+      "Slaaneshi",
+      "Tzeentchian",
+      "Nurglesque",
+    ],
+    suffixes: [
+      "Marauders",
+      "Warriors",
+      "Berserkers",
+      "Daemonhost",
+      "Doombringers",
+      "Skull-Crushers",
+      "Renegades",
+      "Champions",
+      "Forsaken",
+      "Damned",
+    ],
+  },
+
+  undead: {
+    prefixes: [
+      "Sylvanian",
+      "Crypt",
+      "Tomb",
+      "Drakwald",
+      "Mortis",
+      "Necropolis",
+      "Cursed",
+      "Eternal",
+      "Bone",
+      "Shadowed",
+    ],
+    suffixes: [
+      "Wights",
+      "Wraiths",
+      "Mummies",
+      "Ghouls",
+      "Crypt Horrors",
+      "Skeletons",
+      "Shamblers",
+      "Banshees",
+      "Necromancers",
+      "Risen Dead",
+    ],
+  },
+
+  amazon: {
+    prefixes: [
+      "Lustrian",
+      "Jungle",
+      "Coatl",
+      "Sun-Blessed",
+      "Vine-Striders",
+      "Amazon",
+      "Quetzl",
+      "Itza",
+      "Kroxa",
+      "Spear-Throwers",
+    ],
+    suffixes: [
+      "Huntresses",
+      "Spear-Sisters",
+      "Vine-Striders",
+      "Coatl Riders",
+      "Sun-Blessed",
+      "Catchers",
+      "Wardens",
+      "Predators",
+      "Jungle Stalkers",
+      "Eagle Warriors",
+    ],
+  },
+
+  norse: {
+    prefixes: [
+      "Norscan",
+      "Frostbeard",
+      "Ulfsark",
+      "Bjornling",
+      "Stormbreaker",
+      "Sea-Wolf",
+      "Wolfship",
+      "Iron Reaver",
+      "Frozen Crag",
+      "Snowbound",
+    ],
+    suffixes: [
+      "Bulldozers",
+      "Berserkers",
+      "Reavers",
+      "Wolves",
+      "Sea-Raiders",
+      "Frostbeards",
+      "Ulfwerenar",
+      "Marauders",
+      "Snow-Strikers",
+      "Stormcallers",
+    ],
+  },
+
+  generic: {
+    prefixes: [
+      "Iron",
+      "Bloodied",
+      "Eternal",
+      "Stalwart",
+      "Wild",
+      "Burning",
+      "Stormcalled",
+      "Thunder",
+      "Black",
+      "Crimson",
+    ],
+    suffixes: [
+      "Champions",
+      "Wardens",
+      "Reavers",
+      "Marauders",
+      "Crushers",
+      "Thunderers",
+      "Stalwarts",
+      "Predators",
+      "Brawlers",
+      "Stormbringers",
+    ],
+  },
+};
+
+/** Mapping roster slug → famille thématique. */
+const ROSTER_FAMILY_MAP: Record<string, string> = {
+  skaven: "skaven",
+  underworld: "skaven",
+  lizardmen: "lizardmen",
+  slann: "lizardmen",
+  dwarf: "dwarf",
+  chaos_dwarf: "dwarf",
+  wood_elf: "elf",
+  dark_elf: "elf",
+  high_elf: "elf",
+  elven_union: "elf",
+  human: "human",
+  imperial_nobility: "human",
+  old_world_alliance: "human",
+  bretonnian: "human",
+  orc: "orc",
+  black_orc: "orc",
+  goblin: "goblin",
+  snotling: "goblin",
+  halfling: "halfling",
+  ogre: "ogre",
+  chaos_chosen: "chaos",
+  chaos_renegade: "chaos",
+  khorne: "chaos",
+  nurgle: "chaos",
+  undead: "undead",
+  necromantic_horror: "undead",
+  vampire: "undead",
+  tomb_kings: "undead",
+  amazon: "amazon",
+  norse: "norse",
+  gnome: "halfling",
+};
+
+export function rosterToFamily(roster: string): string {
+  return ROSTER_FAMILY_MAP[roster] ?? "generic";
+}
+
+export interface GenerateTeamNameOptions {
+  /** RNG injectable (priorité sur `seed` ; pratique pour tests). */
+  rng?: () => number;
+  /** Seed déterministe ; ignorée si `rng` est fourni. */
+  seed?: string;
+}
+
+function pick<T>(items: readonly T[], rng: () => number): T {
+  if (items.length === 0) {
+    throw new Error("pick: items must be non-empty");
+  }
+  const idx = Math.floor(rng() * items.length);
+  return items[Math.min(idx, items.length - 1)];
+}
+
+export function generateTeamName(
+  roster: string,
+  opts: GenerateTeamNameOptions = {},
+): string {
+  const family = rosterToFamily(roster);
+  const bank = TEAM_NAME_FAMILIES[family] ?? TEAM_NAME_FAMILIES.generic;
+  const rng =
+    opts.rng ??
+    makeRNG(opts.seed ?? `${roster}-${randomBytes(8).toString("hex")}`);
+  const prefix = pick(bank.prefixes, rng);
+  const suffix = pick(bank.suffixes, rng);
+  return `${prefix} ${suffix}`;
+}


### PR DESCRIPTION
## Resume

Premiere brique de **O.8 (Cosmetiques)** : un generateur de noms d'equipe Blood Bowl par roster. La tache d'origine couvrait deux livrables tres differents (logos d'equipe + generateur de noms) ; je l'ai decoupee en deux pour livrer la partie code immediatement et garder les assets graphiques (O.8b) en attente.

### Changements
- **Service** `apps/server/src/services/team-name-generator.ts` :
  - 13 familles thematiques de noms (skaven, lizardmen, dwarf, elf, human, orc, goblin, ogre, halfling, chaos, undead, amazon, norse) + fallback `generic`
  - Mapping `ROSTER_FAMILY_MAP` couvrant les 30 rosters supportes (ex: `imperial_nobility -> human`, `black_orc -> orc`, `vampire -> undead`, `slann -> lizardmen`)
  - API : `generateTeamName(roster, { rng?, seed? })` -> string `<Prefixe> <Suffixe>`
  - RNG : `rng` injectable pour tests deterministes, sinon seed via `crypto.randomBytes` -> `makeRNG` du game-engine. Jamais `Math.random()`.
- **Route** `GET /team/name-generator?roster=skaven&seed=optional` : public (pas d'auth, aide a la creation), retourne `{ name, roster }`.
- **TODO.md** : split de O.8 en O.8a (livree, cochee) + O.8b (logos, en attente).

### Exemples generes
- `skaven` : "Clan Pestilens Stormvermin", "Warp Plague Bringers"
- `dwarf` : "Karaz-a-Karak Forgehammers", "Iron Slayers"
- `lizardmen` : "Hexoatl Saurus", "Sotek Sun-Heralds"
- `chaos_chosen` : "Doombringer Marauders", "Bloodbound Berserkers"

## Tache roadmap

Sprint 22+, tache **O.8a — Generateur de noms d'equipe par roster** (sous-tache de O.8).

## Plan de test

- [x] `pnpm --filter @bb/server test` (693/693, dont 9 nouveaux sur `team-name-generator.test.ts`)
- [x] `pnpm --filter @bb/server typecheck`
- [x] Determinisme verifie : meme seed -> meme nom
- [x] Format `<Prefixe> <Suffixe>` Title Case verifie
- [ ] Brancher cote frontend (proposition "Suggerer un nom" sur l'ecran de creation d'equipe) — hors scope cette PR, suit dans une PR UI dediee


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_