### PR TITLE
refactor(play): extract kickoff-actions API helpers (S26.0d)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -65,6 +65,7 @@ import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { normalizeState } from "./utils/normalize-state";
+import * as kickoffActions from "./utils/kickoff-actions";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { ForfeitWarning } from "../../components/ForfeitWarning";
 import GameChat from "../../components/GameChat";
@@ -287,114 +288,13 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
     setDraggedPlayerId(null);
   };
 
-  // Fonction pour placer le ballon de kickoff
-  const handlePlaceKickoffBall = async (position: Position) => {
-    if (!state) return;
-
-    try {
-      const token = localStorage.getItem("auth_token");
-      if (!token) {
-        window.location.href = "/lobby";
-        return;
-      }
-
-      const response = await fetch(
-        `${API_BASE}/match/${matchId}/place-kickoff-ball`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ position }),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Erreur lors du placement du ballon");
-      }
-
-      const responseData = await response.json();
-      const normalizedState = normalizeState(responseData.gameState);
-      setState(normalizedState);
-
-      webLog.debug("Ballon placé:", responseData.message);
-    } catch (error) {
-      console.error("Erreur lors du placement du ballon:", error);
-    }
-  };
-
-  // Fonction pour calculer la déviation
-  const handleCalculateDeviation = async () => {
-    if (!state) return;
-
-    try {
-      const token = localStorage.getItem("auth_token");
-      if (!token) {
-        window.location.href = "/lobby";
-        return;
-      }
-
-      const response = await fetch(
-        `${API_BASE}/match/${matchId}/calculate-kick-deviation`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Erreur lors du calcul de déviation");
-      }
-
-      const responseData = await response.json();
-      const normalizedState = normalizeState(responseData.gameState);
-      setState(normalizedState);
-
-      webLog.debug("Déviation calculée:", responseData.message);
-    } catch (error) {
-      console.error("Erreur lors du calcul de déviation:", error);
-    }
-  };
-
-  // Fonction pour résoudre l'événement de kickoff
-  const handleResolveKickoffEvent = async () => {
-    if (!state) return;
-
-    try {
-      const token = localStorage.getItem("auth_token");
-      if (!token) {
-        window.location.href = "/lobby";
-        return;
-      }
-
-      const response = await fetch(
-        `${API_BASE}/match/${matchId}/resolve-kickoff-event`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Erreur lors de la résolution de l'événement");
-      }
-
-      const responseData = await response.json();
-      const normalizedState = normalizeState(responseData.gameState);
-      setState(normalizedState);
-
-      webLog.debug("Événement résolu:", responseData.message);
-    } catch (error) {
-      console.error("Erreur lors de la résolution de l'événement:", error);
-    }
-  };
+  // Kickoff handlers extracted to ./utils/kickoff-actions.ts (S26.0d).
+  const handlePlaceKickoffBall = (position: Position) =>
+    kickoffActions.handlePlaceKickoffBall(matchId, setState, position);
+  const handleCalculateDeviation = () =>
+    kickoffActions.handleCalculateDeviation(matchId, setState);
+  const handleResolveKickoffEvent = () =>
+    kickoffActions.handleResolveKickoffEvent(matchId, setState);
 
   // Fonction pour valider le placement et sauvegarder en base
   const handleValidatePlacement = async () => {

--- a/apps/web/app/play/[id]/utils/kickoff-actions.ts
+++ b/apps/web/app/play/[id]/utils/kickoff-actions.ts
@@ -1,0 +1,113 @@
+/**
+ * Helpers d'appel API pour la phase de kickoff (placement du ballon,
+ * deviation, resolution d'evenement).
+ *
+ * Chaque fonction encapsule fetch + normalisation + dispatch React
+ * state. Les redirects /lobby (token absent) restent gérés ici car
+ * factorises a un seul endroit.
+ *
+ * Extraits de `play/[id]/page.tsx` dans le cadre du refactor S26.0d.
+ */
+
+import {
+  type ExtendedGameState,
+  type Position,
+} from "@bb/game-engine";
+import { API_BASE } from "../../../auth-client";
+import { webLog } from "../../../lib/log";
+import { normalizeState } from "./normalize-state";
+
+type SetStateFn = (
+  s:
+    | ExtendedGameState
+    | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+) => void;
+
+/**
+ * Recupere le bearer token depuis localStorage et redirige vers
+ * `/lobby` s'il est absent. Retourne le token quand present.
+ */
+function requireAuthOrRedirect(): string | null {
+  const token = localStorage.getItem("auth_token");
+  if (!token) {
+    if (typeof window !== "undefined") {
+      window.location.href = "/lobby";
+    }
+    return null;
+  }
+  return token;
+}
+
+async function postKickoffAction(
+  matchId: string,
+  endpoint: string,
+  setState: SetStateFn,
+  body?: unknown,
+  errorLabel: string = "Erreur kickoff",
+): Promise<void> {
+  const token = requireAuthOrRedirect();
+  if (!token) return;
+
+  try {
+    const response = await fetch(`${API_BASE}/match/${matchId}/${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+
+    if (!response.ok) {
+      throw new Error(errorLabel);
+    }
+
+    const responseData = await response.json();
+    const normalizedState = normalizeState(responseData.gameState);
+    setState(normalizedState);
+
+    webLog.debug(`${errorLabel}:`, responseData.message);
+  } catch (error) {
+    console.error(`${errorLabel}:`, error);
+  }
+}
+
+export function handlePlaceKickoffBall(
+  matchId: string,
+  setState: SetStateFn,
+  position: Position,
+): Promise<void> {
+  return postKickoffAction(
+    matchId,
+    "place-kickoff-ball",
+    setState,
+    { position },
+    "Erreur lors du placement du ballon",
+  );
+}
+
+export function handleCalculateDeviation(
+  matchId: string,
+  setState: SetStateFn,
+): Promise<void> {
+  return postKickoffAction(
+    matchId,
+    "calculate-kick-deviation",
+    setState,
+    undefined,
+    "Erreur lors du calcul de deviation",
+  );
+}
+
+export function handleResolveKickoffEvent(
+  matchId: string,
+  setState: SetStateFn,
+): Promise<void> {
+  return postKickoffAction(
+    matchId,
+    "resolve-kickoff-event",
+    setState,
+    undefined,
+    "Erreur lors de la resolution de l'evenement",
+  );
+}


### PR DESCRIPTION
## Resume

Quatrieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1448 a 1348 lignes** (cumul depuis le debut : 1666 -> 1348, -318 lignes).

### Extractions

3 handlers kickoff API deplaces dans `apps/web/app/play/[id]/utils/kickoff-actions.ts` :

- `handlePlaceKickoffBall(matchId, setState, position)` -> `POST /match/:id/place-kickoff-ball`
- `handleCalculateDeviation(matchId, setState)` -> `POST /match/:id/calculate-kick-deviation`
- `handleResolveKickoffEvent(matchId, setState)` -> `POST /match/:id/resolve-kickoff-event`

### Deduplication

Helper prive `postKickoffAction(matchId, endpoint, setState, body, label)` factorise les patterns communs :
- auth via `requireAuthOrRedirect` (token absent -> redirect `/lobby`)
- fetch POST avec `Content-Type` + `Authorization`
- normalisation `normalizeState(responseData.gameState)`
- `setState` dispatch
- `webLog.debug` + `console.error` catch

`page.tsx` garde des wrappers minces qui binden `matchId` + `setState` au handler factorise (preserve la signature utilisee dans les callbacks UI sans changer le call site).

### Slices restantes pour S26.0

- `SetupPhaseUI` complete (`handleDrop`, `onCellClick`, `handleValidatePlacement`, ~280 lignes)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`
- Types `Move` unions pour eliminer les **13 `as any`** restants

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0d)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que la phase de kickoff (placement ballon, deviation, evenement) fonctionne toujours sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_