### PR TITLE
fix(e2e): leagues spec uses envelope after sendSuccess migration (S25.5f)

### DIFF
--- a/tests/e2e-api/helpers/api.ts
+++ b/tests/e2e-api/helpers/api.ts
@@ -154,3 +154,19 @@ export async function rawDelete(
 export async function resetDb(): Promise<void> {
   await fetch(`${API_BASE}/__test/reset`, { method: "POST" });
 }
+
+/**
+ * S25.5 — Helper d'unwrap pour les routes ayant migre vers
+ * `ApiResponse<T>` (`{ success, data, error }`). Permet aux specs
+ * d'ecrire :
+ *
+ *   const league = unwrap(await post<{success: true; data: League}>(...));
+ *
+ * sans repeter `.data` partout. Ne touche pas au runtime des helpers
+ * `get`/`post` qui restent generiques (les specs envelope-aware comme
+ * leaderboard, feature-flags, achievements, friends continuent de lire
+ * `.data` / `.meta` / `.success` directement).
+ */
+export function unwrap<T>(envelope: { data: T }): T {
+  return envelope.data;
+}

--- a/tests/e2e-api/specs/leagues-seasons.spec.ts
+++ b/tests/e2e-api/specs/leagues-seasons.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { get, post, rawGet, rawPost, resetDb } from "../helpers/api";
+import { get, post, rawGet, rawPost, resetDb, unwrap } from "../helpers/api";
 import { seedAndLogin, createTeam } from "../helpers/factories";
 
 /**
@@ -142,26 +142,26 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
       const team = await createTeam(userId, "Alice Skavens", "skaven");
 
       // 1. Creer la ligue (autorise le roster Skaven via allowedRosters=null).
-      const league = await post<League>("/leagues", token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", token, {
         name: "Ligue Saison",
-      });
+      }));
 
       // 2. Creer une saison (createur uniquement).
-      const seasonResponse = await post<Season>(
+      const seasonResponse = unwrap(await post<{ success: true; data: Season }>(
         `/leagues/${league.id}/seasons`,
         token,
         { name: "Saison 1" },
-      );
+      ));
       expect(seasonResponse.id).toBeTruthy();
       expect(seasonResponse.leagueId).toBe(league.id);
       expect(seasonResponse.name).toBe("Saison 1");
       const seasonId = seasonResponse.id;
 
       // 3. GET /seasons/:id renvoie la saison + sa ligue serialisee.
-      const detail = await get<SeasonResponse>(
+      const detail = unwrap(await get<{ success: true; data: SeasonResponse }>(
         `/leagues/seasons/${seasonId}`,
         token,
-      );
+      ));
       expect(detail.season.id).toBe(seasonId);
       expect(detail.season.league?.id).toBe(league.id);
 
@@ -188,18 +188,18 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
         "pwd",
         "Alice",
       );
-      const league = await post<League>("/leagues", token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", token, {
         name: "Ligue Standings",
-      });
-      const season = await post<Season>(
+      }));
+      const season = unwrap(await post<{ success: true; data: Season }>(
         `/leagues/${league.id}/seasons`,
         token,
         { name: "S1" },
-      );
-      const standings = await get<StandingsResponse>(
+      ));
+      const standings = unwrap(await get<{ success: true; data: StandingsResponse }>(
         `/leagues/seasons/${season.id}/standings`,
         token,
-      );
+      ));
       expect(standings).toBeDefined();
       // computeSeasonStandings renvoie un objet avec standings (peut etre
       // un tableau vide si aucun match termine).
@@ -211,9 +211,9 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
     it("POST /leagues/:id/seasons par non-createur -> 403", async () => {
       const alice = await seedAndLogin("alice@ls.test", "pwd-a", "Alice");
       const bob = await seedAndLogin("bob@ls.test", "pwd-b", "Bob");
-      const league = await post<League>("/leagues", alice.token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", alice.token, {
         name: "Ligue Alice",
-      });
+      }));
       const res = await rawPost(
         `/leagues/${league.id}/seasons`,
         bob.token,
@@ -225,14 +225,14 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
     it("POST /leagues/seasons/:seasonId/rounds par non-createur -> 403", async () => {
       const alice = await seedAndLogin("alice@ls.test", "pwd-a", "Alice");
       const bob = await seedAndLogin("bob@ls.test", "pwd-b", "Bob");
-      const league = await post<League>("/leagues", alice.token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", alice.token, {
         name: "Ligue rondes",
-      });
-      const season = await post<Season>(
+      }));
+      const season = unwrap(await post<{ success: true; data: Season }>(
         `/leagues/${league.id}/seasons`,
         alice.token,
         { name: "S1" },
-      );
+      ));
       const res = await rawPost(
         `/leagues/seasons/${season.id}/rounds`,
         bob.token,
@@ -249,9 +249,9 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
         "pwd",
         "Alice",
       );
-      const league = await post<League>("/leagues", token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", token, {
         name: "Ligue Validation",
-      });
+      }));
       const res = await rawPost(
         `/leagues/${league.id}/seasons`,
         token,
@@ -266,14 +266,14 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
         "pwd",
         "Alice",
       );
-      const league = await post<League>("/leagues", token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", token, {
         name: "Ligue Join",
-      });
-      const season = await post<Season>(
+      }));
+      const season = unwrap(await post<{ success: true; data: Season }>(
         `/leagues/${league.id}/seasons`,
         token,
         { name: "S1" },
-      );
+      ));
       const res = await rawPost(
         `/leagues/seasons/${season.id}/join`,
         token,
@@ -288,14 +288,14 @@ describe("E2E API — /leagues (saisons & rondes)", () => {
         "pwd",
         "Alice",
       );
-      const league = await post<League>("/leagues", token, {
+      const league = unwrap(await post<{ success: true; data: League }>("/leagues", token, {
         name: "Ligue Rounds",
-      });
-      const season = await post<Season>(
+      }));
+      const season = unwrap(await post<{ success: true; data: Season }>(
         `/leagues/${league.id}/seasons`,
         token,
         { name: "S1" },
-      );
+      ));
       const res = await rawPost(
         `/leagues/seasons/${season.id}/rounds`,
         token,

--- a/tests/e2e-api/specs/leagues.spec.ts
+++ b/tests/e2e-api/specs/leagues.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { rawGet, rawPost, post, get, resetDb } from "../helpers/api";
+import { rawGet, rawPost, post, get, resetDb, unwrap } from "../helpers/api";
 import { seedAndLogin } from "../helpers/factories";
 
 /**
@@ -60,7 +60,9 @@ describe("E2E API — /leagues", () => {
       "password-lg1",
       "LG1",
     );
-    const json = await get<ListResponse>("/leagues", token);
+    const json = unwrap(
+      await get<{ success: true; data: ListResponse }>("/leagues", token),
+    );
     expect(json).toHaveProperty("leagues");
     expect(Array.isArray(json.leagues)).toBe(true);
     expect(json.leagues).toEqual([]);
@@ -72,10 +74,12 @@ describe("E2E API — /leagues", () => {
       "password-lg2",
       "LG2",
     );
-    const created = await post<League>("/leagues", token, {
-      name: "Ligue E2E",
-      description: "Creee par le spec leagues.spec.ts",
-    });
+    const created = unwrap(
+      await post<{ success: true; data: League }>("/leagues", token, {
+        name: "Ligue E2E",
+        description: "Creee par le spec leagues.spec.ts",
+      }),
+    );
     expect(created.id).toBeTruthy();
     expect(created.name).toBe("Ligue E2E");
     expect(created.creatorId).toBe(userId);
@@ -90,7 +94,9 @@ describe("E2E API — /leagues", () => {
     // allowedRosters par defaut = null (pas de restriction)
     expect(created.allowedRosters).toBeNull();
 
-    const list = await get<ListResponse>("/leagues", token);
+    const list = unwrap(
+      await get<{ success: true; data: ListResponse }>("/leagues", token),
+    );
     expect(list.leagues.length).toBe(1);
     expect(list.leagues[0].id).toBe(created.id);
   });
@@ -101,10 +107,12 @@ describe("E2E API — /leagues", () => {
       "password-lg3",
       "LG3",
     );
-    const created = await post<League>("/leagues", token, {
-      name: "Open 5 Teams",
-      allowedRosters: ["skaven", "lizardmen", "dwarves"],
-    });
+    const created = unwrap(
+      await post<{ success: true; data: League }>("/leagues", token, {
+        name: "Open 5 Teams",
+        allowedRosters: ["skaven", "lizardmen", "dwarves"],
+      }),
+    );
     expect(Array.isArray(created.allowedRosters)).toBe(true);
     expect(created.allowedRosters).toEqual([
       "skaven",
@@ -159,13 +167,17 @@ describe("E2E API — /leagues", () => {
       "password-lg7",
       "LG7",
     );
-    const created = await post<League>("/leagues", token, {
-      name: "Ligue detail",
-      description: "Pour le test /:id",
-    });
-    const detail = await get<DetailResponse>(
-      `/leagues/${created.id}`,
-      token,
+    const created = unwrap(
+      await post<{ success: true; data: League }>("/leagues", token, {
+        name: "Ligue detail",
+        description: "Pour le test /:id",
+      }),
+    );
+    const detail = unwrap(
+      await get<{ success: true; data: DetailResponse }>(
+        `/leagues/${created.id}`,
+        token,
+      ),
     );
     expect(detail.league.id).toBe(created.id);
     expect(detail.league.name).toBe("Ligue detail");
@@ -183,13 +195,17 @@ describe("E2E API — /leagues", () => {
       "password-lg8b",
       "LG8B",
     );
-    const created = await post<League>("/leagues", creator.token, {
-      name: "Ligue publique",
-      isPublic: true,
-    });
-    const list = await get<ListResponse>(
-      "/leagues?publicOnly=true",
-      viewer.token,
+    const created = unwrap(
+      await post<{ success: true; data: League }>("/leagues", creator.token, {
+        name: "Ligue publique",
+        isPublic: true,
+      }),
+    );
+    const list = unwrap(
+      await get<{ success: true; data: ListResponse }>(
+        "/leagues?publicOnly=true",
+        viewer.token,
+      ),
     );
     const ids = list.leagues.map((l) => l.id);
     expect(ids).toContain(created.id);


### PR DESCRIPTION
## Resume

Suite de S25.5e (#417) qui a migre les success paths de
`apps/server/src/routes/league.ts` vers `sendSuccess`. Les test specs
e2e `leagues.spec.ts` lisaient encore `created.id` / `json.leagues` au
top-level alors que la response est maintenant
`{success: true, data: {...}}`. Le job CI E2E API #417 a echoue sur
ce point (mais la PR a ete mergee quand meme — cette PR repare le main).

**Fix**
- `tests/e2e-api/helpers/api.ts` : exporte un helper `unwrap<T>(env)`
  pour eviter de repeter `.data` dans les specs.
- `tests/e2e-api/specs/leagues.spec.ts` : 6 appels `post<League>`,
  `get<ListResponse>`, `get<DetailResponse>` annotes avec le type
  envelope et passes a `unwrap()`.
- Les autres specs envelope-aware (achievements, friends, leaderboard,
  feature-flags) restent inchangees : elles consomment deja `.data`
  directement.

## Tache roadmap

Sprint S25, tache S25.5 (Adopter ApiResponse<T> sur les routes restantes)
— slice S25.5f (fix e2e specs cascade de S25.5e).
Source : `docs/roadmap/sprints/S25-observabilite-qualite.md`

## Plan de test

- [x] `pnpm typecheck` : pas de nouvelle erreur (3 erreurs pre-existantes admin/feature-flags)
- [x] Verifie en local : leagues.spec.ts passe (10/10) quand le test server demarre
- [ ] CI : valider que le job E2E API repasse vert sur cette PR
- [ ] Si flakiness persiste sur d'autres specs (ECONNREFUSED), tracer dans une issue infra dediee


---
_Generated by [Claude Code](https://claude.ai/code/session_01GrduBMYgzSjqyYNozDMvrG)_