### PR TITLE
Add PDF export for local match summaries with full game recap

### DIFF
--- a/apps/web/app/local-matches/[id]/LocalMatchSummary.tsx
+++ b/apps/web/app/local-matches/[id]/LocalMatchSummary.tsx
@@ -58,10 +58,12 @@ type LocalMatch = {
   teamA: {
     id: string;
     name: string;
+    roster?: string | null;
   };
   teamB: {
     id: string;
     name: string;
+    roster?: string | null;
   };
   scoreTeamA: number | null;
   scoreTeamB: number | null;
@@ -84,6 +86,24 @@ type LocalMatch = {
         description: string;
       };
     };
+    matchStats?: Record<string, {
+      touchdowns: number;
+      casualties: number;
+      completions: number;
+      interceptions: number;
+      mvp: boolean;
+    }>;
+    matchResult?: {
+      winner?: "A" | "B";
+      spp?: Record<string, number>;
+    };
+    players?: Array<{
+      id: string;
+      team: "A" | "B";
+      name: string;
+      number: number;
+      position: string;
+    }>;
   };
 };
 
@@ -139,57 +159,6 @@ function formatActionDescription(action: LocalMatchAction, teamAName: string, te
   return desc;
 }
 
-// Fonction pour formater les actions pour le PDF (sans emojis)
-function formatActionDescriptionForPDF(action: LocalMatchAction, teamAName: string, teamBName: string): string {
-  const teamName = action.playerTeam === "A" ? teamAName : teamBName;
-  const opponentTeamName = action.playerTeam === "A" ? teamBName : teamAName;
-  
-  // Utiliser des symboles texte au lieu d'emojis
-  const actionSymbols: Record<ActionType, string> = {
-    passe: "[P]",
-    reception: "[R]",
-    td: "[TD]",
-    blocage: "[B]",
-    blitz: "[BL]",
-    transmission: "[T]",
-    aggression: "[A]",
-    sprint: "[S]",
-    esquive: "[E]",
-    apothicaire: "[AP]",
-    interception: "[I]",
-  };
-  
-  let desc = `${actionSymbols[action.actionType]} ${ActionLabels[action.actionType]} - ${action.playerName} (${teamName})`;
-  
-  if (action.opponentName) {
-    desc += ` vs ${action.opponentName} (${opponentTeamName})`;
-  }
-  
-  if (action.diceResult !== null) {
-    desc += ` - Dé: ${action.diceResult}`;
-  }
-  
-  if (action.fumble) {
-    desc += " [ECHEC]";
-    if (action.playerState) {
-      desc += ` (${action.playerState})`;
-    }
-  } else if (action.actionType === "blocage" || action.actionType === "blitz") {
-    if (action.armorBroken) {
-      desc += " [ARMURE CASSEE]";
-      if (action.opponentState) {
-        desc += ` (${action.opponentState})`;
-      }
-    } else {
-      desc += " [ARMURE NON CASSEE]";
-    }
-  } else if (action.actionType === "passe" && action.passType) {
-    desc += ` - ${action.passType}`;
-  }
-  
-  return desc;
-}
-
 export default function LocalMatchSummary({ matchId, match }: LocalMatchSummaryProps) {
   const [actions, setActions] = useState<LocalMatchAction[]>([]);
   const [loading, setLoading] = useState(true);
@@ -232,223 +201,12 @@ export default function LocalMatchSummary({ matchId, match }: LocalMatchSummaryP
 
   const exportToPDF = async () => {
     try {
-      const { default: jsPDF } = await import('jspdf');
-      const { default: autoTable } = await import('jspdf-autotable');
-
-      const doc = new jsPDF({
-        orientation: 'portrait',
-        unit: 'mm',
-        format: 'a4',
-      });
-
-      // Titre
-      doc.setFontSize(20);
-      doc.text('Récapitulatif du Match', 105, 20, { align: 'center' });
-
-      // Informations du match
-      doc.setFontSize(14);
-      doc.text(match.name || 'Partie offline', 105, 30, { align: 'center' });
-      
-      doc.setFontSize(12);
-      const yStart = 40;
-      let yPos = yStart;
-      
-      doc.text(`${match.teamA.name} vs ${match.teamB.name}`, 105, yPos, { align: 'center' });
-      yPos += 10;
-      
-      if (match.cup) {
-        doc.text(`Coupe: ${match.cup.name}`, 105, yPos, { align: 'center' });
-        yPos += 10;
-      }
-
-      // Score façon football US
-      const scoreTeamA = match.scoreTeamA || 0;
-      const scoreTeamB = match.scoreTeamB || 0;
-      
-      // Compter les joueurs éliminés/exclus par équipe
-      const eliminatedA = actions.filter(a => 
-        (a.playerTeam === "A" && a.playerState === "elimine") ||
-        (a.playerTeam === "B" && a.opponentState === "elimine" && a.opponentId && a.opponentName)
-      ).length;
-      const eliminatedB = actions.filter(a => 
-        (a.playerTeam === "B" && a.playerState === "elimine") ||
-        (a.playerTeam === "A" && a.opponentState === "elimine" && a.opponentId && a.opponentName)
-      ).length;
-      
-      doc.setFontSize(14);
-      doc.setFont('helvetica', 'bold');
-      doc.text('SCORE FINAL', 105, yPos + 5, { align: 'center' });
-      yPos += 12;
-      
-      // Score en grand
-      doc.setFontSize(28);
-      doc.setFont('helvetica', 'bold');
-      const scoreText = `${scoreTeamA} - ${scoreTeamB}`;
-      doc.text(scoreText, 105, yPos, { align: 'center' });
-      yPos += 12;
-      
-      // Équipes et éliminations
-      doc.setFontSize(11);
-      doc.setFont('helvetica', 'normal');
-      const teamAText = `${match.teamA.name}: ${eliminatedA} Éliminé${eliminatedA > 1 ? 's' : ''}`;
-      const teamBText = `${match.teamB.name}: ${eliminatedB} Éliminé${eliminatedB > 1 ? 's' : ''}`;
-      doc.text(teamAText, 105, yPos, { align: 'center' });
-      yPos += 6;
-      doc.text(teamBText, 105, yPos, { align: 'center' });
-      yPos += 15;
-
-      // Dates
-      if (match.startedAt) {
-        doc.setFontSize(10);
-        doc.setFont('helvetica', 'normal');
-        doc.text(`Début: ${new Date(match.startedAt).toLocaleString('fr-FR')}`, 20, yPos);
-        yPos += 6;
-      }
-      if (match.completedAt) {
-        doc.setFontSize(10);
-        doc.setFont('helvetica', 'normal');
-        doc.text(`Fin: ${new Date(match.completedAt).toLocaleString('fr-FR')}`, 20, yPos);
-        yPos += 12;
-      }
-
-      // Informations de pré-match
-      if (match.gameState?.preMatch && (match.gameState.preMatch.fanFactor || match.gameState.preMatch.weather)) {
-        // Nouvelle page si nécessaire
-        if (yPos > 250) {
-          doc.addPage();
-          yPos = 20;
-        }
-
-        doc.setFontSize(14);
-        doc.setFont('helvetica', 'bold');
-        doc.text('INFORMATIONS D\'AVANT-MATCH', 105, yPos, { align: 'center' });
-        yPos += 12;
-
-        // Fans dévoués
-        if (match.gameState.preMatch.fanFactor) {
-          doc.setFontSize(12);
-          doc.setFont('helvetica', 'bold');
-          doc.text('Fans dévoués', 20, yPos);
-          yPos += 8;
-
-          doc.setFontSize(10);
-          doc.setFont('helvetica', 'normal');
-          const fanFactorA = match.gameState.preMatch.fanFactor.teamA;
-          const fanFactorB = match.gameState.preMatch.fanFactor.teamB;
-          doc.text(`${match.teamA.name}: Fan Factor ${fanFactorA.total} (D3: ${fanFactorA.d3} + Fans: ${fanFactorA.dedicatedFans})`, 25, yPos);
-          yPos += 6;
-          doc.text(`${match.teamB.name}: Fan Factor ${fanFactorB.total} (D3: ${fanFactorB.d3} + Fans: ${fanFactorB.dedicatedFans})`, 25, yPos);
-          yPos += 10;
-        }
-
-        // Conditions météorologiques
-        if (match.gameState.preMatch.weather) {
-          doc.setFontSize(12);
-          doc.setFont('helvetica', 'bold');
-          doc.text('Conditions météorologiques', 20, yPos);
-          yPos += 8;
-
-          doc.setFontSize(10);
-          doc.setFont('helvetica', 'normal');
-          const weather = match.gameState.preMatch.weather;
-          doc.text(`Type: ${match.gameState.preMatch.weatherType || 'classique'}`, 25, yPos);
-          yPos += 6;
-          doc.text(`Total 2D6: ${weather.total}`, 25, yPos);
-          yPos += 6;
-          doc.setFont('helvetica', 'bold');
-          doc.text(weather.condition, 25, yPos);
-          yPos += 6;
-          doc.setFont('helvetica', 'normal');
-          const descLines = doc.splitTextToSize(weather.description, 160);
-          doc.text(descLines, 25, yPos);
-          yPos += descLines.length * 5 + 10;
-        }
-      }
-
-      // Liste des actions par mi-temps
-      const actionsByHalf = actions.reduce((acc, action) => {
-        if (!acc[action.half]) {
-          acc[action.half] = [];
-        }
-        acc[action.half].push(action);
-        return acc;
-      }, {} as Record<number, LocalMatchAction[]>);
-
-      for (const half of [1, 2]) {
-        const halfActions = actionsByHalf[half] || [];
-        if (halfActions.length === 0) continue;
-
-        // Nouvelle page si nécessaire
-        if (yPos > 250) {
-          doc.addPage();
-          yPos = 20;
-        }
-
-        doc.setFontSize(14);
-        doc.text(`MI-TEMPS ${half}`, 20, yPos);
-        yPos += 10;
-
-        // Grouper par tour
-        const actionsByTurn = halfActions.reduce((acc, action) => {
-          if (!acc[action.turn]) {
-            acc[action.turn] = [];
-          }
-          acc[action.turn].push(action);
-          return acc;
-        }, {} as Record<number, LocalMatchAction[]>);
-
-        for (const turn of Object.keys(actionsByTurn).map(Number).sort((a, b) => a - b)) {
-          const turnActions = actionsByTurn[turn];
-          
-          // Vérifier si on a besoin d'une nouvelle page avant d'ajouter le tour
-          // Laisser plus d'espace pour éviter les superpositions
-          if (yPos > 240) {
-            doc.addPage();
-            yPos = 20;
-          }
-          
-          doc.setFontSize(11);
-          doc.setFont('helvetica', 'bold');
-          doc.text(`Tour ${turn}`, 25, yPos);
-          yPos += 8;
-
-          doc.setFontSize(9);
-          doc.setFont('helvetica', 'normal');
-          for (const action of turnActions) {
-            // Vérifier si on a besoin d'une nouvelle page avant chaque action
-            // Laisser plus d'espace pour éviter les superpositions
-            if (yPos > 270) {
-              doc.addPage();
-              yPos = 20;
-            }
-            
-            // Utiliser la fonction sans emojis pour le PDF
-            const desc = formatActionDescriptionForPDF(action, match.teamA.name, match.teamB.name);
-            // Largeur réduite pour éviter les coupures et permettre les retours à la ligne
-            const lines = doc.splitTextToSize(desc, 160);
-            
-            // Vérifier qu'on a assez d'espace pour toutes les lignes
-            const neededSpace = lines.length * 5 + 3;
-            if (yPos + neededSpace > 280) {
-              doc.addPage();
-              yPos = 20;
-            }
-            
-            doc.text(lines, 30, yPos);
-            // Espacement dynamique selon le nombre de lignes avec marge supplémentaire
-            yPos += neededSpace;
-          }
-          yPos += 6; // Espacement entre les tours
-        }
-        yPos += 5;
-      }
-
-      // Sauvegarder le PDF
-      const fileName = `${(match.name || 'match').replace(/[^a-z0-9]/gi, '_')}_recap.pdf`;
-      doc.save(fileName);
+      const { generateMatchPdf } = await import("./pdf");
+      const result = await generateMatchPdf(match, actions);
+      result.save();
     } catch (error) {
-      console.error('Erreur lors de l\'export PDF:', error);
-      alert('Erreur lors de la génération du PDF');
+      console.error("Erreur lors de l'export PDF:", error);
+      alert("Erreur lors de la génération du PDF");
     }
   };
 

--- a/apps/web/app/local-matches/[id]/page.tsx
+++ b/apps/web/app/local-matches/[id]/page.tsx
@@ -904,10 +904,12 @@ export default function LocalMatchPage() {
               teamA: {
                 id: localMatch.teamA.id,
                 name: localMatch.teamA.name,
+                roster: localMatch.teamA.roster,
               },
               teamB: {
                 id: localMatch.teamB.id,
                 name: localMatch.teamB.name,
+                roster: localMatch.teamB.roster,
               },
               scoreTeamA: localMatch.scoreTeamA,
               scoreTeamB: localMatch.scoreTeamB,

--- a/apps/web/app/local-matches/[id]/pdf/aggregations.test.ts
+++ b/apps/web/app/local-matches/[id]/pdf/aggregations.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests unitaires des agregations utilisees par le PDF de recap.
+ * Logique pure: aucune dependance jsPDF, runnable en jsdom.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  computeAggregates,
+  computeMvp,
+  computeOutcome,
+  computeTeamStats,
+  countActionsByType,
+} from "./aggregations";
+import type { PdfAction, PdfMatch } from "./types";
+
+function makeAction(overrides: Partial<PdfAction> = {}): PdfAction {
+  return {
+    id: overrides.id ?? "a-" + Math.random().toString(36).slice(2),
+    half: overrides.half ?? 1,
+    turn: overrides.turn ?? 1,
+    actionType: overrides.actionType ?? "blocage",
+    playerId: overrides.playerId ?? "p1",
+    playerName: overrides.playerName ?? "Joueur 1",
+    playerTeam: overrides.playerTeam ?? "A",
+    opponentId: overrides.opponentId ?? null,
+    opponentName: overrides.opponentName ?? null,
+    diceResult: overrides.diceResult ?? null,
+    fumble: overrides.fumble ?? false,
+    playerState: overrides.playerState ?? null,
+    armorBroken: overrides.armorBroken ?? false,
+    opponentState: overrides.opponentState ?? null,
+    passType: overrides.passType ?? null,
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+  };
+}
+
+const baseMatch: PdfMatch = {
+  id: "m1",
+  name: "Test Match",
+  teamA: { id: "tA", name: "Skaven Stars", roster: "skaven" },
+  teamB: { id: "tB", name: "Wood Eaters", roster: "wood_elf" },
+  scoreTeamA: 2,
+  scoreTeamB: 1,
+  startedAt: null,
+  completedAt: null,
+  cup: null,
+  gameState: undefined,
+};
+
+describe("computeOutcome", () => {
+  it("retourne A quand scoreA > scoreB", () => {
+    expect(computeOutcome(2, 1)).toBe("A");
+  });
+  it("retourne B quand scoreB > scoreA", () => {
+    expect(computeOutcome(0, 3)).toBe("B");
+  });
+  it("retourne DRAW quand egalite", () => {
+    expect(computeOutcome(1, 1)).toBe("DRAW");
+    expect(computeOutcome(null, null)).toBe("DRAW");
+  });
+});
+
+describe("computeTeamStats", () => {
+  it("compte correctement les TD, passes, blocs, fumbles par equipe", () => {
+    const actions: PdfAction[] = [
+      makeAction({ playerTeam: "A", actionType: "td" }),
+      makeAction({ playerTeam: "A", actionType: "passe" }),
+      makeAction({ playerTeam: "A", actionType: "passe", fumble: true }),
+      makeAction({ playerTeam: "B", actionType: "blocage", armorBroken: true, opponentState: "elimine" }),
+      makeAction({ playerTeam: "B", actionType: "blitz", armorBroken: true, opponentState: "ko" }),
+      makeAction({ playerTeam: "B", actionType: "aggression", armorBroken: false }),
+    ];
+    const { teamA, teamB } = computeTeamStats(actions);
+
+    expect(teamA.touchdowns).toBe(1);
+    expect(teamA.completions).toBe(1);
+    expect(teamA.fumbles).toBe(1);
+    expect(teamA.totalActions).toBe(3);
+
+    expect(teamB.blocks).toBe(1);
+    expect(teamB.blitzes).toBe(1);
+    expect(teamB.fouls).toBe(1);
+    expect(teamB.armorBreaks).toBe(2);
+
+    // Convention BB — casualty/KO credites a l'equipe AGISSANTE (B), pas a la victime.
+    expect(teamB.casualties).toBe(1);
+    expect(teamB.kos).toBe(1);
+    expect(teamA.casualties).toBe(0);
+    expect(teamA.kos).toBe(0);
+  });
+
+  it("retourne stats vides pour 0 action", () => {
+    const { teamA, teamB } = computeTeamStats([]);
+    expect(teamA.totalActions).toBe(0);
+    expect(teamB.totalActions).toBe(0);
+  });
+});
+
+describe("countActionsByType", () => {
+  it("groupe par equipe et type", () => {
+    const actions: PdfAction[] = [
+      makeAction({ playerTeam: "A", actionType: "passe" }),
+      makeAction({ playerTeam: "A", actionType: "passe" }),
+      makeAction({ playerTeam: "B", actionType: "blocage" }),
+    ];
+    const counts = countActionsByType(actions);
+    expect(counts.A.passe).toBe(2);
+    expect(counts.B.blocage).toBe(1);
+    expect(counts.A.blocage).toBeUndefined();
+  });
+});
+
+describe("computeMvp", () => {
+  it("priorise un joueur marque MVP dans matchStats meme avec moins de SPP", () => {
+    const match: PdfMatch = {
+      ...baseMatch,
+      gameState: {
+        matchStats: {
+          p1: { touchdowns: 0, casualties: 0, completions: 0, interceptions: 0, mvp: true },
+          p2: { touchdowns: 3, casualties: 2, completions: 5, interceptions: 1, mvp: false },
+        },
+        players: [
+          { id: "p1", team: "A", name: "MVP Officiel", number: 1, position: "skaven_blitzer" },
+          { id: "p2", team: "B", name: "Top Scorer", number: 7, position: "wood_elf_thrower" },
+        ],
+      },
+    };
+    const mvp = computeMvp(match, []);
+    expect(mvp).not.toBeNull();
+    expect(mvp?.playerId).toBe("p1");
+    expect(mvp?.playerName).toBe("MVP Officiel");
+  });
+
+  it("a defaut, choisit le joueur avec le plus haut SPP", () => {
+    const match: PdfMatch = {
+      ...baseMatch,
+      gameState: {
+        matchStats: {
+          p1: { touchdowns: 1, casualties: 0, completions: 0, interceptions: 0, mvp: false },
+          p2: { touchdowns: 0, casualties: 2, completions: 0, interceptions: 0, mvp: false },
+        },
+        players: [
+          { id: "p1", team: "A", name: "Scorer", number: 1, position: "skaven_blitzer" },
+          { id: "p2", team: "B", name: "Killer", number: 2, position: "wood_elf_treeman" },
+        ],
+      },
+    };
+    const mvp = computeMvp(match, []);
+    expect(mvp?.playerId).toBe("p2"); // 2 cas * 2 = 4 SPP > 1 TD * 3 = 3 SPP
+  });
+
+  it("retourne null si aucune donnee disponible", () => {
+    expect(computeMvp(baseMatch, [])).toBeNull();
+  });
+
+  it("fallback: derive le MVP depuis les actions si gameState absent", () => {
+    const actions: PdfAction[] = [
+      makeAction({ playerId: "p1", playerName: "Speedy", playerTeam: "A", actionType: "td" }),
+      makeAction({ playerId: "p1", playerName: "Speedy", playerTeam: "A", actionType: "td" }),
+      makeAction({ playerId: "p2", playerName: "Smasher", playerTeam: "B", actionType: "blocage", armorBroken: true, opponentState: "elimine" }),
+    ];
+    const mvp = computeMvp(baseMatch, actions);
+    expect(mvp?.playerId).toBe("p1");
+    expect(mvp?.touchdowns).toBe(2);
+    expect(mvp?.spp).toBe(6); // 2 * 3
+  });
+});
+
+describe("computeAggregates", () => {
+  it("expose teamA, teamB, mvp et outcome", () => {
+    const actions: PdfAction[] = [
+      makeAction({ playerTeam: "A", actionType: "td", playerId: "p1", playerName: "Star" }),
+      makeAction({ playerTeam: "A", actionType: "td", playerId: "p1", playerName: "Star" }),
+    ];
+    const agg = computeAggregates({ ...baseMatch, scoreTeamA: 2, scoreTeamB: 0 }, actions);
+    expect(agg.teamA.touchdowns).toBe(2);
+    expect(agg.teamB.touchdowns).toBe(0);
+    expect(agg.outcome).toBe("A");
+    expect(agg.mvp?.playerId).toBe("p1");
+  });
+});

--- a/apps/web/app/local-matches/[id]/pdf/aggregations.ts
+++ b/apps/web/app/local-matches/[id]/pdf/aggregations.ts
@@ -1,0 +1,296 @@
+/**
+ * Calculs purs sur les actions et le gameState pour produire les agregats
+ * affiches dans le PDF (box score, MVP, casualties).
+ *
+ * Tout est extrait du composant pour rester testable en isolation et reutilisable.
+ */
+
+import type {
+  ActionType,
+  MatchAggregates,
+  MvpInfo,
+  PdfAction,
+  PdfMatch,
+  TeamAggregateStats,
+} from "./types";
+
+const EMPTY_TEAM_STATS: TeamAggregateStats = {
+  touchdowns: 0,
+  completions: 0,
+  receptions: 0,
+  blitzes: 0,
+  blocks: 0,
+  fouls: 0,
+  sprints: 0,
+  dodges: 0,
+  interceptions: 0,
+  armorBreaks: 0,
+  casualties: 0,
+  kos: 0,
+  stuns: 0,
+  fumbles: 0,
+  totalActions: 0,
+};
+
+function newTeamStats(): TeamAggregateStats {
+  return { ...EMPTY_TEAM_STATS };
+}
+
+/**
+ * Calcule les stats par equipe a partir des actions.
+ * Logique alignee sur celle deja en place dans LocalMatchSummary (UI) pour
+ * eviter toute divergence entre l'affichage et l'export.
+ */
+export function computeTeamStats(actions: ReadonlyArray<PdfAction>): {
+  teamA: TeamAggregateStats;
+  teamB: TeamAggregateStats;
+} {
+  const teamA = newTeamStats();
+  const teamB = newTeamStats();
+
+  for (const action of actions) {
+    const stats = action.playerTeam === "A" ? teamA : teamB;
+    stats.totalActions += 1;
+
+    if (action.fumble) {
+      stats.fumbles += 1;
+    }
+
+    switch (action.actionType) {
+      case "td":
+        stats.touchdowns += 1;
+        break;
+      case "passe":
+        if (!action.fumble) stats.completions += 1;
+        break;
+      case "reception":
+        stats.receptions += 1;
+        break;
+      case "blocage":
+        stats.blocks += 1;
+        if (action.armorBroken) stats.armorBreaks += 1;
+        break;
+      case "blitz":
+        stats.blitzes += 1;
+        if (action.armorBroken) stats.armorBreaks += 1;
+        break;
+      case "aggression":
+        stats.fouls += 1;
+        if (action.armorBroken) stats.armorBreaks += 1;
+        break;
+      case "sprint":
+        stats.sprints += 1;
+        break;
+      case "esquive":
+        stats.dodges += 1;
+        break;
+      case "interception":
+        stats.interceptions += 1;
+        break;
+      default:
+        break;
+    }
+
+    // Casualties / KO / stun: convention BB — credites a l'equipe AGISSANTE
+    // (qui a inflige le dommage), pas a la victime. Aligne sur la logique
+    // d'agregation deja en place dans LocalMatchSummary.tsx.
+    if (
+      action.actionType === "blocage" ||
+      action.actionType === "blitz" ||
+      action.actionType === "aggression"
+    ) {
+      const state = (action.opponentState || "").toLowerCase();
+      if (state === "elimine") stats.casualties += 1;
+      else if (state === "ko") stats.kos += 1;
+      else if (state === "sonne" || state === "stun" || state === "stunned")
+        stats.stuns += 1;
+    }
+  }
+
+  return { teamA, teamB };
+}
+
+/** Compte les actions reussies par type, par equipe — utilise pour le drive chart. */
+export function countActionsByType(
+  actions: ReadonlyArray<PdfAction>,
+): Record<"A" | "B", Partial<Record<ActionType, number>>> {
+  const acc: Record<"A" | "B", Partial<Record<ActionType, number>>> = { A: {}, B: {} };
+  for (const a of actions) {
+    const tally = acc[a.playerTeam];
+    tally[a.actionType] = (tally[a.actionType] ?? 0) + 1;
+  }
+  return acc;
+}
+
+/** Calcule le gagnant a partir des scores (null => DRAW). */
+export function computeOutcome(
+  scoreA: number | null,
+  scoreB: number | null,
+): "A" | "B" | "DRAW" {
+  const a = scoreA ?? 0;
+  const b = scoreB ?? 0;
+  if (a > b) return "A";
+  if (b > a) return "B";
+  return "DRAW";
+}
+
+const SPP_VALUES = {
+  touchdown: 3,
+  casualty: 2,
+  completion: 1,
+  interception: 1,
+  mvp: 4,
+} as const;
+
+function sppFromStats(stats: {
+  touchdowns: number;
+  casualties: number;
+  completions: number;
+  interceptions: number;
+  mvp: boolean;
+}): number {
+  return (
+    stats.touchdowns * SPP_VALUES.touchdown +
+    stats.casualties * SPP_VALUES.casualty +
+    stats.completions * SPP_VALUES.completion +
+    stats.interceptions * SPP_VALUES.interception +
+    (stats.mvp ? SPP_VALUES.mvp : 0)
+  );
+}
+
+/**
+ * Determine le MVP du match en se basant prioritairement sur gameState.matchStats
+ * (champ MVP officiel + SPP), puis en fallback sur les actions brutes.
+ */
+export function computeMvp(
+  match: PdfMatch,
+  actions: ReadonlyArray<PdfAction>,
+): MvpInfo | null {
+  const matchStats = match.gameState?.matchStats;
+  const players = match.gameState?.players ?? [];
+  const playerLookup = new Map(players.map((p) => [p.id, p]));
+
+  if (matchStats) {
+    const buildInfo = (
+      playerId: string,
+      stats: PdfMatch["gameState"] extends infer GS
+        ? GS extends { matchStats?: infer MS }
+          ? MS extends Record<string, infer V>
+            ? V
+            : never
+          : never
+        : never,
+    ): MvpInfo => {
+      const meta = playerLookup.get(playerId);
+      const fallbackName =
+        actions.find((a) => a.playerId === playerId)?.playerName ??
+        meta?.name ??
+        "Inconnu";
+      const team =
+        meta?.team ??
+        actions.find((a) => a.playerId === playerId)?.playerTeam ??
+        "A";
+      return {
+        playerId,
+        playerName: meta?.name ?? fallbackName,
+        team,
+        number: meta?.number ?? null,
+        position: meta?.position ?? null,
+        spp: sppFromStats(stats),
+        touchdowns: stats.touchdowns,
+        casualties: stats.casualties,
+        completions: stats.completions,
+        interceptions: stats.interceptions,
+      };
+    };
+
+    // Two-pass: 1) si un joueur est marque mvp officiel, on le retient, en
+    // departageant les ex-aequo (pathologique) par SPP. 2) sinon, on prend
+    // le plus haut SPP du match.
+    let officialMvp: MvpInfo | null = null;
+    let topByScore: MvpInfo | null = null;
+    for (const [playerId, stats] of Object.entries(matchStats)) {
+      const info = buildInfo(playerId, stats);
+      if (stats.mvp && (officialMvp === null || info.spp > officialMvp.spp)) {
+        officialMvp = info;
+      }
+      if (topByScore === null || info.spp > topByScore.spp) {
+        topByScore = info;
+      }
+    }
+    if (officialMvp) return officialMvp;
+    if (topByScore) return topByScore;
+  }
+
+  // Fallback: deriver depuis les actions
+  const perPlayer = new Map<
+    string,
+    {
+      playerName: string;
+      team: "A" | "B";
+      touchdowns: number;
+      casualties: number;
+      completions: number;
+      interceptions: number;
+    }
+  >();
+
+  for (const action of actions) {
+    const cur = perPlayer.get(action.playerId) ?? {
+      playerName: action.playerName,
+      team: action.playerTeam,
+      touchdowns: 0,
+      casualties: 0,
+      completions: 0,
+      interceptions: 0,
+    };
+    if (action.actionType === "td") cur.touchdowns += 1;
+    else if (action.actionType === "passe" && !action.fumble) cur.completions += 1;
+    else if (action.actionType === "interception") cur.interceptions += 1;
+    if (
+      (action.actionType === "blocage" ||
+        action.actionType === "blitz" ||
+        action.actionType === "aggression") &&
+      action.armorBroken &&
+      (action.opponentState || "").toLowerCase() === "elimine"
+    ) {
+      cur.casualties += 1;
+    }
+    perPlayer.set(action.playerId, cur);
+  }
+
+  let best: MvpInfo | null = null;
+  let bestSpp = -1;
+  for (const [playerId, stats] of perPlayer.entries()) {
+    const spp = sppFromStats({ ...stats, mvp: false });
+    if (spp <= bestSpp) continue;
+    const meta = playerLookup.get(playerId);
+    bestSpp = spp;
+    best = {
+      playerId,
+      playerName: stats.playerName,
+      team: stats.team,
+      number: meta?.number ?? null,
+      position: meta?.position ?? null,
+      spp,
+      touchdowns: stats.touchdowns,
+      casualties: stats.casualties,
+      completions: stats.completions,
+      interceptions: stats.interceptions,
+    };
+  }
+  return best;
+}
+
+export function computeAggregates(
+  match: PdfMatch,
+  actions: ReadonlyArray<PdfAction>,
+): MatchAggregates {
+  const { teamA, teamB } = computeTeamStats(actions);
+  return {
+    teamA,
+    teamB,
+    mvp: computeMvp(match, actions),
+    outcome: computeOutcome(match.scoreTeamA, match.scoreTeamB),
+  };
+}

--- a/apps/web/app/local-matches/[id]/pdf/chrome.ts
+++ b/apps/web/app/local-matches/[id]/pdf/chrome.ts
@@ -1,0 +1,116 @@
+/**
+ * Chrome de page: fond parchemin, footer ornemente, numerotation finale.
+ *
+ * Le fond et le footer sont appeles a chaque page. Le footer est dessine
+ * sans le numero "Page i/N" qui est applique en post-traitement (une fois
+ * que le total de pages est connu) via `paginate(doc, matchName)`.
+ */
+
+import type jsPDF from "jspdf";
+import { PALETTE, setDrawHex, setFillHex, setTextHex } from "./colors";
+import { drawClosedPath } from "./icons";
+
+export const PAGE_WIDTH_MM = 210;
+export const PAGE_HEIGHT_MM = 297;
+export const MARGIN_MM = 12;
+export const CONTENT_WIDTH_MM = PAGE_WIDTH_MM - MARGIN_MM * 2;
+
+const PAGE_FOOTER_PLACEHOLDER = "__PAGE_NUMBER__";
+
+/**
+ * Fond parchemin avec mouchetures deterministes.
+ */
+export function drawParchment(doc: jsPDF): void {
+  setFillHex(doc, PALETTE.PARCHMENT);
+  doc.rect(0, 0, PAGE_WIDTH_MM, PAGE_HEIGHT_MM, "F");
+  setFillHex(doc, PALETTE.PARCHMENT_DARK);
+  for (let i = 0; i < 80; i++) {
+    const x = ((i * 73) % 200) + 5;
+    const y = ((i * 109) % 285) + 6;
+    const r = 0.25 + ((i * 17) % 5) * 0.08;
+    doc.circle(x, y, r, "F");
+  }
+  // Coins ornementes
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.3);
+  const corners: Array<[number, number, number, number]> = [
+    [4, 4, 14, 4],
+    [4, 4, 4, 14],
+    [PAGE_WIDTH_MM - 14, 4, PAGE_WIDTH_MM - 4, 4],
+    [PAGE_WIDTH_MM - 4, 4, PAGE_WIDTH_MM - 4, 14],
+    [4, PAGE_HEIGHT_MM - 14, 4, PAGE_HEIGHT_MM - 4],
+    [4, PAGE_HEIGHT_MM - 4, 14, PAGE_HEIGHT_MM - 4],
+    [PAGE_WIDTH_MM - 14, PAGE_HEIGHT_MM - 4, PAGE_WIDTH_MM - 4, PAGE_HEIGHT_MM - 4],
+    [PAGE_WIDTH_MM - 4, PAGE_HEIGHT_MM - 14, PAGE_WIDTH_MM - 4, PAGE_HEIGHT_MM - 4],
+  ];
+  for (const [x1, y1, x2, y2] of corners) {
+    doc.line(x1, y1, x2, y2);
+  }
+}
+
+/**
+ * Footer + filet decoratif. Le numero de page est laisse en placeholder, a
+ * remplacer apres generation complete (cf. paginate).
+ */
+export function drawFooter(doc: jsPDF, matchName: string): void {
+  const y = PAGE_HEIGHT_MM - 10;
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.4);
+  doc.line(MARGIN_MM, y - 2, PAGE_WIDTH_MM - MARGIN_MM, y - 2);
+
+  // Losange dore central
+  setFillHex(doc, PALETTE.GOLD);
+  const cx = PAGE_WIDTH_MM / 2;
+  drawClosedPath(
+    doc,
+    [
+      [cx, y - 4],
+      [cx + 1.5, y - 2],
+      [cx, y],
+      [cx - 1.5, y - 2],
+    ],
+    "F",
+  );
+
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.5);
+  setTextHex(doc, PALETTE.INK_SOFT);
+
+  const truncated = matchName.length > 50 ? matchName.slice(0, 47) + "..." : matchName;
+  doc.text(truncated, MARGIN_MM, y + 1.5);
+
+  doc.setFont("helvetica", "bold");
+  doc.setCharSpace(0.6);
+  doc.text("NUFFLE BE PRAISED", cx, y + 2.4, { align: "center" });
+  doc.setCharSpace(0);
+
+  doc.setFont("helvetica", "normal");
+  doc.text(PAGE_FOOTER_PLACEHOLDER, PAGE_WIDTH_MM - MARGIN_MM, y + 1.5, { align: "right" });
+}
+
+/** Decore une nouvelle page: parchemin + footer (sans numero). */
+export function decoratePage(doc: jsPDF, matchName: string): void {
+  drawParchment(doc);
+  drawFooter(doc, matchName);
+}
+
+/**
+ * Remplace le placeholder __PAGE_NUMBER__ par "Page i/N" sur chaque page.
+ * Doit etre appele en derniere etape de generation.
+ */
+export function paginate(doc: jsPDF): void {
+  const total = doc.getNumberOfPages();
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    const y = PAGE_HEIGHT_MM - 10;
+    // jsPDF n'a pas d'API pour effacer du texte: on masque la zone du
+    // placeholder en redessinant un rect parchemin local avant d'imprimer
+    // "Page i / N" par-dessus.
+    setFillHex(doc, PALETTE.PARCHMENT);
+    doc.rect(PAGE_WIDTH_MM - MARGIN_MM - 30, y - 0.5, 30, 5, "F");
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7.5);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    doc.text(`Page ${i} / ${total}`, PAGE_WIDTH_MM - MARGIN_MM, y + 1.5, { align: "right" });
+  }
+}

--- a/apps/web/app/local-matches/[id]/pdf/colors.test.ts
+++ b/apps/web/app/local-matches/[id]/pdf/colors.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests des helpers couleur du PDF de recap. Pures, aucune dep jsPDF.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  darken,
+  ensureContrast,
+  intToHex,
+  lighten,
+  luminance,
+  parseHex,
+  resolveTeamColors,
+  rgbToHex,
+} from "./colors";
+
+describe("intToHex", () => {
+  it("convertit un entier 0xRRGGBB en string '#RRGGBB' uppercase", () => {
+    expect(intToHex(0x1e3a8a)).toBe("#1E3A8A");
+    expect(intToHex(0x000000)).toBe("#000000");
+    expect(intToHex(0xffffff)).toBe("#FFFFFF");
+  });
+});
+
+describe("parseHex / rgbToHex", () => {
+  it("aller-retour est l'identite", () => {
+    expect(rgbToHex(parseHex("#1A140C"))).toBe("#1A140C");
+    expect(rgbToHex(parseHex("#FF8800"))).toBe("#FF8800");
+  });
+
+  it("parseHex tolere absence du #", () => {
+    expect(parseHex("1A140C")).toEqual([26, 20, 12]);
+  });
+
+  it("parseHex retourne [0,0,0] sur input invalide", () => {
+    expect(parseHex("invalid")).toEqual([0, 0, 0]);
+    expect(parseHex("#XYZXYZ")).toEqual([0, 0, 0]);
+  });
+
+  it("rgbToHex clampe les valeurs hors borne", () => {
+    expect(rgbToHex([300, -10, 128])).toBe("#FF0080");
+  });
+});
+
+describe("lighten / darken", () => {
+  it("lighten vers le blanc quand factor=1", () => {
+    expect(lighten("#000000", 1)).toBe("#FFFFFF");
+  });
+  it("darken vers le noir quand factor=1", () => {
+    expect(darken("#FFFFFF", 1)).toBe("#000000");
+  });
+  it("factor=0 conserve la couleur", () => {
+    expect(lighten("#7A1414", 0)).toBe("#7A1414");
+    expect(darken("#7A1414", 0)).toBe("#7A1414");
+  });
+});
+
+describe("luminance", () => {
+  it("noir => 0, blanc => 1", () => {
+    expect(luminance("#000000")).toBeCloseTo(0, 3);
+    expect(luminance("#FFFFFF")).toBeCloseTo(1, 3);
+  });
+});
+
+describe("ensureContrast", () => {
+  it("ne touche pas une couleur deja contrastee", () => {
+    expect(ensureContrast("#000000", "#FFFFFF")).toBe("#000000");
+  });
+
+  it("assombrit une couleur claire sur fond clair", () => {
+    const out = ensureContrast("#FAFAFA", "#F4E8C8");
+    expect(luminance(out)).toBeLessThan(luminance("#FAFAFA"));
+  });
+});
+
+describe("resolveTeamColors", () => {
+  it("convertit les ints roster en hex et calcule un tint clair", () => {
+    const colors = resolveTeamColors(0x1e3a8a, 0xfbbf24);
+    expect(colors.primary).toBe("#1E3A8A");
+    expect(colors.secondary).toBe("#FBBF24");
+    expect(luminance(colors.tint)).toBeGreaterThan(luminance(colors.primary));
+  });
+
+  it("fournit un fallback neutre si roster manquant", () => {
+    const colors = resolveTeamColors(undefined, undefined);
+    expect(colors.primary).toBe("#888888");
+    expect(colors.secondary).toBe("#FFFFFF");
+  });
+});

--- a/apps/web/app/local-matches/[id]/pdf/colors.ts
+++ b/apps/web/app/local-matches/[id]/pdf/colors.ts
@@ -1,0 +1,130 @@
+/**
+ * Palette + helpers couleur pour le PDF de recap de match Blood Bowl.
+ *
+ * - Palette parchemin/sang/or, inspiree des programmes de match GW.
+ * - Helpers convertissent entre 0xRRGGBB (game-engine), hex string ("#RRGGBB")
+ *   et tuple RGB [r,g,b] attendu par jspdf-autotable.
+ * - `lighten` et `ensureContrast` rendent les couleurs d'equipe dynamiques
+ *   utilisables sur fond parchemin sans illisibilite.
+ */
+
+import type jsPDF from "jspdf";
+
+export type RGB = [number, number, number];
+
+export const PALETTE = {
+  INK: "#1A140C",
+  INK_SOFT: "#3A2E1F",
+  PARCHMENT: "#F4E8C8",
+  PARCHMENT_DARK: "#E5D2A1",
+  PARCHMENT_HIGHLIGHT: "#F2E0A6",
+  BLOOD: "#7A1414",
+  BLOOD_DARK: "#3F0808",
+  GOLD: "#C9A24A",
+  GOLD_DARK: "#8C6A1F",
+  BONE: "#EFE3C2",
+  IRON: "#2B2B2B",
+  WIN_GREEN: "#365E2A",
+  LOSS_RED: "#7A1414",
+  DRAW_GREY: "#5A5A5A",
+} as const;
+
+export type PaletteKey = keyof typeof PALETTE;
+
+export function intToHex(n: number): string {
+  return "#" + n.toString(16).padStart(6, "0").toUpperCase();
+}
+
+export function parseHex(hex: string): RGB {
+  const clean = hex.replace("#", "");
+  if (clean.length !== 6) {
+    return [0, 0, 0];
+  }
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  if ([r, g, b].some((v) => Number.isNaN(v))) {
+    return [0, 0, 0];
+  }
+  return [r, g, b];
+}
+
+export function rgbToHex(rgb: RGB): string {
+  return (
+    "#" +
+    rgb
+      .map((v) => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, "0"))
+      .join("")
+      .toUpperCase()
+  );
+}
+
+export function setFillHex(doc: jsPDF, hex: string): void {
+  const [r, g, b] = parseHex(hex);
+  doc.setFillColor(r, g, b);
+}
+
+export function setDrawHex(doc: jsPDF, hex: string): void {
+  const [r, g, b] = parseHex(hex);
+  doc.setDrawColor(r, g, b);
+}
+
+export function setTextHex(doc: jsPDF, hex: string): void {
+  const [r, g, b] = parseHex(hex);
+  doc.setTextColor(r, g, b);
+}
+
+/** Mixe une couleur vers le blanc (factor=0 => identique, factor=1 => blanc). */
+export function lighten(hex: string, factor: number): string {
+  const [r, g, b] = parseHex(hex);
+  const f = Math.max(0, Math.min(1, factor));
+  return rgbToHex([r + (255 - r) * f, g + (255 - g) * f, b + (255 - b) * f]);
+}
+
+/** Mixe une couleur vers le noir (factor=0 => identique, factor=1 => noir). */
+export function darken(hex: string, factor: number): string {
+  const [r, g, b] = parseHex(hex);
+  const f = Math.max(0, Math.min(1, factor));
+  return rgbToHex([r * (1 - f), g * (1 - f), b * (1 - f)]);
+}
+
+/** Luminance perceptuelle (0..1). */
+export function luminance(hex: string): number {
+  const [r, g, b] = parseHex(hex);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/**
+ * Si la couleur est trop proche du fond (delta luminance < threshold),
+ * la fonce ou l'eclaircit pour garantir la lisibilite.
+ */
+export function ensureContrast(hex: string, bgHex: string, threshold = 0.3): string {
+  const fg = luminance(hex);
+  const bg = luminance(bgHex);
+  if (Math.abs(fg - bg) >= threshold) return hex;
+  return bg > 0.5 ? darken(hex, 0.45) : lighten(hex, 0.45);
+}
+
+export interface ResolvedTeamColors {
+  primary: string;
+  secondary: string;
+  /** Variante 12% utilisee pour fond de cellules. */
+  tint: string;
+}
+
+/**
+ * Convertit les couleurs d'un roster (0xRRGGBB) en hex strings,
+ * avec un fallback neutre + un tint clair derive du primary.
+ */
+export function resolveTeamColors(
+  primaryInt: number | undefined,
+  secondaryInt: number | undefined,
+): ResolvedTeamColors {
+  const primary = primaryInt !== undefined ? intToHex(primaryInt) : "#888888";
+  const secondary = secondaryInt !== undefined ? intToHex(secondaryInt) : "#FFFFFF";
+  return {
+    primary,
+    secondary,
+    tint: lighten(primary, 0.78),
+  };
+}

--- a/apps/web/app/local-matches/[id]/pdf/icons.ts
+++ b/apps/web/app/local-matches/[id]/pdf/icons.ts
@@ -1,0 +1,482 @@
+/**
+ * Primitives de dessin vectoriel pour le PDF de recap.
+ *
+ * Tout est dessine en jsPDF natif (rect/line/circle/ellipse/lines), pas de
+ * dependance externe ni de polices custom. Les ornements respectent la palette
+ * Blood Bowl (parchemin/sang/or) et acceptent une couleur en argument quand
+ * pertinent (ex: emblemes d'equipe colorises selon le roster).
+ */
+
+import type jsPDF from "jspdf";
+import { PALETTE, setDrawHex, setFillHex, setTextHex } from "./colors";
+import type { ActionType } from "./types";
+
+export type IconKind =
+  | ActionType
+  | "casualty"
+  | "fumble"
+  | "armorBroken";
+
+/**
+ * Trace un polygone ferme via doc.lines(). Pratique pour des formes type
+ * shield/diamond/hexagon ou ruban. Style: 'F' fill, 'D' stroke, 'FD' both.
+ */
+export function drawClosedPath(
+  doc: jsPDF,
+  points: Array<[number, number]>,
+  style: "F" | "D" | "FD" = "FD",
+): void {
+  if (points.length < 2) return;
+  const deltas: Array<[number, number]> = [];
+  for (let i = 1; i < points.length; i++) {
+    deltas.push([points[i][0] - points[i - 1][0], points[i][1] - points[i - 1][1]]);
+  }
+  const last = points[points.length - 1];
+  const first = points[0];
+  deltas.push([first[0] - last[0], first[1] - last[1]]);
+  doc.lines(deltas, first[0], first[1], [1, 1], style, true);
+}
+
+export type EmblemShape = "shield" | "circle" | "diamond" | "hexagon";
+
+/**
+ * Dessine l'embleme d'une equipe (shield/circle/diamond/hexagon) +
+ * le glyph monogramme au centre. Coordonnees = centre.
+ */
+export function drawEmblem(
+  doc: jsPDF,
+  shape: EmblemShape,
+  primary: string,
+  secondary: string,
+  glyph: string,
+  cx: number,
+  cy: number,
+  size = 36,
+): void {
+  const half = size / 2;
+  setFillHex(doc, primary);
+  setDrawHex(doc, secondary);
+  doc.setLineWidth(1.2);
+
+  switch (shape) {
+    case "shield": {
+      const pts: Array<[number, number]> = [
+        [cx, cy - half],
+        [cx + half * 0.85, cy - half * 0.75],
+        [cx + half * 0.85, cy],
+        [cx + half * 0.5, cy + half * 0.85],
+        [cx, cy + half],
+        [cx - half * 0.5, cy + half * 0.85],
+        [cx - half * 0.85, cy],
+        [cx - half * 0.85, cy - half * 0.75],
+      ];
+      drawClosedPath(doc, pts, "FD");
+      break;
+    }
+    case "circle":
+      doc.circle(cx, cy, half, "FD");
+      break;
+    case "diamond":
+      drawClosedPath(
+        doc,
+        [
+          [cx, cy - half],
+          [cx + half, cy],
+          [cx, cy + half],
+          [cx - half, cy],
+        ],
+        "FD",
+      );
+      break;
+    case "hexagon":
+      drawClosedPath(
+        doc,
+        [
+          [cx, cy - half],
+          [cx + half * 0.87, cy - half * 0.5],
+          [cx + half * 0.87, cy + half * 0.5],
+          [cx, cy + half],
+          [cx - half * 0.87, cy + half * 0.5],
+          [cx - half * 0.87, cy - half * 0.5],
+        ],
+        "FD",
+      );
+      break;
+  }
+
+  // Anneau interne dore — ne s'applique qu'au cercle, ou les autres formes
+  // (shield/diamond/hexagon) ont deja une silhouette caracteristique.
+  if (shape === "circle") {
+    setDrawHex(doc, PALETTE.GOLD);
+    doc.setLineWidth(0.4);
+    doc.circle(cx, cy, half * 0.78, "D");
+  }
+
+  // Glyph monogramme
+  doc.setFont("helvetica", "bold");
+  const fontSize = glyph.length >= 3 ? 12 : glyph.length === 2 ? 16 : 22;
+  doc.setFontSize(fontSize);
+  setTextHex(doc, secondary);
+  doc.text(glyph, cx, cy + fontSize * 0.32, { align: "center" });
+}
+
+/**
+ * Sceau circulaire decoratif type "tampon officiel" pour l'en-tete.
+ */
+export function drawSeal(doc: jsPDF, cx: number, cy: number, radius = 11): void {
+  setFillHex(doc, PALETTE.BLOOD_DARK);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(1);
+  doc.circle(cx, cy, radius, "FD");
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.3);
+  doc.circle(cx, cy, radius * 0.78, "D");
+
+  // Couronne de petits triangles (rayons)
+  setFillHex(doc, PALETTE.GOLD);
+  const spikes = 12;
+  for (let i = 0; i < spikes; i++) {
+    const angle = (i / spikes) * Math.PI * 2;
+    const r1 = radius * 0.92;
+    const r2 = radius * 1.08;
+    const x1 = cx + Math.cos(angle - 0.08) * r1;
+    const y1 = cy + Math.sin(angle - 0.08) * r1;
+    const x2 = cx + Math.cos(angle) * r2;
+    const y2 = cy + Math.sin(angle) * r2;
+    const x3 = cx + Math.cos(angle + 0.08) * r1;
+    const y3 = cy + Math.sin(angle + 0.08) * r1;
+    drawClosedPath(
+      doc,
+      [
+        [x1, y1],
+        [x2, y2],
+        [x3, y3],
+      ],
+      "F",
+    );
+  }
+
+  // Glyph BB centre
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(radius * 0.95);
+  setTextHex(doc, PALETTE.GOLD);
+  doc.text("BB", cx, cy + radius * 0.32, { align: "center" });
+}
+
+/**
+ * Ruban diagonal "STAR OF THE MATCH" (forme bannerole).
+ */
+export function drawRibbon(
+  doc: jsPDF,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  label: string,
+): void {
+  const cut = 6;
+  setFillHex(doc, PALETTE.BLOOD);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.8);
+  drawClosedPath(
+    doc,
+    [
+      [x + cut, y],
+      [x + w - cut, y],
+      [x + w, y + h / 2],
+      [x + w - cut, y + h],
+      [x + cut, y + h],
+      [x, y + h / 2],
+    ],
+    "FD",
+  );
+
+  // Pointes repliees (effet pli)
+  setFillHex(doc, PALETTE.BLOOD_DARK);
+  drawClosedPath(
+    doc,
+    [
+      [x, y + h / 2],
+      [x + cut, y + h + 2],
+      [x + cut, y + h],
+    ],
+    "F",
+  );
+  drawClosedPath(
+    doc,
+    [
+      [x + w, y + h / 2],
+      [x + w - cut, y + h + 2],
+      [x + w - cut, y + h],
+    ],
+    "F",
+  );
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(13);
+  setTextHex(doc, PALETTE.BONE);
+  doc.setCharSpace(0.8);
+  doc.text(label, x + w / 2, y + h / 2 + 1.5, { align: "center", baseline: "middle" });
+  doc.setCharSpace(0);
+}
+
+/** Separateur ornemental: filets + losange dore au centre. */
+export function drawOrnament(doc: jsPDF, x1: number, x2: number, y: number): void {
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.4);
+  const cx = (x1 + x2) / 2;
+  doc.line(x1, y, cx - 4, y);
+  doc.line(cx + 4, y, x2, y);
+  setFillHex(doc, PALETTE.GOLD);
+  drawClosedPath(
+    doc,
+    [
+      [cx, y - 2],
+      [cx + 3, y],
+      [cx, y + 2],
+      [cx - 3, y],
+    ],
+    "F",
+  );
+}
+
+/** Badge rectangulaire (type chip) avec texte centre. */
+export function drawBadge(
+  doc: jsPDF,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  label: string,
+  fillHex: string,
+  textHex: string,
+  fontSize = 9,
+): void {
+  setFillHex(doc, fillHex);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.4);
+  doc.roundedRect(x, y, w, h, 1.2, 1.2, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(fontSize);
+  setTextHex(doc, textHex);
+  doc.setCharSpace(0.4);
+  doc.text(label, x + w / 2, y + h / 2 + fontSize * 0.18, { align: "center" });
+  doc.setCharSpace(0);
+}
+
+/**
+ * Icone meteo simple (soleil / pluie / neige / generique).
+ * Cle = condition (texte libre du jeu), match insensible a la casse.
+ */
+export function drawWeatherIcon(
+  doc: jsPDF,
+  cx: number,
+  cy: number,
+  size: number,
+  condition: string,
+): void {
+  const lc = condition.toLowerCase();
+  setDrawHex(doc, PALETTE.INK);
+  setFillHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.5);
+  const half = size / 2;
+
+  if (lc.includes("pluie") || lc.includes("rain") || lc.includes("averse") || lc.includes("orage")) {
+    setDrawHex(doc, PALETTE.INK_SOFT);
+    setFillHex(doc, PALETTE.PARCHMENT_DARK);
+    doc.ellipse(cx, cy - 1, half * 0.9, half * 0.55, "FD");
+    setDrawHex(doc, "#1E3A8A");
+    doc.setLineWidth(0.7);
+    for (let i = -1; i <= 1; i++) {
+      doc.line(cx + i * 1.6, cy + 1.3, cx + i * 1.6 - 0.6, cy + 3);
+    }
+  } else if (lc.includes("neige") || lc.includes("snow") || lc.includes("blizzard") || lc.includes("glace")) {
+    setDrawHex(doc, "#1E3A8A");
+    doc.setLineWidth(0.6);
+    doc.line(cx - half, cy, cx + half, cy);
+    doc.line(cx, cy - half, cx, cy + half);
+    doc.line(cx - half * 0.7, cy - half * 0.7, cx + half * 0.7, cy + half * 0.7);
+    doc.line(cx - half * 0.7, cy + half * 0.7, cx + half * 0.7, cy - half * 0.7);
+  } else if (lc.includes("sweltering") || lc.includes("canicule") || lc.includes("chaud")) {
+    doc.circle(cx, cy, half * 0.55, "F");
+    setDrawHex(doc, PALETTE.GOLD_DARK);
+    for (let i = 0; i < 8; i++) {
+      const a = (i / 8) * Math.PI * 2;
+      doc.line(
+        cx + Math.cos(a) * half * 0.7,
+        cy + Math.sin(a) * half * 0.7,
+        cx + Math.cos(a) * half,
+        cy + Math.sin(a) * half,
+      );
+    }
+  } else if (lc.includes("vent") || lc.includes("wind") || lc.includes("tornade")) {
+    setDrawHex(doc, PALETTE.INK_SOFT);
+    doc.setLineWidth(0.7);
+    doc.line(cx - half, cy - half * 0.5, cx + half * 0.6, cy - half * 0.5);
+    doc.line(cx - half * 0.7, cy, cx + half, cy);
+    doc.line(cx - half, cy + half * 0.5, cx + half * 0.4, cy + half * 0.5);
+  } else {
+    // Generique: soleil voile
+    doc.circle(cx, cy, half * 0.65, "F");
+    setDrawHex(doc, PALETTE.GOLD_DARK);
+    doc.setLineWidth(0.4);
+    doc.circle(cx, cy, half * 0.65, "D");
+  }
+}
+
+/**
+ * Icone d'action 6mm cote, dessinee en primitives. La couleur de fond
+ * (carte/cellule) est laissee a l'appelant. `failed` superpose une croix rouge.
+ */
+export function drawIcon(
+  doc: jsPDF,
+  type: IconKind,
+  x: number,
+  y: number,
+  color = PALETTE.INK,
+  size = 6,
+  failed = false,
+): void {
+  const cx = x + size / 2;
+  const cy = y + size / 2;
+  setDrawHex(doc, color);
+  setFillHex(doc, color);
+  doc.setLineWidth(0.4);
+
+  switch (type) {
+    case "td":
+      drawClosedPath(
+        doc,
+        [
+          [cx, y],
+          [x + size, cy],
+          [cx, y + size],
+          [x, cy],
+        ],
+        "F",
+      );
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(4.5);
+      setTextHex(doc, PALETTE.PARCHMENT);
+      doc.text("TD", cx, cy + 0.8, { align: "center" });
+      break;
+    case "blocage":
+      doc.rect(x + 0.5, y + 0.5, size - 1, size - 1, "F");
+      setDrawHex(doc, PALETTE.PARCHMENT);
+      doc.setLineWidth(0.6);
+      doc.line(x + 1.5, y + 1.5, x + size - 1.5, y + size - 1.5);
+      doc.line(x + size - 1.5, y + 1.5, x + 1.5, y + size - 1.5);
+      break;
+    case "blitz": {
+      const pts: Array<[number, number]> = [
+        [cx - 0.8, y + 0.4],
+        [cx + 1.2, cy - 0.6],
+        [cx + 0.1, cy - 0.3],
+        [cx + 1.4, y + size - 0.4],
+        [cx - 1.0, cy + 0.6],
+        [cx + 0.1, cy + 0.3],
+      ];
+      drawClosedPath(doc, pts, "F");
+      break;
+    }
+    case "passe":
+      doc.ellipse(cx, cy, size * 0.42, size * 0.28, "D");
+      doc.setLineWidth(0.5);
+      doc.line(x + 1.2, cy - 0.5, x + size - 1.2, cy + 0.5);
+      break;
+    case "reception":
+      doc.setLineWidth(0.6);
+      doc.line(x + 1, cy + 1.2, cx, cy - 0.6);
+      doc.line(cx, cy - 0.6, x + size - 1, cy + 1.2);
+      doc.circle(cx, cy + 1.6, 0.6, "F");
+      break;
+    case "transmission":
+      doc.setLineWidth(0.5);
+      doc.line(x + 1, cy - 1, x + size - 1, cy - 1);
+      doc.line(x + size - 1.2, cy - 1.6, x + size - 1, cy - 1);
+      doc.line(x + size - 1.2, cy - 0.4, x + size - 1, cy - 1);
+      doc.line(x + size - 1, cy + 1, x + 1, cy + 1);
+      doc.line(x + 1.2, cy + 0.4, x + 1, cy + 1);
+      doc.line(x + 1.2, cy + 1.6, x + 1, cy + 1);
+      break;
+    case "aggression":
+      doc.rect(cx - 1.4, cy - 1.4, 2.8, 2, "F");
+      doc.rect(cx - 1.4, cy + 0.3, 0.6, 1.4, "F");
+      doc.rect(cx - 0.6, cy + 0.3, 0.6, 1.4, "F");
+      doc.rect(cx + 0.2, cy + 0.3, 0.6, 1.4, "F");
+      doc.rect(cx + 1.0, cy + 0.3, 0.6, 1.4, "F");
+      break;
+    case "sprint":
+      doc.setLineWidth(0.55);
+      doc.line(x + 1.5, cy - 1.4, x + size - 0.8, cy - 1.4);
+      doc.line(x + 1.0, cy, x + size - 0.5, cy);
+      doc.line(x + 1.5, cy + 1.4, x + size - 0.8, cy + 1.4);
+      break;
+    case "esquive":
+      doc.setLineWidth(0.5);
+      // Spirale approximee par 3 ellipses
+      doc.ellipse(cx, cy, 1.8, 1.2, "D");
+      doc.ellipse(cx, cy, 1.2, 0.8, "D");
+      doc.circle(cx, cy, 0.4, "F");
+      break;
+    case "apothicaire":
+      doc.rect(cx - 0.7, y + 1, 1.4, size - 2, "F");
+      doc.rect(x + 1, cy - 0.7, size - 2, 1.4, "F");
+      break;
+    case "interception":
+      drawClosedPath(
+        doc,
+        [
+          [cx, y + 0.3],
+          [x + size - 0.5, y + 1.5],
+          [x + size - 0.5, cy + 0.5],
+          [cx, y + size - 0.3],
+          [x + 0.5, cy + 0.5],
+          [x + 0.5, y + 1.5],
+        ],
+        "F",
+      );
+      break;
+    case "casualty":
+      doc.circle(cx, cy - 0.4, 1.7, "F");
+      setFillHex(doc, PALETTE.PARCHMENT);
+      doc.circle(cx - 0.6, cy - 0.6, 0.4, "F");
+      doc.circle(cx + 0.6, cy - 0.6, 0.4, "F");
+      setDrawHex(doc, color);
+      doc.setLineWidth(0.4);
+      doc.line(cx - 1, cy + 1.2, cx - 1, cy + 2.1);
+      doc.line(cx, cy + 1.2, cx, cy + 2.1);
+      doc.line(cx + 1, cy + 1.2, cx + 1, cy + 2.1);
+      break;
+    case "fumble":
+      setDrawHex(doc, PALETTE.LOSS_RED);
+      doc.setLineWidth(0.6);
+      doc.circle(cx, cy, size * 0.4, "D");
+      doc.line(x + 1, y + size - 1, x + size - 1, y + 1);
+      break;
+    case "armorBroken":
+      drawClosedPath(
+        doc,
+        [
+          [cx, y + 0.5],
+          [cx + 0.6, cy - 0.4],
+          [cx + 1.6, cy - 0.6],
+          [cx + 0.8, cy + 0.3],
+          [cx + 1.4, cy + 1.4],
+          [cx, cy + 0.6],
+          [cx - 1.4, cy + 1.4],
+          [cx - 0.8, cy + 0.3],
+          [cx - 1.6, cy - 0.6],
+          [cx - 0.6, cy - 0.4],
+        ],
+        "F",
+      );
+      break;
+  }
+
+  if (failed && type !== "fumble") {
+    setDrawHex(doc, PALETTE.LOSS_RED);
+    doc.setLineWidth(0.7);
+    doc.line(x + 1, y + size - 1, x + size - 1, y + 1);
+  }
+}

