### PR TITLE
refactor(play): introduce LegalAction, eliminate all 13 as any (S26.0f)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   ApothecaryChoicePopup,
   GameLog,
   ToastProvider,
+  type TerrainSkinId,
 } from "@bb/ui";
 
 // GameBoardWithDugouts pulls in the entire Pixi.js + @pixi/react bundle.
@@ -68,6 +69,7 @@ import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
+import { type LegalAction } from "./utils/legal-action";
 import { ForfeitWarning } from "../../components/ForfeitWarning";
 import GameChat from "../../components/GameChat";
 import {
@@ -158,27 +160,26 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
     setTimeout(() => setSetupError(null), 2500);
   }
 
-  const legal = useMemo(() => {
+  const legal = useMemo<LegalAction[]>(() => {
     if (!state) return [];
     const extState = state as ExtendedGameState;
     if (extState.preMatch?.phase === "setup") {
       // En setup, legal moves = positions pour placer selectedFromReserve
       if (selectedFromReserve) {
-        return extState.preMatch.legalSetupPositions.map(
-          (p) =>
-            ({
-              type: "PLACE" as const,
-              playerId: selectedFromReserve,
-              to: p,
-            }) as any,
+        return extState.preMatch.legalSetupPositions.map<LegalAction>(
+          (p) => ({
+            type: "PLACE",
+            playerId: selectedFromReserve,
+            to: p,
+          }),
         );
       }
       return []; // Pas de moves sans sélection
     }
     return getLegalMoves(state);
   }, [state, selectedFromReserve]);
-  const isMove = (m: Move, pid: string): m is Extract<Move, { type: "MOVE" }> =>
-    m.type === "MOVE" && (m as any).playerId === pid;
+  const isMove = (m: LegalAction, pid: string): m is Extract<Move, { type: "MOVE" }> =>
+    m.type === "MOVE" && m.playerId === pid;
   const movesForSelected = useMemo(() => {
     if (!state || !state.selectedPlayerId) return [];
     return legal
@@ -188,7 +189,9 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
 
   const blockTargets = useMemo(() => {
     if (!state || !state.selectedPlayerId) return [];
-    return computeBlockTargets(state.selectedPlayerId, legal, state.players);
+    // computeBlockTargets ignore les PLACE synthetiques (S26.0f).
+    const realMoves = legal.filter((m): m is Move => m.type !== "PLACE");
+    return computeBlockTargets(state.selectedPlayerId, realMoves, state.players);
   }, [state?.selectedPlayerId, legal, state?.players]);
 
   // Ajouter handlers après onCellClick
@@ -422,8 +425,8 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             legal.some(
               (m) =>
                 m.type === "THROW_TEAM_MATE" &&
-                (m as any).playerId === state.selectedPlayerId &&
-                (m as any).thrownPlayerId === clickedPlayer.id,
+                m.playerId === state.selectedPlayerId &&
+                m.thrownPlayerId === clickedPlayer.id,
             )
           ) {
             setThrowTeamMateThrownId(clickedPlayer.id);
@@ -432,12 +435,12 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
         }
         // Phase 2 : selectionner la position cible
         const move = legal.find(
-          (m) =>
+          (m): m is Extract<Move, { type: "THROW_TEAM_MATE" }> =>
             m.type === "THROW_TEAM_MATE" &&
-            (m as any).playerId === state.selectedPlayerId &&
-            (m as any).thrownPlayerId === throwTeamMateThrownId &&
-            (m as any).targetPos.x === pos.x &&
-            (m as any).targetPos.y === pos.y,
+            m.playerId === state.selectedPlayerId &&
+            m.thrownPlayerId === throwTeamMateThrownId &&
+            m.targetPos.x === pos.x &&
+            m.targetPos.y === pos.y,
         );
         if (!move) return; // hors portee : ignore
         if (isActiveMatch) {
@@ -471,10 +474,10 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       );
       if (target && (currentAction === "BLOCK" || currentAction === "BLITZ")) {
         const blockMove = legal.find(
-          (m) =>
+          (m): m is Extract<Move, { type: "BLOCK" }> =>
             m.type === "BLOCK" &&
-            (m as any).playerId === state.selectedPlayerId &&
-            (m as any).targetId === target.id,
+            m.playerId === state.selectedPlayerId &&
+            m.targetId === target.id,
         );
         if (blockMove) {
           if (isActiveMatch) {
@@ -519,7 +522,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
               const ns = normalizeState(result.gameState);
               setState(ns);
               setIsMyTurn(result.isMyTurn);
-              const p = ns.players.find((pl) => pl.id === (candidate as any).playerId);
+              const p = ns.players.find((pl) => pl.id === candidate.playerId);
               if (!p || p.pm <= 0) setState((s) => s ? { ...s, selectedPlayerId: null } : null);
               if (ns.lastDiceResult) setShowDicePopup(true);
               setSelectedFromReserve(null);
@@ -1020,7 +1023,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                 isSetupPhase={
                   (state as ExtendedGameState).preMatch?.phase === "setup"
                 }
-                initialTerrainSkin={(state as any).terrainSkin || undefined}
+                initialTerrainSkin={(state as ExtendedGameState).terrainSkin as TerrainSkinId | undefined}
               />
             </div>
             {/* PlayerDetails is now integrated in GameBoardWithDugouts */}
@@ -1081,7 +1084,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             legal.some(
               (m) =>
                 m.type === "THROW_TEAM_MATE" &&
-                (m as any).playerId === state.selectedPlayerId,
+                m.playerId === state.selectedPlayerId,
             );
           const available: Array<
             "MOVE" | "BLOCK" | "BLITZ" | "PASS" | "HANDOFF" | "FOUL" | "THROW_TEAM_MATE"

--- a/apps/web/app/play/[id]/utils/legal-action.ts
+++ b/apps/web/app/play/[id]/utils/legal-action.ts
@@ -1,0 +1,41 @@
+/**
+ * Type-union des "actions legales" affichables dans l'UI play/[id].
+ *
+ * Le moteur expose `Move` (discriminated union) qui couvre toutes les
+ * actions reelles d'un tour. En phase de setup pre-match, l'UI a aussi
+ * besoin de representer un placement synthetique (pas une vraie action
+ * du moteur, juste une position legale pour le drag/click). On modelise
+ * ce cas via `PlaceAction` puis on union avec `Move` pour eviter les
+ * `as any` partout dans `page.tsx`.
+ *
+ * Cree dans le cadre du refactor S26.0f.
+ */
+
+import type { Move, Position } from "@bb/game-engine";
+
+/**
+ * Action synthetique uniquement utilisee en phase de setup pour
+ * representer un placement potentiel dans le tableau `legal` consomme
+ * par les composants Pixi/board. Le moteur ne connait pas ce type.
+ */
+export interface PlaceAction {
+  type: "PLACE";
+  playerId: string;
+  to: Position;
+}
+
+/** Union de tout ce qui peut apparaitre dans `legal[]` cote UI. */
+export type LegalAction = Move | PlaceAction;
+
+/** Type guard: vrai si l'action est un Move type "MOVE" pour le pid donne. */
+export function isMoveForPlayer(
+  action: LegalAction,
+  playerId: string,
+): action is Extract<Move, { type: "MOVE" }> {
+  return action.type === "MOVE" && action.playerId === playerId;
+}
+
+/** Type guard: vrai si l'action est un placement setup synthetique. */
+export function isPlaceAction(action: LegalAction): action is PlaceAction {
+  return action.type === "PLACE";
+}


### PR DESCRIPTION
## Resume

Sixieme tranche du refactor **S26.0** — l'objectif **"0 `as any`"** du DoD est **atteint** sur `play/[id]/page.tsx` (13 -> 0).

### Changements

#### Nouveau type `LegalAction`

Cree `apps/web/app/play/[id]/utils/legal-action.ts` :
- `PlaceAction` : action synthetique pour le setup pre-match (pas connue du moteur)
- `LegalAction = Move | PlaceAction`
- Type guards `isMoveForPlayer(action, pid)` et `isPlaceAction(action)`

#### Resorption des `as any`

Le memo `legal` est maintenant type `LegalAction[]` au lieu d'etre implicitement `any[]` (le `as any` precedent venait du `map(...)` qui produisait un PlaceAction non assignable a Move). La narrowing TypeScript fonctionne correctement sur `m.type === "BLOCK" / "THROW_TEAM_MATE" / "MOVE"` et permet d'acceder aux champs sans cast.

Type predicates explicites dans `find()` pour preserver le narrowing :
- `blockMove: Extract<Move, { type: "BLOCK" }>`
- `move (THROW_TEAM_MATE): Extract<Move, { type: "THROW_TEAM_MATE" }>`

`computeBlockTargets` recoit maintenant un `Move[]` filtre via `legal.filter((m): m is Move => m.type !== "PLACE")` (les PLACE synthetiques sont ignores en mode actif).

Cast restant pour `terrainSkin` traduit en `as TerrainSkinId | undefined` (string -> enum etroit) en important le type depuis `@bb/ui` — c'est un cast type-narrow, pas un `as any`.

### Stats

`play/[id]/page.tsx` : 1322 -> 1325 lignes (+3 net : type guards verbeux mais **0 `as any`**).

Cumul depuis le debut : **1666 -> 1325 lignes (-341 lignes, -13 `as any`)**.

### Critere DoD S26.0

> `play/[id]/page.tsx` < 600 lignes, **0 `as any`**, types Move unions stricts

- Lignes : 1325 (cible 600, encore plus de la moitie a faire)
- `as any` : **0** ✅
- types Move unions stricts : ✅ (LegalAction propre, narrowing correcte)

### Slices restantes pour S26.0

- `SetupPhaseUI` (handleDrop + onCellClick + reserve handling, ~280 lignes)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0f)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le board (BLOCK, THROW_TEAM_MATE, MOVE, setup PLACE) fonctionne toujours sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_