### PR TITLE
feat(seo): JSON-LD DefinedTermSet/ItemList + metadata sur /skills (Q.12)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -383,7 +383,7 @@
 | Q.9 | `manifest.json` enrichi (shortcuts PWA : equipes, rosters, stars) | SEO | [x] |
 | Q.10 | Metadata + JSON-LD `SportsTeam` dynamique sur `/teams/[slug]` (31 pages) | SEO | [x] |
 | Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [x] |
-| Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [ ] |
+| Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [x] |
 | Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [ ] |
 | Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [ ] |

--- a/apps/web/app/skills/SkillsStructuredData.tsx
+++ b/apps/web/app/skills/SkillsStructuredData.tsx
@@ -1,0 +1,18 @@
+import {
+  buildSkillsSchema,
+  type BuildSkillsSchemaInput,
+} from "./skills-structured-data";
+
+/**
+ * Composant serveur emettant le JSON-LD DefinedTermSet + ItemList +
+ * BreadcrumbList pour la page `/skills` (Q.12 — Sprint 23).
+ */
+export default function SkillsStructuredData(props: BuildSkillsSchemaInput) {
+  const data = buildSkillsSchema(props);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
 import { fetchServerJson, getServerApiBase } from "../lib/serverApi";
 import SkillsClient, { type Skill } from "./SkillsClient";
+import SkillsStructuredData from "./SkillsStructuredData";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
 
 // ISR — skill definitions change only with rules edition updates.
 export const revalidate = 3600;
@@ -17,12 +21,73 @@ interface SkillsPageProps {
   searchParams: { ruleset?: string };
 }
 
+export async function generateMetadata({
+  searchParams,
+}: SkillsPageProps): Promise<Metadata> {
+  const selectedRuleset =
+    searchParams.ruleset === "season_3" ? "season_3" : "season_2";
+  const url = `${BASE_URL}/skills`;
+  const title = "Compétences Blood Bowl - Skills, Mutations et Traits";
+  const description =
+    "Explorez les 130+ compétences, mutations et traits Blood Bowl : effets en jeu, catégories (Général, Agilité, Force, Passe, Mutations, Traits), versions Saison 2 et Saison 3.";
+  return {
+    title,
+    description,
+    keywords: [
+      "Blood Bowl",
+      "Compétences",
+      "Skills",
+      "Mutations",
+      "Traits",
+      "Nuffle Arena",
+      `Ruleset ${selectedRuleset}`,
+    ],
+    alternates: {
+      canonical: url,
+      languages: {
+        "fr-FR": url,
+        en: url,
+        "x-default": url,
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      url,
+      siteName: "Nuffle Arena",
+      images: [
+        {
+          url: `${BASE_URL}/images/logo.png`,
+          width: 1200,
+          height: 630,
+          alt: "Compétences Blood Bowl - Nuffle Arena",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [`${BASE_URL}/images/logo.png`],
+    },
+  };
+}
+
 export default async function SkillsPage({ searchParams }: SkillsPageProps) {
   const selectedRuleset =
     searchParams.ruleset === "season_3" ? "season_3" : "season_2";
   const skills = await fetchSkills(selectedRuleset);
 
   return (
-    <SkillsClient skills={skills} selectedRuleset={selectedRuleset} />
+    <>
+      <SkillsStructuredData
+        skills={skills}
+        ruleset={selectedRuleset}
+        baseUrl={BASE_URL}
+        lang="fr"
+      />
+      <SkillsClient skills={skills} selectedRuleset={selectedRuleset} />
+    </>
   );
 }

--- a/apps/web/app/skills/skills-structured-data.test.ts
+++ b/apps/web/app/skills/skills-structured-data.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests pour `buildSkillsSchema` (Q.12 — Sprint 23).
+ *
+ * Helper pur produisant le JSON-LD `DefinedTermSet` + `ItemList` +
+ * `BreadcrumbList` pour la page `/skills` (130+ entries citables).
+ *
+ * Invariants :
+ *  - chaque skill est emis comme `DefinedTerm` avec slug, nom, description,
+ *    categorie (`termCode`)
+ *  - le DefinedTermSet englobe tous les skills via `hasDefinedTerm[]`
+ *  - l'ItemList fournit l'ordre canonique des skills
+ *  - serializable JSON
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildSkillsSchema } from "./skills-structured-data";
+
+const SKILLS = [
+  {
+    slug: "block",
+    nameFr: "Blocage",
+    nameEn: "Block",
+    description: "Le joueur ignore le résultat 'Tomber Tous Les Deux'.",
+    descriptionEn: "The player ignores the 'Both Down' result.",
+    category: "General",
+  },
+  {
+    slug: "dodge",
+    nameFr: "Esquive",
+    nameEn: "Dodge",
+    description: "Permet de relancer un jet d'esquive raté.",
+    descriptionEn: "Allows to reroll a failed dodge roll.",
+    category: "Agility",
+  },
+  {
+    slug: "stunty",
+    nameFr: "Court sur Pattes",
+    nameEn: "Stunty",
+    description: "Ignore les zones de tacle pour l'esquive.",
+    descriptionEn: "Ignores tackle zones for dodging.",
+    category: "Trait",
+  },
+];
+
+describe("buildSkillsSchema", () => {
+  it("retourne un @graph contenant DefinedTermSet, ItemList et BreadcrumbList", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(schema["@context"]).toBe("https://schema.org");
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const types = graph.map((n) => n["@type"]);
+    expect(types).toContain("DefinedTermSet");
+    expect(types).toContain("ItemList");
+    expect(types).toContain("BreadcrumbList");
+  });
+
+  it("DefinedTermSet contient tous les skills en hasDefinedTerm", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    const terms = set.hasDefinedTerm as Array<Record<string, unknown>>;
+    expect(terms.length).toBe(3);
+    expect(terms[0]["@type"]).toBe("DefinedTerm");
+    expect(terms.map((t) => t.identifier)).toEqual(["block", "dodge", "stunty"]);
+  });
+
+  it("chaque DefinedTerm contient name, description, termCode et inDefinedTermSet", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    const term = (set.hasDefinedTerm as Array<Record<string, unknown>>)[0];
+    expect(term.name).toBe("Blocage");
+    expect(term.description).toContain("Tomber");
+    expect(term.termCode).toBe("General");
+    expect(term.inDefinedTermSet).toEqual({ "@id": set["@id"] });
+  });
+
+  it("utilise nameEn et descriptionEn quand lang=en", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+      lang: "en",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    const term = (set.hasDefinedTerm as Array<Record<string, unknown>>)[0];
+    expect(term.name).toBe("Block");
+    expect(term.description).toContain("Both Down");
+    expect(term.inLanguage).toBe("en");
+  });
+
+  it("retombe sur la version FR quand descriptionEn manque", () => {
+    const schema = buildSkillsSchema({
+      skills: [{ ...SKILLS[0], descriptionEn: null }],
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+      lang: "en",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    const term = (set.hasDefinedTerm as Array<Record<string, unknown>>)[0];
+    expect(term.description).toContain("Tomber");
+  });
+
+  it("ItemList ordonne les skills (numberOfItems et itemListElement[])", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const list = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "ItemList",
+    )!;
+    expect(list.numberOfItems).toBe(3);
+    const items = list.itemListElement as Array<{
+      "@type": string;
+      position: number;
+      item: Record<string, unknown>;
+    }>;
+    expect(items.length).toBe(3);
+    expect(items[0]["@type"]).toBe("ListItem");
+    expect(items[0].position).toBe(1);
+    // Chaque ListItem porte une reference vers le DefinedTerm
+    expect((items[0].item as Record<string, unknown>)["@id"]).toMatch(/#term-block$/);
+  });
+
+  it("DefinedTermSet expose un name lisible et une URL canonique", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    expect(set.name).toMatch(/Blood Bowl|competences|skills/i);
+    expect(set.url).toBe("https://nufflearena.fr/skills");
+  });
+
+  it("inclut un @id stable derive du ruleset", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    expect(set["@id"]).toBe(
+      "https://nufflearena.fr/skills#defined-term-set-season_3",
+    );
+  });
+
+  it("breadcrumb : Accueil -> Competences", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const breadcrumb = (
+      schema["@graph"] as Array<Record<string, unknown>>
+    ).find((n) => n["@type"] === "BreadcrumbList")!;
+    const items = breadcrumb.itemListElement as Array<{
+      position: number;
+      name: string;
+      item: string;
+    }>;
+    expect(items.length).toBe(2);
+    expect(items[0]).toMatchObject({ position: 1, name: "Accueil" });
+    expect(items[1].position).toBe(2);
+    expect(items[1].name).toMatch(/competences|skills/i);
+  });
+
+  it("schema serializable JSON", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(() => JSON.stringify(schema)).not.toThrow();
+  });
+
+  it("supporte une liste vide sans crasher", () => {
+    const schema = buildSkillsSchema({
+      skills: [],
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    expect((set.hasDefinedTerm as unknown[]).length).toBe(0);
+    const list = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "ItemList",
+    )!;
+    expect(list.numberOfItems).toBe(0);
+  });
+
+  it("dateModified est ISO 8601", () => {
+    const schema = buildSkillsSchema({
+      skills: SKILLS,
+      ruleset: "season_3",
+      baseUrl: "https://nufflearena.fr",
+    });
+    const set = (schema["@graph"] as Array<Record<string, unknown>>).find(
+      (n) => n["@type"] === "DefinedTermSet",
+    )!;
+    expect(set.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/apps/web/app/skills/skills-structured-data.ts
+++ b/apps/web/app/skills/skills-structured-data.ts
@@ -1,0 +1,128 @@
+/**
+ * Helper pur produisant le JSON-LD `DefinedTermSet` + `ItemList` +
+ * `BreadcrumbList` pour la page `/skills` (Q.12 — Sprint 23).
+ *
+ * Suit le meme pattern que Q.10 (teams) et Q.11 (star players) :
+ * helper pur testable + composant React server qui ne fait qu'emettre
+ * `<script>`.
+ *
+ * Citabilite LLM :
+ *   - chaque skill devient un `DefinedTerm` avec `name`, `description`,
+ *     `identifier` (slug), `termCode` (categorie) -> les LLM peuvent
+ *     citer "le skill X est categorise Y et fait Z"
+ *   - DefinedTermSet rassemble les 130+ skills sous un meme @id stable,
+ *     avec `dateModified` pour la fraicheur
+ *   - ItemList fournit l'ordre canonique pour les rich results
+ */
+
+const ORG_ID_FRAGMENT = "#organization";
+
+export type Lang = "fr" | "en";
+
+export interface SkillInput {
+  slug: string;
+  nameFr: string;
+  nameEn: string;
+  description: string;
+  descriptionEn?: string | null;
+  category: string;
+}
+
+export interface BuildSkillsSchemaInput {
+  skills: SkillInput[];
+  ruleset: "season_2" | "season_3";
+  baseUrl: string;
+  lang?: Lang;
+  /** Override pour tests deterministes ; sinon ISO date du jour. */
+  now?: Date;
+}
+
+function buildName(skill: SkillInput, lang: Lang): string {
+  return lang === "en" ? skill.nameEn : skill.nameFr;
+}
+
+function buildDescription(skill: SkillInput, lang: Lang): string {
+  if (lang === "en") {
+    return skill.descriptionEn ?? skill.description;
+  }
+  return skill.description ?? skill.descriptionEn ?? "";
+}
+
+export function buildSkillsSchema(
+  input: BuildSkillsSchemaInput,
+): Record<string, unknown> {
+  const { skills, ruleset, baseUrl } = input;
+  const lang: Lang = input.lang ?? "fr";
+  const url = `${baseUrl}/skills`;
+  const orgId = `${baseUrl}${ORG_ID_FRAGMENT}`;
+  const setId = `${url}#defined-term-set-${ruleset}`;
+  const dateModified = (input.now ?? new Date()).toISOString().split("T")[0];
+
+  const setName =
+    lang === "en"
+      ? "Blood Bowl Skills, Mutations and Traits"
+      : "Competences, mutations et traits Blood Bowl";
+  const setDescription =
+    lang === "en"
+      ? "All Blood Bowl skills, mutations and traits, with categories and effects."
+      : "Toutes les competences, mutations et traits Blood Bowl, avec categories et effets en jeu.";
+
+  const definedTerms = skills.map((skill) => ({
+    "@type": "DefinedTerm",
+    "@id": `${url}#term-${skill.slug}`,
+    identifier: skill.slug,
+    name: buildName(skill, lang),
+    description: buildDescription(skill, lang),
+    termCode: skill.category,
+    inLanguage: lang === "en" ? "en" : "fr-FR",
+    inDefinedTermSet: { "@id": setId },
+  }));
+
+  const definedTermSet = {
+    "@type": "DefinedTermSet",
+    "@id": setId,
+    name: setName,
+    description: setDescription,
+    url,
+    inLanguage: lang === "en" ? "en" : "fr-FR",
+    dateModified,
+    isPartOf: { "@id": orgId },
+    hasDefinedTerm: definedTerms,
+  };
+
+  const itemList = {
+    "@type": "ItemList",
+    "@id": `${url}#item-list-${ruleset}`,
+    name: setName,
+    numberOfItems: skills.length,
+    itemListElement: skills.map((skill, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      item: { "@id": `${url}#term-${skill.slug}` },
+    })),
+  };
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${url}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Accueil",
+        item: baseUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: lang === "en" ? "Skills" : "Competences",
+        item: url,
+      },
+    ],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [definedTermSet, itemList, breadcrumb],
+  };
+}


