### PR TITLE
refactor(web): leagues/[id] page uses shared apiRequest helper (S25.5d)

### DIFF
--- a/apps/web/app/leagues/[id]/page.tsx
+++ b/apps/web/app/leagues/[id]/page.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { API_BASE } from "../../auth-client";
+import { apiRequest } from "../../lib/api-client";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { SeasonCalendar } from "./SeasonCalendar";
 import { SeasonStandings } from "./SeasonStandings";
@@ -13,20 +13,11 @@ import type {
   StandingRow,
 } from "./types";
 
-function authHeaders(): Record<string, string> {
-  if (typeof window === "undefined") return {};
-  const token = localStorage.getItem("auth_token");
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-async function fetchJson<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(body.error ?? `HTTP ${res.status}`);
-  }
-  return (await res.json()) as T;
-}
+// S25.5d — `apiRequest<T>` (lib/api-client) prend en charge `API_BASE`,
+// l'`Authorization: Bearer ...`, et l'unwrap de l'enveloppe
+// `ApiResponse<T>` quand le serveur l'expose. Tolere encore le format
+// legacy le temps que les success paths de `routes/league.ts` soient
+// migres (cf. roadmap S25.5).
 
 export default function LeagueDetailPage() {
   const { t } = useLanguage();
@@ -50,7 +41,7 @@ export default function LeagueDetailPage() {
       try {
         setLoading(true);
         setError(null);
-        const { league: data } = await fetchJson<{ league: LeagueDetail }>(
+        const { league: data } = await apiRequest<{ league: LeagueDetail }>(
           `/league/${leagueId}`,
         );
         if (cancelled) return;
@@ -81,10 +72,10 @@ export default function LeagueDetailPage() {
         setSeasonLoading(true);
         setSeasonError(null);
         const [seasonRes, standingsRes] = await Promise.all([
-          fetchJson<{ season: LeagueSeasonDetail }>(
+          apiRequest<{ season: LeagueSeasonDetail }>(
             `/league/seasons/${seasonId}`,
           ),
-          fetchJson<{ seasonId: string; standings: StandingRow[] }>(
+          apiRequest<{ seasonId: string; standings: StandingRow[] }>(
             `/league/seasons/${seasonId}/standings`,
           ),
         ]);


### PR DESCRIPTION
## Resume

Quatrieme slice de S25.5 : migre `apps/web/app/leagues/[id]/page.tsx`
vers `apiRequest<T>` (introduit en S25.5b, deja branche sur la liste en
S25.5c).

- 3 appels migres : detail ligue, detail saison, standings.
- Le helper local `fetchJson` est supprime (-9 lignes net).
- `apiRequest` injecte automatiquement `API_BASE` + l'auth header et
  unwrap l'enveloppe `ApiResponse<T>` quand presente. Tolere encore le
  format legacy le temps que `routes/league.ts` migre ses success paths
  cote serveur.

Composants enfants (`SeasonStandings`, `SeasonCalendar`,
`SeasonParticipants`) recoivent leur data en props depuis cette page —
pas de fetch direct, donc pas de migration necessaire.

## Tache roadmap

Sprint S25, tache S25.5 (Adopter ApiResponse<T> sur les routes restantes)
— slice S25.5d.
Source : `docs/roadmap/sprints/S25-observabilite-qualite.md`

## Plan de test

- [x] `pnpm vitest run app/leagues/[id]/page.test.tsx` : 9/9 verts
- [x] `pnpm test` web : 563/563 verts
- [ ] Manuel : login -> ouvrir `/leagues/<id>` -> verifier que toutes
      les sections (info, calendrier, standings, participants) chargent
      sans erreur, et que le selector de saison fonctionne
- [ ] S25.5e (suite) : migrer les success paths de `routes/league.ts`
      cote serveur (sendSuccess) maintenant que tous les consommateurs
      frontend tolerent l'enveloppe


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrduBMYgzSjqyYNozDMvrG)_