### PR TITLE
fix(server): introduce serverLog wrapper for console.* (S24.8)

### DIFF
--- a/apps/server/src/fix-admin.ts
+++ b/apps/server/src/fix-admin.ts
@@ -1,8 +1,9 @@
 import { prisma } from "./prisma";
 import bcrypt from "bcryptjs";
+import { serverLog } from "./utils/server-log";
 
 async function main() {
-  console.log("🔧 Correction du compte admin...\n");
+  serverLog.log("🔧 Correction du compte admin...\n");
 
   const adminEmail = "admin@example.com";
   const adminPassword = "admin123";
@@ -13,7 +14,7 @@ async function main() {
   });
 
   if (!existing) {
-    console.log("❌ Le compte admin n'existe pas. Création...");
+    serverLog.log("❌ Le compte admin n'existe pas. Création...");
     const passwordHash = await bcrypt.hash(adminPassword, 10);
     await prisma.user.create({
       data: {
@@ -27,12 +28,12 @@ async function main() {
         valid: true,
       },
     });
-    console.log("✅ Compte admin créé avec valid: true");
+    serverLog.log("✅ Compte admin créé avec valid: true");
   } else {
-    console.log("📝 Compte admin trouvé. Mise à jour...");
-    console.log(`   - Email: ${existing.email}`);
-    console.log(`   - Rôle: ${existing.role}`);
-    console.log(`   - Valid actuel: ${existing.valid}`);
+    serverLog.log("📝 Compte admin trouvé. Mise à jour...");
+    serverLog.log(`   - Email: ${existing.email}`);
+    serverLog.log(`   - Rôle: ${existing.role}`);
+    serverLog.log(`   - Valid actuel: ${existing.valid}`);
 
     // Mettre à jour le compte pour s'assurer qu'il est validé et a le bon rôle
     const passwordHash = await bcrypt.hash(adminPassword, 10);
@@ -45,10 +46,10 @@ async function main() {
       },
     });
 
-    console.log("✅ Compte admin mis à jour:");
-    console.log(`   - Rôle: ${updated.role}`);
-    console.log(`   - Valid: ${updated.valid}`);
-    console.log(`   - Mot de passe: ${adminPassword}`);
+    serverLog.log("✅ Compte admin mis à jour:");
+    serverLog.log(`   - Rôle: ${updated.role}`);
+    serverLog.log(`   - Valid: ${updated.valid}`);
+    serverLog.log(`   - Mot de passe: ${adminPassword}`);
   }
 
   // Vérifier aussi le compte user
@@ -59,7 +60,7 @@ async function main() {
   });
 
   if (!existingUser) {
-    console.log("\n❌ Le compte user n'existe pas. Création...");
+    serverLog.log("\n❌ Le compte user n'existe pas. Création...");
     const passwordHash = await bcrypt.hash(userPassword, 10);
     await prisma.user.create({
       data: {
@@ -73,9 +74,9 @@ async function main() {
         valid: true,
       },
     });
-    console.log("✅ Compte user créé avec valid: true");
+    serverLog.log("✅ Compte user créé avec valid: true");
   } else if (!existingUser.valid) {
-    console.log("\n📝 Compte user trouvé mais non validé. Mise à jour...");
+    serverLog.log("\n📝 Compte user trouvé mais non validé. Mise à jour...");
     const passwordHash = await bcrypt.hash(userPassword, 10);
     await prisma.user.update({
       where: { email: userEmail },
@@ -84,15 +85,15 @@ async function main() {
         passwordHash,
       },
     });
-    console.log("✅ Compte user validé");
+    serverLog.log("✅ Compte user validé");
   } else {
-    console.log("\n✅ Compte user déjà validé");
+    serverLog.log("\n✅ Compte user déjà validé");
   }
 
-  console.log("\n🎉 Correction terminée !");
-  console.log("\n📋 Identifiants:");
-  console.log(`   Admin: ${adminEmail} / ${adminPassword}`);
-  console.log(`   User:  ${userEmail} / ${userPassword}`);
+  serverLog.log("\n🎉 Correction terminée !");
+  serverLog.log("\n📋 Identifiants:");
+  serverLog.log(`   Admin: ${adminEmail} / ${adminPassword}`);
+  serverLog.log(`   User:  ${userEmail} / ${userPassword}`);
 }
 
 main()
@@ -100,7 +101,7 @@ main()
     await prisma.$disconnect();
   })
   .catch(async (e) => {
-    console.error("❌ Erreur:", e);
+    serverLog.error("❌ Erreur:", e);
     await prisma.$disconnect();
     process.exit(1);
   });

--- a/apps/server/src/game-rooms.ts
+++ b/apps/server/src/game-rooms.ts
@@ -2,6 +2,7 @@ import { Namespace, Socket } from "socket.io";
 import { prisma } from "./prisma";
 import { startForfeitTimer, cancelForfeitTimer } from "./services/forfeit-tracker";
 import { trackUserJoin, trackUserLeave, resetConnectedUsers } from "./services/connected-users";
