### PR TITLE
feat(analytics): dashboards personnel et global (O.10)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -356,7 +356,7 @@
 | O.8a | Generateur de noms d'equipe par roster (service + endpoint) | Engagement | [x] |
 | O.8b | Cosmetiques visuels (logos equipe, assets graphiques) | Engagement | [x] |
 | O.9 | Features communautaires (match of the week, Discord) | Engagement | [x] |
-| O.10 | Dashboard analytics personnel et global | Engagement | [ ] |
+| O.10 | Dashboard analytics personnel et global | Engagement | [x] |
 
 ### Sprint 23 — SEO, GEO & rayonnement (~5 jours)
 

--- a/packages/game-engine/src/analytics/global-dashboard.test.ts
+++ b/packages/game-engine/src/analytics/global-dashboard.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildGlobalDashboard,
+  type GlobalMatchRecord,
+} from './global-dashboard';
+
+const baseRecord = (
+  overrides: Partial<GlobalMatchRecord> = {},
+): GlobalMatchRecord => ({
+  matchId: 'm1',
+  status: 'completed',
+  finishedAt: new Date('2026-04-25T10:00:00Z'),
+  scoreA: 2,
+  scoreB: 1,
+  rosterA: 'skaven',
+  rosterB: 'dwarf',
+  totalCasualties: 3,
+  totalTurns: 16,
+  ...overrides,
+});
+
+describe('Regle: global-dashboard (O.10 analytics global)', () => {
+  it('retourne un dashboard vide pour zero match', () => {
+    const dash = buildGlobalDashboard([]);
+    expect(dash.totalMatches).toBe(0);
+    expect(dash.completedMatches).toBe(0);
+    expect(dash.inProgressMatches).toBe(0);
+    expect(dash.totalTouchdowns).toBe(0);
+    expect(dash.totalCasualties).toBe(0);
+    expect(dash.averageTouchdownsPerMatch).toBe(0);
+    expect(dash.averageCasualtiesPerMatch).toBe(0);
+    expect(dash.averageTurnsPerMatch).toBe(0);
+    expect(dash.rosterPopularity).toEqual([]);
+    expect(dash.topRoster).toBeNull();
+  });
+
+  it('compte total / completed / in_progress', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', status: 'completed' }),
+      baseRecord({ matchId: '2', status: 'completed' }),
+      baseRecord({ matchId: '3', status: 'in_progress' }),
+      baseRecord({ matchId: '4', status: 'cancelled' }),
+    ]);
+    expect(dash.totalMatches).toBe(4);
+    expect(dash.completedMatches).toBe(2);
+    expect(dash.inProgressMatches).toBe(1);
+  });
+
+  it('totalise touchdowns et casualties sur les matches termines uniquement', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', scoreA: 2, scoreB: 1, totalCasualties: 3 }),
+      baseRecord({ matchId: '2', scoreA: 0, scoreB: 4, totalCasualties: 5 }),
+      baseRecord({
+        matchId: 'live',
+        status: 'in_progress',
+        scoreA: 9,
+        scoreB: 9,
+        totalCasualties: 99,
+      }),
+    ]);
+    expect(dash.totalTouchdowns).toBe(7);
+    expect(dash.totalCasualties).toBe(8);
+  });
+
+  it('calcule les moyennes par match termine', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', scoreA: 2, scoreB: 2, totalCasualties: 4, totalTurns: 16 }),
+      baseRecord({ matchId: '2', scoreA: 0, scoreB: 0, totalCasualties: 0, totalTurns: 14 }),
+    ]);
+    expect(dash.averageTouchdownsPerMatch).toBe(2); // (4+0)/2
+    expect(dash.averageCasualtiesPerMatch).toBe(2);
+    expect(dash.averageTurnsPerMatch).toBe(15);
+  });
+
+  it('aggrège la popularite des rosters (les deux cotes comptent)', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', rosterA: 'skaven', rosterB: 'dwarf' }),
+      baseRecord({ matchId: '2', rosterA: 'skaven', rosterB: 'orc' }),
+      baseRecord({ matchId: '3', rosterA: 'dwarf', rosterB: 'orc' }),
+    ]);
+    const skaven = dash.rosterPopularity.find((r) => r.roster === 'skaven');
+    const dwarf = dash.rosterPopularity.find((r) => r.roster === 'dwarf');
+    const orc = dash.rosterPopularity.find((r) => r.roster === 'orc');
+    expect(skaven?.pickCount).toBe(2);
+    expect(dwarf?.pickCount).toBe(2);
+    expect(orc?.pickCount).toBe(2);
+  });
+
+  it('calcule le winRate par roster (sur matches termines)', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', rosterA: 'skaven', rosterB: 'dwarf', scoreA: 3, scoreB: 1 }),
+      baseRecord({ matchId: '2', rosterA: 'skaven', rosterB: 'orc', scoreA: 0, scoreB: 2 }),
+      baseRecord({ matchId: '3', rosterA: 'dwarf', rosterB: 'orc', scoreA: 1, scoreB: 1 }),
+    ]);
+    const skaven = dash.rosterPopularity.find((r) => r.roster === 'skaven');
+    expect(skaven?.winRate).toBe(0.5); // 1W/1L => 0.5
+    const dwarf = dash.rosterPopularity.find((r) => r.roster === 'dwarf');
+    expect(dwarf?.winRate).toBe(0.25); // 0W/1L/1D => (0+0.5)/2 = 0.25
+  });
+
+  it('topRoster est le roster avec le plus de picks', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', rosterA: 'skaven', rosterB: 'dwarf' }),
+      baseRecord({ matchId: '2', rosterA: 'skaven', rosterB: 'skaven' }),
+      baseRecord({ matchId: '3', rosterA: 'orc', rosterB: 'dwarf' }),
+    ]);
+    expect(dash.topRoster).toBe('skaven'); // 3 picks
+  });
+
+  it('topRoster est null si aucune roster connue', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ rosterA: undefined, rosterB: undefined }),
+    ]);
+    expect(dash.topRoster).toBeNull();
+  });
+
+  it('rosterPopularity est trie par pickCount desc, puis nom asc', () => {
+    const dash = buildGlobalDashboard([
+      baseRecord({ matchId: '1', rosterA: 'orc', rosterB: 'orc' }),
+      baseRecord({ matchId: '2', rosterA: 'skaven', rosterB: 'skaven' }),
+      baseRecord({ matchId: '3', rosterA: 'skaven', rosterB: 'dwarf' }),
+      baseRecord({ matchId: '4', rosterA: 'dwarf', rosterB: 'dwarf' }),
+    ]);
+    expect(dash.rosterPopularity.map((r) => r.roster)).toEqual([
+      'dwarf', // 3
+      'skaven', // 3 -> tri alpha apres dwarf
+      'orc', // 2
+    ]);
+  });
+
+  it('reste deterministe : meme entree -> meme sortie', () => {
+    const records = [baseRecord({ matchId: '1' }), baseRecord({ matchId: '2' })];
+    expect(buildGlobalDashboard(records)).toEqual(buildGlobalDashboard(records));
+  });
+});

