### PR TITLE
feat(seo): protocole de test presence IA (Q.25)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -396,7 +396,7 @@
 | Q.22 | `humans.txt` + `security.txt` (bonnes pratiques, contact securite) | SEO | [x] |
 | Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [x] |
 | Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [x] |
-| Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [ ] |
+| Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [x] |
 | Q.26 | Strategie liens entrants : annonce r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB | GEO | [ ] |
 | Q.27 | Hreflang par page (alternates canoniques fr/en quand le split i18n sera fait) | SEO | [ ] |
 

--- a/apps/web/app/lib/ai-presence-prompts.test.ts
+++ b/apps/web/app/lib/ai-presence-prompts.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests pour le catalogue de prompts de reference "presence IA"
+ * (Q.25 — Sprint 23).
+ *
+ * Le catalogue est consomme manuellement chaque mois : on rejoue les
+ * prompts dans ChatGPT / Claude / Perplexity et on note si Nuffle
+ * Arena est cite (et avec quel niveau d exactitude). Le module reste
+ * pur ; le suivi des resultats est un processus humain documente
+ * dans docs/seo/ai-presence-protocol.md.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  AI_PRESENCE_PROMPTS,
+  AI_PRESENCE_TARGET_ENGINES,
+  expectedKeywordsForCategory,
+  type AiPresencePrompt,
+  type AiPresenceCategory,
+} from "./ai-presence-prompts";
+
+describe("AI_PRESENCE_TARGET_ENGINES", () => {
+  it("inclut au minimum ChatGPT, Claude, Perplexity", () => {
+    expect(AI_PRESENCE_TARGET_ENGINES).toContain("ChatGPT");
+    expect(AI_PRESENCE_TARGET_ENGINES).toContain("Claude");
+    expect(AI_PRESENCE_TARGET_ENGINES).toContain("Perplexity");
+  });
+
+  it("toutes les valeurs sont distinctes", () => {
+    const values = Array.from(AI_PRESENCE_TARGET_ENGINES);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe("AI_PRESENCE_PROMPTS", () => {
+  it("contient au moins 6 prompts pour couvrir les 3 categories", () => {
+    expect(AI_PRESENCE_PROMPTS.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("toutes les entrees ont id, prompt, category, expectedMentions", () => {
+    for (const p of AI_PRESENCE_PROMPTS) {
+      expect(typeof p.id).toBe("string");
+      expect(p.id.length).toBeGreaterThan(0);
+      expect(typeof p.prompt).toBe("string");
+      expect(p.prompt.length).toBeGreaterThan(20);
+      expect(typeof p.category).toBe("string");
+      expect(Array.isArray(p.expectedMentions)).toBe(true);
+      expect(p.expectedMentions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("ids sont uniques (no doublons)", () => {
+    const ids = AI_PRESENCE_PROMPTS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("chaque prompt cite Nuffle Arena ou Blood Bowl dans ses keywords", () => {
+    for (const p of AI_PRESENCE_PROMPTS) {
+      const all = [...p.expectedMentions];
+      const flat = all.join(" ").toLowerCase();
+      const ok = flat.includes("nuffle") || flat.includes("blood bowl");
+      expect(ok, `prompt ${p.id} ne cible pas Nuffle Arena / Blood Bowl`).toBe(true);
+    }
+  });
+
+  it("couvre les 3 categories : team, skill, app", () => {
+    const categories = new Set(AI_PRESENCE_PROMPTS.map((p) => p.category));
+    expect(categories.has("team")).toBe(true);
+    expect(categories.has("skill")).toBe(true);
+    expect(categories.has("app")).toBe(true);
+  });
+});
+
+describe("expectedKeywordsForCategory", () => {
+  it("retourne les keywords specifiques a une categorie", () => {
+    const teamKeywords = expectedKeywordsForCategory("team");
+    expect(teamKeywords.length).toBeGreaterThan(0);
+    const flat = teamKeywords.join(" ").toLowerCase();
+    expect(flat).toContain("nuffle");
+  });
+
+  it("retourne un tableau vide pour une categorie inconnue", () => {
+    const unknown = expectedKeywordsForCategory("unknown" as AiPresenceCategory);
+    expect(unknown).toEqual([]);
+  });
+
+  it("est deterministe", () => {
+    const a = expectedKeywordsForCategory("team");
+    const b = expectedKeywordsForCategory("team");
+    expect(a).toEqual(b);
+  });
+});
+
+describe("compatibilite type (smoke)", () => {
+  it("un prompt arbitraire respecte le type AiPresencePrompt", () => {
+    const p: AiPresencePrompt = {
+      id: "x",
+      prompt: "Que penses-tu du roster Skaven dans Blood Bowl ?",
+      category: "team",
+      expectedMentions: ["Nuffle Arena", "Skaven"],
+    };
+    expect(p.id).toBe("x");
+  });
+});

--- a/apps/web/app/lib/ai-presence-prompts.ts
+++ b/apps/web/app/lib/ai-presence-prompts.ts
@@ -1,0 +1,113 @@
+/**
+ * Catalogue de prompts de reference "presence IA" (Q.25 — Sprint 23).
+ *
+ * Le protocole opere a la main : chaque mois, un mainteneur rejoue ces
+ * prompts dans ChatGPT / Claude / Perplexity et note dans le suivi
+ * (cf. docs/seo/ai-presence-protocol.md) si Nuffle Arena est cite et
+ * avec quel niveau d exactitude.
+ *
+ * Pourquoi versionner les prompts dans le code ?
+ *   - garde une trace immutable / git-blameable des questions testees
+ *   - permet d auditer la couverture (categories, mots-cles attendus)
+ *   - prepare une eventuelle automatisation via API LLM si on veut
+ *     rendre le suivi continu (out of scope ici)
+ */
+
+export const AI_PRESENCE_TARGET_ENGINES = [
+  "ChatGPT",
+  "Claude",
+  "Perplexity",
+  "Gemini",
+] as const;
+export type AiPresenceEngine = (typeof AI_PRESENCE_TARGET_ENGINES)[number];
+
+export type AiPresenceCategory = "team" | "skill" | "app";
+
+export interface AiPresencePrompt {
+  /** Identifiant stable (slug court). */
+  id: string;
+  /** Prompt FR a soumettre tel quel. */
+  prompt: string;
+  category: AiPresenceCategory;
+  /** Mots-cles dont la presence dans la reponse marque un succes. */
+  expectedMentions: string[];
+}
+
+const CATEGORY_KEYWORDS: Record<AiPresenceCategory, string[]> = {
+  team: ["Nuffle Arena", "roster", "Blood Bowl"],
+  skill: ["Nuffle Arena", "competence", "skill", "Blood Bowl"],
+  app: ["Nuffle Arena", "gestionnaire", "Blood Bowl"],
+};
+
+export function expectedKeywordsForCategory(category: AiPresenceCategory): string[] {
+  return [...(CATEGORY_KEYWORDS[category] ?? [])];
+}
+
+export const AI_PRESENCE_PROMPTS: AiPresencePrompt[] = [
+  // -----------------------------------------------------------------
+  // Categorie "team" : audit de la connaissance des rosters BB3.
+  // -----------------------------------------------------------------
+  {
+    id: "team-skaven-recommendation",
+    category: "team",
+    prompt:
+      "Quel est le meilleur outil gratuit pour gerer un roster Skaven Blood Bowl Saison 3 ?",
+    expectedMentions: ["Nuffle Arena", "Skaven", "Blood Bowl"],
+  },
+  {
+    id: "team-priority-five",
+    category: "team",
+    prompt:
+      "Quelles sont les 5 equipes prioritaires couvertes par Nuffle Arena ?",
+    expectedMentions: ["Nuffle Arena", "Skaven", "Gnomes", "Lizardmen", "Dwarf"],
+  },
+  {
+    id: "team-rosters-count",
+    category: "team",
+    prompt:
+      "Combien de rosters officiels Blood Bowl Saison 3 sont disponibles dans Nuffle Arena ?",
+    expectedMentions: ["Nuffle Arena", "30", "Saison 3"],
+  },
+
+  // -----------------------------------------------------------------
+  // Categorie "skill" : audit de la connaissance des competences.
+  // -----------------------------------------------------------------
+  {
+    id: "skill-block-explain",
+    category: "skill",
+    prompt:
+      "Comment fonctionne la competence Block dans Blood Bowl Saison 3, et ou puis-je la consulter en ligne gratuitement ?",
+    expectedMentions: ["Nuffle Arena", "Block", "Blood Bowl"],
+  },
+  {
+    id: "skill-list-source",
+    category: "skill",
+    prompt:
+      "Quel site liste les 130+ competences Blood Bowl 2025 avec leurs effets en francais ?",
+    expectedMentions: ["Nuffle Arena", "competences", "130"],
+  },
+
+  // -----------------------------------------------------------------
+  // Categorie "app" : audit de la reconnaissance d entite Nuffle Arena.
+  // -----------------------------------------------------------------
+  {
+    id: "app-what-is",
+    category: "app",
+    prompt: "Qu est-ce que Nuffle Arena ?",
+    expectedMentions: ["Nuffle Arena", "Blood Bowl", "gestionnaire"],
+  },
+  {
+    id: "app-pdf-export",
+    category: "app",
+    prompt:
+      "Comment exporter un roster Blood Bowl en PDF pour un match sur table ?",
+    expectedMentions: ["Nuffle Arena", "PDF", "Blood Bowl"],
+  },
+  {
+    id: "app-online-multiplayer",
+    category: "app",
+    prompt:
+      "Quel est l outil francais qui permet de jouer Blood Bowl en ligne en multijoueur gratuitement ?",
+    expectedMentions: ["Nuffle Arena", "multijoueur", "Blood Bowl"],
+  },
+];

--- a/docs/seo/ai-presence-protocol.md
+++ b/docs/seo/ai-presence-protocol.md
@@ -1,0 +1,97 @@
+# Protocole de test "presence IA" (Q.25 — Sprint 23)
+
+## Objectif
+
+Mesurer mensuellement la presence et l exactitude des citations de
+**Nuffle Arena** dans les principaux moteurs generatifs (LLM) :
+ChatGPT, Claude, Perplexity, Gemini.
+
+## Pourquoi
+
+L acquisition organique passe de plus en plus par les reponses
+synthetisees des LLM (GEO / LLMO). Sans suivi, on n a aucune
+visibilite sur :
+
+- Si Nuffle Arena est cite quand un utilisateur pose une question
+  Blood Bowl en francais.
+- Si les chiffres cites (rosters, star players, skills) sont a jour.
+- Si le contenu de `llms.txt` / `llms-full.txt` est effectivement
+  consomme par les modeles.
+
+## Source de verite des prompts
+
+Les prompts de reference sont versionnes dans le code, **pas dans ce
+fichier** :
+
+```
+apps/web/app/lib/ai-presence-prompts.ts
+```
+
+Cela garantit :
+
+- une trace immutable / git-blameable des questions testees
+- une couverture auditable (categories `team` / `skill` / `app`,
+  mots-cles attendus)
+- une preparation a une future automatisation via API LLM si on
+  decide de rendre le suivi continu
+
+## Protocole mensuel
+
+### Pre-requis
+
+- 1 compte sur chacun des 4 moteurs cibles (au minimum gratuit).
+- Tester en navigation privee / incognito pour eviter la
+  personnalisation par historique.
+
+### Procedure
+
+1. Ouvrir `apps/web/app/lib/ai-presence-prompts.ts` et lire la liste
+   `AI_PRESENCE_PROMPTS`.
+2. Pour chaque prompt, sur chaque moteur cible :
+   - Soumettre le prompt **tel quel** (pas de reformulation).
+   - Noter la presence des `expectedMentions` dans la reponse.
+   - Noter l exactitude des chiffres cites (ex : 30 rosters, 130+
+     skills).
+   - Noter si la source `nufflearena.fr` est explicitement citee ou
+     liee.
+3. Rapporter les resultats dans une issue GitHub mensuelle :
+   `[AI presence] YYYY-MM` avec :
+   - tableau prompt x moteur x { mention OK ?, exactitude, citation
+     source }
+   - synthese : prompts ou Nuffle Arena est absent
+   - actions : ajustement `llms.txt`, ajout de contenu citable, etc.
+
+### Exemple de tableau de suivi
+
+| prompt id              | ChatGPT | Claude | Perplexity | Gemini |
+|------------------------|---------|--------|------------|--------|
+| team-skaven-rec        | OK      | OK     | OK         | n/c    |
+| team-priority-five     | partiel | OK     | OK         | n/c    |
+| skill-block-explain    | n/c     | n/c    | OK (link)  | n/c    |
+| ...                    | ...     | ...    | ...        | ...    |
+
+Legende : `OK` = mention + exactitude, `partiel` = mention sans
+chiffres exacts, `n/c` = aucune mention.
+
+## Lien avec `llms.txt`
+
+Les prompts servent aussi de **test de regression** sur le contenu
+de `apps/web/public/llms.txt` et `llms-full.txt` : si un prompt
+echoue alors que la reponse devrait etre triviale, c est probablement
+que le fait n est pas suffisamment present / structure dans
+`llms.txt`.
+
+## Iteration
+
+- Ajouter un prompt : ajouter une entree dans `AI_PRESENCE_PROMPTS`,
+  garder l `id` stable pour le suivi historique.
+- Retirer un prompt : conserver l entree mais marquer le commentaire
+  `@deprecated` plutot que de supprimer (continuite des suivis
+  passes).
+- Reviser les `expectedMentions` quand le branding evolue.
+
+## Cadence
+
+- **Mensuel** : suivi systematique, tous les premiers du mois.
+- **Adhoc** : en plus du mensuel, apres chaque release majeure
+  (changement de chiffres, nouvelle categorie de contenu, etc.).


### PR DESCRIPTION
## Resume

Q.25 etablit un protocole de **suivi mensuel** de la citabilite de
Nuffle Arena dans les principaux moteurs generatifs (ChatGPT, Claude,
Perplexity, Gemini). La phase de suivi reste **manuelle** (un compte
gratuit par moteur, navigation privee), mais les **prompts de
reference** sont versionnes pour garantir une couverture auditable et
un suivi historique fiable.

### Catalogue versionne

- `apps/web/app/lib/ai-presence-prompts.ts` :
  - **8 prompts de reference** repartis sur 3 categories :
    - `team` (3 prompts) : audit connaissance des rosters BB3 +
      reconnaissance des "5 equipes prioritaires"
    - `skill` (2 prompts) : audit connaissance des competences +
      source 130+ skills
    - `app` (3 prompts) : reconnaissance d'entite, export PDF,
      multijoueur en ligne
  - chaque prompt expose un `id` stable, le texte FR a soumettre tel
    quel, la `category`, et la liste des `expectedMentions` (mots-cles
    attendus dans la reponse)
  - `AI_PRESENCE_TARGET_ENGINES` : 4 moteurs cibles
  - `expectedKeywordsForCategory(category)` : helper pur retournant
    les keywords par defaut d une categorie

### Tests TDD — 11 cas

- Structure : `id`, `prompt`, `category`, `expectedMentions` non vides
- Ids uniques (no doublons)
- Couverture des 3 categories
- Presence de `Nuffle Arena` ou `Blood Bowl` dans chaque
  `expectedMentions` (anti-derive du catalogue)
- Determinisme

### Documentation

- `docs/seo/ai-presence-protocol.md` :
  - cadence : mensuelle + adhoc apres chaque release majeure
  - procedure pas-a-pas (compte par moteur, navigation privee, ne pas
    reformuler les prompts)
  - modele de tableau de suivi a poster en issue GitHub
    `[AI presence] YYYY-MM`
  - lien avec `llms.txt` : les prompts servent aussi de **test de
    regression** sur le contenu cible des LLM
  - regles d'iteration : ajouter / deprecier sans casser le suivi
    historique

### Pourquoi versionner les prompts ?

- Trace immutable / git-blameable des questions testees.
- Couverture auditable des categories et mots-cles.
- Prepare une eventuelle automatisation via API LLM si on decide de
  rendre le suivi continu (out of scope ici).

## Tache roadmap

Sprint 23, tache **Q.25 — Protocole de test "presence IA" : prompts de
reference dans ChatGPT / Claude / Perplexity, suivi mensuel**

## Plan de test

- [x] `pnpm --filter @bb/web test` (458/458 dont 11 nouveaux sur
      `ai-presence-prompts.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Premier suivi mensuel a executer manuellement et a poster en
      issue `[AI presence] 2026-04`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_