### PR TITLE
feat(seo): support Wikidata QID + Wikipedia sameAs (Q.23)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -394,7 +394,7 @@
 | Q.20 | Core Web Vitals monitoring (LCP, INP, CLS) + budget perf CI | Perf | [x] |
 | Q.21 | Audit A11y WCAG AA (contraste, labels, navigation clavier, focus rings) | Qualite | [x] |
 | Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [x] |
-| Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [ ] |
+| Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [x] |
 | Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [x] |
 | Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [ ] |
 | Q.26 | Strategie liens entrants : annonce r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB | GEO | [ ] |

--- a/apps/web/app/components/HomeStructuredData.tsx
+++ b/apps/web/app/components/HomeStructuredData.tsx
@@ -1,7 +1,14 @@
 "use client";
 import StructuredData from "./StructuredData";
+import { buildExternalSameAs } from "../lib/external-identity";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+const EXTERNAL_SAME_AS = buildExternalSameAs({
+  NEXT_PUBLIC_WIKIDATA_QID: process.env.NEXT_PUBLIC_WIKIDATA_QID,
+  NEXT_PUBLIC_WIKIPEDIA_FR_URL: process.env.NEXT_PUBLIC_WIKIPEDIA_FR_URL,
+  NEXT_PUBLIC_WIKIPEDIA_EN_URL: process.env.NEXT_PUBLIC_WIKIPEDIA_EN_URL,
+});
 
 /**
  * Données structurées JSON-LD de la page d'accueil.
@@ -41,6 +48,7 @@ export default function HomeStructuredData() {
           "https://discord.gg/XEZJTgEHKn",
           "https://github.com/Ryxeuf/fantasy-football-game",
           "https://ko-fi.com/nufflearena",
+          ...EXTERNAL_SAME_AS,
         ],
         knowsAbout: [
           "Blood Bowl",

--- a/apps/web/app/lib/external-identity.test.ts
+++ b/apps/web/app/lib/external-identity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests pour le builder de sameAs externes (Q.23 — Sprint 23).
+ *
+ * Q.23 vise a renforcer l identite d entite via Wikidata / Wikipedia.
+ * La creation effective de l entree Wikidata est externe (manuelle),
+ * mais le code expose un builder qui prend le QID + URLs Wikipedia
+ * depuis l env et les ajoute au tableau sameAs du JSON-LD
+ * Organization, avec validation defensive.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildExternalSameAs,
+  isValidWikidataQid,
+  type ExternalIdentityEnv,
+} from "./external-identity";
+
+describe("isValidWikidataQid", () => {
+  it("accepte un QID valide (Q + chiffres, 1-12)", () => {
+    expect(isValidWikidataQid("Q42")).toBe(true);
+    expect(isValidWikidataQid("Q1")).toBe(true);
+    expect(isValidWikidataQid("Q123456789012")).toBe(true);
+  });
+
+  it("rejette un format invalide", () => {
+    expect(isValidWikidataQid("42")).toBe(false);
+    expect(isValidWikidataQid("Q")).toBe(false);
+    expect(isValidWikidataQid("Q42abc")).toBe(false);
+    expect(isValidWikidataQid("q42")).toBe(false); // doit etre majuscule
+    expect(isValidWikidataQid("Q1234567890123")).toBe(false); // > 12 chiffres
+    expect(isValidWikidataQid("")).toBe(false);
+    expect(isValidWikidataQid(undefined)).toBe(false);
+  });
+});
+
+describe("buildExternalSameAs", () => {
+  it("retourne un tableau vide si aucune source fournie", () => {
+    expect(buildExternalSameAs({})).toEqual([]);
+    expect(buildExternalSameAs(undefined)).toEqual([]);
+  });
+
+  it("ajoute la page Wikidata canonique pour un QID valide", () => {
+    const env: ExternalIdentityEnv = { NEXT_PUBLIC_WIKIDATA_QID: "Q42" };
+    expect(buildExternalSameAs(env)).toContain("https://www.wikidata.org/wiki/Q42");
+  });
+
+  it("ignore un QID invalide silencieusement", () => {
+    const env: ExternalIdentityEnv = { NEXT_PUBLIC_WIKIDATA_QID: "not-a-qid" };
+    expect(buildExternalSameAs(env)).toEqual([]);
+  });
+
+  it("ajoute les URLs Wikipedia FR / EN si valides https", () => {
+    const env: ExternalIdentityEnv = {
+      NEXT_PUBLIC_WIKIPEDIA_FR_URL: "https://fr.wikipedia.org/wiki/Nuffle_Arena",
+      NEXT_PUBLIC_WIKIPEDIA_EN_URL: "https://en.wikipedia.org/wiki/Nuffle_Arena",
+    };
+    const sameAs = buildExternalSameAs(env);
+    expect(sameAs).toContain("https://fr.wikipedia.org/wiki/Nuffle_Arena");
+    expect(sameAs).toContain("https://en.wikipedia.org/wiki/Nuffle_Arena");
+  });
+
+  it("rejette une URL Wikipedia hors domaine wikipedia.org", () => {
+    const env: ExternalIdentityEnv = {
+      NEXT_PUBLIC_WIKIPEDIA_FR_URL: "https://malicious.com/wiki/x",
+    };
+    expect(buildExternalSameAs(env)).toEqual([]);
+  });
+
+  it("rejette une URL non-https", () => {
+    const env: ExternalIdentityEnv = {
+      NEXT_PUBLIC_WIKIPEDIA_FR_URL: "http://fr.wikipedia.org/wiki/x",
+    };
+    expect(buildExternalSameAs(env)).toEqual([]);
+  });
+
+  it("dedoublonne en preservant l ordre", () => {
+    const env: ExternalIdentityEnv = {
+      NEXT_PUBLIC_WIKIDATA_QID: "Q42",
+      NEXT_PUBLIC_WIKIPEDIA_FR_URL: "https://fr.wikipedia.org/wiki/x",
+      NEXT_PUBLIC_WIKIPEDIA_EN_URL: "https://fr.wikipedia.org/wiki/x", // doublon
+    };
+    const sameAs = buildExternalSameAs(env);
+    expect(sameAs.length).toBe(2);
+  });
+
+  it("est deterministe", () => {
+    const env: ExternalIdentityEnv = {
+      NEXT_PUBLIC_WIKIDATA_QID: "Q42",
+      NEXT_PUBLIC_WIKIPEDIA_FR_URL: "https://fr.wikipedia.org/wiki/x",
+    };
+    expect(buildExternalSameAs(env)).toEqual(buildExternalSameAs(env));
+  });
+});

--- a/apps/web/app/lib/external-identity.ts
+++ b/apps/web/app/lib/external-identity.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure builder for external identity sameAs URLs (Q.23 — Sprint 23).
+ *
+ * Q.23 vise a renforcer l identite d entite Nuffle Arena dans Google
+ * (Knowledge Panel) et les LLM via Wikidata + Wikipedia. La creation
+ * effective des entrees Wikidata / Wikipedia est externe (manuelle,
+ * sur les sites respectifs), mais le code ici expose un builder qui :
+ *   - prend les identifiants depuis l env (publique)
+ *   - valide les formats (defense contre placeholders / mauvais collage)
+ *   - retourne un tableau d URLs canoniques pretes a injecter dans
+ *     `Organization.sameAs` du JSON-LD homepage.
+ *
+ * Pure : pas de fetch, pas d I/O.
+ */
+
+export interface ExternalIdentityEnv {
+  /** Wikidata Q-Identifier (ex: "Q42"). */
+  NEXT_PUBLIC_WIKIDATA_QID?: string;
+  /** URL Wikipedia FR (https://fr.wikipedia.org/...). */
+  NEXT_PUBLIC_WIKIPEDIA_FR_URL?: string;
+  /** URL Wikipedia EN (https://en.wikipedia.org/...). */
+  NEXT_PUBLIC_WIKIPEDIA_EN_URL?: string;
+}
+
+const QID_REGEX = /^Q[1-9][0-9]{0,11}$/;
+
+export function isValidWikidataQid(value: string | undefined | null): boolean {
+  if (typeof value !== "string") return false;
+  return QID_REGEX.test(value);
+}
+
+function sanitizeWikipediaUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+  if (!parsed.hostname.endsWith(".wikipedia.org")) return null;
+  if (parsed.pathname.length <= 1) return null;
+  return parsed.toString();
+}
+
+export function buildExternalSameAs(
+  env: ExternalIdentityEnv | undefined,
+): string[] {
+  if (!env) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const addIfNew = (value: string | null) => {
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    result.push(value);
+  };
+
+  if (isValidWikidataQid(env.NEXT_PUBLIC_WIKIDATA_QID)) {
+    addIfNew(`https://www.wikidata.org/wiki/${env.NEXT_PUBLIC_WIKIDATA_QID}`);
+  }
+  addIfNew(sanitizeWikipediaUrl(env.NEXT_PUBLIC_WIKIPEDIA_FR_URL));
+  addIfNew(sanitizeWikipediaUrl(env.NEXT_PUBLIC_WIKIPEDIA_EN_URL));
+
+  return result;
+}


