### PR TITLE
feat(seo): JSON-LD Person/SportsAthlete + canonical/hreflang sur /star-players/[slug] (Q.11)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -382,7 +382,7 @@
 | Q.8 | `sameAs` + `knowsAbout` + `dateModified` dans JSON-LD (citabilite LLM) | GEO | [x] |
 | Q.9 | `manifest.json` enrichi (shortcuts PWA : equipes, rosters, stars) | SEO | [x] |
 | Q.10 | Metadata + JSON-LD `SportsTeam` dynamique sur `/teams/[slug]` (31 pages) | SEO | [x] |
-| Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [ ] |
+| Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [x] |
 | Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [ ] |
 | Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [ ] |
 | Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |

--- a/apps/web/app/star-players/[slug]/StarPlayerStructuredData.tsx
+++ b/apps/web/app/star-players/[slug]/StarPlayerStructuredData.tsx
@@ -1,0 +1,27 @@
+import { buildStarPlayerSchema, type StarPlayerInput } from "./star-player-structured-data";
+
+interface StarPlayerStructuredDataProps {
+  starPlayer: StarPlayerInput;
+  baseUrl: string;
+  lang?: "fr" | "en";
+}
+
+/**
+ * Composant serveur emettant le JSON-LD Person/SportsAthlete +
+ * BreadcrumbList pour la page detail d'un Star Player (Q.11 — Sprint 23).
+ *
+ * Pas de "use client" : balise `<script>` rendue dans le HTML statique
+ * pour que les crawlers SEO et LLM aspirent les donnees sans executer
+ * de JS.
+ */
+export default function StarPlayerStructuredData(
+  props: StarPlayerStructuredDataProps,
+) {
+  const data = buildStarPlayerSchema(props);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/apps/web/app/star-players/[slug]/layout.tsx
+++ b/apps/web/app/star-players/[slug]/layout.tsx
@@ -1,85 +1,108 @@
 import { Metadata } from 'next';
+import StarPlayerStructuredData from './StarPlayerStructuredData';
+import type { StarPlayerInput } from './star-player-structured-data';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8201';
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://nufflearena.fr';
 
-export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
-  const { slug } = params;
-  
+interface ApiEnvelope {
+  success?: boolean;
+  data?: StarPlayerInput;
+}
+
+async function fetchStarPlayer(slug: string): Promise<StarPlayerInput | null> {
   try {
     const response = await fetch(`${API_BASE}/star-players/${slug}`, {
-      next: { revalidate: 3600 }, // Cache pendant 1 heure
+      next: { revalidate: 3600 },
     });
-    
-    if (!response.ok) {
-      return {
-        title: 'Star Player introuvable',
-        description: 'Le Star Player demandé n\'a pas été trouvé.',
-      };
-    }
-    
-    const data = await response.json();
-    
-    if (!data.success || !data.data) {
-      return {
-        title: 'Star Player introuvable',
-        description: 'Le Star Player demandé n\'a pas été trouvé.',
-      };
-    }
-    
-    const starPlayer = data.data;
-    const title = `${starPlayer.displayName} - Star Player Blood Bowl`;
-    const description = `Découvrez ${starPlayer.displayName}, Star Player Blood Bowl. Coût: ${(starPlayer.cost / 1000).toLocaleString()}k po. MA ${starPlayer.ma}, ST ${starPlayer.st}, AG ${starPlayer.ag}+. ${starPlayer.hirableBy.includes('all') ? 'Disponible pour toutes les équipes' : `Disponible pour ${starPlayer.hirableBy.length} ligue(s)`}.`;
-    
-    return {
-      title,
-      description,
-      keywords: [
-        starPlayer.displayName,
-        'Star Player',
-        'Blood Bowl',
-        'Mercenaire',
-        'Nuffle Arena',
-      ],
-      openGraph: {
-        title,
-        description,
-        type: 'website',
-        url: `${BASE_URL}/star-players/${slug}`,
-        siteName: 'Nuffle Arena',
-        images: starPlayer.imageUrl ? [
-          {
-            url: starPlayer.imageUrl.replace('/data/Star-Players_files/', `${BASE_URL}/images/star-players/`),
-            width: 1200,
-            height: 1200,
-            alt: `${starPlayer.displayName} - Star Player Blood Bowl`,
-          },
-        ] : [
-          {
-            url: `${BASE_URL}/images/logo.png`,
-            width: 1200,
-            height: 630,
-            alt: `${starPlayer.displayName} - Star Player Blood Bowl`,
-          },
-        ],
-      },
-      twitter: {
-        card: 'summary_large_image',
-        title,
-        description,
-        images: starPlayer.imageUrl ? [starPlayer.imageUrl.replace('/data/Star-Players_files/', `${BASE_URL}/images/star-players/`)] : [`${BASE_URL}/images/logo.png`],
-      },
-    };
+    if (!response.ok) return null;
+    const payload: ApiEnvelope = await response.json();
+    if (!payload.success || !payload.data) return null;
+    return payload.data;
   } catch (error) {
-    console.error('Erreur lors de la génération des métadonnées:', error);
-    return {
-      title: 'Star Player - Nuffle Arena',
-      description: 'Découvrez les Star Players Blood Bowl disponibles sur Nuffle Arena.',
-    };
+    console.error("Erreur lors du chargement du Star Player:", error);
+    return null;
   }
 }
 
-export default function StarPlayerLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const { slug } = params;
+  const starPlayer = await fetchStarPlayer(slug);
+
+  if (!starPlayer) {
+    return {
+      title: 'Star Player introuvable',
+      description: 'Le Star Player demandé n\'a pas été trouvé.',
+    };
+  }
+
+  const title = `${starPlayer.displayName} - Star Player Blood Bowl`;
+  const description = `Découvrez ${starPlayer.displayName}, Star Player Blood Bowl. Coût: ${(starPlayer.cost / 1000).toLocaleString()}k po. MA ${starPlayer.ma}, ST ${starPlayer.st}, AG ${starPlayer.ag}+. ${starPlayer.hirableBy.includes('all') ? 'Disponible pour toutes les équipes' : `Disponible pour ${starPlayer.hirableBy.length} ligue(s)`}.`;
+
+  const imageAbsolute = starPlayer.imageUrl
+    ? starPlayer.imageUrl.replace('/data/Star-Players_files/', `${BASE_URL}/images/star-players/`)
+    : `${BASE_URL}/images/logo.png`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      starPlayer.displayName,
+      'Star Player',
+      'Blood Bowl',
+      'Mercenaire',
+      'Nuffle Arena',
+    ],
+    alternates: {
+      canonical: `${BASE_URL}/star-players/${slug}`,
+      languages: {
+        'fr-FR': `${BASE_URL}/star-players/${slug}`,
+        'en': `${BASE_URL}/star-players/${slug}`,
+        'x-default': `${BASE_URL}/star-players/${slug}`,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      url: `${BASE_URL}/star-players/${slug}`,
+      siteName: 'Nuffle Arena',
+      images: [
+        {
+          url: imageAbsolute,
+          width: 1200,
+          height: starPlayer.imageUrl ? 1200 : 630,
+          alt: `${starPlayer.displayName} - Star Player Blood Bowl`,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [imageAbsolute],
+    },
+  };
 }
 
+export default async function StarPlayerLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { slug: string };
+}) {
+  const starPlayer = await fetchStarPlayer(params.slug);
+  return (
+    <>
+      {starPlayer && (
+        <StarPlayerStructuredData
+          starPlayer={starPlayer}
+          baseUrl={BASE_URL}
+          lang="fr"
+        />
+      )}
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/star-players/[slug]/star-player-structured-data.test.ts
+++ b/apps/web/app/star-players/[slug]/star-player-structured-data.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests pour `buildStarPlayerSchema` (Q.11 — Sprint 23).
+ *
+ * Helper pur produisant le JSON-LD `Person` / `SportsAthlete` +
+ * `BreadcrumbList` pour `/star-players/[slug]`. Memes invariants que
+ * `buildTeamSchema` (Q.10) :
+ *  - serializable JSON
+ *  - resilient aux donnees partielles (specialRule absent, image absente)
+ *  - canonical + dateModified
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildStarPlayerSchema } from "./star-player-structured-data";
+
+const BASE_STAR = {
+  slug: "morg_n_thorg",
+  displayName: "Morg 'n' Thorg",
+  cost: 430,
+  ma: 6,
+  st: 6,
+  ag: 4,
+  pa: 5 as number | null,
+  av: 10,
+  skills: "block,mighty-blow,thick-skull,loner",
+  hirableBy: ["all"],
+  specialRule: "Mega Star : impossible d'apothecaire.",
+  specialRuleEn: "Mega Star: cannot use apothecary.",
+  imageUrl: "/data/Star-Players_files/morg_n_thorg.jpg",
+  isMegaStar: true,
+};
+
+describe("buildStarPlayerSchema", () => {
+  it("retourne un @graph contenant Person/SportsAthlete et BreadcrumbList", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(schema["@context"]).toBe("https://schema.org");
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const personNode = graph.find((n) => {
+      const t = n["@type"];
+      return Array.isArray(t) && t.includes("Person") && t.includes("SportsAthlete");
+    });
+    expect(personNode).toBeDefined();
+    expect(graph.some((n) => n["@type"] === "BreadcrumbList")).toBe(true);
+  });
+
+  it("definit url, name et sport", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.name).toBe("Morg 'n' Thorg");
+    expect(node.url).toBe(
+      "https://nufflearena.fr/star-players/morg_n_thorg",
+    );
+    expect(node.sport).toBe("Blood Bowl");
+    expect(node.jobTitle).toMatch(/Star Player/i);
+  });
+
+  it("@id est stable et derive du slug", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node["@id"]).toBe(
+      "https://nufflearena.fr/star-players/morg_n_thorg#athlete",
+    );
+  });
+
+  it("utilise la specialRule francaise quand lang=fr", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+      lang: "fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.description).toContain("apothecaire");
+  });
+
+  it("utilise la specialRule anglaise quand lang=en", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+      lang: "en",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.description).toContain("apothecary");
+  });
+
+  it("retombe sur un fallback si specialRule manque", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: { ...BASE_STAR, specialRule: undefined, specialRuleEn: undefined },
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.description).toBeTypeOf("string");
+    expect((node.description as string).length).toBeGreaterThan(0);
+  });
+
+  it("inclut MA/ST/AG/PA/AV en additionalProperty", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    const props = node.additionalProperty as Array<{
+      name: string;
+      value: string | number;
+    }>;
+    expect(props.find((p) => p.name === "MA")?.value).toBe(6);
+    expect(props.find((p) => p.name === "ST")?.value).toBe(6);
+    expect(props.find((p) => p.name === "AG")?.value).toBe("4+");
+    expect(props.find((p) => p.name === "PA")?.value).toBe("5+");
+    expect(props.find((p) => p.name === "AV")?.value).toBe("10+");
+  });
+
+  it("affiche PA = -- quand pa est null", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: { ...BASE_STAR, pa: null },
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    const props = node.additionalProperty as Array<{
+      name: string;
+      value: string | number;
+    }>;
+    expect(props.find((p) => p.name === "PA")?.value).toBe("-");
+  });
+
+  it("inclut le flag Mega Star quand isMegaStar=true", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    const props = node.additionalProperty as Array<{
+      name: string;
+      value: string | number;
+    }>;
+    expect(props.find((p) => p.name === "Mega Star")?.value).toBe("Oui");
+  });
+
+  it("expose les skills dans knowsAbout (citabilite LLM)", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.knowsAbout).toEqual(
+      expect.arrayContaining(["block", "mighty-blow", "thick-skull", "loner"]),
+    );
+  });
+
+  it("convertit imageUrl du dossier asset vers public/images quand present", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.image).toBe(
+      "https://nufflearena.fr/images/star-players/morg_n_thorg.jpg",
+    );
+  });
+
+  it("omet image si imageUrl manque", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: { ...BASE_STAR, imageUrl: undefined },
+      baseUrl: "https://nufflearena.fr",
+    });
+    const node = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) =>
+        Array.isArray(n["@type"]) && (n["@type"] as string[]).includes("Person"),
+    )!;
+    expect(node.image).toBeUndefined();
+  });
+
+  it("breadcrumb : Accueil -> Star Players -> [nom]", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    const breadcrumb = (
+      schema["@graph"] as Array<Record<string, unknown>>
+    ).find((n) => n["@type"] === "BreadcrumbList")!;
+    const items = breadcrumb.itemListElement as Array<{
+      position: number;
+      name: string;
+      item: string;
+    }>;
+    expect(items.length).toBe(3);
+    expect(items[0]).toMatchObject({ position: 1, name: "Accueil" });
+    expect(items[1]).toMatchObject({ position: 2, name: "Star Players" });
+    expect(items[2].name).toBe("Morg 'n' Thorg");
+  });
+
+  it("schema serializable JSON", () => {
+    const schema = buildStarPlayerSchema({
+      starPlayer: BASE_STAR,
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(() => JSON.stringify(schema)).not.toThrow();
+  });
+});