+import { serverLog } from "./utils/server-log";
 
 /**
  * Tracks which users are connected to which match rooms.
@@ -89,7 +90,7 @@ export function registerGameRoomHandlers(gameNamespace: Namespace): void {
       trackUserJoin(matchId, socket.id, userId);
 
       const connectedCount = matchRooms.get(matchId)!.size;
-      console.log(
+      serverLog.log(
         `[game-rooms] Socket ${socket.id} joined room ${matchId} (${connectedCount} connected)`,
       );
 
@@ -141,7 +142,7 @@ function leaveRoom(socket: Socket, matchId: string): void {
       matchRooms.delete(matchId);
     }
 
-    console.log(
+    serverLog.log(
       `[game-rooms] Socket ${socket.id} left room ${matchId} (${remaining} remaining)`,
     );
 

--- a/apps/server/src/game-spectator.ts
+++ b/apps/server/src/game-spectator.ts
@@ -1,4 +1,5 @@
 import { Namespace, Socket } from "socket.io";
+import { serverLog } from "./utils/server-log";
 
 /**
  * Tracks spectator sockets per match room.
@@ -51,7 +52,7 @@ export function registerSpectatorHandlers(gameNamespace: Namespace): void {
         spectatorSockets.get(matchId)!.add(socket.id);
 
         const count = spectatorSockets.get(matchId)!.size;
-        console.log(
+        serverLog.log(
           `[game-spectator] Socket ${socket.id} spectating ${matchId} (${count} spectators)`,
         );
 
@@ -109,7 +110,7 @@ function leaveSpectate(
       spectatorSockets.delete(matchId);
     }
 
-    console.log(
+    serverLog.log(
       `[game-spectator] Socket ${socket.id} stopped spectating ${matchId} (${remaining} spectators)`,
     );
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -40,6 +40,7 @@ import { securityHeaders } from "./middleware/securityHeaders";
 import { setupSocket } from "./socket";
 import { CORS_ORIGINS } from "./config";
 import { invalidateAllMemo } from "./utils/memoize-async";
+import { serverLog } from "./utils/server-log";
 
 dotenv.config({ path: "../../prisma/.env" });
 // Si tests SQLite: pousser le schéma SQLite en mémoire partagée au démarrage
@@ -55,9 +56,9 @@ if (process.env.TEST_SQLITE === "1") {
         env: { ...process.env, TEST_DATABASE_URL: url },
       },
     );
-    console.log(`SQLite schema pushed (TEST_DATABASE_URL=${url})`);
+    serverLog.log(`SQLite schema pushed (TEST_DATABASE_URL=${url})`);
   } catch (e) {
-    console.error("Failed to push SQLite schema for tests", e);
+    serverLog.error("Failed to push SQLite schema for tests", e);
   }
 }
 
@@ -134,7 +135,7 @@ if (process.env.TEST_SQLITE === "1") {
         await fn();
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
-        console.warn(`[__test/reset] ${label}: ${msg.slice(0, 160)}`);
+        serverLog.warn(`[__test/reset] ${label}: ${msg.slice(0, 160)}`);
       }
     };
     try {
@@ -185,7 +186,7 @@ if (process.env.TEST_SQLITE === "1") {
       invalidateAllMemo();
       return res.json({ ok: true });
     } catch (e: any) {
-      console.error(e);
+      serverLog.error(e);
       return res.status(500).json({ error: e?.message || "reset failed" });
     }
   });
@@ -235,7 +236,7 @@ if (process.env.TEST_SQLITE === "1") {
 
       return res.json({ id: user.id, email: user.email, name: user.name });
     } catch (e: any) {
-      console.error(e);
+      serverLog.error(e);
       return res
         .status(500)
         .json({ error: e?.message || "seed-user failed" });
@@ -295,7 +296,7 @@ if (process.env.TEST_SQLITE === "1") {
 
       return res.json({ id: team.id, name: team.name, roster: team.roster });
     } catch (e: any) {
-      console.error(e);
+      serverLog.error(e);
       return res
         .status(500)
         .json({ error: e?.message || "seed-team failed" });
@@ -348,7 +349,7 @@ if (process.env.TEST_SQLITE === "1") {
       });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error("[__test/seed-skills]", msg);
+      serverLog.error("[__test/seed-skills]", msg);
       return res.status(500).json({ error: msg || "seed-skills failed" });
     }
   });
@@ -423,7 +424,7 @@ if (process.env.TEST_SQLITE === "1") {
       });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error("[__test/seed-rosters]", msg);
+      serverLog.error("[__test/seed-rosters]", msg);
       return res.status(500).json({ error: msg || "seed-rosters failed" });
     }
   });
@@ -433,5 +434,5 @@ const httpServer = createServer(app);
 setupSocket(httpServer);
 
 httpServer.listen(API_PORT, () => {
-  console.log(`Express API server listening on http://localhost:${API_PORT}`);
+  serverLog.log(`Express API server listening on http://localhost:${API_PORT}`);
 });

--- a/apps/server/src/list-users.ts
+++ b/apps/server/src/list-users.ts
@@ -1,10 +1,11 @@
 import { prisma } from "./prisma";
+import { serverLog } from "./utils/server-log";
 
 async function main() {
   const users = await prisma.user.findMany({
     select: { email: true, role: true, createdAt: true },
   });
-  console.log(JSON.stringify(users, null, 2));
+  serverLog.log(JSON.stringify(users, null, 2));
 }
 
 main().then(() => prisma.$disconnect());

--- a/apps/server/src/middleware/adminOnly.ts
+++ b/apps/server/src/middleware/adminOnly.ts
@@ -2,6 +2,7 @@ import { Response, NextFunction } from "express";
 import { AuthenticatedRequest } from "./authUser";
 import { prisma } from "../prisma";
 import { hasRole, normalizeRoles } from "../utils/roles";
+import { serverLog } from "../utils/server-log";
 
 export async function adminOnly(
   req: AuthenticatedRequest,
@@ -28,7 +29,7 @@ export async function adminOnly(
 
     return next();
   } catch (error) {
-    console.error("Erreur lors de la vérification du rôle admin:", error);
+    serverLog.error("Erreur lors de la vérification du rôle admin:", error);
     return res.status(500).json({ error: "Erreur serveur lors de la vérification des droits" });
   }
 }

--- a/apps/server/src/middleware/requestTiming.ts
+++ b/apps/server/src/middleware/requestTiming.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import { serverLog } from "../utils/server-log";
 
 /**
  * Logs `method path status duration_ms` for every HTTP request. Slow calls
@@ -19,13 +20,13 @@ export function requestTiming(warnThresholdMs = 500) {
         Number(process.hrtime.bigint() - startedAt) / 1_000_000;
       const line = `${req.method} ${req.originalUrl || req.url} ${res.statusCode} ${durationMs.toFixed(1)}ms`;
       if (durationMs >= warnThresholdMs) {
-        console.warn(`[slow] ${line}`);
+        serverLog.warn(`[slow] ${line}`);
         return;
       }
       if (process.env.REQUEST_LOG !== "1") return;
       const isHealth = req.path === "/health" && res.statusCode < 400;
       if (isHealth) return;
-      console.log(line);
+      serverLog.log(line);
     });
     next();
   };

--- a/apps/server/src/middleware/requireFeatureFlag.ts
+++ b/apps/server/src/middleware/requireFeatureFlag.ts
@@ -4,6 +4,7 @@ import { isEnabled } from "../services/featureFlags";
 import { JWT_SECRET } from "../config";
 import { normalizeRoles } from "../utils/roles";
 import { AuthenticatedRequest } from "./authUser";
+import { serverLog } from "../utils/server-log";
 
 /**
  * Middleware Express qui bloque la route avec un 403 lorsque le feature flag
@@ -57,7 +58,7 @@ export function requireFeatureFlag(key: string) {
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : "Erreur serveur";
-      console.error(`[requireFeatureFlag:${key}]`, message);
+      serverLog.error(`[requireFeatureFlag:${key}]`, message);
       return res.status(500).json({ error: message });
     }
   };

--- a/apps/server/src/prisma.ts
+++ b/apps/server/src/prisma.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { createRequire } from "node:module";
+import { serverLog } from "./utils/server-log";
 
 let client: any;
 if (process.env.TEST_SQLITE === "1") {
@@ -21,9 +22,9 @@ if (process.env.TEST_SQLITE === "1") {
       );
     }
     client = new SQLiteClient();
-    console.log("[prisma] Using SQLite test client");
+    serverLog.log("[prisma] Using SQLite test client");
   } catch (e) {
-    console.error(
+    serverLog.error(
       "[prisma] Impossible de charger le client SQLite de test, fallback Postgres:",
       e instanceof Error ? e.message : e,
     );

--- a/apps/server/src/routes/achievements.ts
+++ b/apps/server/src/routes/achievements.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authUser, AuthenticatedRequest } from "../middleware/authUser";
 import { getUserAchievements } from "../services/achievements";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -18,7 +19,7 @@ router.get("/", authUser, async (req: AuthenticatedRequest, res) => {
     return res.json({ success: true, data: result });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Erreur serveur";
-    console.error("[GET /achievements] error:", message);
+    serverLog.error("[GET /achievements] error:", message);
     return res.status(500).json({ success: false, error: message });
   }
 });

--- a/apps/server/src/routes/admin-data.ts
+++ b/apps/server/src/routes/admin-data.ts
@@ -28,6 +28,7 @@ import {
   createStarPlayerDataSchema,
   updateStarPlayerDataSchema,
 } from "../schemas/admin-data.schemas";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -64,7 +65,7 @@ router.get("/skills", validateQuery(adminSkillsQuerySchema), async (req, res) =>
     });
     res.json({ skills });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération des compétences:", error);
+    serverLog.error("Erreur lors de la récupération des compétences:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -87,7 +88,7 @@ router.get("/skills/:id", async (req, res) => {
     }
     res.json({ skill });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération de la compétence:", error);
+    serverLog.error("Erreur lors de la récupération de la compétence:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -106,7 +107,7 @@ router.post("/skills", validate(createSkillSchema), async (req, res) => {
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Cette compétence existe déjà pour ce ruleset" });
     }
-    console.error("Erreur lors de la création de la compétence:", error);
+    serverLog.error("Erreur lors de la création de la compétence:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -150,7 +151,7 @@ router.put("/skills/:id", validate(updateSkillSchema), async (req, res) => {
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Ce slug existe déjà pour ce ruleset" });
     }
-    console.error("Erreur lors de la mise à jour de la compétence:", error);
+    serverLog.error("Erreur lors de la mise à jour de la compétence:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -203,7 +204,7 @@ router.post("/skills/:id/duplicate", validate(duplicateToRulesetSchema), async (
       message: `Compétence dupliquée avec succès vers ${newRuleset}`,
     });
   } catch (error: any) {
-    console.error("Erreur lors de la duplication de la compétence:", error);
+    serverLog.error("Erreur lors de la duplication de la compétence:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -218,7 +219,7 @@ router.delete("/skills/:id", async (req, res) => {
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Compétence non trouvée" });
     }
-    console.error("Erreur lors de la suppression de la compétence:", error);
+    serverLog.error("Erreur lors de la suppression de la compétence:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -270,7 +271,7 @@ router.get("/rosters", validateQuery(adminRostersQuerySchema), async (req, res) 
     }));
     res.json({ rosters: rostersWithParsedRules });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération des rosters:", error);
+    serverLog.error("Erreur lors de la récupération des rosters:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -314,7 +315,7 @@ router.get("/rosters/:id", async (req, res) => {
     };
     res.json({ roster: rosterWithParsedRules });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération du roster:", error);
+    serverLog.error("Erreur lors de la récupération du roster:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -358,7 +359,7 @@ router.post("/rosters", validate(createRosterSchema), async (req, res) => {
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Ce roster existe déjà pour ce ruleset" });
     }
-    console.error("Erreur lors de la création du roster:", error);
+    serverLog.error("Erreur lors de la création du roster:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -407,7 +408,7 @@ router.put("/rosters/:id", validate(updateRosterSchema), async (req, res) => {
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Slug déjà utilisé pour ce ruleset" });
     }
-    console.error("Erreur lors de la mise à jour du roster:", error);
+    serverLog.error("Erreur lors de la mise à jour du roster:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -500,7 +501,7 @@ router.post("/rosters/:id/duplicate", validate(duplicateToRulesetSchema), async 
       message: `Roster dupliqué avec succès vers ${newRuleset}`,
     });
   } catch (error: any) {
-    console.error("Erreur lors de la duplication du roster:", error);
+    serverLog.error("Erreur lors de la duplication du roster:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -515,7 +516,7 @@ router.delete("/rosters/:id", async (req, res) => {
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Roster non trouvé" });
     }
-    console.error("Erreur lors de la suppression du roster:", error);
+    serverLog.error("Erreur lors de la suppression du roster:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -559,7 +560,7 @@ router.get("/positions", validateQuery(adminPositionsQuerySchema), async (req, r
     });
     res.json({ positions });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération des positions:", error);
+    serverLog.error("Erreur lors de la récupération des positions:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -588,7 +589,7 @@ router.get("/positions/:id", async (req, res) => {
     }
     res.json({ position });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération de la position:", error);
+    serverLog.error("Erreur lors de la récupération de la position:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -630,7 +631,7 @@ router.post("/positions", validate(createPositionSchema), async (req, res) => {
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Cette position existe déjà pour ce roster" });
     }
-    console.error("Erreur lors de la création de la position:", error);
+    serverLog.error("Erreur lors de la création de la position:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -677,7 +678,7 @@ router.put("/positions/:id", validate(updatePositionSchema), async (req, res) =>
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Position non trouvée" });
     }
-    console.error("Erreur lors de la mise à jour de la position:", error);
+    serverLog.error("Erreur lors de la mise à jour de la position:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -752,7 +753,7 @@ router.post("/positions/:id/duplicate", validate(duplicatePositionSchema), async
       message: `Position dupliquée avec succès vers le roster ${targetRoster.name}`,
     });
   } catch (error: any) {
-    console.error("Erreur lors de la duplication de la position:", error);
+    serverLog.error("Erreur lors de la duplication de la position:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -767,7 +768,7 @@ router.delete("/positions/:id", async (req, res) => {
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Position non trouvée" });
     }
-    console.error("Erreur lors de la suppression de la position:", error);
+    serverLog.error("Erreur lors de la suppression de la position:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -802,7 +803,7 @@ router.get("/star-players", validateQuery(adminStarPlayersQuerySchema), async (r
     });
     res.json({ starPlayers });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération des Star Players:", error);
+    serverLog.error("Erreur lors de la récupération des Star Players:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -825,7 +826,7 @@ router.get("/star-players/:id", async (req, res) => {
     }
     res.json({ starPlayer });
   } catch (error: any) {
-    console.error("Erreur lors de la récupération du Star Player:", error);
+    serverLog.error("Erreur lors de la récupération du Star Player:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -876,7 +877,7 @@ router.post("/star-players", validate(createStarPlayerDataSchema), async (req, r
     if (error.code === "P2002") {
       return res.status(409).json({ error: "Ce Star Player existe déjà" });
     }
-    console.error("Erreur lors de la création du Star Player:", error);
+    serverLog.error("Erreur lors de la création du Star Player:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -936,7 +937,7 @@ router.put("/star-players/:id", validate(updateStarPlayerDataSchema), async (req
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Star Player non trouvé" });
     }
-    console.error("Erreur lors de la mise à jour du Star Player:", error);
+    serverLog.error("Erreur lors de la mise à jour du Star Player:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });
@@ -951,7 +952,7 @@ router.delete("/star-players/:id", async (req, res) => {
     if (error.code === "P2025") {
       return res.status(404).json({ error: "Star Player non trouvé" });
     }
-    console.error("Erreur lors de la suppression du Star Player:", error);
+    serverLog.error("Erreur lors de la suppression du Star Player:", error);
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
 });

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -13,6 +13,7 @@ import {
   updateUserValidSchema,
   updateMatchStatusSchema,
 } from "../schemas/admin.schemas";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -100,7 +101,7 @@ router.get("/users", validateQuery(adminUsersQuerySchema), async (req, res) => {
       },
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la récupération des utilisateurs" });
   }
 });
@@ -172,7 +173,7 @@ router.get("/users/:id", async (req, res) => {
 
     res.json({ user: userWithRoles });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la récupération de l'utilisateur" });
   }
 });
@@ -229,7 +230,7 @@ router.patch("/users/:id/role", validate(updateUserRoleSchema), async (req, res)
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Utilisateur non trouvé" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la modification du rôle" });
   }
 });
@@ -251,7 +252,7 @@ router.patch("/users/:id/patreon", validate(updateUserPatreonSchema), async (req
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Utilisateur non trouvé" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la modification du statut Patreon" });
   }
 });
@@ -273,7 +274,7 @@ router.patch("/users/:id/valid", validate(updateUserValidSchema), async (req, re
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Utilisateur non trouvé" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la modification du statut de validation" });
   }
 });
@@ -297,7 +298,7 @@ router.delete("/users/:id", async (req, res) => {
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Utilisateur non trouvé" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la suppression de l'utilisateur" });
   }
 });
@@ -400,7 +401,7 @@ router.get("/matches", validateQuery(adminMatchesQuerySchema), async (req, res) 
       },
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des parties:", e);
+    serverLog.error("Erreur lors de la récupération des parties:", e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -447,7 +448,7 @@ router.get("/matches/:id", async (req, res) => {
 
     res.json({ match });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la récupération de la partie" });
   }
 });
@@ -469,7 +470,7 @@ router.patch("/matches/:id/status", validate(updateMatchStatusSchema), async (re
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Partie non trouvée" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la modification du statut" });
   }
 });
@@ -502,7 +503,7 @@ router.delete("/matches/:id", async (req, res) => {
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Partie non trouvée" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la suppression de la partie" });
   }
 });
@@ -517,7 +518,7 @@ router.post("/matches/purge", async (_req, res) => {
     await prisma.match.deleteMany({});
     res.json({ ok: true });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la purge des parties" });
   }
 });
@@ -536,7 +537,7 @@ router.post("/test/reset", async (_req, res) => {
     await prisma.user.deleteMany({});
     res.json({ ok: true });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur reset tests" });
   }
 });
@@ -628,7 +629,7 @@ router.get("/stats", async (_req, res) => {
       time: new Date().toISOString(),
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des statistiques:", e);
+    serverLog.error("Erreur lors de la récupération des statistiques:", e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -723,7 +724,7 @@ router.get("/teams", validateQuery(adminTeamsQuerySchema), async (req, res) => {
       },
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la récupération des équipes" });
   }
 });
@@ -756,7 +757,7 @@ router.get("/teams/:id", async (req, res) => {
 
     res.json({ team });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la récupération de l'équipe" });
   }
 });
@@ -801,7 +802,7 @@ router.delete("/teams/:id", async (req, res) => {
     if (e.code === "P2025") {
       return res.status(404).json({ error: "Équipe non trouvée" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur lors de la suppression de l'équipe" });
   }
 });

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -17,6 +17,7 @@ import {
   ensureKofiLinkCode,
 } from "../services/kofi-claim";
 import { isSupporter } from "../services/kofi";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -59,7 +60,7 @@ router.post("/register", validate(registerSchema), async (req, res) => {
       await ensureKofiLinkCode(created.id);
       await claimOrphanKofiTransactions(created.id, created.email);
     } catch (kofiErr) {
-      console.error("[register] kofi post-create hooks failed:", kofiErr);
+      serverLog.error("[register] kofi post-create hooks failed:", kofiErr);
     }
 
     const roles = normalizeRoles((created as any).roles ?? created.role);
@@ -88,7 +89,7 @@ router.post("/register", validate(registerSchema), async (req, res) => {
     if (err?.code === "P2002") {
       return res.status(409).json({ error: "Email déjà utilisé" });
     }
-    console.error(err);
+    serverLog.error(err);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -99,11 +100,11 @@ router.post("/login", validate(loginSchema), async (req, res) => {
 
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
-      console.log(`[LOGIN] Utilisateur non trouvé: ${email}`);
+      serverLog.log(`[LOGIN] Utilisateur non trouvé: ${email}`);
       return res.status(401).json({ error: "Identifiants invalides" });
     }
 
-    console.log(
+    serverLog.log(
       `[LOGIN] Tentative de connexion pour ${email}: valid=${user.valid}, role=${user.role}`,
     );
     
@@ -111,17 +112,17 @@ router.post("/login", validate(loginSchema), async (req, res) => {
     // Sur les autres schémas (ex: SQLite de test), il est undefined et le
     // compte doit être traité comme valide.
     if (user.valid === false) {
-      console.log(`[LOGIN] Compte non validé pour ${email}`);
+      serverLog.log(`[LOGIN] Compte non validé pour ${email}`);
       return res.status(403).json({ error: "Votre compte n'est pas encore validé. Veuillez contacter un administrateur." });
     }
 
     const ok = await bcrypt.compare(password, user.passwordHash);
     if (!ok) {
-      console.log(`[LOGIN] Mot de passe incorrect pour ${email}`);
+      serverLog.log(`[LOGIN] Mot de passe incorrect pour ${email}`);
       return res.status(401).json({ error: "Identifiants invalides" });
     }
 
-    console.log(`[LOGIN] Connexion réussie pour ${email}`);
+    serverLog.log(`[LOGIN] Connexion réussie pour ${email}`);
 
     // Rattrape les dons orphelins reçus avant l'inscription et garantit que
     // le compte a un kofiLinkCode. Jamais bloquant sur le login.
@@ -129,7 +130,7 @@ router.post("/login", validate(loginSchema), async (req, res) => {
       await ensureKofiLinkCode(user.id);
       await claimOrphanKofiTransactions(user.id, user.email);
     } catch (kofiErr) {
-      console.error("[login] kofi post-login hooks failed:", kofiErr);
+      serverLog.error("[login] kofi post-login hooks failed:", kofiErr);
     }
 
     const roles = normalizeRoles((user as any).roles ?? user.role);
@@ -156,7 +157,7 @@ router.post("/login", validate(loginSchema), async (req, res) => {
     );
     return res.json({ user: publicUser, token });
   } catch (err) {
-    console.error(err);
+    serverLog.error(err);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -184,7 +185,7 @@ router.delete("/me", authUser, async (req: AuthenticatedRequest, res) => {
         "Votre compte a été désactivé avec succès. Vous ne pourrez plus vous connecter avec cet accès.",
     });
   } catch (err) {
-    console.error(err);
+    serverLog.error(err);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -240,7 +241,7 @@ router.get("/me", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ user: publicUser });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -308,7 +309,7 @@ router.put("/me", authUser, validate(updateProfileSchema), async (req: Authentic
       }
       return res.status(409).json({ error: "Email déjà utilisé" });
     }
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -354,7 +355,7 @@ router.put("/me/password", authUser, validate(changePasswordSchema), async (req:
     
     res.json({ message: "Mot de passe modifié avec succès" });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });

--- a/apps/server/src/routes/career-stats.ts
+++ b/apps/server/src/routes/career-stats.ts
@@ -8,6 +8,7 @@ import {
   type TeamMatchRecord,
   type TeamPlayerForStats,
 } from "../services/career-stats";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -171,7 +172,7 @@ router.get(
         players,
       });
     } catch (e: any) {
-      console.error("Erreur lors du calcul des stats de carriere:", e);
+      serverLog.error("Erreur lors du calcul des stats de carriere:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   },

--- a/apps/server/src/routes/cup.ts
+++ b/apps/server/src/routes/cup.ts
@@ -15,6 +15,7 @@ import {
   unregisterCupSchema,
   updateCupStatusSchema,
 } from "../schemas/cup.schemas";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -136,7 +137,7 @@ router.get("/", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ cups: formattedCups });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des coupes:", e);
+    serverLog.error("Erreur lors de la récupération des coupes:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -221,7 +222,7 @@ router.get("/archived", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ cups: formattedCups });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des coupes archivées:", e);
+    serverLog.error("Erreur lors de la récupération des coupes archivées:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -412,7 +413,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ cup: formattedCup });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération de la coupe:", e);
+    serverLog.error("Erreur lors de la récupération de la coupe:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -556,7 +557,7 @@ router.post("/", authUser, validate(createCupSchema), async (req: AuthenticatedR
 
     res.status(201).json({ cup: formattedCup });
   } catch (e: any) {
-    console.error("Erreur lors de la création de la coupe:", e);
+    serverLog.error("Erreur lors de la création de la coupe:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -679,7 +680,7 @@ router.post(
         message: "Équipe inscrite avec succès",
       });
     } catch (e: any) {
-      console.error("Erreur lors de l'inscription à la coupe:", e);
+      serverLog.error("Erreur lors de l'inscription à la coupe:", e);
       if (e?.code === "P2002") {
         return res
           .status(409)
@@ -799,7 +800,7 @@ router.post(
         message: "Équipe retirée avec succès",
       });
     } catch (e: any) {
-      console.error("Erreur lors du retrait de l'équipe:", e);
+      serverLog.error("Erreur lors du retrait de l'équipe:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   },
@@ -894,7 +895,7 @@ router.post(
         message: "Coupe validée avec succès",
       });
     } catch (e: any) {
-      console.error("Erreur lors de la validation de la coupe:", e);
+      serverLog.error("Erreur lors de la validation de la coupe:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   },
@@ -1006,7 +1007,7 @@ router.post(
         message: "Statut mis à jour avec succès",
       });
     } catch (e: any) {
-      console.error("Erreur lors de la mise à jour du statut:", e);
+      serverLog.error("Erreur lors de la mise à jour du statut:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   },

--- a/apps/server/src/routes/feature-flags.ts
+++ b/apps/server/src/routes/feature-flags.ts
@@ -20,6 +20,7 @@ import {
   removeUserOverride,
 } from "../services/featureFlags";
 import { sendSuccess, sendError } from "../utils/api-response";
+import { serverLog } from "../utils/server-log";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Erreur serveur";
@@ -43,7 +44,7 @@ userFeatureFlagsRouter.get("/me", async (req: AuthenticatedRequest, res) => {
     });
     return sendSuccess(res, keys);
   } catch (error: unknown) {
-    console.error("[featureFlags] /me error:", error);
+    serverLog.error("[featureFlags] /me error:", error);
     return sendError(res, errorMessage(error));
   }
 });
@@ -61,7 +62,7 @@ adminFeatureFlagsRouter.get("/", async (_req, res) => {
     const flags = await listAll();
     return sendSuccess(res, flags);
   } catch (error: unknown) {
-    console.error("[featureFlags] GET / error:", error);
+    serverLog.error("[featureFlags] GET / error:", error);
     return sendError(res, errorMessage(error));
   }
 });
@@ -83,7 +84,7 @@ adminFeatureFlagsRouter.post(
       const flag = await createFlag({ key, description, enabled });
       return sendSuccess(res, flag, 201);
     } catch (error: unknown) {
-      console.error("[featureFlags] POST / error:", error);
+      serverLog.error("[featureFlags] POST / error:", error);
       return sendError(res, errorMessage(error));
     }
   },
@@ -101,7 +102,7 @@ adminFeatureFlagsRouter.patch(
       const flag = await updateFlag(req.params.id, req.body);
       return sendSuccess(res, flag);
     } catch (error: unknown) {
-      console.error("[featureFlags] PATCH /:id error:", error);
+      serverLog.error("[featureFlags] PATCH /:id error:", error);
       return sendError(res, errorMessage(error));
     }
   },
@@ -116,7 +117,7 @@ adminFeatureFlagsRouter.delete("/:id", async (req, res) => {
     await deleteFlag(req.params.id);
     return sendSuccess(res, { id: req.params.id });
   } catch (error: unknown) {
-    console.error("[featureFlags] DELETE /:id error:", error);
+    serverLog.error("[featureFlags] DELETE /:id error:", error);
     return sendError(res, errorMessage(error));
   }
 });
@@ -130,7 +131,7 @@ adminFeatureFlagsRouter.get("/:id/users", async (req, res) => {
     const users = await listUsersForFlag(req.params.id);
     return sendSuccess(res, users);
   } catch (error: unknown) {
-    console.error("[featureFlags] GET /:id/users error:", error);
+    serverLog.error("[featureFlags] GET /:id/users error:", error);
     return sendError(res, errorMessage(error));
   }
 });
@@ -152,7 +153,7 @@ adminFeatureFlagsRouter.post(
       await addUserOverride(req.params.id, userId);
       return sendSuccess(res, { userId }, 201);
     } catch (error: unknown) {
-      console.error("[featureFlags] POST /:id/users error:", error);
+      serverLog.error("[featureFlags] POST /:id/users error:", error);
       return sendError(res, errorMessage(error));
     }
   },
@@ -167,7 +168,7 @@ adminFeatureFlagsRouter.delete("/:id/users/:userId", async (req, res) => {
     await removeUserOverride(req.params.id, req.params.userId);
     return sendSuccess(res, { userId: req.params.userId });
   } catch (error: unknown) {
-    console.error("[featureFlags] DELETE /:id/users/:userId error:", error);
+    serverLog.error("[featureFlags] DELETE /:id/users/:userId error:", error);
     return sendError(res, errorMessage(error));
   }
 });

--- a/apps/server/src/routes/kofi.ts
+++ b/apps/server/src/routes/kofi.ts
@@ -13,6 +13,7 @@ import {
   matchKofiPayloadToUser,
   normaliseEmail,
 } from "../services/kofi";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -194,7 +195,7 @@ export async function handleKofiWebhook(
       matchedVia: match?.matchedVia ?? null,
     });
   } catch (err) {
-    console.error("[kofi-webhook] error processing payload:", err);
+    serverLog.error("[kofi-webhook] error processing payload:", err);
     // On retourne 500 pour que Ko-fi retente la livraison.
     return res.status(500).json({ error: "Server error" });
   }

--- a/apps/server/src/routes/local-match.ts
+++ b/apps/server/src/routes/local-match.ts
@@ -44,6 +44,7 @@ import {
   validateShareTokenSchema,
   localMatchInducementsSchema,
 } from "../schemas/local-match.schemas";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -183,7 +184,7 @@ router.get("/", authUser, validateQuery(localMatchListQuerySchema), async (req: 
 
     res.json({ localMatches, meta: buildApiMeta({ total, limit, offset }) });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des parties offline:", e);
+    serverLog.error("Erreur lors de la récupération des parties offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -254,7 +255,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
     
     res.json({ localMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération de la partie offline:", e);
+    serverLog.error("Erreur lors de la récupération de la partie offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -421,7 +422,7 @@ router.post("/", authUser, validate(createLocalMatchSchema), async (req: Authent
     
     res.status(201).json({ localMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la création de la partie offline:", e);
+    serverLog.error("Erreur lors de la création de la partie offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -665,7 +666,7 @@ router.post("/:id/start", authUser, async (req: AuthenticatedRequest, res) => {
       gameState,
     });
   } catch (e: any) {
-    console.error("Erreur lors du démarrage de la partie offline:", e);
+    serverLog.error("Erreur lors du démarrage de la partie offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -803,7 +804,7 @@ router.post("/:id/inducements", authUser, validate(localMatchInducementsSchema),
       pettyCash: calculatePettyCash(pettyCashInput),
     });
   } catch (e: any) {
-    console.error("Erreur lors du traitement des inducements:", e);
+    serverLog.error("Erreur lors du traitement des inducements:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -871,7 +872,7 @@ router.get("/:id/inducements-info", authUser, async (req: AuthenticatedRequest, 
       },
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des infos d'inducements:", e);
+    serverLog.error("Erreur lors de la récupération des infos d'inducements:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -929,7 +930,7 @@ router.put("/:id/state", authUser, validate(updateLocalMatchStateSchema), async 
     
     res.json({ localMatch: updatedMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la sauvegarde de l'état:", e);
+    serverLog.error("Erreur lors de la sauvegarde de l'état:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1017,7 +1018,7 @@ router.post("/:id/complete", authUser, validate(completeLocalMatchSchema), async
           );
         }
       } catch (sppError) {
-        console.error("Erreur lors de la persistence des SPP:", sppError);
+        serverLog.error("Erreur lors de la persistence des SPP:", sppError);
         // Non-blocking: match completion succeeds even if SPP persistence fails
       }
 
@@ -1032,7 +1033,7 @@ router.post("/:id/complete", authUser, validate(completeLocalMatchSchema), async
           );
         }
       } catch (deathError) {
-        console.error("Erreur lors de la persistence des morts:", deathError);
+        serverLog.error("Erreur lors de la persistence des morts:", deathError);
         // Non-blocking: match completion succeeds even if death persistence fails
       }
 
@@ -1047,14 +1048,14 @@ router.post("/:id/complete", authUser, validate(completeLocalMatchSchema), async
           );
         }
       } catch (injuryError) {
-        console.error("Erreur lors de la persistence des blessures permanentes:", injuryError);
+        serverLog.error("Erreur lors de la persistence des blessures permanentes:", injuryError);
         // Non-blocking: match completion succeeds even if injury persistence fails
       }
     }
 
     res.json({ localMatch: updatedMatch, sppUpdatedCount, deathsPersistedCount, injuriesPersistedCount });
   } catch (e: any) {
-    console.error("Erreur lors de la finalisation de la partie offline:", e);
+    serverLog.error("Erreur lors de la finalisation de la partie offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1149,7 +1150,7 @@ router.patch("/:id/status", authUser, validate(updateLocalMatchStatusSchema), as
     
     res.json({ localMatch: updatedMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la modification du statut:", e);
+    serverLog.error("Erreur lors de la modification du statut:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1178,7 +1179,7 @@ router.delete("/:id", authUser, async (req: AuthenticatedRequest, res) => {
     
     res.json({ message: "Partie offline supprimée avec succès" });
   } catch (e: any) {
-    console.error("Erreur lors de la suppression de la partie offline:", e);
+    serverLog.error("Erreur lors de la suppression de la partie offline:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1236,7 +1237,7 @@ router.get("/:id/actions", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ actions, meta: buildApiMeta({ total, limit, offset }) });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des actions:", e);
+    serverLog.error("Erreur lors de la récupération des actions:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1314,7 +1315,7 @@ router.post("/:id/actions", authUser, validate(createLocalMatchActionSchema), as
     
     res.json({ action });
   } catch (e: any) {
-    console.error("Erreur lors de la création de l'action:", e);
+    serverLog.error("Erreur lors de la création de l'action:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1362,7 +1363,7 @@ router.delete("/:id/actions/:actionId", authUser, async (req: AuthenticatedReque
     
     res.json({ message: "Action supprimée avec succès" });
   } catch (e: any) {
-    console.error("Erreur lors de la suppression de l'action:", e);
+    serverLog.error("Erreur lors de la suppression de l'action:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1428,7 +1429,7 @@ router.get("/share/:token", async (req, res) => {
     
     res.json({ localMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération du match via le token:", e);
+    serverLog.error("Erreur lors de la récupération du match via le token:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1615,7 +1616,7 @@ router.post("/share/:token/validate", authUser, validate(validateShareTokenSchem
     
     res.json({ localMatch: updatedMatch });
   } catch (e: any) {
-    console.error("Erreur lors de la validation de la participation:", e);
+    serverLog.error("Erreur lors de la validation de la participation:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });

--- a/apps/server/src/routes/match.ts
+++ b/apps/server/src/routes/match.ts
@@ -24,6 +24,7 @@ import { runAIKickoffIfNeeded } from "../services/ai-kickoff";
 import type { AIDifficulty } from "@bb/game-engine";
 import { getSpectatorCount } from "../game-spectator";
 import { MATCH_SECRET } from "../config";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 const ALLOWED_TEAMS = ["skaven", "lizardmen"] as const;
@@ -66,7 +67,7 @@ router.post("/create", authUser, validate(createMatchSchema), async (req: Authen
     );
     return res.status(201).json({ match, matchToken: token });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: e?.message || "Erreur serveur" });
   }
 });
@@ -87,7 +88,7 @@ router.post("/join", authUser, validate(joinMatchSchema), async (req: Authentica
     );
     return res.json({ match, matchToken: token });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: e?.message || "Erreur serveur" });
   }
 });
@@ -104,7 +105,7 @@ router.post("/accept", authUser, validate(acceptMatchSchema), async (req: Authen
       return res.status(result.status).json({ error: result.error });
     return res.json(result);
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: e?.message || "Erreur serveur" });
   }
 });
@@ -166,7 +167,7 @@ router.post(
               ? 400
               : 500;
       if (status >= 500) {
-        console.error("Erreur creation match pratique online:", e);
+        serverLog.error("Erreur creation match pratique online:", e);
       }
       return res.status(status).json({ error: message });
     }
@@ -199,7 +200,7 @@ router.post(
 
       return res.json(result);
     } catch (e: any) {
-      console.error("Erreur lors de l'application du coup:", e);
+      serverLog.error("Erreur lors de l'application du coup:", e);
       return res.status(500).json({ error: e?.message || "Erreur serveur" });
     }
   },
@@ -280,7 +281,7 @@ router.get("/details", async (req, res) => {
       },
     });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -336,7 +337,7 @@ router.get("/:id/details", authUser, async (req: AuthenticatedRequest, res) => {
       visitor: { teamName: teamName(visitor), coachName: coachName(visitor), eloRating: eloRating(visitor) },
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -383,7 +384,7 @@ router.get("/:id/teams", authUser, async (req: AuthenticatedRequest, res) => {
 
     return res.json({ teamA, teamB });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -467,7 +468,7 @@ router.get("/my-matches", authUser, async (req: AuthenticatedRequest, res) => {
 
     return res.json({ matches: result });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -555,7 +556,7 @@ router.get("/:id/summary", authUser, async (req: AuthenticatedRequest, res) => {
       acceptances: { local: localAccepted, visitor: visitorAccepted },
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -652,7 +653,7 @@ router.get("/:id/state", authUser, async (req: AuthenticatedRequest, res) => {
         : null;
 
       if (!teamA || !teamB) {
-        console.log("Teams not found:", s1.teamId, s2.teamId);
+        serverLog.log("Teams not found:", s1.teamId, s2.teamId);
         return res.status(400).json({ error: "Équipes non trouvées" });
       }
 
@@ -685,7 +686,7 @@ router.get("/:id/state", authUser, async (req: AuthenticatedRequest, res) => {
           skills: p.skills || "",
         }));
 
-      console.log(
+      serverLog.log(
         "Players loaded for prematch:",
         teamAData.length,
         teamBData.length,
@@ -756,7 +757,7 @@ router.get("/:id/state", authUser, async (req: AuthenticatedRequest, res) => {
 
     res.json({ gameState });
   } catch (e: any) {
-    console.error(e);
+    serverLog.error(e);
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -967,7 +968,7 @@ router.post(
         myTeamSide: userTeamSide,
       });
     } catch (e: any) {
-      console.error("Erreur lors de la validation du setup:", e);
+      serverLog.error("Erreur lors de la validation du setup:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   },
@@ -1044,7 +1045,7 @@ router.post(
         message: "Ballon placé pour le kickoff",
       });
     } catch (e: any) {
-      console.error("Erreur lors du placement du ballon:", e);
+      serverLog.error("Erreur lors du placement du ballon:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   }
@@ -1111,7 +1112,7 @@ router.post(
         message: "Déviation du kickoff calculée",
       });
     } catch (e: any) {
-      console.error("Erreur lors du calcul de déviation:", e);
+      serverLog.error("Erreur lors du calcul de déviation:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   }
@@ -1215,7 +1216,7 @@ router.post(
         message: "Événement de kickoff résolu - Le match commence !",
       });
     } catch (e: any) {
-      console.error("Erreur lors de la résolution de l'événement:", e);
+      serverLog.error("Erreur lors de la résolution de l'événement:", e);
       return res.status(500).json({ error: "Erreur serveur" });
     }
   }
@@ -1273,7 +1274,7 @@ router.get("/:id/turns", authUser, async (req: AuthenticatedRequest, res) => {
 
     return res.json({ matchId, turns: turnSummaries });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des turns:", e);
+    serverLog.error("Erreur lors de la récupération des turns:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1385,7 +1386,7 @@ router.get("/:id/results", authUser, async (req: AuthenticatedRequest, res) => {
       })),
     });
   } catch (e) {
-    console.error("Erreur lors de la récupération des résultats:", e);
+    serverLog.error("Erreur lors de la récupération des résultats:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1458,7 +1459,7 @@ router.get("/live", authUser, async (_req: AuthenticatedRequest, res) => {
 
     return res.json({ matches: result });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1527,7 +1528,7 @@ router.get("/:id/spectate", authUser, async (req: AuthenticatedRequest, res) => 
         : null,
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1599,7 +1600,7 @@ router.get("/:id/replay", authUser, async (req: AuthenticatedRequest, res) => {
       createdAt: match.createdAt,
     });
   } catch (e) {
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });

--- a/apps/server/src/routes/public-positions.ts
+++ b/apps/server/src/routes/public-positions.ts
@@ -7,6 +7,7 @@ import { Router } from "express";
 import { prisma } from "../prisma";
 import { resolveRuleset, DEFAULT_RULESET } from "../utils/ruleset-helpers";
 import { memoizeAsync } from "../utils/memoize-async";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -107,7 +108,7 @@ router.get("/positions", async (req, res) => {
     );
     res.json(payload);
   } catch (error: any) {
-    console.error("Erreur lors de la récupération des positions:", error);
+    serverLog.error("Erreur lors de la récupération des positions:", error);
     res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }
@@ -135,7 +136,7 @@ router.get("/positions/:slug", async (req, res) => {
     }
     res.json(payload);
   } catch (error: any) {
-    console.error("Erreur lors de la récupération de la position:", error);
+    serverLog.error("Erreur lors de la récupération de la position:", error);
     res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: error.message || "Erreur serveur" });
   }

--- a/apps/server/src/routes/public-rosters.ts
+++ b/apps/server/src/routes/public-rosters.ts
@@ -11,6 +11,7 @@ import {
   RULESETS,
 } from "../utils/ruleset-helpers";
 import { memoizeAsync } from "../utils/memoize-async";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -78,7 +79,7 @@ async function loadRosterList(
   });
 
   if (rosters.length === 0) {
-    console.warn(
+    serverLog.warn(
       `[public-rosters] No rosters found for ruleset=${ruleset}. ` +
         "The database may need a seed for this ruleset.",
     );
@@ -159,7 +160,7 @@ router.get("/rosters", async (req, res) => {
     res.json(payload);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Erreur serveur";
-    console.error("Erreur lors de la récupération des rosters:", error);
+    serverLog.error("Erreur lors de la récupération des rosters:", error);
     res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: message });
   }
@@ -188,7 +189,7 @@ router.get("/rosters/:slug", async (req, res) => {
     res.json(payload);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Erreur serveur";
-    console.error("Erreur lors de la récupération du roster:", error);
+    serverLog.error("Erreur lors de la récupération du roster:", error);
     res.setHeader("Cache-Control", "no-store");
     res.status(500).json({ error: message });
   }

--- a/apps/server/src/routes/public-skills.ts
+++ b/apps/server/src/routes/public-skills.ts
@@ -7,6 +7,7 @@ import { Router } from "express";
 import { prisma } from "../prisma";
 import { resolveRuleset } from "../utils/ruleset-helpers";
 import { memoizeAsync } from "../utils/memoize-async";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -91,7 +92,7 @@ router.get("/skills", async (req, res) => {
     );
     res.json(payload);
   } catch (error: any) {
-    console.error(
+    serverLog.error(
       "Erreur lors de la récupération des compétences publiques:",
       error,
     );

--- a/apps/server/src/routes/star-players.ts
+++ b/apps/server/src/routes/star-players.ts
@@ -7,6 +7,7 @@ import {
   type StarPlayerDefinition,
 } from "@bb/game-engine";
 import { resolveRuleset, DEFAULT_RULESET } from "../utils/ruleset-helpers";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 
@@ -53,7 +54,7 @@ router.get("/", async (req, res) => {
       data: transformedStarPlayers
     });
   } catch (error) {
-    console.error("Error fetching star players:", error);
+    serverLog.error("Error fetching star players:", error);
     res.status(500).json({
       success: false,
       error: "Failed to fetch star players"
@@ -109,7 +110,7 @@ router.get("/:slug", async (req, res) => {
       data: transformedStarPlayer
     });
   } catch (error) {
-    console.error("Error fetching star player:", error);
+    serverLog.error("Error fetching star player:", error);
     res.status(500).json({
       success: false,
       error: "Failed to fetch star player"
@@ -205,7 +206,7 @@ router.get("/available/:roster", async (req, res) => {
       starPlayers: transformedStarPlayers
     });
   } catch (error) {
-    console.error("Error fetching available star players:", error);
+    serverLog.error("Error fetching available star players:", error);
     res.status(500).json({
       success: false,
       error: "Failed to fetch available star players"
@@ -236,7 +237,7 @@ router.get("/regional-rules/:roster", (req, res) => {
       regionalRules
     });
   } catch (error) {
-    console.error("Error fetching regional rules:", error);
+    serverLog.error("Error fetching regional rules:", error);
     res.status(500).json({
       success: false,
       error: "Failed to fetch regional rules"
@@ -323,7 +324,7 @@ router.get("/search", async (req, res) => {
       data: transformedStarPlayers
     });
   } catch (error) {
-    console.error("Error searching star players:", error);
+    serverLog.error("Error searching star players:", error);
     res.status(500).json({
       success: false,
       error: "Failed to search star players"

--- a/apps/server/src/routes/team.ts
+++ b/apps/server/src/routes/team.ts
@@ -44,6 +44,7 @@ import {
   addStarPlayerToTeamSchema,
 } from "../schemas/team.schemas";
 import { chooseTeamSchema } from "../schemas/match.schemas";
+import { serverLog } from "../utils/server-log";
 
 const router = Router();
 const ALLOWED_TEAMS = [
@@ -339,7 +340,7 @@ router.post("/choose", authUser, validate(chooseTeamSchema), async (req: Authent
             ? "Vous avez déjà choisi une équipe pour ce match"
             : "Conflit d'unicité pour ce match",
         });
-    console.error(e);
+    serverLog.error(e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -919,7 +920,7 @@ router.put("/:id/info", authUser, validate(updateTeamInfoSchema), async (req: Au
 
     res.json({ team: finalTeam });
   } catch (e: any) {
-    console.error("Erreur lors de la modification des informations d'équipe:", e);
+    serverLog.error("Erreur lors de la modification des informations d'équipe:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -952,7 +953,7 @@ router.post("/:id/recalculate", authUser, async (req: AuthenticatedRequest, res)
       message: `Valeurs recalculées: VE=${teamValue.toLocaleString()} po, VEA=${currentValue.toLocaleString()} po`
     });
   } catch (e: any) {
-    console.error("Erreur lors du recalcul des valeurs d'équipe:", e);
+    serverLog.error("Erreur lors du recalcul des valeurs d'équipe:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1083,7 +1084,7 @@ router.put("/:id", authUser, validate(updateTeamSchema), async (req: Authenticat
 
     res.json({ team: updatedTeam });
   } catch (e: any) {
-    console.error("Erreur lors de la modification de l'équipe:", e);
+    serverLog.error("Erreur lors de la modification de l'équipe:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1218,7 +1219,7 @@ router.post("/:id/players", authUser, validate(addPlayerSchema), async (req: Aut
       newPlayer: newPlayer
     });
   } catch (e: any) {
-    console.error("Erreur lors de l'ajout du joueur:", e);
+    serverLog.error("Erreur lors de l'ajout du joueur:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1282,7 +1283,7 @@ router.delete("/:id/players/:playerId", authUser, async (req: AuthenticatedReque
 
     res.json({ team: updatedTeam });
   } catch (e: any) {
-    console.error("Erreur lors de la suppression du joueur:", e);
+    serverLog.error("Erreur lors de la suppression du joueur:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1449,7 +1450,7 @@ router.put("/:id/players/:playerId/skills", authUser, validate(updatePlayerSkill
       advancement: newAdvancement,
     });
   } catch (e: any) {
-    console.error("Erreur lors de l'ajout de compétence:", e);
+    serverLog.error("Erreur lors de l'ajout de compétence:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1508,7 +1509,7 @@ router.get("/:id/available-positions", authUser, async (req: AuthenticatedReques
       maxPlayers: 16
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des positions disponibles:", e);
+    serverLog.error("Erreur lors de la récupération des positions disponibles:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1549,7 +1550,7 @@ router.get("/:id/star-players", authUser, async (req: AuthenticatedRequest, res)
       count: enrichedStarPlayers.length
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des Star Players:", e);
+    serverLog.error("Erreur lors de la récupération des Star Players:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1647,7 +1648,7 @@ router.get("/:id/available-star-players", authUser, async (req: AuthenticatedReq
       totalBudget: team.initialBudget
     });
   } catch (e: any) {
-    console.error("Erreur lors de la récupération des Star Players disponibles:", e);
+    serverLog.error("Erreur lors de la récupération des Star Players disponibles:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -1798,7 +1799,7 @@ router.post("/:id/star-players", authUser, validate(addStarPlayerToTeamSchema), 
         : `${enrichedNewStarPlayers[0].displayName} recruté avec succès`
     });
   } catch (e: any) {
-    console.error("Erreur lors du recrutement du Star Player:", e);
+    serverLog.error("Erreur lors du recrutement du Star Player:", e);
     
     // Gérer les erreurs de contrainte unique
     if (e?.code === "P2002") {
@@ -1890,7 +1891,7 @@ router.delete("/:id/star-players/:starPlayerId", authUser, async (req: Authentic
         : "Star Player retiré avec succès"
     });
   } catch (e: any) {
-    console.error("Erreur lors du retrait du Star Player:", e);
+    serverLog.error("Erreur lors du retrait du Star Player:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -2142,7 +2143,7 @@ router.post("/:id/purchase", authUser, validate(purchaseSchema), async (req: Aut
       purchase: { type, cost, description },
     });
   } catch (e: any) {
-    console.error("Erreur lors de l'achat:", e);
+    serverLog.error("Erreur lors de l'achat:", e);
     return res.status(500).json({ error: "Erreur serveur" });
   }
 });

--- a/apps/server/src/scripts/fix-existing-positions-ruleset.ts
+++ b/apps/server/src/scripts/fix-existing-positions-ruleset.ts
@@ -4,9 +4,10 @@
  */
 
 import { prisma } from "../prisma";
