### PR TITLE
feat(auth): JWT access/refresh helpers (S24.3a, slice 1/4)

### DIFF
--- a/apps/server/src/services/auth-tokens.test.ts
+++ b/apps/server/src/services/auth-tokens.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import jwt from "jsonwebtoken";
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyRefreshToken,
+  ACCESS_TOKEN_TTL_SECONDS,
+  REFRESH_TOKEN_TTL_SECONDS,
+} from "./auth-tokens";
+import { JWT_SECRET } from "../config";
+
+describe("Rule: auth-tokens helpers (S24.3a)", () => {
+  describe("TTL constants", () => {
+    it("access token TTL is 15 minutes", () => {
+      expect(ACCESS_TOKEN_TTL_SECONDS).toBe(15 * 60);
+    });
+
+    it("refresh token TTL is 7 days", () => {
+      expect(REFRESH_TOKEN_TTL_SECONDS).toBe(7 * 24 * 60 * 60);
+    });
+
+    it("access TTL is shorter than refresh TTL", () => {
+      expect(ACCESS_TOKEN_TTL_SECONDS).toBeLessThan(
+        REFRESH_TOKEN_TTL_SECONDS,
+      );
+    });
+  });
+
+  describe("signAccessToken", () => {
+    it("includes sub, role, roles and typ='access' in payload", () => {
+      const token = signAccessToken({
+        sub: "user-1",
+        role: "user",
+        roles: ["user"],
+      });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.sub).toBe("user-1");
+      expect(decoded.role).toBe("user");
+      expect(decoded.roles).toEqual(["user"]);
+      expect(decoded.typ).toBe("access");
+    });
+
+    it("token expires within 15 minutes (+/- 2s tolerance)", () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = signAccessToken({
+        sub: "user-1",
+        role: "user",
+        roles: ["user"],
+      });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, number>;
+      const expectedExp = before + ACCESS_TOKEN_TTL_SECONDS;
+      expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 2);
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 2);
+    });
+
+    it("supports admin role with multiple roles", () => {
+      const token = signAccessToken({
+        sub: "admin-1",
+        role: "admin",
+        roles: ["user", "admin"],
+      });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.roles).toEqual(["user", "admin"]);
+    });
+  });
+
+  describe("signRefreshToken", () => {
+    it("includes sub and typ='refresh' but no role/roles", () => {
+      const token = signRefreshToken({ sub: "user-1" });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.sub).toBe("user-1");
+      expect(decoded.typ).toBe("refresh");
+      expect(decoded.role).toBeUndefined();
+      expect(decoded.roles).toBeUndefined();
+    });
+
+    it("token expires in 7 days (+/- 2s tolerance)", () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = signRefreshToken({ sub: "user-1" });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, number>;
+      const expectedExp = before + REFRESH_TOKEN_TTL_SECONDS;
+      expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 2);
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 2);
+    });
+  });
+
+  describe("verifyRefreshToken", () => {
+    it("returns payload for a valid refresh token", () => {
+      const token = signRefreshToken({ sub: "user-1" });
+      const payload = verifyRefreshToken(token);
+      expect(payload).toEqual(
+        expect.objectContaining({ sub: "user-1", typ: "refresh" }),
+      );
+    });
+
+    it("rejects an access token by typ check", () => {
+      const accessToken = signAccessToken({
+        sub: "user-1",
+        role: "user",
+        roles: ["user"],
+      });
+      expect(() => verifyRefreshToken(accessToken)).toThrow(
+        /not a refresh token/i,
+      );
+    });
+
+    it("rejects a token signed with a different secret", () => {
+      const fakeToken = jwt.sign(
+        { sub: "user-1", typ: "refresh" },
+        "wrong-secret",
+        { expiresIn: "7d" },
+      );
+      expect(() => verifyRefreshToken(fakeToken)).toThrow();
+    });
+
+    it("rejects an expired refresh token", () => {
+      const expired = jwt.sign(
+        { sub: "user-1", typ: "refresh" },
+        JWT_SECRET,
+        { expiresIn: "-1s" },
+      );
+      expect(() => verifyRefreshToken(expired)).toThrow(
+        /jwt expired|TokenExpiredError/i,
+      );
+    });
+
+    it("rejects a token without typ claim", () => {
+      const token = jwt.sign({ sub: "user-1" }, JWT_SECRET, {
+        expiresIn: "7d",
+      });
+      expect(() => verifyRefreshToken(token)).toThrow(/not a refresh token/i);
+    });
+
+    it("rejects malformed tokens", () => {
+      expect(() => verifyRefreshToken("not-a-jwt")).toThrow();
+    });
+  });
+});

