### PR TITLE
refactor(play): extract SetupPhasePanel component (S26.0h)

### DIFF
--- a/apps/web/app/play/[id]/components/SetupPhasePanel.tsx
+++ b/apps/web/app/play/[id]/components/SetupPhasePanel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Panneau d'UI pour la phase de setup pre-match (placement des 11 joueurs).
+ *
+ * Affiche :
+ *  - les 3 etapes (Receiver place / Kicker place / Kickoff)
+ *  - le coach actuel a placer
+ *  - le compteur joueurs places / target
+ *  - l'erreur de placement transitoire
+ *  - bouton "Pret !" quand tous les joueurs sont places, sinon
+ *    message d'attente adverse
+ *
+ * Le composant est purement UI : les actions sont injectees via
+ * `onValidatePlacement`.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0h.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+import { getMySide } from "../utils/setup-validation";
+
+interface SetupPhasePanelProps {
+  state: ExtendedGameState;
+  myTeamSide: "A" | "B" | null;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+  setupError: string | null;
+  setupSubmitting: boolean;
+  onValidatePlacement: () => void | Promise<void>;
+}
+
+export function SetupPhasePanel({
+  state,
+  myTeamSide,
+  teamNameA,
+  teamNameB,
+  setupError,
+  setupSubmitting,
+  onValidatePlacement,
+}: SetupPhasePanelProps) {
+  const currentCoach = state.preMatch?.currentCoach;
+  const availableCount =
+    state.players?.filter(
+      (p) => p.team === currentCoach && (!p.state || p.state === "active"),
+    ).length || 0;
+  const target = Math.min(11, availableCount);
+  const onFieldCount =
+    state.players?.filter((p) => p.team === currentCoach && p.pos.x >= 0)
+      .length || 0;
+  const mySide = myTeamSide || getMySide(state, teamNameA, teamNameB);
+
+  return (
+    <div>
+      {/* Etapes de setup */}
+      <div className="mb-2">
+        <div className="flex items-center justify-center gap-2 text-xs text-gray-400 mb-2">
+          <span
+            className={`px-2 py-0.5 rounded ${
+              state.preMatch?.currentCoach === state.preMatch?.receivingTeam
+                ? "bg-green-100 text-green-700 font-semibold"
+                : "bg-gray-100 text-gray-500 line-through"
+            }`}
+          >
+            1.{" "}
+            {state.preMatch?.receivingTeam === "A"
+              ? state.teamNames.teamA
+              : state.teamNames.teamB}{" "}
+            place
+          </span>
+          <span className="text-gray-300">&rarr;</span>
+          <span
+            className={`px-2 py-0.5 rounded ${
+              state.preMatch?.currentCoach === state.preMatch?.kickingTeam
+                ? "bg-green-100 text-green-700 font-semibold"
+                : "bg-gray-100 text-gray-400"
+            }`}
+          >
+            2.{" "}
+            {state.preMatch?.kickingTeam === "A"
+              ? state.teamNames.teamA
+              : state.teamNames.teamB}{" "}
+            place
+          </span>
+          <span className="text-gray-300">&rarr;</span>
+          <span className="px-2 py-0.5 rounded bg-gray-100 text-gray-400">
+            3. Kickoff
+          </span>
+        </div>
+      </div>
+
+      <div className="font-semibold text-gray-800">
+        Au tour de{" "}
+        <span className="px-2 py-1 rounded bg-green-600 text-white">
+          {currentCoach === "A" ? state.teamNames.teamA : state.teamNames.teamB}
+        </span>{" "}
+        de placer ses joueurs
+      </div>
+
+      <div className="text-xs text-gray-500 mt-1">
+        Joueurs placés : {onFieldCount}/{target}
+      </div>
+
+      {setupError && (
+        <div className="mt-2 px-3 py-2 bg-red-100 text-red-700 rounded border border-red-300">
+          {setupError}
+        </div>
+      )}
+
+      {/* Bouton de validation ou message d'attente */}
+      {mySide && mySide !== currentCoach && (
+        <div className="mt-3 px-3 py-2 bg-yellow-50 text-yellow-700 rounded border border-yellow-300 text-sm">
+          En attente du placement adverse...
+        </div>
+      )}
+
+      {onFieldCount === target && mySide === currentCoach && (
+        <div className="mt-3">
+          <button
+            onClick={onValidatePlacement}
+            disabled={setupSubmitting}
+            className={`px-6 py-3 text-white rounded-lg font-bold text-lg transition-all shadow-md ${
+              setupSubmitting
+                ? "bg-gray-400 cursor-not-allowed"
+                : "bg-green-600 hover:bg-green-700 hover:shadow-lg active:scale-95"
+            }`}
+          >
+            {setupSubmitting ? "Validation..." : "Prêt !"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -66,6 +66,7 @@ import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
+import { SetupPhasePanel } from "./components/SetupPhasePanel";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { validateSetupPlacement } from "./utils/validate-setup";
@@ -750,100 +751,15 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                     onResolveKickoffEvent={handleResolveKickoffEvent}
                   />
                 ) : state.preMatch?.phase === "setup" ? (
-                  <div>
-                    {/* Étapes de setup */}
-                    <div className="mb-2">
-                      <div className="flex items-center justify-center gap-2 text-xs text-gray-400 mb-2">
-                        <span className={`px-2 py-0.5 rounded ${
-                          state.preMatch.currentCoach === state.preMatch.receivingTeam
-                            ? "bg-green-100 text-green-700 font-semibold"
-                            : "bg-gray-100 text-gray-500 line-through"
-                        }`}>
-                          1. {state.preMatch.receivingTeam === "A" ? state.teamNames.teamA : state.teamNames.teamB} place
-                        </span>
-                        <span className="text-gray-300">&rarr;</span>
-                        <span className={`px-2 py-0.5 rounded ${
-                          state.preMatch.currentCoach === state.preMatch.kickingTeam
-                            ? "bg-green-100 text-green-700 font-semibold"
-                            : "bg-gray-100 text-gray-400"
-                        }`}>
-                          2. {state.preMatch.kickingTeam === "A" ? state.teamNames.teamA : state.teamNames.teamB} place
-                        </span>
-                        <span className="text-gray-300">&rarr;</span>
-                        <span className="px-2 py-0.5 rounded bg-gray-100 text-gray-400">
-                          3. Kickoff
-                        </span>
-                      </div>
-                    </div>
-
-                    <div className="font-semibold text-gray-800">
-                      Au tour de{" "}
-                      <span className="px-2 py-1 rounded bg-green-600 text-white">
-                        {state.preMatch.currentCoach === "A"
-                          ? state.teamNames.teamA
-                          : state.teamNames.teamB}
-                      </span>{" "}
-                      de placer ses joueurs
-                    </div>
-                    {(() => {
-                      const currentCoach = state.preMatch?.currentCoach;
-                      const availableCount = state.players?.filter(
-                        p => p.team === currentCoach && (!p.state || p.state === "active")
-                      ).length || 0;
-                      const target = Math.min(11, availableCount);
-                      const onFieldCount = state.players?.filter(
-                        p => p.team === currentCoach && p.pos.x >= 0
-                      ).length || 0;
-                      return (
-                        <div className="text-xs text-gray-500 mt-1">
-                          Joueurs placés : {onFieldCount}/{target}
-                        </div>
-                      );
-                    })()}
-                    {setupError && (
-                      <div className="mt-2 px-3 py-2 bg-red-100 text-red-700 rounded border border-red-300">
-                        {setupError}
-                      </div>
-                    )}
-                    {/* Bouton de validation ou message d'attente */}
-                    {(() => {
-                      const currentCoach = state.preMatch?.currentCoach;
-                      const availableCount = state.players?.filter(
-                        p => p.team === currentCoach && (!p.state || p.state === "active")
-                      ).length || 0;
-                      const target = Math.min(11, availableCount);
-                      const playersOnField = state.players?.filter(p => p.team === currentCoach && p.pos.x >= 0).length || 0;
-                      const mySide = myTeamSide || getMySide(state as ExtendedGameState, teamNameA, teamNameB);
-
-                      if (mySide && mySide !== currentCoach) {
-                        return (
-                          <div className="mt-3 px-3 py-2 bg-yellow-50 text-yellow-700 rounded border border-yellow-300 text-sm">
-                            En attente du placement adverse...
-                          </div>
-                        );
-                      }
-
-                      if (playersOnField === target && mySide === currentCoach) {
-                        return (
-                          <div className="mt-3">
-                            <button
-                              onClick={handleValidatePlacement}
-                              disabled={setupSubmitting}
-                              className={`px-6 py-3 text-white rounded-lg font-bold text-lg transition-all shadow-md ${
-                                setupSubmitting
-                                  ? "bg-gray-400 cursor-not-allowed"
-                                  : "bg-green-600 hover:bg-green-700 hover:shadow-lg active:scale-95"
-                              }`}
-                            >
-                              {setupSubmitting ? "Validation..." : "Prêt !"}
-                            </button>
-                          </div>
-                        );
-                      }
-
-                      return null;
-                    })()}
-                  </div>
+                  <SetupPhasePanel
+                    state={state as ExtendedGameState}
+                    myTeamSide={myTeamSide}
+                    teamNameA={teamNameA}
+                    teamNameB={teamNameB}
+                    setupError={setupError}
+                    setupSubmitting={setupSubmitting}
+                    onValidatePlacement={handleValidatePlacement}
+                  />
                 ) : (
                   <div>
                     <div className="text-gray-500">Phase pré-match en cours...</div>


### PR DESCRIPTION
## Resume

Huitieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1259 a 1175 lignes** (cumul depuis le debut : 1666 -> 1175, -491 lignes).

### Extraction

Panneau JSX de la phase setup (~94 lignes) deplace dans `apps/web/app/play/[id]/components/SetupPhasePanel.tsx` avec interface props nommee `SetupPhasePanelProps`.

Le composant gere :
- Les 3 etapes (Receiver place / Kicker place / Kickoff)
- Le coach actuel a placer
- Le compteur joueurs places / target (joueurs disponibles cap a 11)
- Le message d'erreur transitoire (`setupError`)
- Le bouton "Pret !" quand `onFieldCount === target && mySide === currentCoach`, sinon le message d'attente adverse

Les IIFE inline qui calculaient `currentCoach`, `availableCount`, `target`, `onFieldCount`, `mySide` (3 fois dans la version originale) sont **consolidees une seule fois** en haut du composant.

L'action `handleValidatePlacement` est passee en props (`onValidatePlacement`). `page.tsx` remplace le bloc inline par un seul element `<SetupPhasePanel />` de 8 lignes.

### Slices restantes pour S26.0

- `handleDrop` + `onCellClick` (logique de manipulation, plus complexe car deeply intertwined avec React state — necessitera probablement un hook custom)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0h)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le panneau setup affiche bien les etapes, le coach actuel, le compteur de joueurs et le bouton "Pret !" / message d'attente sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_