### PR TITLE
feat(community): match of the week + Discord helpers (O.9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -355,7 +355,7 @@
 | O.7 | Optimiser queries DB (pagination, select) | Perf | [x] |
 | O.8a | Generateur de noms d'equipe par roster (service + endpoint) | Engagement | [x] |
 | O.8b | Cosmetiques visuels (logos equipe, assets graphiques) | Engagement | [x] |
-| O.9 | Features communautaires (match of the week, Discord) | Engagement | [ ] |
+| O.9 | Features communautaires (match of the week, Discord) | Engagement | [x] |
 | O.10 | Dashboard analytics personnel et global | Engagement | [ ] |
 
 ### Sprint 23 — SEO, GEO & rayonnement (~5 jours)

--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -5,6 +5,11 @@ import Logo from "./Logo";
 import { useLanguage } from "../contexts/LanguageContext";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { ONLINE_PLAY_FLAG } from "../lib/featureFlagKeys";
+import { buildCommunityLinks } from "@bb/game-engine";
+
+const COMMUNITY_LINKS = buildCommunityLinks({
+  DISCORD_INVITE_URL: process.env.NEXT_PUBLIC_DISCORD_INVITE_URL,
+});
 
 export default function Footer() {
   const { t } = useLanguage();
@@ -78,7 +83,7 @@ export default function Footer() {
             <ul className="text-sm text-nuffle-anthracite/80 space-y-1 font-body">
               <li>
                 <a
-                  href="https://discord.gg/XEZJTgEHKn"
+                  href={COMMUNITY_LINKS.discordInviteUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-nuffle-gold hover:underline transition-colors inline-flex items-center gap-1.5"

--- a/packages/game-engine/src/community/community-config.test.ts
+++ b/packages/game-engine/src/community/community-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_COMMUNITY_LINKS,
+  buildCommunityLinks,
+  type CommunityEnv,
+} from './community-config';
+
+describe('Regle: community-config (O.9 community)', () => {
+  describe('DEFAULT_COMMUNITY_LINKS', () => {
+    it('expose un lien Discord en defaut (string non vide)', () => {
+      expect(typeof DEFAULT_COMMUNITY_LINKS.discordInviteUrl).toBe('string');
+      expect(DEFAULT_COMMUNITY_LINKS.discordInviteUrl.length).toBeGreaterThan(0);
+      expect(DEFAULT_COMMUNITY_LINKS.discordInviteUrl).toMatch(/^https:\/\/discord\.gg\//);
+    });
+  });
+
+  describe('buildCommunityLinks(env)', () => {
+    it('retourne les defauts si env est vide ou undefined', () => {
+      expect(buildCommunityLinks({})).toEqual(DEFAULT_COMMUNITY_LINKS);
+      expect(buildCommunityLinks(undefined)).toEqual(DEFAULT_COMMUNITY_LINKS);
+    });
+
+    it('override DISCORD_INVITE_URL si fourni dans env', () => {
+      const env: CommunityEnv = {
+        DISCORD_INVITE_URL: 'https://discord.gg/customServer',
+      };
+      const links = buildCommunityLinks(env);
+      expect(links.discordInviteUrl).toBe('https://discord.gg/customServer');
+    });
+
+    it('ignore une URL non-https Discord (securite)', () => {
+      const env: CommunityEnv = {
+        DISCORD_INVITE_URL: 'http://malicious.example.com/discord',
+      };
+      const links = buildCommunityLinks(env);
+      expect(links.discordInviteUrl).toBe(DEFAULT_COMMUNITY_LINKS.discordInviteUrl);
+    });
+
+    it('ignore une URL completement invalide (fallback aux defauts)', () => {
+      const env: CommunityEnv = { DISCORD_INVITE_URL: 'not a url' };
+      const links = buildCommunityLinks(env);
+      expect(links.discordInviteUrl).toBe(DEFAULT_COMMUNITY_LINKS.discordInviteUrl);
+    });
+
+    it('ignore une chaine vide', () => {
+      const env: CommunityEnv = { DISCORD_INVITE_URL: '' };
+      const links = buildCommunityLinks(env);
+      expect(links.discordInviteUrl).toBe(DEFAULT_COMMUNITY_LINKS.discordInviteUrl);
+    });
+  });
+});

--- a/packages/game-engine/src/community/community-config.ts
+++ b/packages/game-engine/src/community/community-config.ts
@@ -1,0 +1,56 @@
+/**
+ * Community config (O.9 community features).
+ *
+ * Centralises the public community links (Discord invite, etc.) so the
+ * web client, server, and mobile share the same source of truth.
+ *
+ * Resolution: caller passes an env-shaped object (typically `process.env`
+ * filtered to whitelisted keys). Invalid / non-https values fall back to
+ * the canonical defaults to avoid leaking misconfigured URLs into the UI.
+ */
+
+export interface CommunityLinks {
+  /** Discord invite URL (must be https://discord.gg/...). */
+  discordInviteUrl: string;
+}
+
+export interface CommunityEnv {
+  DISCORD_INVITE_URL?: string;
+}
+
+/**
+ * Canonical defaults — kept in sync with what currently ships in the web
+ * footer so behaviour is unchanged when no override is provided.
+ */
+export const DEFAULT_COMMUNITY_LINKS: CommunityLinks = {
+  discordInviteUrl: 'https://discord.gg/XEZJTgEHKn',
+};
+
+/**
+ * Resolve community links from environment overrides.
+ *
+ * Validation rules:
+ *   - URL must parse as a valid URL
+ *   - URL must use https://discord.gg/ prefix (no other hosts allowed)
+ *   - On any failure, fall back to {@link DEFAULT_COMMUNITY_LINKS}
+ */
+export function buildCommunityLinks(env: CommunityEnv | undefined): CommunityLinks {
+  const discord = sanitizeDiscordInvite(env?.DISCORD_INVITE_URL);
+  return {
+    discordInviteUrl: discord ?? DEFAULT_COMMUNITY_LINKS.discordInviteUrl,
+  };
+}
+
+function sanitizeDiscordInvite(value: string | undefined): string | null {
+  if (!value || value.length === 0) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') return null;
+  if (parsed.hostname !== 'discord.gg') return null;
+  if (parsed.pathname.length <= 1) return null;
+  return parsed.toString().replace(/\/$/, '');
+}

--- a/packages/game-engine/src/community/discord-webhook.test.ts
+++ b/packages/game-engine/src/community/discord-webhook.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDiscordMatchAnnouncement,
+  type DiscordMatchAnnouncementInput,
+} from './discord-webhook';
+
+const baseInput = (
+  overrides: Partial<DiscordMatchAnnouncementInput> = {},
+): DiscordMatchAnnouncementInput => ({
+  matchUrl: 'https://nuffle.example.com/match/m1',
+  teamAName: 'Skaven FC',
+  teamBName: 'Dwarves United',
+  teamARoster: 'skaven',
+  teamBRoster: 'dwarf',
+  scoreA: 2,
+  scoreB: 1,
+  totalCasualties: 4,
+  highlight: 'Match of the Week',
+  ...overrides,
+});
+
+describe('Regle: discord-webhook (O.9 community)', () => {
+  it('produit un payload structuré avec embed Discord', () => {
+    const payload = buildDiscordMatchAnnouncement(baseInput());
+    expect(Array.isArray(payload.embeds)).toBe(true);
+    expect(payload.embeds.length).toBe(1);
+    expect(payload.embeds[0].title).toBeDefined();
+  });
+
+  it('inclut un titre lisible avec les noms des equipes et le score', () => {
+    const payload = buildDiscordMatchAnnouncement(baseInput());
+    expect(payload.embeds[0].title).toContain('Skaven FC');
+    expect(payload.embeds[0].title).toContain('Dwarves United');
+    expect(payload.embeds[0].title).toContain('2');
+    expect(payload.embeds[0].title).toContain('1');
+  });
+
+  it('inclut le highlight (ex: Match of the Week)', () => {
+    const payload = buildDiscordMatchAnnouncement(baseInput());
+    expect(payload.content || payload.embeds[0].description || '').toContain(
+      'Match of the Week',
+    );
+  });
+
+  it('expose un champ url cliquable pointant vers le match', () => {
+    const payload = buildDiscordMatchAnnouncement(baseInput());
+    expect(payload.embeds[0].url).toBe('https://nuffle.example.com/match/m1');
+  });
+
+  it('utilise une couleur d embed deterministe basee sur la roster gagnante', () => {
+    const skavenWin = buildDiscordMatchAnnouncement(baseInput({ scoreA: 3, scoreB: 0 }));
+    const dwarfWin = buildDiscordMatchAnnouncement(baseInput({ scoreA: 0, scoreB: 3 }));
+    expect(typeof skavenWin.embeds[0].color).toBe('number');
+    expect(typeof dwarfWin.embeds[0].color).toBe('number');
+    expect(skavenWin.embeds[0].color).not.toBe(dwarfWin.embeds[0].color);
+  });
+
+  it('expose des champs structurés avec stats du match', () => {
+    const payload = buildDiscordMatchAnnouncement(baseInput());
+    const fields = payload.embeds[0].fields ?? [];
+    const names = fields.map((f) => f.name.toLowerCase());
+    expect(names.some((n) => n.includes('score') || n.includes('touchdown'))).toBe(true);
+    expect(names.some((n) => n.includes('casual'))).toBe(true);
+  });
+
+  it('reste deterministe : meme entree -> meme sortie', () => {
+    const a = buildDiscordMatchAnnouncement(baseInput());
+    const b = buildDiscordMatchAnnouncement(baseInput());
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('rejette une URL invalide en levant une erreur claire', () => {
+    expect(() =>
+      buildDiscordMatchAnnouncement(baseInput({ matchUrl: 'not-a-url' })),
+    ).toThrow(/url/i);
+  });
+
+  it('tronque le titre si trop long pour respecter la limite Discord (256)', () => {
+    const longName = 'A'.repeat(150);
+    const payload = buildDiscordMatchAnnouncement(
+      baseInput({ teamAName: longName, teamBName: longName }),
+    );
+    expect(payload.embeds[0].title.length).toBeLessThanOrEqual(256);
+  });
+});

--- a/packages/game-engine/src/community/discord-webhook.ts
+++ b/packages/game-engine/src/community/discord-webhook.ts
@@ -1,0 +1,119 @@
+/**
+ * Discord webhook payload builder (O.9 community features).
+ *
+ * Pure formatter — given a featured match (typically the Match of the
+ * Week), produces a Discord-compatible webhook payload that the server
+ * can POST to a configured webhook URL.
+ *
+ * No side effects, no fetch — keeps the engine free of HTTP concerns.
+ */
+import { ROSTER_COLORS, DEFAULT_TEAM_COLORS } from '../rosters/team-colors';
+
+export interface DiscordMatchAnnouncementInput {
+  /** Public URL of the match page (must be a valid http/https URL). */
+  matchUrl: string;
+  teamAName: string;
+  teamBName: string;
+  teamARoster?: string;
+  teamBRoster?: string;
+  scoreA: number;
+  scoreB: number;
+  totalCasualties: number;
+  /** Optional banner string, e.g. "Match of the Week". */
+  highlight?: string;
+}
+
+/** Discord embed field — keep aligned with Discord's webhook spec. */
+export interface DiscordEmbedField {
+  name: string;
+  value: string;
+  inline?: boolean;
+}
+
+export interface DiscordEmbed {
+  title: string;
+  url?: string;
+  description?: string;
+  color?: number;
+  fields?: DiscordEmbedField[];
+}
+
+export interface DiscordWebhookPayload {
+  content?: string;
+  embeds: DiscordEmbed[];
+}
+
+const TITLE_LIMIT = 256;
+
+/**
+ * Build a Discord webhook payload announcing a featured match.
+ *
+ * @throws if `matchUrl` is not a valid http(s) URL.
+ */
+export function buildDiscordMatchAnnouncement(
+  input: DiscordMatchAnnouncementInput,
+): DiscordWebhookPayload {
+  assertHttpUrl(input.matchUrl);
+
+  const winnerRoster = pickWinnerRoster(input);
+  const color = winnerRoster
+    ? (ROSTER_COLORS[winnerRoster]?.primary ?? DEFAULT_TEAM_COLORS.primary)
+    : DEFAULT_TEAM_COLORS.primary;
+
+  const title = truncate(
+    `${input.teamAName} ${input.scoreA} - ${input.scoreB} ${input.teamBName}`,
+    TITLE_LIMIT,
+  );
+
+  const description = input.highlight ? `**${input.highlight}**` : undefined;
+
+  const fields: DiscordEmbedField[] = [
+    {
+      name: 'Score',
+      value: `${input.scoreA} - ${input.scoreB}`,
+      inline: true,
+    },
+    {
+      name: 'Casualties',
+      value: `${Math.max(0, input.totalCasualties)}`,
+      inline: true,
+    },
+  ];
+
+  return {
+    embeds: [
+      {
+        title,
+        url: input.matchUrl,
+        description,
+        color,
+        fields,
+      },
+    ],
+  };
+}
+
+function pickWinnerRoster(
+  input: DiscordMatchAnnouncementInput,
+): string | undefined {
+  if (input.scoreA > input.scoreB) return input.teamARoster;
+  if (input.scoreB > input.scoreA) return input.teamBRoster;
+  return undefined; // draw: keep default colour
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max - 1) + '…';
+}
+
+function assertHttpUrl(value: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`Invalid match URL: ${value}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid match URL protocol: ${parsed.protocol}`);
+  }
+}

--- a/packages/game-engine/src/community/index.ts
+++ b/packages/game-engine/src/community/index.ts
@@ -1,0 +1,22 @@
+export {
+  pickMatchOfTheWeek,
+  scoreMatchEngagement,
+  type MatchSummary,
+  type PickMatchOptions,
+  type MatchOfTheWeek,
+} from './match-of-the-week';
+
+export {
+  buildDiscordMatchAnnouncement,
+  type DiscordMatchAnnouncementInput,
+  type DiscordWebhookPayload,
+  type DiscordEmbed,
+  type DiscordEmbedField,
+} from './discord-webhook';
+
+export {
+  DEFAULT_COMMUNITY_LINKS,
+  buildCommunityLinks,
+  type CommunityLinks,
+  type CommunityEnv,
+} from './community-config';

--- a/packages/game-engine/src/community/match-of-the-week.test.ts
+++ b/packages/game-engine/src/community/match-of-the-week.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pickMatchOfTheWeek,
+  scoreMatchEngagement,
+  type MatchSummary,
+} from './match-of-the-week';
+
+const baseMatch = (overrides: Partial<MatchSummary> = {}): MatchSummary => ({
+  matchId: 'm1',
+  status: 'completed',
+  finishedAt: new Date('2026-04-25T10:00:00Z'),
+  teamAName: 'Skaven FC',
+  teamBName: 'Dwarves United',
+  teamARoster: 'skaven',
+  teamBRoster: 'dwarf',
+  scoreA: 2,
+  scoreB: 1,
+  totalTurns: 16,
+  totalCasualties: 4,
+  hasComeback: false,
+  ...overrides,
+});
+
+describe('Regle: match-of-the-week (O.9 community)', () => {
+  describe('scoreMatchEngagement()', () => {
+    it('retourne un score numerique fini', () => {
+      const score = scoreMatchEngagement(baseMatch());
+      expect(typeof score).toBe('number');
+      expect(Number.isFinite(score)).toBe(true);
+    });
+
+    it('plus de touchdowns -> score plus eleve', () => {
+      const low = scoreMatchEngagement(baseMatch({ scoreA: 0, scoreB: 0 }));
+      const high = scoreMatchEngagement(baseMatch({ scoreA: 4, scoreB: 3 }));
+      expect(high).toBeGreaterThan(low);
+    });
+
+    it('plus de casualties -> score plus eleve', () => {
+      const low = scoreMatchEngagement(baseMatch({ totalCasualties: 0 }));
+      const high = scoreMatchEngagement(baseMatch({ totalCasualties: 10 }));
+      expect(high).toBeGreaterThan(low);
+    });
+
+    it('un comeback bonifie le score', () => {
+      const noCb = scoreMatchEngagement(baseMatch({ hasComeback: false }));
+      const cb = scoreMatchEngagement(baseMatch({ hasComeback: true }));
+      expect(cb).toBeGreaterThan(noCb);
+    });
+
+    it('un score serre est plus engageant qu un blowout (a TD totaux egaux)', () => {
+      // 3-3 (close) vs 6-0 (blowout) : meme nb de TD, mais 3-3 plus equilibre.
+      const close = scoreMatchEngagement(baseMatch({ scoreA: 3, scoreB: 3 }));
+      const blowout = scoreMatchEngagement(baseMatch({ scoreA: 6, scoreB: 0 }));
+      expect(close).toBeGreaterThanOrEqual(blowout);
+    });
+
+    it('un match non termine recoit un score 0', () => {
+      const notDone = scoreMatchEngagement(baseMatch({ status: 'in_progress' }));
+      expect(notDone).toBe(0);
+    });
+
+    it('reste deterministe : meme entree -> meme sortie', () => {
+      const m = baseMatch();
+      expect(scoreMatchEngagement(m)).toBe(scoreMatchEngagement(m));
+    });
+  });
+
+  describe('pickMatchOfTheWeek()', () => {
+    it('retourne null si la liste est vide', () => {
+      expect(pickMatchOfTheWeek([], { now: new Date('2026-04-26T00:00:00Z') })).toBeNull();
+    });
+
+    it('retourne null si tous les matches sont en dehors de la fenetre 7 jours', () => {
+      const old = baseMatch({
+        matchId: 'old',
+        finishedAt: new Date('2026-04-01T00:00:00Z'),
+      });
+      const result = pickMatchOfTheWeek([old], {
+        now: new Date('2026-04-26T00:00:00Z'),
+      });
+      expect(result).toBeNull();
+    });
+
+    it('selectionne le match avec le plus haut score d engagement dans la fenetre', () => {
+      const dull = baseMatch({
+        matchId: 'dull',
+        scoreA: 0,
+        scoreB: 0,
+        totalCasualties: 0,
+        finishedAt: new Date('2026-04-25T10:00:00Z'),
+      });
+      const epic = baseMatch({
+        matchId: 'epic',
+        scoreA: 4,
+        scoreB: 3,
+        totalCasualties: 8,
+        hasComeback: true,
+        finishedAt: new Date('2026-04-24T10:00:00Z'),
+      });
+      const result = pickMatchOfTheWeek([dull, epic], {
+        now: new Date('2026-04-26T00:00:00Z'),
+      });
+      expect(result?.match.matchId).toBe('epic');
+      expect(result?.score).toBeGreaterThan(0);
+    });
+
+    it('exclut les matches non termines', () => {
+      const inProgress = baseMatch({
+        matchId: 'live',
+        status: 'in_progress',
+        scoreA: 9,
+        scoreB: 9,
+        totalCasualties: 99,
+      });
+      const completed = baseMatch({
+        matchId: 'done',
+        scoreA: 1,
+        scoreB: 0,
+      });
+      const result = pickMatchOfTheWeek([inProgress, completed], {
+        now: new Date('2026-04-26T00:00:00Z'),
+      });
+      expect(result?.match.matchId).toBe('done');
+    });
+
+    it('utilise la fenetre par defaut de 7 jours quand aucune option n est fournie', () => {
+      const recent = baseMatch({
+        matchId: 'recent',
+        finishedAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
+      });
+      const result = pickMatchOfTheWeek([recent]);
+      expect(result?.match.matchId).toBe('recent');
+    });
+
+    it('inclut les details du score pour transparence', () => {
+      const result = pickMatchOfTheWeek([baseMatch()], {
+        now: new Date('2026-04-26T00:00:00Z'),
+      });
+      expect(result).not.toBeNull();
+      if (!result) return;
+      expect(typeof result.score).toBe('number');
+      expect(result.score).toBeGreaterThan(0);
+    });
+
+    it('en cas d egalite parfaite, prefere le plus recent', () => {
+      const older = baseMatch({
+        matchId: 'older',
+        finishedAt: new Date('2026-04-20T10:00:00Z'),
+      });
+      const newer = baseMatch({
+        matchId: 'newer',
+        finishedAt: new Date('2026-04-25T10:00:00Z'),
+      });
+      const result = pickMatchOfTheWeek([older, newer], {
+        now: new Date('2026-04-26T00:00:00Z'),
+      });
+      expect(result?.match.matchId).toBe('newer');
+    });
+
+    it('respecte la fenetre custom passee en option (windowDays)', () => {
+      const day14 = baseMatch({
+        matchId: 'd14',
+        finishedAt: new Date('2026-04-12T00:00:00Z'),
+      });
+      const now = new Date('2026-04-26T00:00:00Z');
+      // window 7 jours -> exclu
+      expect(pickMatchOfTheWeek([day14], { now, windowDays: 7 })).toBeNull();
+      // window 30 jours -> inclus
+      expect(pickMatchOfTheWeek([day14], { now, windowDays: 30 })?.match.matchId).toBe(
+        'd14',
+      );
+    });
+  });
+});

--- a/packages/game-engine/src/community/match-of-the-week.ts
+++ b/packages/game-engine/src/community/match-of-the-week.ts
@@ -1,0 +1,136 @@
+/**
+ * Match of the Week (O.9 community features).
+ *
+ * Pure ranking algorithm — given a list of completed match summaries,
+ * picks the most engaging one of the recent window. Stays totally
+ * decoupled from Prisma / HTTP : the caller is responsible for
+ * fetching match summaries (server) or stubbing them (tests).
+ *
+ * Engagement scoring favors:
+ *   - high total touchdowns (entertaining offense)
+ *   - high casualty count (memorable mayhem)
+ *   - close score gap (suspense > blowouts at equal TD count)
+ *   - comeback flag (narrative bonus)
+ *
+ * Matches that are not completed receive score 0 and are filtered out
+ * by `pickMatchOfTheWeek`.
+ */
+
+export interface MatchSummary {
+  /** Stable match identifier (DB id, slug, …). */
+  matchId: string;
+  /** Match status; only "completed" matches are eligible for ranking. */
+  status: string;
+  /** When the match ended. Null/undefined matches are excluded from window filtering. */
+  finishedAt: Date | null;
+  teamAName: string;
+  teamBName: string;
+  /** Optional roster slugs — used downstream to colour Discord embeds, etc. */
+  teamARoster?: string;
+  teamBRoster?: string;
+  scoreA: number;
+  scoreB: number;
+  /** Total number of half-turns played across both teams. */
+  totalTurns: number;
+  /** Total casualties inflicted (any side). */
+  totalCasualties: number;
+  /** True if the eventual winner trailed by 2+ TDs at some point. */
+  hasComeback: boolean;
+}
+
+export interface PickMatchOptions {
+  /** Reference "now" used to compute the recency window. Defaults to `new Date()`. */
+  now?: Date;
+  /** Window size in days. Defaults to 7. */
+  windowDays?: number;
+}
+
+export interface MatchOfTheWeek {
+  match: MatchSummary;
+  /** Computed engagement score (>= 0). Useful for UI explanations / debug. */
+  score: number;
+}
+
+const TD_WEIGHT = 3;
+const CASUALTY_WEIGHT = 2;
+const COMEBACK_BONUS = 5;
+/**
+ * Bonus for tight games. We add `CLOSE_BONUS_BASE / (1 + abs(diff))` so:
+ *  - diff = 0 → +6 (e.g. 3-3)
+ *  - diff = 1 → +3 (e.g. 2-1)
+ *  - diff = 2 → +2
+ *  - diff = 6 → +0.85 (blowout)
+ */
+const CLOSE_BONUS_BASE = 6;
+
+const DEFAULT_WINDOW_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the engagement score for a single match. Pure, deterministic.
+ *
+ * Returns 0 for any non-completed match — callers can also rely on
+ * {@link pickMatchOfTheWeek} which filters those out anyway.
+ */
+export function scoreMatchEngagement(match: MatchSummary): number {
+  if (match.status !== 'completed') return 0;
+
+  const totalTd = Math.max(0, match.scoreA) + Math.max(0, match.scoreB);
+  const cas = Math.max(0, match.totalCasualties);
+  const diff = Math.abs(match.scoreA - match.scoreB);
+
+  const tdScore = totalTd * TD_WEIGHT;
+  const casScore = cas * CASUALTY_WEIGHT;
+  const closeBonus = CLOSE_BONUS_BASE / (1 + diff);
+  const comebackBonus = match.hasComeback ? COMEBACK_BONUS : 0;
+
+  return tdScore + casScore + closeBonus + comebackBonus;
+}
+
+/**
+ * Select the most engaging match in the recent window.
+ *
+ * Selection rules:
+ *   1. Match must have status === "completed".
+ *   2. Match must have `finishedAt` within the last `windowDays` (default 7).
+ *   3. Highest engagement score wins.
+ *   4. Tie-breaker: most recent `finishedAt`.
+ *
+ * Returns `null` if no candidate remains.
+ */
+export function pickMatchOfTheWeek(
+  matches: ReadonlyArray<MatchSummary>,
+  options: PickMatchOptions = {},
+): MatchOfTheWeek | null {
+  const now = options.now ?? new Date();
+  const windowDays = options.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const windowMs = windowDays * MS_PER_DAY;
+  const minTimestamp = now.getTime() - windowMs;
+
+  let best: MatchOfTheWeek | null = null;
+
+  for (const match of matches) {
+    if (match.status !== 'completed') continue;
+    if (!match.finishedAt) continue;
+    const finishedTs = match.finishedAt.getTime();
+    if (finishedTs < minTimestamp) continue;
+    if (finishedTs > now.getTime()) continue; // future-dated — ignore
+
+    const score = scoreMatchEngagement(match);
+    if (!best) {
+      best = { match, score };
+      continue;
+    }
+    if (score > best.score) {
+      best = { match, score };
+    } else if (score === best.score) {
+      // Tie-breaker: most recent.
+      const bestTs = best.match.finishedAt?.getTime() ?? 0;
+      if (finishedTs > bestTs) {
+        best = { match, score };
+      }
+    }
+  }
+
+  return best;
+}

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -359,6 +359,9 @@ export {
 // Export des rosters et positions
 export * from './rosters';
 
+// Export du module communautaire (O.9 : match of the week, Discord helpers)
+export * from './community';
+
 // Export des compétences (skills)
 export * from './skills';
 export * from './skills/skill-effects';


### PR DESCRIPTION
## Resume

Materialise les features communautaires reclamees par la roadmap, sous forme
de modules purs cote game-engine reutilisables depuis web/server/mobile sans
toucher a la couche HTTP/DB.

### `packages/game-engine/src/community/`

#### Match of the Week — `match-of-the-week.ts`
- `scoreMatchEngagement(match)` : scoring deterministe combinant TDs (poids 3),
  casualties (poids 2), bonus comeback (+5), bonus de score serre
  (`6 / (1 + |diff|)` — favorise les matches proches).
- `pickMatchOfTheWeek(matches, opts?)` : selectionne dans une fenetre glissante
  (defaut 7 jours), filtre les matches non termines / hors fenetre, tie-breaker
  par recence.
- 100 % pure, le caller (server) fournit la liste `MatchSummary[]` apres
  agregation depuis Prisma — la logique de selection reste totalement
  decouplee de la DB.

#### Discord webhook payload — `discord-webhook.ts`
- `buildDiscordMatchAnnouncement(input)` produit un `DiscordWebhookPayload`
  pret a POST sur un webhook Discord.
- Embed avec titre `"<TeamA> X - Y <TeamB>"`, url cliquable, fields
  `Score` + `Casualties`, couleur derivee de la `ROSTER_COLORS` de la roster
  gagnante (fallback couleur neutre en cas d'egalite).
- Validation stricte de l'URL (http/https requis, autres protocoles rejetes
  pour eviter d'injecter des `javascript:` dans Discord).
- Troncature des titres trop longs (limite Discord = 256 caracteres).

#### Centralisation des liens communautaires — `community-config.ts`
- `DEFAULT_COMMUNITY_LINKS` reprend l'invite Discord historiquement codee en
  dur dans le footer.
- `buildCommunityLinks(env)` valide les overrides : URL parsable, protocole
  https, hostname `discord.gg` exclusif. Toute valeur invalide retombe
  silencieusement sur les defauts (pas de leak d'URL malveillante dans le DOM).

### `apps/web/app/components/Footer.tsx`
- Le lien Discord du footer utilise maintenant `buildCommunityLinks` avec
  `NEXT_PUBLIC_DISCORD_INVITE_URL` en override optionnel — UX inchangee mais
  configurable par environnement.

## Tache roadmap

Sprint 22+, tache **O.9 — Features communautaires (match of the week, Discord)**

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` (4786/4786 dont 30 nouveaux sur
  community : 15 match-of-the-week + 9 discord-webhook + 6 community-config)
- [x] `pnpm --filter @bb/web test` (319/319, footer integre sans regression)
- [x] `pnpm --filter @bb/game-engine typecheck`
- [x] `pnpm --filter @bb/game-engine build`
- [ ] Verification manuelle : footer affiche toujours le lien Discord
- [ ] Brancher le service `pickMatchOfTheWeek` cote serveur (PR follow-up :
  agregation SQL des matches de la semaine + endpoint `/api/community/match-of-week`)
- [ ] Brancher le webhook Discord cote serveur (PR follow-up : config de
  l'URL webhook + cron hebdo qui POST le `buildDiscordMatchAnnouncement`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_