### PR TITLE
refactor(play): extract validateSetupPlacement helper (S26.0e)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -66,6 +66,7 @@ import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
+import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { ForfeitWarning } from "../../components/ForfeitWarning";
 import GameChat from "../../components/GameChat";
@@ -296,47 +297,20 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
   const handleResolveKickoffEvent = () =>
     kickoffActions.handleResolveKickoffEvent(matchId, setState);
 
-  // Fonction pour valider le placement et sauvegarder en base
+  // Fonction pour valider le placement et sauvegarder en base (S26.0e — extracted)
   const handleValidatePlacement = async () => {
     if (!state || setupSubmitting) return;
     const extState = state as ExtendedGameState;
 
     setSetupSubmitting(true);
     try {
-      const token = localStorage.getItem("auth_token");
-      if (!token) {
-        window.location.href = "/lobby";
-        return;
-      }
-
-      // Sauvegarder le placement en base de données
-      const response = await fetch(
-        `${API_BASE}/match/${matchId}/validate-setup`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            placedPlayers: extState.preMatch.placedPlayers,
-            playerPositions: extState.players
-              .filter((p) => p.pos.x >= 0) // Seulement les joueurs sur le terrain
-              .map((p) => ({ playerId: p.id, x: p.pos.x, y: p.pos.y })),
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Erreur lors de la sauvegarde du placement");
-      }
-
-      // Mettre à jour l'état local
-      const responseData = await response.json();
-      const normalizedState = normalizeState(responseData.gameState);
-      setState(normalizedState);
-      if (typeof responseData.isMyTurn === "boolean") setIsMyTurn(responseData.isMyTurn);
-      if (responseData.myTeamSide) setMyTeamSide(responseData.myTeamSide);
+      await validateSetupPlacement({
+        matchId,
+        extState,
+        setState,
+        setIsMyTurn,
+        setMyTeamSide,
+      });
     } catch (error) {
       console.error("Erreur lors de la validation du placement:", error);
       showSetupError("Erreur lors de la sauvegarde du placement");

--- a/apps/web/app/play/[id]/utils/validate-setup.ts
+++ b/apps/web/app/play/[id]/utils/validate-setup.ts
@@ -1,0 +1,70 @@
+/**
+ * Helper d'appel API pour la validation du setup pre-match.
+ *
+ * Different des kickoff actions car la response contient des
+ * meta-infos (isMyTurn, myTeamSide) que la page doit hydrater
+ * dans des etats React separes.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0e.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+import { API_BASE } from "../../../auth-client";
+import { normalizeState } from "./normalize-state";
+
+interface ValidateSetupOptions {
+  matchId: string;
+  extState: ExtendedGameState;
+  setState: (s: ExtendedGameState) => void;
+  setIsMyTurn: (v: boolean) => void;
+  setMyTeamSide: (v: "A" | "B") => void;
+}
+
+/**
+ * Sauvegarde le placement en base via `POST /match/:id/validate-setup`
+ * et hydrate les etats React (gameState, isMyTurn, myTeamSide) avec la
+ * response. Throw au caller en cas d'erreur reseau ou response.ok=false.
+ */
+export async function validateSetupPlacement({
+  matchId,
+  extState,
+  setState,
+  setIsMyTurn,
+  setMyTeamSide,
+}: ValidateSetupOptions): Promise<void> {
+  const token = localStorage.getItem("auth_token");
+  if (!token) {
+    if (typeof window !== "undefined") {
+      window.location.href = "/lobby";
+    }
+    return;
+  }
+
+  const response = await fetch(`${API_BASE}/match/${matchId}/validate-setup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      placedPlayers: extState.preMatch?.placedPlayers,
+      playerPositions: extState.players
+        .filter((p) => p.pos.x >= 0)
+        .map((p) => ({ playerId: p.id, x: p.pos.x, y: p.pos.y })),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Erreur lors de la sauvegarde du placement");
+  }
+
+  const responseData = await response.json();
+  const normalizedState = normalizeState(responseData.gameState);
+  setState(normalizedState);
+  if (typeof responseData.isMyTurn === "boolean") {
+    setIsMyTurn(responseData.isMyTurn);
+  }
+  if (responseData.myTeamSide) {
+    setMyTeamSide(responseData.myTeamSide);
+  }
+}


### PR DESCRIPTION
## Resume

Cinquieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1348 a 1322 lignes** (cumul depuis le debut : 1666 -> 1322, -344 lignes).

### Extraction

Appel API `POST /match/:id/validate-setup` extrait en fonction pure `validateSetupPlacement()` dans `apps/web/app/play/[id]/utils/validate-setup.ts`. Different des kickoff actions car la response contient des meta-infos (`isMyTurn`, `myTeamSide`) que la page doit hydrater dans des etats React separes — l'helper prend les callbacks en options.

`handleValidatePlacement` (page.tsx) garde la responsabilite UI :
- `setSetupSubmitting(true)` avant
- try/catch avec `showSetupError` en case d'erreur
- `finally` -> `setSetupSubmitting(false)`

### Slices restantes pour S26.0

- `SetupPhaseUI` (handleDrop + onCellClick + reserve handling, ~280 lignes)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`
- Types `Move` unions pour eliminer les **13 `as any`** restants

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0e)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que la validation du placement (clic "Valider" en setup) sur `/play/[id]` envoie toujours les positions au serveur et hydrate `isMyTurn` / `myTeamSide`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_