--- a/apps/web/app/local-matches/[id]/pdf/index.test.ts
+++ b/apps/web/app/local-matches/[id]/pdf/index.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Smoke test d'integration: generateMatchPdf execute en jsdom sans crash
+ * et produit un blob non vide. Verifie aussi les chemins degrades:
+ *   - sans roster sur les equipes
+ *   - sans gameState
+ *   - sans actions
+ *   - avec beaucoup d'actions (force la pagination du play log)
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateMatchPdf } from "./index";
+import type { PdfAction, PdfMatch } from "./types";
+
+function makeAction(overrides: Partial<PdfAction> = {}): PdfAction {
+  return {
+    id: overrides.id ?? "a-" + Math.random().toString(36).slice(2),
+    half: overrides.half ?? 1,
+    turn: overrides.turn ?? 1,
+    actionType: overrides.actionType ?? "blocage",
+    playerId: overrides.playerId ?? "p1",
+    playerName: overrides.playerName ?? "Joueur 1",
+    playerTeam: overrides.playerTeam ?? "A",
+    opponentId: overrides.opponentId ?? null,
+    opponentName: overrides.opponentName ?? null,
+    diceResult: overrides.diceResult ?? null,
+    fumble: overrides.fumble ?? false,
+    playerState: overrides.playerState ?? null,
+    armorBroken: overrides.armorBroken ?? false,
+    opponentState: overrides.opponentState ?? null,
+    passType: overrides.passType ?? null,
+    createdAt: overrides.createdAt ?? new Date(2026, 0, 1).toISOString(),
+  };
+}
+
+function baseMatch(overrides: Partial<PdfMatch> = {}): PdfMatch {
+  return {
+    id: "m1",
+    name: "Skaven vs Wood Elves",
+    teamA: { id: "tA", name: "Skaven Stars", roster: "skaven" },
+    teamB: { id: "tB", name: "Wood Eaters", roster: "wood_elf" },
+    scoreTeamA: 2,
+    scoreTeamB: 1,
+    startedAt: new Date(2026, 0, 1).toISOString(),
+    completedAt: new Date(2026, 0, 1, 1, 30).toISOString(),
+    cup: { id: "c1", name: "Coupe du Vieux Monde" },
+    gameState: {
+      preMatch: {
+        fanFactor: {
+          teamA: { d3: 2, dedicatedFans: 3, total: 5 },
+          teamB: { d3: 1, dedicatedFans: 2, total: 3 },
+        },
+        weatherType: "classique",
+        weather: {
+          total: 8,
+          condition: "Pluie battante",
+          description: "Le terrain est detrempe, les passes sont plus risquees.",
+        },
+      },
+      matchStats: {
+        p1: { touchdowns: 2, casualties: 1, completions: 3, interceptions: 0, mvp: true },
+        p2: { touchdowns: 1, casualties: 0, completions: 2, interceptions: 1, mvp: false },
+      },
+      players: [
+        { id: "p1", team: "A", name: "Squiek", number: 11, position: "skaven_gutter_runner" },
+        { id: "p2", team: "B", name: "Sylvanis", number: 5, position: "wood_elf_thrower" },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("generateMatchPdf (smoke)", () => {
+  it("genere un PDF non vide pour un match standard", async () => {
+    const match = baseMatch();
+    const actions: PdfAction[] = [
+      makeAction({ playerTeam: "A", actionType: "td", playerId: "p1", playerName: "Squiek", half: 1, turn: 4 }),
+      makeAction({ playerTeam: "A", actionType: "passe", playerId: "p1", playerName: "Squiek", half: 1, turn: 3 }),
+      makeAction({ playerTeam: "B", actionType: "blocage", armorBroken: true, opponentState: "elimine", half: 2, turn: 1 }),
+      makeAction({ playerTeam: "B", actionType: "td", playerId: "p2", playerName: "Sylvanis", half: 2, turn: 5 }),
+      makeAction({ playerTeam: "A", actionType: "td", playerId: "p1", playerName: "Squiek", half: 2, turn: 7 }),
+    ];
+    const pdf = await generateMatchPdf(match, actions);
+    expect(pdf.filename).toMatch(/_recap\.pdf$/);
+    expect(typeof pdf.save).toBe("function");
+  });
+
+  it("tolere un match sans roster sur les equipes", async () => {
+    const match = baseMatch({
+      teamA: { id: "tA", name: "Sans Roster A", roster: null },
+      teamB: { id: "tB", name: "Sans Roster B" },
+    });
+    const pdf = await generateMatchPdf(match, []);
+    expect(pdf.filename).toBeTruthy();
+  });
+
+  it("tolere un match sans gameState ni actions", async () => {
+    const match = baseMatch({ gameState: undefined });
+    const pdf = await generateMatchPdf(match, []);
+    expect(pdf.filename).toBeTruthy();
+  });
+
+  it("gere un grand nombre d'actions (pagination du play log)", async () => {
+    const actions: PdfAction[] = [];
+    for (let i = 0; i < 80; i++) {
+      actions.push(
+        makeAction({
+          id: `a${i}`,
+          half: i < 40 ? 1 : 2,
+          turn: (i % 8) + 1,
+          actionType: i % 5 === 0 ? "td" : "blocage",
+          playerTeam: i % 2 === 0 ? "A" : "B",
+          playerId: i % 2 === 0 ? "p1" : "p2",
+          playerName: i % 2 === 0 ? "Squiek" : "Sylvanis",
+          armorBroken: i % 3 === 0,
+          opponentState: i % 7 === 0 ? "elimine" : i % 4 === 0 ? "ko" : null,
+        }),
+      );
+    }
+    const pdf = await generateMatchPdf(baseMatch(), actions);
+    expect(pdf.filename).toBeTruthy();
+  });
+
+  it("gere un nom de match vide en produisant un filename par defaut", async () => {
+    const pdf = await generateMatchPdf(baseMatch({ name: null }), []);
+    expect(pdf.filename).toMatch(/^Match_Blood_Bowl_recap\.pdf$|^match_recap\.pdf$/);
+  });
+});

--- a/apps/web/app/local-matches/[id]/pdf/index.ts
+++ b/apps/web/app/local-matches/[id]/pdf/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Orchestrateur de l'export PDF de recap de match.
+ *
+ * Page 1: Header + Scoreboard + Pre-game + Box score
+ * Page 2: Star of the Match + Drive Chart (1ere et 2eme mi-temps)
+ * Page 3+: Play-by-Play log (autotable, multi-pages auto)
+ *
+ * Tous les modules de dessin sont purs cote PDF: aucun acces DOM/React. La
+ * fonction est asynchrone car jsPDF/jspdf-autotable sont importes en lazy
+ * pour ne pas alourdir le bundle initial.
+ */
+
+import { computeAggregates } from "./aggregations";
+import { decoratePage, paginate, PAGE_HEIGHT_MM } from "./chrome";
+import { drawHeader } from "./sections/header";
+import { drawScoreboard } from "./sections/scoreboard";
+import { drawPregame } from "./sections/pregame";
+import { drawBoxScore } from "./sections/boxScore";
+import { drawMvpSection } from "./sections/mvp";
+import { drawDriveChart } from "./sections/driveChart";
+import { drawPlayLog } from "./sections/playLog";
+import type { PdfAction, PdfMatch } from "./types";
+
+export type { PdfAction, PdfMatch } from "./types";
+
+export interface GenerateMatchPdfResult {
+  filename: string;
+  save(): void;
+}
+
+export async function generateMatchPdf(
+  match: PdfMatch,
+  actions: ReadonlyArray<PdfAction>,
+): Promise<GenerateMatchPdfResult> {
+  const { default: jsPDFCtor } = await import("jspdf");
+  // Charger le plugin autotable: il s'attache au prototype de jsPDF.
+  await import("jspdf-autotable");
+
+  const doc = new jsPDFCtor({ orientation: "portrait", unit: "mm", format: "a4" });
+  const matchName = (match.name && match.name.trim()) || "Match Blood Bowl";
+  const decorate = () => decoratePage(doc, matchName);
+
+  decorate();
+  const aggregates = computeAggregates(match, actions);
+
+  // Page 1
+  const { bottomY: headerBottom } = drawHeader(doc, match, 12);
+  const scoreStart = headerBottom + 5;
+  const { bottomY: scoreboardBottom } = drawScoreboard(doc, match, aggregates, scoreStart);
+  const pregameStart = scoreboardBottom + 6;
+  const { bottomY: pregameBottom } = drawPregame(doc, match, pregameStart);
+  const boxScoreStart = pregameBottom + 6;
+  drawBoxScore(doc, match, aggregates, boxScoreStart);
+
+  // Page 2
+  doc.addPage();
+  decorate();
+  const mvpStart = 14;
+  const { bottomY: mvpBottom } = drawMvpSection(doc, match, aggregates, mvpStart);
+  const driveStart = mvpBottom + 8;
+  const { bottomY: driveBottom } = drawDriveChart(doc, match, actions, driveStart, decorate);
+
+  // Page 3+: play log (peut consommer plusieurs pages)
+  // Hauteur minimale (bandeau titre + 3 rangees + marges) pour eviter de
+  // commencer la table en bas de page.
+  const PLAYLOG_MIN_HEIGHT = 40;
+  if (actions.length > 0) {
+    if (driveBottom + PLAYLOG_MIN_HEIGHT > PAGE_HEIGHT_MM - 18) {
+      doc.addPage();
+      decorate();
+      drawPlayLog(doc, match, actions, 12, decorate);
+    } else {
+      drawPlayLog(doc, match, actions, driveBottom + 4, decorate);
+    }
+  }
+
+  paginate(doc);
+
+  const safeName = matchName.replace(/[^a-z0-9]/gi, "_").slice(0, 60) || "match";
+  const filename = `${safeName}_recap.pdf`;
+
+  return {
+    filename,
+    save: () => doc.save(filename),
+  };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/boxScore.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/boxScore.ts
@@ -1,0 +1,149 @@
+/**
+ * Box score: tableau Stat | Team A | Team B avec mise en avant du leader.
+ * Utilise jspdf-autotable.
+ */
+
+import type jsPDF from "jspdf";
+import autoTable from "jspdf-autotable";
+import { PALETTE, parseHex, setDrawHex, setFillHex, setTextHex } from "../colors";
+import { drawClosedPath } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM } from "../chrome";
+import type { MatchAggregates, PdfMatch, TeamAggregateStats } from "../types";
+
+interface StatRow {
+  label: string;
+  a: number;
+  b: number;
+}
+
+function buildRows(agg: MatchAggregates): StatRow[] {
+  const rows: Array<[string, keyof TeamAggregateStats]> = [
+    ["Touchdowns", "touchdowns"],
+    ["Passes completees", "completions"],
+    ["Receptions", "receptions"],
+    ["Blitz", "blitzes"],
+    ["Blocages", "blocks"],
+    ["Agressions", "fouls"],
+    ["Sprints", "sprints"],
+    ["Esquives", "dodges"],
+    ["Interceptions", "interceptions"],
+    ["Armures cassees", "armorBreaks"],
+    ["Casualties", "casualties"],
+    ["KO", "kos"],
+    ["Sonnes", "stuns"],
+    ["Echecs (fumbles)", "fumbles"],
+    ["Total actions", "totalActions"],
+  ];
+  return rows.map(([label, key]) => ({
+    label,
+    a: agg.teamA[key],
+    b: agg.teamB[key],
+  }));
+}
+
+export interface BoxScoreResult {
+  bottomY: number;
+}
+
+function drawTitleBand(doc: jsPDF, y: number, label: string): number {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+  const h = 7;
+  setFillHex(doc, PALETTE.BLOOD);
+  doc.rect(x, y, w, h, "F");
+  setFillHex(doc, PALETTE.GOLD);
+  drawClosedPath(
+    doc,
+    [
+      [x + 4, y + h / 2 - 1.5],
+      [x + 8, y + h / 2],
+      [x + 4, y + h / 2 + 1.5],
+    ],
+    "F",
+  );
+  drawClosedPath(
+    doc,
+    [
+      [x + w - 4, y + h / 2 - 1.5],
+      [x + w - 8, y + h / 2],
+      [x + w - 4, y + h / 2 + 1.5],
+    ],
+    "F",
+  );
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10);
+  setTextHex(doc, PALETTE.BONE);
+  doc.setCharSpace(1.8);
+  doc.text(label, x + w / 2, y + h / 2 + 1.4, { align: "center" });
+  doc.setCharSpace(0);
+  return y + h;
+}
+
+export function drawBoxScore(
+  doc: jsPDF,
+  match: PdfMatch,
+  agg: MatchAggregates,
+  startY: number,
+): BoxScoreResult {
+  const tableStartY = drawTitleBand(doc, startY, "BOX SCORE — STATISTIQUES PAR EQUIPE");
+  const rows = buildRows(agg);
+
+  const inkRgb = parseHex(PALETTE.INK);
+  const boneRgb = parseHex(PALETTE.BONE);
+  const lineRgb = parseHex(PALETTE.INK_SOFT);
+  const parchmentDarkRgb = parseHex(PALETTE.PARCHMENT_DARK);
+  const highlightRgb = parseHex(PALETTE.PARCHMENT_HIGHLIGHT);
+
+  autoTable(doc, {
+    startY: tableStartY,
+    margin: { left: MARGIN_MM, right: MARGIN_MM },
+    head: [["STATISTIQUE", match.teamA.name, match.teamB.name]],
+    body: rows.map((r) => [r.label, String(r.a), String(r.b)]),
+    theme: "grid",
+    styles: {
+      font: "helvetica",
+      fontSize: 9,
+      textColor: inkRgb,
+      lineColor: lineRgb,
+      lineWidth: 0.1,
+      cellPadding: { top: 1.6, right: 2, bottom: 1.6, left: 2 },
+    },
+    headStyles: {
+      fillColor: inkRgb,
+      textColor: boneRgb,
+      fontStyle: "bold",
+      halign: "center",
+      fontSize: 9,
+    },
+    bodyStyles: {
+      fillColor: parseHex(PALETTE.PARCHMENT),
+    },
+    alternateRowStyles: {
+      fillColor: parchmentDarkRgb,
+    },
+    tableWidth: CONTENT_WIDTH_MM,
+    columnStyles: {
+      0: { fontStyle: "bold", halign: "left" },
+      1: { halign: "center" },
+      2: { halign: "center" },
+    },
+    didParseCell: (data) => {
+      if (data.section !== "body") return;
+      const idx = data.row.index;
+      const row = rows[idx];
+      if (!row) return;
+      if (data.column.index === 1 && row.a > row.b) {
+        data.cell.styles.fillColor = highlightRgb;
+        data.cell.styles.fontStyle = "bold";
+      }
+      if (data.column.index === 2 && row.b > row.a) {
+        data.cell.styles.fillColor = highlightRgb;
+        data.cell.styles.fontStyle = "bold";
+      }
+    },
+  });
+
+  // @ts-expect-error lastAutoTable is added by autotable plugin
+  const finalY = (doc.lastAutoTable?.finalY ?? tableStartY + 80) as number;
+  return { bottomY: finalY };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/driveChart.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/driveChart.ts
@@ -1,0 +1,188 @@
+/**
+ * Drive chart par mi-temps: une bande horizontale par tour avec les pictogrammes
+ * d'actions, code-couleur sur la team active et indicateur d'echec.
+ */
+
+import type jsPDF from "jspdf";
+import { getTeamColors } from "@bb/game-engine";
+import {
+  PALETTE,
+  resolveTeamColors,
+  setDrawHex,
+  setFillHex,
+  setTextHex,
+} from "../colors";
+import { drawIcon, type IconKind } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM, PAGE_HEIGHT_MM } from "../chrome";
+import type { PdfAction, PdfMatch } from "../types";
+
+const TURN_HEIGHT = 9;
+const ICON_SIZE = 5.4;
+const ICON_GAP = 1.4;
+
+interface ActionsByHalfTurn {
+  half: number;
+  turn: number;
+  actions: PdfAction[];
+}
+
+function groupActions(actions: ReadonlyArray<PdfAction>): ActionsByHalfTurn[] {
+  const map = new Map<string, ActionsByHalfTurn>();
+  for (const a of actions) {
+    const key = `${a.half}-${a.turn}`;
+    const cur = map.get(key);
+    if (cur) cur.actions.push(a);
+    else map.set(key, { half: a.half, turn: a.turn, actions: [a] });
+  }
+  return Array.from(map.values()).sort((x, y) =>
+    x.half !== y.half ? x.half - y.half : x.turn - y.turn,
+  );
+}
+
+function actionToIcon(a: PdfAction): { kind: IconKind; failed: boolean } {
+  if (a.fumble) return { kind: a.actionType, failed: true };
+  if (
+    (a.actionType === "blocage" ||
+      a.actionType === "blitz" ||
+      a.actionType === "aggression") &&
+    a.armorBroken &&
+    (a.opponentState || "").toLowerCase() === "elimine"
+  ) {
+    return { kind: "casualty", failed: false };
+  }
+  return { kind: a.actionType, failed: false };
+}
+
+function drawHalfBand(doc: jsPDF, y: number, label: string): number {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+  const h = 7;
+  setFillHex(doc, PALETTE.INK);
+  doc.rect(x, y, w, h, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  setTextHex(doc, PALETTE.GOLD);
+  doc.setCharSpace(2);
+  doc.text(label, x + w / 2, y + h / 2 + 1.4, { align: "center" });
+  doc.setCharSpace(0);
+  return y + h;
+}
+
+function ensureSpace(
+  doc: jsPDF,
+  needed: number,
+  currentY: number,
+  decorate: () => void,
+): number {
+  if (currentY + needed > PAGE_HEIGHT_MM - 18) {
+    doc.addPage();
+    decorate();
+    return 18;
+  }
+  return currentY;
+}
+
+export interface DriveChartResult {
+  bottomY: number;
+}
+
+export function drawDriveChart(
+  doc: jsPDF,
+  match: PdfMatch,
+  actions: ReadonlyArray<PdfAction>,
+  startY: number,
+  decoratePage: () => void,
+): DriveChartResult {
+  const grouped = groupActions(actions);
+  if (grouped.length === 0) {
+    return { bottomY: startY };
+  }
+
+  const colorsA = resolveTeamColors(
+    match.teamA.roster ? getTeamColors(match.teamA.roster).primary : undefined,
+    match.teamA.roster ? getTeamColors(match.teamA.roster).secondary : undefined,
+  );
+  const colorsB = resolveTeamColors(
+    match.teamB.roster ? getTeamColors(match.teamB.roster).primary : undefined,
+    match.teamB.roster ? getTeamColors(match.teamB.roster).secondary : undefined,
+  );
+
+  let y = startY;
+  let lastHalf = -1;
+
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+
+  for (const group of grouped) {
+    if (group.half !== lastHalf) {
+      y = ensureSpace(doc, 28, y, decoratePage);
+      const label = group.half === 1 ? "PREMIERE MI-TEMPS" : `MI-TEMPS ${group.half}`;
+      y = drawHalfBand(doc, y + 2, label) + 2;
+      lastHalf = group.half;
+    }
+
+    y = ensureSpace(doc, TURN_HEIGHT + 2, y, decoratePage);
+
+    // Determiner la team dominante du tour
+    const aCount = group.actions.filter((a) => a.playerTeam === "A").length;
+    const bCount = group.actions.length - aCount;
+    const dominant = aCount >= bCount ? colorsA : colorsB;
+
+    // Stripe team
+    setFillHex(doc, dominant.tint);
+    doc.rect(x, y, w, TURN_HEIGHT, "F");
+    setFillHex(doc, dominant.primary);
+    doc.rect(x, y, 2, TURN_HEIGHT, "F");
+
+    // Badge tour
+    setFillHex(doc, PALETTE.INK);
+    doc.rect(x + 3, y + 1, 14, TURN_HEIGHT - 2, "F");
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7.5);
+    setTextHex(doc, PALETTE.BONE);
+    doc.text(`T${group.turn}`, x + 10, y + TURN_HEIGHT / 2 + 1.4, { align: "center" });
+
+    // Icones
+    const iconsStart = x + 19;
+    const iconsMaxWidth = w - 36;
+    const maxIconsPerRow = Math.floor(iconsMaxWidth / (ICON_SIZE + ICON_GAP));
+    const total = group.actions.length;
+    const visible = Math.min(total, maxIconsPerRow);
+    for (let i = 0; i < visible; i++) {
+      const a = group.actions[i];
+      const tint = a.playerTeam === "A" ? colorsA.primary : colorsB.primary;
+      const ix = iconsStart + i * (ICON_SIZE + ICON_GAP);
+      const iy = y + (TURN_HEIGHT - ICON_SIZE) / 2;
+      // mini fond colore d'equipe pour rappel visuel
+      setFillHex(doc, a.playerTeam === "A" ? colorsA.tint : colorsB.tint);
+      setDrawHex(doc, tint);
+      doc.setLineWidth(0.2);
+      doc.rect(ix - 0.4, iy - 0.4, ICON_SIZE + 0.8, ICON_SIZE + 0.8, "FD");
+      const icon = actionToIcon(a);
+      drawIcon(doc, icon.kind, ix, iy, PALETTE.INK, ICON_SIZE, icon.failed);
+    }
+    if (total > visible) {
+      doc.setFont("helvetica", "bold");
+      doc.setFontSize(7);
+      setTextHex(doc, PALETTE.INK_SOFT);
+      doc.text(
+        `+${total - visible}`,
+        iconsStart + visible * (ICON_SIZE + ICON_GAP) + 1,
+        y + TURN_HEIGHT / 2 + 1.5,
+      );
+    }
+
+    // Repartition droite
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7);
+    setTextHex(doc, PALETTE.INK);
+    doc.text(`${aCount} / ${bCount}`, x + w - 4, y + TURN_HEIGHT / 2 + 1.5, {
+      align: "right",
+    });
+
+    y += TURN_HEIGHT + 1;
+  }
+
+  return { bottomY: y };
+}
+

--- a/apps/web/app/local-matches/[id]/pdf/sections/header.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/header.ts
@@ -1,0 +1,95 @@
+/**
+ * En-tete cartouche de la page 1: bandeau "BLOOD BOWL — GAME SUMMARY"
+ * + sous-bandeau coupe & date avec sceau circulaire.
+ */
+
+import type jsPDF from "jspdf";
+import { PALETTE, setDrawHex, setFillHex, setTextHex } from "../colors";
+import { drawSeal } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM } from "../chrome";
+import type { PdfMatch } from "../types";
+
+const BANNER_HEIGHT = 28;
+const SUB_BANNER_HEIGHT = 8;
+
+export interface HeaderRenderResult {
+  /** Y en mm immediatement sous l'en-tete (utile pour chainer la section suivante). */
+  bottomY: number;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function drawHeader(doc: jsPDF, match: PdfMatch, startY = 12): HeaderRenderResult {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+
+  // Bandeau principal sang
+  setFillHex(doc, PALETTE.BLOOD);
+  doc.rect(x, startY, w, BANNER_HEIGHT, "F");
+
+  // Double filet dore
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.8);
+  doc.rect(x + 1.5, startY + 1.5, w - 3, BANNER_HEIGHT - 3, "D");
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.3);
+  doc.rect(x + 3, startY + 3, w - 6, BANNER_HEIGHT - 6, "D");
+
+  // Titre principal
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(26);
+  setTextHex(doc, PALETTE.BONE);
+  doc.setCharSpace(1.4);
+  doc.text("BLOOD BOWL", x + 8, startY + 16);
+  doc.setCharSpace(0);
+
+  // Sous-titre
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  setTextHex(doc, PALETTE.GOLD);
+  doc.setCharSpace(2);
+  doc.text("OFFICIAL GAME SUMMARY", x + 8, startY + 23);
+  doc.setCharSpace(0);
+
+  // Sceau circulaire
+  drawSeal(doc, x + w - 18, startY + BANNER_HEIGHT / 2, 10);
+
+  // Sous-bandeau ink: nom de match / coupe / date
+  const subY = startY + BANNER_HEIGHT;
+  setFillHex(doc, PALETTE.INK);
+  doc.rect(x, subY, w, SUB_BANNER_HEIGHT, "F");
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(9);
+  setTextHex(doc, PALETTE.BONE);
+
+  const matchName = match.name?.trim() || "Match amical";
+  const cup = match.cup?.name?.trim() || null;
+  const dateStr = formatDate(match.completedAt ?? match.startedAt);
+
+  // Gauche : nom du match (+ coupe inline avec separateur losange)
+  let leftLabel = matchName;
+  if (cup) leftLabel += `  ◆  ${cup.toUpperCase()}`;
+  const maxLeftWidth = w / 2 - 4;
+  const leftLines = doc.splitTextToSize(leftLabel.toUpperCase(), maxLeftWidth);
+  doc.text(leftLines[0] ?? "", x + 4, subY + SUB_BANNER_HEIGHT / 2 + 1.4);
+
+  // Droite : date
+  if (dateStr) {
+    doc.setFont("helvetica", "normal");
+    doc.text(dateStr, x + w - 4, subY + SUB_BANNER_HEIGHT / 2 + 1.4, { align: "right" });
+  }
+
+  return { bottomY: subY + SUB_BANNER_HEIGHT };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/mvp.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/mvp.ts
@@ -1,0 +1,158 @@
+/**
+ * Section "STAR OF THE MATCH": ruban diagonal + carte MVP avec medaillon
+ * et grille de stats (TD / CAS / PASS / INT).
+ */
+
+import type jsPDF from "jspdf";
+import { getTeamColors } from "@bb/game-engine";
+import {
+  PALETTE,
+  ensureContrast,
+  resolveTeamColors,
+  setDrawHex,
+  setFillHex,
+  setTextHex,
+} from "../colors";
+import { drawClosedPath, drawIcon, drawRibbon } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM } from "../chrome";
+import type { MatchAggregates, PdfMatch } from "../types";
+
+const RIBBON_HEIGHT = 14;
+const CARD_HEIGHT = 56;
+
+function drawMedallion(doc: jsPDF, cx: number, cy: number, radius: number): void {
+  setFillHex(doc, PALETTE.GOLD);
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.8);
+  doc.circle(cx, cy, radius, "FD");
+  setDrawHex(doc, PALETTE.INK);
+  doc.setLineWidth(0.5);
+  doc.circle(cx, cy, radius * 0.83, "D");
+
+  // Etoile 5 branches
+  const points: Array<[number, number]> = [];
+  for (let i = 0; i < 10; i++) {
+    const r = i % 2 === 0 ? radius * 0.62 : radius * 0.27;
+    const angle = (Math.PI / 5) * i - Math.PI / 2;
+    points.push([cx + Math.cos(angle) * r, cy + Math.sin(angle) * r]);
+  }
+  setFillHex(doc, PALETTE.BLOOD);
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.4);
+  drawClosedPath(doc, points, "FD");
+}
+
+export interface MvpResult {
+  bottomY: number;
+}
+
+export function drawMvpSection(
+  doc: jsPDF,
+  match: PdfMatch,
+  agg: MatchAggregates,
+  startY: number,
+): MvpResult {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+
+  // Ruban
+  drawRibbon(doc, x, startY, w, RIBBON_HEIGHT, "STAR OF THE MATCH");
+
+  const cardY = startY + RIBBON_HEIGHT + 4;
+  // Carte
+  setFillHex(doc, PALETTE.PARCHMENT_DARK);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.8);
+  doc.roundedRect(x, cardY, w, CARD_HEIGHT, 2, 2, "FD");
+  setDrawHex(doc, PALETTE.INK_SOFT);
+  doc.setLineWidth(0.3);
+  doc.roundedRect(x + 1.5, cardY + 1.5, w - 3, CARD_HEIGHT - 3, 1.5, 1.5, "D");
+
+  if (!agg.mvp) {
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(11);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    doc.text("Aucun MVP designe pour ce match", x + w / 2, cardY + CARD_HEIGHT / 2, {
+      align: "center",
+    });
+    return { bottomY: cardY + CARD_HEIGHT };
+  }
+
+  // Medaillon a gauche
+  const mcx = x + 24;
+  const mcy = cardY + CARD_HEIGHT / 2;
+  drawMedallion(doc, mcx, mcy, 18);
+
+  // Bloc texte au centre
+  const textX = x + 50;
+  const mvp = agg.mvp;
+  const teamMeta = mvp.team === "A" ? match.teamA : match.teamB;
+  const teamColors = resolveTeamColors(
+    teamMeta.roster ? getTeamColors(teamMeta.roster).primary : undefined,
+    teamMeta.roster ? getTeamColors(teamMeta.roster).secondary : undefined,
+  );
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(15);
+  setTextHex(doc, PALETTE.INK);
+  const numberPart = mvp.number !== null ? `#${mvp.number}  ` : "";
+  doc.text(`${numberPart}${mvp.playerName}`, textX, cardY + 14);
+
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(9);
+  setTextHex(doc, ensureContrast(teamColors.primary, PALETTE.PARCHMENT_DARK));
+  const teamLine = `${teamMeta.name}${mvp.position ? `  •  ${mvp.position}` : ""}`;
+  doc.text(teamLine, textX, cardY + 21);
+
+  // Badge SPP
+  const badgeW = 32;
+  const badgeH = 9;
+  const badgeX = textX;
+  const badgeY = cardY + 26;
+  setFillHex(doc, PALETTE.INK);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.5);
+  doc.roundedRect(badgeX, badgeY, badgeW, badgeH, 1.2, 1.2, "FD");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8.5);
+  setTextHex(doc, PALETTE.GOLD);
+  doc.setCharSpace(0.6);
+  doc.text(`PERFORMANCE  ${mvp.spp} SPP`, badgeX + badgeW / 2, badgeY + badgeH / 2 + 1.4, {
+    align: "center",
+  });
+  doc.setCharSpace(0);
+
+  // Grille de stats a droite
+  const stats: Array<{ key: "td" | "casualty" | "passe" | "interception"; label: string; value: number }> = [
+    { key: "td", label: "TD", value: mvp.touchdowns },
+    { key: "casualty", label: "CAS", value: mvp.casualties },
+    { key: "passe", label: "PASS", value: mvp.completions },
+    { key: "interception", label: "INT", value: mvp.interceptions },
+  ];
+
+  const cellW = 22;
+  const cellH = 24;
+  const gridX = x + w - cellW * 4 - 6;
+  const gridY = cardY + (CARD_HEIGHT - cellH) / 2;
+
+  stats.forEach((s, i) => {
+    const cx = gridX + i * cellW;
+    setFillHex(doc, PALETTE.PARCHMENT);
+    setDrawHex(doc, PALETTE.GOLD_DARK);
+    doc.setLineWidth(0.3);
+    doc.rect(cx, gridY, cellW - 1.2, cellH, "FD");
+    drawIcon(doc, s.key === "casualty" ? "casualty" : s.key, cx + (cellW - 1.2) / 2 - 3, gridY + 2.5, PALETTE.INK, 6);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(15);
+    setTextHex(doc, PALETTE.INK);
+    doc.text(String(s.value), cx + (cellW - 1.2) / 2, gridY + 16, { align: "center" });
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(6.5);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    doc.setCharSpace(0.6);
+    doc.text(s.label, cx + (cellW - 1.2) / 2, gridY + 21, { align: "center" });
+    doc.setCharSpace(0);
+  });
+
+  return { bottomY: cardY + CARD_HEIGHT };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/playLog.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/playLog.ts
@@ -1,0 +1,280 @@
+/**
+ * Play-by-play log: tableau autotable plein cadre, multi-pages.
+ * Colonnes: H | T | TEAM | ICON | EVENEMENT (wrap) | RESULTAT.
+ */
+
+import type jsPDF from "jspdf";
+import autoTable, { type CellHookData } from "jspdf-autotable";
+import { getTeamColors } from "@bb/game-engine";
+import {
+  PALETTE,
+  parseHex,
+  resolveTeamColors,
+  setDrawHex,
+  setFillHex,
+  setTextHex,
+} from "../colors";
+import { drawIcon, type IconKind } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM, PAGE_HEIGHT_MM, PAGE_WIDTH_MM } from "../chrome";
+import type { ActionType, PdfAction, PdfMatch } from "../types";
+
+const ACTION_LABELS: Record<ActionType, string> = {
+  passe: "Passe",
+  reception: "Reception",
+  td: "Touchdown",
+  blocage: "Blocage",
+  blitz: "Blitz",
+  transmission: "Transmission",
+  aggression: "Agression",
+  sprint: "Sprint",
+  esquive: "Esquive",
+  apothicaire: "Apothicaire",
+  interception: "Interception",
+};
+
+function eventDescription(action: PdfAction, teamAName: string, teamBName: string): string {
+  const teamName = action.playerTeam === "A" ? teamAName : teamBName;
+  const oppTeamName = action.playerTeam === "A" ? teamBName : teamAName;
+  let desc = `${ACTION_LABELS[action.actionType]} — ${action.playerName} (${teamName})`;
+  if (action.opponentName) {
+    desc += ` vs ${action.opponentName} (${oppTeamName})`;
+  }
+  if (action.diceResult !== null) {
+    desc += ` — De ${action.diceResult}`;
+  }
+  if (action.actionType === "passe" && action.passType) {
+    desc += ` — ${action.passType}`;
+  }
+  return desc;
+}
+
+function resultLabel(action: PdfAction): { text: string; color: string } {
+  if (action.fumble) {
+    return {
+      text: action.playerState ? `ECHEC — ${action.playerState.toUpperCase()}` : "ECHEC",
+      color: PALETTE.LOSS_RED,
+    };
+  }
+  if (action.actionType === "blocage" || action.actionType === "blitz" || action.actionType === "aggression") {
+    if (action.armorBroken) {
+      const state = (action.opponentState || "").toUpperCase();
+      if (state === "ELIMINE") return { text: "CASUALTY", color: PALETTE.BLOOD };
+      if (state === "KO") return { text: "KO", color: PALETTE.GOLD_DARK };
+      if (state === "SONNE") return { text: "SONNE", color: PALETTE.IRON };
+      return { text: "ARMURE BRISEE", color: PALETTE.GOLD_DARK };
+    }
+    return { text: "ARMURE TENUE", color: PALETTE.INK_SOFT };
+  }
+  if (action.actionType === "td") return { text: "TOUCHDOWN", color: PALETTE.WIN_GREEN };
+  if (action.actionType === "interception") return { text: "INTERCEPTION", color: PALETTE.WIN_GREEN };
+  return { text: "OK", color: PALETTE.INK_SOFT };
+}
+
+/**
+ * Footer alternatif pour les pages de continuation creees par autotable.
+ * Ne dessine PAS de rect parchemin (qui masquerait la table) — uniquement
+ * le filet dore + le losange + le texte. Le numero de page est laisse au
+ * placeholder pour etre remplace en post par paginate().
+ */
+function drawContinuationFooter(doc: jsPDF, matchName: string): void {
+  const y = PAGE_HEIGHT_MM - 10;
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.4);
+  doc.line(MARGIN_MM, y - 2, MARGIN_MM + CONTENT_WIDTH_MM, y - 2);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(7.5);
+  setTextHex(doc, PALETTE.INK_SOFT);
+  const truncated = matchName.length > 50 ? matchName.slice(0, 47) + "..." : matchName;
+  doc.text(truncated, MARGIN_MM, y + 1.5);
+  doc.setFont("helvetica", "bold");
+  doc.setCharSpace(0.6);
+  doc.text("NUFFLE BE PRAISED", PAGE_WIDTH_MM / 2, y + 2.4, { align: "center" });
+  doc.setCharSpace(0);
+  doc.setFont("helvetica", "normal");
+  // Placeholder identique a celui pose par drawFooter — paginate() s'en occupe.
+  doc.text("__PAGE_NUMBER__", PAGE_WIDTH_MM - MARGIN_MM, y + 1.5, { align: "right" });
+}
+
+function drawTitleBand(doc: jsPDF, y: number): number {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+  const h = 7;
+  setFillHex(doc, PALETTE.BLOOD);
+  doc.rect(x, y, w, h, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10);
+  setTextHex(doc, PALETTE.BONE);
+  doc.setCharSpace(2);
+  doc.text("OFFICIAL PLAY-BY-PLAY LOG", x + w / 2, y + h / 2 + 1.4, { align: "center" });
+  doc.setCharSpace(0);
+  return y + h;
+}
+
+export interface PlayLogResult {
+  bottomY: number;
+}
+
+function ensurePageHeader(doc: jsPDF, decoratePage: () => void): number {
+  doc.addPage();
+  decoratePage();
+  return drawTitleBand(doc, 14);
+}
+
+interface RowMeta {
+  team: "A" | "B";
+  iconKind: IconKind;
+  failed: boolean;
+  resultColor: string;
+}
+
+export function drawPlayLog(
+  doc: jsPDF,
+  match: PdfMatch,
+  actions: ReadonlyArray<PdfAction>,
+  startY: number,
+  decoratePage: () => void,
+): PlayLogResult {
+  if (actions.length === 0) {
+    return { bottomY: startY };
+  }
+
+  // Si on n'a pas la place pour le bandeau + au moins 3 lignes, on saute en page suivante.
+  let tableStartY: number;
+  let firstTablePage: number;
+  if (startY + 30 > PAGE_HEIGHT_MM - 18) {
+    tableStartY = ensurePageHeader(doc, decoratePage);
+    firstTablePage = doc.getCurrentPageInfo().pageNumber;
+  } else {
+    tableStartY = drawTitleBand(doc, startY + 4);
+    firstTablePage = doc.getCurrentPageInfo().pageNumber;
+  }
+
+  const teamAName = match.teamA.name;
+  const teamBName = match.teamB.name;
+
+  const colorsA = resolveTeamColors(
+    match.teamA.roster ? getTeamColors(match.teamA.roster).primary : undefined,
+    match.teamA.roster ? getTeamColors(match.teamA.roster).secondary : undefined,
+  );
+  const colorsB = resolveTeamColors(
+    match.teamB.roster ? getTeamColors(match.teamB.roster).primary : undefined,
+    match.teamB.roster ? getTeamColors(match.teamB.roster).secondary : undefined,
+  );
+
+  const inkRgb = parseHex(PALETTE.INK);
+  const boneRgb = parseHex(PALETTE.BONE);
+  const lineRgb = parseHex(PALETTE.INK_SOFT);
+  const parchmentRgb = parseHex(PALETTE.PARCHMENT);
+  const parchmentDarkRgb = parseHex(PALETTE.PARCHMENT_DARK);
+
+  const sorted = [...actions].sort((a, b) => {
+    if (a.half !== b.half) return a.half - b.half;
+    if (a.turn !== b.turn) return a.turn - b.turn;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+
+  const rowMetas: RowMeta[] = sorted.map((a) => {
+    const iconKind: IconKind = a.fumble
+      ? a.actionType
+      : (a.actionType === "blocage" || a.actionType === "blitz" || a.actionType === "aggression") &&
+          a.armorBroken &&
+          (a.opponentState || "").toLowerCase() === "elimine"
+        ? "casualty"
+        : a.actionType;
+    return {
+      team: a.playerTeam,
+      iconKind,
+      failed: a.fumble,
+      resultColor: resultLabel(a).color,
+    };
+  });
+
+  const body = sorted.map((a) => {
+    const r = resultLabel(a);
+    return [
+      String(a.half),
+      String(a.turn),
+      a.playerTeam === "A" ? "A" : "B",
+      "", // icone dessinee en didDrawCell
+      eventDescription(a, teamAName, teamBName),
+      r.text,
+    ];
+  });
+
+  autoTable(doc, {
+    startY: tableStartY,
+    margin: { left: MARGIN_MM, right: MARGIN_MM, top: 14, bottom: 14 },
+    head: [["MT", "T", "EQ", "", "EVENEMENT", "RESULTAT"]],
+    body,
+    theme: "grid",
+    styles: {
+      font: "helvetica",
+      fontSize: 8,
+      textColor: inkRgb,
+      lineColor: lineRgb,
+      lineWidth: 0.1,
+      cellPadding: { top: 1.4, right: 1.6, bottom: 1.4, left: 1.6 },
+      valign: "middle",
+    },
+    headStyles: {
+      fillColor: inkRgb,
+      textColor: boneRgb,
+      fontStyle: "bold",
+      halign: "center",
+      fontSize: 8,
+    },
+    bodyStyles: {
+      fillColor: parchmentRgb,
+    },
+    alternateRowStyles: {
+      fillColor: parchmentDarkRgb,
+    },
+    tableWidth: CONTENT_WIDTH_MM,
+    columnStyles: {
+      0: { halign: "center", cellWidth: 8 },
+      1: { halign: "center", cellWidth: 8 },
+      2: { halign: "center", cellWidth: 9, fontStyle: "bold" },
+      3: { halign: "center", cellWidth: 8 },
+      4: { halign: "left" },
+      5: { halign: "center", cellWidth: 32, fontStyle: "bold" },
+    },
+    didParseCell: (data: CellHookData) => {
+      if (data.section !== "body") return;
+      const meta = rowMetas[data.row.index];
+      if (!meta) return;
+      if (data.column.index === 2) {
+        const tint = meta.team === "A" ? colorsA.tint : colorsB.tint;
+        data.cell.styles.fillColor = parseHex(tint);
+      }
+      if (data.column.index === 5) {
+        data.cell.styles.textColor = parseHex(meta.resultColor);
+      }
+    },
+    didDrawCell: (data: CellHookData) => {
+      if (data.section !== "body" || data.column.index !== 3) return;
+      const meta = rowMetas[data.row.index];
+      if (!meta) return;
+      const size = 4.6;
+      const px = data.cell.x + (data.cell.width - size) / 2;
+      const py = data.cell.y + (data.cell.height - size) / 2;
+      drawIcon(doc, meta.iconKind, px, py, PALETTE.INK, size, meta.failed);
+    },
+    didDrawPage: () => {
+      // didDrawPage est appele APRES que la table de la page ait ete dessinee.
+      // On ne peut donc pas redessiner le parchemin par-dessus sans masquer
+      // les rangees. Sur les pages de continuation creees par autotable, on
+      // ajoute juste le bandeau titre (qui occupe la zone reservee par
+      // margin.top) et un footer leger (filet + texte) sans repeindre le fond.
+      const current = doc.getCurrentPageInfo().pageNumber;
+      if (current === firstTablePage) return;
+      drawTitleBand(doc, 6);
+      drawContinuationFooter(doc, match.name?.trim() || "Match Blood Bowl");
+    },
+  });
+
+  // @ts-expect-error lastAutoTable is added by autotable plugin
+  const finalY = (doc.lastAutoTable?.finalY ?? tableStartY + 80) as number;
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.2);
+  return { bottomY: finalY };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/pregame.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/pregame.ts
@@ -1,0 +1,154 @@
+/**
+ * Encart "PRE-GAME CONDITIONS": meteo + fan factor sur deux colonnes.
+ * Si rien n'est disponible, retourne immediatement le bottomY = startY.
+ */
+
+import type jsPDF from "jspdf";
+import { getTeamColors } from "@bb/game-engine";
+import {
+  PALETTE,
+  resolveTeamColors,
+  setDrawHex,
+  setFillHex,
+  setTextHex,
+} from "../colors";
+import { drawWeatherIcon } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM } from "../chrome";
+import type { PdfMatch } from "../types";
+
+const HEIGHT = 36;
+
+export interface PregameResult {
+  bottomY: number;
+  drawn: boolean;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
+}
+
+export function drawPregame(doc: jsPDF, match: PdfMatch, startY: number): PregameResult {
+  const preMatch = match.gameState?.preMatch;
+  if (!preMatch || (!preMatch.weather && !preMatch.fanFactor)) {
+    return { bottomY: startY, drawn: false };
+  }
+
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+
+  // Conteneur
+  setFillHex(doc, PALETTE.PARCHMENT);
+  setDrawHex(doc, PALETTE.INK_SOFT);
+  doc.setLineWidth(0.4);
+  doc.rect(x, startY, w, HEIGHT, "FD");
+
+  // Bandeau titre
+  setFillHex(doc, PALETTE.INK);
+  doc.rect(x, startY, w, 6, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8);
+  setTextHex(doc, PALETTE.BONE);
+  doc.setCharSpace(1.6);
+  doc.text("PRE-GAME CONDITIONS", x + w / 2, startY + 4.2, { align: "center" });
+  doc.setCharSpace(0);
+
+  const colY = startY + 11;
+  const colHeight = HEIGHT - 11;
+  const colWidth = w / 2;
+
+  // Separateur central
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.3);
+  doc.line(x + colWidth, startY + 9, x + colWidth, startY + HEIGHT - 3);
+
+  // Colonne gauche : Weather
+  const weather = preMatch.weather;
+  if (weather) {
+    drawWeatherIcon(doc, x + 12, colY + colHeight / 2 - 2, 10, weather.condition);
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(10);
+    setTextHex(doc, PALETTE.INK);
+    doc.text(weather.condition, x + 22, colY + 5);
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7.5);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    const desc = truncate(weather.description, 80);
+    const lines = doc.splitTextToSize(desc, colWidth - 28);
+    doc.text(lines.slice(0, 2), x + 22, colY + 10);
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(7);
+    doc.setCharSpace(0.6);
+    setTextHex(doc, PALETTE.GOLD_DARK);
+    doc.text(`2D6 = ${weather.total}`, x + 22, colY + colHeight - 4);
+    doc.setCharSpace(0);
+  } else {
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(8);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    doc.text("Meteo non enregistree", x + 6, colY + colHeight / 2);
+  }
+
+  // Colonne droite : Fan Factor
+  const fanFactor = preMatch.fanFactor;
+  if (fanFactor) {
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(8);
+    setTextHex(doc, PALETTE.INK);
+    doc.setCharSpace(1.4);
+    doc.text("FAN FACTOR", x + colWidth + 4, colY + 3);
+    doc.setCharSpace(0);
+
+    // Plancher minimal pour eviter une barre quasi-invisible quand les deux
+    // equipes ont un fan factor faible.
+    const FAN_FACTOR_BAR_MIN = 6;
+    const max = Math.max(fanFactor.teamA.total, fanFactor.teamB.total, FAN_FACTOR_BAR_MIN);
+    const barX = x + colWidth + 4;
+    const barW = colWidth - 18;
+
+    const colorsA = resolveTeamColors(
+      match.teamA.roster ? getTeamColors(match.teamA.roster).primary : undefined,
+      match.teamA.roster ? getTeamColors(match.teamA.roster).secondary : undefined,
+    );
+    const colorsB = resolveTeamColors(
+      match.teamB.roster ? getTeamColors(match.teamB.roster).primary : undefined,
+      match.teamB.roster ? getTeamColors(match.teamB.roster).secondary : undefined,
+    );
+
+    // Bar A
+    const yA = colY + 8;
+    setFillHex(doc, PALETTE.PARCHMENT_DARK);
+    doc.rect(barX, yA, barW, 4, "F");
+    setFillHex(doc, colorsA.primary);
+    doc.rect(barX, yA, (barW * fanFactor.teamA.total) / max, 4, "F");
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7);
+    setTextHex(doc, PALETTE.INK);
+    doc.text(
+      `${truncate(match.teamA.name, 18)}  •  ${fanFactor.teamA.total}  (D3 ${fanFactor.teamA.d3} + Fans ${fanFactor.teamA.dedicatedFans})`,
+      barX,
+      yA - 1,
+    );
+
+    // Bar B
+    const yB = colY + 18;
+    setFillHex(doc, PALETTE.PARCHMENT_DARK);
+    doc.rect(barX, yB, barW, 4, "F");
+    setFillHex(doc, colorsB.primary);
+    doc.rect(barX, yB, (barW * fanFactor.teamB.total) / max, 4, "F");
+    doc.text(
+      `${truncate(match.teamB.name, 18)}  •  ${fanFactor.teamB.total}  (D3 ${fanFactor.teamB.d3} + Fans ${fanFactor.teamB.dedicatedFans})`,
+      barX,
+      yB - 1,
+    );
+  } else {
+    doc.setFont("helvetica", "italic");
+    doc.setFontSize(8);
+    setTextHex(doc, PALETTE.INK_SOFT);
+    doc.text("Fan factor non enregistre", x + colWidth + 6, colY + colHeight / 2);
+  }
+
+  return { bottomY: startY + HEIGHT, drawn: true };
+}

--- a/apps/web/app/local-matches/[id]/pdf/sections/scoreboard.ts
+++ b/apps/web/app/local-matches/[id]/pdf/sections/scoreboard.ts
@@ -1,0 +1,141 @@
+/**
+ * Scoreboard hero: emblemes des deux equipes, score geant central,
+ * chips de resultat et stats compactes (TD / CAS) sous chaque equipe.
+ */
+
+import type jsPDF from "jspdf";
+import { getTeamColors, getTeamLogo } from "@bb/game-engine";
+import {
+  PALETTE,
+  ensureContrast,
+  resolveTeamColors,
+  setDrawHex,
+  setFillHex,
+  setTextHex,
+} from "../colors";
+import { drawBadge, drawEmblem } from "../icons";
+import { CONTENT_WIDTH_MM, MARGIN_MM } from "../chrome";
+import type { MatchAggregates, PdfMatch } from "../types";
+
+const HEIGHT = 70;
+
+export interface ScoreboardResult {
+  bottomY: number;
+}
+
+function teamLabel(name: string, max = 22): string {
+  if (name.length <= max) return name;
+  return name.slice(0, max - 1) + "…";
+}
+
+export function drawScoreboard(
+  doc: jsPDF,
+  match: PdfMatch,
+  agg: MatchAggregates,
+  startY: number,
+): ScoreboardResult {
+  const x = MARGIN_MM;
+  const w = CONTENT_WIDTH_MM;
+
+  // Conteneur principal
+  setFillHex(doc, PALETTE.PARCHMENT_DARK);
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(0.8);
+  doc.roundedRect(x, startY, w, HEIGHT, 2, 2, "FD");
+  setDrawHex(doc, PALETTE.INK_SOFT);
+  doc.setLineWidth(0.3);
+  doc.roundedRect(x + 1.5, startY + 1.5, w - 3, HEIGHT - 3, 1.5, 1.5, "D");
+
+  const colorsA = resolveTeamColors(
+    match.teamA.roster ? getTeamColors(match.teamA.roster).primary : undefined,
+    match.teamA.roster ? getTeamColors(match.teamA.roster).secondary : undefined,
+  );
+  const colorsB = resolveTeamColors(
+    match.teamB.roster ? getTeamColors(match.teamB.roster).primary : undefined,
+    match.teamB.roster ? getTeamColors(match.teamB.roster).secondary : undefined,
+  );
+
+  // Stripes verticales aux extremites
+  setFillHex(doc, colorsA.primary);
+  doc.rect(x + 3, startY + 3, 5, HEIGHT - 6, "F");
+  setFillHex(doc, colorsA.secondary);
+  doc.rect(x + 8, startY + 3, 1.5, HEIGHT - 6, "F");
+
+  setFillHex(doc, colorsB.primary);
+  doc.rect(x + w - 8, startY + 3, 5, HEIGHT - 6, "F");
+  setFillHex(doc, colorsB.secondary);
+  doc.rect(x + w - 9.5, startY + 3, 1.5, HEIGHT - 6, "F");
+
+  // Emblemes
+  const logoA = match.teamA.roster ? getTeamLogo(match.teamA.roster) : { shape: "circle" as const, glyph: "A" };
+  const logoB = match.teamB.roster ? getTeamLogo(match.teamB.roster) : { shape: "circle" as const, glyph: "B" };
+
+  const emblemSize = 32;
+  const emblemY = startY + 26;
+  drawEmblem(
+    doc,
+    logoA.shape,
+    colorsA.primary,
+    ensureContrast(colorsA.secondary, colorsA.primary),
+    logoA.glyph,
+    x + 26,
+    emblemY,
+    emblemSize,
+  );
+  drawEmblem(
+    doc,
+    logoB.shape,
+    colorsB.primary,
+    ensureContrast(colorsB.secondary, colorsB.primary),
+    logoB.glyph,
+    x + w - 26,
+    emblemY,
+    emblemSize,
+  );
+
+  // Noms d'equipes au-dessus des emblemes
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(11);
+  setTextHex(doc, PALETTE.INK);
+  doc.text(teamLabel(match.teamA.name), x + 26, startY + 9, { align: "center" });
+  doc.text(teamLabel(match.teamB.name), x + w - 26, startY + 9, { align: "center" });
+
+  // Score geant centre
+  const scoreA = match.scoreTeamA ?? 0;
+  const scoreB = match.scoreTeamB ?? 0;
+  const cx = x + w / 2;
+  const cy = startY + 38;
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(54);
+  setTextHex(doc, PALETTE.INK);
+  doc.text(String(scoreA), cx - 14, cy + 4, { align: "right" });
+  doc.text(String(scoreB), cx + 14, cy + 4, { align: "left" });
+
+  // Tiret central
+  setDrawHex(doc, PALETTE.GOLD);
+  doc.setLineWidth(2.2);
+  doc.line(cx - 6, cy - 4, cx + 6, cy - 4);
+  setDrawHex(doc, PALETTE.GOLD_DARK);
+  doc.setLineWidth(0.6);
+  doc.line(cx - 6, cy - 2.5, cx + 6, cy - 2.5);
+
+  // Chip resultat: le badge designe TOUJOURS le vainqueur (vert), ou DRAW gris.
+  const resultLabel =
+    agg.outcome === "DRAW"
+      ? "MATCH NUL"
+      : `VICTOIRE — ${teamLabel(agg.outcome === "A" ? match.teamA.name : match.teamB.name, 24).toUpperCase()}`;
+  const resultColor = agg.outcome === "DRAW" ? PALETTE.DRAW_GREY : PALETTE.WIN_GREEN;
+  drawBadge(doc, cx - 45, startY + 50, 90, 9, resultLabel, resultColor, PALETTE.BONE, 8.5);
+
+  // Mini stats sous chaque emblem
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(8);
+  setTextHex(doc, PALETTE.INK_SOFT);
+  const statsLineA = `${agg.teamA.touchdowns} TD · ${agg.teamA.casualties} CAS`;
+  const statsLineB = `${agg.teamB.touchdowns} TD · ${agg.teamB.casualties} CAS`;
+  doc.text(statsLineA, x + 26, startY + 64, { align: "center" });
+  doc.text(statsLineB, x + w - 26, startY + 64, { align: "center" });
+
+  return { bottomY: startY + HEIGHT };
+}

--- a/apps/web/app/local-matches/[id]/pdf/types.ts
+++ b/apps/web/app/local-matches/[id]/pdf/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types partages par tous les modules de generation du PDF de recap de match.
+ * Decouples du composant React: ces types sont les seuls inputs de generateMatchPdf.
+ */
+
+export type ActionType =
+  | "passe"
+  | "reception"
+  | "td"
+  | "blocage"
+  | "blitz"
+  | "transmission"
+  | "aggression"
+  | "sprint"
+  | "esquive"
+  | "apothicaire"
+  | "interception";
+
+export interface PdfAction {
+  id: string;
+  half: number;
+  turn: number;
+  actionType: ActionType;
+  playerId: string;
+  playerName: string;
+  playerTeam: "A" | "B";
+  opponentId: string | null;
+  opponentName: string | null;
+  diceResult: number | null;
+  fumble: boolean;
+  playerState: string | null;
+  armorBroken: boolean;
+  opponentState: string | null;
+  passType: string | null;
+  createdAt: string;
+}
+
+export interface PdfTeam {
+  id: string;
+  name: string;
+  /** Roster slug — ex: "skaven", "human". Manquant => emblème neutre. */
+  roster?: string | null;
+}
+
+export interface PdfFanFactor {
+  d3: number;
+  dedicatedFans: number;
+  total: number;
+}
+
+export interface PdfWeather {
+  total: number;
+  condition: string;
+  description: string;
+}
+
+export interface PdfMatchStatsEntry {
+  touchdowns: number;
+  casualties: number;
+  completions: number;
+  interceptions: number;
+  mvp: boolean;
+}
+
+export interface PdfMatch {
+  id: string;
+  name: string | null;
+  teamA: PdfTeam;
+  teamB: PdfTeam;
+  scoreTeamA: number | null;
+  scoreTeamB: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  cup: { id: string; name: string } | null;
+  gameState?: {
+    preMatch?: {
+      fanFactor?: { teamA: PdfFanFactor; teamB: PdfFanFactor };
+      weatherType?: string;
+      weather?: PdfWeather;
+    };
+    matchStats?: Record<string, PdfMatchStatsEntry>;
+    matchResult?: { winner?: "A" | "B"; spp?: Record<string, number> };
+    players?: Array<{
+      id: string;
+      team: "A" | "B";
+      name: string;
+      number: number;
+      position: string;
+    }>;
+  };
+}
+
+/** Resultat agrege des actions, calcule en amont des sections. */
+export interface TeamAggregateStats {
+  touchdowns: number;
+  completions: number;
+  receptions: number;
+  blitzes: number;
+  blocks: number;
+  fouls: number;
+  sprints: number;
+  dodges: number;
+  interceptions: number;
+  armorBreaks: number;
+  casualties: number;
+  kos: number;
+  stuns: number;
+  fumbles: number;
+  totalActions: number;
+}
+
+export interface MvpInfo {
+  playerId: string;
+  playerName: string;
+  team: "A" | "B";
+  number: number | null;
+  position: string | null;
+  spp: number;
+  touchdowns: number;
+  casualties: number;
+  completions: number;
+  interceptions: number;
+}
+
+export interface MatchAggregates {
+  teamA: TeamAggregateStats;
+  teamB: TeamAggregateStats;
+  mvp: MvpInfo | null;
+  outcome: "A" | "B" | "DRAW";
+}


### PR DESCRIPTION
## Résumé

Implements a complete PDF export feature for local match summaries in Blood Bowl. The export generates a multi-page professional game recap including:
- Header with match info and team emblems
- Scoreboard with final score and team stats
- Pre-game conditions (weather, fan factor)
- Box score statistics table
- MVP section with player stats
- Drive chart showing action distribution by turn
- Full play-by-play log with action details

The implementation is modular and testable, with pure calculation logic separated from PDF rendering.

## Changes

### New PDF Generation System (`apps/web/app/local-matches/[id]/pdf/`)

**Core modules:**
- `index.ts` - Main orchestrator that chains all sections across multiple pages
- `types.ts` - Shared TypeScript interfaces for PDF data (PdfMatch, PdfAction, etc.)
- `colors.ts` - Palette management and color utilities (hex/RGB conversion, contrast checking, team color resolution)
- `icons.ts` - Vector drawing primitives (emblems, ribbons, badges, weather icons, seals)
- `chrome.ts` - Page layout (parchment background, footer, pagination)
- `aggregations.ts` - Pure calculation logic (team stats, MVP determination, outcome computation)

**Section modules:**
- `sections/header.ts` - Title banner with match info and seal
- `sections/scoreboard.ts` - Hero section with team emblems and final score
- `sections/pregame.ts` - Weather and fan factor display
- `sections/boxScore.ts` - Statistics table (autotable)
- `sections/mvp.ts` - Star of the Match ribbon and player card
- `sections/driveChart.ts` - Turn-by-turn action visualization
- `sections/playLog.ts` - Multi-page play-by-play table with icons

**Tests:**
- `colors.test.ts` - Color conversion and contrast utilities
- `aggregations.test.ts` - Team stats and MVP calculation logic
- `index.test.ts` - Integration smoke tests (no crash, valid output)

### Modified Files

**`LocalMatchSummary.tsx`:**
- Added `roster` field to team type definitions
- Added `matchStats`, `matchResult`, and `players` to gameState type
- Replaced inline PDF generation with call to new `generateMatchPdf()` function
- Removed ~200 lines of PDF rendering code (now in dedicated modules)

**`page.tsx`:**
- Pass `roster` field when constructing PdfMatch object

## Design Highlights

- **Modular architecture**: Each section (header, scoreboard, MVP, etc.) is independent and testable
- **Pure calculations**: Aggregation logic (`computeTeamStats`, `computeMvp`, etc.) has no PDF dependencies and can be unit tested in jsdom
- **Lazy imports**: jsPDF and jspdf-autotable imported only when export is triggered
- **Blood Bowl theming**: Custom vector graphics (emblems, ribbons, seals) using native jsPDF drawing, no external assets
- **Responsive pagination**: Play-by-play log automatically spans multiple pages with proper headers/footers
- **Team colors**: Dynamically resolves team colors from roster data with contrast checking for readability

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (aggregations, colors, integration smoke test)
- [x] Changeset ajouté

https://claude.ai/code/session_016HErZPQDERaK5tvxEpRaRX