### PR TITLE
feat(seo): /humans.txt + /.well-known/security.txt (Q.22)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -393,7 +393,7 @@
 | Q.19 | Ajouter Umami events cles (clic equipe, recrut star player, export PDF, support CTA) | Analytics | [x] |
 | Q.20 | Core Web Vitals monitoring (LCP, INP, CLS) + budget perf CI | Perf | [x] |
 | Q.21 | Audit A11y WCAG AA (contraste, labels, navigation clavier, focus rings) | Qualite | [x] |
-| Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [ ] |
+| Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [x] |
 | Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [ ] |
 | Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [ ] |
 | Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [ ] |

--- a/apps/web/app/.well-known/security.txt/route.ts
+++ b/apps/web/app/.well-known/security.txt/route.ts
@@ -1,0 +1,41 @@
+/**
+ * /.well-known/security.txt (Q.22 — Sprint 23).
+ *
+ * RFC 9116 : indique aux chercheurs en securite comment reporter une
+ * vulnerabilite. Champs Contact + Expires obligatoires. Expiration
+ * fixee a 1 an par defaut, regenere a chaque rebuild (force-static
+ * + revalidate 24h pour rafraichir).
+ */
+import { NextResponse } from "next/server";
+import { buildSecurityTxt } from "../../lib/well-known";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const dynamic = "force-static";
+export const revalidate = 86400;
+
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+export async function GET(): Promise<NextResponse> {
+  const expires = new Date(Date.now() + ONE_YEAR_MS);
+  const body = buildSecurityTxt({
+    contact:
+      process.env.NEXT_PUBLIC_SECURITY_CONTACT ??
+      "https://github.com/Ryxeuf/fantasy-football-game/security/advisories/new",
+    expires,
+    preferredLanguages: ["fr", "en"],
+    canonical: `${stripTrailingSlash(SITE_URL)}/.well-known/security.txt`,
+    acknowledgments: `${stripTrailingSlash(SITE_URL)}/a-propos`,
+  });
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+    },
+  });
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}

--- a/apps/web/app/humans.txt/route.ts
+++ b/apps/web/app/humans.txt/route.ts
@@ -1,0 +1,29 @@
+/**
+ * /humans.txt (Q.22 — Sprint 23).
+ *
+ * Convention humanstxt.org : credit l equipe et l environnement
+ * technique en texte libre. Servi en text/plain; charset=utf-8 avec
+ * cache 24h.
+ */
+import { NextResponse } from "next/server";
+import { buildHumansTxt } from "../lib/well-known";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const dynamic = "force-static";
+export const revalidate = 86400;
+
+export async function GET(): Promise<NextResponse> {
+  const body = buildHumansTxt({
+    siteUrl: SITE_URL,
+    teamLine: "Nuffle Arena maintainers (Ryxeuf et la communaute)",
+    contactUrl: "https://github.com/Ryxeuf/fantasy-football-game/issues",
+  });
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400, s-maxage=86400",
+    },
+  });
+}

