### PR TITLE
feat(auth): refresh-token jti + in-memory store rotation (S24.3b)

### DIFF
--- a/apps/server/src/services/auth-tokens.test.ts
+++ b/apps/server/src/services/auth-tokens.test.ts
@@ -82,6 +82,23 @@ describe("Rule: auth-tokens helpers (S24.3a)", () => {
       expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 2);
       expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 2);
     });
+
+    it("auto-generates a unique jti when none is provided", () => {
+      const t1 = signRefreshToken({ sub: "user-1" });
+      const t2 = signRefreshToken({ sub: "user-1" });
+      const d1 = jwt.verify(t1, JWT_SECRET) as Record<string, unknown>;
+      const d2 = jwt.verify(t2, JWT_SECRET) as Record<string, unknown>;
+      expect(typeof d1.jti).toBe("string");
+      expect(typeof d2.jti).toBe("string");
+      expect((d1.jti as string).length).toBeGreaterThan(0);
+      expect(d1.jti).not.toEqual(d2.jti);
+    });
+
+    it("uses the provided jti when supplied", () => {
+      const token = signRefreshToken({ sub: "user-1", jti: "fixed-jti-123" });
+      const decoded = jwt.verify(token, JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.jti).toBe("fixed-jti-123");
+    });
   });
 
   describe("verifyRefreshToken", () => {
@@ -91,6 +108,21 @@ describe("Rule: auth-tokens helpers (S24.3a)", () => {
       expect(payload).toEqual(
         expect.objectContaining({ sub: "user-1", typ: "refresh" }),
       );
+    });
+
+    it("returns the jti claim for a valid refresh token", () => {
+      const token = signRefreshToken({ sub: "user-1", jti: "abc-123" });
+      const payload = verifyRefreshToken(token);
+      expect(payload.jti).toBe("abc-123");
+    });
+
+    it("rejects a refresh token without jti", () => {
+      const token = jwt.sign(
+        { sub: "user-1", typ: "refresh" },
+        JWT_SECRET,
+        { expiresIn: "7d" },
+      );
+      expect(() => verifyRefreshToken(token)).toThrow(/missing jti/i);
     });
 
     it("rejects an access token by typ check", () => {

--- a/apps/server/src/services/auth-tokens.ts
+++ b/apps/server/src/services/auth-tokens.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import jwt, { type SignOptions } from "jsonwebtoken";
 import { JWT_SECRET } from "../config";
 
@@ -18,6 +19,7 @@ interface AccessTokenClaims {
 
 interface RefreshTokenClaims {
   sub: string;
+  jti?: string;
 }
 
 export interface AccessTokenPayload extends AccessTokenClaims {
@@ -26,7 +28,9 @@ export interface AccessTokenPayload extends AccessTokenClaims {
   exp: number;
 }
 
-export interface RefreshTokenPayload extends RefreshTokenClaims {
+export interface RefreshTokenPayload {
+  sub: string;
+  jti: string;
   typ: "refresh";
   iat: number;
   exp: number;
@@ -45,8 +49,9 @@ export function signAccessToken(claims: AccessTokenClaims): string {
 }
 
 export function signRefreshToken(claims: RefreshTokenClaims): string {
+  const jti = claims.jti ?? randomUUID();
   return jwt.sign(
-    { ...claims, typ: "refresh" },
+    { sub: claims.sub, jti, typ: "refresh" },
     JWT_SECRET,
     { ...COMMON_OPTIONS, expiresIn: REFRESH_TOKEN_TTL_SECONDS },
   );
@@ -63,6 +68,9 @@ export function verifyRefreshToken(token: string): RefreshTokenPayload {
   }
   if (typeof payload.sub !== "string" || !payload.sub) {
     throw new Error("Refresh token: missing sub claim");
+  }
+  if (typeof payload.jti !== "string" || !payload.jti) {
+    throw new Error("Refresh token: missing jti claim");
   }
   return payload as unknown as RefreshTokenPayload;
 }

--- a/apps/server/src/services/refresh-token-store.test.ts
+++ b/apps/server/src/services/refresh-token-store.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  InMemoryRefreshTokenStore,
+  rotateRefreshToken,
+  RefreshTokenReuseError,
+  type RefreshTokenStore,
+} from "./refresh-token-store";
+import { signRefreshToken, verifyRefreshToken } from "./auth-tokens";
+
+describe("Rule: refresh-token-store (S24.3b)", () => {
+  let store: RefreshTokenStore;
+
+  beforeEach(() => {
+    store = new InMemoryRefreshTokenStore();
+  });
+
+  describe("InMemoryRefreshTokenStore.register / isActive / isRevoked", () => {
+    it("an unregistered jti is neither active nor revoked", () => {
+      expect(store.isActive("unknown")).toBe(false);
+      expect(store.isRevoked("unknown")).toBe(false);
+    });
+
+    it("after register, jti is active and not revoked", () => {
+      store.register({
+        jti: "j1",
+        sub: "user-1",
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      });
+      expect(store.isActive("j1")).toBe(true);
+      expect(store.isRevoked("j1")).toBe(false);
+    });
+
+    it("after revoke, jti is no longer active and is revoked", () => {
+      store.register({
+        jti: "j1",
+        sub: "user-1",
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      });
+      store.revoke("j1");
+      expect(store.isActive("j1")).toBe(false);
+      expect(store.isRevoked("j1")).toBe(true);
+    });
+
+    it("an expired jti is no longer active (auto eviction)", () => {
+      store.register({
+        jti: "j1",
+        sub: "user-1",
+        expiresAt: Math.floor(Date.now() / 1000) - 1,
+      });
+      expect(store.isActive("j1")).toBe(false);
+    });
+
+    it("revokeAllForUser revokes every jti owned by a user", () => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 60;
+      store.register({ jti: "j1", sub: "user-1", expiresAt });
+      store.register({ jti: "j2", sub: "user-1", expiresAt });
+      store.register({ jti: "j3", sub: "user-2", expiresAt });
+      store.revokeAllForUser("user-1");
+      expect(store.isRevoked("j1")).toBe(true);
+      expect(store.isRevoked("j2")).toBe(true);
+      expect(store.isRevoked("j3")).toBe(false);
+    });
+  });
+
+  describe("rotateRefreshToken", () => {
+    it("issues a new refresh token, registers its jti, revokes the old one", () => {
+      const oldToken = signRefreshToken({ sub: "user-1", jti: "old-jti" });
+      store.register({
+        jti: "old-jti",
+        sub: "user-1",
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      });
+
+      const result = rotateRefreshToken(oldToken, store);
+
+      expect(result.sub).toBe("user-1");
+      expect(typeof result.token).toBe("string");
+      expect(result.token).not.toEqual(oldToken);
+      expect(store.isRevoked("old-jti")).toBe(true);
+
+      const newPayload = verifyRefreshToken(result.token);
+      expect(newPayload.sub).toBe("user-1");
+      expect(store.isActive(newPayload.jti)).toBe(true);
+    });
+
+    it("rejects a refresh token whose jti was never registered", () => {
+      const orphanToken = signRefreshToken({
+        sub: "user-1",
+        jti: "never-issued",
+      });
+      expect(() => rotateRefreshToken(orphanToken, store)).toThrow();
+    });
+
+    it("rejects an already-revoked refresh token and signals reuse", () => {
+      const token = signRefreshToken({ sub: "user-1", jti: "j1" });
+      store.register({
+        jti: "j1",
+        sub: "user-1",
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      });
+      store.revoke("j1");
+
+      expect(() => rotateRefreshToken(token, store)).toThrow(
+        RefreshTokenReuseError,
+      );
+    });
+
+    it("on reuse, revokes ALL refresh tokens for that user (defense in depth)", () => {
+      const expiresAt = Math.floor(Date.now() / 1000) + 60;
+      const oldToken = signRefreshToken({ sub: "user-1", jti: "old-jti" });
+      store.register({ jti: "old-jti", sub: "user-1", expiresAt });
+      store.register({ jti: "other-jti", sub: "user-1", expiresAt });
+      store.revoke("old-jti");
+
+      expect(() => rotateRefreshToken(oldToken, store)).toThrow(
+        RefreshTokenReuseError,
+      );
+      expect(store.isRevoked("other-jti")).toBe(true);
+    });
+
+    it("rejects a malformed or invalid signature token", () => {
+      expect(() => rotateRefreshToken("not-a-jwt", store)).toThrow();
+    });
+  });
+});

--- a/apps/server/src/services/refresh-token-store.ts
+++ b/apps/server/src/services/refresh-token-store.ts
@@ -1,0 +1,116 @@
+import {
+  signRefreshToken,
+  verifyRefreshToken,
+  REFRESH_TOKEN_TTL_SECONDS,
+  type RefreshTokenPayload,
+} from "./auth-tokens";
+
+/**
+ * Refresh token registry (S24.3b). Each refresh token carries a unique `jti`
+ * claim. The store records the active jti per user, supports rotation
+ * (revoke old + issue new atomically) and detects reuse of an already-revoked
+ * token — a strong signal that the previous token was stolen. On reuse, every
+ * refresh token of the user is revoked as a defense-in-depth measure.
+ *
+ * The current implementation is in-memory; persistence (Prisma) will land in a
+ * follow-up slice without changing this interface.
+ */
+
+export interface RefreshTokenRecord {
+  jti: string;
+  sub: string;
+  /** UNIX seconds. */
+  expiresAt: number;
+  revokedAt?: number;
+}
+
+export interface RefreshTokenStore {
+  register(record: { jti: string; sub: string; expiresAt: number }): void;
+  revoke(jti: string): void;
+  revokeAllForUser(sub: string): void;
+  isActive(jti: string): boolean;
+  isRevoked(jti: string): boolean;
+}
+
+export class RefreshTokenReuseError extends Error {
+  constructor(message = "Refresh token reuse detected") {
+    super(message);
+    this.name = "RefreshTokenReuseError";
+  }
+}
+
+export class InMemoryRefreshTokenStore implements RefreshTokenStore {
+  private readonly records = new Map<string, RefreshTokenRecord>();
+
+  register(record: { jti: string; sub: string; expiresAt: number }): void {
+    this.records.set(record.jti, { ...record });
+  }
+
+  revoke(jti: string): void {
+    const existing = this.records.get(jti);
+    if (!existing) return;
+    this.records.set(jti, {
+      ...existing,
+      revokedAt: Math.floor(Date.now() / 1000),
+    });
+  }
+
+  revokeAllForUser(sub: string): void {
+    const now = Math.floor(Date.now() / 1000);
+    for (const [jti, rec] of this.records.entries()) {
+      if (rec.sub === sub && !rec.revokedAt) {
+        this.records.set(jti, { ...rec, revokedAt: now });
+      }
+    }
+  }
+
+  isActive(jti: string): boolean {
+    const rec = this.records.get(jti);
+    if (!rec) return false;
+    if (rec.revokedAt) return false;
+    if (rec.expiresAt <= Math.floor(Date.now() / 1000)) return false;
+    return true;
+  }
+
+  isRevoked(jti: string): boolean {
+    const rec = this.records.get(jti);
+    if (!rec) return false;
+    return Boolean(rec.revokedAt);
+  }
+}
+
+export interface RotateRefreshTokenResult {
+  token: string;
+  payload: RefreshTokenPayload;
+  sub: string;
+}
+
+export function rotateRefreshToken(
+  presentedToken: string,
+  store: RefreshTokenStore,
+): RotateRefreshTokenResult {
+  const payload = verifyRefreshToken(presentedToken);
+
+  if (store.isRevoked(payload.jti)) {
+    store.revokeAllForUser(payload.sub);
+    throw new RefreshTokenReuseError(
+      "Refresh token reuse detected: all sessions revoked",
+    );
+  }
+
+  if (!store.isActive(payload.jti)) {
+    throw new Error("Refresh token: jti not registered or expired");
+  }
+
+  store.revoke(payload.jti);
+
+  const newToken = signRefreshToken({ sub: payload.sub });
+  const newPayload = verifyRefreshToken(newToken);
+  store.register({
+    jti: newPayload.jti,
+    sub: newPayload.sub,
+    expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+  });
+
+  return { token: newToken, payload: newPayload, sub: newPayload.sub };
+}


### PR DESCRIPTION
## Resume

Slice 2/4 de **S24.3 — JWT refresh token (15 min access + 7j refresh, rotation + blacklist)**.

S'appuie sur les helpers livres en S24.3a (#398). Ce slice introduit l'identifiant unique de refresh token (`jti`) et le registre in-memory qui permettra la rotation et la detection de reutilisation.

Changements :

* `signRefreshToken` exige maintenant un `jti` unique (auto-genere via `randomUUID()` si non fourni). `verifyRefreshToken` rejette les refresh tokens sans `jti`.
* Nouveau `RefreshTokenStore` (interface + impl in-memory `InMemoryRefreshTokenStore`) : `register`, `revoke`, `revokeAllForUser`, `isActive`, `isRevoked`. Auto-eviction des `jti` expires.
* `rotateRefreshToken(token, store)` : verifie -> revoke ancien `jti` -> emet un nouveau token avec un nouveau `jti` -> enregistre. Si le token presente est deja revoque (= reutilisation = signal de vol), `RefreshTokenReuseError` est leve **et** tous les refresh tokens de l'utilisateur sont revoques (defense in depth).

La persistance Prisma du registre arrive dans le slice 3 (S24.3c). L'endpoint `POST /auth/refresh` + l'integration login/register suivront en S24.3d (slice 4).

## Tache roadmap

Sprint S24, tache S24.3 (slice 2/4)
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`

## Plan de test

- [x] Tests RED puis GREEN sur `signRefreshToken` (auto-jti, jti fourni) et `verifyRefreshToken` (rejet sans jti)
- [x] 10 tests `refresh-token-store.test.ts` couvrant register / revoke / isActive / isRevoked / revokeAllForUser / rotation / detection de reutilisation / token orphelin / token mal forme
- [x] Suite complete `apps/server` : 729 / 729 verts (60 fichiers de tests)
- [x] `pnpm lint` : OK (warnings only)
- [x] `pnpm typecheck` : OK sur web + server + game-engine + ui
- [x] Build server + game-engine + ui OK ; build web bloque uniquement par Google Fonts (sandbox offline, sans lien avec ce slice)
- [ ] CI verte sur la PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmwbgrzTsrid9XY6ZAkXwy)_