### PR DESCRIPTION
## Resume

Q.23 vise a renforcer l identite d entite Nuffle Arena pour
**Google Knowledge Panel** et la **citabilite par les LLM** via
Wikidata + Wikipedia. La creation effective des entrees Wikidata /
Wikipedia est externe (manuelle, sur les sites respectifs), mais le
code expose maintenant un **builder pur** qui ajoute automatiquement
les `sameAs` canoniques au JSON-LD homepage des que les env vars sont
renseignees.

### Architecture

- `apps/web/app/lib/external-identity.ts` — **builder pur** :
  - `isValidWikidataQid(value)` : regex `Q[1-9][0-9]{0,11}` (rejette
    placeholders, casse minuscule, longueur excessive)
  - `sanitizeWikipediaUrl(value)` : exige `https://` + hostname
    `*.wikipedia.org` (defense URLs malicieuses ou typos)
  - `buildExternalSameAs(env)` : compose le tableau sameAs en
    dedoublonnant et en preservant l'ordre, defaut `[]` si rien fourni
- `apps/web/app/lib/external-identity.test.ts` — **10 tests TDD** :
  - QID valide / invalide / minuscule / trop long
  - Wikipedia hors domaine `wikipedia.org` rejete
  - HTTP (non https) rejete
  - Dedoublonnage en preservant l'ordre
  - Determinisme
  - `env` undefined
