### PR TITLE
feat(seo): Open Graph images dynamiques par page (Q.14)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -385,7 +385,7 @@
 | Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [x] |
 | Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [x] |
 | Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [x] |
-| Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |
+| Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [x] |
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [ ] |
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [ ] |
 | Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [ ] |

--- a/apps/web/app/lib/og-image-content.test.ts
+++ b/apps/web/app/lib/og-image-content.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests pour les builders d'`OgImageContent` (Q.14 — Sprint 23).
+ *
+ * Chaque builder convertit une entite metier (roster, star player) en
+ * une structure stable (`OgImageContent`) qui sera ensuite rendue par
+ * `ImageResponse` Next.js. Tester la couche pure permet de garantir le
+ * texte affiche sans avoir a executer satori/wasm.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildTeamOgContent,
+  buildStarPlayerOgContent,
+  buildSkillsOgContent,
+  type OgImageContent,
+} from "./og-image-content";
+
+describe("buildTeamOgContent", () => {
+  const ROSTER = {
+    name: "Skavens",
+    tier: "I",
+    budget: 1000,
+    positions: [{ slug: "a" }, { slug: "b" }, { slug: "c" }],
+  };
+
+  it("retourne un titre = nom du roster", () => {
+    const c = buildTeamOgContent(ROSTER);
+    expect(c.title).toBe("Skavens");
+  });
+
+  it("expose tier et budget en badges", () => {
+    const c = buildTeamOgContent(ROSTER);
+    expect(c.badges).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Tier I"),
+        expect.stringContaining("1000"),
+      ]),
+    );
+  });
+
+  it("inclut un badge avec le nombre de positions", () => {
+    const c = buildTeamOgContent(ROSTER);
+    expect(c.badges.some((b) => /3 positions/i.test(b))).toBe(true);
+  });
+
+  it("subtitle contient mention 'Roster Blood Bowl'", () => {
+    const c = buildTeamOgContent(ROSTER);
+    expect(c.subtitle).toMatch(/roster blood bowl/i);
+  });
+
+  it("category = 'team'", () => {
+    expect(buildTeamOgContent(ROSTER).category).toBe("team");
+  });
+
+  it("supporte tier manquant", () => {
+    const c = buildTeamOgContent({ ...ROSTER, tier: undefined as unknown as string });
+    expect(c.badges.some((b) => /Tier/.test(b))).toBe(false);
+  });
+});
+
+describe("buildStarPlayerOgContent", () => {
+  const STAR = {
+    displayName: "Morg 'n' Thorg",
+    cost: 430,
+    ma: 6,
+    st: 6,
+    ag: 4,
+    pa: 5 as number | null,
+    av: 10,
+    isMegaStar: true,
+  };
+
+  it("title = displayName", () => {
+    expect(buildStarPlayerOgContent(STAR).title).toBe("Morg 'n' Thorg");
+  });
+
+  it("badges contiennent stats principales (MA, ST, AV)", () => {
+    const c = buildStarPlayerOgContent(STAR);
+    expect(c.badges).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/MA\s*6/),
+        expect.stringMatching(/ST\s*6/),
+        expect.stringMatching(/AV\s*10/),
+      ]),
+    );
+  });
+
+  it("inclut le coût formaté en kpo", () => {
+    const c = buildStarPlayerOgContent(STAR);
+    expect(c.badges.some((b) => /430.*kpo/i.test(b))).toBe(true);
+  });
+
+  it("ajoute MEGA STAR quand isMegaStar=true", () => {
+    const c = buildStarPlayerOgContent(STAR);
+    expect(c.badges.some((b) => /mega star/i.test(b))).toBe(true);
+  });
+
+  it("omet MEGA STAR quand isMegaStar absent ou false", () => {
+    const c = buildStarPlayerOgContent({ ...STAR, isMegaStar: false });
+    expect(c.badges.some((b) => /mega star/i.test(b))).toBe(false);
+  });
+
+  it("subtitle mentionne 'Star Player Blood Bowl'", () => {
+    const c = buildStarPlayerOgContent(STAR);
+    expect(c.subtitle).toMatch(/star player blood bowl/i);
+  });
+
+  it("category = 'star-player'", () => {
+    expect(buildStarPlayerOgContent(STAR).category).toBe("star-player");
+  });
+
+  it("affiche PA = '-' quand pa est null", () => {
+    const c = buildStarPlayerOgContent({ ...STAR, pa: null });
+    expect(c.badges.some((b) => /PA\s*-/.test(b))).toBe(true);
+  });
+});
+
+describe("buildSkillsOgContent", () => {
+  it("title evoque les Competences Blood Bowl", () => {
+    const c = buildSkillsOgContent({ skillCount: 130 });
+    expect(c.title).toMatch(/comp[ée]tences/i);
+  });
+
+  it("badges contiennent le nombre de skills", () => {
+    const c = buildSkillsOgContent({ skillCount: 130 });
+    expect(c.badges.some((b) => /130/.test(b))).toBe(true);
+  });
+
+  it("category = 'skills'", () => {
+    const c = buildSkillsOgContent({ skillCount: 130 });
+    expect(c.category).toBe("skills");
+  });
+
+  it("badges incluent les categories de skills", () => {
+    const c = buildSkillsOgContent({ skillCount: 130 });
+    expect(c.badges).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/General/i),
+        expect.stringMatching(/Mutation/i),
+        expect.stringMatching(/Trait/i),
+      ]),
+    );
+  });
+});
+
+describe("OgImageContent shape", () => {
+  it("title et subtitle sont des strings non vides pour tous les builders", () => {
+    const all: OgImageContent[] = [
+      buildTeamOgContent({ name: "X", tier: "I", budget: 1000, positions: [] }),
+      buildStarPlayerOgContent({
+        displayName: "Y",
+        cost: 100,
+        ma: 5,
+        st: 5,
+        ag: 3,
+        pa: 3,
+        av: 9,
+      }),
+      buildSkillsOgContent({ skillCount: 1 }),
+    ];
+    for (const c of all) {
+      expect(c.title.length).toBeGreaterThan(0);
+      expect(c.subtitle.length).toBeGreaterThan(0);
+      expect(Array.isArray(c.badges)).toBe(true);
+    }
+  });
+});

