### PR TITLE
feat(seo): codes verification webmasters (Q.17)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -388,7 +388,7 @@
 | Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [x] |
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [x] |
-| Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [ ] |
+| Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [x] |
 | Q.18 | Soumission sitemap + monitoring indexation (Google Search Console, Bing Webmaster Tools) | SEO | [ ] |
 | Q.19 | Ajouter Umami events cles (clic equipe, recrut star player, export PDF, support CTA) | Analytics | [ ] |
 | Q.20 | Core Web Vitals monitoring (LCP, INP, CLS) + budget perf CI | Perf | [ ] |

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { Cinzel_Decorative, Cinzel, Montserrat, Inter, Bebas_Neue } from "next/f
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import { ClientLayout } from "./components/ClientLayout";
+import { buildWebmasterVerification } from "./lib/webmaster-verification";
 
 const cinzelDecorative = Cinzel_Decorative({
   subsets: ["latin"],
@@ -143,12 +144,20 @@ export const metadata: Metadata = {
     "geo.placename": "France",
     "ICBM": "46.603354, 1.888334",
   },
-  verification: {
-    // Ajoutez vos codes de vérification ici si nécessaire
-    // google: "votre-code-google",
-    // yandex: "votre-code-yandex",
-    // bing: "votre-code-bing",
-  },
+  // Codes de vérification webmasters (Q.17 — Sprint 23).
+  // Pilote depuis l'env public, valide via `buildWebmasterVerification`
+  // (rejet des placeholders, chaines vides, espaces internes, > 200 chars).
+  // Variables : NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+  //            NEXT_PUBLIC_YANDEX_VERIFICATION,
+  //            NEXT_PUBLIC_BING_SITE_VERIFICATION (devient meta msvalidate.01).
+  verification: buildWebmasterVerification({
+    NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION:
+      process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    NEXT_PUBLIC_YANDEX_VERIFICATION:
+      process.env.NEXT_PUBLIC_YANDEX_VERIFICATION,
+    NEXT_PUBLIC_BING_SITE_VERIFICATION:
+      process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION,
+  }),
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/web/app/lib/webmaster-verification.test.ts
+++ b/apps/web/app/lib/webmaster-verification.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests pour le builder de codes de verification webmasters
+ * (Q.17 — Sprint 23).
+ *
+ * Le builder est pur : il prend les codes depuis l'env et produit un
+ * objet `verification` consommable par `metadata.verification` de
+ * Next.js. Validation defensive pour eviter de leaker des placeholders
+ * ("votre-code-...", chaines vides, espaces).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildWebmasterVerification,
+  type WebmasterVerificationEnv,
+} from "./webmaster-verification";
+
+describe("buildWebmasterVerification", () => {
+  it("retourne un objet vide quand aucun code fourni", () => {
+    expect(buildWebmasterVerification({})).toEqual({});
+    expect(buildWebmasterVerification(undefined)).toEqual({});
+  });
+
+  it("propage google quand fourni et valide", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "abcDEF1234567890validCode",
+    };
+    expect(buildWebmasterVerification(env).google).toBe(
+      "abcDEF1234567890validCode",
+    );
+  });
+
+  it("propage yandex et bing quand fournis", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_YANDEX_VERIFICATION: "yandex-deadbeef1234",
+      NEXT_PUBLIC_BING_SITE_VERIFICATION: "BING1234567890abcdefABC123",
+    };
+    const result = buildWebmasterVerification(env);
+    expect(result.yandex).toBe("yandex-deadbeef1234");
+    expect(result.other?.["msvalidate.01"]).toBe("BING1234567890abcdefABC123");
+  });
+
+  it("ignore les chaines vides", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "",
+      NEXT_PUBLIC_YANDEX_VERIFICATION: "   ",
+    };
+    expect(buildWebmasterVerification(env)).toEqual({});
+  });
+
+  it("ignore les codes avec espaces internes (probable mauvais collage)", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "abc def ghi",
+    };
+    expect(buildWebmasterVerification(env)).toEqual({});
+  });
+
+  it("ignore les placeholders evidents (defense contre commit accidentel)", () => {
+    const placeholders = [
+      "votre-code-google",
+      "votre code yandex",
+      "your-code-bing",
+      "TODO",
+      "FIXME",
+      "xxx",
+      "<insert>",
+    ];
+    for (const placeholder of placeholders) {
+      const env: WebmasterVerificationEnv = {
+        NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: placeholder,
+      };
+      expect(
+        buildWebmasterVerification(env).google,
+        `placeholder accepte: ${placeholder}`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("ignore un code trop long (> 200 chars, defense)", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "a".repeat(201),
+    };
+    expect(buildWebmasterVerification(env).google).toBeUndefined();
+  });
+
+  it("trim les espaces de bord avant validation", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "  validCode123  ",
+    };
+    expect(buildWebmasterVerification(env).google).toBe("validCode123");
+  });
+
+  it("garde other.msvalidate.01 vide quand bing absent", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "validCode123",
+    };
+    expect(buildWebmasterVerification(env).other).toBeUndefined();
+  });
+
+  it("est deterministe : meme entree -> meme sortie", () => {
+    const env: WebmasterVerificationEnv = {
+      NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: "validCode123",
+      NEXT_PUBLIC_YANDEX_VERIFICATION: "validYandex456",
+    };
+    expect(buildWebmasterVerification(env)).toEqual(
+      buildWebmasterVerification(env),
+    );
+  });
+});

