### PR TITLE
refactor(web): leagues page uses shared apiRequest helper (S25.5c)

### DIFF
--- a/apps/web/app/leagues/page.tsx
+++ b/apps/web/app/leagues/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { API_BASE } from "../auth-client";
+import { apiRequest } from "../lib/api-client";
 import { useLanguage } from "../contexts/LanguageContext";
 
 type LeagueStatus =
@@ -39,11 +39,14 @@ const STATUS_VALUES: LeagueStatus[] = [
   "archived",
 ];
 
-function buildListUrl(status: StatusFilter): string {
+// S25.5c — chemin relatif (sans API_BASE) : `apiRequest` re-prefixe en
+// ajoutant API_BASE et l'`Authorization: Bearer ...` automatiquement,
+// puis unwrap l'enveloppe `ApiResponse<T>` quand elle est presente.
+function buildListPath(status: StatusFilter): string {
   const params = new URLSearchParams();
   if (status !== "all") params.set("status", status);
   const qs = params.toString();
-  return `${API_BASE}/league${qs ? `?${qs}` : ""}`;
+  return `/league${qs ? `?${qs}` : ""}`;
 }
 
 export default function LeaguesPage() {
@@ -59,21 +62,10 @@ export default function LeaguesPage() {
       try {
         setLoading(true);
         setError(null);
-        const token =
-          typeof window !== "undefined"
-            ? localStorage.getItem("auth_token")
-            : null;
-        const headers: Record<string, string> = {};
-        if (token) headers.Authorization = `Bearer ${token}`;
-        const response = await fetch(buildListUrl(statusFilter), { headers });
-        if (!response.ok) {
-          const body = (await response.json().catch(() => ({}))) as {
-            error?: string;
-          };
-          throw new Error(body.error ?? t.leagues.errorLoad);
-        }
-        const json = (await response.json()) as { leagues: League[] };
-        if (!cancelled) setLeagues(json.leagues);
+        const body = await apiRequest<{ leagues: League[] }>(
+          buildListPath(statusFilter),
+        );
+        if (!cancelled) setLeagues(body.leagues ?? []);
       } catch (err: unknown) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : t.leagues.errorLoad);


### PR DESCRIPTION
## Resume

Troisieme slice de S25.5 : migre `apps/web/app/leagues/page.tsx` vers
`apiRequest<T>` introduit en S25.5b. Comportement utilisateur identique
mais le code se simplifie (-8 lignes nettes).

**Migration**
- Le helper ajoute automatiquement `API_BASE` et l'`Authorization: Bearer ...`.
- Il unwrap l'enveloppe `{success, data, error}` quand elle est presente,
  et tolere le format legacy `{ leagues: [...] }` que le serveur retourne
  actuellement (le chemin de succes de `league.ts` n'a pas encore ete
  migre, cf. roadmap S25.5).
- Le bloc `try/catch` se simplifie : toute erreur 4xx/5xx remonte
  desormais en `ApiClientError` thrown depuis `apiRequest`, plutot qu'en
  deux passes (status check + body parse).

## Tache roadmap

Sprint S25, tache S25.5 (Adopter ApiResponse<T> sur les routes restantes)
— slice S25.5c.
Source : `docs/roadmap/sprints/S25-observabilite-qualite.md`

## Plan de test

- [x] `pnpm vitest app/leagues/page.test.tsx` : 8/8 verts (le mock fetch
      continue de poser `Authorization: Bearer test-token` parce que
      `apiRequest` lit `auth_token` du mock localStorage)
- [x] `pnpm test` web : 563/563 verts
- [ ] Manuel : login -> ouvrir `/leagues` -> verifier l'affichage et le
      filtre statut. La requete reseau sortante doit toujours porter
      l'`Authorization` header et toucher `/league?status=...`.
- [ ] S25.5d (suite) : migrer `leagues/[id]/page.tsx`,
      `SeasonStandings`, `SeasonCalendar`, `SeasonParticipants` puis
      basculer les chemins de succes du serveur (`sendSuccess`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrduBMYgzSjqyYNozDMvrG)_