### PR TITLE
feat(seo): BreadcrumbList JSON-LD sur /tutoriel + helper partage (Q.13)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -384,7 +384,7 @@
 | Q.10 | Metadata + JSON-LD `SportsTeam` dynamique sur `/teams/[slug]` (31 pages) | SEO | [x] |
 | Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [x] |
 | Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [x] |
-| Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [ ] |
+| Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [x] |
 | Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [ ] |
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [ ] |

--- a/apps/web/app/components/BreadcrumbStructuredData.tsx
+++ b/apps/web/app/components/BreadcrumbStructuredData.tsx
@@ -1,0 +1,24 @@
+import {
+  buildBreadcrumbSchema,
+  type BuildBreadcrumbSchemaInput,
+} from "./breadcrumb-schema";
+
+/**
+ * Composant serveur emettant un JSON-LD `BreadcrumbList` autonome.
+ *
+ * Utiliser pour les pages profondes qui n'ont pas deja un `@graph`
+ * embarquant leur breadcrumb (ex: tutoriel). Pour les pages qui ont
+ * deja un schema racine (teams, star-players, skills), prefere
+ * inliner le breadcrumb dans leur `@graph`.
+ */
+export default function BreadcrumbStructuredData(
+  props: BuildBreadcrumbSchemaInput,
+) {
+  const data = buildBreadcrumbSchema(props);
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/apps/web/app/components/breadcrumb-schema.test.ts
+++ b/apps/web/app/components/breadcrumb-schema.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests pour `buildBreadcrumbSchema` (Q.13 — Sprint 23).
+ *
+ * Helper partage qui produit le JSON-LD `BreadcrumbList` autonome
+ * (avec `@context`) pour les pages profondes du site.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildBreadcrumbSchema } from "./breadcrumb-schema";
+
+describe("buildBreadcrumbSchema", () => {
+  it("retourne un schema avec @context et un BreadcrumbList", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("BreadcrumbList");
+  });
+
+  it("auto-numerote les positions a partir de 1", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+        { name: "Mon Premier Match", path: "/tutoriel/mon-premier-match" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    const items = schema.itemListElement as Array<{
+      position: number;
+      name: string;
+      item: string;
+    }>;
+    expect(items[0].position).toBe(1);
+    expect(items[1].position).toBe(2);
+    expect(items[2].position).toBe(3);
+  });
+
+  it("convertit les paths relatifs en URLs absolues avec baseUrl", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    const items = schema.itemListElement as Array<{
+      item: string;
+    }>;
+    expect(items[0].item).toBe("https://nufflearena.fr/");
+    expect(items[1].item).toBe("https://nufflearena.fr/tutoriel");
+  });
+
+  it("preserve les URLs deja absolues", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Externe", path: "https://example.com/page" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    const items = schema.itemListElement as Array<{ item: string }>;
+    expect(items[0].item).toBe("https://example.com/page");
+  });
+
+  it("emet le name de chaque item", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+        { name: "Mon Premier Match", path: "/tutoriel/mon-premier-match" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    const items = schema.itemListElement as Array<{ name: string }>;
+    expect(items.map((i) => i.name)).toEqual([
+      "Accueil",
+      "Tutoriels",
+      "Mon Premier Match",
+    ]);
+  });
+
+  it("emet `@type: ListItem` pour chaque element", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    const items = schema.itemListElement as Array<{ "@type": string }>;
+    expect(items.every((i) => i["@type"] === "ListItem")).toBe(true);
+  });
+
+  it("supporte un id stable optionnel", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+      id: "https://nufflearena.fr/tutoriel#breadcrumb",
+    });
+    expect(schema["@id"]).toBe("https://nufflearena.fr/tutoriel#breadcrumb");
+  });
+
+  it("supporte une liste vide sans crasher", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [],
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(schema.itemListElement).toEqual([]);
+  });
+
+  it("le schema est entierement serializable JSON", () => {
+    const schema = buildBreadcrumbSchema({
+      items: [
+        { name: "Accueil", path: "/" },
+        { name: "Tutoriels", path: "/tutoriel" },
+      ],
+      baseUrl: "https://nufflearena.fr",
+    });
+    expect(() => JSON.stringify(schema)).not.toThrow();
+  });
+});

