### PR TITLE
refactor(play): extract KickoffSequencePanel component (S26.0g)

### DIFF
--- a/apps/web/app/play/[id]/components/KickoffSequencePanel.tsx
+++ b/apps/web/app/play/[id]/components/KickoffSequencePanel.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Panneau d'UI pour la sequence de kickoff pre-match.
+ *
+ * Couvre les 4 sous-etapes (`kickoffStep`):
+ * - place-ball : kicker pose le ballon (instructions adverses sinon)
+ * - kick-deviation : bouton "Calculer la deviation"
+ * - kickoff-event : bouton "Resoudre l'evenement"
+ * - undefined : spinner d'attente
+ *
+ * Les actions API sont passees en props (extraites dans
+ * utils/kickoff-actions.ts par S26.0d) ; ce composant ne gere que la
+ * presentation et le clic.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0g.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+
+interface KickoffSequencePanelProps {
+  state: ExtendedGameState;
+  myTeamSide: "A" | "B" | null;
+  onCalculateDeviation: () => void | Promise<void>;
+  onResolveKickoffEvent: () => void | Promise<void>;
+}
+
+export function KickoffSequencePanel({
+  state,
+  myTeamSide,
+  onCalculateDeviation,
+  onResolveKickoffEvent,
+}: KickoffSequencePanelProps) {
+  return (
+    <div className="space-y-3">
+      <div className="text-lg font-bold text-green-600 mb-1">Sequence de Kickoff</div>
+
+      {state.preMatch?.kickoffStep === "place-ball" && (
+        <div>
+          <p className="text-sm text-gray-600 mb-2">
+            L&apos;equipe qui frappe doit placer le ballon dans la moitie adverse
+            {state.preMatch?.receivingTeam && (
+              <>
+                {" "}(zone de{" "}
+                <span className="font-semibold text-green-700">
+                  {state.preMatch.receivingTeam === "A"
+                    ? state.teamNames.teamA
+                    : state.teamNames.teamB}
+                </span>
+                )
+              </>
+            )}
+            .
+          </p>
+          {myTeamSide === state.preMatch?.kickingTeam ? (
+            <p className="text-sm font-semibold text-blue-600">
+              Cliquez sur une case de la moitie adverse pour placer le ballon.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
+                <span className="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+                En attente du placement du ballon par l&apos;adversaire...
+              </div>
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="text-xs text-gray-500 underline hover:text-gray-700"
+              >
+                Rien ne se passe ? Rafraichir la page
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {state.preMatch?.kickoffStep === "kick-deviation" && (
+        <div>
+          <p className="text-sm text-gray-600 mb-2">Calcul de la deviation du ballon...</p>
+          <button
+            onClick={onCalculateDeviation}
+            className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-semibold rounded-lg shadow transition-all"
+          >
+            Calculer la deviation
+          </button>
+        </div>
+      )}
+
+      {state.preMatch?.kickoffStep === "kickoff-event" && (
+        <div>
+          <p className="text-sm text-gray-600 mb-2">Resolution de l&apos;evenement de kickoff...</p>
+          <button
+            onClick={onResolveKickoffEvent}
+            className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-semibold rounded-lg shadow transition-all"
+          >
+            Resoudre l&apos;evenement
+          </button>
+        </div>
+      )}
+
+      {!state.preMatch?.kickoffStep && (
+        <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
+          <span className="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
+          Preparation du kickoff...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -65,6 +65,7 @@ import MatchEndScreen from "../../components/MatchEndScreen";
 import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
+import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { validateSetupPlacement } from "./utils/validate-setup";
@@ -742,79 +743,12 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                 )}
 
                 {state.preMatch?.phase === "kickoff" || state.preMatch?.phase === "kickoff-sequence" ? (
-                  <div className="space-y-3">
-                    <div className="text-lg font-bold text-green-600 mb-1">Sequence de Kickoff</div>
-
-                    {state.preMatch?.kickoffStep === "place-ball" && (
-                      <div>
-                        <p className="text-sm text-gray-600 mb-2">
-                          L&apos;equipe qui frappe doit placer le ballon dans la moitie adverse
-                          {state.preMatch?.receivingTeam && (
-                            <>
-                              {" "}(zone de{" "}
-                              <span className="font-semibold text-green-700">
-                                {state.preMatch.receivingTeam === "A"
-                                  ? state.teamNames.teamA
-                                  : state.teamNames.teamB}
-                              </span>
-                              )
-                            </>
-                          )}
-                          .
-                        </p>
-                        {myTeamSide === state.preMatch?.kickingTeam ? (
-                          <p className="text-sm font-semibold text-blue-600">
-                            Cliquez sur une case de la moitie adverse pour placer le ballon.
-                          </p>
-                        ) : (
-                          <div className="space-y-2">
-                            <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
-                              <span className="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
-                              En attente du placement du ballon par l&apos;adversaire...
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => window.location.reload()}
-                              className="text-xs text-gray-500 underline hover:text-gray-700"
-                            >
-                              Rien ne se passe ? Rafraichir la page
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {state.preMatch?.kickoffStep === "kick-deviation" && (
-                      <div>
-                        <p className="text-sm text-gray-600 mb-2">Calcul de la deviation du ballon...</p>
-                        <button
-                          onClick={handleCalculateDeviation}
-                          className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-semibold rounded-lg shadow transition-all"
-                        >
-                          Calculer la deviation
-                        </button>
-                      </div>
-                    )}
-
-                    {state.preMatch?.kickoffStep === "kickoff-event" && (
-                      <div>
-                        <p className="text-sm text-gray-600 mb-2">Resolution de l&apos;evenement de kickoff...</p>
-                        <button
-                          onClick={handleResolveKickoffEvent}
-                          className="px-4 py-2 bg-nuffle-gold hover:bg-nuffle-gold/90 text-nuffle-anthracite font-semibold rounded-lg shadow transition-all"
-                        >
-                          Resoudre l&apos;evenement
-                        </button>
-                      </div>
-                    )}
-
-                    {!state.preMatch?.kickoffStep && (
-                      <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
-                        <span className="inline-block w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" />
-                        Preparation du kickoff...
-                      </div>
-                    )}
-                  </div>
+                  <KickoffSequencePanel
+                    state={state as ExtendedGameState}
+                    myTeamSide={myTeamSide}
+                    onCalculateDeviation={handleCalculateDeviation}
+                    onResolveKickoffEvent={handleResolveKickoffEvent}
+                  />
                 ) : state.preMatch?.phase === "setup" ? (
                   <div>
                     {/* Étapes de setup */}


### PR DESCRIPTION
## Resume

Septieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1325 a 1259 lignes** (cumul depuis le debut : 1666 -> 1259, -407 lignes).

### Extraction

Panneau JSX du kickoff (~73 lignes) deplace dans `apps/web/app/play/[id]/components/KickoffSequencePanel.tsx` avec interface props nommee `KickoffSequencePanelProps`.

Le composant gere les 4 sous-etapes (`kickoffStep`):
- `place-ball` : kicker pose le ballon (instructions adverses + spinner d'attente sinon)
- `kick-deviation` : bouton "Calculer la deviation"
- `kickoff-event` : bouton "Resoudre l'evenement"
- `undefined` : spinner generique d'attente

Les actions API sont injectees via 2 callbacks (`onCalculateDeviation`, `onResolveKickoffEvent`) — le composant ne fait que de la presentation.

`page.tsx` remplace le bloc inline par un seul element `<KickoffSequencePanel />` de 6 lignes.

### Slices restantes pour S26.0

- `SetupPhaseUI` : le gros morceau qui reste (handleDrop + onCellClick + reserve handling + le bloc JSX setup ~120 lignes)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0g)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que la sequence de kickoff (place-ball / deviation / kickoff-event) fonctionne toujours sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_