### PR TITLE
test(e2e-api): unwrap /:id/summary ApiResponse envelope (S25.5k follow-up)

### DIFF
--- a/tests/e2e-api/specs/match-routes.spec.ts
+++ b/tests/e2e-api/specs/match-routes.spec.ts
@@ -82,16 +82,21 @@ describe("E2E API — routes /match/*", () => {
   it("GET /match/:id/summary retourne un objet stable pour un coach membre", async () => {
     const { coachA, match } = await bootMatch();
 
-    const summary = await get<{
-      id: string;
-      status: string;
-      teams: {
-        local: { name: string; coach: string };
-        visitor: { name: string; coach: string };
-      };
-      acceptances: { local: boolean; visitor: boolean };
-      score: { teamA: number; teamB: number };
-    }>(`/match/${match.id}/summary`, coachA.token);
+    const summary = unwrap(
+      await get<{
+        success: true;
+        data: {
+          id: string;
+          status: string;
+          teams: {
+            local: { name: string; coach: string };
+            visitor: { name: string; coach: string };
+          };
+          acceptances: { local: boolean; visitor: boolean };
+          score: { teamA: number; teamB: number };
+        };
+      }>(`/match/${match.id}/summary`, coachA.token),
+    );
 
     expect(summary.id).toBe(match.id);
     expect(typeof summary.status).toBe("string");

--- a/tests/e2e-api/specs/smoke.spec.ts
+++ b/tests/e2e-api/specs/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { resetDb, get } from "../helpers/api";
+import { resetDb, get, unwrap } from "../helpers/api";
 import {
   bootMatch,
   createTwoCoaches,
@@ -54,9 +54,11 @@ describe("E2E API — smoke", () => {
     expect(started.receivingUserId).toBeTruthy();
     expect(started.kickingUserId).not.toBe(started.receivingUserId);
 
-    const summary = await get<{ status: string }>(
-      `/match/${match.id}/summary`,
-      coachA.token,
+    const summary = unwrap(
+      await get<{ success: true; data: { status: string } }>(
+        `/match/${match.id}/summary`,
+        coachA.token,
+      ),
     );
     // Au retour de /match/accept le serveur passe la partie en prematch-setup
     // et lance la séquence pré-match automatique. Le statut "active" n'arrive
@@ -73,13 +75,17 @@ describe("E2E API — smoke", () => {
     expect(started.kickingUserId).toBeTruthy();
 
     // Le match n'est plus en pending; on le vérifie via /summary (route légère).
-    const summaryA = await get<{ status: string }>(
-      `/match/${match.id}/summary`,
-      coachA.token,
+    const summaryA = unwrap(
+      await get<{ success: true; data: { status: string } }>(
+        `/match/${match.id}/summary`,
+        coachA.token,
+      ),
     );
-    const summaryB = await get<{ status: string }>(
-      `/match/${match.id}/summary`,
-      coachB.token,
+    const summaryB = unwrap(
+      await get<{ success: true; data: { status: string } }>(
+        `/match/${match.id}/summary`,
+        coachB.token,
+      ),
     );
     expect(summaryA.status).not.toBe("pending");
     expect(summaryB.status).not.toBe("pending");


### PR DESCRIPTION
## Resume

Suivi rapide de **S25.5k** (#432). Apres son merge dans `main`, la route
`GET /match/:id/summary` retourne desormais l'enveloppe
`{ success: true, data: {...} }` au lieu du shape brut, ce qui casse les
specs E2E API qui consomment encore le shape pre-migration via
`get<{ status: string }>(...)`. Le job `E2E API (vitest)` echoue donc
sur `main` avec :

- `smoke.spec.ts:64` — `expected [ 'prematch-setup', 'active' ] to include undefined`
- `match-routes.spec.ts:96` — `expected undefined to be 'cmoirue2u00li52ysr7yrajsv'`

## Correctif

- `tests/e2e-api/specs/smoke.spec.ts` : 3 callsites passes sous
  `unwrap(await get<{success:true; data: T}>(...))`.
- `tests/e2e-api/specs/match-routes.spec.ts` : le test "GET
  /match/:id/summary retourne un objet stable" aligne sur le meme
  pattern. Les `rawGet` (404) restent inchanges (le 404 retourne deja
  l'enveloppe ApiError mais le test ne lit que `res.status`).

Pattern aligne sur les slices S25.5h-j qui utilisaient deja
`unwrap(await get<...>())` pour `/match/my-matches` etc.

## Tache roadmap

Suivi de Sprint S25, tache S25.5k (deja `[x]` dans la roadmap).
Source : `docs/roadmap/sprints/S25-observabilite-qualite.md`

## Plan de test

- [x] `pnpm test` E2E API local : `smoke.spec.ts` 4/4 + `match-routes.spec.ts` 9/9 verts
- [ ] CI `E2E API (vitest)` doit redevenir verte sur cette PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXHzzguDSKMDcb1dY1vbou)_