--- a/apps/web/app/components/breadcrumb-schema.ts
+++ b/apps/web/app/components/breadcrumb-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Helper pur produisant un JSON-LD `BreadcrumbList` autonome
+ * (avec `@context`) pour les pages profondes (Q.13 — Sprint 23).
+ *
+ * Reutilisable depuis n'importe quelle page. Distinct des breadcrumbs
+ * inlinees dans les `@graph` de Q.10/Q.11/Q.12 : ce helper produit un
+ * document JSON-LD a part entiere quand on n'a pas de schema racine
+ * a etendre (ex: page tutoriel sans SportsTeam ou DefinedTermSet).
+ */
+
+export interface BreadcrumbItem {
+  /** Libelle visible dans le fil d'Ariane. */
+  name: string;
+  /** URL relative ("/tutoriel") ou absolue ("https://..."). */
+  path: string;
+}
+
+export interface BuildBreadcrumbSchemaInput {
+  items: BreadcrumbItem[];
+  baseUrl: string;
+  /** `@id` stable optionnel (utile pour cross-referencer). */
+  id?: string;
+}
+
+function resolveUrl(path: string, baseUrl: string): string {
+  if (path.startsWith("http://") || path.startsWith("https://")) return path;
+  if (path.startsWith("/")) return `${baseUrl}${path}`;
+  return `${baseUrl}/${path}`;
+}
+
+export function buildBreadcrumbSchema(
+  input: BuildBreadcrumbSchemaInput,
+): Record<string, unknown> {
+  const { items, baseUrl, id } = input;
+  const schema: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((entry, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      name: entry.name,
+      item: resolveUrl(entry.path, baseUrl),
+    })),
+  };
+  if (id) {
+    schema["@id"] = id;
+  }
+  return schema;
+}

