### PR TITLE
feat(seo): strategie liens entrants - templates outreach (Q.26)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -397,7 +397,7 @@
 | Q.23 | Entry Wikidata (et/ou section Wikipedia ebauche) pour renforcer l'identite d'entite | GEO | [x] |
 | Q.24 | Schema.org `Event` pour les tournois/ligues publics (quand online_play sera ouvert) | SEO | [x] |
 | Q.25 | Protocole de test "presence IA" : prompts de reference dans ChatGPT / Claude / Perplexity, suivi mensuel | GEO | [x] |
-| Q.26 | Strategie liens entrants : annonce r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB | GEO | [ ] |
+| Q.26 | Strategie liens entrants : annonce r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB | GEO | [x] |
 | Q.27 | Hreflang par page (alternates canoniques fr/en quand le split i18n sera fait) | SEO | [ ] |
 
 ---

--- a/apps/web/app/lib/outreach-templates.test.ts
+++ b/apps/web/app/lib/outreach-templates.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests pour le module de templates d'annonce communautaire
+ * (Q.26 — Sprint 23).
+ *
+ * Le module versionne les templates de messages d'annonce destines aux
+ * canaux communautaires (r/bloodbowl, TalkFantasyFootball, Discord BB,
+ * blog Mordorbihan, etc.). Le suivi opere a la main, mais les
+ * templates sont versionnes pour garantir la coherence du ton.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  OUTREACH_CHANNELS,
+  OUTREACH_TEMPLATES,
+  renderOutreachTemplate,
+  type OutreachChannel,
+  type OutreachTemplate,
+} from "./outreach-templates";
+
+describe("OUTREACH_CHANNELS", () => {
+  it("inclut au minimum les 4 canaux cibles de Q.26", () => {
+    expect(OUTREACH_CHANNELS).toContain("reddit_bloodbowl");
+    expect(OUTREACH_CHANNELS).toContain("talkfantasyfootball");
+    expect(OUTREACH_CHANNELS).toContain("discord_bloodbowl");
+    expect(OUTREACH_CHANNELS).toContain("mordorbihan_blog");
+  });
+
+  it("toutes les valeurs sont distinctes", () => {
+    const values = Array.from(OUTREACH_CHANNELS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe("OUTREACH_TEMPLATES", () => {
+  it("definit un template par canal", () => {
+    for (const channel of OUTREACH_CHANNELS) {
+      expect(
+        OUTREACH_TEMPLATES[channel],
+        `template manquant pour ${channel}`,
+      ).toBeDefined();
+    }
+  });
+
+  it("chaque template a title, body, callToAction non vides", () => {
+    for (const channel of OUTREACH_CHANNELS) {
+      const t = OUTREACH_TEMPLATES[channel];
+      expect(t.title.length).toBeGreaterThan(0);
+      expect(t.body.length).toBeGreaterThan(20);
+      expect(t.callToAction.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("chaque template mentionne {siteUrl} pour interpolation", () => {
+    for (const channel of OUTREACH_CHANNELS) {
+      const t = OUTREACH_TEMPLATES[channel];
+      const all = `${t.title} ${t.body} ${t.callToAction}`;
+      expect(
+        all.includes("{siteUrl}"),
+        `template ${channel} doit utiliser {siteUrl}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("renderOutreachTemplate", () => {
+  const baseInput = {
+    siteUrl: "https://nufflearena.fr",
+    discordInvite: "https://discord.gg/XEZJTgEHKn",
+  };
+
+  it("interpole {siteUrl} au minimum dans le call to action", () => {
+    const r = renderOutreachTemplate("reddit_bloodbowl", baseInput);
+    expect(r.callToAction).toContain("https://nufflearena.fr");
+  });
+
+  it("ne laisse aucun siteUrl placeholder non resolu", () => {
+    for (const channel of OUTREACH_CHANNELS) {
+      const r = renderOutreachTemplate(channel, baseInput);
+      const all = `${r.title} ${r.body} ${r.callToAction}`;
+      expect(all.includes("{siteUrl}"), `${channel} a un siteUrl non resolu`).toBe(false);
+    }
+  });
+
+  it("interpole {discordInvite} si fourni", () => {
+    const r = renderOutreachTemplate("discord_bloodbowl", {
+      ...baseInput,
+      discordInvite: "https://discord.gg/customInvite",
+    });
+    const all = `${r.title} ${r.body} ${r.callToAction}`;
+    expect(all).toContain("https://discord.gg/customInvite");
+  });
+
+  it("ne laisse aucun placeholder {x} non resolu apres render", () => {
+    for (const channel of OUTREACH_CHANNELS) {
+      const r = renderOutreachTemplate(channel, baseInput);
+      const all = `${r.title} ${r.body} ${r.callToAction}`;
+      expect(/\{[^}]+\}/.test(all), `${channel} a un placeholder non resolu`).toBe(false);
+    }
+  });
+
+  it("est deterministe : meme entree -> meme sortie", () => {
+    const a = renderOutreachTemplate("reddit_bloodbowl", baseInput);
+    const b = renderOutreachTemplate("reddit_bloodbowl", baseInput);
+    expect(a).toEqual(b);
+  });
+
+  it("leve une erreur pour un canal inconnu", () => {
+    expect(() =>
+      renderOutreachTemplate("unknown" as OutreachChannel, baseInput),
+    ).toThrow(/channel/i);
+  });
+
+  it("rejette siteUrl vide / non-url", () => {
+    expect(() =>
+      renderOutreachTemplate("reddit_bloodbowl", {
+        ...baseInput,
+        siteUrl: "not-a-url",
+      }),
+    ).toThrow(/siteUrl/i);
+  });
+});
+
+describe("compatibilite type", () => {
+  it("OutreachTemplate accepte le shape attendu", () => {
+    const t: OutreachTemplate = {
+      title: "x",
+      body: "y",
+      callToAction: "z",
+    };
+    expect(t.title).toBe("x");
+  });
+});

--- a/apps/web/app/lib/outreach-templates.ts
+++ b/apps/web/app/lib/outreach-templates.ts
@@ -1,0 +1,117 @@
+/**
+ * Templates d'annonce communautaire pour la strategie liens entrants
+ * (Q.26 — Sprint 23).
+ *
+ * Q.26 demande une strategie de liens entrants vers Nuffle Arena
+ * (r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB).
+ * La phase d'outreach reste manuelle, mais les **templates de message
+ * sont versionnes** pour garantir la coherence du ton, eviter les
+ * derives de contenu entre canaux, et permettre une revue editoriale
+ * en PR.
+ *
+ * Pure : pas de fetch, pas d'I/O. Les templates sont rendered en
+ * substituant {siteUrl} et {discordInvite}.
+ */
+
+export const OUTREACH_CHANNELS = [
+  "reddit_bloodbowl",
+  "talkfantasyfootball",
+  "discord_bloodbowl",
+  "mordorbihan_blog",
+] as const;
+export type OutreachChannel = (typeof OUTREACH_CHANNELS)[number];
+
+export interface OutreachTemplate {
+  /** Sujet / titre de la communication. */
+  title: string;
+  /** Corps du message (peut etre multiligne, markdown leger toler  e). */
+  body: string;
+  /** Phrase d'appel a l'action / lien final. */
+  callToAction: string;
+}
+
+export interface OutreachInput {
+  /** URL canonique du site (validee https). */
+  siteUrl: string;
+  /** URL d'invitation Discord (utilisee uniquement par discord_bloodbowl). */
+  discordInvite?: string;
+}
+
+const TEMPLATES: Record<OutreachChannel, OutreachTemplate> = {
+  reddit_bloodbowl: {
+    title: "[Tool] Nuffle Arena — gestionnaire d'equipes Blood Bowl gratuit ({siteUrl})",
+    body:
+      "Bonjour r/bloodbowl,\n\n" +
+      "Je partage Nuffle Arena, une plateforme gratuite et open-source\n" +
+      "pour gerer vos equipes Blood Bowl Saison 3 :\n\n" +
+      "- 30 rosters officiels Saison 2 + Saison 3\n" +
+      "- 60+ Star Players avec regles speciales\n" +
+      "- 130+ competences en FR/EN\n" +
+      "- Export PDF pour vos matchs sur table\n" +
+      "- Mode multijoueur en ligne (matchmaking + ELO)\n\n" +
+      "Aucune pub, aucune revente de donnees. Code public sur GitHub.\n" +
+      "Tout retour est le bienvenu.\n",
+    callToAction: "Lien : {siteUrl}",
+  },
+  talkfantasyfootball: {
+    title: "Nuffle Arena — free open-source Blood Bowl team manager ({siteUrl})",
+    body:
+      "Hi all,\n\n" +
+      "Sharing Nuffle Arena, a free, open-source Blood Bowl team manager:\n" +
+      "30 official rosters (Season 2 + 3), 60+ Star Players, 130+ skills,\n" +
+      "PDF export for tabletop matches, and an online multiplayer mode.\n\n" +
+      "No ads, no data resale. Built by the community for the community.\n" +
+      "Feedback very welcome here or on GitHub.\n",
+    callToAction: "Link: {siteUrl}",
+  },
+  discord_bloodbowl: {
+    title: "Nuffle Arena — outil gratuit Blood Bowl ({siteUrl})",
+    body:
+      "Salut tout le monde,\n\n" +
+      "Pour ceux qui cherchent un outil gratuit pour gerer leurs\n" +
+      "equipes Blood Bowl Saison 3, jeter un coup d'oeil a Nuffle Arena :\n" +
+      "rosters officiels, Star Players, competences en FR/EN, export PDF,\n" +
+      "et bientot un mode multijoueur en ligne complet.\n\n" +
+      "Discord du projet : {discordInvite}\n",
+    callToAction: "Site : {siteUrl}",
+  },
+  mordorbihan_blog: {
+    title: "Nuffle Arena — un nouvel outil francophone pour vos equipes Blood Bowl ({siteUrl})",
+    body:
+      "Bonjour Mordorbihan,\n\n" +
+      "Je voulais te presenter Nuffle Arena, une plateforme francophone\n" +
+      "gratuite et open-source dediee a la gestion d equipes Blood Bowl\n" +
+      "(Saison 2 et Saison 3). 30 rosters officiels, 60+ Star Players,\n" +
+      "130+ competences traduites, export PDF prepare pour les matchs sur\n" +
+      "table. Aucune pub, code 100 % public sur GitHub.\n\n" +
+      "Si ca peut interesser ton lectorat, je serais ravi qu'on echange.\n",
+    callToAction: "Site : {siteUrl}",
+  },
+};
+
+export const OUTREACH_TEMPLATES: Record<OutreachChannel, OutreachTemplate> = TEMPLATES;
+
+const HTTPS_REGEX = /^https:\/\/[^\s]+$/;
+
+export function renderOutreachTemplate(
+  channel: OutreachChannel,
+  input: OutreachInput,
+): OutreachTemplate {
+  const template = OUTREACH_TEMPLATES[channel];
+  if (!template) {
+    throw new Error(`Unknown outreach channel: ${channel}`);
+  }
+  if (!HTTPS_REGEX.test(input.siteUrl)) {
+    throw new Error(`Invalid siteUrl (must be https://): ${input.siteUrl}`);
+  }
+  const discord = input.discordInvite ?? "https://discord.gg/XEZJTgEHKn";
+
+  const interpolate = (text: string): string =>
+    text.replace(/\{siteUrl\}/g, input.siteUrl).replace(/\{discordInvite\}/g, discord);
+
+  return {
+    title: interpolate(template.title),
+    body: interpolate(template.body),
+    callToAction: interpolate(template.callToAction),
+  };
+}

--- a/docs/seo/inbound-links-strategy.md
+++ b/docs/seo/inbound-links-strategy.md
@@ -1,0 +1,97 @@
+# Strategie liens entrants (Q.26 — Sprint 23)
+
+## Objectif
+
+Acquerir des **backlinks de qualite** vers Nuffle Arena depuis les
+canaux communautaires Blood Bowl francophones et internationaux. Ces
+backlinks renforcent :
+
+- l autorite de domaine (signal SEO classique)
+- la decouvrabilite via les communautes existantes
+- la citabilite par les LLM (qui consultent les forums et blogs)
+
+## Canaux cibles
+
+| Canal | Type | Audience | Frequence |
+|-------|------|----------|-----------|
+| **r/bloodbowl** | Subreddit | Anglophone, ~30k membres | 1x release majeure |
+| **TalkFantasyFootball.org** | Forum | Anglophone, joueurs serieux | 1x release majeure |
+| **Discord BB francophones** | Discord | Francophone, joueurs actifs | Mensuel + releases |
+| **Mordorbihan / blogs Blood Bowl FR** | Blog | Francophone, lecture longue | 1x trimestre (proposer un article invite) |
+
+## Templates versionnes
+
+Les templates de message sont versionnes dans le code, **pas dans ce
+fichier** :
+
+```
+apps/web/app/lib/outreach-templates.ts
+```
+
+Cela garantit :
+
+- coherence du ton entre canaux
+- absence de derive (chaque modification passe par PR review)
+- interpolation centralisee de `{siteUrl}` et `{discordInvite}`
+  (eviter les hardcodes errones)
+
+Pour rendre un template :
+
+```ts
+import { renderOutreachTemplate } from "@/lib/outreach-templates";
+
+const message = renderOutreachTemplate("reddit_bloodbowl", {
+  siteUrl: "https://nufflearena.fr",
+});
+console.log(message.title);
+console.log(message.body);
+console.log(message.callToAction);
+```
+
+## Procedure d outreach
+
+### Pre-requis
+
+- Compte actif sur le canal cible (verifier la regle anti-self-promo
+  de chaque sub / forum avant de poster).
+- Avoir contribue ou interagi prealablement sur le canal (anti-spam).
+- Une release recente / nouveaute concrete a annoncer.
+
+### Sequence
+
+1. Lire les templates dans `outreach-templates.ts` et choisir le
+   canal cible.
+2. Adapter eventuellement le titre / corps a la culture du canal
+   (ex: ajouter une question ouverte sur Reddit).
+3. Poster ; epingler le lien `{siteUrl}` en CTA.
+4. Suivre la conversation pendant 48h, repondre aux questions.
+5. Logger le post dans une issue mensuelle
+   `[Outreach] YYYY-MM` :
+   - canal, date, lien post
+   - feedback (upvotes, comments, sentiment)
+   - signal de conversion (clics, inscriptions) si trackable
+
+## Anti-patterns a eviter
+
+- **Cross-posting strict identique** sur tous les canaux le meme jour
+  (Reddit + forums anti-spam).
+- **Auto-promo sans contexte** : toujours apporter une valeur
+  (changelog, retour communautaire, AMA, screenshot).
+- **Demander du karma / des votes** explicitement (banni partout).
+- **Liens raccourcis** (bit.ly, tinyurl) -> rejet auto.
+- **Commenter ses propres posts comme un autre** -> ban definitif.
+
+## Iteration sur les templates
+
+- Ajouter un canal : ajouter `OUTREACH_CHANNELS` + entry dans
+  `OUTREACH_TEMPLATES`. Garder l id stable (slug).
+- Reviser un template : modifier en place, garder les placeholders
+  `{siteUrl}` / `{discordInvite}` pour que `renderOutreachTemplate`
+  reste fonctionnel.
+
+## Cadence
+
+- **Mensuel** : 1 message Discord + 1 message blog FR si nouveaute.
+- **Par release majeure** : annonce sur les 4 canaux dans la meme
+  semaine, mais espacees de 24-48h.
+- **Adhoc** : reponses aux questions, AMA spontane, etc.


### PR DESCRIPTION
## Resume

Q.26 demande une strategie de **liens entrants** vers Nuffle Arena
(r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB).

La phase d'outreach reste **manuelle** (chaque message etant
contextualise par un humain), mais les **templates de message** sont
maintenant versionnes pour garantir la coherence du ton, eviter les
derives entre canaux, et permettre une **revue editoriale en PR** des
formulations utilisees.

### Templates versionnes

- `apps/web/app/lib/outreach-templates.ts` :
  - 4 templates typees, un par canal :
    - `reddit_bloodbowl` (anglais, sub-reddit)
    - `talkfantasyfootball` (anglais, forum)
    - `discord_bloodbowl` (francais, Discord communautaires)
    - `mordorbihan_blog` (francais, demande d'article invite)
  - chaque template expose `title`, `body`, `callToAction`
  - placeholders `{siteUrl}` et `{discordInvite}` interpolables
- `renderOutreachTemplate(channel, input)` :
  - **valide siteUrl https obligatoire** (anti-leak http en prod)
  - **leve sur canal inconnu** (defense)
  - retourne le template entierement interpole

### Tests TDD — 13 cas

- Structure : `title`/`body`/`callToAction` non vides
- Couverture des 4 canaux
- Presence de `{siteUrl}` dans chaque template source
- Interpolation : aucun placeholder `{x}` restant apres render
- Determinisme
- Defense canal inconnu / siteUrl invalide
- Compatibilite type smoke

### Documentation

- `docs/seo/inbound-links-strategy.md` :
  - **canaux + audience + frequence** sous forme de tableau
  - lien explicite vers le module versionne (zero duplication)
  - **procedure outreach** : pre-requis, sequence pas-a-pas, modele
    de tableau de suivi `[Outreach] YYYY-MM`
  - **anti-patterns a eviter** : cross-posting strict identique,
    auto-promo sans contexte, demande de karma, liens raccourcis
  - cadence (mensuelle + adhoc + par release majeure)

### Pourquoi versionner les templates ?

- Coherence editoriale entre canaux (meme positionnement, memes
  chiffres cites).
- Revue PR des formulations utilisees publiquement (anti-derive).
- Interpolation centralisee de l'URL canonique : impossible de poster
  une URL devalidee ou un placeholder.

## Tache roadmap

Sprint 23, tache **Q.26 — Strategie liens entrants : annonce
r/bloodbowl, TalkFantasyFootball, blog Mordorbihan, Discord BB**

## Plan de test

- [x] `pnpm --filter @bb/web test` (471/471 dont 13 nouveaux sur
      `outreach-templates.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Premier outreach a executer manuellement et a logger en issue
      `[Outreach] 2026-04`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_