### PR TITLE
feat(seo): JSON-LD SportsTeam + canonical/hreflang sur /teams/[slug] (Q.10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -381,7 +381,7 @@
 | Q.7 | Regles explicites pour 20 crawlers IA (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended, CCBot...) | GEO | [x] |
 | Q.8 | `sameAs` + `knowsAbout` + `dateModified` dans JSON-LD (citabilite LLM) | GEO | [x] |
 | Q.9 | `manifest.json` enrichi (shortcuts PWA : equipes, rosters, stars) | SEO | [x] |
-| Q.10 | Metadata + JSON-LD `SportsTeam` dynamique sur `/teams/[slug]` (31 pages) | SEO | [ ] |
+| Q.10 | Metadata + JSON-LD `SportsTeam` dynamique sur `/teams/[slug]` (31 pages) | SEO | [x] |
 | Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [ ] |
 | Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [ ] |
 | Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [ ] |

--- a/apps/web/app/teams/[slug]/TeamStructuredData.tsx
+++ b/apps/web/app/teams/[slug]/TeamStructuredData.tsx
@@ -1,0 +1,22 @@
+import {
+  buildTeamSchema,
+  type BuildTeamSchemaInput,
+} from "./team-structured-data";
+
+/**
+ * Composant serveur emettant le JSON-LD SportsTeam + BreadcrumbList
+ * pour la page detail d'une equipe (Q.10 — Sprint 23).
+ *
+ * Pas de "use client" : on rend une simple balise <script> dans le DOM
+ * statique pour que les crawlers SEO et LLM aspirent les donnees sans
+ * executer de JS.
+ */
+export default function TeamStructuredData(props: BuildTeamSchemaInput) {
+  const data = buildTeamSchema(props);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/apps/web/app/teams/[slug]/layout.tsx
+++ b/apps/web/app/teams/[slug]/layout.tsx
@@ -35,6 +35,14 @@ export async function generateMetadata({ params }: { params: { slug: string } })
         'Fantasy Football',
         'Nuffle Arena',
       ],
+      alternates: {
+        canonical: `${BASE_URL}/teams/${slug}`,
+        languages: {
+          'fr-FR': `${BASE_URL}/teams/${slug}`,
+          'en': `${BASE_URL}/teams/${slug}`,
+          'x-default': `${BASE_URL}/teams/${slug}`,
+        },
+      },
       openGraph: {
         title,
         description,

--- a/apps/web/app/teams/[slug]/page.tsx
+++ b/apps/web/app/teams/[slug]/page.tsx
@@ -2,6 +2,9 @@ import { notFound } from "next/navigation";
 import { DEFAULT_RULESET, type Ruleset } from "@bb/game-engine";
 import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
 import TeamDetailClient from "./TeamDetailClient";
+import TeamStructuredData from "./TeamStructuredData";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
 
 // ISR — roster definitions are reference data that rarely changes.
 export const revalidate = 3600;
@@ -41,11 +44,20 @@ export default async function TeamDetailPage({
   }
 
   return (
-    <TeamDetailClient
-      slug={params.slug}
-      selectedRuleset={selectedRuleset}
-      actualRuleset={payload.ruleset}
-      initialTeam={payload.roster}
-    />
+    <>
+      <TeamStructuredData
+        slug={params.slug}
+        roster={payload.roster}
+        ruleset={payload.ruleset}
+        baseUrl={SITE_URL}
+        lang="fr"
+      />
+      <TeamDetailClient
+        slug={params.slug}
+        selectedRuleset={selectedRuleset}
+        actualRuleset={payload.ruleset}
+        initialTeam={payload.roster}
+      />
+    </>
   );
 }

--- a/apps/web/app/teams/[slug]/team-structured-data.test.ts
+++ b/apps/web/app/teams/[slug]/team-structured-data.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests pour `buildTeamSchema` (Q.10 — Sprint 23).
+ *
+ * Helper pur qui produit le JSON-LD `SportsTeam` + `BreadcrumbList`
+ * pour la page `/teams/[slug]`. Doit etre :
+ *  - serializable JSON
+ *  - resilient aux donnees partielles (description absente, etc.)
+ *  - canonique (URL absolue, dateModified ISO 8601)
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildTeamSchema } from "./team-structured-data";
+
+const BASE_ROSTER = {
+  name: "Skavens",
+  budget: 1000,
+  tier: "I" as const,
+  naf: true,
+  descriptionFr:
+    "Les Skavens sont une race de rats humanoides agiles et rapides.",
+  descriptionEn: "Skaven are agile and fast humanoid rats.",
+  positions: [
+    {
+      slug: "skaven_lineman",
+      displayName: "Lineman",
+      cost: 50,
+      min: 0,
+      max: 16,
+      ma: 7,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 8,
+      skills: "",
+    },
+    {
+      slug: "skaven_thrower",
+      displayName: "Thrower",
+      cost: 80,
+      min: 0,
+      max: 2,
+      ma: 7,
+      st: 3,
+      ag: 3,
+      pa: 2,
+      av: 8,
+      skills: "pass,sure-hands",
+    },
+  ],
+};
+
+describe("buildTeamSchema", () => {
+  it("retourne un @graph contenant SportsTeam et BreadcrumbList", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(schema["@context"]).toBe("https://schema.org");
+    const graph = schema["@graph"] as Array<{ "@type": string }>;
+    expect(graph).toBeDefined();
+    const types = graph.map((n) => n["@type"]);
+    expect(types).toContain("SportsTeam");
+    expect(types).toContain("BreadcrumbList");
+  });
+
+  it("definit url, name et sport pour SportsTeam", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team.name).toBe("Skavens");
+    expect(team.url).toBe("https://nufflearena.fr/teams/skaven");
+    expect(team.sport).toBe("Blood Bowl");
+  });
+
+  it("genere un identifier @id stable", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team["@id"]).toBe(
+      "https://nufflearena.fr/teams/skaven#sportsteam",
+    );
+  });
+
+  it("preserve la description francaise quand lang=fr", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+      lang: "fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team.description).toContain("Skavens");
+  });
+
+  it("utilise la description anglaise quand lang=en", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+      lang: "en",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team.description).toContain("Skaven are agile");
+  });
+
+  it("retombe sur un fallback si la description est manquante", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: { ...BASE_ROSTER, descriptionFr: undefined, descriptionEn: undefined },
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team.description).toBeTypeOf("string");
+    expect((team.description as string).length).toBeGreaterThan(0);
+  });
+
+  it("inclut tier comme additionalProperty", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    const props = team.additionalProperty as Array<{
+      name: string;
+      value: string | number;
+    }>;
+    const tier = props.find((p) => p.name === "Tier");
+    expect(tier).toBeDefined();
+    expect(tier!.value).toBe("I");
+  });
+
+  it("inclut le budget en milliers de pieces d'or", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    const props = team.additionalProperty as Array<{
+      name: string;
+      value: string | number;
+    }>;
+    expect(props.find((p) => p.name === "Budget")).toBeDefined();
+  });
+
+  it("liste les positions comme `athlete` (Person)", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    const athletes = team.athlete as Array<{
+      "@type": string;
+      name: string;
+    }>;
+    expect(athletes.length).toBe(2);
+    expect(athletes[0]["@type"]).toBe("Person");
+    expect(athletes.map((a) => a.name)).toEqual(["Lineman", "Thrower"]);
+  });
+
+  it("breadcrumb : Accueil -> Equipes -> [equipe]", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const breadcrumb = (
+      schema["@graph"] as Array<Record<string, unknown>>
+    ).find((n) => n["@type"] === "BreadcrumbList")!;
+    const items = breadcrumb.itemListElement as Array<{
+      position: number;
+      name: string;
+      item: string;
+    }>;
+    expect(items.length).toBe(3);
+    expect(items[0]).toMatchObject({ position: 1, name: "Accueil" });
+    expect(items[1]).toMatchObject({ position: 2, name: "Equipes" });
+    expect(items[2].position).toBe(3);
+    expect(items[2].name).toBe("Skavens");
+  });
+
+  it("dateModified est au format ISO 8601 (date)", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const team = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "SportsTeam",
+    )!;
+    expect(team.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("le schema est entierement serializable JSON", () => {
+    const schema = buildTeamSchema({
+      slug: "skaven",
+      roster: BASE_ROSTER,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(() => JSON.stringify(schema)).not.toThrow();
+    const round = JSON.parse(JSON.stringify(schema));
+    expect(round["@graph"]).toBeDefined();
+  });
+});

--- a/apps/web/app/teams/[slug]/team-structured-data.ts
+++ b/apps/web/app/teams/[slug]/team-structured-data.ts
@@ -1,0 +1,184 @@
+/**
+ * Helper pur produisant le JSON-LD `SportsTeam` + `BreadcrumbList`
+ * pour la page detail d'une equipe (Q.10 — Sprint 23).
+ *
+ * Le helper est volontairement decouple du composant React pour rester
+ * testable sans dependance Next.js / DOM. Le composant React rendu cote
+ * serveur se contente d'envelopper le JSON dans une balise <script>.
+ *
+ * Citabilite LLM (GEO) : on enrichit avec
+ *   - alternateName (si dispo)
+ *   - additionalProperty (Tier, Budget, NAF, Ruleset)
+ *   - athlete[] = positions du roster (chacune comme Person + role)
+ *   - dateModified (signal de fraicheur)
+ *   - isPartOf -> Organization (chaine de confiance)
+ */
+
+const ORG_ID_FRAGMENT = "#organization";
+
+export type Lang = "fr" | "en";
+
+export interface TeamSchemaPosition {
+  slug: string;
+  displayName: string;
+  cost?: number;
+  ma?: number;
+  st?: number;
+  ag?: number;
+  pa?: number;
+  av?: number;
+}
+
+export interface TeamSchemaRoster {
+  name: string;
+  budget?: number;
+  tier?: string;
+  naf?: boolean;
+  descriptionFr?: string;
+  descriptionEn?: string;
+  positions: TeamSchemaPosition[];
+}
+
+export interface BuildTeamSchemaInput {
+  slug: string;
+  roster: TeamSchemaRoster;
+  ruleset: "season_2" | "season_3";
+  baseUrl: string;
+  lang?: Lang;
+  /** Override pour tests deterministes ; sinon ISO date du jour. */
+  now?: Date;
+}
+
+/** Fallback de description quand le roster n'en a pas. */
+function fallbackDescription(name: string, lang: Lang): string {
+  if (lang === "en") {
+    return `Discover the ${name} Blood Bowl roster: positions, costs, skills and tier information for tabletop play.`;
+  }
+  return `Decouvrez le roster Blood Bowl ${name} : positions, couts, competences et tier pour jouer sur table.`;
+}
+
+/** Convertit un tier en libelle lisible (Tier I -> "Tier I"). */
+function tierLabel(tier?: string): string {
+  return tier ? `Tier ${tier}` : "Tier inconnu";
+}
+
+/** Construit le JSON-LD SportsTeam + BreadcrumbList pour une page d'equipe. */
+export function buildTeamSchema(
+  input: BuildTeamSchemaInput,
+): Record<string, unknown> {
+  const lang: Lang = input.lang ?? "fr";
+  const url = `${input.baseUrl}/teams/${input.slug}`;
+  const orgId = `${input.baseUrl}${ORG_ID_FRAGMENT}`;
+  const dateModified = (input.now ?? new Date()).toISOString().split("T")[0];
+
+  const description =
+    (lang === "en" ? input.roster.descriptionEn : input.roster.descriptionFr) ??
+    input.roster.descriptionFr ??
+    input.roster.descriptionEn ??
+    fallbackDescription(input.roster.name, lang);
+
+  const additionalProperty: Array<{
+    "@type": "PropertyValue";
+    name: string;
+    value: string | number;
+  }> = [];
+
+  if (input.roster.tier) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Tier",
+      value: input.roster.tier,
+    });
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Tier Label",
+      value: tierLabel(input.roster.tier),
+    });
+  }
+  if (typeof input.roster.budget === "number") {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Budget",
+      value: `${input.roster.budget} kpo`,
+    });
+  }
+  additionalProperty.push({
+    "@type": "PropertyValue",
+    name: "Ruleset",
+    value: input.ruleset === "season_3" ? "Saison 3" : "Saison 2",
+  });
+  if (typeof input.roster.naf === "boolean") {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "NAF Approved",
+      value: input.roster.naf ? "Oui" : "Non",
+    });
+  }
+  additionalProperty.push({
+    "@type": "PropertyValue",
+    name: "Positions",
+    value: input.roster.positions.length,
+  });
+
+  const athlete = input.roster.positions.map((p) => {
+    const person: Record<string, unknown> = {
+      "@type": "Person",
+      name: p.displayName,
+      identifier: p.slug,
+      jobTitle: p.displayName,
+      memberOf: { "@id": `${url}#sportsteam` },
+    };
+    if (typeof p.cost === "number") {
+      person.estimatedSalary = {
+        "@type": "MonetaryAmount",
+        currency: "GBP",
+        value: { "@type": "QuantitativeValue", value: p.cost * 1000 },
+      };
+    }
+    return person;
+  });
+
+  const sportsTeam = {
+    "@type": "SportsTeam",
+    "@id": `${url}#sportsteam`,
+    name: input.roster.name,
+    url,
+    sport: "Blood Bowl",
+    description,
+    inLanguage: lang === "en" ? "en" : "fr-FR",
+    dateModified,
+    isPartOf: { "@id": orgId },
+    additionalProperty,
+    athlete,
+  } as Record<string, unknown>;
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${url}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Accueil",
+        item: input.baseUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Equipes",
+        item: `${input.baseUrl}/teams`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: input.roster.name,
+        item: url,
+      },
+    ],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [sportsTeam, breadcrumb],
+  };
+}


