### PR TITLE
feat(server): Helmet + HSTS + CSP + X-Frame-Options DENY (S24.2)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^17.2.2",
     "express": "^4.19.2",
     "express-rate-limit": "^8.3.1",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "socket.io": "^4.8.3",
     "web-push": "^3.6.7",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -35,6 +35,7 @@ import { prisma } from "./prisma";
 import { authRateLimiter, apiRateLimiter } from "./middleware/rateLimiter";
 import { publicCache } from "./middleware/publicCache";
 import { requestTiming } from "./middleware/requestTiming";
+import { securityHeaders } from "./middleware/securityHeaders";
 import { setupSocket } from "./socket";
 import { CORS_ORIGINS } from "./config";
 import { invalidateAllMemo } from "./utils/memoize-async";
@@ -65,6 +66,11 @@ const API_PORT = parseInt(process.env.API_PORT || "8201", 10);
 const app = express();
 // Trust le premier proxy (Traefik) pour obtenir la vraie IP client via X-Forwarded-For
 app.set("trust proxy", 1);
+// Security envelope (HSTS, X-Frame-Options, CSP, X-Content-Type-Options,
+// Referrer-Policy). Must run before route handlers so the headers ship on
+// every response, including 4xx/5xx. CSP defaults to Report-Only — set
+// SECURITY_CSP_MODE=enforce once the report endpoint is wired.
+app.use(securityHeaders());
 app.use(cors({ origin: CORS_ORIGINS }));
 // gzip/deflate/br responses over ~1KB. Team payloads with 11-16 players
 // plus star players commonly exceed 50KB uncompressed.