--- a/packages/game-engine/src/analytics/global-dashboard.ts
+++ b/packages/game-engine/src/analytics/global-dashboard.ts
@@ -1,0 +1,136 @@
+/**
+ * Global analytics dashboard (O.10 — analytics global).
+ *
+ * Pure aggregation : caller (server) loads platform-wide matches from
+ * Prisma and maps them into {@link GlobalMatchRecord}; this module
+ * computes the global dashboard summary deterministically.
+ *
+ * Conventions :
+ *   - touchdown / casualty totals only sum completed matches
+ *   - rosterPopularity counts both sides ; in-progress matches are
+ *     ignored entirely (no roster pick, no win-rate)
+ *   - winRate per roster weights draws as 0.5 (same convention as
+ *     personal-dashboard / career-stats)
+ */
+
+export interface GlobalMatchRecord {
+  matchId: string;
+  status: string;
+  finishedAt: Date | null;
+  scoreA: number;
+  scoreB: number;
+  rosterA: string | undefined;
+  rosterB: string | undefined;
+  totalCasualties: number;
+  totalTurns: number;
+}
+
+export interface RosterPopularityStat {
+  roster: string;
+  pickCount: number;
+  /** Win-rate (draws weighted 0.5) over completed matches with this roster. */
+  winRate: number;
+}
+
+export interface GlobalDashboard {
+  totalMatches: number;
+  completedMatches: number;
+  inProgressMatches: number;
+  totalTouchdowns: number;
+  totalCasualties: number;
+  averageTouchdownsPerMatch: number;
+  averageCasualtiesPerMatch: number;
+  averageTurnsPerMatch: number;
+  /** All known rosters sorted by pickCount desc then name asc. */
+  rosterPopularity: RosterPopularityStat[];
+  /** Most-picked roster slug; null if none observed. */
+  topRoster: string | null;
+}
+
+interface RosterAcc {
+  pickCount: number;
+  w: number;
+  l: number;
+  d: number;
+}
+
+export function buildGlobalDashboard(
+  records: ReadonlyArray<GlobalMatchRecord>,
+): GlobalDashboard {
+  let completedMatches = 0;
+  let inProgressMatches = 0;
+  let totalTouchdowns = 0;
+  let totalCasualties = 0;
+  let totalTurns = 0;
+
+  const rosterAcc = new Map<string, RosterAcc>();
+
+  for (const r of records) {
+    if (r.status === 'in_progress') inProgressMatches += 1;
+    if (r.status !== 'completed') continue;
+
+    completedMatches += 1;
+    totalTouchdowns += Math.max(0, r.scoreA) + Math.max(0, r.scoreB);
+    totalCasualties += Math.max(0, r.totalCasualties);
+    totalTurns += Math.max(0, r.totalTurns);
+
+    const outcomeA = matchOutcome(r.scoreA, r.scoreB);
+    const outcomeB = matchOutcome(r.scoreB, r.scoreA);
+
+    if (r.rosterA) bumpRoster(rosterAcc, r.rosterA, outcomeA);
+    if (r.rosterB) bumpRoster(rosterAcc, r.rosterB, outcomeB);
+  }
+
+  const totalMatches = records.length;
+  const averageTouchdownsPerMatch =
+    completedMatches === 0 ? 0 : totalTouchdowns / completedMatches;
+  const averageCasualtiesPerMatch =
+    completedMatches === 0 ? 0 : totalCasualties / completedMatches;
+  const averageTurnsPerMatch =
+    completedMatches === 0 ? 0 : totalTurns / completedMatches;
+
+  const rosterPopularity: RosterPopularityStat[] = Array.from(rosterAcc.entries())
+    .map(([roster, s]) => ({
+      roster,
+      pickCount: s.pickCount,
+      winRate: s.pickCount === 0 ? 0 : (s.w + s.d * 0.5) / s.pickCount,
+    }))
+    .sort((a, b) => {
+      if (b.pickCount !== a.pickCount) return b.pickCount - a.pickCount;
+      return a.roster.localeCompare(b.roster);
+    });
+
+  const topRoster = rosterPopularity.length > 0 ? rosterPopularity[0].roster : null;
+
+  return {
+    totalMatches,
+    completedMatches,
+    inProgressMatches,
+    totalTouchdowns,
+    totalCasualties,
+    averageTouchdownsPerMatch,
+    averageCasualtiesPerMatch,
+    averageTurnsPerMatch,
+    rosterPopularity,
+    topRoster,
+  };
+}
+
+function bumpRoster(
+  acc: Map<string, RosterAcc>,
+  roster: string,
+  outcome: 'W' | 'L' | 'D',
+): void {
+  const slot = acc.get(roster) ?? { pickCount: 0, w: 0, l: 0, d: 0 };
+  slot.pickCount += 1;
+  if (outcome === 'W') slot.w += 1;
+  else if (outcome === 'L') slot.l += 1;
+  else slot.d += 1;
+  acc.set(roster, slot);
+}
+
+function matchOutcome(myScore: number, oppScore: number): 'W' | 'L' | 'D' {
+  if (myScore > oppScore) return 'W';
+  if (myScore < oppScore) return 'L';
+  return 'D';
+}

