### PR TITLE
feat(seo): builder schema.org Event pour ligues publiques (Q.24)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -395,7 +395,7 @@
 | Q.21 | Audit A11y WCAG AA (contraste, labels, navigation clavier, focus rings) | Qualite | [x] |
 | Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [x] |
 | Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [ ] |
-| Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [ ] |
+| Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [x] |
 | Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [ ] |
 | Q.26 | Strategie liens entrants : annonce r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB | GEO | [ ] |
 | Q.27 | Hreflang par page (alternates canoniques fr/en quand le split i18n sera fait) | SEO | [ ] |

--- a/apps/web/app/leagues/event-schema.test.ts
+++ b/apps/web/app/leagues/event-schema.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests pour le builder schema.org Event pour les ligues publiques
+ * (Q.24 — Sprint 23).
+ *
+ * Le builder produit un JSON-LD `SportsEvent` consommable par Google
+ * (Rich Results Event) et les LLM (citabilite). Champs obligatoires :
+ * name, startDate, location ; champs recommandes : description,
+ * organizer, eventStatus, eventAttendanceMode.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildLeagueEventSchema,
+  type LeagueEventInput,
+} from "./event-schema";
+
+const baseInput: LeagueEventInput = {
+  baseUrl: "https://nufflearena.fr",
+  league: {
+    id: "open-5-teams",
+    name: "Open 5 Teams - Saison 1",
+    description: "Ligue ouverte aux 5 equipes prioritaires",
+    status: "open",
+    startDate: new Date("2026-05-01T18:00:00Z"),
+    endDate: new Date("2026-08-01T18:00:00Z"),
+    maxParticipants: 16,
+    isPublic: true,
+  },
+};
+
+describe("buildLeagueEventSchema", () => {
+  it("retourne null pour une ligue non publique (pas d emission JSON-LD)", () => {
+    const schema = buildLeagueEventSchema({
+      ...baseInput,
+      league: { ...baseInput.league, isPublic: false },
+    });
+    expect(schema).toBeNull();
+  });
+
+  it("retourne un objet @context schema.org + SportsEvent", () => {
+    const schema = buildLeagueEventSchema(baseInput);
+    expect(schema).not.toBeNull();
+    expect(schema!["@context"]).toBe("https://schema.org");
+    expect(schema!["@type"]).toBe("SportsEvent");
+  });
+
+  it("inclut name, description, identifier", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.name).toBe("Open 5 Teams - Saison 1");
+    expect(schema.description).toContain("Ligue ouverte");
+    expect(schema.identifier).toBe("open-5-teams");
+  });
+
+  it("inclut startDate et endDate au format ISO 8601", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.startDate).toBe("2026-05-01T18:00:00.000Z");
+    expect(schema.endDate).toBe("2026-08-01T18:00:00.000Z");
+  });
+
+  it("expose une URL canonique vers la page de la ligue", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.url).toBe("https://nufflearena.fr/leagues/open-5-teams");
+  });
+
+  it("expose location.@type = VirtualLocation (online event)", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.location["@type"]).toBe("VirtualLocation");
+    expect(schema.location.url).toBe("https://nufflearena.fr/leagues/open-5-teams");
+    expect(schema.eventAttendanceMode).toBe(
+      "https://schema.org/OnlineEventAttendanceMode",
+    );
+  });
+
+  it("expose organizer reliant l Organization global", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.organizer["@id"]).toBe("https://nufflearena.fr#organization");
+  });
+
+  it("expose offers gratuit (price=0, EUR, InStock)", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.offers).toBeDefined();
+    expect(schema.offers!.price).toBe("0");
+    expect(schema.offers!.priceCurrency).toBe("EUR");
+    expect(schema.offers!.availability).toBe("https://schema.org/InStock");
+  });
+
+  it("mappe le status interne sur eventStatus schema.org", () => {
+    expect(buildLeagueEventSchema(baseInput)!.eventStatus).toBe(
+      "https://schema.org/EventScheduled",
+    );
+    expect(
+      buildLeagueEventSchema({
+        ...baseInput,
+        league: { ...baseInput.league, status: "completed" },
+      })!.eventStatus,
+    ).toBe("https://schema.org/EventScheduled");
+    expect(
+      buildLeagueEventSchema({
+        ...baseInput,
+        league: { ...baseInput.league, status: "cancelled" },
+      })!.eventStatus,
+    ).toBe("https://schema.org/EventCancelled");
+  });
+
+  it("inclut maximumAttendeeCapacity quand maxParticipants > 0", () => {
+    const schema = buildLeagueEventSchema(baseInput)!;
+    expect(schema.maximumAttendeeCapacity).toBe(16);
+  });
+
+  it("omet endDate si non fournie", () => {
+    const schema = buildLeagueEventSchema({
+      ...baseInput,
+      league: { ...baseInput.league, endDate: null },
+    })!;
+    expect(schema.endDate).toBeUndefined();
+  });
+
+  it("est deterministe", () => {
+    const a = JSON.stringify(buildLeagueEventSchema(baseInput));
+    const b = JSON.stringify(buildLeagueEventSchema(baseInput));
+    expect(a).toBe(b);
+  });
+});