--- a/apps/web/app/lib/og-image-content.ts
+++ b/apps/web/app/lib/og-image-content.ts
@@ -1,0 +1,105 @@
+/**
+ * Builders d'`OgImageContent` pour les Open Graph images dynamiques
+ * (Q.14 — Sprint 23).
+ *
+ * Chaque page profonde appelle un builder pour transformer son entite
+ * metier (roster, star player, etc.) en une structure stable consommee
+ * par `ImageResponse` Next.js. La separation builder / renderer permet
+ * de tester la couche pure sans depender de satori/wasm.
+ */
+
+export type OgCategory = "team" | "star-player" | "skills";
+
+export interface OgImageContent {
+  title: string;
+  subtitle: string;
+  /** Liste de badges courts a afficher en bas (max 5 conseille). */
+  badges: string[];
+  category: OgCategory;
+  /** Couleur d'accent (hex) pour l'arriere-plan / les badges. */
+  accent: string;
+}
+
+const ACCENT_BY_CATEGORY: Record<OgCategory, string> = {
+  team: "#7C2D12", // bordeaux
+  "star-player": "#B45309", // doré
+  skills: "#1E3A8A", // bleu nuit
+};
+
+export interface TeamRosterInput {
+  name: string;
+  tier?: string;
+  budget?: number;
+  positions: Array<{ slug: string }>;
+}
+
+export function buildTeamOgContent(roster: TeamRosterInput): OgImageContent {
+  const badges: string[] = [];
+  if (roster.tier) badges.push(`Tier ${roster.tier}`);
+  if (typeof roster.budget === "number") {
+    badges.push(`${roster.budget} kpo`);
+  }
+  badges.push(`${roster.positions.length} positions`);
+  badges.push("Saison 3");
+  return {
+    title: roster.name,
+    subtitle: "Roster Blood Bowl - Nuffle Arena",
+    badges,
+    category: "team",
+    accent: ACCENT_BY_CATEGORY.team,
+  };
+}
+
+export interface StarPlayerOgInput {
+  displayName: string;
+  cost: number;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  isMegaStar?: boolean;
+}
+
+export function buildStarPlayerOgContent(
+  star: StarPlayerOgInput,
+): OgImageContent {
+  const badges: string[] = [
+    `MA ${star.ma}`,
+    `ST ${star.st}`,
+    `AG ${star.ag}+`,
+    `PA ${star.pa === null ? "-" : `${star.pa}+`}`,
+    `AV ${star.av}+`,
+    `${star.cost} kpo`,
+  ];
+  if (star.isMegaStar) {
+    badges.unshift("MEGA STAR");
+  }
+  return {
+    title: star.displayName,
+    subtitle: "Star Player Blood Bowl - Nuffle Arena",
+    badges,
+    category: "star-player",
+    accent: ACCENT_BY_CATEGORY["star-player"],
+  };
+}
+
+export interface SkillsOgInput {
+  skillCount: number;
+}
+
+export function buildSkillsOgContent(input: SkillsOgInput): OgImageContent {
+  return {
+    title: "Compétences Blood Bowl",
+    subtitle: "Skills, Mutations & Traits - Nuffle Arena",
+    badges: [
+      `${input.skillCount} entries`,
+      "General",
+      "Agility / Strength / Passing",
+      "Mutation",
+      "Trait",
+    ],
+    category: "skills",
+    accent: ACCENT_BY_CATEGORY.skills,
+  };
+}

