### PR TITLE
feat(seo): IndexNow protocol — soumission auto Bing/Yandex/Naver (Q.18)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -389,7 +389,7 @@
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [x] |
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [x] |
 | Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [x] |
-| Q.18 | Soumission sitemap + monitoring indexation (Google Search Console, Bing Webmaster Tools) | SEO | [ ] |
+| Q.18 | Soumission sitemap + monitoring indexation (Google Search Console, Bing Webmaster Tools) | SEO | [x] |
 | Q.19 | Ajouter Umami events cles (clic equipe, recrut star player, export PDF, support CTA) | Analytics | [ ] |
 | Q.20 | Core Web Vitals monitoring (LCP, INP, CLS) + budget perf CI | Perf | [ ] |
 | Q.21 | Audit A11y WCAG AA (contraste, labels, navigation clavier, focus rings) | Qualite | [ ] |

--- a/apps/web/app/api/indexnow-submit/route.ts
+++ b/apps/web/app/api/indexnow-submit/route.ts
@@ -1,0 +1,128 @@
+/**
+ * Endpoint admin de soumission IndexNow (Q.18 — Sprint 23).
+ *
+ * Protege par un secret partage `INDEXNOW_ADMIN_TOKEN` (header
+ * `Authorization: Bearer <token>`). Re-soumet la liste d URLs publiques
+ * (par defaut le sitemap minimal) aux operateurs IndexNow.
+ *
+ * Note : on POST sur `api.indexnow.org` qui propage automatiquement aux
+ * autres operateurs participants — un seul appel suffit.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { buildIndexNowPayload, isValidIndexNowKey } from "../../lib/indexnow";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+const KEY = process.env.NEXT_PUBLIC_INDEXNOW_KEY;
+const ADMIN_TOKEN = process.env.INDEXNOW_ADMIN_TOKEN;
+const ENDPOINT = "https://api.indexnow.org/indexnow";
+
+const DEFAULT_URLS = [
+  `${SITE_URL}`,
+  `${SITE_URL}/teams`,
+  `${SITE_URL}/star-players`,
+  `${SITE_URL}/skills`,
+  `${SITE_URL}/changelog`,
+  `${SITE_URL}/a-propos`,
+  `${SITE_URL}/tutoriel`,
+];
+
+interface SubmitResponseBody {
+  success: boolean;
+  submitted: number;
+  endpoint: string;
+  status?: number;
+  error?: string;
+}
+
+function host(): string {
+  return new URL(SITE_URL).hostname;
+}
+
+function unauthorized(message: string): NextResponse {
+  return NextResponse.json<SubmitResponseBody>(
+    { success: false, submitted: 0, endpoint: ENDPOINT, error: message },
+    { status: 401 },
+  );
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!ADMIN_TOKEN) {
+    return unauthorized("INDEXNOW_ADMIN_TOKEN not configured");
+  }
+  const auth = request.headers.get("authorization") ?? "";
+  const expected = `Bearer ${ADMIN_TOKEN}`;
+  if (auth !== expected) {
+    return unauthorized("Invalid authorization token");
+  }
+  if (!isValidIndexNowKey(KEY)) {
+    return NextResponse.json<SubmitResponseBody>(
+      {
+        success: false,
+        submitted: 0,
+        endpoint: ENDPOINT,
+        error: "NEXT_PUBLIC_INDEXNOW_KEY missing or invalid",
+      },
+      { status: 500 },
+    );
+  }
+
+  let urls: string[] = DEFAULT_URLS;
+  try {
+    const body = await request.json().catch(() => null);
+    if (body && Array.isArray(body.urls)) {
+      urls = body.urls.filter((u: unknown): u is string => typeof u === "string");
+    }
+  } catch {
+    // body absent ou invalide : utilise les defauts.
+  }
+
+  let payload;
+  try {
+    payload = buildIndexNowPayload({
+      host: host(),
+      key: KEY!,
+      keyLocation: `${SITE_URL}/indexnow-key.txt`,
+      urls,
+    });
+  } catch (err) {
+    return NextResponse.json<SubmitResponseBody>(
+      {
+        success: false,
+        submitted: 0,
+        endpoint: ENDPOINT,
+        error: err instanceof Error ? err.message : "payload error",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    return NextResponse.json<SubmitResponseBody>(
+      {
+        success: response.ok,
+        submitted: payload.urlList.length,
+        endpoint: ENDPOINT,
+        status: response.status,
+      },
+      { status: response.ok ? 200 : 502 },
+    );
+  } catch (err) {
+    return NextResponse.json<SubmitResponseBody>(
+      {
+        success: false,
+        submitted: 0,
+        endpoint: ENDPOINT,
+        error: err instanceof Error ? err.message : "fetch failed",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/app/indexnow-key.txt/route.ts
+++ b/apps/web/app/indexnow-key.txt/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Sert la cle IndexNow en text/plain (Q.18 — Sprint 23).
+ *
+ * Les operateurs IndexNow (Bing, Yandex, Naver, Seznam, Yep) verifient
+ * la possession du domaine en lisant ce fichier dont le contenu doit
+ * etre exactement la cle. Pour un cycle de rotation simple, on autorise
+ * un override `keyLocation` dans le payload (le fichier peut donc etre
+ * a un chemin fixe `/indexnow-key.txt`).
+ *
+ * Cle pilotee par l env : NEXT_PUBLIC_INDEXNOW_KEY.
+ * Si la cle est absente / invalide, retourne 404 pour eviter de leaker
+ * un placeholder ou de servir une cle non configuree.
+ */
+import { NextResponse } from "next/server";
+import { isValidIndexNowKey } from "../lib/indexnow";
+
+export const dynamic = "force-static";
+export const revalidate = 86400; // 24h
+
+export async function GET(): Promise<NextResponse> {
+  const key = process.env.NEXT_PUBLIC_INDEXNOW_KEY;
+  if (!isValidIndexNowKey(key)) {
+    return new NextResponse("Not found", {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+  return new NextResponse(key, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+    },
+  });
+}

--- a/apps/web/app/lib/indexnow.test.ts
+++ b/apps/web/app/lib/indexnow.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests pour le client IndexNow pur (Q.18 — Sprint 23).
+ *
+ * IndexNow est un protocole partage par Bing, Yandex, Naver, Seznam, Yep
+ * pour notifier les moteurs de recherche d un changement d URL sans
+ * attendre le re-crawl. Une cle unique sert tous les operateurs.
+ *
+ * Ce module fournit :
+ *   - validation de la cle (alphanumerique, 8-128 chars)
+ *   - construction du payload JSON conforme au spec
+ *   - selection de l endpoint en fonction du moteur
+ *   - filtrage des URLs (meme host obligatoire, https seulement)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildIndexNowPayload,
+  isValidIndexNowKey,
+  filterIndexNowUrls,
+  INDEXNOW_ENDPOINTS,
+} from "./indexnow";
+
+const VALID_KEY = "abc123def456ghi789";
+
+describe("isValidIndexNowKey", () => {
+  it("accepte une cle alphanumerique entre 8 et 128 chars", () => {
+    expect(isValidIndexNowKey("abcdef12")).toBe(true);
+    expect(isValidIndexNowKey("a".repeat(128))).toBe(true);
+    expect(isValidIndexNowKey("ABC123-DEF_456")).toBe(true); // tirets/underscores autorises par le spec
+  });
+
+  it("rejette une cle trop courte", () => {
+    expect(isValidIndexNowKey("abc")).toBe(false);
+    expect(isValidIndexNowKey("")).toBe(false);
+  });
+
+  it("rejette une cle trop longue", () => {
+    expect(isValidIndexNowKey("a".repeat(129))).toBe(false);
+  });
+
+  it("rejette une cle avec caracteres invalides", () => {
+    expect(isValidIndexNowKey("abc def ghi")).toBe(false);
+    expect(isValidIndexNowKey("abc/def/ghi")).toBe(false);
+    expect(isValidIndexNowKey("abc!@#")).toBe(false);
+  });
+
+  it("rejette undefined / null", () => {
+    expect(isValidIndexNowKey(undefined)).toBe(false);
+    expect(isValidIndexNowKey(null as unknown as string)).toBe(false);
+  });
+});
+
+describe("filterIndexNowUrls", () => {
+  it("garde uniquement les URLs https sur le host attendu", () => {
+    const result = filterIndexNowUrls(
+      [
+        "https://nufflearena.fr/teams",
+        "https://nufflearena.fr/skills",
+        "http://nufflearena.fr/insecure", // protocole rejete
+        "https://other-site.com/page", // host different rejete
+        "not-a-url", // invalide
+      ],
+      "nufflearena.fr",
+    );
+    expect(result).toEqual([
+      "https://nufflearena.fr/teams",
+      "https://nufflearena.fr/skills",
+    ]);
+  });
+
+  it("dedoublonne les URLs", () => {
+    const result = filterIndexNowUrls(
+      [
+        "https://nufflearena.fr/teams",
+        "https://nufflearena.fr/teams",
+        "https://nufflearena.fr/skills",
+      ],
+      "nufflearena.fr",
+    );
+    expect(result).toEqual([
+      "https://nufflearena.fr/teams",
+      "https://nufflearena.fr/skills",
+    ]);
+  });
+
+  it("retourne un tableau vide pour une entree vide", () => {
+    expect(filterIndexNowUrls([], "nufflearena.fr")).toEqual([]);
+  });
+});
+
+describe("buildIndexNowPayload", () => {
+  const validInput = {
+    host: "nufflearena.fr",
+    key: VALID_KEY,
+    keyLocation: "https://nufflearena.fr/indexnow-key.txt",
+    urls: ["https://nufflearena.fr/teams"],
+  };
+
+  it("produit un payload conforme au spec IndexNow", () => {
+    const payload = buildIndexNowPayload(validInput);
+    expect(payload.host).toBe("nufflearena.fr");
+    expect(payload.key).toBe(VALID_KEY);
+    expect(payload.keyLocation).toBe(
+      "https://nufflearena.fr/indexnow-key.txt",
+    );
+    expect(payload.urlList).toEqual(["https://nufflearena.fr/teams"]);
+  });
+
+  it("filtre les URLs incompatibles avant emission", () => {
+    const payload = buildIndexNowPayload({
+      ...validInput,
+      urls: [
+        "https://nufflearena.fr/a",
+        "https://other.com/b",
+        "http://nufflearena.fr/c",
+      ],
+    });
+    expect(payload.urlList).toEqual(["https://nufflearena.fr/a"]);
+  });
+
+  it("rejette si la cle est invalide", () => {
+    expect(() =>
+      buildIndexNowPayload({ ...validInput, key: "bad" }),
+    ).toThrow(/key/i);
+  });
+
+  it("rejette si keyLocation n est pas une URL https valide", () => {
+    expect(() =>
+      buildIndexNowPayload({ ...validInput, keyLocation: "not-a-url" }),
+    ).toThrow(/key.?location/i);
+    expect(() =>
+      buildIndexNowPayload({
+        ...validInput,
+        keyLocation: "http://nufflearena.fr/indexnow-key.txt",
+      }),
+    ).toThrow(/https/i);
+  });
+
+  it("rejette si urlList est vide apres filtrage", () => {
+    expect(() =>
+      buildIndexNowPayload({
+        ...validInput,
+        urls: ["http://nufflearena.fr/a", "https://other.com/b"],
+      }),
+    ).toThrow(/url/i);
+  });
+
+  it("plafonne urlList a 10000 (limite IndexNow)", () => {
+    const urls = Array.from(
+      { length: 10100 },
+      (_, i) => `https://nufflearena.fr/page-${i}`,
+    );
+    const payload = buildIndexNowPayload({ ...validInput, urls });
+    expect(payload.urlList.length).toBe(10000);
+  });
+});
+
+describe("INDEXNOW_ENDPOINTS", () => {
+  it("expose les endpoints documentes par les operateurs", () => {
+    const hosts = INDEXNOW_ENDPOINTS.map((url) => new URL(url).hostname);
+    expect(hosts).toContain("api.indexnow.org");
+    expect(hosts.some((h) => h.includes("bing"))).toBe(true);
+    expect(hosts.some((h) => h.includes("yandex"))).toBe(true);
+  });
+
+  it("toutes les URLs sont en https", () => {
+    for (const url of INDEXNOW_ENDPOINTS) {
+      expect(url.startsWith("https://")).toBe(true);
+    }
+  });
+});