--- a/packages/game-engine/src/analytics/index.ts
+++ b/packages/game-engine/src/analytics/index.ts
@@ -1,0 +1,13 @@
+export {
+  buildPersonalDashboard,
+  type PersonalMatchRecord,
+  type PersonalDashboard,
+  type RosterUsageStat,
+} from './personal-dashboard';
+
+export {
+  buildGlobalDashboard,
+  type GlobalMatchRecord,
+  type GlobalDashboard,
+  type RosterPopularityStat,
+} from './global-dashboard';

--- a/packages/game-engine/src/analytics/personal-dashboard.test.ts
+++ b/packages/game-engine/src/analytics/personal-dashboard.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPersonalDashboard,
+  type PersonalMatchRecord,
+} from './personal-dashboard';
+
+const baseRecord = (
+  overrides: Partial<PersonalMatchRecord> = {},
+): PersonalMatchRecord => ({
+  matchId: 'm1',
+  status: 'completed',
+  finishedAt: new Date('2026-04-25T10:00:00Z'),
+  myScore: 2,
+  oppScore: 1,
+  myRoster: 'skaven',
+  oppRoster: 'dwarf',
+  casualtiesInflicted: 2,
+  casualtiesSuffered: 1,
+  totalTurns: 16,
+  ...overrides,
+});
+
+describe('Regle: personal-dashboard (O.10 analytics personnel)', () => {
+  it('retourne un dashboard vide pour zero match', () => {
+    const dash = buildPersonalDashboard([]);
+    expect(dash.totalMatches).toBe(0);
+    expect(dash.completedMatches).toBe(0);
+    expect(dash.wins).toBe(0);
+    expect(dash.losses).toBe(0);
+    expect(dash.draws).toBe(0);
+    expect(dash.winRate).toBe(0);
+    expect(dash.recentForm).toEqual([]);
+    expect(dash.rosterUsage).toEqual([]);
+  });
+
+  it('compte les matches totaux et termines separement', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: 'a', status: 'completed' }),
+      baseRecord({ matchId: 'b', status: 'in_progress' }),
+      baseRecord({ matchId: 'c', status: 'completed' }),
+    ]);
+    expect(dash.totalMatches).toBe(3);
+    expect(dash.completedMatches).toBe(2);
+  });
+
+  it('compte wins/losses/draws sur les matches termines uniquement', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: 'w', myScore: 3, oppScore: 1 }),
+      baseRecord({ matchId: 'l', myScore: 0, oppScore: 2 }),
+      baseRecord({ matchId: 'd', myScore: 1, oppScore: 1 }),
+      baseRecord({ matchId: 'live', status: 'in_progress', myScore: 9, oppScore: 0 }),
+    ]);
+    expect(dash.wins).toBe(1);
+    expect(dash.losses).toBe(1);
+    expect(dash.draws).toBe(1);
+  });
+
+  it('calcule winRate correctement (draws comptent 0.5)', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: 'w', myScore: 3, oppScore: 1 }),
+      baseRecord({ matchId: 'd', myScore: 1, oppScore: 1 }),
+      baseRecord({ matchId: 'l', myScore: 0, oppScore: 1 }),
+      baseRecord({ matchId: 'l2', myScore: 0, oppScore: 1 }),
+    ]);
+    // (1 + 0.5) / 4 = 0.375
+    expect(dash.winRate).toBeCloseTo(0.375, 4);
+  });
+
+  it('totalise touchdowns et casualties pour et contre', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({
+        myScore: 2,
+        oppScore: 1,
+        casualtiesInflicted: 3,
+        casualtiesSuffered: 2,
+      }),
+      baseRecord({
+        matchId: 'm2',
+        myScore: 1,
+        oppScore: 3,
+        casualtiesInflicted: 1,
+        casualtiesSuffered: 4,
+      }),
+    ]);
+    expect(dash.totalTouchdownsFor).toBe(3);
+    expect(dash.totalTouchdownsAgainst).toBe(4);
+    expect(dash.totalCasualtiesInflicted).toBe(4);
+    expect(dash.totalCasualtiesSuffered).toBe(6);
+  });
+
+  it('calcule la moyenne de turns par match termine (zero matches -> 0)', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ totalTurns: 16 }),
+      baseRecord({ matchId: 'm2', totalTurns: 14 }),
+    ]);
+    expect(dash.averageTurnsPerMatch).toBe(15);
+    expect(buildPersonalDashboard([]).averageTurnsPerMatch).toBe(0);
+  });
+
+  it('exclut les matches en cours du calcul de moyenne de turns', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ totalTurns: 16 }),
+      baseRecord({ matchId: 'live', status: 'in_progress', totalTurns: 0 }),
+    ]);
+    expect(dash.averageTurnsPerMatch).toBe(16);
+  });
+
+  it('aggrège l usage par roster avec son winRate dedie', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: '1', myRoster: 'skaven', myScore: 3, oppScore: 1 }),
+      baseRecord({ matchId: '2', myRoster: 'skaven', myScore: 0, oppScore: 2 }),
+      baseRecord({ matchId: '3', myRoster: 'dwarf', myScore: 2, oppScore: 1 }),
+    ]);
+    const skaven = dash.rosterUsage.find((r) => r.roster === 'skaven');
+    const dwarf = dash.rosterUsage.find((r) => r.roster === 'dwarf');
+    expect(skaven?.count).toBe(2);
+    expect(skaven?.winRate).toBe(0.5);
+    expect(dwarf?.count).toBe(1);
+    expect(dwarf?.winRate).toBe(1);
+  });
+
+  it('ignore les rosters undefined dans rosterUsage', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: '1', myRoster: undefined }),
+      baseRecord({ matchId: '2', myRoster: 'orc' }),
+    ]);
+    expect(dash.rosterUsage.length).toBe(1);
+    expect(dash.rosterUsage[0].roster).toBe('orc');
+  });
+
+  it('trie rosterUsage par count desc puis nom', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({ matchId: '1', myRoster: 'orc' }),
+      baseRecord({ matchId: '2', myRoster: 'skaven' }),
+      baseRecord({ matchId: '3', myRoster: 'skaven' }),
+      baseRecord({ matchId: '4', myRoster: 'dwarf' }),
+      baseRecord({ matchId: '5', myRoster: 'dwarf' }),
+    ]);
+    expect(dash.rosterUsage.map((r) => r.roster)).toEqual([
+      'dwarf',
+      'skaven',
+      'orc',
+    ]);
+  });
+
+  it('expose recentForm : 5 derniers matches termines (du plus recent au plus ancien)', () => {
+    const records: PersonalMatchRecord[] = [];
+    // 7 matches, termines, dates croissantes
+    for (let i = 0; i < 7; i++) {
+      records.push(
+        baseRecord({
+          matchId: `m${i}`,
+          finishedAt: new Date(`2026-04-${20 + i}T10:00:00Z`),
+          myScore: i,
+          oppScore: 0,
+        }),
+      );
+    }
+    const dash = buildPersonalDashboard(records);
+    // Le plus recent est m6 (myScore=6 -> W), m5 (W), m4 (W), m3 (W), m2 (W)
+    expect(dash.recentForm).toEqual(['W', 'W', 'W', 'W', 'W']);
+    expect(dash.recentForm.length).toBe(5);
+  });
+
+  it('recentForm exclut les matches en cours', () => {
+    const dash = buildPersonalDashboard([
+      baseRecord({
+        matchId: '1',
+        myScore: 1,
+        oppScore: 0,
+        finishedAt: new Date('2026-04-21T10:00:00Z'),
+      }),
+      baseRecord({
+        matchId: 'live',
+        status: 'in_progress',
+        finishedAt: null,
+      }),
+    ]);
+    expect(dash.recentForm).toEqual(['W']);
+  });
+
+  it('reste deterministe : meme entree -> meme sortie', () => {
+    const records = [baseRecord({ matchId: '1' }), baseRecord({ matchId: '2' })];
+    expect(buildPersonalDashboard(records)).toEqual(buildPersonalDashboard(records));
+  });
+});