### PR DESCRIPTION
## Resume

Enrichissement SEO/GEO de la page detail equipe `/teams/[slug]` (31 pages dynamiques) avec un schema `SportsTeam` complet + breadcrumb + canonical + hreflang. Suit les patterns Q.1-Q.9 deja livres pour la homepage et les Star Players.

### Changements
- **Helper pur** `apps/web/app/teams/[slug]/team-structured-data.ts` :
  - `buildTeamSchema({ slug, roster, ruleset, baseUrl, lang? })` -> JSON-LD `@graph` avec `SportsTeam` + `BreadcrumbList`
  - SportsTeam : `@id` stable, name, url, sport, description multi-langue avec fallback, `inLanguage`, `dateModified`, `isPartOf` -> Organization
  - `additionalProperty` : Tier, Tier Label, Budget (kpo), Ruleset, NAF Approved, Positions count
  - `athlete[]` : positions du roster (Person + jobTitle + identifier + estimatedSalary)
  - BreadcrumbList : Accueil -> Equipes -> {nom equipe}
- **Composant serveur** `TeamStructuredData.tsx` : balise `<script type="application/ld+json">` rendue cote serveur (sans "use client")
- **Integration** dans `page.tsx` autour du client component existant
- **Metadata** (`layout.tsx`) : ajout `alternates.canonical` + `alternates.languages` (fr-FR, en, x-default)