--- a/apps/web/app/star-players/[slug]/star-player-structured-data.ts
+++ b/apps/web/app/star-players/[slug]/star-player-structured-data.ts
@@ -1,0 +1,174 @@
+/**
+ * Helper pur produisant le JSON-LD `Person` / `SportsAthlete` +
+ * `BreadcrumbList` pour la page detail d'un Star Player (Q.11 — Sprint 23).
+ *
+ * Pattern aligne sur `buildTeamSchema` (Q.10) : helper pur testable,
+ * composant React server qui ne fait qu'emettre `<script>`.
+ *
+ * Citabilite LLM (GEO) :
+ *   - description en deux langues avec fallback
+ *   - knowsAbout[] = liste des skills/competences (utile pour LLM)
+ *   - additionalProperty[] = stats brutes (MA, ST, AG+, PA+, AV+, Mega Star)
+ *   - dateModified ISO
+ *   - isPartOf -> Organization
+ */
+
+const ORG_ID_FRAGMENT = "#organization";
+
+export type Lang = "fr" | "en";
+
+export interface StarPlayerInput {
+  slug: string;
+  displayName: string;
+  cost: number;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  skills: string;
+  hirableBy: string[];
+  specialRule?: string;
+  specialRuleEn?: string;
+  imageUrl?: string;
+  isMegaStar?: boolean;
+}
+
+export interface BuildStarPlayerSchemaInput {
+  starPlayer: StarPlayerInput;
+  baseUrl: string;
+  lang?: Lang;
+  /** Override pour tests deterministes ; sinon ISO date du jour. */
+  now?: Date;
+}
+
+function fallbackDescription(name: string, lang: Lang): string {
+  if (lang === "en") {
+    return `${name} is a Blood Bowl Star Player available for hire. See stats, skills and special rules.`;
+  }
+  return `${name} est un Star Player Blood Bowl disponible au recrutement. Voir stats, competences et regle speciale.`;
+}
+
+/** Convertit une URL d'asset interne vers une URL publique (`/images/...`). */
+function resolveImageUrl(
+  imageUrl: string | undefined,
+  slug: string,
+  baseUrl: string,
+): string | undefined {
+  if (!imageUrl) return undefined;
+  // Patterns rencontres : "/data/Star-Players_files/<file>" ou deja absolu
+  if (imageUrl.startsWith("http")) return imageUrl;
+  const file = imageUrl
+    .replace("/data/Star-Players_files/", "")
+    .replace(/^\/+/, "");
+  const finalFile = file.includes(slug) ? file : `${slug}.jpg`;
+  return `${baseUrl}/images/star-players/${finalFile}`;
+}
+
+function parseSkills(skills: string): string[] {
+  return skills
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export function buildStarPlayerSchema(
+  input: BuildStarPlayerSchemaInput,
+): Record<string, unknown> {
+  const { starPlayer, baseUrl } = input;
+  const lang: Lang = input.lang ?? "fr";
+  const url = `${baseUrl}/star-players/${starPlayer.slug}`;
+  const orgId = `${baseUrl}${ORG_ID_FRAGMENT}`;
+  const dateModified = (input.now ?? new Date()).toISOString().split("T")[0];
+
+  const description =
+    (lang === "en"
+      ? starPlayer.specialRuleEn ?? starPlayer.specialRule
+      : starPlayer.specialRule ?? starPlayer.specialRuleEn) ??
+    fallbackDescription(starPlayer.displayName, lang);
+
+  const additionalProperty: Array<{
+    "@type": "PropertyValue";
+    name: string;
+    value: string | number;
+  }> = [
+    {
+      "@type": "PropertyValue",
+      name: "Cost",
+      value: `${(starPlayer.cost / 1000).toLocaleString("fr-FR")} kpo`,
+    },
+    { "@type": "PropertyValue", name: "MA", value: starPlayer.ma },
+    { "@type": "PropertyValue", name: "ST", value: starPlayer.st },
+    { "@type": "PropertyValue", name: "AG", value: `${starPlayer.ag}+` },
+    {
+      "@type": "PropertyValue",
+      name: "PA",
+      value: starPlayer.pa === null ? "-" : `${starPlayer.pa}+`,
+    },
+    { "@type": "PropertyValue", name: "AV", value: `${starPlayer.av}+` },
+  ];
+  if (starPlayer.isMegaStar) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Mega Star",
+      value: "Oui",
+    });
+  }
+  if (starPlayer.hirableBy.length > 0) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Hirable By",
+      value: starPlayer.hirableBy.join(", "),
+    });
+  }
+
+  const image = resolveImageUrl(starPlayer.imageUrl, starPlayer.slug, baseUrl);
+
+  const person: Record<string, unknown> = {
+    "@type": ["Person", "SportsAthlete"],
+    "@id": `${url}#athlete`,
+    name: starPlayer.displayName,
+    url,
+    description,
+    sport: "Blood Bowl",
+    jobTitle: "Blood Bowl Star Player",
+    inLanguage: lang === "en" ? "en" : "fr-FR",
+    dateModified,
+    isPartOf: { "@id": orgId },
+    additionalProperty,
+    knowsAbout: parseSkills(starPlayer.skills),
+  };
+  if (image) {
+    person.image = image;
+  }
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${url}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Accueil",
+        item: baseUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Star Players",
+        item: `${baseUrl}/star-players`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: starPlayer.displayName,
+        item: url,
+      },
+    ],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [person, breadcrumb],
+  };
+}