+import { serverLog } from "../utils/server-log";
 
 async function main() {
-  console.log("🔧 Début de la correction des rulesets des positions...\n");
+  serverLog.log("🔧 Début de la correction des rulesets des positions...\n");
 
   // Récupérer tous les rosters avec leur ruleset
   const rosters = await prisma.roster.findMany({
@@ -18,7 +19,7 @@ async function main() {
     },
   });
 
-  console.log(`📊 Nombre de rosters trouvés: ${rosters.length}\n`);
+  serverLog.log(`📊 Nombre de rosters trouvés: ${rosters.length}\n`);
 
   let totalUpdated = 0;
 
@@ -29,25 +30,25 @@ async function main() {
     });
 
     if (positionCount > 0) {
-      console.log(
+      serverLog.log(
         `📝 Roster: ${roster.name} (${roster.slug}) - Ruleset: ${roster.ruleset} - ${positionCount} positions`
       );
       totalUpdated += positionCount;
     }
   }
 
-  console.log(`\n✅ Total de positions vérifiées: ${totalUpdated}`);
-  console.log(
+  serverLog.log(`\n✅ Total de positions vérifiées: ${totalUpdated}`);
+  serverLog.log(
     "\nℹ️  Note: Les positions héritent automatiquement du ruleset de leur roster via la relation."
   );
-  console.log(
+  serverLog.log(
     "Si vous voyez 'Ruleset: Inconnu' dans l'UI, vérifiez que le roster a bien un ruleset défini."
   );
 }
 
 main()
   .catch((e) => {
-    console.error("❌ Erreur:", e);
+    serverLog.error("❌ Erreur:", e);
     process.exit(1);
   })
   .finally(async () => {

--- a/apps/server/src/scripts/verify-ruleset-consistency.ts
+++ b/apps/server/src/scripts/verify-ruleset-consistency.ts
@@ -3,9 +3,10 @@
  */
 
 import { prisma } from "../prisma";
+import { serverLog } from "../utils/server-log";
 
 async function main() {
-  console.log("🔍 Vérification de la cohérence des rulesets...\n");
+  serverLog.log("🔍 Vérification de la cohérence des rulesets...\n");
 
   // 1. Vérifier que tous les rosters ont un ruleset (pas de null)
   const allRosters = await prisma.roster.findMany({
@@ -20,13 +21,13 @@ async function main() {
   const rostersWithoutRuleset = allRosters.filter((r: any) => !r.ruleset);
 
   if (rostersWithoutRuleset.length > 0) {
-    console.log(`❌ ${rostersWithoutRuleset.length} rosters SANS ruleset trouvés:`);
+    serverLog.log(`❌ ${rostersWithoutRuleset.length} rosters SANS ruleset trouvés:`);
     rostersWithoutRuleset.forEach((r: any) => {
-      console.log(`   - ${r.name} (${r.slug}) - ID: ${r.id}`);
+      serverLog.log(`   - ${r.name} (${r.slug}) - ID: ${r.id}`);
     });
-    console.log();
+    serverLog.log();
   } else {
-    console.log("✅ Tous les rosters ont un ruleset défini\n");
+    serverLog.log("✅ Tous les rosters ont un ruleset défini\n");
   }
 
   // 2. Compter les rosters par ruleset
@@ -35,11 +36,11 @@ async function main() {
     _count: true,
   });
 
-  console.log("📊 Répartition des rosters par ruleset:");
+  serverLog.log("📊 Répartition des rosters par ruleset:");
   rosterStats.forEach((stat: any) => {
-    console.log(`   - ${stat.ruleset}: ${stat._count} rosters`);
+    serverLog.log(`   - ${stat.ruleset}: ${stat._count} rosters`);
   });
-  console.log();
+  serverLog.log();
 
   // 3. Compter les positions par ruleset de leur roster
   const positionStats = await prisma.position.findMany({
@@ -58,11 +59,11 @@ async function main() {
     positionsByRuleset[ruleset] = (positionsByRuleset[ruleset] || 0) + 1;
   });
 
-  console.log("📊 Répartition des positions par ruleset (via leur roster):");
+  serverLog.log("📊 Répartition des positions par ruleset (via leur roster):");
   Object.entries(positionsByRuleset).forEach(([ruleset, count]) => {
-    console.log(`   - ${ruleset}: ${count} positions`);
+    serverLog.log(`   - ${ruleset}: ${count} positions`);
   });
-  console.log();
+  serverLog.log();
 
   // 4. Vérifier les équipes sans ruleset
   const allTeams = await prisma.team.findMany({
@@ -76,17 +77,17 @@ async function main() {
   const teamsWithoutRuleset = allTeams.filter((t: any) => !t.ruleset);
 
   if (teamsWithoutRuleset.length > 0) {
-    console.log(
+    serverLog.log(
       `⚠️  ${teamsWithoutRuleset.length} équipes SANS ruleset (devrait être season_3 par défaut)`
     );
     teamsWithoutRuleset.slice(0, 5).forEach((t: any) => {
-      console.log(`   - ${t.name} (ID: ${t.id})`);
+      serverLog.log(`   - ${t.name} (ID: ${t.id})`);
     });
     if (teamsWithoutRuleset.length > 5) {
-      console.log(`   ... et ${teamsWithoutRuleset.length - 5} autres`);
+      serverLog.log(`   ... et ${teamsWithoutRuleset.length - 5} autres`);
     }
   } else {
-    console.log("✅ Toutes les équipes ont un ruleset défini");
+    serverLog.log("✅ Toutes les équipes ont un ruleset défini");
   }
 
   const teamStats = await prisma.team.groupBy({
@@ -94,18 +95,18 @@ async function main() {
     _count: true,
   });
 
-  console.log("\n📊 Répartition des équipes par ruleset:");
+  serverLog.log("\n📊 Répartition des équipes par ruleset:");
   teamStats.forEach((stat: any) => {
-    console.log(`   - ${stat.ruleset}: ${stat._count} équipes`);
+    serverLog.log(`   - ${stat.ruleset}: ${stat._count} équipes`);
   });
-  console.log();
+  serverLog.log();
 
-  console.log("✅ Vérification terminée!");
+  serverLog.log("✅ Vérification terminée!");
 }
 
 main()
   .catch((e) => {
-    console.error("❌ Erreur:", e);
+    serverLog.error("❌ Erreur:", e);
     process.exit(1);
   })
   .finally(async () => {

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -19,19 +19,20 @@ import {
 import { UNKNOWN_USER_ID } from "./utils/user-constants";
 import { ONLINE_PLAY_FLAG, AI_TRAINING_FLAG } from "./services/featureFlags";
 import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
+import { serverLog } from "./utils/server-log";
 
 async function main() {
-  console.log("🌱 Début du seed...\n");
+  serverLog.log("🌱 Début du seed...\n");
 
   // =============================================================================
   // 1. SEED DES COMPÉTENCES (Skills) - Pour chaque ruleset
   // =============================================================================
-  console.log("📚 Seed des compétences...");
+  serverLog.log("📚 Seed des compétences...");
   let skillsCreated = 0;
   let skillsSkipped = 0;
   
   // Supprimer les compétences S3-only qui ont été créées par erreur en S2
-  console.log("   🧹 Nettoyage des compétences S3-only créées par erreur en S2...");
+  serverLog.log("   🧹 Nettoyage des compétences S3-only créées par erreur en S2...");
   const s3OnlySlugs = SKILLS_DEFINITIONS
     .filter(s => s.season3Only)
     .map(s => s.slug);
@@ -44,13 +45,13 @@ async function main() {
       }
     });
     if (deleted.count > 0) {
-      console.log(`   ✅ ${deleted.count} compétences S3-only supprimées de S2`);
+      serverLog.log(`   ✅ ${deleted.count} compétences S3-only supprimées de S2`);
     }
   }
 
   // Créer les compétences pour chaque ruleset (season_2 et season_3)
   for (const ruleset of RULESETS) {
-    console.log(`   📖 Seed des compétences pour ${ruleset}...`);
+    serverLog.log(`   📖 Seed des compétences pour ${ruleset}...`);
     const isSeason3 = ruleset === "season_3";
     
     for (const skillDef of SKILLS_DEFINITIONS) {
@@ -130,7 +131,7 @@ async function main() {
           skillsCreated++;
         }
       } catch (error) {
-        console.error(`❌ Erreur lors du seed de la compétence ${skillDef.slug} (${ruleset}):`, error);
+        serverLog.error(`❌ Erreur lors du seed de la compétence ${skillDef.slug} (${ruleset}):`, error);
       }
     }
   }
@@ -138,7 +139,7 @@ async function main() {
   // =============================================================================
   // 1b. SEED DES NOUVELLES COMPÉTENCES SAISON 3
   // =============================================================================
-  console.log("📚 Seed des nouvelles compétences Saison 3...");
+  serverLog.log("📚 Seed des nouvelles compétences Saison 3...");
   let s3SkillsCreated = 0;
   let s3SkillsUpdated = 0;
 
@@ -179,17 +180,17 @@ async function main() {
         s3SkillsCreated++;
       }
     } catch (error) {
-      console.error(`❌ Erreur lors du seed de la compétence S3 ${s3Skill.slug}:`, error);
+      serverLog.error(`❌ Erreur lors du seed de la compétence S3 ${s3Skill.slug}:`, error);
     }
   }
 
-  console.log(`✅ Compétences: ${skillsCreated} créées, ${skillsSkipped} mises à jour`);
-  console.log(`✅ Nouvelles compétences S3: ${s3SkillsCreated} créées, ${s3SkillsUpdated} mises à jour\n`);
+  serverLog.log(`✅ Compétences: ${skillsCreated} créées, ${skillsSkipped} mises à jour`);
+  serverLog.log(`✅ Nouvelles compétences S3: ${s3SkillsCreated} créées, ${s3SkillsUpdated} mises à jour\n`);
 
   // =============================================================================
   // 2. SEED DES ROSTERS
   // =============================================================================
-  console.log("🏈 Seed des rosters...");
+  serverLog.log("🏈 Seed des rosters...");
   let rostersCreated = 0;
   let rostersSkipped = 0;
   
@@ -275,19 +276,19 @@ async function main() {
           rostersCreated++;
         }
       } catch (error) {
-        console.error(
+        serverLog.error(
           `❌ Erreur lors du seed du roster ${slug} (${ruleset}):`,
           error,
         );
       }
     }
   }
-  console.log(`✅ Rosters: ${rostersCreated} créés, ${rostersSkipped} mis à jour\n`);
+  serverLog.log(`✅ Rosters: ${rostersCreated} créés, ${rostersSkipped} mis à jour\n`);
 
   // =============================================================================
   // 3. SEED DES POSITIONS
   // =============================================================================
-  console.log("👥 Seed des positions...");
+  serverLog.log("👥 Seed des positions...");
   let positionsCreated = 0;
   let positionsSkipped = 0;
   
@@ -299,7 +300,7 @@ async function main() {
       });
 
       if (!roster) {
-        console.error(
+        serverLog.error(
           `❌ Roster ${rosterSlug} (${ruleset}) non trouvé, impossible de créer les positions`,
         );
         continue;
@@ -367,14 +368,14 @@ async function main() {
                   },
                 });
               } else {
-                console.warn(
+                serverLog.warn(
                   `⚠️  Compétence ${skillSlug} non trouvée pour la position ${positionDef.slug} (${ruleset})`,
                 );
               }
             }
           }
         } catch (error) {
-          console.error(
+          serverLog.error(
             `❌ Erreur lors du seed de la position ${positionDef.slug} (${ruleset}):`,
             error,
           );
@@ -382,12 +383,12 @@ async function main() {
       }
     }
   }
-  console.log(`✅ Positions: ${positionsCreated} créées, ${positionsSkipped} mises à jour\n`);
+  serverLog.log(`✅ Positions: ${positionsCreated} créées, ${positionsSkipped} mises à jour\n`);
 
   // =============================================================================
   // 4. SEED DES STAR PLAYERS
   // =============================================================================
-  console.log("⭐ Seed des Star Players...");
+  serverLog.log("⭐ Seed des Star Players...");
   let starPlayersCreated = 0;
   let starPlayersSkipped = 0;
   
@@ -450,7 +451,7 @@ async function main() {
                 }
               });
             } else {
-              console.warn(`⚠️  Compétence ${skillSlug} non trouvée pour le Star Player ${slug} (${ruleset})`);
+              serverLog.warn(`⚠️  Compétence ${skillSlug} non trouvée pour le Star Player ${slug} (${ruleset})`);
             }
           }
         }