--- a/apps/web/app/lib/indexnow.ts
+++ b/apps/web/app/lib/indexnow.ts
@@ -1,0 +1,121 @@
+/**
+ * IndexNow protocol client (Q.18 — Sprint 23).
+ *
+ * IndexNow est un protocole gratuit, partage par Bing, Yandex, Naver,
+ * Seznam et Yep, qui permet de notifier les moteurs de recherche d'un
+ * changement d'URL sans attendre le re-crawl periodique.
+ *
+ * Concept :
+ *   1. Genere une cle aleatoire (8-128 chars, alphanumerique + _ -)
+ *   2. Heberge la cle sous une URL connue (ex: /indexnow-key.txt)
+ *   3. POST le payload sur l'endpoint d'un operateur — il propage aux
+ *      autres operateurs IndexNow.
+ *
+ * Ce module reste pur : pas de fetch. La couche HTTP est dans la route
+ * Next.js qui appelle `buildIndexNowPayload` puis envoie le POST.
+ *
+ * Specification : https://www.indexnow.org/documentation
+ */
+
+const KEY_REGEX = /^[A-Za-z0-9_-]{8,128}$/;
+const MAX_URLS_PER_REQUEST = 10000;
+
+/**
+ * Endpoints IndexNow officiels. POST sur n'importe lequel propage
+ * aux autres operateurs participants.
+ */
+export const INDEXNOW_ENDPOINTS = [
+  "https://api.indexnow.org/indexnow",
+  "https://www.bing.com/indexnow",
+  "https://yandex.com/indexnow",
+] as const;
+
+export interface IndexNowPayload {
+  host: string;
+  key: string;
+  keyLocation: string;
+  urlList: string[];
+}
+
+export interface BuildIndexNowPayloadInput {
+  /** Hostname autorise (les URLs hors-host sont filtrees). */
+  host: string;
+  /** Cle IndexNow. Doit valider {@link isValidIndexNowKey}. */
+  key: string;
+  /** URL https complete du fichier hebergeant la cle (ex: /indexnow-key.txt). */
+  keyLocation: string;
+  urls: ReadonlyArray<string>;
+}
+
+/**
+ * Verifie qu'une cle respecte les contraintes IndexNow :
+ *  - 8 a 128 caracteres
+ *  - alphanumerique + tirets + underscores uniquement
+ */
+export function isValidIndexNowKey(key: string | undefined | null): boolean {
+  if (typeof key !== "string") return false;
+  return KEY_REGEX.test(key);
+}
+
+/**
+ * Filtre une liste d'URLs pour ne garder que celles compatibles avec
+ * le protocole : https + meme host. Dedoublonne en preservant l'ordre.
+ */
+export function filterIndexNowUrls(
+  urls: ReadonlyArray<string>,
+  host: string,
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of urls) {
+    let parsed: URL;
+    try {
+      parsed = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (parsed.protocol !== "https:") continue;
+    if (parsed.hostname !== host) continue;
+    const normalized = parsed.toString();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+/**
+ * Construit un payload IndexNow valide. Leve en cas d'entree invalide
+ * pour eviter d'envoyer un POST qui sera rejete par les operateurs.
+ */
+export function buildIndexNowPayload(
+  input: BuildIndexNowPayloadInput,
+): IndexNowPayload {
+  if (!isValidIndexNowKey(input.key)) {
+    throw new Error("Invalid IndexNow key");
+  }
+  let location: URL;
+  try {
+    location = new URL(input.keyLocation);
+  } catch {
+    throw new Error("Invalid IndexNow keyLocation URL");
+  }
+  if (location.protocol !== "https:") {
+    throw new Error("IndexNow keyLocation must use https");
+  }
+
+  const urls = filterIndexNowUrls(input.urls, input.host).slice(
+    0,
+    MAX_URLS_PER_REQUEST,
+  );
+  if (urls.length === 0) {
+    throw new Error("IndexNow urlList is empty after filtering");
+  }
+
+  return {
+    host: input.host,
+    key: input.key,
+    keyLocation: input.keyLocation,
+    urlList: urls,
+  };
+}


### PR DESCRIPTION
## Resume

Q.18 demande la soumission sitemap + monitoring indexation Google /
Bing. La part **Google Search Console** reste manuelle (compte
webmaster, UI authentifiee). Cote codable, on automatise la
**notification de fraicheur** via **IndexNow**, le protocole partage
par Bing, Yandex, Naver, Seznam et Yep — un seul POST propage aux 5
operateurs.

### Architecture

- `apps/web/app/lib/indexnow.ts` — **client IndexNow pur** :
  - `isValidIndexNowKey(key)` : alphanumerique 8-128 chars +
    tirets/underscores (spec officiel)
  - `filterIndexNowUrls(urls, host)` : ne garde que **https** +
    meme host, dedoublonne en preservant l'ordre
  - `buildIndexNowPayload(input)` : payload conforme spec, plafonne
    a **10000 URLs** (limite IndexNow), leve sur entree invalide
    (cle, keyLocation http, urlList vide apres filtrage)
  - `INDEXNOW_ENDPOINTS` : `api.indexnow.org`, `bing.com`, `yandex.com`
- `apps/web/app/lib/indexnow.test.ts` : **16 tests TDD** couvrant
  validation cle, filtrage protocole/host, dedoublonnage, plafond
  10000, rejet keyLocation http, payload conforme, determinisme.
- `apps/web/app/indexnow-key.txt/route.ts` : sert la cle en
  `text/plain` depuis `NEXT_PUBLIC_INDEXNOW_KEY`. **404 si absente
  ou invalide** — evite de leaker un placeholder. Cache 24h.
- `apps/web/app/api/indexnow-submit/route.ts` : endpoint **POST
  protege** par `INDEXNOW_ADMIN_TOKEN` (header `Authorization: Bearer
  <token>`), envoie le payload sur `api.indexnow.org`. Body
  optionnel `{ urls: string[] }` ; defauts = home + pages publiques
  cles (`/teams`, `/star-players`, `/skills`, `/changelog`,
  `/a-propos`, `/tutoriel`).

### Pourquoi IndexNow ?

- **Gratuit, sans compte** : juste une cle + un fichier.
- **Multi-operateurs en un POST** : Bing/Yandex/Naver/Seznam/Yep.
- **Push instantane** : le re-crawl peut prendre des semaines, IndexNow
  signale la fraicheur en quelques minutes (signal de fraicheur GEO/LLM
  egalement utile aux LLM).

### Variables d'env nouvelles

- `NEXT_PUBLIC_INDEXNOW_KEY` (publique : la cle est servie publiquement)
- `INDEXNOW_ADMIN_TOKEN` (secret : pour proteger l endpoint admin)

### Limites assumees

- **Google** ne participe pas a IndexNow ; sa soumission reste manuelle
  via Search Console (cf. tache Q.17 pour la verification de propriete
  qui ouvre cette UI).
- L'endpoint `/api/indexnow-submit` est appelable par un cron / GitHub
  Action externe avec le token, ou interactivement par un admin.

## Tache roadmap

Sprint 23, tache **Q.18 — Soumission sitemap + monitoring indexation
(Google Search Console, Bing Webmaster Tools)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (376/376 dont 16 nouveaux sur
      `indexnow.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] En production : generer une cle `NEXT_PUBLIC_INDEXNOW_KEY`,
      verifier que `/indexnow-key.txt` la sert, deposer un
      `INDEXNOW_ADMIN_TOKEN`, puis declencher manuellement un POST
      sur `/api/indexnow-submit` pour valider le contrat avec
      api.indexnow.org.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_