--- a/apps/server/src/middleware/securityHeaders.test.ts
+++ b/apps/server/src/middleware/securityHeaders.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { securityHeaders } from "./securityHeaders";
+
+/**
+ * Helmet wraps several middlewares in a chain and calls next() for each
+ * before invoking the user's next(). We collect the headers it sets via a
+ * mock res.setHeader and assert the security envelope is present.
+ */
+function runMiddleware(): Promise<Record<string, string>> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader(name: string, value: string | number | readonly string[]) {
+        headers[name.toLowerCase()] = String(value);
+      },
+      removeHeader(name: string) {
+        delete headers[name.toLowerCase()];
+      },
+      getHeader(name: string) {
+        return headers[name.toLowerCase()];
+      },
+    } as unknown as Response;
+
+    const req = { method: "GET", headers: {} } as unknown as Request;
+
+    const mw = securityHeaders();
+    const finalNext: NextFunction = (err?: unknown) => {
+      if (err) reject(err);
+      else resolve(headers);
+    };
+    mw(req, res, finalNext);
+  });
+}
+
+describe("Rule: securityHeaders middleware", () => {
+  it("sets Strict-Transport-Security with max-age >= 1 year", async () => {
+    const headers = await runMiddleware();
+    const hsts = headers["strict-transport-security"];
+    expect(hsts).toBeDefined();
+    const match = /max-age=(\d+)/.exec(hsts!);
+    expect(match).not.toBeNull();
+    const maxAge = Number(match![1]);
+    expect(maxAge).toBeGreaterThanOrEqual(31536000);
+    expect(hsts).toContain("includeSubDomains");
+  });
+
+  it("sets X-Frame-Options to DENY", async () => {
+    const headers = await runMiddleware();
+    expect(headers["x-frame-options"]).toBe("DENY");
+  });
+
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    const headers = await runMiddleware();
+    expect(headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("sets Referrer-Policy to strict-origin-when-cross-origin", async () => {
+    const headers = await runMiddleware();
+    expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("sets a Content-Security-Policy header", async () => {
+    const headers = await runMiddleware();
+    const csp =
+      headers["content-security-policy"] ||
+      headers["content-security-policy-report-only"];
+    expect(csp).toBeDefined();
+    expect(csp).toMatch(/default-src/);
+  });
+
+  it("CSP allows Pixi.js bundle (script-src 'self' with allowed inline) and Umami analytics", async () => {
+    const headers = await runMiddleware();
+    const csp =
+      headers["content-security-policy"] ||
+      headers["content-security-policy-report-only"];
+    expect(csp).toBeDefined();
+    expect(csp).toContain("script-src");
+    // Umami runs from analytics.umami.is by default; the project uses a self
+    // hosted instance configured via env. The CSP must at minimum allow self
+    // so the loader script ships, then connect-src for the beacon.
+    expect(csp).toContain("'self'");
+  });
+
+  it("calls next() exactly once for a normal request", async () => {
+    const headers: Record<string, string> = {};
+    const res = {
+      setHeader(name: string, value: unknown) {
+        headers[name.toLowerCase()] = String(value);
+      },
+      removeHeader() {},
+      getHeader() {
+        return undefined;
+      },
+    } as unknown as Response;
+    const req = { method: "GET", headers: {} } as unknown as Request;
+    const next = vi.fn();
+    securityHeaders()(req, res, next);
+    // helmet chains internally and finally calls our next() once.
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("hides the X-Powered-By Express fingerprint", async () => {
+    const headers: Record<string, string> = { "x-powered-by": "Express" };
+    const res = {
+      setHeader(name: string, value: unknown) {
+        headers[name.toLowerCase()] = String(value);
+      },
+      removeHeader(name: string) {
+        delete headers[name.toLowerCase()];
+      },
+      getHeader(name: string) {
+        return headers[name.toLowerCase()];
+      },
+    } as unknown as Response;
+    const req = { method: "GET", headers: {} } as unknown as Request;
+    securityHeaders()(req, res, () => {});
+    expect(headers["x-powered-by"]).toBeUndefined();
+  });
+});

--- a/apps/server/src/middleware/securityHeaders.ts
+++ b/apps/server/src/middleware/securityHeaders.ts
@@ -1,0 +1,71 @@
+import helmet from "helmet";
+import type { RequestHandler } from "express";
+
+/**
+ * Security headers envelope for the API. Sets HSTS (1 year, includeSubDomains,
+ * preload), X-Frame-Options DENY, X-Content-Type-Options nosniff, a strict
+ * Referrer-Policy and a baseline CSP that ships in Report-Only mode by default
+ * so it can be observed in production before being enforced.
+ *
+ * CSP is configurable via SECURITY_CSP_MODE:
+ *   - "report-only" (default): Content-Security-Policy-Report-Only header
+ *   - "enforce": Content-Security-Policy header
+ *   - "off": no CSP header (escape hatch for emergencies)
+ *
+ * The directive set is intentionally permissive at first (allows 'unsafe-inline'
+ * for styles to keep Tailwind happy and 'self' for scripts) so we can roll out
+ * the rest of the envelope without breaking Pixi.js bundles, Umami analytics
+ * or inline styles. Tightening to nonces/hashes is a follow-up task.
+ */
+const ONE_YEAR_SECONDS = 31_536_000;
+
+type CspMode = "report-only" | "enforce" | "off";
+
+function resolveCspMode(): CspMode {
+  const raw = (process.env.SECURITY_CSP_MODE || "report-only").toLowerCase();
+  if (raw === "enforce" || raw === "off") return raw;
+  return "report-only";
+}
+
+export function securityHeaders(): RequestHandler {
+  const cspMode = resolveCspMode();
+
+  const cspDirectives = {
+    "default-src": ["'self'"],
+    "base-uri": ["'self'"],
+    "object-src": ["'none'"],
+    "frame-ancestors": ["'none'"],
+    "img-src": ["'self'", "data:", "blob:", "https:"],
+    "font-src": ["'self'", "data:", "https:"],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+    "connect-src": ["'self'", "https:", "wss:"],
+    "worker-src": ["'self'", "blob:"],
+    "form-action": ["'self'"],
+  };
+
+  const cspOption =
+    cspMode === "off"
+      ? false
+      : {
+          useDefaults: false,
+          directives: cspDirectives,
+          reportOnly: cspMode === "report-only",
+        };
+
+  return helmet({
+    contentSecurityPolicy: cspOption,
+    crossOriginEmbedderPolicy: false,
+    crossOriginOpenerPolicy: { policy: "same-origin" },
+    crossOriginResourcePolicy: { policy: "cross-origin" },
+    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+    strictTransportSecurity: {
+      maxAge: ONE_YEAR_SECONDS,
+      includeSubDomains: true,
+      preload: true,
+    },
+    frameguard: { action: "deny" },
+    noSniff: true,
+    hidePoweredBy: true,
+  });
+}

--- a/docs/roadmap/sprints/S24-stabilite-securite.md
+++ b/docs/roadmap/sprints/S24-stabilite-securite.md
@@ -10,7 +10,7 @@
 | # | Tache | Cat | Effort | Statut | Detail |
 |---|-------|-----|--------|--------|--------|
 | S24.1 | Cookie `auth_token` httpOnly=true + sameSite=strict + secure=true | FIX | S | [x] | `apps/web/app/api/sync-auth-cookie/route.ts:22`. Bloque le vol via XSS. Actuellement httpOnly=false "pour synchro JS" mais le token est deja en localStorage donc surface deja redondante. |
-| S24.2 | Helmet + CSP + HSTS + X-Frame-Options DENY | FIX | M | [ ] | `apps/server/src/index.ts:65-100`. Aucun en-tete securite actuellement. Au minimum X-Frame, X-Content-Type-Options nosniff, HSTS 1 an, CSP img-src + script-src self. |
+| S24.2 | Helmet + CSP + HSTS + X-Frame-Options DENY | FIX | M | [x] | `apps/server/src/index.ts:65-100`. Aucun en-tete securite actuellement. Au minimum X-Frame, X-Content-Type-Options nosniff, HSTS 1 an, CSP img-src + script-src self. |
 | S24.3 | JWT refresh token (15 min access + 7j refresh, rotation + blacklist) | FIX | M | [ ] | `apps/server/src/routes/auth.ts:90-100`. Token actuel 7j sans rotation = 7j de fenetre si compromission. Pattern refresh + access. |
 | S24.4 | WebSocket cleanup listeners + room leak | FIX | S | [ ] | `apps/web/app/play/[id]/hooks/useGameSocket.ts:365-370`. Listeners non desabonnes apres disconnect : fuite memoire progressive sur sessions longues. |
 | S24.5 | Polling fallback 3s -> 10s + backoff exponentiel | FIX | M | [ ] | `apps/web/app/play/[id]/hooks/useGameState.ts:301`. Quand WS degrade, X clients = X requetes/3s. Trop agressif a la scale beta. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       express-rate-limit:
         specifier: ^8.3.1
         version: 8.3.1(express@4.21.2)
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -1587,7 +1590,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -4529,6 +4532,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   hermes-estree@0.19.1:
     resolution: {integrity: sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==}
@@ -13135,6 +13142,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.1.0: {}
 
   hermes-estree@0.19.1: {}
 


### PR DESCRIPTION
## Resume

- Ajoute le middleware `securityHeaders()` (helmet) sur l'API Express.
- HSTS 1 an + includeSubDomains + preload, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin, suppression de X-Powered-By.
- CSP par defaut en mode **Report-Only** pour observer sans casser Pixi.js / Umami / Tailwind. Bascule via `SECURITY_CSP_MODE=enforce` (ou `off` pour escape hatch).

## Tache roadmap

Sprint S24, tache S24.2 — Helmet + CSP + HSTS + X-Frame-Options DENY.
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`.

## Plan de test

non termine
- [x] Tests unitaires : 8 cas couvrent chaque header (`apps/server/src/middleware/securityHeaders.test.ts`).
- [x] `pnpm --filter @bb/server test` : 701/701 verts.
- [x] `pnpm typecheck` global : 4/4 packages OK.
- [ ] `curl -I` sur prod : verifier presence HSTS, X-Frame-Options, X-Content-Type-Options, CSP-Report-Only apres deploy.
- [ ] Surveiller logs CSP en mode Report-Only sur 24-48h, puis basculer `SECURITY_CSP_MODE=enforce`.
- [ ] Suivi : tightening CSP avec nonces (followup, pas dans S24).

## Risques

CSP ship en Report-Only pour eviter de casser Pixi.js, Umami ou les inline styles Tailwind. Les directives initiales tolerent `'unsafe-inline'` et `'unsafe-eval'` afin de garantir que la mise en prod ne degrade aucun flux. La phase d'enforcement et le passage aux nonces sont laisses en follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uRoHLxYL25j6S2jfZGRkF)_