### Pourquoi un helper pur separe du composant ?
Pour pouvoir tester sans dependance Next/DOM. `buildTeamSchema` est testable en isolation, `TeamStructuredData` n'est qu'un emetteur de balise. Pattern coherent avec le reste du repo.

### Citabilite LLM
- Fallback de description active : aucune SportsTeam n'aura jamais une `description` vide
- `dateModified` ISO 8601 pour signaler la fraicheur
- `isPartOf -> #organization` pour la chaine de confiance avec l'entite Nuffle Arena

## Tache roadmap

Sprint 23, tache **Q.10 — Metadata + JSON-LD SportsTeam dynamique sur /teams/[slug]**

## Plan de test

- [x] `pnpm --filter @bb/web test` (276/276 dont 12 nouveaux sur `team-structured-data.test.ts`)
- [x] Schema serializable JSON (round-trip JSON.stringify/parse verifie)
- [x] Determinisme : meme entree -> meme schema (avec `now` injecte pour la date)
- [x] Fallback description multi-langue + fallback generique
- [x] BreadcrumbList correct (positions, items absolus)
- [ ] Verification manuelle sur https://search.google.com/test/rich-results apres deploiement (les 31 pages doivent etre detectees comme rich results SportsTeam)
- [ ] Verification rapide rich snippets dans les SERPs apres re-crawl

### Note typecheck
3 erreurs TypeScript preexistantes dans `app/admin/feature-flags/*` (non touche par cette PR) — verifie via `git stash` avant et apres.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_