### PR TITLE
feat(devops): docker hot-reload + 5 daily-dev make targets (S24.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ screenshots/
 
 # Deploy state (ecrit par scripts/deploy.sh apres chaque deploy reussi)
 .last-deployed-commit
+snapshots/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # BlooBowl - Makefile
 # Commandes utiles pour le développement du jeu Blood Bowl
 
-.PHONY: help install dev dev-web dev-mobile dev-server dev-engine build clean lint format typecheck test docker docker-up docker-down docker-logs setup db-seed db-reset-pg db-migrate db-migrate-deploy db-migrate-status db-migrate-data deploy deploy-no-cache maintenance-on maintenance-off maintenance-status
+.PHONY: help install dev dev-web dev-mobile dev-server dev-engine build clean lint format typecheck test docker docker-up docker-down docker-logs setup db-seed db-reset-pg db-migrate db-migrate-deploy db-migrate-status db-migrate-data deploy deploy-no-cache maintenance-on maintenance-off maintenance-status seed reset-db tunnel snapshot-prod
 
 # Variables
 PNPM := pnpm
@@ -327,3 +327,37 @@ db-migrate-data: ## Exécute le script de migration des données statiques (rost
 	@echo "📦 Migration des données statiques vers la base de données..."
 	@cd apps/server && $(PNPM) exec tsx migrate-static-data-to-db.ts
 	@echo "✅ Migration des données terminée"
+
+# Daily-dev shortcuts (S24.9) — alias courts vers les cibles existantes +
+# nouveaux raccourcis pour les workflows quotidiens.
+seed: db-seed ## Alias court de db-seed (importe les fixtures dans Postgres)
+
+reset-db: db-reset-pg ## Alias court de db-reset-pg (drop + push + seed)
+
+tunnel: ## Expose le web local via un tunnel cloudflared (override : TUNNEL_PORT, TUNNEL_HOSTNAME)
+	@echo "🌐 Tunnel cloudflared vers http://localhost:$${TUNNEL_PORT:-$(WEB_PORT)}..."
+	@command -v cloudflared >/dev/null 2>&1 || { \
+		echo "❌ cloudflared introuvable."; \
+		echo "   Installation: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"; \
+		echo "   macOS  : brew install cloudflared"; \
+		echo "   Linux  : sudo apt-get install cloudflared (ou téléchargement direct)"; \
+		exit 1; \
+	}
+	@if [ -n "$$TUNNEL_HOSTNAME" ]; then \
+		cloudflared tunnel run --hostname "$$TUNNEL_HOSTNAME" --url "http://localhost:$${TUNNEL_PORT:-$(WEB_PORT)}"; \
+	else \
+		cloudflared tunnel --url "http://localhost:$${TUNNEL_PORT:-$(WEB_PORT)}"; \
+	fi
+
+snapshot-prod: ## Dump Postgres prod compressé vers snapshots/ (PROD_DATABASE_URL requis)
+	@if [ -z "$$PROD_DATABASE_URL" ]; then \
+		echo "❌ PROD_DATABASE_URL requis."; \
+		echo "   Exemple: PROD_DATABASE_URL=postgresql://user:pass@prod-host:5432/db make snapshot-prod"; \
+		exit 1; \
+	fi
+	@command -v pg_dump >/dev/null 2>&1 || { echo "❌ pg_dump introuvable (apt-get install postgresql-client)"; exit 1; }
+	@mkdir -p snapshots
+	@SNAPSHOT_FILE="snapshots/prod-$$(date -u +%Y%m%dT%H%M%SZ).sql.gz"; \
+		echo "📸 Dump prod -> $$SNAPSHOT_FILE..."; \
+		pg_dump --no-owner --no-acl --clean --if-exists "$$PROD_DATABASE_URL" | gzip > "$$SNAPSHOT_FILE" && \
+		echo "✅ Snapshot écrit ($$(du -h "$$SNAPSHOT_FILE" | cut -f1))"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,13 +21,27 @@ services:
     ports:
       - "8200:3100"
     container_name: nufflearena_web
+    init: true
     environment:
       - NODE_ENV=development
       - PORT=3100
       - NEXT_PUBLIC_API_BASE=https://api.nufflearena.fr
       - SERVER_API_BASE=http://nufflearena_server:8201
+      # Force polling so chokidar/Next picks up file changes through the
+      # bind mount on macOS/Windows hosts where inotify events are lost.
+      - CHOKIDAR_USEPOLLING=1
+      - WATCHPACK_POLLING=true
     volumes:
+      # S24.9 hot-reload : bind mount du workspace + anonymous volumes
+      # pour preserver les binaires node_modules Linux du conteneur et
+      # eviter qu'un node_modules cote hote (macOS/Windows) ne les ecrase.
       - .:/app
+      - /app/node_modules
+      - /app/apps/web/node_modules
+      - /app/apps/server/node_modules
+      - /app/packages/game-engine/node_modules
+      - /app/packages/ui/node_modules
+      - /app/apps/web/.next
     working_dir: /app
     command: >
       sh -c "
@@ -60,6 +74,7 @@ services:
       dockerfile: Dockerfile.server
     restart: unless-stopped
     container_name: nufflearena_server
+    init: true
     healthcheck:
       disable: true
     ports:
@@ -70,8 +85,17 @@ services:
       - DATABASE_URL=postgresql://bb_user:bb_pass@db:5432/bb_db?schema=public
       - CORS_ORIGINS=https://nufflearena.fr,http://localhost:3100
       - RATE_LIMIT_WHITELIST=82.67.200.127
+      # tsx watch utilise chokidar en interne — polling necessaire si le
+      # host n'emet pas d'evenements inotify a travers le bind mount.
+      - CHOKIDAR_USEPOLLING=1
+      - TSX_WATCH_POLL=1
     volumes:
       - .:/app
+      - /app/node_modules
+      - /app/apps/web/node_modules
+      - /app/apps/server/node_modules
+      - /app/packages/game-engine/node_modules
+      - /app/packages/ui/node_modules
     working_dir: /app/apps/server
     networks:
       - traefik-network

--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -9,7 +9,7 @@
 
 | Sprint | Theme | Fichier | Etat |
 |--------|-------|---------|------|
-| **S24** | Stabilite & DX core (fix P0 + securite + hot-reload dev) | [sprints/S24-stabilite-securite.md](./sprints/S24-stabilite-securite.md) | A faire |
+| **S24** | Stabilite & DX core (fix P0 + securite + hot-reload dev) | [sprints/S24-stabilite-securite.md](./sprints/S24-stabilite-securite.md) | TERMINE |
 | **S25** | Observabilite, perf & qualite (logs, metrics, tests, bundle) | [sprints/S25-observabilite-qualite.md](./sprints/S25-observabilite-qualite.md) | A faire |
 | **S26** | Refactor + Retention & engagement (page.tsx prerequis, achievements, profil, ligues) | [sprints/S26-retention-engagement.md](./sprints/S26-retention-engagement.md) | A faire |
 | **S27** | Evolutions & confort (esport, mobile parite, S4 skeleton, audit log, B0.1 residuels) | [sprints/S27-evolutions-confort.md](./sprints/S27-evolutions-confort.md) | A faire |

--- a/docs/roadmap/sprints/S24-stabilite-securite.md
+++ b/docs/roadmap/sprints/S24-stabilite-securite.md
@@ -17,7 +17,7 @@
 | S24.6 | Verifier `app.use(authRateLimiter)` + couverture `/leagues` GET | FIX | S | [x] | Divergence detectee entre agents backend ("non applique") et securite ("present"). Confirmer end-to-end + ajouter tests. |
 | S24.7 | Retirer `console.log` debug en prod (web) | FIX | S | [x] | `apps/web/app/play/[id]/page.tsx:615,729,743` + autres. 10+ logs de debug visibles dans les devtools. |
 | S24.8 | Wrapper minimal pour `console.error` backend (preparation S25) | FIX | S | [x] | 270 console.* eparpilles dans `apps/server/src/`. Wrapper temporaire `serverLog.error()` qui delegue a console mais permet swap vers pino en S25 sans toucher chaque call site. |
-| S24.9 | Docker compose dev hot-reload + 5 make targets quotidiens | CONFORT | S | [ ] | `docker-compose.yml` actuellement statique (`pnpm install && pnpm run dev`). Ajouter bind mount + nodemon/turbopack hot reload. Targets : `make logs`, `make reset-db`, `make seed`, `make tunnel`, `make snapshot-prod`. Cycle dev x5 plus rapide. |
+| S24.9 | Docker compose dev hot-reload + 5 make targets quotidiens | CONFORT | S | [x] | `docker-compose.yml` actuellement statique (`pnpm install && pnpm run dev`). Ajouter bind mount + nodemon/turbopack hot reload. Targets : `make logs`, `make reset-db`, `make seed`, `make tunnel`, `make snapshot-prod`. Cycle dev x5 plus rapide. |
 
 ## Definition of done
 

--- a/scripts/tests/infra-smoke.sh
+++ b/scripts/tests/infra-smoke.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Infra smoke test — verifie que les 5 cibles make du daily dev existent
+# et que docker-compose.yml inclut bien la configuration hot-reload (S24.9).
+#
+# Pas de docker requis : `docker compose config` est tente uniquement si
+# le binaire est present (sinon on fallback sur un parsing YAML naif).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "  ❌ $1" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "  ✅ $1"
+  PASS=$((PASS + 1))
+}
+
+echo "→ Make targets daily-dev (S24.9)"
+for target in logs reset-db seed tunnel snapshot-prod; do
+  if make -n "$target" >/dev/null 2>&1; then
+    ok "make $target existe"
+  else
+    fail "make $target introuvable ou casse"
+  fi
+done
+
+echo ""
+echo "→ docker-compose.yml hot-reload"
+
+# Mount workspace bind
+if grep -qE "^\s*-\s*\.:/app\s*$" docker-compose.yml; then
+  ok "bind mount workspace (./:/app) present"
+else
+  fail "bind mount workspace manquant"
+fi
+
+# Anonymous volumes pour eviter l'overlay node_modules host
+if grep -qE "^\s*-\s*/app/node_modules\s*$" docker-compose.yml; then
+  ok "anonymous volume /app/node_modules present"
+else
+  fail "anonymous volume /app/node_modules manquant"
+fi
+
+# next build artefact masque pour eviter conflit dev/prod
+if grep -qE "^\s*-\s*/app/apps/web/\.next\s*$" docker-compose.yml; then
+  ok "anonymous volume /app/apps/web/.next present"
+else
+  fail "anonymous volume /app/apps/web/.next manquant"
+fi
+
+# init: true pour signal handling correct (Ctrl+C, SIGTERM)
+if [ "$(grep -cE '^[[:space:]]+init:[[:space:]]+true[[:space:]]*$' docker-compose.yml)" -ge 2 ]; then
+  ok "init: true actif sur web + server (signal handling)"
+else
+  fail "init: true manquant — Ctrl+C ne propagera pas SIGTERM aux processes Node"
+fi
+
+# docker compose config si dispo
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  if docker compose config >/dev/null 2>&1; then
+    ok "docker compose config parse OK"
+  else
+    fail "docker compose config echoue"
+  fi
+fi
+
+echo ""
+echo "Total: $PASS reussis, $FAIL echecs"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Resume

Cloture S24 en livrant le confort dev quotidien : hot-reload propre dans
les conteneurs Docker + 5 raccourcis Make pour les operations repetitives.

**docker-compose.yml**
- Anonymous volumes (`/app/node_modules`, `/app/apps/*/node_modules`,
  `/app/packages/*/node_modules`, `/app/apps/web/.next`) sur les
  services `web` et `server`. Le bind mount `./:/app` continue de
  fournir le hot-reload via `tsx watch` (server) et `next dev` (web),
  mais les binaires `node_modules` du conteneur Linux ne sont plus
  ecrases par un `node_modules` cote host (macOS/Windows) — fini les
  `Error: Cannot find module` au boot apres un `pnpm install` host.
- `init: true` sur `web` et `server` pour propager `Ctrl+C` / SIGTERM
  correctement aux processus Node enfants.
- Variables `CHOKIDAR_USEPOLLING=1`, `WATCHPACK_POLLING=true`,
  `TSX_WATCH_POLL=1` pour garantir le rebuild quand le bind mount
  n'emet pas d'inotify a travers la frontiere VM (Docker Desktop).

**Makefile**
- `make seed` : alias court de `db-seed`
- `make reset-db` : alias court de `db-reset-pg`
- `make tunnel` : `cloudflared` pointant sur le web local (override
  `TUNNEL_PORT` / `TUNNEL_HOSTNAME`), avec message d'aide si le
  binaire est absent
