### PR TITLE
feat(seo): Open Graph images dynamiques par page (Q.14)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -385,7 +385,7 @@
 | Q.11 | Metadata + JSON-LD `Person` / `SportsAthlete` dynamique sur `/star-players/[slug]` (~67 pages) | SEO | [x] |
 | Q.12 | Metadata + JSON-LD `ItemList` / `DefinedTermSet` sur `/skills` (130+ entries citables) | SEO | [x] |
 | Q.13 | `BreadcrumbList` JSON-LD sur toutes les pages profondes (teams, star-players, skills, tutoriel) | SEO | [x] |
-| Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [ ] |
+| Q.14 | Open Graph images dynamiques par page via `ImageResponse` Next.js (og:image contextualise) | SEO | [x] |
 | Q.15 | Page `/a-propos` (About) citable : histoire, chiffres, equipe, roadmap publique | GEO | [x] |
 | Q.16 | Section blog / changelog public + flux RSS (`/feed.xml`) comme signal de fraicheur LLM | GEO | [x] |
 | Q.17 | Codes de verification webmasters dans `layout.tsx` (Google Search Console, Bing, Yandex) | SEO | [x] |

--- a/apps/web/app/lib/og-image-content.test.ts
+++ b/apps/web/app/lib/og-image-content.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests pour les builders de contenu Open Graph image (Q.14 — Sprint 23).
+ *
+ * Le builder est pur : il prend les donnees fonctionnelles (roster,
+ * star player, count) et produit la structure { title, subtitle,
+ * badges[], accent } consommee par le template visuel React rendu via
+ * Next.js ImageResponse / satori.
+ *
+ * Tester le builder sans satori/wasm permet d itterer rapidement sur
+ * le contenu de l image OG sans devoir generer un PNG a chaque fois.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildTeamOgContent,
+  buildStarPlayerOgContent,
+  buildSkillsOgContent,
+  type TeamOgInput,
+  type StarPlayerOgInput,
+} from "./og-image-content";
+
+describe("buildTeamOgContent", () => {
+  const baseRoster: TeamOgInput = {
+    name: "Skaven",
+    tier: "II",
+    budget: 1150000,
+    positionCount: 6,
+    ruleset: "season_3",
+  };
+
+  it("expose title = nom du roster", () => {
+    expect(buildTeamOgContent(baseRoster).title).toBe("Skaven");
+  });
+
+  it("expose un subtitle court", () => {
+    expect(buildTeamOgContent(baseRoster).subtitle).toBeTruthy();
+  });
+
+  it("emet 4 badges : Tier, Budget, Positions, Saison", () => {
+    const badges = buildTeamOgContent(baseRoster).badges;
+    expect(badges.length).toBe(4);
+    const labels = badges.map((b) => b.toLowerCase());
+    expect(labels.some((l) => l.includes("tier"))).toBe(true);
+    expect(labels.some((l) => l.includes("budget") || l.includes("po"))).toBe(true);
+    expect(labels.some((l) => l.includes("position"))).toBe(true);
+    expect(labels.some((l) => l.includes("saison") || l.includes("season"))).toBe(true);
+  });
+
+  it("formate le budget avec separateurs (lisibilite)", () => {
+    const badges = buildTeamOgContent({ ...baseRoster, budget: 1150000 }).badges;
+    // Normalise les espaces (incluant NBSP / fines) pour le matching.
+    const flat = badges.join(" ").replace(/[\s  ]+/g, " ");
+    expect(flat.includes("1 150") || flat.includes("1,150") || flat.includes("1150")).toBe(true);
+  });
+
+  it("expose accent = bordeaux pour les teams", () => {
+    expect(buildTeamOgContent(baseRoster).accent).toBe("team");
+  });
+
+  it("est deterministe", () => {
+    expect(buildTeamOgContent(baseRoster)).toEqual(buildTeamOgContent(baseRoster));
+  });
+
+  it("clamp positionCount negatif a 0", () => {
+    const badges = buildTeamOgContent({ ...baseRoster, positionCount: -3 }).badges;
+    expect(badges.find((b) => b.toLowerCase().includes("position"))).toContain("0");
+  });
+
+  it("supporte un tier absent (fallback)", () => {
+    const out = buildTeamOgContent({ ...baseRoster, tier: undefined });
+    const flat = out.badges.join(" ");
+    expect(flat).toBeTruthy();
+  });
+});
+
+describe("buildStarPlayerOgContent", () => {
+  const baseStar: StarPlayerOgInput = {
+    displayName: "Morg 'n' Thorg",
+    cost: 430000,
+    ma: 6,
+    st: 7,
+    ag: 3,
+    pa: 4,
+    av: 11,
+    isMegaStar: true,
+  };
+
+  it("expose title = displayName", () => {
+    expect(buildStarPlayerOgContent(baseStar).title).toBe("Morg 'n' Thorg");
+  });
+
+  it("prefixe MEGA STAR dans le subtitle quand isMegaStar=true", () => {
+    expect(buildStarPlayerOgContent(baseStar).subtitle.toUpperCase()).toContain("MEGA STAR");
+  });
+
+  it("ne prefixe PAS MEGA STAR quand isMegaStar absent / false", () => {
+    const out = buildStarPlayerOgContent({ ...baseStar, isMegaStar: false });
+    expect(out.subtitle.toUpperCase().includes("MEGA STAR")).toBe(false);
+  });
+
+  it("emet des badges pour MA, ST, AG+, AV+, Cost", () => {
+    const badges = buildStarPlayerOgContent(baseStar).badges;
+    const flat = badges.join(" ");
+    expect(flat).toContain("MA");
+    expect(flat).toContain("ST");
+    expect(flat).toContain("AG");
+    expect(flat).toContain("AV");
+    expect(flat).toMatch(/Cost|po|gp/i);
+  });
+
+  it("inclut PA quand pa != null", () => {
+    const flat = buildStarPlayerOgContent(baseStar).badges.join(" ");
+    expect(flat).toContain("PA");
+  });
+
+  it("omet PA quand pa = null", () => {
+    const flat = buildStarPlayerOgContent({ ...baseStar, pa: null }).badges.join(" ");
+    expect(flat.includes("PA")).toBe(false);
+  });
+
+  it("expose accent = star pour les star players", () => {
+    expect(buildStarPlayerOgContent(baseStar).accent).toBe("star");
+  });
+
+  it("est deterministe", () => {
+    expect(buildStarPlayerOgContent(baseStar)).toEqual(
+      buildStarPlayerOgContent(baseStar),
+    );
+  });
+});
+
+describe("buildSkillsOgContent", () => {
+  it("expose title qui mentionne 'Competences' (FR)", () => {
+    // Comparaison insensible aux accents (compétences vs competences).
+    const normalized = buildSkillsOgContent({ skillCount: 130 })
+      .title.toLowerCase()
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "");
+    expect(normalized).toContain("competences");
+  });
+
+  it("expose un badge contenant le count", () => {
+    const flat = buildSkillsOgContent({ skillCount: 132 }).badges.join(" ");
+    expect(flat).toContain("132");
+  });
+
+  it("clamp skillCount negatif a 0", () => {
+    const flat = buildSkillsOgContent({ skillCount: -5 }).badges.join(" ");
+    expect(flat).toContain("0");
+  });
+
+  it("expose accent = skill", () => {
+    expect(buildSkillsOgContent({ skillCount: 130 }).accent).toBe("skill");
+  });
+
+  it("emet plusieurs badges pour donner du contexte (count + categories)", () => {
+    expect(buildSkillsOgContent({ skillCount: 130 }).badges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("est deterministe", () => {
+    expect(buildSkillsOgContent({ skillCount: 130 })).toEqual(
+      buildSkillsOgContent({ skillCount: 130 }),
+    );
+  });
+});

--- a/apps/web/app/lib/og-image-content.ts
+++ b/apps/web/app/lib/og-image-content.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure builders for Open Graph image content (Q.14 — Sprint 23).
+ *
+ * Avant Q.14 : toutes les pages exposaient `og:image = logo.png`
+ * (image statique). Avec Q.14 : chaque page profonde (teams, star
+ * players, skills) genere son propre OG contextualise via
+ * Next.js `ImageResponse` (satori).
+ *
+ * Architecture en 2 niveaux :
+ *   1. ce fichier : builders purs sans dependance React/satori,
+ *      100 % testables (validation du contenu / des badges sans
+ *      generer de PNG)
+ *   2. og-image-template.tsx : template visuel React rendu par
+ *      ImageResponse (uniquement flexbox, pas de grid : satori ne
+ *      supporte pas grid)
+ */
+
+export type OgAccent = "team" | "star" | "skill";
+
+export interface OgContent {
+  /** Titre principal affiche en grand. */
+  title: string;
+  /** Sous-titre / accroche secondaire. */
+  subtitle: string;
+  /** Pillules / badges de contexte (chiffres cles). */
+  badges: string[];
+  /** Identifiant de palette accent ("team" / "star" / "skill"). */
+  accent: OgAccent;
+}
+
+export interface TeamOgInput {
+  name: string;
+  tier?: string;
+  budget: number;
+  positionCount: number;
+  ruleset: "season_2" | "season_3" | string;
+}
+
+export interface StarPlayerOgInput {
+  displayName: string;
+  cost: number;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  isMegaStar?: boolean;
+}
+
+export interface SkillsOgInput {
+  skillCount: number;
+}
+
+const NBSP = " ";
+
+function clampNonNegative(value: number): number {
+  return value < 0 ? 0 : Math.floor(value);
+}
+
+function formatBudget(value: number): string {
+  // 1150000 -> "1 150 000" (format FR avec espaces fines)
+  const v = clampNonNegative(value);
+  return v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, NBSP);
+}
+
+function formatRuleset(ruleset: string): string {
+  if (ruleset === "season_3") return "Saison 3";
+  if (ruleset === "season_2") return "Saison 2";
+  return ruleset;
+}
+
+export function buildTeamOgContent(input: TeamOgInput): OgContent {
+  const positions = clampNonNegative(input.positionCount);
+  const tierLabel = input.tier ? `Tier ${input.tier}` : "Tier inconnu";
+  return {
+    title: input.name,
+    subtitle: "Roster Blood Bowl",
+    badges: [
+      tierLabel,
+      `Budget ${formatBudget(input.budget)}${NBSP}po`,
+      `${positions}${NBSP}positions`,
+      formatRuleset(input.ruleset),
+    ],
+    accent: "team",
+  };
+}
+
+export function buildStarPlayerOgContent(input: StarPlayerOgInput): OgContent {
+  const badges: string[] = [
+    `MA ${input.ma}`,
+    `ST ${input.st}`,
+    `AG ${input.ag}+`,
+  ];
+  if (input.pa !== null && input.pa !== undefined) {
+    badges.push(`PA ${input.pa}+`);
+  }
+  badges.push(`AV ${input.av}+`);
+  badges.push(`Cost ${formatBudget(input.cost)}${NBSP}po`);
+
+  const subtitle = input.isMegaStar
+    ? "MEGA STAR — Star Player Blood Bowl"
+    : "Star Player Blood Bowl";
+
+  return {
+    title: input.displayName,
+    subtitle,
+    badges,
+    accent: "star",
+  };
+}
+
+export function buildSkillsOgContent(input: SkillsOgInput): OgContent {
+  const count = clampNonNegative(input.skillCount);
+  return {
+    title: "Compétences Blood Bowl",
+    subtitle: "Catalogue complet FR / EN",
+    badges: [
+      `${count} compétences`,
+      "Général · Agilité · Force",
+      "Passe · Mutations · Traits",
+    ],
+    accent: "skill",
+  };
+}

--- a/apps/web/app/lib/og-image-template.tsx
+++ b/apps/web/app/lib/og-image-template.tsx
@@ -1,0 +1,160 @@
+/**
+ * Template visuel React pour ImageResponse / satori (Q.14 — Sprint 23).
+ *
+ * IMPORTANT : satori ne supporte que **flexbox** (pas de grid).
+ * Toutes les positions sont gerees via display: flex et les
+ * dimensions absolutes (px / fractions de 1200x630).
+ *
+ * Le template est purement presentation : il consomme la structure
+ * { title, subtitle, badges[], accent } produite par
+ * `og-image-content.ts` et la mappe sur des elements styles inline.
+ */
+import type { OgContent, OgAccent } from "./og-image-content";
+
+interface AccentTheme {
+  background: string;
+  accent: string;
+  text: string;
+  badgeBg: string;
+  badgeText: string;
+}
+
+const THEMES: Record<OgAccent, AccentTheme> = {
+  team: {
+    background: "linear-gradient(135deg, #1f1212 0%, #4a1f1f 60%, #6b1414 100%)",
+    accent: "#fbbf24",
+    text: "#f5f5f5",
+    badgeBg: "rgba(251, 191, 36, 0.18)",
+    badgeText: "#fde68a",
+  },
+  star: {
+    background: "linear-gradient(135deg, #1f1a0a 0%, #4a3a1a 60%, #b8860b 100%)",
+    accent: "#fde047",
+    text: "#fff8e7",
+    badgeBg: "rgba(253, 224, 71, 0.18)",
+    badgeText: "#fff8c4",
+  },
+  skill: {
+    background: "linear-gradient(135deg, #0a1228 0%, #1e3a8a 60%, #2563eb 100%)",
+    accent: "#93c5fd",
+    text: "#eff6ff",
+    badgeBg: "rgba(147, 197, 253, 0.18)",
+    badgeText: "#dbeafe",
+  },
+};
+
+interface OgImageTemplateProps {
+  content: OgContent;
+  /** URL canonique a afficher en footer (ex: nufflearena.fr/teams/skaven). */
+  canonicalUrl: string;
+}
+
+export function OgImageTemplate({ content, canonicalUrl }: OgImageTemplateProps) {
+  const theme = THEMES[content.accent];
+
+  return (
+    <div
+      style={{
+        width: "1200px",
+        height: "630px",
+        display: "flex",
+        flexDirection: "column",
+        background: theme.background,
+        color: theme.text,
+        padding: "60px 80px",
+        fontFamily: "Verdana, Geneva, sans-serif",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          fontSize: "28px",
+          color: theme.accent,
+          letterSpacing: "4px",
+          fontWeight: 700,
+        }}
+      >
+        NUFFLE ARENA
+      </div>
+
+      {/* Title block (centered vertically via flex-grow) */}
+      <div
+        style={{
+          flexGrow: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "92px",
+            fontWeight: 800,
+            lineHeight: 1.05,
+            color: theme.text,
+            marginBottom: "24px",
+            // satori ne wrap pas automatiquement les longs titres ; on
+            // augmente la zone via maxWidth pour eviter la troncature.
+            maxWidth: "1040px",
+            display: "flex",
+          }}
+        >
+          {content.title}
+        </div>
+        <div
+          style={{
+            fontSize: "32px",
+            color: theme.accent,
+            fontWeight: 600,
+            display: "flex",
+          }}
+        >
+          {content.subtitle}
+        </div>
+      </div>
+
+      {/* Badges row */}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "16px",
+          marginBottom: "32px",
+        }}
+      >
+        {content.badges.map((badge) => (
+          <div
+            key={badge}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "12px 22px",
+              borderRadius: "999px",
+              background: theme.badgeBg,
+              color: theme.badgeText,
+              fontSize: "26px",
+              fontWeight: 600,
+            }}
+          >
+            {badge}
+          </div>
+        ))}
+      </div>
+
+      {/* Footer URL */}
+      <div
+        style={{
+          display: "flex",
+          fontSize: "24px",
+          color: theme.accent,
+          opacity: 0.9,
+          letterSpacing: "1px",
+        }}
+      >
+        {canonicalUrl}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/skills/opengraph-image.tsx
+++ b/apps/web/app/skills/opengraph-image.tsx
@@ -1,0 +1,28 @@
+/**
+ * Open Graph image dynamique pour /skills (Q.14 — Sprint 23).
+ */
+import { ImageResponse } from "next/og";
+import { SKILLS_DEFINITIONS } from "@bb/game-engine";
+import { buildSkillsOgContent } from "../lib/og-image-content";
+import { OgImageTemplate } from "../lib/og-image-template";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  const content = buildSkillsOgContent({ skillCount: SKILLS_DEFINITIONS.length });
+
+  return new ImageResponse(
+    (
+      <OgImageTemplate
+        content={content}
+        canonicalUrl={`${SITE_URL.replace(/\/$/, "")}/skills`}
+      />
+    ),
+    size,
+  );
+}

--- a/apps/web/app/star-players/[slug]/opengraph-image.tsx
+++ b/apps/web/app/star-players/[slug]/opengraph-image.tsx
@@ -1,0 +1,63 @@
+/**
+ * Open Graph image dynamique pour /star-players/[slug] (Q.14 — Sprint 23).
+ */
+import { ImageResponse } from "next/og";
+import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
+import { buildStarPlayerOgContent } from "../../lib/og-image-content";
+import { OgImageTemplate } from "../../lib/og-image-template";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface StarPayload {
+  displayName?: string;
+  cost?: number;
+  ma?: number;
+  st?: number;
+  ag?: number;
+  pa?: number | null;
+  av?: number;
+  isMegaStar?: boolean;
+}
+
+async function fetchStar(slug: string): Promise<StarPayload | null> {
+  try {
+    const base = getServerApiBase();
+    const data = await fetchServerJson<{ data?: StarPayload; success?: boolean }>(
+      `${base}/star-players/${encodeURIComponent(slug)}`,
+      { next: { revalidate: 3600 } },
+    );
+    if (data?.success && data?.data) return data.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function Image({ params }: { params: { slug: string } }) {
+  const star = await fetchStar(params.slug);
+  const content = buildStarPlayerOgContent({
+    displayName: star?.displayName ?? "Star Player Blood Bowl",
+    cost: star?.cost ?? 0,
+    ma: star?.ma ?? 6,
+    st: star?.st ?? 3,
+    ag: star?.ag ?? 3,
+    pa: star?.pa ?? null,
+    av: star?.av ?? 9,
+    isMegaStar: star?.isMegaStar,
+  });
+
+  return new ImageResponse(
+    (
+      <OgImageTemplate
+        content={content}
+        canonicalUrl={`${SITE_URL.replace(/\/$/, "")}/star-players/${params.slug}`}
+      />
+    ),
+    size,
+  );
+}

--- a/apps/web/app/teams/[slug]/opengraph-image.tsx
+++ b/apps/web/app/teams/[slug]/opengraph-image.tsx
@@ -1,0 +1,61 @@
+/**
+ * Open Graph image dynamique pour /teams/[slug] (Q.14 — Sprint 23).
+ *
+ * Auto-detecte par Next.js : le seul fait de poser un fichier
+ * `opengraph-image.tsx` dans le dossier de la route override
+ * `openGraph.images` du `generateMetadata` de la route avec le PNG
+ * genere ici.
+ */
+import { ImageResponse } from "next/og";
+import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
+import { buildTeamOgContent } from "../../lib/og-image-content";
+import { OgImageTemplate } from "../../lib/og-image-template";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface RosterPayload {
+  name?: string;
+  tier?: string;
+  budget?: number;
+  _count?: { positions?: number };
+  ruleset?: string;
+}
+
+async function fetchRoster(slug: string): Promise<RosterPayload | null> {
+  try {
+    const base = getServerApiBase();
+    const data = await fetchServerJson<{ roster?: RosterPayload }>(
+      `${base}/api/rosters/${encodeURIComponent(slug)}?lang=fr&ruleset=season_3`,
+      { next: { revalidate: 3600 } },
+    );
+    return data?.roster ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function Image({ params }: { params: { slug: string } }) {
+  const roster = await fetchRoster(params.slug);
+  const content = buildTeamOgContent({
+    name: roster?.name ?? "Roster Blood Bowl",
+    tier: roster?.tier,
+    budget: roster?.budget ?? 1000000,
+    positionCount: roster?._count?.positions ?? 0,
+    ruleset: roster?.ruleset ?? "season_3",
+  });
+
+  return new ImageResponse(
+    (
+      <OgImageTemplate
+        content={content}
+        canonicalUrl={`${SITE_URL.replace(/\/$/, "")}/teams/${params.slug}`}
+      />
+    ),
+    size,
+  );
+}


### PR DESCRIPTION
## Resume

Avant Q.14 : toutes les pages exposaient `og:image = logo.png` (image
statique). Avec Q.14 : **chaque page profonde** (teams, star players,
skills) genere son propre **OG contextualise** via Next.js
`ImageResponse` (satori).

> Note : la PR #376 (sur la branche `claude/admiring-fermi-xLllX`) a
> tente Q.14 il y a 4h mais sa CI est en `failure`, le `mergeable_state`
> est `unknown` et la branche est severement diverged de main. Pour
> debloquer la roadmap (Q.14 etait la derniere tache du Sprint 23),
> cette PR re-implemente Q.14 sur ma branche en partant de main a jour.

### Architecture en 2 niveaux

#### 1. Builders purs — `apps/web/app/lib/og-image-content.ts`

- `buildTeamOgContent(roster)` -> `{ title=name, subtitle, badges[], accent='team' }`
  badges = `[Tier X, Budget formate FR (NBSP), N positions, Saison 2/3]`
- `buildStarPlayerOgContent(star)` -> `{ title=displayName, subtitle (prefixe MEGA STAR si isMegaStar), badges[], accent='star' }`
  badges = `[MA, ST, AG+, PA+ si pa!=null, AV+, Cost]`
- `buildSkillsOgContent({ skillCount })` -> `{ title='Compétences Blood Bowl', subtitle, badges[], accent='skill' }`

**22 tests TDD** couvrant : structure, badges attendus, format budget
FR avec NBSP, omission PA si null, MEGA STAR conditionnel, accent par
type, clamp negatif, determinisme.

#### 2. Template visuel — `apps/web/app/lib/og-image-template.tsx`

- React component pour `ImageResponse` / satori
- **flexbox uniquement** (satori ne supporte pas `grid`)
- **3 themes accents** :
  - `team` : bordeaux + or (Reikland)
  - `star` : noir + or (luxe)
  - `skill` : bleu nuit + bleu clair (sobre)
- header `NUFFLE ARENA` + title + subtitle + badges en pillules + footer URL canonique

#### 3. Routes `opengraph-image.tsx` (auto-detectees par Next.js)

- `apps/web/app/teams/[slug]/opengraph-image.tsx` : fetch roster
  server-side via `fetchServerJson`, fallback "Roster Blood Bowl"
- `apps/web/app/star-players/[slug]/opengraph-image.tsx` : fetch star
  player, fallback "Star Player Blood Bowl"
- `apps/web/app/skills/opengraph-image.tsx` : utilise
  `SKILLS_DEFINITIONS.length` du moteur (zero fetch)

Toutes en `runtime: 'nodejs'`, `size: 1200x630`, `contentType: 'image/png'`,
`revalidate: 3600`. Next.js auto-detecte ces fichiers et **override
`openGraph.images`** du `generateMetadata` de chaque route — pas
besoin de modifier les `layout.tsx` existants.

### Resilience

Chaque route a un **fallback complet** (titre + valeurs par defaut).
Un crash API ne casse jamais l'OG : on rendra une image generique
plutot qu'un 500.

### Pourquoi separer builders / template ?

- Les builders sont des fonctions pures, **testables sans satori/wasm**
  (22 tests TDD).
- Le template est un composant React tres petit qui ne fait que mapper
  la structure aux elements styles.
- Changement de design -> on touche le template ; evolution de
  donnees -> on touche le builder.

## Tache roadmap

Sprint 23, tache **Q.14 — Open Graph images dynamiques par page via
`ImageResponse` Next.js**

## Plan de test

- [x] `pnpm --filter @bb/web test` (505/505 dont 22 nouveaux sur
      `og-image-content.test.ts`)
- [x] typecheck OK pour les fichiers ajoutes (3 erreurs preexistantes
      hors scope dans `app/admin/feature-flags/*`)
- [ ] Verification manuelle : visiter `/teams/skaven/opengraph-image`,
      `/star-players/morg_n_thorg/opengraph-image`, `/skills/opengraph-image`
      et controler le rendu PNG
- [ ] Validation OG via Twitter Card Validator / Facebook Debugger
      apres deploiement

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAYS5xMYLW8YvagVjJPaVd)_