--- a/apps/web/app/leagues/event-schema.ts
+++ b/apps/web/app/leagues/event-schema.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure builder for schema.org SportsEvent JSON-LD on public leagues
+ * (Q.24 — Sprint 23).
+ *
+ * Genere un objet JSON-LD `SportsEvent` consommable par Google
+ * (Rich Results Event) et les LLM (citabilite). Pure : pas de fetch,
+ * pas d'I/O. La page `/leagues/[id]` consomme ce builder pour emettre
+ * le `<script type="application/ld+json">`.
+ *
+ * Conditions d'emission :
+ *   - league.isPublic === true
+ *   - sinon : retourne `null` (pas de leak de ligues privees)
+ */
+
+export type LeaguePublicStatus =
+  | "draft"
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | string;
+
+export interface LeagueEventLeague {
+  id: string;
+  name: string;
+  description: string | null;
+  status: LeaguePublicStatus;
+  startDate: Date | null;
+  endDate: Date | null;
+  maxParticipants: number;
+  isPublic: boolean;
+}
+
+export interface LeagueEventInput {
+  baseUrl: string;
+  league: LeagueEventLeague;
+}
+
+export interface SportsEventOffers {
+  "@type": "Offer";
+  price: string;
+  priceCurrency: string;
+  availability: string;
+  url?: string;
+}
+
+export interface SportsEventSchema {
+  "@context": "https://schema.org";
+  "@type": "SportsEvent";
+  name: string;
+  description?: string;
+  identifier: string;
+  url: string;
+  startDate?: string;
+  endDate?: string;
+  eventStatus: string;
+  eventAttendanceMode: string;
+  location: {
+    "@type": "VirtualLocation";
+    url: string;
+  };
+  organizer: {
+    "@id": string;
+  };
+  offers?: SportsEventOffers;
+  maximumAttendeeCapacity?: number;
+}
+
+const STATUS_MAP: Record<string, string> = {
+  draft: "https://schema.org/EventScheduled",
+  open: "https://schema.org/EventScheduled",
+  in_progress: "https://schema.org/EventScheduled",
+  completed: "https://schema.org/EventScheduled",
+  cancelled: "https://schema.org/EventCancelled",
+  postponed: "https://schema.org/EventPostponed",
+  rescheduled: "https://schema.org/EventRescheduled",
+};
+
+export function buildLeagueEventSchema(
+  input: LeagueEventInput,
+): SportsEventSchema | null {
+  const { baseUrl, league } = input;
+  if (!league.isPublic) return null;
+
+  const cleanBase = stripTrailingSlash(baseUrl);
+  const url = `${cleanBase}/leagues/${league.id}`;
+  const eventStatus =
+    STATUS_MAP[league.status] ?? "https://schema.org/EventScheduled";
+
+  const schema: SportsEventSchema = {
+    "@context": "https://schema.org",
+    "@type": "SportsEvent",
+    name: league.name,
+    identifier: league.id,
+    url,
+    eventStatus,
+    eventAttendanceMode: "https://schema.org/OnlineEventAttendanceMode",
+    location: { "@type": "VirtualLocation", url },
+    organizer: { "@id": `${cleanBase}#organization` },
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "EUR",
+      availability: "https://schema.org/InStock",
+      url,
+    },
+  };
+
+  if (league.description) {
+    schema.description = league.description;
+  }
+  if (league.startDate) {
+    schema.startDate = league.startDate.toISOString();
+  }
+  if (league.endDate) {
+    schema.endDate = league.endDate.toISOString();
+  }
+  if (league.maxParticipants > 0) {
+    schema.maximumAttendeeCapacity = league.maxParticipants;
+  }
+
+  return schema;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}


### PR DESCRIPTION
## Resume

Q.24 demande un schema.org `Event` pour les tournois / ligues publics
**"quand online_play sera ouvert"**. Cette PR prepare le **builder pur**,
pret a etre branche cote `apps/web/app/leagues/[id]/layout.tsx` quand le
feature flag online_play sera active.

### Builder pur — `apps/web/app/leagues/event-schema.ts`

`buildLeagueEventSchema(input)` retourne :
- **`null`** pour les ligues non publiques (pas de leak des ligues
  privees dans Google / les LLM)
- un **`SportsEvent`** JSON-LD complet sinon :
  - `name`, `description`, `identifier`, `url`
  - `startDate` / `endDate` ISO 8601
  - `eventStatus` mappe depuis le status interne :
    - `open` / `in_progress` / `completed` -> `EventScheduled`
    - `cancelled` -> `EventCancelled`
    - fallback : `EventScheduled`
  - `eventAttendanceMode = OnlineEventAttendanceMode`
  - `location.@type = VirtualLocation` avec `url` vers la page
  - `organizer.@id` reliant l'`Organization` global deja declare dans
    `HomeStructuredData`
  - `offers` gratuit (`price: 0`, `EUR`, `InStock`)
  - `maximumAttendeeCapacity` quand `maxParticipants > 0`

### Tests TDD — 12 cas

- non public -> `null` (anti-leak)
- structure complete (`@context`, `@type`, name, description...)
- mapping status (open / completed / cancelled)
- ISO 8601 dates
- VirtualLocation + OnlineEventAttendanceMode
- offers gratuit
- maximumAttendeeCapacity
- omission endDate optionnelle
- determinisme

### Pourquoi ne pas wirer immediatement ?

La page `/leagues/[id]` est gatee par `OnlinePlayGate` (feature flag
online_play). Tant que le flag est OFF, la page n'est pas servie au
public, et il serait premature de wirer le JSON-LD (ca pourrait
generer une cascade Prisma au build pour des contenus pas encore
publics). Le builder est pret a etre consomme dans le layout via un
simple `<script type="application/ld+json">` des que online_play sera
ON — aucune mutation du builder requise.

## Tache roadmap

Sprint 23, tache **Q.24 — Schema.org `Event` pour les tournois/ligues
publics (quand online_play sera ouvert)**

## Plan de test

- [x] `pnpm --filter @bb/web test` (437/437 dont 12 nouveaux sur
      `event-schema.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Quand online_play sera active : wirer le builder dans le layout
      `/leagues/[id]/layout.tsx` et valider via Google Rich Results Test

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_