--- a/packages/game-engine/src/analytics/personal-dashboard.ts
+++ b/packages/game-engine/src/analytics/personal-dashboard.ts
@@ -1,0 +1,153 @@
+/**
+ * Personal analytics dashboard (O.10 — analytics personnel).
+ *
+ * Pure aggregation : caller (server) loads the user's matches from
+ * Prisma and maps them into {@link PersonalMatchRecord}; this module
+ * computes the dashboard summary deterministically.
+ *
+ * Conventions :
+ *   - W/L/D and per-roster stats only count matches with status === "completed".
+ *   - "totalMatches" counts every record passed in (including in-progress
+ *     and cancelled), so the UI can show "5 played, 2 in progress".
+ *   - winRate weights draws as 0.5 (same convention as career-stats.ts).
+ */
+
+export interface PersonalMatchRecord {
+  matchId: string;
+  /** Status string from the server (e.g. "completed", "in_progress", "cancelled"). */
+  status: string;
+  /** When the match ended; null for live/cancelled matches. */
+  finishedAt: Date | null;
+  /** Touchdowns scored by the user. */
+  myScore: number;
+  /** Touchdowns scored by the opponent. */
+  oppScore: number;
+  /** Roster slug used by the user (undefined when unknown). */
+  myRoster: string | undefined;
+  /** Roster slug used by the opponent (undefined when unknown). */
+  oppRoster: string | undefined;
+  /** Casualties inflicted by the user during the match. */
+  casualtiesInflicted: number;
+  /** Casualties suffered by the user during the match. */
+  casualtiesSuffered: number;
+  /** Total turns played in the match (both halves combined). */
+  totalTurns: number;
+}
+
+export interface RosterUsageStat {
+  roster: string;
+  count: number;
+  /** Win-rate (draws weighted 0.5) over completed matches with this roster. */
+  winRate: number;
+}
+
+export interface PersonalDashboard {
+  totalMatches: number;
+  completedMatches: number;
+  wins: number;
+  losses: number;
+  draws: number;
+  /** Win-rate over completed matches; 0 when no completed matches. */
+  winRate: number;
+  totalTouchdownsFor: number;
+  totalTouchdownsAgainst: number;
+  totalCasualtiesInflicted: number;
+  totalCasualtiesSuffered: number;
+  /** Average turns over completed matches; 0 when none. */
+  averageTurnsPerMatch: number;
+  /** Per-roster usage + win-rate, sorted by count desc then name asc. */
+  rosterUsage: RosterUsageStat[];
+  /** Last 5 completed matches' outcomes from most recent to oldest. */
+  recentForm: Array<'W' | 'L' | 'D'>;
+}
+
+const FORM_LIMIT = 5;
+
+export function buildPersonalDashboard(
+  records: ReadonlyArray<PersonalMatchRecord>,
+): PersonalDashboard {
+  const completed = records.filter((r) => r.status === 'completed');
+
+  let wins = 0;
+  let losses = 0;
+  let draws = 0;
+  let touchdownsFor = 0;
+  let touchdownsAgainst = 0;
+  let casualtiesInflicted = 0;
+  let casualtiesSuffered = 0;
+  let totalTurns = 0;
+
+  const rosterAcc = new Map<
+    string,
+    { count: number; w: number; l: number; d: number }
+  >();
+
+  for (const r of completed) {
+    touchdownsFor += r.myScore;
+    touchdownsAgainst += r.oppScore;
+    casualtiesInflicted += r.casualtiesInflicted;
+    casualtiesSuffered += r.casualtiesSuffered;
+    totalTurns += r.totalTurns;
+
+    const outcome = matchOutcome(r.myScore, r.oppScore);
+    if (outcome === 'W') wins += 1;
+    else if (outcome === 'L') losses += 1;
+    else draws += 1;
+
+    if (r.myRoster) {
+      const slot = rosterAcc.get(r.myRoster) ?? { count: 0, w: 0, l: 0, d: 0 };
+      slot.count += 1;
+      if (outcome === 'W') slot.w += 1;
+      else if (outcome === 'L') slot.l += 1;
+      else slot.d += 1;
+      rosterAcc.set(r.myRoster, slot);
+    }
+  }
+
+  const winRate =
+    completed.length === 0 ? 0 : (wins + draws * 0.5) / completed.length;
+  const averageTurnsPerMatch =
+    completed.length === 0 ? 0 : totalTurns / completed.length;
+
+  const rosterUsage: RosterUsageStat[] = Array.from(rosterAcc.entries())
+    .map(([roster, s]) => ({
+      roster,
+      count: s.count,
+      winRate: s.count === 0 ? 0 : (s.w + s.d * 0.5) / s.count,
+    }))
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.roster.localeCompare(b.roster);
+    });
+
+  const recentForm = [...completed]
+    .sort((a, b) => {
+      const ta = a.finishedAt?.getTime() ?? 0;
+      const tb = b.finishedAt?.getTime() ?? 0;
+      return tb - ta;
+    })
+    .slice(0, FORM_LIMIT)
+    .map((r) => matchOutcome(r.myScore, r.oppScore));
+
+  return {
+    totalMatches: records.length,
+    completedMatches: completed.length,
+    wins,
+    losses,
+    draws,
+    winRate,
+    totalTouchdownsFor: touchdownsFor,
+    totalTouchdownsAgainst: touchdownsAgainst,
+    totalCasualtiesInflicted: casualtiesInflicted,
+    totalCasualtiesSuffered: casualtiesSuffered,
+    averageTurnsPerMatch,
+    rosterUsage,
+    recentForm,
+  };
+}
+
+function matchOutcome(myScore: number, oppScore: number): 'W' | 'L' | 'D' {
+  if (myScore > oppScore) return 'W';
+  if (myScore < oppScore) return 'L';
+  return 'D';
+}

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -362,6 +362,9 @@ export * from './rosters';
 // Export du module communautaire (O.9 : match of the week, Discord helpers)
 export * from './community';
 