--- a/apps/web/app/lib/well-known.test.ts
+++ b/apps/web/app/lib/well-known.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests pour les builders /humans.txt et /.well-known/security.txt
+ * (Q.22 — Sprint 23).
+ *
+ * - humans.txt : convention humanstxt.org, document texte qui credite
+ *   l equipe + l environnement technique.
+ * - security.txt : RFC 9116, document texte qui indique comment
+ *   reporter une vulnerabilite (Contact, Expires obligatoires).
+ */
+import { describe, it, expect } from "vitest";
+import { buildHumansTxt, buildSecurityTxt } from "./well-known";
+
+describe("buildHumansTxt", () => {
+  it("inclut les sections TEAM et SITE de la convention humanstxt.org", () => {
+    const txt = buildHumansTxt({
+      siteUrl: "https://nufflearena.fr",
+      teamLine: "Nuffle Arena maintainers",
+      contactUrl: "https://github.com/Ryxeuf/fantasy-football-game",
+    });
+    expect(txt).toContain("/* TEAM */");
+    expect(txt).toContain("/* SITE */");
+    expect(txt).toContain("Nuffle Arena maintainers");
+  });
+
+  it("inclut un Last update au format YYYY/MM/DD", () => {
+    const txt = buildHumansTxt({
+      siteUrl: "https://nufflearena.fr",
+      teamLine: "x",
+      contactUrl: "https://github.com/x/y",
+      lastUpdate: new Date("2026-04-26T10:00:00Z"),
+    });
+    expect(txt).toContain("Last update: 2026/04/26");
+  });
+
+  it("inclut la stack technologique (Next.js, TypeScript)", () => {
+    const txt = buildHumansTxt({
+      siteUrl: "https://nufflearena.fr",
+      teamLine: "x",
+      contactUrl: "https://github.com/x/y",
+    });
+    expect(txt.toLowerCase()).toContain("next.js");
+    expect(txt.toLowerCase()).toContain("typescript");
+  });
+
+  it("est deterministe pour une lastUpdate fixe", () => {
+    const input = {
+      siteUrl: "https://nufflearena.fr",
+      teamLine: "x",
+      contactUrl: "https://github.com/x/y",
+      lastUpdate: new Date("2026-04-26T00:00:00Z"),
+    };
+    expect(buildHumansTxt(input)).toBe(buildHumansTxt(input));
+  });
+});
+
+describe("buildSecurityTxt", () => {
+  const today = new Date("2026-04-26T00:00:00Z");
+
+  it("inclut Contact et Expires (champs obligatoires RFC 9116)", () => {
+    const txt = buildSecurityTxt({
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+    });
+    expect(txt).toContain("Contact: mailto:security@nufflearena.fr");
+    expect(txt).toMatch(/Expires: 2027-04-26T00:00:00\.000Z/);
+  });
+
+  it("inclut Preferred-Languages quand fourni", () => {
+    const txt = buildSecurityTxt({
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+      preferredLanguages: ["fr", "en"],
+    });
+    expect(txt).toContain("Preferred-Languages: fr, en");
+  });
+
+  it("inclut Canonical quand fourni (URL completes)", () => {
+    const txt = buildSecurityTxt({
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+      canonical: "https://nufflearena.fr/.well-known/security.txt",
+    });
+    expect(txt).toContain(
+      "Canonical: https://nufflearena.fr/.well-known/security.txt",
+    );
+  });
+
+  it("inclut Acknowledgments si fourni", () => {
+    const txt = buildSecurityTxt({
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+      acknowledgments: "https://nufflearena.fr/security-thanks",
+    });
+    expect(txt).toContain(
+      "Acknowledgments: https://nufflearena.fr/security-thanks",
+    );
+  });
+
+  it("rejette une expiration deja passee (defense)", () => {
+    expect(() =>
+      buildSecurityTxt({
+        contact: "mailto:security@nufflearena.fr",
+        expires: new Date("2020-01-01T00:00:00Z"),
+        now: today,
+      }),
+    ).toThrow(/expires/i);
+  });
+
+  it("rejette un contact ne ressemblant pas a une URL/mailto", () => {
+    expect(() =>
+      buildSecurityTxt({
+        contact: "not-a-url-or-mailto",
+        expires: new Date("2027-04-26T00:00:00Z"),
+      }),
+    ).toThrow(/contact/i);
+  });
+
+  it("est deterministe", () => {
+    const input = {
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+    };
+    expect(buildSecurityTxt(input)).toBe(buildSecurityTxt(input));
+  });
+
+  it("se termine par une nouvelle ligne (convention text/plain)", () => {
+    const txt = buildSecurityTxt({
+      contact: "mailto:security@nufflearena.fr",
+      expires: new Date("2027-04-26T00:00:00Z"),
+    });
+    expect(txt.endsWith("\n")).toBe(true);
+  });
+});