@@ -499,21 +500,21 @@ async function main() {
           }
         }
       } catch (error) {
-        console.error(`❌ Erreur lors du seed du Star Player ${slug} (${ruleset}):`, error);
+        serverLog.error(`❌ Erreur lors du seed du Star Player ${slug} (${ruleset}):`, error);
       }
     }
   }
-  console.log(`✅ Star Players: ${starPlayersCreated} créés, ${starPlayersSkipped} mis à jour\n`);
+  serverLog.log(`✅ Star Players: ${starPlayersCreated} créés, ${starPlayersSkipped} mis à jour\n`);
 
   // =============================================================================
   // 5. SEED DES UTILISATEURS ET ÉQUIPES (code existant)
   // =============================================================================
-  console.log("👤 Seed des utilisateurs et équipes...");
+  serverLog.log("👤 Seed des utilisateurs et équipes...");
 
   // Utilisateur technique "Unknown" utilisé pour représenter un compte inconnu/supprimé
   // Cet utilisateur possède un ID fixe défini dans UNKNOWN_USER_ID pour pouvoir
   // être référencé de manière stable dans le code applicatif.
-  console.log("👤 Seed de l'utilisateur technique 'Unknown'...");
+  serverLog.log("👤 Seed de l'utilisateur technique 'Unknown'...");
   const unknownPasswordHash = await bcrypt.hash("unknown123", 10);
   await prisma.user.upsert({
     where: { id: UNKNOWN_USER_ID },
@@ -893,7 +894,7 @@ async function main() {
   // =============================================================================
   // 6. SEED D'UN COACH ET D'UNE ÉQUIPE PAR ROSTER
   // =============================================================================
-  console.log("👥 Seed d'un coach et d'une équipe type par roster...");
+  serverLog.log("👥 Seed d'un coach et d'une équipe type par roster...");
   for (const [rosterSlug, rosterDef] of Object.entries(TEAM_ROSTERS)) {
     const email = `coach+${rosterSlug}@example.com`;
     let coach = await prisma.user.findUnique({
@@ -942,7 +943,7 @@ async function main() {
   // =============================================================================
   // 6b. SEED DES FEATURE FLAGS
   // =============================================================================
-  console.log("🚩 Seed des feature flags...");
+  serverLog.log("🚩 Seed des feature flags...");
   // "online_play" : gate toute la partie "Jouer en ligne" du site.
   // Par défaut désactivé globalement ; les admins ont un bypass automatique
   // (cf. services/featureFlags.ts) et l'utilisateur "user@example.com" reçoit
@@ -960,7 +961,7 @@ async function main() {
       enabled: false,
     },
   });
-  console.log(
+  serverLog.log(
     `   ✅ Flag '${ONLINE_PLAY_FLAG}' ${onlinePlayFlag.enabled ? "actif" : "inactif (override admin/user)"}`,
   );
 
@@ -975,7 +976,7 @@ async function main() {
       create: { flagId: onlinePlayFlag.id, userId: testUser.id },
       update: {},
     });
-    console.log(
+    serverLog.log(
       `   ✅ Override '${ONLINE_PLAY_FLAG}' ajouté pour user@example.com`,
     );
   }
@@ -998,7 +999,7 @@ async function main() {
       enabled: false,
     },
   });
-  console.log(
+  serverLog.log(
     `   ✅ Flag '${AI_TRAINING_FLAG}' ${aiTrainingFlag.enabled ? "actif" : "inactif (override admin/user)"}`,
   );
 
@@ -1010,7 +1011,7 @@ async function main() {
       create: { flagId: aiTrainingFlag.id, userId: testUser.id },
       update: {},
     });
-    console.log(
+    serverLog.log(
       `   ✅ Override '${AI_TRAINING_FLAG}' ajouté pour user@example.com`,
     );
   }
@@ -1018,7 +1019,7 @@ async function main() {
   // =============================================================================
   // 7. SEED D'UNE COUPE ET D'UN MATCH LOCAL (fixtures de test)
   // =============================================================================
-  console.log("🏆 Seed d'une coupe et d'un match local de test...");
+  serverLog.log("🏆 Seed d'une coupe et d'un match local de test...");
   
   const adminUser = await prisma.user.findUnique({
     where: { email: "admin@example.com" },
@@ -1061,7 +1062,7 @@ async function main() {
 
       let cup;
       if (existingCup) {
-        console.log("   ⚠️  La coupe 'Test 1' existe déjà, mise à jour de la configuration de points");
+        serverLog.log("   ⚠️  La coupe 'Test 1' existe déjà, mise à jour de la configuration de points");
         cup = await prisma.cup.update({
           where: { id: existingCup.id },
           data: {
@@ -1080,7 +1081,7 @@ async function main() {
             ...defaultCupScoring,
           },
         });
-        console.log("   ✅ Coupe 'Test 1' créée");
+        serverLog.log("   ✅ Coupe 'Test 1' créée");
       }
 
       // Inscrire les équipes à la coupe : Admin (Skaven) + 11 rosters différents
@@ -1114,7 +1115,7 @@ async function main() {
         }
       }
 
-      console.log(
+      serverLog.log(
         `   ✅ ${participantTeams.length} équipes sélectionnées pour la coupe (objectif 12)`,
       );
 
@@ -1132,7 +1133,7 @@ async function main() {
               teamId: team.id,
             },
           });
-          console.log(
+          serverLog.log(
             `   ✅ Équipe ${team.name} (${team.roster}) inscrite à la coupe`,
           );
         }
@@ -1160,9 +1161,9 @@ async function main() {
             teamBOwnerValidated: false,
           },
         });
-        console.log("   ✅ Match local créé (Admin-Skavens vs User-Lizardmen)");
+        serverLog.log("   ✅ Match local créé (Admin-Skavens vs User-Lizardmen)");
       } else {
-        console.log("   ⚠️  Le match local existe déjà");
+        serverLog.log("   ⚠️  Le match local existe déjà");
       }
 
       // Valider le match et générer les actions
@@ -1206,7 +1207,7 @@ async function main() {
             gameState: gameState as any,
           },
         });
-        console.log("   ✅ Match validé et complété avec informations de pré-match");
+        serverLog.log("   ✅ Match validé et complété avec informations de pré-match");
 
         // Récupérer les joueurs des deux équipes
         const skavenPlayers = await prisma.teamPlayer.findMany({
@@ -1830,9 +1831,9 @@ async function main() {
           await prisma.localMatchAction.createMany({
             data: actions,
           });
-          console.log(`   ✅ ${actions.length} actions générées pour le match`);
+          serverLog.log(`   ✅ ${actions.length} actions générées pour le match`);
         } else {
-          console.log(`   ⚠️  Le match a déjà ${existingActions.length} actions`);
+          serverLog.log(`   ⚠️  Le match a déjà ${existingActions.length} actions`);
         }
       }
 
@@ -1883,7 +1884,7 @@ async function main() {
               completedAt: new Date(Date.now() - 60 * 60 * 1000),
             },
           });