--- a/apps/web/app/tutoriel/[slug]/layout.tsx
+++ b/apps/web/app/tutoriel/[slug]/layout.tsx
@@ -1,0 +1,87 @@
+import type { Metadata } from "next";
+import { findTutorialScript } from "@bb/game-engine";
+import BreadcrumbStructuredData from "../../components/BreadcrumbStructuredData";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: { slug: string };
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Promise<Metadata> {
+  const script = findTutorialScript(params.slug);
+  if (!script) {
+    return {
+      title: "Tutoriel introuvable - Nuffle Arena",
+      description: "Le tutoriel demande n'a pas ete trouve.",
+    };
+  }
+  const url = `${BASE_URL}/tutoriel/${params.slug}`;
+  const title = `${script.titleFr} - Tutoriel Blood Bowl`;
+  return {
+    title,
+    description: script.summaryFr,
+    keywords: [
+      "Blood Bowl",
+      "Tutoriel",
+      script.titleFr,
+      "Nuffle Arena",
+      script.difficulty,
+    ],
+    alternates: {
+      canonical: url,
+      languages: {
+        "fr-FR": url,
+        en: url,
+        "x-default": url,
+      },
+    },
+    openGraph: {
+      title,
+      description: script.summaryFr,
+      type: "website",
+      url,
+      siteName: "Nuffle Arena",
+      images: [
+        {
+          url: `${BASE_URL}/images/logo.png`,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: script.summaryFr,
+      images: [`${BASE_URL}/images/logo.png`],
+    },
+  };
+}
+
+export default function TutorielSlugLayout({ children, params }: LayoutProps) {
+  const script = findTutorialScript(params.slug);
+  const breadcrumbItems = [
+    { name: "Accueil", path: "/" },
+    { name: "Tutoriels", path: "/tutoriel" },
+    ...(script
+      ? [{ name: script.titleFr, path: `/tutoriel/${params.slug}` }]
+      : []),
+  ];
+  return (
+    <>
+      <BreadcrumbStructuredData
+        baseUrl={BASE_URL}
+        id={`${BASE_URL}/tutoriel/${params.slug}#breadcrumb`}
+        items={breadcrumbItems}
+      />
+      {children}
+    </>
+  );
+}

--- a/apps/web/app/tutoriel/layout.tsx
+++ b/apps/web/app/tutoriel/layout.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import BreadcrumbStructuredData from "../components/BreadcrumbStructuredData";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+const URL = `${BASE_URL}/tutoriel`;
+
+export const metadata: Metadata = {
+  title: "Tutoriels Blood Bowl - Apprenez Nuffle Arena",
+  description:
+    "Tutoriels interactifs Blood Bowl pour debutants et joueurs experimentes : decouvrez les regles, le placement, les actions et la strategie pas a pas.",
+  keywords: [
+    "Blood Bowl",
+    "Tutoriel",
+    "Apprendre Blood Bowl",
+    "Regles",
+    "Nuffle Arena",
+    "Debutant",
+  ],
+  alternates: {
+    canonical: URL,
+    languages: {
+      "fr-FR": URL,
+      en: URL,
+      "x-default": URL,
+    },
+  },
+  openGraph: {
+    title: "Tutoriels Blood Bowl - Nuffle Arena",
+    description:
+      "Tutoriels interactifs Blood Bowl pour decouvrir les regles, le placement, les actions et la strategie pas a pas.",
+    type: "website",
+    url: URL,
+    siteName: "Nuffle Arena",
+    images: [
+      {
+        url: `${BASE_URL}/images/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "Tutoriels Blood Bowl - Nuffle Arena",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Tutoriels Blood Bowl - Nuffle Arena",
+    description:
+      "Tutoriels interactifs Blood Bowl : regles, placement, actions, strategie.",
+    images: [`${BASE_URL}/images/logo.png`],
+  },
+};
+
+export default function TutorielLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <BreadcrumbStructuredData
+        baseUrl={BASE_URL}
+        id={`${URL}#breadcrumb`}
+        items={[
+          { name: "Accueil", path: "/" },
+          { name: "Tutoriels", path: "/tutoriel" },
+        ]}
+      />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Resume

Cloture de Q.13 — `BreadcrumbList` JSON-LD sur toutes les pages profondes. Q.10 (teams), Q.11 (star-players), Q.12 (skills) ont deja livre leurs breadcrumbs inlines dans leur `@graph` respectif. Cette PR ajoute les pages tutoriel manquantes et standardise le helper.

### Changements
- **Helper partage** `apps/web/app/components/breadcrumb-schema.ts` :
  - `buildBreadcrumbSchema({ items, baseUrl, id? })` -> JSON-LD `BreadcrumbList` autonome (avec `@context`)
  - Resolution automatique paths relatifs -> URLs absolues
  - 9 tests TDD
- **Composant serveur** `BreadcrumbStructuredData.tsx` : balise `<script>` reutilisable
- **Page liste tutoriels** `/tutoriel` :
  - Nouveau `layout.tsx` avec metadata Next.js complets (title, description, canonical, hreflang fr-FR/en/x-default, OG, Twitter) — etaient absents
  - BreadcrumbList : Accueil -> Tutoriels
- **Page detail tutoriel** `/tutoriel/[slug]` :
  - Nouveau `layout.tsx` avec `generateMetadata` qui tire le titre et le resume depuis `findTutorialScript` du game-engine (synchrone, pas de fetch)
  - BreadcrumbList : Accueil -> Tutoriels -> {titre du script}

### Pourquoi un nouveau helper plutot que reutiliser ceux de Q.10-12 ?
Les breadcrumbs de teams/star-players/skills sont **inlines** dans le `@graph` de leur schema racine (SportsTeam, Person, DefinedTermSet). Le helper Q.13 produit un document JSON-LD **autonome** (avec son `@context`) — adapte aux pages qui n'ont pas de schema racine a etendre, comme tutoriel. Cohabitation propre, pas de double declaration.

## Tache roadmap

Sprint 23, tache **Q.13 — BreadcrumbList JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (311/311 dont 9 nouveaux sur `breadcrumb-schema.test.ts`)
- [x] Schema serializable JSON
- [x] Tests : @context, positions, URLs relatives/absolues, names, liste vide
- [ ] Verification manuelle https://search.google.com/test/rich-results sur `/tutoriel` et `/tutoriel/mon-premier-match`


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_