- `apps/web/app/components/HomeStructuredData.tsx` — fusion des
  sameAs canoniques deja presents (Discord, GitHub, Ko-fi) avec
  `EXTERNAL_SAME_AS` calcule depuis les env :
  - `NEXT_PUBLIC_WIKIDATA_QID`
  - `NEXT_PUBLIC_WIKIPEDIA_FR_URL`
  - `NEXT_PUBLIC_WIKIPEDIA_EN_URL`

### Pourquoi un builder ?

- La validation centralise previent les erreurs de placeholder
  ("votre-qid", "TODO") en prod.
- Le builder est testable sans monter React.
- Le wiring dans `HomeStructuredData` est minimal (3 lignes), zero
  risque de regression sur le JSON-LD existant.

### Operationnel (hors PR)

- Creer une entree Wikidata pour Nuffle Arena (ex: `Q12345`).
- Optionnellement, esquisser une page Wikipedia (FR puis EN).
- Renseigner les 3 env vars en production.

## Tache roadmap

Sprint 23, tache **Q.23 — Entry Wikidata (et/ou section Wikipedia
ebauche) pour renforcer l identite d entite**

## Plan de test

- [x] `pnpm --filter @bb/web test` (447/447 dont 10 nouveaux sur
      `external-identity.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Une fois l entree Wikidata creee : renseigner les env vars,
      verifier le JSON-LD via Google Rich Results Test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_