### PR TITLE
Improve match completion dialog with team names

### DIFF
--- a/apps/web/app/local-matches/[id]/page.tsx
+++ b/apps/web/app/local-matches/[id]/page.tsx
@@ -283,22 +283,27 @@ export default function LocalMatchPage() {
   };
 
   const handleComplete = async () => {
-    const scoreTeamAStr = prompt("Score de l'équipe A :", "0");
-    const scoreTeamBStr = prompt("Score de l'équipe B :", "0");
-    
-    if (scoreTeamAStr === null || scoreTeamBStr === null) {
+    const teamAName = localMatch?.teamA?.name ?? "Équipe A";
+    const teamBName = localMatch?.teamB?.name ?? "Équipe B";
+
+    const scoreTeamAStr = prompt(`Score de ${teamAName} :`, "0");
+    if (scoreTeamAStr === null) {
       return; // L'utilisateur a annulé
     }
-    
+    const scoreTeamBStr = prompt(`Score de ${teamBName} :`, "0");
+    if (scoreTeamBStr === null) {
+      return; // L'utilisateur a annulé
+    }
+
     const scoreTeamA = parseInt(scoreTeamAStr, 10);
     const scoreTeamB = parseInt(scoreTeamBStr, 10);
-    
+
     if (isNaN(scoreTeamA) || isNaN(scoreTeamB)) {
       alert("Les scores doivent être des nombres valides");
       return;
     }
-    
-    if (!confirm(`Terminer la partie avec le score ${scoreTeamA} - ${scoreTeamB} ?`)) {
+
+    if (!confirm(`Terminer la partie avec le score ${teamAName} ${scoreTeamA} - ${scoreTeamB} ${teamBName} ?`)) {
       return;
     }
 


### PR DESCRIPTION
## Résumé

- [x] Améliorer l'UX du dialogue de fin de partie en affichant les noms réels des équipes dans les prompts et la confirmation

## Description

Cette PR améliore l'expérience utilisateur lors de la finalisation d'une partie locale en :

1. **Affichage des noms d'équipes** : Les prompts de saisie des scores affichent maintenant les noms réels des équipes (ex: "Score de Paris FC :" au lieu de "Score de l'équipe A :") avec des valeurs par défaut ("Équipe A" / "Équipe B")

2. **Meilleure confirmation** : Le message de confirmation affiche le score au format `Équipe A 2 - 1 Équipe B` pour plus de clarté

3. **Gestion améliorée des annulations** : Les prompts sont maintenant traités individuellement, permettant à l'utilisateur d'annuler à chaque étape plutôt que de devoir annuler les deux à la fois

4. **Nettoyage du code** : Suppression des espaces inutiles et amélioration de la lisibilité

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (N/A - changement UI mineur)
- [x] Tests e2e (N/A - changement UI mineur)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01TooefLpvHH84jgbeT1LwY8