### PR DESCRIPTION
## Resume

Enrichissement SEO/GEO de la page `/skills` avec un schema `DefinedTermSet` + `ItemList` + `BreadcrumbList`. Suite naturelle de Q.10 (teams) et Q.11 (star players). 130+ skills deviennent citables individuellement par les LLM via leurs `DefinedTerm`.

### Changements
- **Helper pur** `apps/web/app/skills/skills-structured-data.ts` :
  - `buildSkillsSchema({ skills, ruleset, baseUrl, lang? })` -> JSON-LD `@graph`
  - DefinedTermSet : `@id` stable scope par ruleset (`#defined-term-set-season_3`), name, description, url, dateModified, isPartOf -> Organization, hasDefinedTerm[]
  - DefinedTerm par skill : identifier (slug), name, description, termCode (categorie : General/Agility/Strength/Passing/Mutation/Trait), inLanguage, inDefinedTermSet (ref vers le set)
  - ItemList : numberOfItems + itemListElement[] referencant chaque DefinedTerm par `@id` (ordre canonique)
  - BreadcrumbList : Accueil -> Competences
- **Composant serveur** `SkillsStructuredData.tsx` : balise `<script>` rendue cote serveur
- **Refacto page** `apps/web/app/skills/page.tsx` :
  - Ajout de `generateMetadata` (etait absent — pas de title/description/canonical jusqu'ici)
  - Ajout `alternates.canonical` + hreflang fr-FR/en/x-default
  - Insertion de `<SkillsStructuredData>` au-dessus du client component existant

### Citabilite LLM (GEO)
- Chaque skill devient un `DefinedTerm` independant -> les LLM peuvent citer "le skill Block ignore le resultat 'Both Down'" en s'appuyant sur la donnee structuree
- Categorie via `termCode` -> les LLM peuvent regrouper "skills d'agilite" ou "mutations"
- DefinedTermSet englobant -> les LLM connaissent l'ensemble des 130+ entries comme un corpus coherent

### Resilience
- Fallback FR si `descriptionEn` manque (et reciproquement)
- Liste vide supportee sans crasher (`numberOfItems: 0`)
- `dateModified` ISO 8601

## Tache roadmap

Sprint 23, tache **Q.12 — Metadata + JSON-LD ItemList / DefinedTermSet sur /skills (130+ entries citables)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (302/302 dont 12 nouveaux sur `skills-structured-data.test.ts`)
- [x] Schema serializable JSON
- [x] Tests : graph, multi-langues, fallback, ItemList ordre, `@id` stables, breadcrumb, liste vide, dateModified
- [ ] Verification manuelle https://search.google.com/test/rich-results : DefinedTermSet et ItemList valides
- [ ] Verification que les nouveaux DefinedTerm apparaissent dans la SERP en rich results


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_