-          console.log(
+          serverLog.log(
             `   ✅ Match local créé pour le premier round: ${teamA.name} vs ${teamB.name}`,
           );
         }
@@ -1954,50 +1955,50 @@ async function main() {
           await prisma.localMatchAction.createMany({
             data: simpleActions,
           });
-          console.log(
+          serverLog.log(
             `   ✅ Actions générées pour le match ${teamA.name} vs ${teamB.name}`,
           );
         }
       }
     } else {
-      console.log("   ⚠️  Impossible de créer la coupe : équipes non trouvées");
+      serverLog.log("   ⚠️  Impossible de créer la coupe : équipes non trouvées");
     }
   } else {
-    console.log("   ⚠️  Impossible de créer la coupe : utilisateurs non trouvés");
+    serverLog.log("   ⚠️  Impossible de créer la coupe : utilisateurs non trouvés");
   }
-  console.log("✅ Fixtures de coupe et match local terminées\n");
+  serverLog.log("✅ Fixtures de coupe et match local terminées\n");
 
   // =============================================================================
   // 8. SEED DES LIGUES PAR DEFAUT (L.2 — Sprint 17)
   // =============================================================================
-  console.log("🏟️  Seed des ligues par défaut...");
+  serverLog.log("🏟️  Seed des ligues par défaut...");
   const leagueCreator = await prisma.user.findUnique({
     where: { email: "admin@example.com" },
     select: { id: true },
   });
   if (leagueCreator) {
     await seedDefaultLeagues({ creatorId: leagueCreator.id });
-    console.log(`   ✅ Ligue '${DEFAULT_LEAGUE_NAME}' prête (saison 1, rounds initiaux, 5 équipes prioritaires)`);
+    serverLog.log(`   ✅ Ligue '${DEFAULT_LEAGUE_NAME}' prête (saison 1, rounds initiaux, 5 équipes prioritaires)`);
   } else {
-    console.log("   ⚠️  Admin introuvable, seeder des ligues ignoré");
+    serverLog.log("   ⚠️  Admin introuvable, seeder des ligues ignoré");
   }