--- a/apps/web/app/lib/well-known.ts
+++ b/apps/web/app/lib/well-known.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure builders for /humans.txt and /.well-known/security.txt
+ * (Q.22 — Sprint 23).
+ *
+ * - humans.txt : convention humanstxt.org (texte libre, sections
+ *   marquees par /+ TEAM +/ / /+ SITE +/ etc., ici servis litteraux)
+ * - security.txt : RFC 9116 (champs Contact / Expires obligatoires,
+ *   Preferred-Languages / Canonical / Acknowledgments optionnels).
+ *
+ * Pure : pas de fetch, pas d I/O. Les routes Next.js consomment ces
+ * fonctions et servent du text/plain charset=utf-8.
+ */
+
+export interface HumansTxtInput {
+  siteUrl: string;
+  /** Une ligne decrivant l equipe ("Nuffle Arena maintainers"). */
+  teamLine: string;
+  /** URL pour contacter l equipe (Issues GitHub typiquement). */
+  contactUrl: string;
+  /** Date de mise a jour (defaut : aujourd hui). */
+  lastUpdate?: Date;
+}
+
+const STACK_LINES = [
+  "Language: Français / English",
+  "Doctype: HTML5",
+  "Standards: WCAG 2.1 AA",
+  "Components: Next.js, React, TypeScript, Tailwind CSS, Pixi.js",
+  "Software: VS Code, Claude Code",
+];
+
+export function buildHumansTxt(input: HumansTxtInput): string {
+  const lastUpdate = input.lastUpdate ?? new Date();
+  const dateStr = formatYyyyMmDdSlash(lastUpdate);
+
+  return [
+    "/* TEAM */",
+    `Maintainers: ${input.teamLine}`,
+    `Contact: ${input.contactUrl}`,
+    `Site: ${stripTrailingSlash(input.siteUrl)}`,
+    "",
+    "/* THANKS */",
+    "Thanks: Games Workshop pour Blood Bowl, la communaute francophone et",
+    "Thanks: tous les contributeurs open-source du projet.",
+    "",
+    "/* SITE */",
+    `Last update: ${dateStr}`,
+    ...STACK_LINES,
+    "",
+  ].join("\n");
+}
+
+export interface SecurityTxtInput {
+  /** Contact valide (mailto:, https:, tel:). */
+  contact: string;
+  /** Date d expiration future (rejet si dans le passe). */
+  expires: Date;
+  /** Date "maintenant" pour la verification expires (test only). */
+  now?: Date;
+  preferredLanguages?: string[];
+  canonical?: string;
+  acknowledgments?: string;
+}
+
+const CONTACT_REGEX = /^(mailto:|https?:\/\/|tel:)/;
+
+export function buildSecurityTxt(input: SecurityTxtInput): string {
+  if (!CONTACT_REGEX.test(input.contact)) {
+    throw new Error(
+      "Invalid Contact field: must start with mailto:, https://, or tel:",
+    );
+  }
+  const now = input.now ?? new Date();
+  if (input.expires.getTime() <= now.getTime()) {
+    throw new Error("Invalid Expires field: must be in the future");
+  }
+
+  const lines: string[] = [];
+  lines.push(`Contact: ${input.contact}`);
+  lines.push(`Expires: ${input.expires.toISOString()}`);
+  if (input.preferredLanguages && input.preferredLanguages.length > 0) {
+    lines.push(`Preferred-Languages: ${input.preferredLanguages.join(", ")}`);
+  }
+  if (input.canonical) {
+    lines.push(`Canonical: ${input.canonical}`);
+  }
+  if (input.acknowledgments) {
+    lines.push(`Acknowledgments: ${input.acknowledgments}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function formatYyyyMmDdSlash(date: Date): string {
+  const yyyy = date.getUTCFullYear();
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  return `${yyyy}/${mm}/${dd}`;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}


### PR DESCRIPTION
## Resume

Ajoute deux fichiers de bonnes pratiques attendus a la racine d un
site moderne :

- **`/humans.txt`** (convention humanstxt.org) : credit equipe +
  stack tech + remerciements
- **`/.well-known/security.txt`** (RFC 9116) : indique aux chercheurs
  en securite comment reporter une vulnerabilite. Champs `Contact` et
  `Expires` obligatoires, plus `Preferred-Languages` / `Canonical` /
  `Acknowledgments`.

### Architecture

- `apps/web/app/lib/well-known.ts` — **2 builders purs** :
  - `buildHumansTxt(input)` : sections `/+ TEAM +/` `/+ THANKS +/`
    `/+ SITE +/`, `Last update YYYY/MM/DD` UTC, stack listee
    (Next.js, React, TypeScript, Tailwind, Pixi.js).
  - `buildSecurityTxt(input)` : **valide Contact** (mailto:, https://
    ou tel:), **valide Expires futur** (`now` injectable pour les
    tests), emet ISO 8601 pour Expires conformement RFC 9116.
- `apps/web/app/lib/well-known.test.ts` — **12 tests TDD** : sections
  obligatoires, formats date, determinisme, defense Contact invalide,
  defense Expires passe, presence trailing newline.
- `apps/web/app/humans.txt/route.ts` — text/plain charset utf-8,
  cache 24h. Pointe vers le repo GitHub pour le contact.
- `apps/web/app/.well-known/security.txt/route.ts` — text/plain
  charset utf-8, cache 24h. **Expires fixee a 1 an apres rebuild**
  (regenere a chaque revalidate). Contact override possible via
  `NEXT_PUBLIC_SECURITY_CONTACT` ; defaut = page security advisories
  GitHub du repo.

### Pourquoi des routes Next.js plutot que des fichiers statiques ?

- Permet de regenerer `Expires` automatiquement (sinon il faudrait un
  CI qui republie un fichier toutes les semaines).
- Permet de surcharger le `Contact` via env sans modifier le code.
- Le builder pur reste 100 % testable independamment.

## Tache roadmap

Sprint 23, tache **Q.22 — `humans.txt` + `security.txt` (bonnes
pratiques, contact securite)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (425/425 dont 12 nouveaux sur
      `well-known.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Verification manuelle apres deploiement :
      `curl https://nufflearena.fr/humans.txt`
      et `curl https://nufflearena.fr/.well-known/security.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_