### PR TITLE
refactor(play): extract InGameListeners components (S26.0b)

### DIFF
--- a/apps/web/app/play/[id]/components/InGameListeners.tsx
+++ b/apps/web/app/play/[id]/components/InGameListeners.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * Composants d'ecoute / controles "in-game" sans logique metier (UI helpers).
+ *
+ * - `TurnNotificationListener` : declenche la notification "c'est ton tour"
+ *   via `useTurnNotification` (hook). Ne rend rien.
+ * - `SoundEffectsListener` : joue les SFX sur changement de gameLog via
+ *   `useSoundEffects` (hook). Ne rend rien.
+ * - `SoundToggleButton` : bouton flottant mute/unmute, UI pure cliente du
+ *   `sound-manager`.
+ *
+ * Extraits de `play/[id]/page.tsx` dans le cadre du refactor S26.0b.
+ */
+
+import { useState, useCallback } from "react";
+import { type ExtendedGameState } from "@bb/game-engine";
+import { useTurnNotification } from "../hooks/useTurnNotification";
+import { useSoundEffects } from "../hooks/useSoundEffects";
+import { getSoundManager } from "../hooks/sound-manager";
+
+interface TurnNotificationListenerProps {
+  isMyTurn: boolean;
+  isActiveMatch: boolean;
+}
+
+export function TurnNotificationListener({
+  isMyTurn,
+  isActiveMatch,
+}: TurnNotificationListenerProps) {
+  useTurnNotification({ isMyTurn, isActiveMatch });
+  return null;
+}
+
+interface SoundEffectsListenerProps {
+  state: ExtendedGameState | null;
+}
+
+export function SoundEffectsListener({ state }: SoundEffectsListenerProps) {
+  useSoundEffects({ state });
+  return null;
+}
+
+export function SoundToggleButton() {
+  const [muted, setMuted] = useState(() => getSoundManager().isMuted());
+  const handleToggle = useCallback(() => {
+    const newMuted = getSoundManager().toggleMuted();
+    setMuted(newMuted);
+  }, []);
+  return (
+    <button
+      onClick={handleToggle}
+      className="fixed bottom-4 right-4 z-50 bg-gray-800 hover:bg-gray-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors"
+      title={muted ? "Activer le son" : "Couper le son"}
+      aria-label={muted ? "Activer le son" : "Couper le son"}
+    >
+      {muted ? (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
+          <path d="M11 5L6 9H2v6h4l5 4V5z" />
+          <line x1="23" y1="9" x2="17" y2="15" />
+          <line x1="17" y1="9" x2="23" y2="15" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
+          <path d="M11 5L6 9H2v6h4l5 4V5z" />
+          <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+          <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -67,57 +67,14 @@ import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { normalizeState } from "./utils/normalize-state";
 import { ForfeitWarning } from "../../components/ForfeitWarning";
 import GameChat from "../../components/GameChat";
-import { useTurnNotification } from "./hooks/useTurnNotification";
-import { useSoundEffects } from "./hooks/useSoundEffects";
+import {
+  TurnNotificationListener,
+  SoundEffectsListener,
+  SoundToggleButton,
+} from "./components/InGameListeners";
 import { useGameChat } from "./hooks/useGameChat";
-import { getSoundManager } from "./hooks/sound-manager";
 
 /** Renders nothing — just fires turn notification side-effects inside ToastProvider. */
-function TurnNotificationListener({ isMyTurn, isActiveMatch }: { isMyTurn: boolean; isActiveMatch: boolean }) {
-  useTurnNotification({ isMyTurn, isActiveMatch });
-  return null;
-}
-
-/** Renders nothing — just fires sound effect side-effects based on gameLog changes. */
-function SoundEffectsListener({ state }: { state: ExtendedGameState | null }) {
-  useSoundEffects({ state });
-  return null;
-}
-
-/** Inducements phase UI for online pre-match.
- *  Each player only sees and submits inducements for their own team.
- *  Submission goes via WebSocket (game:submit-inducements). */
-
-/** Floating mute/unmute toggle button for sound effects. */
-function SoundToggleButton() {
-  const [muted, setMuted] = useState(() => getSoundManager().isMuted());
-  const handleToggle = useCallback(() => {
-    const newMuted = getSoundManager().toggleMuted();
-    setMuted(newMuted);
-  }, []);
-  return (
-    <button
-      onClick={handleToggle}
-      className="fixed bottom-4 right-4 z-50 bg-gray-800 hover:bg-gray-700 text-white rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors"
-      title={muted ? "Activer le son" : "Couper le son"}
-      aria-label={muted ? "Activer le son" : "Couper le son"}
-    >
-      {muted ? (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
-          <path d="M11 5L6 9H2v6h4l5 4V5z" />
-          <line x1="23" y1="9" x2="17" y2="15" />
-          <line x1="17" y1="9" x2="23" y2="15" />
-        </svg>
-      ) : (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
-          <path d="M11 5L6 9H2v6h4l5 4V5z" />
-          <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
-          <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-        </svg>
-      )}
-    </button>
-  );
-}
 
 // `normalizeState` extracted to ./utils/normalize-state.ts (S26.0a refactor).
 


### PR DESCRIPTION
## Resume

Deuxieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1557 a 1514 lignes** (cumul depuis le debut : 1666 -> 1514, -152 lignes).

### Extractions

3 helpers UI "in-game" deplaces dans `apps/web/app/play/[id]/components/InGameListeners.tsx` avec interfaces props nommees :

- `TurnNotificationListener` (4 lignes — wrapper sur `useTurnNotification`)
- `SoundEffectsListener` (4 lignes — wrapper sur `useSoundEffects`)
- `SoundToggleButton` (~30 lignes — bouton flottant mute/unmute)

### Cleanup imports

`page.tsx` perd 3 imports inutilises : `useTurnNotification`, `useSoundEffects`, `getSoundManager` (consommes uniquement par les composants extraits).

### Slices restantes pour S26.0

- `SetupPhaseUI` (le gros morceau — ~280 lignes selon les references `setup*` dans page.tsx, sera split en plusieurs slices a son tour)
- `BlockChoiceFlow`
- `ThrowTeamMateFlow`
- types `Move` unions explicites pour eliminer les **13 `as any`** restants

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0b)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que la notif de tour, les SFX et le bouton mute fonctionnent toujours sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_