-  console.log("✅ Ligues par défaut terminées\n");
+  serverLog.log("✅ Ligues par défaut terminées\n");
 }
 
 main()
   .then(async () => {
     await prisma.$disconnect();
-    console.log("\n🎉 Seed terminé avec succès !");
-    console.log("   - Toutes les compétences ont été importées");
-    console.log("   - Tous les rosters ont été importés");
-    console.log("   - Toutes les positions ont été importées");
-    console.log("   - Tous les Star Players ont été importés");
-    console.log("   - Les comptes par défaut sont prêts");
-    console.log("   - La coupe 'Test 1' et un match local ont été créés");
-    console.log(`   - La ligue '${DEFAULT_LEAGUE_NAME}' est prête`);
+    serverLog.log("\n🎉 Seed terminé avec succès !");
+    serverLog.log("   - Toutes les compétences ont été importées");
+    serverLog.log("   - Tous les rosters ont été importés");
+    serverLog.log("   - Toutes les positions ont été importées");
+    serverLog.log("   - Tous les Star Players ont été importés");
+    serverLog.log("   - Les comptes par défaut sont prêts");
+    serverLog.log("   - La coupe 'Test 1' et un match local ont été créés");
+    serverLog.log(`   - La ligue '${DEFAULT_LEAGUE_NAME}' est prête`);
   })
   .catch(async (e) => {
-    console.error("❌ Erreur lors du seed:", e);
+    serverLog.error("❌ Erreur lors du seed:", e);
     await prisma.$disconnect();
     process.exit(1);
   });

