### PR TITLE
feat(analytics): Umami events cles (Q.19)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -390,7 +390,7 @@
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [x] |
 | Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [x] |
 | Q.18 | Soumission sitemap + monitoring indexation (Google Search Console, Bing Webmaster Tools) | SEO | [x] |
-| Q.19 | Ajouter Umami events cles (clic equipe, recrut star player, export PDF, support CTA) | Analytics | [ ] |
+| Q.19 | Ajouter Umami events cles (clic equipe, recrut star player, export PDF, support CTA) | Analytics | [x] |
 | Q.20 | Core Web Vitals monitoring (LCP, INP, CLS) + budget perf CI | Perf | [ ] |
 | Q.21 | Audit A11y WCAG AA (contraste, labels, navigation clavier, focus rings) | Qualite | [ ] |
 | Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [ ] |

--- a/apps/web/app/lib/umami-events.test.ts
+++ b/apps/web/app/lib/umami-events.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests pour le helper Umami events (Q.19 — Sprint 23).
+ *
+ * Le helper expose `trackUmamiEvent(name, data?)` qui appelle
+ * `window.umami.track(name, data)` si Umami est charge, sinon ne fait
+ * rien (silencieux en dev / quand l opt-out est actif). Cela evite
+ * d'avoir a tester `typeof window === 'undefined'` partout.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  trackUmamiEvent,
+  UMAMI_EVENTS,
+  type UmamiEventName,
+} from "./umami-events";
+
+describe("UMAMI_EVENTS", () => {
+  it("expose les 4 events de Q.19", () => {
+    expect(UMAMI_EVENTS.TEAM_CLICK).toBeTruthy();
+    expect(UMAMI_EVENTS.STAR_PLAYER_HIRE).toBeTruthy();
+    expect(UMAMI_EVENTS.PDF_EXPORT).toBeTruthy();
+    expect(UMAMI_EVENTS.SUPPORT_CTA).toBeTruthy();
+  });
+
+  it("toutes les valeurs sont distinctes", () => {
+    const values = Object.values(UMAMI_EVENTS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("toutes les valeurs sont en kebab-case lisible", () => {
+    for (const v of Object.values(UMAMI_EVENTS)) {
+      expect(typeof v).toBe("string");
+      expect(v.length).toBeGreaterThan(0);
+      expect(/^[a-z][a-z0-9-]*$/.test(v as string)).toBe(true);
+    }
+  });
+});
+
+describe("trackUmamiEvent", () => {
+  let originalUmami: unknown;
+
+  beforeEach(() => {
+    originalUmami = (globalThis as Record<string, unknown>).umami;
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).umami = originalUmami as never;
+  });
+
+  it("ne crashe pas si window.umami est absent", () => {
+    delete (globalThis as Record<string, unknown>).umami;
+    expect(() =>
+      trackUmamiEvent(UMAMI_EVENTS.TEAM_CLICK as UmamiEventName, {
+        slug: "skaven",
+      }),
+    ).not.toThrow();
+  });
+
+  it("appelle window.umami.track avec event + data quand disponible", () => {
+    const track = vi.fn();
+    (globalThis as Record<string, unknown>).umami = { track };
+    trackUmamiEvent(UMAMI_EVENTS.TEAM_CLICK as UmamiEventName, {
+      slug: "skaven",
+    });
+    expect(track).toHaveBeenCalledWith("team-click", { slug: "skaven" });
+  });
+
+  it("appelle track sans data quand non fournie", () => {
+    const track = vi.fn();
+    (globalThis as Record<string, unknown>).umami = { track };
+    trackUmamiEvent(UMAMI_EVENTS.SUPPORT_CTA as UmamiEventName);
+    expect(track).toHaveBeenCalledWith("support-cta", undefined);
+  });
+
+  it("ne crashe pas si window.umami.track est absent", () => {
+    (globalThis as Record<string, unknown>).umami = {};
+    expect(() =>
+      trackUmamiEvent(UMAMI_EVENTS.PDF_EXPORT as UmamiEventName),
+    ).not.toThrow();
+  });
+
+  it("avale les exceptions du tracker (non bloquant)", () => {
+    const track = vi.fn(() => {
+      throw new Error("network down");
+    });
+    (globalThis as Record<string, unknown>).umami = { track };
+    expect(() =>
+      trackUmamiEvent(UMAMI_EVENTS.PDF_EXPORT as UmamiEventName),
+    ).not.toThrow();
+  });
+
+  it("rejette silencieusement les noms d event vides", () => {
+    const track = vi.fn();
+    (globalThis as Record<string, unknown>).umami = { track };
+    trackUmamiEvent("" as UmamiEventName);
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/umami-events.ts
+++ b/apps/web/app/lib/umami-events.ts
@@ -1,0 +1,61 @@
+/**
+ * Umami events helper (Q.19 — Sprint 23).
+ *
+ * Wrapper safe autour du `window.umami.track()` charge dans le root
+ * layout. Permet de tracker des events cles sans avoir a tester
+ * `typeof window === 'undefined'` ou `window.umami` partout.
+ *
+ * Comportement :
+ *   - silencieux si Umami n est pas charge (dev, opt-out, network down)
+ *   - avale les exceptions du tracker (analytics ne doit jamais casser
+ *     l UI)
+ *   - centralise les noms d events dans `UMAMI_EVENTS` pour eviter les
+ *     typos / inconsistances entre call sites
+ */
+
+/** Catalogue des events trackes — Q.19. */
+export const UMAMI_EVENTS = {
+  /** Clic sur une carte d'equipe (route `/teams`). */
+  TEAM_CLICK: "team-click",
+  /** Clic sur une carte de star player (route `/star-players`). */
+  STAR_PLAYER_HIRE: "star-player-hire",
+  /** Export PDF (roster, skill sheet, match sheet). */
+  PDF_EXPORT: "pdf-export",
+  /** Clic sur un CTA Ko-fi / soutien. */
+  SUPPORT_CTA: "support-cta",
+} as const;
+
+export type UmamiEventName = (typeof UMAMI_EVENTS)[keyof typeof UMAMI_EVENTS];
+
+/** Donnees additionnelles attachees a un event (evite `any`). */
+export type UmamiEventData = Record<string, string | number | boolean | undefined>;
+
+interface UmamiTracker {
+  track: (name: string, data?: UmamiEventData) => void;
+}
+
+interface MaybeUmamiHost {
+  umami?: Partial<UmamiTracker>;
+}
+
+function getTracker(): Partial<UmamiTracker> | null {
+  // En SSR / test : globalThis.umami peut etre defini (vitest stub).
+  // En navigateur : window === globalThis, donc cette branche couvre les deux.
+  const host = globalThis as unknown as MaybeUmamiHost;
+  if (!host.umami) return null;
+  return host.umami;
+}
+
+export function trackUmamiEvent(
+  name: UmamiEventName,
+  data?: UmamiEventData,
+): void {
+  if (!name || typeof name !== "string") return;
+  const tracker = getTracker();
+  if (!tracker || typeof tracker.track !== "function") return;
+  try {
+    tracker.track(name, data);
+  } catch {
+    // Analytics ne doit jamais casser l UI.
+  }
+}

--- a/apps/web/app/me/teams/[id]/page.tsx
+++ b/apps/web/app/me/teams/[id]/page.tsx
@@ -6,6 +6,7 @@ import TeamInfoDisplay from "../components/TeamInfoDisplay";
 import { getPlayerCost, getDisplayName, getRerollCost } from "@bb/game-engine";
 import { exportTeamToPDF, exportSkillsSheet, exportMatchSheet } from "../utils/exportPDF";
 import { useLanguage } from "../../../contexts/LanguageContext";
+import { UMAMI_EVENTS, trackUmamiEvent } from "../../../lib/umami-events";
 
 async function fetchJSON(path: string) {
   const token = localStorage.getItem("auth_token");
@@ -107,6 +108,7 @@ export default function TeamDetailPage() {
   const handleExportRoster = async () => {
     if (!team) return;
     try {
+      trackUmamiEvent(UMAMI_EVENTS.PDF_EXPORT, { kind: "roster" });
       await exportTeamToPDF(team, getPlayerCost, userName, language);
       setExportMenuOpen(false);
     } catch (error) {
@@ -118,6 +120,7 @@ export default function TeamDetailPage() {
   const handleExportSkills = async () => {
     if (!team) return;
     try {
+      trackUmamiEvent(UMAMI_EVENTS.PDF_EXPORT, { kind: "skills" });
       await exportSkillsSheet(team, language);
       setExportMenuOpen(false);
     } catch (error) {
@@ -129,6 +132,7 @@ export default function TeamDetailPage() {
   const handleExportMatch = async () => {
     if (!team) return;
     try {
+      trackUmamiEvent(UMAMI_EVENTS.PDF_EXPORT, { kind: "match" });
       await exportMatchSheet(team, undefined, language);
       setExportMenuOpen(false);
     } catch (error) {

--- a/apps/web/app/star-players/page.tsx
+++ b/apps/web/app/star-players/page.tsx
@@ -6,6 +6,7 @@ import StarPlayerCard from '../components/StarPlayerCard';
 import CopyrightFooter from '../components/CopyrightFooter';
 import type { StarPlayerDefinition } from '@bb/game-engine';
 import { useLanguage } from '../contexts/LanguageContext';
+import { UMAMI_EVENTS, trackUmamiEvent } from '../lib/umami-events';
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8201';
 
@@ -100,6 +101,10 @@ export default function StarPlayersPage() {
   };
 
   const handlePlayerClick = (player: StarPlayerDefinition) => {
+    trackUmamiEvent(UMAMI_EVENTS.STAR_PLAYER_HIRE, {
+      slug: player.slug,
+      cost: player.cost,
+    });
     router.push(`/star-players/${player.slug}`);
   };
 

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { API_BASE } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
+import { UMAMI_EVENTS, trackUmamiEvent } from "../lib/umami-events";
 
 const KOFI_USERNAME = "nufflearena";
 const KOFI_URL = `https://ko-fi.com/${KOFI_USERNAME}`;
@@ -208,6 +209,9 @@ export default function SupportPage() {
               href={KOFI_URL}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() =>
+                trackUmamiEvent(UMAMI_EVENTS.SUPPORT_CTA, { placement: "hero" })
+              }
               className="inline-flex items-center gap-2 px-8 py-4 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-subtitle font-bold rounded-lg shadow-lg hover:shadow-xl transition-all transform hover:scale-105 text-lg"
             >
               <CoffeeIcon className="w-6 h-6" />
@@ -389,6 +393,9 @@ export default function SupportPage() {
             href={KOFI_URL}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              trackUmamiEvent(UMAMI_EVENTS.SUPPORT_CTA, { placement: "footer-cta" })
+            }
             className="inline-flex items-center gap-2 px-8 py-4 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-subtitle font-bold rounded-lg shadow-lg hover:shadow-xl transition-all transform hover:scale-105 text-lg"
           >
             <CoffeeIcon className="w-6 h-6" />

--- a/apps/web/app/teams/TeamsListClient.tsx
+++ b/apps/web/app/teams/TeamsListClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLanguage } from "../contexts/LanguageContext";
 import TeamLogo from "../components/TeamLogo";
+import { UMAMI_EVENTS, trackUmamiEvent } from "../lib/umami-events";
 
 export type Season = "season_2" | "season_3";
 type Tier = "all" | "I" | "II" | "III" | "IV";
@@ -195,6 +196,13 @@ export default function TeamsListClient({
           <Link
             key={team.slug}
             href={`/teams/${team.slug}?ruleset=${initialSeason}`}
+            onClick={() =>
+              trackUmamiEvent(UMAMI_EVENTS.TEAM_CLICK, {
+                slug: team.slug,
+                tier: team.tier,
+                ruleset: initialSeason,
+              })
+            }
             className="rounded-xl border-2 border-blue-200 bg-white p-6 hover:border-blue-400 hover:shadow-lg transition-all text-left"
           >
             <div className="flex items-start gap-3 mb-3">


### PR DESCRIPTION
## Resume

Helper pur `trackUmamiEvent` + **4 events** branches sur les actions cles
demandees par la roadmap : clic equipe, clic star player, export PDF,
CTA Ko-fi.

### Architecture

- `apps/web/app/lib/umami-events.ts` — **wrapper safe** autour de
  `window.umami.track` :
  - silencieux si Umami absent (dev / opt-out / network down)
  - avale les exceptions du tracker (analytics ne doit jamais casser
    l'UI)
  - centralise les noms d'events dans `UMAMI_EVENTS` pour eviter les
    typos / inconsistances entre call sites
  - signature typee `trackUmamiEvent(name, data?)` avec
    `UmamiEventName` litteral et `UmamiEventData = Record<string,
    string|number|boolean|undefined>`
- `apps/web/app/lib/umami-events.test.ts` — **9 tests TDD** :
  - 4 events presents et distincts, kebab-case
  - window absent, umami absent, track absent
  - exception du tracker non bloquante
  - name vide rejete silencieusement
  - data optionnelle

### Wiring

- `apps/web/app/teams/TeamsListClient.tsx` : `team-click` `{ slug, tier, ruleset }`
  au clic sur chaque card du listing.
- `apps/web/app/star-players/page.tsx` : `star-player-hire` `{ slug, cost }`
  dans `handlePlayerClick`.
- `apps/web/app/me/teams/[id]/page.tsx` : `pdf-export` `{ kind: 'roster' | 'skills' | 'match' }`
  sur les 3 handlers d'export.
- `apps/web/app/support/page.tsx` : `support-cta` `{ placement: 'hero' | 'footer-cta' }`
  sur les deux boutons Ko-fi.

### Conventions

- Noms d'events en **kebab-case** (convention Umami).
- Pas de PII dans les `data` (slugs publics, montants, kinds — jamais
  d'email / userId).
- Le `<script defer>` Umami existant dans `layout.tsx` n'est pas
  modifie ; le helper se cale sur l'API publique `window.umami.track`
  documentee.

## Tache roadmap

Sprint 23, tache **Q.19 — Ajouter Umami events cles (clic equipe,
recrut star player, export PDF, support CTA)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (385/385 dont 9 nouveaux sur
      `umami-events.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Verifier dans Umami que les 4 events apparaissent apres
      deploiement (declenchement manuel via la UI de chaque page)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_