+// Export du module analytics (O.10 : dashboard personnel + global)
+export * from './analytics';
+
 // Export des compétences (skills)
 export * from './skills';
 export * from './skills/skill-effects';


### PR DESCRIPTION
## Resume

Materialise les agregations analytics reclamees par la roadmap O.10.
Modules purs cote `@bb/game-engine` : le caller (server) charge les
matches via Prisma puis appelle les builders qui calculent les stats
deterministiquement, sans toucher a la DB.

### `packages/game-engine/src/analytics/`

#### Personal dashboard — `personal-dashboard.ts`
`buildPersonalDashboard(records)` produit un `PersonalDashboard` :
- `totalMatches`, `completedMatches`, `wins / losses / draws`
- `winRate` (draws ponderes 0.5, meme convention que `career-stats.ts`)
- `totalTouchdownsFor / Against`, `casualtiesInflicted / Suffered`
- `averageTurnsPerMatch` calcule sur les matches termines uniquement
- `rosterUsage` : par roster utilise par le joueur, `count` + `winRate`
  dedie, trie par count desc puis nom asc
- `recentForm` : derniers 5 W/L/D du plus recent au plus ancien

#### Global dashboard — `global-dashboard.ts`
`buildGlobalDashboard(records)` produit un `GlobalDashboard` :
- `totalMatches`, `completedMatches`, `inProgressMatches`
- `totalTouchdowns`, `totalCasualties` (matches termines uniquement)
- `averageTouchdownsPerMatch` / `averageCasualtiesPerMatch` / `averageTurnsPerMatch`
- `rosterPopularity` : les deux cotes comptent ; chaque entree expose
  `pickCount` + `winRate` dedie, tri par count desc puis nom asc
