### PR TITLE
test(e2e-api): unwrap /match/:id/state ApiResponse envelope (S25.5l follow-up)

### DIFF
--- a/tests/e2e-api/specs/prematch.spec.ts
+++ b/tests/e2e-api/specs/prematch.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { resetDb, get } from "../helpers/api";
+import { resetDb, get, unwrap } from "../helpers/api";
 import {
   bootMatch,
   createTwoCoaches,
@@ -71,9 +71,12 @@ describe("E2E API — pré-match automatisé", () => {
     let lastPhase: string | undefined;
     while (Date.now() < deadline) {
       try {
-        const state = await get<{
-          gameState: { preMatch?: { phase?: string } };
-        }>(`/match/${match.id}/state`, coachA.token);
+        const state = unwrap(
+          await get<{
+            success: true;
+            data: { gameState: { preMatch?: { phase?: string } } };
+          }>(`/match/${match.id}/state`, coachA.token),
+        );
         lastPhase = state.gameState?.preMatch?.phase;
         if (
           lastPhase === "inducements" ||

--- a/tests/e2e-api/specs/setup.spec.ts
+++ b/tests/e2e-api/specs/setup.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { resetDb, get, rawPost } from "../helpers/api";
+import { resetDb, get, rawPost, unwrap } from "../helpers/api";
 import { bootMatch } from "../helpers/factories";
 
 /**
@@ -50,9 +50,11 @@ describe("E2E API — phase de setup", () => {
     const deadline = Date.now() + 12_000;
     while (Date.now() < deadline) {
       try {
-        const res = await get<SetupStateResponse>(
-          `/match/${matchId}/state`,
-          coachToken,
+        const res = unwrap(
+          await get<{ success: true; data: SetupStateResponse }>(
+            `/match/${matchId}/state`,
+            coachToken,
+          ),
         );
         if (
           res.gameState?.preMatch?.phase === "setup" ||
@@ -164,10 +166,18 @@ describe("E2E API — phase de setup", () => {
       // la transition idle → setup s'exécutait sans persistance dans /state,
       // donc deux appels concurrents pouvaient renvoyer des gameState
       // distincts (joueurs ou positions différents) ou un 500.
-      const [resA, resB] = await Promise.all([
-        get<SetupStateResponse>(`/match/${match.id}/state`, coachA.token),
-        get<SetupStateResponse>(`/match/${match.id}/state`, coachB.token),
+      const [envA, envB] = await Promise.all([
+        get<{ success: true; data: SetupStateResponse }>(
+          `/match/${match.id}/state`,
+          coachA.token,
+        ),
+        get<{ success: true; data: SetupStateResponse }>(
+          `/match/${match.id}/state`,
+          coachB.token,
+        ),
       ]);
+      const resA = unwrap(envA);
+      const resB = unwrap(envB);
 
       const idsA = resA.gameState.players.map((p) => p.id).sort();
       const idsB = resB.gameState.players.map((p) => p.id).sort();


### PR DESCRIPTION
## Resume

Suivi rapide de **S25.5l** (#435) qui a migre `GET /match/:id/state` vers l'enveloppe `ApiResponse<T>` (`{ success, data, error }`) mais sans mettre a jour les specs E2E qui consomment encore le shape pre-migration via `get<SetupStateResponse>(...)`. Le job `E2E API (vitest)` echoue donc sur `main` (et bloque toutes les PR derivees, ex. #437, #438) avec :

- `prematch.spec.ts:94` — `expect(["inducements", "kicking-team", "setup"].includes(lastPhase ?? "")).toBe(true)` : `lastPhase` est `undefined` car `state.gameState?.preMatch?.phase` est lu sur l'enveloppe.
- `setup.spec.ts:104,161,191` — `waitForSetupReady` retourne `null` pour la meme raison.
- `setup.spec.ts:174` — sur le test concurrent, `resA.gameState` est `undefined`.

## Correctif

- `tests/e2e-api/specs/prematch.spec.ts` : helper de polling `/state` passe sous `unwrap()`.
- `tests/e2e-api/specs/setup.spec.ts` : helper `waitForSetupReady` + test "deux appels `/state` concurrents" passes sous `unwrap()`.

Pattern aligne sur PR #434 (suivi S25.5k) qui utilisait deja `unwrap()` pour les routes `/summary` migrees.

## Tache roadmap

Suivi de Sprint S25, tache S25.5l (deja `[x]` dans la roadmap).
Source : `docs/roadmap/sprints/S25-observabilite-qualite.md`

## Plan de test

- [x] `pnpm run test` E2E API local : 464/464 verts (incluant `setup.spec.ts` 5/5 + `prematch.spec.ts` 2/2).
- [ ] CI `E2E API (vitest)` doit redevenir verte sur cette PR (et debloquer les autres PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_