### PR TITLE
feat(auth): wire access+refresh rotation into login/refresh/logout (S24.3)

### DIFF
--- a/apps/server/src/routes/auth.test.ts
+++ b/apps/server/src/routes/auth.test.ts
@@ -1,0 +1,252 @@
+/**
+ * S24.3 — Tests des routes /auth/refresh et /auth/logout.
+ *
+ * Pattern unitaire : prisma mocke + store injecte (InMemoryRefreshTokenStore),
+ * req/res faits a la main (idem league.test.ts, authUser.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../config", () => ({ JWT_SECRET: "test-secret" }));
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import type { Request, Response } from "express";
+import { prisma } from "../prisma";
+import {
+  handleLogout,
+  handleRefresh,
+  setRefreshTokenStore,
+} from "./auth";
+import {
+  signRefreshToken,
+  signAccessToken,
+  REFRESH_TOKEN_TTL_SECONDS,
+  verifyRefreshToken,
+} from "../services/auth-tokens";
+import { InMemoryRefreshTokenStore } from "../services/refresh-token-store";
+
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+function createRes() {
+  const res: Partial<Response> & {
+    statusCode?: number;
+    payload?: unknown;
+    sentEmpty?: boolean;
+  } = {};
+  res.status = vi.fn().mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  });
+  res.json = vi.fn().mockImplementation((body: unknown) => {
+    res.payload = body;
+    return res as Response;
+  });
+  res.send = vi.fn().mockImplementation(() => {
+    res.sentEmpty = true;
+    return res as Response;
+  });
+  return res as Response & {
+    statusCode?: number;
+    payload?: unknown;
+    sentEmpty?: boolean;
+  };
+}
+
+function createReq(body: unknown): Request {
+  return { body } as Request;
+}
+
+describe("Rule: /auth/refresh (S24.3)", () => {
+  let store: InMemoryRefreshTokenStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new InMemoryRefreshTokenStore();
+    setRefreshTokenStore(store);
+  });
+
+  it("returns 400 when refreshToken is missing", async () => {
+    const res = createRes();
+    await handleRefresh(createReq({}), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toEqual({ error: "refreshToken requis" });
+  });
+
+  it("returns 401 when the refresh token is malformed", async () => {
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: "not-a-jwt" }), res);
+    expect(res.statusCode).toBe(401);
+    expect(res.payload).toEqual({ error: "Refresh token invalide" });
+  });
+
+  it("returns 401 when the refresh token is signed but jti is unknown", async () => {
+    const orphan = signRefreshToken({ sub: "user-1", jti: "never-issued" });
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: orphan }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects an access token presented as refresh", async () => {
+    const access = signAccessToken({
+      sub: "user-1",
+      role: "user",
+      roles: ["user"],
+    });
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: access }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rotates a valid refresh token and issues a new pair (happy path)", async () => {
+    const oldRefresh = signRefreshToken({ sub: "user-1", jti: "old-jti" });
+    await store.register({
+      jti: "old-jti",
+      sub: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      role: "user",
+      roles: ["user"],
+      valid: true,
+    });
+
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: oldRefresh }), res);
+
+    expect(res.statusCode).toBeUndefined(); // 200 default
+    const payload = res.payload as { token: string; refreshToken: string };
+    expect(typeof payload.token).toBe("string");
+    expect(typeof payload.refreshToken).toBe("string");
+    expect(payload.refreshToken).not.toEqual(oldRefresh);
+
+    expect(await store.isRevoked("old-jti")).toBe(true);
+    const newPayload = verifyRefreshToken(payload.refreshToken);
+    expect(await store.isActive(newPayload.jti)).toBe(true);
+  });
+
+  it("on reuse of a revoked refresh token, returns 401 and revokes ALL user sessions", async () => {
+    const stolen = signRefreshToken({ sub: "user-1", jti: "stolen-jti" });
+    const expiresAt = Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS;
+    await store.register({ jti: "stolen-jti", sub: "user-1", expiresAt });
+    await store.register({ jti: "other-jti", sub: "user-1", expiresAt });
+    await store.revoke("stolen-jti");
+
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: stolen }), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.payload).toEqual({ error: "Refresh token reuse detected" });
+    expect(await store.isRevoked("other-jti")).toBe(true);
+  });
+
+  it("returns 401 and revokes all sessions when user no longer exists", async () => {
+    const refresh = signRefreshToken({ sub: "ghost-user", jti: "j1" });
+    await store.register({
+      jti: "j1",
+      sub: "ghost-user",
+      expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: refresh }), res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 403 and revokes all sessions when user is disabled (valid=false)", async () => {
+    const refresh = signRefreshToken({ sub: "user-1", jti: "j1" });
+    await store.register({
+      jti: "j1",
+      sub: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      role: "user",
+      roles: ["user"],
+      valid: false,
+    });
+
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: refresh }), res);
+
+    expect(res.statusCode).toBe(403);
+    expect(await store.isRevoked("j1")).toBe(true);
+  });
+
+  it("re-reads roles from prisma so role changes apply on next refresh", async () => {
+    const refresh = signRefreshToken({ sub: "user-1", jti: "j1" });
+    await store.register({
+      jti: "j1",
+      sub: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      role: "admin",
+      roles: ["user", "admin"],
+      valid: true,
+    });
+
+    const res = createRes();
+    await handleRefresh(createReq({ refreshToken: refresh }), res);
+
+    const payload = res.payload as { token: string };
+    const decoded = JSON.parse(
+      Buffer.from(payload.token.split(".")[1], "base64url").toString("utf8"),
+    );
+    expect(decoded.roles).toEqual(["user", "admin"]);
+    expect(decoded.role).toBe("user");
+  });
+});
+
+describe("Rule: /auth/logout (S24.3)", () => {
+  let store: InMemoryRefreshTokenStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new InMemoryRefreshTokenStore();
+    setRefreshTokenStore(store);
+  });
+
+  it("returns 204 when no refreshToken is provided (idempotent)", async () => {
+    const res = createRes();
+    await handleLogout(createReq({}), res);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 204 and revokes the jti for a valid refresh token", async () => {
+    const refresh = signRefreshToken({ sub: "user-1", jti: "j1" });
+    await store.register({
+      jti: "j1",
+      sub: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+    });
+    const res = createRes();
+    await handleLogout(createReq({ refreshToken: refresh }), res);
+    expect(res.statusCode).toBe(204);
+    expect(await store.isRevoked("j1")).toBe(true);
+  });
+
+  it("returns 204 silently on a malformed refresh token", async () => {
+    const res = createRes();
+    await handleLogout(createReq({ refreshToken: "garbage" }), res);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 204 on a token whose jti is not registered (no-op revoke)", async () => {
+    const refresh = signRefreshToken({ sub: "user-1", jti: "ghost" });
+    const res = createRes();
+    await handleLogout(createReq({ refreshToken: refresh }), res);
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -1,24 +1,73 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 import { prisma } from "../prisma";
 import bcrypt from "bcryptjs";
-import jwt from "jsonwebtoken";
 import { authUser, AuthenticatedRequest } from "../middleware/authUser";
 import { normalizeRoles } from "../utils/roles";
 import { validate } from "../middleware/validate";
 import {
   loginSchema,
+  refreshTokenSchema,
   registerSchema,
   updateProfileSchema,
   changePasswordSchema,
 } from "../schemas/auth.schemas";
-import { JWT_SECRET } from "../config";
 import {
   claimOrphanKofiTransactions,
   ensureKofiLinkCode,
 } from "../services/kofi-claim";
 import { isSupporter } from "../services/kofi";
+import {
+  REFRESH_TOKEN_TTL_SECONDS,
+  signAccessToken,
+  signRefreshToken,
+  verifyRefreshToken,
+} from "../services/auth-tokens";
+import {
+  RefreshTokenReuseError,
+  rotateRefreshToken,
+  type RefreshTokenStore,
+} from "../services/refresh-token-store";
+import { PrismaRefreshTokenStore } from "../services/prisma-refresh-token-store";
 
 const router = Router();
+
+/**
+ * Default Prisma-backed store. Tests inject a fake via `setRefreshTokenStore`
+ * to avoid coupling to the database layer.
+ */
+let refreshTokenStore: RefreshTokenStore = new PrismaRefreshTokenStore();
+
+export function setRefreshTokenStore(store: RefreshTokenStore): void {
+  refreshTokenStore = store;
+}
+
+export function getRefreshTokenStore(): RefreshTokenStore {
+  return refreshTokenStore;
+}
+
+/**
+ * S24.3 — Issues a fresh access/refresh pair for `userId` and registers the
+ * refresh jti in the store. Returns both tokens to the caller.
+ */
+async function issueTokenPair(params: {
+  userId: string;
+  primaryRole: string | undefined;
+  roles: string[];
+}): Promise<{ token: string; refreshToken: string }> {
+  const accessToken = signAccessToken({
+    sub: params.userId,
+    role: params.primaryRole ?? "user",
+    roles: params.roles,
+  });
+  const refreshToken = signRefreshToken({ sub: params.userId });
+  const refreshPayload = verifyRefreshToken(refreshToken);
+  await refreshTokenStore.register({
+    jti: refreshPayload.jti,
+    sub: params.userId,
+    expiresAt: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_TTL_SECONDS,
+  });
+  return { token: accessToken, refreshToken };
+}
 
 router.post("/register", validate(registerSchema), async (req, res) => {
   try {
@@ -78,12 +127,12 @@ router.post("/register", validate(registerSchema), async (req, res) => {
       createdAt: created.createdAt,
     };
 
-    const token = jwt.sign(
-      { sub: created.id, role: primaryRole, roles },
-      JWT_SECRET,
-      { expiresIn: "7d" },
-    );
-    return res.status(201).json({ user: publicUser, token });
+    const { token, refreshToken } = await issueTokenPair({
+      userId: created.id,
+      primaryRole,
+      roles,
+    });
+    return res.status(201).json({ user: publicUser, token, refreshToken });
   } catch (err: any) {
     if (err?.code === "P2002") {
       return res.status(409).json({ error: "Email déjà utilisé" });
@@ -147,19 +196,94 @@ router.post("/login", validate(loginSchema), async (req, res) => {
       roles,
       createdAt: user.createdAt,
     };
-    const token = jwt.sign(
-      { sub: user.id, role: primaryRole, roles },
-      JWT_SECRET,
-      {
-        expiresIn: "7d",
-      },
-    );
-    return res.json({ user: publicUser, token });
+    const { token, refreshToken } = await issueTokenPair({
+      userId: user.id,
+      primaryRole,
+      roles,
+    });
+    return res.json({ user: publicUser, token, refreshToken });
   } catch (err) {
     console.error(err);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
+
+/**
+ * POST /auth/refresh — S24.3
+ *
+ * Rotates a refresh token: revokes the presented jti and issues a new pair.
+ * If the presented refresh token is already revoked, treats it as theft and
+ * revokes every active refresh token of the user (defense in depth).
+ *
+ * The user's roles are re-read from Prisma so that role changes (e.g. promote
+ * to admin) take effect on the next refresh without requiring re-login.
+ */
+export async function handleRefresh(req: Request, res: Response): Promise<Response> {
+  const refreshToken = (req.body as { refreshToken?: string })?.refreshToken;
+  if (typeof refreshToken !== "string" || refreshToken.length === 0) {
+    return res.status(400).json({ error: "refreshToken requis" });
+  }
+
+  let rotation;
+  try {
+    rotation = await rotateRefreshToken(refreshToken, refreshTokenStore);
+  } catch (err: unknown) {
+    if (err instanceof RefreshTokenReuseError) {
+      return res.status(401).json({ error: "Refresh token reuse detected" });
+    }
+    return res.status(401).json({ error: "Refresh token invalide" });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: rotation.sub },
+    select: { id: true, role: true, roles: true, valid: true },
+  });
+  if (!user) {
+    await refreshTokenStore.revokeAllForUser(rotation.sub);
+    return res.status(401).json({ error: "Utilisateur introuvable" });
+  }
+  if (user.valid === false) {
+    await refreshTokenStore.revokeAllForUser(rotation.sub);
+    return res.status(403).json({ error: "Compte désactivé" });
+  }
+
+  const roles = normalizeRoles(
+    (user as { roles?: string[] | null }).roles ?? user.role,
+  );
+  const primaryRole = roles[0];
+  const accessToken = signAccessToken({
+    sub: user.id,
+    role: primaryRole ?? "user",
+    roles,
+  });
+
+  return res.json({ token: accessToken, refreshToken: rotation.token });
+}
+
+router.post("/refresh", validate(refreshTokenSchema), handleRefresh);
+
+/**
+ * POST /auth/logout — S24.3
+ *
+ * Revokes the presented refresh token. Idempotent: missing or already-revoked
+ * tokens still respond 204. Access tokens themselves are stateless — they
+ * remain valid until expiry, but their <=15min TTL bounds the exposure.
+ */
+export async function handleLogout(req: Request, res: Response): Promise<Response> {
+  const refreshToken = (req.body as { refreshToken?: string })?.refreshToken;
+  if (typeof refreshToken !== "string" || refreshToken.length === 0) {
+    return res.status(204).send();
+  }
+  try {
+    const payload = verifyRefreshToken(refreshToken);
+    await refreshTokenStore.revoke(payload.jti);
+  } catch {
+    // ignore: malformed/expired tokens are already useless
+  }
+  return res.status(204).send();
+}
+
+router.post("/logout", handleLogout);
 
 // Désactiver le compte courant (suppression logique)
 router.delete("/me", authUser, async (req: AuthenticatedRequest, res) => {

--- a/apps/server/src/schemas/auth.schemas.ts
+++ b/apps/server/src/schemas/auth.schemas.ts
@@ -21,6 +21,14 @@ export const loginSchema = z.object({
   password: z.string().min(1, "Mot de passe requis"),
 });
 
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1, "refreshToken requis"),
+});
+
+export const logoutSchema = z.object({
+  refreshToken: z.string().min(1, "refreshToken requis"),
+});
+
 /**
  * Snowflake Discord : 17 à 20 chiffres (cf. https://discord.com/developers/docs/reference#snowflakes).
  * Chaîne vide acceptée et traitée comme un effacement (null) côté route.

--- a/apps/web/app/AuthBar.tsx
+++ b/apps/web/app/AuthBar.tsx
@@ -5,6 +5,10 @@ import { useLanguage } from "./contexts/LanguageContext";
 import { useFeatureFlag } from "./hooks/useFeatureFlag";
 import { ONLINE_PLAY_FLAG } from "./lib/featureFlagKeys";
 import { syncAuthCookie, clearAuthCookie } from "./lib/auth-cookie";
+import {
+  clearAuthTokens,
+  getRefreshToken,
+} from "./lib/auth-storage";
 
 type UserData = {
   email: string;
@@ -77,7 +81,21 @@ export default function AuthBar({ isMobileMenu = false }: AuthBarProps) {
   }, [menuOpen]);
 
   async function logout() {
-    localStorage.removeItem("auth_token");
+    // Best-effort : revoque le refresh jti cote serveur (S24.3). On ne bloque
+    // pas le logout si le serveur est down ou repond une erreur.
+    const refreshToken = getRefreshToken();
+    if (refreshToken) {
+      try {
+        await fetch(`${API_BASE}/auth/logout`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refreshToken }),
+        });
+      } catch {
+        // ignore
+      }
+    }
+    clearAuthTokens();
     // Le cookie est httpOnly : seul le serveur peut l'effacer (S24.1).
     await clearAuthCookie();
     setHasToken(false);

--- a/apps/web/app/components/AuthRefreshLoop.tsx
+++ b/apps/web/app/components/AuthRefreshLoop.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * Boucle de rafraichissement silencieux (S24.3).
+ *
+ * Monte un interval qui rafraichit l'access token (~13 min) tant qu'un refresh
+ * token est present en localStorage. Sans cette boucle, l'access token de 15
+ * minutes expirerait et chaque appel API existant ferait 401.
+ *
+ * Le composant ne rend rien : il sert uniquement a piloter l'effet de bord.
+ */
+
+import { useEffect } from "react";
+import { refreshAccessToken } from "../lib/auth-refresh";
+import { getRefreshToken } from "../lib/auth-storage";
+
+const REFRESH_INTERVAL_MS = 13 * 60 * 1000; // 13 min, marge de 2 min sur l'expiry 15 min
+
+export default function AuthRefreshLoop(): null {
+  useEffect(() => {
+    if (!getRefreshToken()) return;
+
+    const id = window.setInterval(() => {
+      void refreshAccessToken();
+    }, REFRESH_INTERVAL_MS);
+
+    return () => window.clearInterval(id);
+  }, []);
+
+  return null;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import Footer from "./components/Footer";
 import Header from "./components/Header";
 import { ClientLayout } from "./components/ClientLayout";
 import WebVitalsReporter from "./components/WebVitalsReporter";
+import AuthRefreshLoop from "./components/AuthRefreshLoop";
 import { buildWebmasterVerification } from "./lib/webmaster-verification";
 
 const cinzelDecorative = Cinzel_Decorative({
@@ -179,6 +180,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           Aller au contenu principal
         </a>
         <WebVitalsReporter />
+        <AuthRefreshLoop />
         <ClientLayout>
           <div className="flex-1 w-screen relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw]">
             <div className="w-full p-4 sm:p-6">

--- a/apps/web/app/lib/auth-refresh.test.ts
+++ b/apps/web/app/lib/auth-refresh.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests pour le helper de rafraichissement silencieux (S24.3).
+ *
+ * fetch et la route /api/sync-auth-cookie sont mockes pour eviter le reseau.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  window.localStorage.clear();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+import { refreshAccessToken } from "./auth-refresh";
+import { setAuthTokens, getAuthToken, getRefreshToken } from "./auth-storage";
+
+function mockResponse(status: number, body?: unknown): Response {
+  return new Response(body ? JSON.stringify(body) : null, {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Rule: refreshAccessToken (S24.3)", () => {
+  it("returns null when no refresh token is stored", async () => {
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls /auth/refresh with the stored refresh token", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/auth/refresh")) {
+        return Promise.resolve(
+          mockResponse(200, { token: "new-access", refreshToken: "new-refresh" }),
+        );
+      }
+      // /api/sync-auth-cookie
+      return Promise.resolve(mockResponse(200));
+    });
+
+    const result = await refreshAccessToken();
+    expect(result).toBe("new-access");
+
+    const refreshCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).endsWith("/auth/refresh"),
+    );
+    expect(refreshCall).toBeDefined();
+    const init = refreshCall![1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      refreshToken: "old-refresh",
+    });
+  });
+
+  it("stores the new pair in localStorage on success", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockResolvedValue(
+      mockResponse(200, { token: "new-access", refreshToken: "new-refresh" }),
+    );
+
+    await refreshAccessToken();
+    expect(getAuthToken()).toBe("new-access");
+    expect(getRefreshToken()).toBe("new-refresh");
+  });
+
+  it("clears tokens on 401 (server signaled reuse or invalid token)", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockResolvedValue(mockResponse(401, { error: "boom" }));
+
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    expect(getAuthToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it("clears tokens on 403 (account disabled)", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockResolvedValue(mockResponse(403));
+
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it("returns null and keeps tokens on network error (fetch throws)", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    // Network errors are transient — keep the existing tokens so the next
+    // attempt can retry without forcing a logout.
+    expect(getRefreshToken()).toBe("old-refresh");
+  });
+
+  it("returns null when response is missing token field", async () => {
+    setAuthTokens({ token: "old-access", refreshToken: "old-refresh" });
+    fetchMock.mockResolvedValue(mockResponse(200, { foo: "bar" }));
+
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/app/lib/auth-refresh.ts
+++ b/apps/web/app/lib/auth-refresh.ts
@@ -1,0 +1,55 @@
+/**
+ * Rafraichissement silencieux du token d'acces (S24.3).
+ *
+ * Le serveur emet un access token de 15 minutes + un refresh token de 7 jours
+ * (rotatif). Cette fonction echange un refresh token contre une nouvelle paire
+ * et met a jour le localStorage + le cookie httpOnly.
+ *
+ * Retourne le nouvel access token en cas de succes, null sinon (refresh
+ * absent, rotation rejetee, reseau down). En cas d'echec, les tokens sont
+ * effaces : la session est consideree perdue.
+ */
+
+import { API_BASE } from "../auth-client";
+import { syncAuthCookie, clearAuthCookie } from "./auth-cookie";
+import {
+  clearAuthTokens,
+  getRefreshToken,
+  setAuthTokens,
+} from "./auth-storage";
+
+export interface RefreshResponse {
+  token: string;
+  refreshToken: string;
+}
+
+export async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return null;
+
+  try {
+    const res = await fetch(`${API_BASE}/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!res.ok) {
+      // 401 = reuse detecte ou token invalide. On force le logout local.
+      if (res.status === 401 || res.status === 403) {
+        clearAuthTokens();
+        await clearAuthCookie();
+      }
+      return null;
+    }
+
+    const data = (await res.json()) as Partial<RefreshResponse>;
+    if (!data.token || !data.refreshToken) return null;
+
+    setAuthTokens({ token: data.token, refreshToken: data.refreshToken });
+    await syncAuthCookie(data.token);
+    return data.token;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/app/lib/auth-storage.test.ts
+++ b/apps/web/app/lib/auth-storage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  clearAuthTokens,
+  getAuthToken,
+  getRefreshToken,
+  setAuthTokens,
+} from "./auth-storage";
+
+describe("Rule: auth-storage helpers (S24.3)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when no token has been stored", () => {
+    expect(getAuthToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it("setAuthTokens stores both access and refresh tokens", () => {
+    setAuthTokens({ token: "access-1", refreshToken: "refresh-1" });
+    expect(getAuthToken()).toBe("access-1");
+    expect(getRefreshToken()).toBe("refresh-1");
+  });
+
+  it("setAuthTokens with no refreshToken keeps the existing refresh token untouched", () => {
+    setAuthTokens({ token: "access-1", refreshToken: "refresh-1" });
+    setAuthTokens({ token: "access-2" });
+    expect(getAuthToken()).toBe("access-2");
+    expect(getRefreshToken()).toBe("refresh-1");
+  });
+
+  it("clearAuthTokens removes both access and refresh tokens", () => {
+    setAuthTokens({ token: "access-1", refreshToken: "refresh-1" });
+    clearAuthTokens();
+    expect(getAuthToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it("uses the legacy 'auth_token' key for backward compatibility with existing code", () => {
+    setAuthTokens({ token: "abc", refreshToken: "def" });
+    expect(window.localStorage.getItem("auth_token")).toBe("abc");
+    expect(window.localStorage.getItem("auth_refresh_token")).toBe("def");
+  });
+});

--- a/apps/web/app/lib/auth-storage.ts
+++ b/apps/web/app/lib/auth-storage.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers de persistance des tokens d'authentification (S24.3).
+ *
+ * Le couple access/refresh remplace le token unique 7j historique :
+ * - access ("auth_token") : 15 min, envoye dans l'en-tete Authorization
+ * - refresh ("auth_refresh_token") : 7 jours, utilise pour rotation silencieuse
+ *
+ * Tous les helpers sont safe en SSR : ils renvoient null/no-op si window est
+ * absent.
+ */
+
+const ACCESS_KEY = "auth_token";
+const REFRESH_KEY = "auth_refresh_token";
+
+function hasWindow(): boolean {
+  return typeof window !== "undefined";
+}
+
+export function getAuthToken(): string | null {
+  if (!hasWindow()) return null;
+  return window.localStorage.getItem(ACCESS_KEY);
+}
+
+export function getRefreshToken(): string | null {
+  if (!hasWindow()) return null;
+  return window.localStorage.getItem(REFRESH_KEY);
+}
+
+export function setAuthTokens(params: {
+  token: string;
+  refreshToken?: string | null;
+}): void {
+  if (!hasWindow()) return;
+  window.localStorage.setItem(ACCESS_KEY, params.token);
+  if (params.refreshToken) {
+    window.localStorage.setItem(REFRESH_KEY, params.refreshToken);
+  }
+}
+
+export function clearAuthTokens(): void {
+  if (!hasWindow()) return;
+  window.localStorage.removeItem(ACCESS_KEY);
+  window.localStorage.removeItem(REFRESH_KEY);
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { apiPost, API_BASE } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
 import { syncAuthCookie } from "../lib/auth-cookie";
+import { setAuthTokens } from "../lib/auth-storage";
 
 // Autorise uniquement les redirections internes (chemins relatifs commençant par "/"
 // et ne pouvant être interprétés comme des URLs externes).
@@ -50,8 +51,11 @@ export default function LoginPage() {
     e.preventDefault();
     setError(null);
     try {
-      const { token } = await apiPost("/auth/login", { email, password });
-      localStorage.setItem("auth_token", token);
+      const { token, refreshToken } = await apiPost("/auth/login", {
+        email,
+        password,
+      });
+      setAuthTokens({ token, refreshToken });
       // Cookie httpOnly synchronise via la route serveur (S24.1).
       await syncAuthCookie(token);
       window.location.href = redirectTo;

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { apiPost } from "../auth-client";
 import { useLanguage } from "../contexts/LanguageContext";
 import { syncAuthCookie } from "../lib/auth-cookie";
+import { setAuthTokens } from "../lib/auth-storage";
 
 // Autorise uniquement les redirections internes (chemins relatifs commençant par "/"
 // et ne pouvant être interprétés comme des URLs externes).
@@ -57,7 +58,10 @@ export default function RegisterPage() {
       const response = await apiPost("/auth/register", payload);
 
       if (response?.token) {
-        localStorage.setItem("auth_token", response.token);
+        setAuthTokens({
+          token: response.token,
+          refreshToken: response.refreshToken,
+        });
         // Cookie httpOnly synchronise via la route serveur (S24.1).
         await syncAuthCookie(response.token);
         window.location.href = redirectTo;

--- a/docs/roadmap/sprints/S24-stabilite-securite.md
+++ b/docs/roadmap/sprints/S24-stabilite-securite.md
@@ -11,7 +11,7 @@
 |---|-------|-----|--------|--------|--------|
 | S24.1 | Cookie `auth_token` httpOnly=true + sameSite=strict + secure=true | FIX | S | [x] | `apps/web/app/api/sync-auth-cookie/route.ts:22`. Bloque le vol via XSS. Actuellement httpOnly=false "pour synchro JS" mais le token est deja en localStorage donc surface deja redondante. |
 | S24.2 | Helmet + CSP + HSTS + X-Frame-Options DENY | FIX | M | [x] | `apps/server/src/index.ts:65-100`. Aucun en-tete securite actuellement. Au minimum X-Frame, X-Content-Type-Options nosniff, HSTS 1 an, CSP img-src + script-src self. |
-| S24.3 | JWT refresh token (15 min access + 7j refresh, rotation + blacklist) | FIX | M | [ ] | `apps/server/src/routes/auth.ts:90-100`. Token actuel 7j sans rotation = 7j de fenetre si compromission. Pattern refresh + access. |
+| S24.3 | JWT refresh token (15 min access + 7j refresh, rotation + blacklist) | FIX | M | [x] | `apps/server/src/routes/auth.ts:90-100`. Token actuel 7j sans rotation = 7j de fenetre si compromission. Pattern refresh + access. |
 | S24.4 | WebSocket cleanup listeners + room leak | FIX | S | [ ] | `apps/web/app/play/[id]/hooks/useGameSocket.ts:365-370`. Listeners non desabonnes apres disconnect : fuite memoire progressive sur sessions longues. |
 | S24.5 | Polling fallback 3s -> 10s + backoff exponentiel | FIX | M | [ ] | `apps/web/app/play/[id]/hooks/useGameState.ts:301`. Quand WS degrade, X clients = X requetes/3s. Trop agressif a la scale beta. |
 | S24.6 | Verifier `app.use(authRateLimiter)` + couverture `/leagues` GET | FIX | S | [ ] | Divergence detectee entre agents backend ("non applique") et securite ("present"). Confirmer end-to-end + ajouter tests. |


### PR DESCRIPTION
## Resume

Cloture la tranche S24.3 (JWT refresh token) en branchant les helpers et le
Prisma store deja livres en S24.3a/b/c sur la surface auth vivante :

- **Server** : `/auth/register` et `/auth/login` emettent un access token 15 min
  + un refresh token 7 jours (rotatif). Nouveaux endpoints `POST /auth/refresh`
  (rotation + detection de reuse + revocation totale en cas de vol) et
  `POST /auth/logout` (revocation idempotente du jti). Les roles sont relus
  depuis Prisma a chaque refresh.
- **Frontend** : helpers `auth-storage` (token + refresh), composant
  `AuthRefreshLoop` monte dans le layout qui rafraichit silencieusement
  l'access token toutes les ~13 min. Les callsites existants qui lisent
  `localStorage("auth_token")` continuent de fonctionner sans migration.
  `login`, `register` et le logout d'`AuthBar` sont mis a jour.

Le passage du token de session 7j a un access 15min + refresh 7j reduit la
fenetre d'exposition d'un access token vole de 7 jours a 15 minutes, tout en
gardant l'experience utilisateur transparente grace a la rotation silencieuse.

## Tache roadmap

Sprint S24, tache S24.3 (JWT refresh token, rotation + blacklist)
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`

## Plan de test

- [x] `pnpm test` server : 754 tests verts (dont 13 nouveaux cas /auth/refresh + /auth/logout)
- [x] `pnpm test` web : 527 tests verts (dont 12 nouveaux cas auth-storage + auth-refresh)
- [x] `pnpm typecheck` server + web : OK
- [x] `pnpm lint` : pas de nouveau warning sur les fichiers modifies
- [ ] Manuel : login -> attendre 13 min -> verifier que `auth_token` a change en localStorage et que les requetes API ne renvoient pas 401
- [ ] Manuel : login depuis 2 onglets, declencher reuse en jouant 2 refresh successifs sur le meme refresh token -> verifier deconnexion globale
- [ ] Manuel : logout -> verifier que le jti est revoque cote serveur (toute tentative de refresh apres logout doit echouer)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDVJdCU5WALqhntg6pvY1f)_