- `make snapshot-prod` : `pg_dump` compresse vers `snapshots/`
  horodatage UTC (`PROD_DATABASE_URL` requis). `snapshots/` ajoute a
  `.gitignore`.
- `make logs` existait deja et reste inchange.

**Tests**
Nouveau `scripts/tests/infra-smoke.sh` qui verifie via `make -n` et
parsing yaml que les 5 cibles existent et que la config docker
hot-reload est bien en place. 10/10 verts.

**Roadmap**
- Coche S24.9 dans `docs/roadmap/sprints/S24-stabilite-securite.md`
- Marque S24 `TERMINE` dans `docs/roadmap/phases.md` (commit dedie)

## Tache roadmap

Sprint S24, tache S24.9 (Docker compose dev hot-reload + 5 make
targets quotidiens) — *cloture le sprint S24*.

Source : `docs/roadmap/sprints/S24-stabilite-securite.md`

## Plan de test

- [x] `bash scripts/tests/infra-smoke.sh` : 10/10 verts (5 cibles make + 5 checks docker)
- [x] `make -n logs reset-db seed tunnel snapshot-prod` : commands expand correctement
- [x] Tests unitaires monorepo : 6 112 verts (server 769, web 534, game-engine 4809)
- [ ] Manuel : `docker compose up -d` puis editer `apps/server/src/routes/auth.ts` -> tsx watch detecte et redemarre le serveur en < 2s sans relance manuelle
- [ ] Manuel : `docker compose up -d` puis editer `apps/web/app/page.tsx` -> next dev HMR rafraichit le navigateur sans rebuild complet
- [ ] Manuel : `docker compose up` (foreground), Ctrl+C : les conteneurs s'arretent proprement (init: true + SIGTERM)
- [ ] Manuel : `make tunnel` : verifier que cloudflared expose bien `localhost:3100`
- [ ] Manuel : `PROD_DATABASE_URL=... make snapshot-prod` : verifier qu'un fichier `.sql.gz` horodatage est cree


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrduBMYgzSjqyYNozDMvrG)_