### PR TITLE
feat(cosmetics): logos d'equipe SVG programmatiques (O.8b)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -354,7 +354,7 @@
 | O.6 | Standardiser error handling (`ApiResponse<T>`) | Qualite | [x] |
 | O.7 | Optimiser queries DB (pagination, select) | Perf | [x] |
 | O.8a | Generateur de noms d'equipe par roster (service + endpoint) | Engagement | [x] |
-| O.8b | Cosmetiques visuels (logos equipe, assets graphiques) | Engagement | [ ] |
+| O.8b | Cosmetiques visuels (logos equipe, assets graphiques) | Engagement | [x] |
 | O.9 | Features communautaires (match of the week, Discord) | Engagement | [ ] |
 | O.10 | Dashboard analytics personnel et global | Engagement | [ ] |
 

--- a/apps/web/app/components/TeamLogo.test.tsx
+++ b/apps/web/app/components/TeamLogo.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import TeamLogo from "./TeamLogo";
+
+describe("TeamLogo", () => {
+  it("rend un SVG inline pour un slug connu", () => {
+    const { container } = render(<TeamLogo slug="skaven" />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute("viewBox")).toBe("0 0 64 64");
+  });
+
+  it("respecte la taille passee en prop", () => {
+    const { container } = render(<TeamLogo slug="skaven" size={96} />);
+    const svg = container.querySelector("svg");
+    expect(svg!.getAttribute("width")).toBe("96");
+    expect(svg!.getAttribute("height")).toBe("96");
+  });
+
+  it("expose un titre accessible quand title est fourni", () => {
+    const { container, getByRole } = render(
+      <TeamLogo slug="dwarf" title="Dwarf Roster" />
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("role")).toBe("img");
+    expect(svg.getAttribute("aria-label")).toBe("Dwarf Roster");
+    expect(getByRole("img")).toBe(svg);
+  });
+
+  it("est decoratif (aria-hidden) sans title", () => {
+    const { container } = render(<TeamLogo slug="dwarf" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("aria-hidden")).toBe("true");
+    expect(svg.getAttribute("role")).toBeNull();
+  });
+
+  it("applique la className passee au wrapper", () => {
+    const { container } = render(
+      <TeamLogo slug="skaven" className="custom-class" />
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("custom-class");
+  });
+
+  it("fallback gracieux pour un slug undefined", () => {
+    const { container } = render(<TeamLogo slug={undefined} />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+  });
+
+  it("fallback gracieux pour un slug inconnu", () => {
+    const { container } = render(<TeamLogo slug="not_a_real_roster" />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    // logo par defaut contient le glyph "NA"
+    expect(svg!.textContent).toContain("NA");
+  });
+
+  it("rend des SVG differents selon le slug", () => {
+    const { container: a } = render(<TeamLogo slug="skaven" />);
+    const { container: b } = render(<TeamLogo slug="dwarf" />);
+    expect(a.querySelector("svg")!.outerHTML).not.toBe(
+      b.querySelector("svg")!.outerHTML
+    );
+  });
+});

--- a/apps/web/app/components/TeamLogo.tsx
+++ b/apps/web/app/components/TeamLogo.tsx
@@ -1,0 +1,51 @@
+/**
+ * TeamLogo (O.8b — cosmetiques visuels).
+ *
+ * Composant React qui affiche le logo programmatique d'une equipe en
+ * inlinant le SVG genere par `renderTeamLogoSvg` (game-engine). Pas de
+ * fetch, pas d'asset a embarquer : le SVG est entierement reconstruit
+ * a partir du slug + couleurs canoniques.
+ */
+import { renderTeamLogoSvg } from "@bb/game-engine";
+import type { TeamColors } from "@bb/game-engine";
+
+interface TeamLogoProps {
+  /** Roster slug (ex: "skaven", "dwarf"). undefined -> logo neutre. */
+  slug: string | undefined;
+  /** Taille en pixels (carre). Defaut 64. */
+  size?: number;
+  /**
+   * Titre accessible. Si fourni, le SVG expose role="img" + aria-label,
+   * sinon il est marque comme decoratif (aria-hidden).
+   */
+  title?: string;
+  /** Override des couleurs canoniques (rare ; utile pour previews). */
+  colorsOverride?: TeamColors;
+  /** Classe CSS appliquee au span wrapper. */
+  className?: string;
+}
+
+export default function TeamLogo({
+  slug,
+  size = 64,
+  title,
+  colorsOverride,
+  className = "",
+}: TeamLogoProps) {
+  const svg = renderTeamLogoSvg(slug, {
+    size,
+    title,
+    override: colorsOverride,
+  });
+
+  return (
+    <span
+      className={`inline-flex items-center justify-center ${className}`.trim()}
+      style={{ width: size, height: size }}
+      // Le SVG est genere cote serveur de maniere deterministe a partir
+      // d'un slug controle ; les valeurs utilisateur (title) sont
+      // echappees par renderTeamLogoSvg. Pas de XSS possible ici.
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/apps/web/app/teams/TeamsListClient.tsx
+++ b/apps/web/app/teams/TeamsListClient.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLanguage } from "../contexts/LanguageContext";
+import TeamLogo from "../components/TeamLogo";
 
 export type Season = "season_2" | "season_3";
 type Tier = "all" | "I" | "II" | "III" | "IV";
@@ -196,8 +197,9 @@ export default function TeamsListClient({
             href={`/teams/${team.slug}?ruleset=${initialSeason}`}
             className="rounded-xl border-2 border-blue-200 bg-white p-6 hover:border-blue-400 hover:shadow-lg transition-all text-left"
           >
-            <div className="flex items-start justify-between mb-3">
-              <h2 className="text-lg font-semibold text-blue-900">
+            <div className="flex items-start gap-3 mb-3">
+              <TeamLogo slug={team.slug} size={48} title={team.name} />
+              <h2 className="text-lg font-semibold text-blue-900 flex-1">
                 {team.name}
               </h2>
             </div>

--- a/packages/game-engine/src/rosters/index.ts
+++ b/packages/game-engine/src/rosters/index.ts
@@ -39,6 +39,18 @@ export {
   type TeamColors,
 } from './team-colors';
 
+// Export des logos d'equipes (O.8b — cosmetiques visuels)
+export {
+  DEFAULT_TEAM_LOGO,
+  ROSTER_LOGOS,
+  TEAM_LOGO_SHAPES,
+  getTeamLogo,
+  renderTeamLogoSvg,
+  type TeamLogo,
+  type TeamLogoShape,
+  type RenderTeamLogoOptions,
+} from './team-logos';
+
 // Export du registry de sprite manifests (H.6 — sub-task 4/5)
 export {
   TEAM_SPRITE_MANIFESTS,

--- a/packages/game-engine/src/rosters/team-logos.test.ts
+++ b/packages/game-engine/src/rosters/team-logos.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TEAM_LOGO,
+  ROSTER_LOGOS,
+  getTeamLogo,
+  renderTeamLogoSvg,
+  TEAM_LOGO_SHAPES,
+  type TeamLogo,
+} from './team-logos';
+import { TEAM_ROSTERS_BY_RULESET } from './positions';
+import { ROSTER_COLORS } from './team-colors';
+
+describe('Regle: team-logos (O.8b cosmetiques visuels)', () => {
+  describe('DEFAULT_TEAM_LOGO', () => {
+    it('expose une forme et un glyph valides', () => {
+      expect(TEAM_LOGO_SHAPES).toContain(DEFAULT_TEAM_LOGO.shape);
+      expect(typeof DEFAULT_TEAM_LOGO.glyph).toBe('string');
+      expect(DEFAULT_TEAM_LOGO.glyph.length).toBeGreaterThan(0);
+      expect(DEFAULT_TEAM_LOGO.glyph.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('ROSTER_LOGOS map', () => {
+    it('definit un logo pour chaque roster connu (cohesion avec ROSTER_COLORS)', () => {
+      for (const slug of Object.keys(ROSTER_COLORS)) {
+        expect(ROSTER_LOGOS[slug], `missing logo for roster "${slug}"`).toBeDefined();
+      }
+    });
+
+    it('definit un logo pour chaque roster declare dans tous les rulesets', () => {
+      const allSlugs = new Set<string>();
+      for (const ruleset of Object.keys(TEAM_ROSTERS_BY_RULESET) as Array<
+        keyof typeof TEAM_ROSTERS_BY_RULESET
+      >) {
+        for (const slug of Object.keys(TEAM_ROSTERS_BY_RULESET[ruleset])) {
+          allSlugs.add(slug);
+        }
+      }
+      for (const slug of allSlugs) {
+        expect(ROSTER_LOGOS[slug], `missing logo for roster "${slug}"`).toBeDefined();
+      }
+    });
+
+    it('chaque entree expose une forme valide et un glyph 1 a 3 caracteres', () => {
+      for (const [slug, logo] of Object.entries(ROSTER_LOGOS)) {
+        expect(TEAM_LOGO_SHAPES, `${slug}.shape invalide`).toContain(logo.shape);
+        expect(typeof logo.glyph, `${slug}.glyph type`).toBe('string');
+        expect(logo.glyph.length, `${slug}.glyph empty`).toBeGreaterThan(0);
+        expect(logo.glyph.length, `${slug}.glyph trop long`).toBeLessThanOrEqual(3);
+      }
+    });
+
+    it('produit au moins 3 formes distinctes pour la diversite visuelle', () => {
+      const shapes = new Set(Object.values(ROSTER_LOGOS).map((l) => l.shape));
+      expect(shapes.size).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('getTeamLogo()', () => {
+    it('retourne DEFAULT_TEAM_LOGO si le slug est undefined', () => {
+      expect(getTeamLogo(undefined)).toEqual(DEFAULT_TEAM_LOGO);
+    });
+
+    it('retourne DEFAULT_TEAM_LOGO si le slug est une chaine vide', () => {
+      expect(getTeamLogo('')).toEqual(DEFAULT_TEAM_LOGO);
+    });
+
+    it('retourne DEFAULT_TEAM_LOGO pour un slug inconnu', () => {
+      expect(getTeamLogo('not_a_real_roster_zzz')).toEqual(DEFAULT_TEAM_LOGO);
+    });
+
+    it('retourne le logo canonique pour un slug connu', () => {
+      const skaven = getTeamLogo('skaven');
+      expect(skaven).toEqual(ROSTER_LOGOS.skaven);
+    });
+  });
+
+  describe('renderTeamLogoSvg()', () => {
+    it('produit un SVG bien forme avec namespace, viewBox 64x64 par defaut', () => {
+      const svg = renderTeamLogoSvg('skaven');
+      expect(svg).toMatch(/^<svg /);
+      expect(svg).toContain('xmlns="http://www.w3.org/2000/svg"');
+      expect(svg).toContain('viewBox="0 0 64 64"');
+      expect(svg.trim().endsWith('</svg>')).toBe(true);
+    });
+
+    it('respecte la taille demandee via opts.size', () => {
+      const svg = renderTeamLogoSvg('skaven', { size: 128 });
+      expect(svg).toContain('width="128"');
+      expect(svg).toContain('height="128"');
+    });
+
+    it('inclut un titre accessible via opts.title', () => {
+      const svg = renderTeamLogoSvg('skaven', { title: 'Skaven Logo' });
+      expect(svg).toContain('<title>Skaven Logo</title>');
+      expect(svg).toContain('role="img"');
+      expect(svg).toContain('aria-label="Skaven Logo"');
+    });
+
+    it('marque le SVG comme decoratif quand aucun titre nest fourni', () => {
+      const svg = renderTeamLogoSvg('skaven');
+      expect(svg).toContain('aria-hidden="true"');
+      expect(svg).not.toContain('<title>');
+    });
+
+    it('utilise les couleurs canoniques de la roster', () => {
+      const svg = renderTeamLogoSvg('skaven');
+      // skaven primary 0x92400e -> #92400e (rust)
+      expect(svg.toLowerCase()).toContain('#92400e');
+      // skaven secondary 0xd6d3d1 -> #d6d3d1 (bone)
+      expect(svg.toLowerCase()).toContain('#d6d3d1');
+    });
+
+    it('accepte une override de couleurs', () => {
+      const svg = renderTeamLogoSvg('skaven', {
+        override: { primary: 0x123456, secondary: 0xabcdef },
+      });
+      expect(svg.toLowerCase()).toContain('#123456');
+      expect(svg.toLowerCase()).toContain('#abcdef');
+      expect(svg.toLowerCase()).not.toContain('#92400e');
+    });
+
+    it('inclut le glyph du roster en sortie', () => {
+      const expectedGlyph = ROSTER_LOGOS.skaven.glyph;
+      const svg = renderTeamLogoSvg('skaven');
+      expect(svg).toContain(`>${escapeXml(expectedGlyph)}<`);
+    });
+
+    it('echappe les caracteres dangereux dans le glyph et le titre (no XSS)', () => {
+      const customLogo: TeamLogo = { shape: 'circle', glyph: '<&>"' };
+      const svg = renderTeamLogoSvg(undefined, {
+        title: '<script>alert(1)</script>',
+        logo: customLogo,
+      });
+      expect(svg).not.toContain('<script>');
+      expect(svg).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(svg).toContain('&lt;&amp;&gt;&quot;');
+    });
+
+    it('produit des SVG differents selon le slug (diversite visuelle)', () => {
+      const skaven = renderTeamLogoSvg('skaven');
+      const dwarf = renderTeamLogoSvg('dwarf');
+      expect(skaven).not.toBe(dwarf);
+    });
+
+    it('reste deterministe : meme slug -> meme sortie', () => {
+      expect(renderTeamLogoSvg('skaven')).toBe(renderTeamLogoSvg('skaven'));
+    });
+
+    it('fallback sur DEFAULT_TEAM_LOGO quand le slug est inconnu', () => {
+      const unknown = renderTeamLogoSvg('not_a_real_roster_zzz');
+      const defaultGlyph = DEFAULT_TEAM_LOGO.glyph;
+      expect(unknown).toContain(`>${escapeXml(defaultGlyph)}<`);
+    });
+
+    it('rejete une taille non strictement positive (clamp ou fallback a 64)', () => {
+      const zero = renderTeamLogoSvg('skaven', { size: 0 });
+      expect(zero).toContain('width="64"');
+      const negative = renderTeamLogoSvg('skaven', { size: -10 });
+      expect(negative).toContain('width="64"');
+    });
+  });
+});
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/packages/game-engine/src/rosters/team-logos.ts
+++ b/packages/game-engine/src/rosters/team-logos.ts
@@ -1,0 +1,206 @@
+/**
+ * Team logos (O.8b cosmetiques visuels — logos equipe).
+ *
+ * Generates programmatic SVG emblems for each roster, using the canonical
+ * roster colors from {@link ROSTER_COLORS} and a per-roster shape + glyph.
+ *
+ * Why a programmatic SVG approach?
+ *   - zero asset shipping cost (no PNG/atlas to maintain)
+ *   - deterministic output, easily testable as pure strings
+ *   - usable both server-side (OG images, PDF export) and client-side (React)
+ *   - per-roster colors automatically picked up via {@link getTeamColors}
+ *   - new rosters only need a 2-line entry to get a fresh emblem
+ *
+ * Renderer-agnostic: returns a self-contained SVG string. The web client
+ * wraps this via the `<TeamLogo>` React component; the mobile / server side
+ * can also embed it as `dangerouslySetInnerHTML` or convert to PNG via
+ * `@vercel/og` / `satori` when needed.
+ */
+import { DEFAULT_TEAM_COLORS, ROSTER_COLORS, type TeamColors } from './team-colors';
+
+/** Available silhouette shapes — kept small on purpose for visual coherence. */
+export const TEAM_LOGO_SHAPES = ['shield', 'circle', 'diamond', 'hexagon'] as const;
+export type TeamLogoShape = (typeof TEAM_LOGO_SHAPES)[number];
+
+export interface TeamLogo {
+  /** Outer silhouette shape. */
+  shape: TeamLogoShape;
+  /** 1 to 3 character monogram drawn inside the shape (e.g. "S", "Sk"). */
+  glyph: string;
+}
+
+/** Neutral fallback emblem used for unknown / missing roster slugs. */
+export const DEFAULT_TEAM_LOGO: TeamLogo = {
+  shape: 'circle',
+  glyph: 'NA',
+};
+
+/**
+ * Per-roster emblem definitions. Keys MUST match the slugs of
+ * {@link ROSTER_COLORS} (and therefore of `positions.ts`). The
+ * `team-logos.test.ts` suite enforces exhaustive coverage.
+ *
+ * Glyphs are rendered as drawn-in text — keep them ASCII to ensure
+ * consistent font rendering across browsers / generators.
+ */
+export const ROSTER_LOGOS: Record<string, TeamLogo> = {
+  // Imperial / Order
+  human: { shape: 'shield', glyph: 'H' },
+  imperial_nobility: { shape: 'shield', glyph: 'IN' },
+  old_world_alliance: { shape: 'shield', glyph: 'OW' },
+
+  // Dwarves
+  dwarf: { shape: 'hexagon', glyph: 'D' },
+  chaos_dwarf: { shape: 'hexagon', glyph: 'CD' },
+  gnome: { shape: 'hexagon', glyph: 'G' },
+
+  // Elves
+  high_elf: { shape: 'diamond', glyph: 'HE' },
+  wood_elf: { shape: 'diamond', glyph: 'WE' },
+  dark_elf: { shape: 'diamond', glyph: 'DE' },
+  elven_union: { shape: 'diamond', glyph: 'EU' },
+  slann: { shape: 'diamond', glyph: 'SL' },
+
+  // Greenskins
+  orc: { shape: 'circle', glyph: 'O' },
+  black_orc: { shape: 'circle', glyph: 'BO' },
+  goblin: { shape: 'circle', glyph: 'GO' },
+  snotling: { shape: 'circle', glyph: 'SN' },
+  underworld: { shape: 'circle', glyph: 'UW' },
+
+  // Skaven
+  skaven: { shape: 'circle', glyph: 'S' },
+
+  // Lizards
+  lizardmen: { shape: 'shield', glyph: 'LZ' },
+
+  // Undead
+  undead: { shape: 'shield', glyph: 'U' },
+  necromantic_horror: { shape: 'shield', glyph: 'NH' },
+  tomb_kings: { shape: 'shield', glyph: 'TK' },
+  vampire: { shape: 'diamond', glyph: 'V' },
+
+  // Chaos
+  chaos_chosen: { shape: 'hexagon', glyph: 'CC' },
+  chaos_renegade: { shape: 'hexagon', glyph: 'CR' },
+  khorne: { shape: 'hexagon', glyph: 'K' },
+  nurgle: { shape: 'hexagon', glyph: 'N' },
+
+  // Misc
+  amazon: { shape: 'shield', glyph: 'A' },
+  halfling: { shape: 'circle', glyph: 'HF' },
+  ogre: { shape: 'hexagon', glyph: 'OG' },
+  norse: { shape: 'shield', glyph: 'NO' },
+};
+
+/**
+ * Resolve the emblem for a given roster slug.
+ *
+ * Resolution order:
+ *   1. canonical {@link ROSTER_LOGOS}[slug]
+ *   2. {@link DEFAULT_TEAM_LOGO}
+ */
+export function getTeamLogo(rosterSlug: string | undefined): TeamLogo {
+  if (!rosterSlug) return DEFAULT_TEAM_LOGO;
+  return ROSTER_LOGOS[rosterSlug] ?? DEFAULT_TEAM_LOGO;
+}
+
+export interface RenderTeamLogoOptions {
+  /** Pixel size of the resulting square SVG. Defaults to 64. Non-positive falls back to 64. */
+  size?: number;
+  /** Optional accessible title; when provided the SVG exposes role="img" + aria-label. */
+  title?: string;
+  /** Override the canonical roster colors. */
+  override?: TeamColors;
+  /** Override the canonical roster logo (useful for previews / fixtures). */
+  logo?: TeamLogo;
+}
+
+const DEFAULT_SIZE = 64;
+const VIEW_BOX = 64;
+
+/**
+ * Render a self-contained SVG string for the given roster.
+ *
+ * Pure function — no DOM, no side effects, deterministic output. Safe to
+ * inline server-side (Next.js metadata, OG images) or browser-side via
+ * `dangerouslySetInnerHTML`.
+ */
+export function renderTeamLogoSvg(
+  rosterSlug: string | undefined,
+  options: RenderTeamLogoOptions = {},
+): string {
+  const logo = options.logo ?? getTeamLogo(rosterSlug);
+  const colors = options.override ?? (rosterSlug ? ROSTER_COLORS[rosterSlug] : undefined) ?? DEFAULT_TEAM_COLORS;
+  const sizeOpt = options.size;
+  const size = typeof sizeOpt === 'number' && sizeOpt > 0 ? Math.floor(sizeOpt) : DEFAULT_SIZE;
+
+  const primary = toHexColor(colors.primary);
+  const secondary = toHexColor(colors.secondary);
+
+  const titleNode = options.title
+    ? `<title>${escapeXml(options.title)}</title>`
+    : '';
+  const accessibilityAttrs = options.title
+    ? ` role="img" aria-label="${escapeXml(options.title)}"`
+    : ' aria-hidden="true"';
+
+  const shapePath = renderShape(logo.shape, primary, secondary);
+  const glyph = renderGlyph(logo.glyph, secondary);
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" ` +
+    `viewBox="0 0 ${VIEW_BOX} ${VIEW_BOX}"${accessibilityAttrs}>` +
+    titleNode +
+    shapePath +
+    glyph +
+    `</svg>`
+  );
+}
+
+function renderShape(shape: TeamLogoShape, primary: string, secondary: string): string {
+  const stroke = `stroke="${secondary}" stroke-width="3" stroke-linejoin="round"`;
+  switch (shape) {
+    case 'shield':
+      // Heater-style shield silhouette inscribed in the 64x64 viewbox.
+      return (
+        `<path d="M32 4 L58 12 L58 32 C58 48 46 58 32 60 C18 58 6 48 6 32 L6 12 Z" ` +
+        `fill="${primary}" ${stroke} />`
+      );
+    case 'circle':
+      return `<circle cx="32" cy="32" r="28" fill="${primary}" ${stroke} />`;
+    case 'diamond':
+      return (
+        `<path d="M32 4 L60 32 L32 60 L4 32 Z" fill="${primary}" ${stroke} />`
+      );
+    case 'hexagon':
+      return (
+        `<path d="M32 4 L57 18 L57 46 L32 60 L7 46 L7 18 Z" ` +
+        `fill="${primary}" ${stroke} />`
+      );
+  }
+}
+
+function renderGlyph(glyph: string, color: string): string {
+  // 1 char -> larger font; 2 chars -> medium; 3 chars -> compact.
+  const fontSize = glyph.length >= 3 ? 18 : glyph.length === 2 ? 24 : 32;
+  return (
+    `<text x="32" y="32" text-anchor="middle" dominant-baseline="central" ` +
+    `font-family="Verdana, Geneva, sans-serif" font-weight="700" ` +
+    `font-size="${fontSize}" fill="${color}">${escapeXml(glyph)}</text>`
+  );
+}
+
+function toHexColor(value: number): string {
+  const clamped = Math.max(0, Math.min(0xffffff, Math.floor(value)));
+  return `#${clamped.toString(16).padStart(6, '0')}`;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}


### PR DESCRIPTION
## Resume

Genere un emblem SVG par roster sans aucune asset graphique embarquee,
en s'appuyant sur les couleurs canoniques de `ROSTER_COLORS` + une
forme/glyph par roster. Pure, deterministe, testable et reutilisable
depuis le web, le serveur (OG images, PDF), le mobile et la generation
satori.

### Pourquoi du SVG programmatique ?

- **Zero asset shipping** : pas de PNG, pas d'atlas, pas de pipeline.
- **Determinisme parfait** : meme slug -> meme SVG octet pour octet
  (tests `renderTeamLogoSvg('skaven') === renderTeamLogoSvg('skaven')`).
- **Inlinable partout** : Next.js metadata, OG `ImageResponse`,
  React via `dangerouslySetInnerHTML`, jsPDF, Pixi.js fallback.
- **Nouveau roster = 2 lignes** dans `ROSTER_LOGOS`, le reste est
  resolu par les couleurs deja en place.

### Architecture

- `packages/game-engine/src/rosters/team-logos.ts`
  - `TEAM_LOGO_SHAPES` (4 silhouettes : `shield` / `circle` / `diamond` / `hexagon`)
  - `ROSTER_LOGOS` : map exhaustive des 27 rosters declares dans `ROSTER_COLORS`
  - `getTeamLogo(slug)` : resolveur avec fallback `DEFAULT_TEAM_LOGO`
  - `renderTeamLogoSvg(slug, opts)` : SVG complet (viewBox 64x64), echappement XML, accessibilite (`role="img"` / `aria-label` ou `aria-hidden`), override de couleurs et de taille
- `apps/web/app/components/TeamLogo.tsx` : wrapper React qui inline le SVG (sans XSS — toutes les sources sont controlees / echappees).
- `apps/web/app/teams/TeamsListClient.tsx` : integration sur la grille des equipes pour materialiser le rendu utilisateur.
- `packages/game-engine/src/rosters/index.ts` : re-export.

### Securite

- Toutes les valeurs interpolees dans le SVG sont echappees (`escapeXml`) — un test verifie explicitement qu'un titre `<script>` est neutralise.
- Couleurs clampees `[0, 0xffffff]` avant conversion.
- Tailles non strictement positives -> fallback 64.

## Tache roadmap

Sprint 22+, tache **O.8b — Cosmetiques visuels (logos equipe, assets graphiques)**

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` (4756/4756 dont 21 nouveaux sur `team-logos.test.ts`)
- [x] `pnpm --filter @bb/web test` (319/319 dont 8 nouveaux sur `TeamLogo.test.tsx`)
- [x] `pnpm --filter @bb/game-engine typecheck`
- [x] `pnpm --filter @bb/web typecheck`
- [x] `pnpm --filter @bb/game-engine build`
- [ ] `pnpm --filter @bb/web build` echoue dans le sandbox local (Google Fonts inaccessibles), a verifier en CI
- [ ] Verification visuelle de la grille `/teams` en navigateur
- [ ] Verifier qu'aucun roster ne tombe sur `DEFAULT_TEAM_LOGO` en navigant le selecteur de saison

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_