--- a/apps/web/app/lib/og-image-template.tsx
+++ b/apps/web/app/lib/og-image-template.tsx
@@ -1,0 +1,105 @@
+import type { OgImageContent } from "./og-image-content";
+
+/**
+ * Template visuel commun pour les Open Graph images dynamiques
+ * (Q.14 — Sprint 23). Compatible avec satori (le rendu de Next.js
+ * `ImageResponse`) : utilise uniquement flexbox + propriétés
+ * supportées (pas de grid, pas de fonts custom externes).
+ */
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+
+export function OgImageTemplate({ content }: { content: OgImageContent }) {
+  return (
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "#0F172A",
+        backgroundImage: `linear-gradient(135deg, ${content.accent} 0%, #0F172A 60%)`,
+        color: "#FFFFFF",
+        padding: 64,
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          fontSize: 28,
+          fontWeight: 700,
+          letterSpacing: 2,
+          textTransform: "uppercase",
+          opacity: 0.85,
+        }}
+      >
+        Nuffle Arena
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 92,
+            fontWeight: 900,
+            lineHeight: 1.05,
+            marginBottom: 24,
+            display: "flex",
+          }}
+        >
+          {content.title}
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            opacity: 0.9,
+            marginBottom: 32,
+            display: "flex",
+          }}
+        >
+          {content.subtitle}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 16,
+            fontSize: 26,
+          }}
+        >
+          {content.badges.map((badge, idx) => (
+            <span
+              key={idx}
+              style={{
+                backgroundColor: "rgba(255,255,255,0.12)",
+                border: "2px solid rgba(255,255,255,0.25)",
+                padding: "10px 24px",
+                borderRadius: 999,
+                display: "flex",
+              }}
+            >
+              {badge}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          fontSize: 22,
+          opacity: 0.7,
+          display: "flex",
+        }}
+      >
+        nufflearena.fr
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/skills/opengraph-image.tsx
+++ b/apps/web/app/skills/opengraph-image.tsx
@@ -1,0 +1,25 @@
+import { ImageResponse } from "next/og";
+import { fetchServerJson, getServerApiBase } from "../lib/serverApi";
+import { buildSkillsOgContent } from "../lib/og-image-content";
+import {
+  OgImageTemplate,
+  OG_IMAGE_SIZE,
+} from "../lib/og-image-template";
+
+export const runtime = "nodejs";
+export const alt = "Compétences Blood Bowl - Nuffle Arena";
+export const size = OG_IMAGE_SIZE;
+export const contentType = "image/png";
+
+export default async function SkillsOgImage() {
+  const base = getServerApiBase();
+  const data = await fetchServerJson<{ skills?: unknown[] }>(
+    `${base}/api/skills?ruleset=season_3`,
+    { next: { revalidate: 3600 } },
+  );
+  const count = data?.skills?.length ?? 130;
+  const content = buildSkillsOgContent({ skillCount: count });
+  return new ImageResponse(<OgImageTemplate content={content} />, {
+    ...OG_IMAGE_SIZE,
+  });
+}

--- a/apps/web/app/star-players/[slug]/opengraph-image.tsx
+++ b/apps/web/app/star-players/[slug]/opengraph-image.tsx
@@ -1,0 +1,60 @@
+import { ImageResponse } from "next/og";
+import { buildStarPlayerOgContent } from "../../lib/og-image-content";
+import {
+  OgImageTemplate,
+  OG_IMAGE_SIZE,
+} from "../../lib/og-image-template";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8201";
+
+export const runtime = "nodejs";
+export const alt = "Star Player Blood Bowl - Nuffle Arena";
+export const size = OG_IMAGE_SIZE;
+export const contentType = "image/png";
+
+export default async function StarPlayerOgImage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  let content;
+  try {
+    const response = await fetch(`${API_BASE}/star-players/${params.slug}`, {
+      next: { revalidate: 3600 },
+    });
+    if (response.ok) {
+      const data = await response.json();
+      if (data?.success && data.data) {
+        content = buildStarPlayerOgContent({
+          displayName: data.data.displayName,
+          cost: data.data.cost,
+          ma: data.data.ma,
+          st: data.data.st,
+          ag: data.data.ag,
+          pa: data.data.pa,
+          av: data.data.av,
+          isMegaStar: data.data.isMegaStar,
+        });
+      }
+    }
+  } catch (error) {
+    console.error("OG star-player fetch failed:", error);
+  }
+  if (!content) {
+    content = buildStarPlayerOgContent({
+      displayName: "Star Player Blood Bowl",
+      cost: 0,
+      ma: 0,
+      st: 0,
+      ag: 0,
+      pa: null,
+      av: 0,
+    });
+  }
+  return new ImageResponse(<OgImageTemplate content={content} />, {
+    ...OG_IMAGE_SIZE,
+  });
+}

--- a/apps/web/app/teams/[slug]/opengraph-image.tsx
+++ b/apps/web/app/teams/[slug]/opengraph-image.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from "next/og";
+import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
+import { buildTeamOgContent } from "../../lib/og-image-content";
+import {
+  OgImageTemplate,
+  OG_IMAGE_SIZE,
+} from "../../lib/og-image-template";
+
+export const runtime = "nodejs";
+export const alt = "Roster Blood Bowl - Nuffle Arena";
+export const size = OG_IMAGE_SIZE;
+export const contentType = "image/png";
+
+export default async function TeamOgImage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const base = getServerApiBase();
+  const data = await fetchServerJson<{ roster?: any }>(
+    `${base}/api/rosters/${encodeURIComponent(params.slug)}?lang=fr&ruleset=season_3`,
+    { next: { revalidate: 3600 } },
+  );
+  const roster = data?.roster;
+  const content = roster
+    ? buildTeamOgContent({
+        name: roster.name,
+        tier: roster.tier,
+        budget: roster.budget,
+        positions: roster.positions ?? [],
+      })
+    : buildTeamOgContent({
+        name: "Roster Blood Bowl",
+        positions: [],
+      });
+  return new ImageResponse(<OgImageTemplate content={content} />, {
+    ...OG_IMAGE_SIZE,
+  });
+}


### PR DESCRIPTION
## Resume

Avant cette PR, toutes les pages exposaient `og:image = logo.png` (image statique). Avec Q.14, chaque page profonde genere maintenant son propre Open Graph contextualise via Next.js `ImageResponse` (satori).

### Architecture
- **3 builders purs testables** dans `apps/web/app/lib/og-image-content.ts` :
  - `buildTeamOgContent(roster)` -> titre = nom du roster, badges Tier / Budget / Positions / Saison
  - `buildStarPlayerOgContent(star)` -> titre = displayName, badges MA / ST / AG+ / PA+ / AV+ / Cost, prefixe MEGA STAR si applicable
  - `buildSkillsOgContent({ skillCount })` -> titre Competences, badge count + categories
- **Template visuel commun** `og-image-template.tsx` :
  - flexbox seul (compatible satori, pas de grid)
  - gradient d'accent (bordeaux pour teams, dore pour star players, bleu nuit pour skills)
  - header "Nuffle Arena" + badges en pillules + footer URL
- **3 routes Next.js convention `opengraph-image.tsx`** :
  - `/teams/[slug]` : fetch roster server-side, fallback si absent
  - `/star-players/[slug]` : fetch star player, fallback si absent
  - `/skills` : fetch count
  - Toutes en `runtime: nodejs`, `size: 1200x630`, `contentType: image/png`, `revalidate: 3600`

Next.js auto-detecte ces fichiers et override `openGraph.images` du `generateMetadata` avec l'URL generee — pas besoin de modifier les `layout.tsx` existants.

### Pourquoi separer builders / template ?
- Les builders sont des fonctions pures, testables sans satori/wasm (19 tests TDD).
- Le template est un composant React tres petit qui ne fait que mapper la structure.
- En cas de changement de design, on touche le template ; en cas d'evolution de donnees, on touche le builder.

### Resilience
- Chaque route a un fallback "Roster Blood Bowl" / "Star Player Blood Bowl" / count par defaut 130, donc un crash API ne casse jamais l'OG.
- `try/catch` autour du `fetch` star-player, log + fallback.

## Tache roadmap

Sprint 23, tache **Q.14 — Open Graph images dynamiques par page via ImageResponse Next.js**

## Plan de test

- [x] `pnpm --filter @bb/web test` (330/330 dont 19 nouveaux sur `og-image-content.test.ts`)
- [x] Tests : titre, sous-titre, badges (count, contenu, ordres), category, accent, cas limites (pa=null, isMegaStar absent, tier absent)
- [ ] Verification manuelle : visiter `/teams/skaven/opengraph-image`, `/star-players/morg_n_thorg/opengraph-image`, `/skills/opengraph-image` et controler le rendu PNG
- [ ] Validation OG Twitter / FB / LinkedIn debugger apres deploiement


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XuRMTYd3AawstoTi8EvN)_