### PR TITLE
fix(web): silence debug console.log in prod via webLog wrapper (S24.7)

### DIFF
--- a/apps/web/app/lib/log.test.ts
+++ b/apps/web/app/lib/log.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadLog() {
+  vi.resetModules();
+  return import("./log");
+}
+
+describe("webLog", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("debug() does not call console.log in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { webLog } = await loadLog();
+
+    webLog.debug("hello", { a: 1 });
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("debug() forwards to console.log in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const { webLog } = await loadLog();
+
+    webLog.debug("hello", { a: 1 });
+
+    expect(logSpy).toHaveBeenCalledWith("hello", { a: 1 });
+  });
+
+  it("debug() forwards to console.log in test", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const { webLog } = await loadLog();
+
+    webLog.debug("dbg");
+
+    expect(logSpy).toHaveBeenCalledWith("dbg");
+  });
+
+  it("warn() always forwards to console.warn", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { webLog } = await loadLog();
+
+    webLog.warn("oops", { code: 42 });
+
+    expect(warnSpy).toHaveBeenCalledWith("oops", { code: 42 });
+  });
+
+  it("error() always forwards to console.error", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { webLog } = await loadLog();
+
+    const err = new Error("boom");
+    webLog.error("fail", err);
+
+    expect(errorSpy).toHaveBeenCalledWith("fail", err);
+  });
+
+  it("debug() is a no-op when NODE_ENV is undefined and treated as production", async () => {
+    vi.stubEnv("NODE_ENV", undefined);
+    const { webLog } = await loadLog();
+
+    webLog.debug("nope");
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/log.ts
+++ b/apps/web/app/lib/log.ts
@@ -1,0 +1,19 @@
+type LogArgs = readonly unknown[];
+
+const isProduction = (): boolean => {
+  const env = typeof process !== "undefined" ? process.env?.NODE_ENV : undefined;
+  return env === undefined || env === "production";
+};
+
+export const webLog = {
+  debug(...args: LogArgs): void {
+    if (isProduction()) return;
+    console.log(...args);
+  },
+  warn(...args: LogArgs): void {
+    console.warn(...args);
+  },
+  error(...args: LogArgs): void {
+    console.error(...args);
+  },
+};

--- a/apps/web/app/local-matches/[id]/LocalMatchActions.tsx
+++ b/apps/web/app/local-matches/[id]/LocalMatchActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { API_BASE } from "../../auth-client";
+import { webLog } from "../../lib/log";
 
 type ActionType = "passe" | "reception" | "td" | "blocage" | "blitz" | "transmission" | "aggression" | "sprint" | "esquive" | "apothicaire" | "interception";
 
@@ -346,10 +347,9 @@ export default function LocalMatchActions({
     ? opponentTeam.players
     : (opponentTeam?.players === undefined ? [] : []);
 
-  // Debug: afficher un message si pas de joueurs
   useEffect(() => {
     if (currentTeamPlayers.length === 0 && teamA && teamB) {
-      console.warn("Aucun joueur trouvé pour l'équipe sélectionnée", {
+      webLog.debug("Aucun joueur trouvé pour l'équipe sélectionnée", {
         teamA: teamA.name,
         teamB: teamB.name,
         teamAPlayers: teamA.players?.length || 0,

--- a/apps/web/app/local-matches/[id]/LocalMatchSummary.tsx
+++ b/apps/web/app/local-matches/[id]/LocalMatchSummary.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import { API_BASE } from "../../auth-client";
+import { webLog } from "../../lib/log";
 
 type ActionType = "passe" | "reception" | "td" | "blocage" | "blitz" | "transmission" | "aggression" | "sprint" | "esquive" | "apothicaire" | "interception";
 
@@ -205,9 +206,8 @@ export default function LocalMatchSummary({ matchId, match }: LocalMatchSummaryP
     loadActions();
   }, [matchId]);
 
-  // Debug: vérifier les données de pré-match
   useEffect(() => {
-    console.log("LocalMatchSummary - match data:", {
+    webLog.debug("LocalMatchSummary - match data:", {
       hasGameState: !!match.gameState,
       hasPreMatch: !!match.gameState?.preMatch,
       hasFanFactor: !!match.gameState?.preMatch?.fanFactor,

--- a/apps/web/app/local-matches/[id]/page.tsx
+++ b/apps/web/app/local-matches/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { API_BASE } from "../../auth-client";
+import { webLog } from "../../lib/log";
 import LocalMatchActions from "./LocalMatchActions";
 import LocalMatchInducements from "./LocalMatchInducements";
 import LocalMatchSummary from "./LocalMatchSummary";
@@ -221,7 +222,7 @@ export default function LocalMatchPage() {
     setError(null);
     try {
       const { localMatch: data } = await fetchJSON(`/local-match/${matchId}`);
-      console.log("Match chargé:", {
+      webLog.debug("Match chargé:", {
         teamA: data?.teamA?.name,
         teamB: data?.teamB?.name || null,
         status: data?.status,

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
   type TeamId,
 } from "@bb/game-engine";
 import { API_BASE } from "../../auth-client";
+import { webLog } from "../../lib/log";
 import { useGameMoves } from "./hooks/useGameMoves";
 // useGameSocket is now called only inside useGameState to avoid duplicate connections
 import { useGameState } from "./hooks/useGameState";
@@ -540,7 +541,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       const normalizedState = normalizeState(responseData.gameState);
       setState(normalizedState);
 
-      console.log("Ballon placé:", responseData.message);
+      webLog.debug("Ballon placé:", responseData.message);
     } catch (error) {
       console.error("Erreur lors du placement du ballon:", error);
     }
@@ -576,7 +577,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       const normalizedState = normalizeState(responseData.gameState);
       setState(normalizedState);
 
-      console.log("Déviation calculée:", responseData.message);
+      webLog.debug("Déviation calculée:", responseData.message);
     } catch (error) {
       console.error("Erreur lors du calcul de déviation:", error);
     }
@@ -612,7 +613,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       const normalizedState = normalizeState(responseData.gameState);
       setState(normalizedState);
 
-      console.log("Événement résolu:", responseData.message);
+      webLog.debug("Événement résolu:", responseData.message);
     } catch (error) {
       console.error("Erreur lors de la résolution de l'événement:", error);
     }
@@ -726,7 +727,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
     const player = state.players.find(
       (p) => p.pos.x === pos.x && p.pos.y === pos.y,
     );
-    console.log("onCellClick - player found:", {
+    webLog.debug("onCellClick - player found:", {
       player: !!player,
       playerId: player?.id,
       team: player?.team,
@@ -740,7 +741,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       // En mode THROW_TEAM_MATE, ne PAS re-selectionner un coequipier : il sera traite comme cible a lancer ci-dessous
       !(currentAction === "THROW_TEAM_MATE" && player.id !== state.selectedPlayerId)
     ) {
-      console.log("Setting selectedPlayerId from onCellClick:", player.id);
+      webLog.debug("Setting selectedPlayerId from onCellClick:", player.id);
       setState((s) => (s ? { ...s, selectedPlayerId: player.id } : null));
       setCurrentAction(null);
       setThrowTeamMateThrownId(null);
@@ -1258,7 +1259,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                 onPlayerClick={(playerId) => {
                   if (!state) return;
                   const extState = state as ExtendedGameState;
-                  console.log("onPlayerClick called:", {
+                  webLog.debug("onPlayerClick called:", {
                     playerId,
                     phase: extState.preMatch?.phase,
                     currentCoach: extState.preMatch?.currentCoach,
@@ -1272,12 +1273,12 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                     ) {
                       // Permettre de sélectionner les joueurs déjà placés ou ceux en réserves
                       if (!draggedPlayerId) {
-                        console.log("Setting selectedFromReserve:", playerId);
+                        webLog.debug("Setting selectedFromReserve:", playerId);
                         setSelectedFromReserve(playerId);
                       }
                       return;
                     }
-                    console.log("Ignoring player click in setup phase");
+                    webLog.debug("Ignoring player click in setup phase");
                     return; // Ignore autres en setup
                   }
                   // Logique normale (seulement si pas en phase setup)

--- a/docs/roadmap/sprints/S24-stabilite-securite.md
+++ b/docs/roadmap/sprints/S24-stabilite-securite.md
@@ -15,7 +15,7 @@
 | S24.4 | WebSocket cleanup listeners + room leak | FIX | S | [x] | `apps/web/app/play/[id]/hooks/useGameSocket.ts:365-370`. Listeners non desabonnes apres disconnect : fuite memoire progressive sur sessions longues. |
 | S24.5 | Polling fallback 3s -> 10s + backoff exponentiel | FIX | M | [x] | `apps/web/app/play/[id]/hooks/useGameState.ts:301`. Quand WS degrade, X clients = X requetes/3s. Trop agressif a la scale beta. |
 | S24.6 | Verifier `app.use(authRateLimiter)` + couverture `/leagues` GET | FIX | S | [x] | Divergence detectee entre agents backend ("non applique") et securite ("present"). Confirmer end-to-end + ajouter tests. |
-| S24.7 | Retirer `console.log` debug en prod (web) | FIX | S | [ ] | `apps/web/app/play/[id]/page.tsx:615,729,743` + autres. 10+ logs de debug visibles dans les devtools. |
+| S24.7 | Retirer `console.log` debug en prod (web) | FIX | S | [x] | `apps/web/app/play/[id]/page.tsx:615,729,743` + autres. 10+ logs de debug visibles dans les devtools. |
 | S24.8 | Wrapper minimal pour `console.error` backend (preparation S25) | FIX | S | [ ] | 270 console.* eparpilles dans `apps/server/src/`. Wrapper temporaire `serverLog.error()` qui delegue a console mais permet swap vers pino en S25 sans toucher chaque call site. |
 | S24.9 | Docker compose dev hot-reload + 5 make targets quotidiens | CONFORT | S | [ ] | `docker-compose.yml` actuellement statique (`pnpm install && pnpm run dev`). Ajouter bind mount + nodemon/turbopack hot reload. Targets : `make logs`, `make reset-db`, `make seed`, `make tunnel`, `make snapshot-prod`. Cycle dev x5 plus rapide. |
 


### PR DESCRIPTION
## Resume

- New `apps/web/app/lib/log.ts` wrapper: `webLog.debug()` is a no-op when `NODE_ENV === 'production'` (or unset), forwards to `console.log` otherwise. `warn()` and `error()` always forward.
- Replaces the 11 hand-rolled `console.log` / `console.warn` debug calls that were leaking to prod devtools across `play/[id]/page.tsx` (8 sites), `local-matches/[id]/page.tsx`, `LocalMatchSummary.tsx` and `LocalMatchActions.tsx`.
- Legitimate `console.error` callsites (network/user-facing errors) and the `exportPDF.ts` API-fallback warning are intentionally kept untouched.
- 6 new unit tests (`app/lib/log.test.ts`) cover prod silence, dev forwarding, test forwarding, always-on warn/error, and the `undefined` NODE_ENV case.

## Tache roadmap

Sprint S24, tache S24.7 (Retirer `console.log` debug en prod web)
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`

## Plan de test

- [x] `pnpm test` (apps/web) : 534 tests verts, dont 6 nouveaux pour `webLog`
- [x] `pnpm typecheck` (apps/web) : OK (utilise `vi.stubEnv` pour respecter le typage `readonly` de `NODE_ENV`)
- [x] `pnpm build` (apps/web) : production build OK
- [ ] Manuel : ouvrir devtools en prod -> confirmer absence des dumps "Match charge", "onCellClick - player found", "onPlayerClick called", etc.
- [ ] Manuel : `pnpm dev` -> verifier que les memes traces s'affichent toujours en developpement (pour debug local)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3gznkjEZsL7xAuJBjJaAF)_