### PR DESCRIPTION
## Resume

Enrichissement SEO/GEO de la page detail Star Player `/star-players/[slug]` (~67 pages dynamiques) avec un schema `Person` + `SportsAthlete` complet + breadcrumb + canonical + hreflang. Suite directe de Q.10 (teams), meme pattern.

### Changements
- **Helper pur** `apps/web/app/star-players/[slug]/star-player-structured-data.ts` :
  - `buildStarPlayerSchema({ starPlayer, baseUrl, lang? })` -> JSON-LD `@graph`
  - Person + SportsAthlete : `@id` stable, name, url, sport, jobTitle, description multi-langue avec fallback, `inLanguage`, `dateModified`, `isPartOf` -> Organization
  - `additionalProperty` : Cost (kpo), MA, ST, AG+, PA+ (ou `-`), AV+, Mega Star, Hirable By
  - `knowsAbout[]` : liste des skills/competences (citabilite LLM ++)
  - `image` resolue vers `/images/star-players/<slug>.jpg` quand `imageUrl` dispo
  - BreadcrumbList : Accueil -> Star Players -> {nom}
- **Composant serveur** `StarPlayerStructuredData.tsx` : balise `<script type="application/ld+json">` rendue cote serveur
- **Refacto layout** :
  - Factorisation de la fetch en `fetchStarPlayer(slug)` partagee entre `generateMetadata` et le rendu (Next.js dedupe via `revalidate: 3600`)
  - Ajout `alternates.canonical` + `alternates.languages` (fr-FR, en, x-default)
  - Layout passe de simple passthrough a server component qui rend `<StarPlayerStructuredData>` au-dessus de `{children}`

### Citabilite LLM (GEO)
- `knowsAbout` expose les skills sous forme structuree -> les LLM peuvent citer "Morg 'n' Thorg a Block, Mighty Blow, Thick Skull, Loner"
- description avec fallback : aucune page ne sera muette
- `dateModified` ISO 8601 pour signaler la fraicheur

## Tache roadmap

Sprint 23, tache **Q.11 — Metadata + JSON-LD Person / SportsAthlete dynamique sur /star-players/[slug]**

## Plan de test

- [x] `pnpm --filter @bb/web test` (290/290 dont 14 nouveaux sur `star-player-structured-data.test.ts`)
- [x] Schema serializable JSON
- [x] Tests : description FR/EN, fallback, PA null, Mega Star, knowsAbout, image absente, breadcrumb
- [ ] Verification manuelle sur https://search.google.com/test/rich-results apres deploiement (les 67 pages doivent etre detectees comme rich results SportsAthlete)
- [ ] Verification que le layout cache bien la fetch (DevTools Network : un seul appel par page)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_