### PR TITLE
refactor(play): extract DecisionPopupsLayer component (S26.0i)

### DIFF
--- a/apps/web/app/play/[id]/components/DecisionPopupsLayer.test.tsx
+++ b/apps/web/app/play/[id]/components/DecisionPopupsLayer.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { DecisionPopupsLayer } from "./DecisionPopupsLayer";
+import type { ExtendedGameState, Move, Player } from "@bb/game-engine";
+
+function makePlayer(id: string, name: string, team: "A" | "B" = "A"): Player {
+  return {
+    id,
+    name,
+    team,
+    pos: { x: 0, y: 0 },
+    stats: { ma: 6, st: 3, ag: 3, av: 8 },
+    state: "standing",
+    skills: [],
+    hasMovedThisTurn: false,
+    actionsRemainingThisTurn: 0,
+  } as unknown as Player;
+}
+
+function baseState(overrides: Partial<ExtendedGameState> = {}): ExtendedGameState {
+  return {
+    half: 1,
+    turn: 1,
+    teamTurn: "A",
+    teamRerolls: { teamA: 2, teamB: 1 },
+    teamNames: { teamA: "Reds", teamB: "Blues" },
+    players: [],
+    ball: { carrierId: null, pos: { x: 0, y: 0 } },
+    score: { teamA: 0, teamB: 0 },
+    selectedPlayerId: null,
+    legalMoves: [],
+    pendingBlock: undefined,
+    pendingPushChoice: undefined,
+    pendingFollowUpChoice: undefined,
+    pendingReroll: undefined,
+    pendingApothecary: undefined,
+    ...overrides,
+  } as unknown as ExtendedGameState;
+}
+
+describe("DecisionPopupsLayer", () => {
+  it("ne rend rien quand aucun choix pendant", () => {
+    const onSubmitMove = vi.fn<(move: Move, opts?: { showDiceOnResult?: boolean }) => void>();
+    const { container } = render(
+      <DecisionPopupsLayer
+        state={baseState()}
+        isMyTurn
+        myTeamSide="A"
+        onSubmitMove={onSubmitMove}
+      />,
+    );
+    expect(container.textContent).toBe("");
+    expect(onSubmitMove).not.toHaveBeenCalled();
+  });
+
+  it("rend BlockChoicePopup et delegue le choix au callback avec showDiceOnResult", () => {
+    const onSubmitMove = vi.fn<(move: Move, opts?: { showDiceOnResult?: boolean }) => void>();
+    const state = baseState({
+      players: [
+        makePlayer("att", "Attaquant Z"),
+        makePlayer("def", "Defenseur Y", "B"),
+      ],
+      pendingBlock: {
+        attackerId: "att",
+        targetId: "def",
+        chooser: "attacker",
+        options: ["pushed"],
+      } as unknown as ExtendedGameState["pendingBlock"],
+    });
+    render(
+      <DecisionPopupsLayer
+        state={state}
+        isMyTurn
+        myTeamSide="A"
+        onSubmitMove={onSubmitMove}
+      />,
+    );
+    expect(screen.getByText(/Attaquant Z/)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button")[0]);
+    expect(onSubmitMove).toHaveBeenCalledTimes(1);
+    const [move, opts] = onSubmitMove.mock.calls[0];
+    expect(move.type).toBe("BLOCK_CHOOSE");
+    expect(opts).toEqual({ showDiceOnResult: true });
+  });
+
+  it("ne rend pas RerollChoicePopup quand isMyTurn=false", () => {
+    const onSubmitMove = vi.fn();
+    const state = baseState({
+      players: [makePlayer("p1", "Joueur X")],
+      pendingReroll: {
+        playerId: "p1",
+        rollType: "gfi",
+      } as unknown as ExtendedGameState["pendingReroll"],
+    });
+    const { container } = render(
+      <DecisionPopupsLayer
+        state={state}
+        isMyTurn={false}
+        myTeamSide="A"
+        onSubmitMove={onSubmitMove}
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("rend RerollChoicePopup et delegue le choix avec showDiceOnResult", () => {
+    const onSubmitMove = vi.fn<(move: Move, opts?: { showDiceOnResult?: boolean }) => void>();
+    const state = baseState({
+      players: [makePlayer("p1", "Joueur Reroll")],
+      pendingReroll: {
+        playerId: "p1",
+        rollType: "gfi",
+      } as unknown as ExtendedGameState["pendingReroll"],
+    });
+    render(
+      <DecisionPopupsLayer
+        state={state}
+        isMyTurn
+        myTeamSide="A"
+        onSubmitMove={onSubmitMove}
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onSubmitMove).toHaveBeenCalledTimes(1);
+    const [move, opts] = onSubmitMove.mock.calls[0];
+    expect(move.type).toBe("REROLL_CHOOSE");
+    expect(opts).toEqual({ showDiceOnResult: true });
+  });
+
+  it("rend ApothecaryChoicePopup et delegue sans option dice", () => {
+    const onSubmitMove = vi.fn<(move: Move, opts?: { showDiceOnResult?: boolean }) => void>();
+    const state = baseState({
+      players: [makePlayer("p1", "Joueur Apo")],
+      pendingApothecary: {
+        playerId: "p1",
+        injuryType: "casualty",
+        originalCasualtyOutcome: "badly_hurt",
+      } as unknown as ExtendedGameState["pendingApothecary"],
+    });
+    render(
+      <DecisionPopupsLayer
+        state={state}
+        isMyTurn
+        myTeamSide="A"
+        onSubmitMove={onSubmitMove}
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[0]);
+    expect(onSubmitMove).toHaveBeenCalledTimes(1);
+    const [move, opts] = onSubmitMove.mock.calls[0];
+    expect(move.type).toBe("APOTHECARY_CHOOSE");
+    expect(opts).toBeUndefined();
+  });
+});

--- a/apps/web/app/play/[id]/components/DecisionPopupsLayer.tsx
+++ b/apps/web/app/play/[id]/components/DecisionPopupsLayer.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Pile des popups de decision in-match :
+ * - Block (choix du resultat de blocage)
+ * - Push (choix de la direction de poussee)
+ * - FollowUp (l'attaquant suit ou non)
+ * - Reroll (utiliser le team reroll sur un jet en attente)
+ * - Apothecary (utiliser l'apothicaire sur une blessure / casualty)
+ *
+ * `onSubmitMove` encapsule la logique de dispatch (online vs local) et la
+ * gestion de `setShowDicePopup` cote page.tsx ; ce composant ne fait
+ * que la presentation et l'invocation du callback avec le bon `Move`.
+ *
+ * Extrait de play/[id]/page.tsx dans le cadre du refactor S26.0i.
+ */
+
+import {
+  BlockChoicePopup,
+  PushChoicePopup,
+  FollowUpChoicePopup,
+  RerollChoicePopup,
+  ApothecaryChoicePopup,
+} from "@bb/ui";
+import { type ExtendedGameState, type Move } from "@bb/game-engine";
+import {
+  shouldShowBlockPopup,
+  shouldShowPushPopup,
+  shouldShowFollowUpPopup,
+  shouldShowRerollPopup,
+  buildBlockChooseMove,
+  buildPushChooseMove,
+  buildFollowUpChooseMove,
+  buildRerollChooseMove,
+  buildApothecaryChooseMove,
+} from "../hooks/useBlockPopups";
+
+export interface DecisionPopupsLayerProps {
+  state: ExtendedGameState;
+  isMyTurn: boolean;
+  myTeamSide: "A" | "B" | null;
+  onSubmitMove: (move: Move, opts?: { showDiceOnResult?: boolean }) => void;
+}
+
+export function DecisionPopupsLayer({
+  state,
+  isMyTurn,
+  myTeamSide,
+  onSubmitMove,
+}: DecisionPopupsLayerProps) {
+  return (
+    <>
+      {shouldShowBlockPopup(state) && state.pendingBlock && (
+        <BlockChoicePopup
+          attackerName={
+            state.players.find((p) => p.id === state.pendingBlock!.attackerId)?.name ||
+            "Attaquant"
+          }
+          defenderName={
+            state.players.find((p) => p.id === state.pendingBlock!.targetId)?.name ||
+            "Défenseur"
+          }
+          chooser={state.pendingBlock.chooser}
+          options={state.pendingBlock.options}
+          onChoose={(result) =>
+            onSubmitMove(buildBlockChooseMove(state.pendingBlock!, result), {
+              showDiceOnResult: true,
+            })
+          }
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowPushPopup(state) && state.pendingPushChoice && (
+        <PushChoicePopup
+          attackerName={
+            state.players.find((p) => p.id === state.pendingPushChoice!.attackerId)?.name ||
+            "Attaquant"
+          }
+          targetName={
+            state.players.find((p) => p.id === state.pendingPushChoice!.targetId)?.name ||
+            "Défenseur"
+          }
+          availableDirections={state.pendingPushChoice.availableDirections}
+          onChoose={(direction) =>
+            onSubmitMove(buildPushChooseMove(state.pendingPushChoice!, direction))
+          }
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowFollowUpPopup(state) && state.pendingFollowUpChoice && (
+        <FollowUpChoicePopup
+          attackerName={
+            state.players.find((p) => p.id === state.pendingFollowUpChoice!.attackerId)?.name ||
+            "Attaquant"
+          }
+          targetName={
+            state.players.find((p) => p.id === state.pendingFollowUpChoice!.targetId)?.name ||
+            "Défenseur"
+          }
+          targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
+          targetOldPosition={state.pendingFollowUpChoice.targetOldPosition}
+          onChoose={(followUp) =>
+            onSubmitMove(buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp))
+          }
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowRerollPopup(state) && state.pendingReroll && isMyTurn && (
+        <RerollChoicePopup
+          rollType={state.pendingReroll.rollType}
+          playerName={
+            state.players.find((p) => p.id === state.pendingReroll!.playerId)?.name || "Joueur"
+          }
+          teamRerollsLeft={
+            myTeamSide === "A" ? state.teamRerolls.teamA : state.teamRerolls.teamB
+          }
+          onChoose={(useReroll) =>
+            onSubmitMove(buildRerollChooseMove(useReroll), { showDiceOnResult: true })
+          }
+        />
+      )}
+      {state.pendingApothecary && isMyTurn && (
+        <ApothecaryChoicePopup
+          playerName={
+            state.players.find((p) => p.id === state.pendingApothecary!.playerId)?.name ||
+            "Joueur"
+          }
+          injuryType={state.pendingApothecary.injuryType}
+          casualtyOutcome={state.pendingApothecary.originalCasualtyOutcome}
+          onChoose={(useApothecary) =>
+            onSubmitMove(buildApothecaryChooseMove(useApothecary))
+          }
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -5,11 +5,6 @@ import {
   DiceResultPopup,
   GameScoreboard,
   ActionPickerPopup,
-  BlockChoicePopup,
-  PushChoicePopup,
-  FollowUpChoicePopup,
-  RerollChoicePopup,
-  ApothecaryChoicePopup,
   GameLog,
   ToastProvider,
   type TerrainSkinId,
@@ -48,24 +43,14 @@ import { webLog } from "../../lib/log";
 import { useGameMoves } from "./hooks/useGameMoves";
 // useGameSocket is now called only inside useGameState to avoid duplicate connections
 import { useGameState } from "./hooks/useGameState";
-import {
-  shouldShowBlockPopup,
-  shouldShowPushPopup,
-  shouldShowFollowUpPopup,
-  shouldShowRerollPopup,
-  buildBlockChooseMove,
-  buildPushChooseMove,
-  buildFollowUpChooseMove,
-  buildRerollChooseMove,
-  buildApothecaryChooseMove,
-  computeBlockTargets,
-} from "./hooks/useBlockPopups";
+import { computeBlockTargets } from "./hooks/useBlockPopups";
 import PostMatchSPP from "../../components/PostMatchSPP";
 import MatchEndScreen from "../../components/MatchEndScreen";
 import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
+import { DecisionPopupsLayer } from "./components/DecisionPopupsLayer";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { validateSetupPlacement } from "./utils/validate-setup";
@@ -572,7 +557,37 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, isActiveMatch, submitMove, setState, setIsMyTurn]);
 
-
+  /**
+   * Dispatcher commun pour les decisions in-match (Block / Push / FollowUp /
+   * Reroll / Apothecary). Centralise le branchement online/local et la
+   * mise a jour optionnelle de `showDicePopup` apres un jet declenche.
+   */
+  const dispatchDecisionMove = useCallback(
+    (move: Move, opts?: { showDiceOnResult?: boolean }) => {
+      if (isActiveMatch) {
+        submitMove(move).then((res) => {
+          if (res?.success && res.gameState) {
+            setState(normalizeState(res.gameState));
+            setIsMyTurn(res.isMyTurn);
+            if (opts?.showDiceOnResult && res.gameState.lastDiceResult) {
+              setShowDicePopup(true);
+            }
+          }
+        });
+      } else {
+        setState((s) => {
+          if (!s) return null;
+          const s2 = applyMove(s, move, createRNG()) as ExtendedGameState;
+          if (opts?.showDiceOnResult && s2.lastDiceResult) {
+            setShowDicePopup(true);
+          }
+          return s2;
+        });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isActiveMatch, submitMove, setState, setIsMyTurn],
+  );
 
   const localSide = useMemo(() => {
     if (!state || !teamNameA || !teamNameB || !state.teamNames) {
@@ -1102,121 +1117,13 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             </div>
           );
         })()}
-      {/* Block/Push/FollowUp decision popups */}
-      {state && shouldShowBlockPopup(state) && state.pendingBlock && (
-        <BlockChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingBlock!.attackerId)?.name || "Attaquant"
-          }
-          defenderName={
-            state.players.find((p) => p.id === state.pendingBlock!.targetId)?.name || "Défenseur"
-          }
-          chooser={state.pendingBlock.chooser}
-          options={state.pendingBlock.options}
-          onChoose={(result) => {
-            const move = buildBlockChooseMove(state.pendingBlock!, result);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                  if (res.gameState.lastDiceResult) setShowDicePopup(true);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                const s2 = applyMove(s, move, createRNG());
-                if (s2.lastDiceResult) setShowDicePopup(true);
-                return s2 as ExtendedGameState;
-              });
-            }
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {state && shouldShowPushPopup(state) && state.pendingPushChoice && (
-        <PushChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingPushChoice!.attackerId)?.name || "Attaquant"
-          }
-          targetName={
-            state.players.find((p) => p.id === state.pendingPushChoice!.targetId)?.name || "Défenseur"
-          }
-          availableDirections={state.pendingPushChoice.availableDirections}
-          onChoose={(direction) => {
-            const move = buildPushChooseMove(state.pendingPushChoice!, direction);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => s ? applyMove(s, move, createRNG()) as ExtendedGameState : null);
-            }
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {state && shouldShowFollowUpPopup(state) && state.pendingFollowUpChoice && (
-        <FollowUpChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingFollowUpChoice!.attackerId)?.name || "Attaquant"
-          }
-          targetName={
-            state.players.find((p) => p.id === state.pendingFollowUpChoice!.targetId)?.name || "Défenseur"
-          }
-          targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
-          targetOldPosition={state.pendingFollowUpChoice.targetOldPosition}
-          onChoose={(followUp) => {
-            const move = buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => s ? applyMove(s, move, createRNG()) as ExtendedGameState : null);
-            }
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {/* Reroll decision popup */}
-      {state && shouldShowRerollPopup(state) && state.pendingReroll && isMyTurn && (
-        <RerollChoicePopup
-          rollType={state.pendingReroll.rollType}
-          playerName={
-            state.players.find((p) => p.id === state.pendingReroll!.playerId)?.name || "Joueur"
-          }
-          teamRerollsLeft={
-            myTeamSide === "A"
-              ? state.teamRerolls.teamA
-              : state.teamRerolls.teamB
-          }
-          onChoose={(useReroll) => {
-            const move = buildRerollChooseMove(useReroll);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                  if (res.gameState.lastDiceResult) setShowDicePopup(true);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                const s2 = applyMove(s, move, createRNG());
-                if (s2.lastDiceResult) setShowDicePopup(true);
-                return s2 as ExtendedGameState;
-              });
-            }
-          }}
+      {/* Decision popups (Block / Push / FollowUp / Reroll / Apothecary) */}
+      {state && (
+        <DecisionPopupsLayer
+          state={state}
+          isMyTurn={isMyTurn}
+          myTeamSide={myTeamSide}
+          onSubmitMove={dispatchDecisionMove}
         />
       )}
       {/* In-game chat */}
@@ -1225,32 +1132,6 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
           messages={chatMessages}
           sendMessage={sendChatMessage}
           currentUserId={currentUserId}
-        />
-      )}
-      {/* Apothecary decision popup */}
-      {state && state.pendingApothecary && isMyTurn && (
-        <ApothecaryChoicePopup
-          playerName={
-            state.players.find((p) => p.id === state.pendingApothecary!.playerId)?.name || "Joueur"
-          }
-          injuryType={state.pendingApothecary.injuryType}
-          casualtyOutcome={state.pendingApothecary.originalCasualtyOutcome}
-          onChoose={(useApothecary) => {
-            const move = buildApothecaryChooseMove(useApothecary);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                return applyMove(s, move, createRNG()) as ExtendedGameState;
-              });
-            }
-          }}
         />
       )}
     </div>


### PR DESCRIPTION
## Resume

Neuvieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1259 a 1140 lignes** (cumul depuis le debut : 1666 -> 1140, -526 lignes).

### Extraction

Les 5 popups de decision in-match (Block / Push / FollowUp / Reroll / Apothecary) partageaient une logique de dispatch identique mais dupliquee dans 5 `onChoose` inline (~150 lignes au total). Ils sont regroupes dans le nouveau composant `apps/web/app/play/[id]/components/DecisionPopupsLayer.tsx`.

Le composant :
- Centralise les conditions de visibilite (`shouldShow*Popup` + `isMyTurn` quand requis)
- Construit les `Move` via les builders existants de `useBlockPopups`
- Delegue le dispatch a un seul callback `onSubmitMove(move, opts)` fourni par `page.tsx`

### Helper `dispatchDecisionMove`

`page.tsx` expose un helper `useCallback` qui factorise le pattern partage par tous les popups :
- Branchement online (`submitMove` + `normalizeState`) vs local (`applyMove` + `createRNG`)
- Mise a jour de `setShowDicePopup` conditionnelle a `opts.showDiceOnResult` (preserve le comportement exact : seulement pour Block et Reroll)

### Slices restantes pour S26.0

- `handleDrop` + `onCellClick` (logique deeply intertwined avec React state — necessitera probablement un hook custom)
- `BlockChoiceFlow`, `ThrowTeamMateFlow`
- `MatchEndUI` extraction

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0i)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 612 tests passes (+5 nouveaux pour `DecisionPopupsLayer`, aucune regression).
- [x] `pnpm --filter @bb/web typecheck` OK.
- [x] `pnpm --filter @bb/web build` OK.
- [ ] Verifier en preview que les popups Block/Push/FollowUp/Reroll/Apothecary s'affichent toujours correctement et que le dice popup s'ouvre bien apres un block/reroll qui produit un `lastDiceResult`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111WfbMFHMZpQ5ykfXWCRkB)_