- `topRoster` : roster le plus pris, `null` si aucun

### Decouplage

Les deux modules sont 100 % purs : pas de Prisma, pas de HTTP. Le
caller fournit des `MatchRecord[]` qu'il a fetche / projete depuis la
DB. Les follow-ups naturels (hors scope ici pour rester focus) :
- endpoint `GET /api/me/dashboard` (auth obligatoire) qui charge les
  matches du user et appelle `buildPersonalDashboard`
- endpoint `GET /api/community/global-dashboard` (cache 5 min) qui
  agrege depuis Prisma et appelle `buildGlobalDashboard`
- pages web `/me/dashboard` et `/community/dashboard` qui consomment
  ces endpoints

### Conventions partagees

- W/L/D et stats par roster ne comptent que les matches termines (status === "completed").
- `totalMatches` inclut les matches en cours et annules (la UI peut afficher "5 joues, 2 en cours").
- Win-rate weight 0.5 par draw.
- Tie-breaker par nom alphabetique sur les classements.

## Tache roadmap

Sprint 22+, tache **O.10 — Dashboard analytics personnel et global**

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` (4809/4809 dont 23 nouveaux : 13 personal + 10 global)
- [x] `pnpm --filter @bb/game-engine typecheck`
- [x] `pnpm --filter @bb/game-engine build`
- [ ] Brancher les endpoints serveur (PR follow-up : `/api/me/dashboard` + `/api/community/global-dashboard`)
- [ ] Pages web `/me/dashboard` + `/community/dashboard` (PR follow-up)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_