--- a/apps/server/src/services/ai-loop.ts
+++ b/apps/server/src/services/ai-loop.ts
@@ -23,6 +23,7 @@ import {
 import { prisma } from "../prisma";
 import { computeAIMove, isAITurnToAct } from "./ai-turn";
 import { broadcastGameState, broadcastMatchEnd } from "./game-broadcast";
+import { serverLog } from "../utils/server-log";
 
 export const MAX_MOVES_PER_TURN = 64;
 export const MAX_MS_PER_TURN = 15_000;
@@ -85,7 +86,7 @@ function hashProgress(state: GameState): string {
 /** Fire-and-forget entrypoint used by `processMove`. */
 export function scheduleAILoop(matchId: string): void {
   void runAILoop({ matchId }).catch((err) => {
-    console.error(`[ai-loop] ${matchId} failed:`, err);
+    serverLog.error(`[ai-loop] ${matchId} failed:`, err);
   });
 }
 
@@ -191,7 +192,7 @@ async function executeAILoop(
     try {
       nextState = applyMove(state, chosen, makeRNG(seed)) as ExtendedGameState;
     } catch (err) {
-      console.error(`[ai-loop] ${matchId} applyMove failed`, err);
+      serverLog.error(`[ai-loop] ${matchId} applyMove failed`, err);
       return report("engine-error", start, now, movesApplied);
     }
 

--- a/apps/server/src/services/inducement-processor.ts
+++ b/apps/server/src/services/inducement-processor.ts
@@ -15,6 +15,7 @@ import type {
 import { getUserTeamSide } from "./turn-ownership";
 import { broadcastGameState } from "./game-broadcast";
 import { runAISetupIfNeeded } from "./ai-setup";
+import { serverLog } from "../utils/server-log";
 
 /**
  * In-memory store for pending inducement selections per match.
@@ -212,7 +213,7 @@ export async function processInducementSubmission(
         gameState = report.gameState;
       }
     } catch (err) {
-      console.error(`[inducement-processor] AI auto-setup failed for ${matchId}:`, err);
+      serverLog.error(`[inducement-processor] AI auto-setup failed for ${matchId}:`, err);
     }
   }
 

--- a/apps/server/src/services/match-start.ts
+++ b/apps/server/src/services/match-start.ts
@@ -6,6 +6,7 @@ import {
 } from "@bb/game-engine";
 import { getLinemanStats } from "./journeymen";
 import { runAutomatedPreMatchSequence } from "./pre-match-automation";
+import { serverLog } from "../utils/server-log";
 
 type PrismaLike = {
   match: {
@@ -214,7 +215,7 @@ export async function acceptAndMaybeStartMatch(
         }
       }
     } catch (journeymenError) {
-      console.error("Erreur lors de l'ajout des journeymen:", journeymenError);
+      serverLog.error("Erreur lors de l'ajout des journeymen:", journeymenError);
     }
   }
 
@@ -276,7 +277,7 @@ export async function acceptAndMaybeStartMatch(
   // This is fire-and-forget: the accept response returns immediately,
   // and the client receives the updated state via WebSocket broadcast.
   runAutomatedPreMatchSequence(prisma as any, matchId, gameState, match.seed)
-    .catch((err) => console.error("Pre-match automation error:", err));
+    .catch((err) => serverLog.error("Pre-match automation error:", err));
 
   return {
     ok: true,

--- a/apps/server/src/services/turn-timer-orchestrator.ts
+++ b/apps/server/src/services/turn-timer-orchestrator.ts
@@ -8,6 +8,7 @@
 import { resetTurnTimer, cancelTurnTimer, getTurnTimerDeadline } from "./turn-timer";
 import { broadcastTurnTimerStarted } from "./game-broadcast";
 import { processMove } from "./move-processor";
+import { serverLog } from "../utils/server-log";
 
 export const TURN_TIMER_CONFIG_KEY = "turnTimerSeconds";
 
@@ -85,13 +86,13 @@ export async function handleTurnTimerAutoEnd(
   try {
     const result = await processMove(matchId, userId, { type: "END_TURN" });
     if (result.success) {
-      console.log(
+      serverLog.log(
         `[turn-timer] Auto-ended turn for match ${matchId} (user ${userId})`,
       );
     }
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "Unknown error";
-    console.error(
+    serverLog.error(
       `[turn-timer] Failed to auto-end turn for match ${matchId}: ${msg}`,
     );
   }

--- a/apps/server/src/socket.ts
+++ b/apps/server/src/socket.ts
@@ -7,6 +7,7 @@ import { registerGameChatHandlers } from "./game-chat";
 import { registerSpectatorHandlers } from "./game-spectator";
 import { authSocket } from "./middleware/authSocket";
 import { CORS_ORIGINS } from "./config";
+import { serverLog } from "./utils/server-log";
 
 let io: Server | null = null;
 let gameNamespace: Namespace | null = null;
@@ -42,10 +43,10 @@ export function setupSocket(
 
   gameNamespace.on("connection", (socket) => {
     const userId = socket.data.user?.id ?? "unknown";
-    console.log(`[socket.io] /game client connected: ${socket.id} (user: ${userId})`);
+    serverLog.log(`[socket.io] /game client connected: ${socket.id} (user: ${userId})`);
 
     socket.on("disconnect", (reason) => {
-      console.log(
+      serverLog.log(
         `[socket.io] /game client disconnected: ${socket.id} (${reason})`,
       );
     });

--- a/apps/server/src/utils/server-log.test.ts
+++ b/apps/server/src/utils/server-log.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests pour le wrapper de logging serveur (tâche S24.8).
+ *
+ * Le wrapper délègue aux `console.*` par défaut tout en permettant
+ * d'injecter une autre implémentation (préparation S25 → pino) sans
+ * toucher chaque call site.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  serverLog,
+  setServerLogImpl,
+  resetServerLogImpl,
+  type ServerLogImpl,
+} from "./server-log";
+
+describe("serverLog wrapper", () => {
+  let consoleSpy: {
+    log: ReturnType<typeof vi.spyOn>;
+    info: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+    debug: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      log: vi.spyOn(console, "log").mockImplementation(() => undefined),
+      info: vi.spyOn(console, "info").mockImplementation(() => undefined),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => undefined),
+      error: vi.spyOn(console, "error").mockImplementation(() => undefined),
+      debug: vi.spyOn(console, "debug").mockImplementation(() => undefined),
+    };
+  });
+
+  afterEach(() => {
+    resetServerLogImpl();
+    Object.values(consoleSpy).forEach((s) => s.mockRestore());
+  });
+
+  describe("default delegation to console", () => {
+    it("serverLog.log délègue à console.log", () => {
+      serverLog.log("hello", 42);
+      expect(consoleSpy.log).toHaveBeenCalledWith("hello", 42);
+    });
+
+    it("serverLog.info délègue à console.info", () => {
+      serverLog.info("message", { foo: "bar" });
+      expect(consoleSpy.info).toHaveBeenCalledWith("message", { foo: "bar" });
+    });
+
+    it("serverLog.warn délègue à console.warn", () => {
+      serverLog.warn("attention");
+      expect(consoleSpy.warn).toHaveBeenCalledWith("attention");
+    });
+
+    it("serverLog.error délègue à console.error avec une Error", () => {
+      const err = new Error("boom");
+      serverLog.error("contexte", err);
+      expect(consoleSpy.error).toHaveBeenCalledWith("contexte", err);
+    });
+
+    it("serverLog.debug délègue à console.debug", () => {
+      serverLog.debug("trace");
+      expect(consoleSpy.debug).toHaveBeenCalledWith("trace");
+    });
+  });
+
+  describe("implementation swap (préparation pino S25)", () => {
+    it("setServerLogImpl remplace toutes les méthodes par l'impl injectée", () => {
+      const fake: ServerLogImpl = {
+        log: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      setServerLogImpl(fake);
+      serverLog.log("a");
+      serverLog.info("b");
+      serverLog.warn("c");
+      serverLog.error("d");
+      serverLog.debug("e");
+
+      expect(fake.log).toHaveBeenCalledWith("a");
+      expect(fake.info).toHaveBeenCalledWith("b");
+      expect(fake.warn).toHaveBeenCalledWith("c");
+      expect(fake.error).toHaveBeenCalledWith("d");
+      expect(fake.debug).toHaveBeenCalledWith("e");
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.error).not.toHaveBeenCalled();
+    });
+
+    it("resetServerLogImpl restaure le delegation console par défaut", () => {
+      setServerLogImpl({
+        log: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      });
+
+      resetServerLogImpl();
+      serverLog.error("après reset");
+      expect(consoleSpy.error).toHaveBeenCalledWith("après reset");
+    });
+
+    it("ne mute pas l'objet impl injecté (immutabilité)", () => {
+      const fake: ServerLogImpl = {
+        log: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      const snapshot = { ...fake };
+
+      setServerLogImpl(fake);
+      serverLog.log("x");
+
+      expect(fake).toEqual(snapshot);
+    });
+  });
+
+  describe("immutabilité de l'objet exporté", () => {
+    it("serverLog ne peut pas être muté pour échapper au swap", () => {
+      const customLog = vi.fn();
+      // @ts-expect-error — on tente d'écraser une méthode pour vérifier la garde
+      const writeAttempt = () => (serverLog.log = customLog);
+      expect(writeAttempt).toThrow();
+    });
+  });
+});

--- a/apps/server/src/utils/server-log.ts
+++ b/apps/server/src/utils/server-log.ts
@@ -1,0 +1,79 @@
+/**
+ * Wrapper de logging serveur (tâche S24.8 — Sprint 24).
+ *
+ * Indirection minimale au-dessus de `console.*` pour permettre, en S25,
+ * un swap vers une implémentation structurée (pino) sans devoir toucher
+ * chaque call site.
+ *
+ * Utilisation :
+ *   import { serverLog } from "./utils/server-log";
+ *   serverLog.error("[scope] context", err);
+ *
+ * Migration depuis `console.*` :
+ *   console.error → serverLog.error
+ *   console.warn  → serverLog.warn
+ *   console.log   → serverLog.log
+ *   console.info  → serverLog.info
+ *   console.debug → serverLog.debug
+ *
+ * En S25, `setServerLogImpl(pinoAdapter)` au boot du serveur basculera
+ * tout l'écosystème vers pino sans diff sur les call sites.
+ */
+
+export type LogArg = unknown;
+
+export interface ServerLogImpl {
+  log: (...args: LogArg[]) => void;
+  info: (...args: LogArg[]) => void;
+  warn: (...args: LogArg[]) => void;
+  error: (...args: LogArg[]) => void;
+  debug: (...args: LogArg[]) => void;
+}
+
+/**
+ * Implémentation par défaut : déléguer à `console.*`.
+ * On référence dynamiquement `console` au moment de l'appel pour ne pas
+ * figer la référence (utile pour les tests qui spy sur console).
+ */
+const defaultImpl: ServerLogImpl = {
+  log: (...args) => {
+    console.log(...args);
+  },
+  info: (...args) => {
+    console.info(...args);
+  },
+  warn: (...args) => {
+    console.warn(...args);
+  },
+  error: (...args) => {
+    console.error(...args);
+  },
+  debug: (...args) => {
+    console.debug(...args);
+  },
+};
+
+let activeImpl: ServerLogImpl = defaultImpl;
+
+/** Remplace l'implémentation active (utile pour tests et migration pino). */
+export function setServerLogImpl(impl: ServerLogImpl): void {
+  activeImpl = impl;
+}
+
+/** Restaure le delegation `console.*` par défaut. */
+export function resetServerLogImpl(): void {
+  activeImpl = defaultImpl;
+}
+
+/**
+ * Façade publique gelée : les call sites importent `serverLog` et ne
+ * peuvent pas écraser ses méthodes accidentellement. Le swap se fait
+ * uniquement via `setServerLogImpl`.
+ */
+export const serverLog: ServerLogImpl = Object.freeze({
+  log: (...args: LogArg[]) => activeImpl.log(...args),
+  info: (...args: LogArg[]) => activeImpl.info(...args),
+  warn: (...args: LogArg[]) => activeImpl.warn(...args),
+  error: (...args: LogArg[]) => activeImpl.error(...args),
+  debug: (...args: LogArg[]) => activeImpl.debug(...args),
+});

--- a/docs/roadmap/sprints/S24-stabilite-securite.md
+++ b/docs/roadmap/sprints/S24-stabilite-securite.md
@@ -16,7 +16,7 @@
 | S24.5 | Polling fallback 3s -> 10s + backoff exponentiel | FIX | M | [x] | `apps/web/app/play/[id]/hooks/useGameState.ts:301`. Quand WS degrade, X clients = X requetes/3s. Trop agressif a la scale beta. |
 | S24.6 | Verifier `app.use(authRateLimiter)` + couverture `/leagues` GET | FIX | S | [x] | Divergence detectee entre agents backend ("non applique") et securite ("present"). Confirmer end-to-end + ajouter tests. |
 | S24.7 | Retirer `console.log` debug en prod (web) | FIX | S | [x] | `apps/web/app/play/[id]/page.tsx:615,729,743` + autres. 10+ logs de debug visibles dans les devtools. |
-| S24.8 | Wrapper minimal pour `console.error` backend (preparation S25) | FIX | S | [ ] | 270 console.* eparpilles dans `apps/server/src/`. Wrapper temporaire `serverLog.error()` qui delegue a console mais permet swap vers pino en S25 sans toucher chaque call site. |
+| S24.8 | Wrapper minimal pour `console.error` backend (preparation S25) | FIX | S | [x] | 270 console.* eparpilles dans `apps/server/src/`. Wrapper temporaire `serverLog.error()` qui delegue a console mais permet swap vers pino en S25 sans toucher chaque call site. |
 | S24.9 | Docker compose dev hot-reload + 5 make targets quotidiens | CONFORT | S | [ ] | `docker-compose.yml` actuellement statique (`pnpm install && pnpm run dev`). Ajouter bind mount + nodemon/turbopack hot reload. Targets : `make logs`, `make reset-db`, `make seed`, `make tunnel`, `make snapshot-prod`. Cycle dev x5 plus rapide. |
 
 ## Definition of done


### PR DESCRIPTION
## Resume

Introduit un wrapper minimal `serverLog` au-dessus de `console.*` pour
preparer le swap vers pino prevu en S25, sans avoir a toucher chaque
call site une nouvelle fois.

- **Wrapper** : `apps/server/src/utils/server-log.ts` expose
  `serverLog.{log,info,warn,error,debug}` qui deleguent par defaut a
  `console.*`. `setServerLogImpl(...)` / `resetServerLogImpl()`
  permettront d'injecter une impl pino en S25. La facade exportee est
  gelee (`Object.freeze`) pour eviter qu'un module n'echappe au swap.
- **Migration mecanique** : 270 occurrences de `console.X` reecrites en
  `serverLog.X` dans 32 fichiers de `apps/server/src/` (routes,
  services, middleware, scripts, seed). Aucune modification de la
  signature des appels — runtime output identique.
- **Tests** : 9 nouveaux tests unitaires couvrent la delegation par
  defaut, l'impl swap, le reset et l'immutabilite de la facade.
- **Roadmap** : coche S24.8 dans
  `docs/roadmap/sprints/S24-stabilite-securite.md`.

## Tache roadmap

Sprint S24, tache S24.8 (Wrapper minimal pour `console.error` backend
— preparation S25).
Source : `docs/roadmap/sprints/S24-stabilite-securite.md`

## Plan de test

- [x] `pnpm test` server : 769 tests verts (dont 9 nouveaux pour le wrapper)
- [x] `pnpm typecheck` server : OK
- [x] `pnpm lint` (root) : 0 erreurs
- [x] Build packages typescriptes (`@bb/game-engine`, `@bb/ui`) : OK
- [ ] Manuel : verifier que les logs serveur sont identiques en runtime apres swap (au prochain demarrage local, comparer la sortie de `pnpm --filter @bb/server dev` avec la branche main)
- [ ] S25 : valider que `setServerLogImpl(pinoAdapter)` au boot suffit a basculer toute la stack vers pino sans nouveau diff sur les call sites


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrduBMYgzSjqyYNozDMvrG)_