### PR TITLE
refactor(play): extract InducementsPhaseUI + normalizeState (S26.0a)

### DIFF
--- a/apps/web/app/me/teams/[id]/edit/page.tsx
+++ b/apps/web/app/me/teams/[id]/edit/page.tsx
@@ -143,7 +143,9 @@ export default function TeamEditPage() {
         const [me, d, positionsData] = await Promise.all([
           fetchJSON("/auth/me"),
           apiRequest<any>(`/team/${id}`),
-          apiRequest(`/team/${id}/available-positions`),
+          apiRequest<{ availablePositions: AvailablePosition[] }>(
+            `/team/${id}/available-positions`,
+          ),
         ]);
 
         if (!me?.user) {
@@ -289,7 +291,7 @@ export default function TeamEditPage() {
       // Parallelize the two refetches; they are independent.
       const [d, positionsData] = await Promise.all([
         apiRequest<any>(`/team/${id}`),
-        apiRequest<{ availablePositions: unknown[] }>(
+        apiRequest<{ availablePositions: AvailablePosition[] }>(
           `/team/${id}/available-positions`,
         ),
       ]);
@@ -337,7 +339,7 @@ export default function TeamEditPage() {
 
       const [d, positionsData] = await Promise.all([
         apiRequest<any>(`/team/${id}`),
-        apiRequest<{ availablePositions: unknown[] }>(
+        apiRequest<{ availablePositions: AvailablePosition[] }>(
           `/team/${id}/available-positions`,
         ),
       ]);
@@ -1301,7 +1303,7 @@ export default function TeamEditPage() {
                           const result = await apiRequest<{
                             player: { skills: string; advancements: string; spp: number };
                             sppSpent: number;
-                            advancement: unknown;
+                            advancement: { skillSlug: string };
                           }>(`/team/${id}/players/${player.id}/skills`, {
                             method: "PUT",
                             body: JSON.stringify(body),
@@ -1399,7 +1401,7 @@ export default function TeamEditPage() {
             const d = await apiRequest<any>(`/team/${id}`);
             setData(d);
             setPlayers(d.team?.players || []);
-            const positionsData = await apiRequest<{ availablePositions: unknown[] }>(
+            const positionsData = await apiRequest<{ availablePositions: AvailablePosition[] }>(
               `/team/${id}/available-positions`,
             );
             setAvailablePositions(positionsData.availablePositions || []);

--- a/apps/web/app/play/[id]/components/InducementsPhaseUI.tsx
+++ b/apps/web/app/play/[id]/components/InducementsPhaseUI.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * UI de la phase d'inducements pre-match.
+ *
+ * Le coach voit son budget (petty cash) puis selectionne / skip ses
+ * inducements via `<InducementSelector>`. La selection est emise sur le
+ * socket de jeu (`game:submit-inducements`), et l'UI passe en
+ * "submitted" tant que l'adversaire n'a pas confirme la sienne.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0a.
+ */
+
+import { useState, useCallback } from "react";
+import {
+  INDUCEMENT_CATALOGUE,
+  type InducementSelection,
+  type InducementDefinition,
+  type ExtendedGameState,
+} from "@bb/game-engine";
+import InducementSelector from "../../../components/InducementSelector";
+import { normalizeState } from "../utils/normalize-state";
+import type { useGameSocket } from "../hooks/useGameSocket";
+
+interface InducementsPhaseUIProps {
+  matchId: string;
+  state: ExtendedGameState;
+  stateSource: string | null;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  myTeamSide: "A" | "B" | null;
+  gameSocket: ReturnType<typeof useGameSocket>["socket"];
+}
+
+export function InducementsPhaseUI({
+  matchId,
+  state,
+  setState,
+  myTeamSide,
+  gameSocket,
+}: InducementsPhaseUIProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [inducementError, setInducementError] = useState<string | null>(null);
+
+  const catalogue = INDUCEMENT_CATALOGUE.filter(
+    (ind) => ind.slug !== "star_player",
+  ) as InducementDefinition[];
+
+  const myTeamName =
+    myTeamSide === "A" ? state.teamNames.teamA : state.teamNames.teamB;
+  // Budget info from preMatch state (petty cash computed server-side during pre-match sequence)
+  const myBudget =
+    myTeamSide === "A"
+      ? (state.preMatch?.inducements?.teamA?.pettyCash ?? 0)
+      : (state.preMatch?.inducements?.teamB?.pettyCash ?? 0);
+
+  const handleConfirm = useCallback(
+    (selection: InducementSelection) => {
+      if (!gameSocket || submitting || submitted) return;
+      setSubmitting(true);
+      setInducementError(null);
+
+      gameSocket.emit(
+        "game:submit-inducements",
+        { matchId, selection },
+        (response: any) => {
+          setSubmitting(false);
+          if (!response?.success) {
+            setInducementError(response?.error || "Erreur");
+            return;
+          }
+          setSubmitted(true);
+          if (response.gameState) {
+            setState(normalizeState(response.gameState));
+          }
+        },
+      );
+    },
+    [gameSocket, matchId, submitting, submitted, setState],
+  );
+
+  const handleSkip = useCallback(() => {
+    handleConfirm({ items: [] });
+  }, [handleConfirm]);
+
+  return (
+    <div className="w-full max-w-lg mx-auto">
+      <div className="text-center mb-4">
+        <h2 className="text-xl font-bold text-gray-800">Phase d&apos;Inducements</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Depensez votre budget pour des avantages de match.
+        </p>
+      </div>
+
+      {inducementError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm text-center">
+          {inducementError}
+        </div>
+      )}
+
+      {submitted ? (
+        <div className="rounded border bg-emerald-50 border-emerald-300 p-6 text-center">
+          <div className="font-semibold text-emerald-700">{myTeamName}</div>
+          <div className="text-sm text-emerald-600 mt-1">Selection confirmee</div>
+          <div className="text-xs text-gray-500 mt-3">En attente de l&apos;adversaire...</div>
+        </div>
+      ) : (
+        <InducementSelector
+          catalogue={catalogue}
+          budget={myBudget}
+          pettyCash={myBudget}
+          teamName={myTeamName}
+          disabled={submitting}
+          onConfirm={handleConfirm}
+          onSkip={handleSkip}
+        />
+      )}
+
+      {submitting && (
+        <div className="mt-4 text-center text-gray-500 text-sm">
+          Envoi de la selection...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -63,8 +63,8 @@ import PostMatchSPP from "../../components/PostMatchSPP";
 import MatchEndScreen from "../../components/MatchEndScreen";
 import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
-import InducementSelector from "../../components/InducementSelector";
-import { INDUCEMENT_CATALOGUE, type InducementSelection, type InducementDefinition } from "@bb/game-engine";
+import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
+import { normalizeState } from "./utils/normalize-state";
 import { ForfeitWarning } from "../../components/ForfeitWarning";
 import GameChat from "../../components/GameChat";
 import { useTurnNotification } from "./hooks/useTurnNotification";
@@ -87,102 +87,6 @@ function SoundEffectsListener({ state }: { state: ExtendedGameState | null }) {
 /** Inducements phase UI for online pre-match.
  *  Each player only sees and submits inducements for their own team.
  *  Submission goes via WebSocket (game:submit-inducements). */
-function InducementsPhaseUI({
-  matchId,
-  state,
-  stateSource,
-  setState,
-  myTeamSide,
-  gameSocket,
-}: {
-  matchId: string;
-  state: ExtendedGameState;
-  stateSource: string | null;
-  setState: (s: ExtendedGameState | ((prev: ExtendedGameState | null) => ExtendedGameState | null)) => void;
-  myTeamSide: "A" | "B" | null;
-  gameSocket: ReturnType<typeof import("./hooks/useGameSocket").useGameSocket>["socket"];
-}) {
-  const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-  const [inducementError, setInducementError] = useState<string | null>(null);
-
-  const catalogue = INDUCEMENT_CATALOGUE.filter(
-    (ind) => ind.slug !== "star_player",
-  ) as InducementDefinition[];
-
-  const myTeamName = myTeamSide === "A" ? state.teamNames.teamA : state.teamNames.teamB;
-  // Budget info from preMatch state (petty cash computed server-side during pre-match sequence)
-  const myBudget = myTeamSide === "A"
-    ? (state.preMatch?.inducements?.teamA?.pettyCash ?? 0)
-    : (state.preMatch?.inducements?.teamB?.pettyCash ?? 0);
-
-  const handleConfirm = useCallback((selection: InducementSelection) => {
-    if (!gameSocket || submitting || submitted) return;
-    setSubmitting(true);
-    setInducementError(null);
-
-    gameSocket.emit(
-      "game:submit-inducements",
-      { matchId, selection },
-      (response: any) => {
-        setSubmitting(false);
-        if (!response?.success) {
-          setInducementError(response?.error || "Erreur");
-          return;
-        }
-        setSubmitted(true);
-        if (response.gameState) {
-          setState(normalizeState(response.gameState));
-        }
-      },
-    );
-  }, [gameSocket, matchId, submitting, submitted, setState]);
-
-  const handleSkip = useCallback(() => {
-    handleConfirm({ items: [] });
-  }, [handleConfirm]);
-
-  return (
-    <div className="w-full max-w-lg mx-auto">
-      <div className="text-center mb-4">
-        <h2 className="text-xl font-bold text-gray-800">Phase d&apos;Inducements</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Depensez votre budget pour des avantages de match.
-        </p>
-      </div>
-
-      {inducementError && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm text-center">
-          {inducementError}
-        </div>
-      )}
-
-      {submitted ? (
-        <div className="rounded border bg-emerald-50 border-emerald-300 p-6 text-center">
-          <div className="font-semibold text-emerald-700">{myTeamName}</div>
-          <div className="text-sm text-emerald-600 mt-1">Selection confirmee</div>
-          <div className="text-xs text-gray-500 mt-3">En attente de l&apos;adversaire...</div>
-        </div>
-      ) : (
-        <InducementSelector
-          catalogue={catalogue}
-          budget={myBudget}
-          pettyCash={myBudget}
-          teamName={myTeamName}
-          disabled={submitting}
-          onConfirm={handleConfirm}
-          onSkip={handleSkip}
-        />
-      )}
-
-      {submitting && (
-        <div className="mt-4 text-center text-gray-500 text-sm">
-          Envoi de la selection...
-        </div>
-      )}
-    </div>
-  );
-}
 
 /** Floating mute/unmute toggle button for sound effects. */
 function SoundToggleButton() {
@@ -215,20 +119,7 @@ function SoundToggleButton() {
   );
 }
 
-// Normalise un état reçu du serveur (immutable — returns new object)
-function normalizeState(state: any): ExtendedGameState {
-  if (!state) return state;
-  return {
-    ...state,
-    playerActions: state.playerActions ?? {},
-    teamBlitzCount: state.teamBlitzCount ?? {},
-    teamFoulCount: state.teamFoulCount ?? {},
-    matchStats: state.matchStats ?? {},
-    width: typeof state.width === "number" ? state.width : 26,
-    height: typeof state.height === "number" ? state.height : 15,
-    selectedPlayerId: state.preMatch?.phase === "setup" ? null : state.selectedPlayerId,
-  } as ExtendedGameState;
-}
+// `normalizeState` extracted to ./utils/normalize-state.ts (S26.0a refactor).
 
 export default function PlayByIdPage({ params }: { params: { id: string } }) {
   const matchId = params.id;

--- a/apps/web/app/play/[id]/utils/normalize-state.ts
+++ b/apps/web/app/play/[id]/utils/normalize-state.ts
@@ -1,0 +1,23 @@
+/**
+ * Normalise un etat de jeu recu du serveur en garantissant la presence
+ * des champs optionnels et des dimensions par defaut. Retourne un nouvel
+ * objet (immutable, pas de mutation in-place).
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0a.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+
+export function normalizeState(state: any): ExtendedGameState {
+  if (!state) return state;
+  return {
+    ...state,
+    playerActions: state.playerActions ?? {},
+    teamBlitzCount: state.teamBlitzCount ?? {},
+    teamFoulCount: state.teamFoulCount ?? {},
+    matchStats: state.matchStats ?? {},
+    width: typeof state.width === "number" ? state.width : 26,
+    height: typeof state.height === "number" ? state.height : 15,
+    selectedPlayerId: state.preMatch?.phase === "setup" ? null : state.selectedPlayerId,
+  } as ExtendedGameState;
+}


### PR DESCRIPTION
## Resume

Premiere tranche du refactor **S26.0** (PREREQUIS du sprint S26) — `play/[id]/page.tsx` passe de **1666 a 1559 lignes**.

### Extractions

- `InducementsPhaseUI` (~98 lignes) deplace dans `apps/web/app/play/[id]/components/InducementsPhaseUI.tsx` avec interface props nommee `InducementsPhaseUIProps`.
- `normalizeState` (utilise 16 fois dans `page.tsx` + le nouveau composant) deplace dans `apps/web/app/play/[id]/utils/normalize-state.ts` pour permettre l'import depuis le composant extrait.

### Cleanup imports

`page.tsx` perd 4 imports inutilises (`InducementSelector`, `INDUCEMENT_CATALOGUE`, `InducementSelection`, `InducementDefinition`).

### Fix collateral typecheck

Durcit les types `apiRequest` dans `apps/web/app/me/teams/[id]/edit/page.tsx` :
- `positionsData: { availablePositions: unknown[] }` -> `AvailablePosition[]`
- `result.advancement: unknown` -> `{ skillSlug: string }`

Les erreurs `TS2322 UrlObject | RouteImpl<string>` sur `app/admin/feature-flags/*` sont **pre-existantes** sur main et ne font pas partie de ce diff.

### Slices restantes pour S26.0

- Extraire `SetupPhaseUI`, `MatchEndUI`, `BlockChoiceFlow`, `ThrowTeamMateFlow`
- Creer types `Move` unions explicites (`hooks/types.ts`) pour eliminer les 13 `as any` restants

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0a)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [ ] Verifier en preview que la phase d'inducements pre-match s'affiche et permet la confirmation/skip sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_