--- a/apps/web/app/lib/webmaster-verification.ts
+++ b/apps/web/app/lib/webmaster-verification.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure builder for Next.js `metadata.verification` (Q.17 — Sprint 23).
+ *
+ * Produit l'objet a passer dans `metadata.verification` du root layout
+ * a partir des variables d'env publiques. Validation defensive pour
+ * eviter de leaker des placeholders ("votre-code-...") ou des chaines
+ * vides en production.
+ *
+ * Variables d'env consommees (toutes optionnelles) :
+ *   - NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+ *   - NEXT_PUBLIC_YANDEX_VERIFICATION
+ *   - NEXT_PUBLIC_BING_SITE_VERIFICATION
+ *
+ * Note Bing : Next.js n'a pas de propriete dediee, on passe par
+ * `other['msvalidate.01']` qui est le nom de meta tag attendu.
+ */
+
+export interface WebmasterVerificationEnv {
+  NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION?: string;
+  NEXT_PUBLIC_YANDEX_VERIFICATION?: string;
+  NEXT_PUBLIC_BING_SITE_VERIFICATION?: string;
+}
+
+export interface WebmasterVerification {
+  google?: string;
+  yandex?: string;
+  /**
+   * Map cle->valeur pour les meta tags non standards. Bing/MS attend
+   * `<meta name="msvalidate.01" content="...">`.
+   */
+  other?: Record<string, string>;
+}
+
+const PLACEHOLDER_PATTERNS = [
+  /^votre[-_ ]/i,
+  /^your[-_ ]/i,
+  /^todo$/i,
+  /^fixme$/i,
+  /^xxx+$/i,
+  /^<.*>$/, // <insert>, <code>, etc.
+];
+const MAX_LENGTH = 200;
+
+function sanitize(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim();
+  if (value.length === 0) return undefined;
+  if (value.length > MAX_LENGTH) return undefined;
+  if (/\s/.test(value)) return undefined; // pas d'espace interne
+  for (const pattern of PLACEHOLDER_PATTERNS) {
+    if (pattern.test(value)) return undefined;
+  }
+  return value;
+}
+
+export function buildWebmasterVerification(
+  env: WebmasterVerificationEnv | undefined,
+): WebmasterVerification {
+  const result: WebmasterVerification = {};
+  if (!env) return result;
+
+  const google = sanitize(env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION);
+  if (google) result.google = google;
+
+  const yandex = sanitize(env.NEXT_PUBLIC_YANDEX_VERIFICATION);
+  if (yandex) result.yandex = yandex;
+
+  const bing = sanitize(env.NEXT_PUBLIC_BING_SITE_VERIFICATION);
+  if (bing) {
+    result.other = { ...(result.other ?? {}), "msvalidate.01": bing };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Resume

Active **Google Search Console / Yandex Webmaster / Bing Webmaster Tools**
site verification via les variables d'env publiques, avec **validation
defensive** pour eviter de leaker des placeholders en prod.

### Architecture

- `apps/web/app/lib/webmaster-verification.ts` — **builder pur**
  `buildWebmasterVerification(env)` -> `Metadata['verification']` :
  - `google` : `metadata.verification.google`
  - `yandex` : `metadata.verification.yandex`
  - `bing` : `metadata.verification.other['msvalidate.01']`
    (Next.js n'a pas de propriete dediee Bing — `msvalidate.01` est
    le nom de meta tag que Bing reconnait).
  - **Validation** : rejet des chaines vides, espaces internes (mauvais
    collage), longueur > 200, et placeholders evidents
    (`votre-code-...`, `your-code-...`, `TODO`, `FIXME`, `xxx`,
    `<insert>`). Trim avant validation.
- `apps/web/app/lib/webmaster-verification.test.ts` — 10 tests TDD
  couvrant : tous les codes presents, codes manquants, placeholders
  FR/EN, chaines vides, espaces, longueur excessive, trim, determinisme.
- `apps/web/app/layout.tsx` — remplace l'ancien bloc commente
  (`// google: "votre-code-google"`) par un appel au builder, pilote par
  les env vars publiques :
  - `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`
  - `NEXT_PUBLIC_YANDEX_VERIFICATION`
  - `NEXT_PUBLIC_BING_SITE_VERIFICATION`

### Pourquoi le builder pur ?

- Permet de tester le mapping env -> meta tag sans monter Next.
- Centralise la liste de placeholders interdits, evite que quelqu'un
  ajoute "votre-code-google" en prod.
- Reutilisable depuis n'importe quel layout secondaire si besoin.

## Tache roadmap

Sprint 23, tache **Q.17 — Codes de verification webmasters dans
`layout.tsx` (Google Search Console, Bing, Yandex)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (360/360 dont 10 nouveaux sur
      `webmaster-verification.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Renseigner les vrais codes via env vars en production puis
      valider la decouverte par Google Search Console et Bing
      Webmaster Tools (suivi par la tache **Q.18**)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_