--- a/apps/server/src/services/auth-tokens.ts
+++ b/apps/server/src/services/auth-tokens.ts
@@ -1,0 +1,68 @@
+import jwt, { type SignOptions } from "jsonwebtoken";
+import { JWT_SECRET } from "../config";
+
+/**
+ * Token TTLs (S24.3). Splitting the previous 7-day session token into a
+ * short-lived access token and a long-lived refresh token reduces the window
+ * during which a stolen access token is usable. The refresh path (rotation +
+ * blacklist + endpoint) is implemented in follow-up slices.
+ */
+export const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+export const REFRESH_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+interface AccessTokenClaims {
+  sub: string;
+  role: string;
+  roles: string[];
+}
+
+interface RefreshTokenClaims {
+  sub: string;
+}
+
+export interface AccessTokenPayload extends AccessTokenClaims {
+  typ: "access";
+  iat: number;
+  exp: number;
+}
+
+export interface RefreshTokenPayload extends RefreshTokenClaims {
+  typ: "refresh";
+  iat: number;
+  exp: number;
+}
+
+const COMMON_OPTIONS: SignOptions = {
+  algorithm: "HS256",
+};
+
+export function signAccessToken(claims: AccessTokenClaims): string {
+  return jwt.sign(
+    { ...claims, typ: "access" },
+    JWT_SECRET,
+    { ...COMMON_OPTIONS, expiresIn: ACCESS_TOKEN_TTL_SECONDS },
+  );
+}
+
+export function signRefreshToken(claims: RefreshTokenClaims): string {
+  return jwt.sign(
+    { ...claims, typ: "refresh" },
+    JWT_SECRET,
+    { ...COMMON_OPTIONS, expiresIn: REFRESH_TOKEN_TTL_SECONDS },
+  );
+}
+
+export function verifyRefreshToken(token: string): RefreshTokenPayload {
+  const decoded = jwt.verify(token, JWT_SECRET);
+  if (typeof decoded !== "object" || decoded === null) {
+    throw new Error("Refresh token: invalid payload");
+  }
+  const payload = decoded as Record<string, unknown>;
+  if (payload.typ !== "refresh") {
+    throw new Error("Refresh token: not a refresh token");
+  }
+  if (typeof payload.sub !== "string" || !payload.sub) {
+    throw new Error("Refresh token: missing sub claim");
+  }
+  return payload as unknown as RefreshTokenPayload;
+}


### PR DESCRIPTION
## Resume

Premier slice de **S24.3** (refresh token 15min/7j + rotation + blacklist). Ce slice est purement additif : il ajoute le module `services/auth-tokens.ts` et ses tests sans toucher au flux login/register, pour limiter le blast radius.

- `ACCESS_TOKEN_TTL_SECONDS` = 15 minutes
- `REFRESH_TOKEN_TTL_SECONDS` = 7 jours
- `signAccessToken({sub, role, roles})` — JWT avec `typ: "access"`
- `signRefreshToken({sub})` — JWT avec `typ: "refresh"`, sans role (limite l'expo en cas de leak)
- `verifyRefreshToken(token)` — valide signature + expiration + `typ === "refresh"`

## Tache roadmap

Sprint S24, tache S24.3 — JWT refresh token (slice 1/4).
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`.

## Slices suivants (PRs separees)

- **S24.3b** : refactor `/auth/login` + `/auth/register` pour emettre `{ accessToken, refreshToken }` avec grace period (anciens tokens 7j tolerated 24h via dual-verify dans authUser).
- **S24.3c** : endpoint `POST /auth/refresh` (rotation : invalide l'ancien refresh, emet un nouveau couple).
- **S24.3d** : blacklist persistante (table `RevokedRefreshToken` ou Redis) + cleanup job + integration tests E2E auth.

## Plan de test

non termine
- [x] 14 tests unitaires TDD : TTL, payload `typ`/`sub`/`role`/`roles`, expiration +/-2s, rejet des tokens forges (mauvais secret, expires, typ manquant ou access).
- [x] `pnpm --filter @bb/server test` : 715/715 verts.
- [x] `pnpm --filter @bb/server typecheck` : OK.
- [ ] Slice 1/4 ne change aucun comportement runtime — pas de smoke test prod necessaire avant le slice b.

## Risques

Aucun pour ce slice : code purement additif, non importe par les routes existantes. `JWT_SECRET` reste partage entre access et refresh (suffisant pour HS256 ; un secret dedie sera envisage si on passe RS256).

---
_Generated by [Claude Code](https://claude.ai/code/session_013uRoHLxYL25j6S2jfZGRkF)_