### PR TITLE
refactor(play): extract ThrowTeamMateIndicator + applyOrSubmitMove (S26.0i)

### DIFF
--- a/apps/web/app/play/[id]/components/ThrowTeamMateIndicator.tsx
+++ b/apps/web/app/play/[id]/components/ThrowTeamMateIndicator.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * Indicateur fixe en haut de l'ecran qui explique l'etape courante
+ * du flow THROW_TEAM_MATE (selectionner le coequipier a lancer puis
+ * la case d'arrivee). Inclut un bouton Annuler.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0i.
+ */
+
+interface ThrowTeamMateIndicatorProps {
+  thrownPlayerId: string | null;
+  onCancel: () => void;
+}
+
+export function ThrowTeamMateIndicator({
+  thrownPlayerId,
+  onCancel,
+}: ThrowTeamMateIndicatorProps) {
+  return (
+    <div className="fixed top-20 left-1/2 -translate-x-1/2 z-40 bg-purple-700 text-white px-4 py-2 rounded-lg shadow-lg text-sm font-semibold flex items-center gap-3">
+      <span>
+        {thrownPlayerId
+          ? "Cliquez sur la case d'arrivée"
+          : "Cliquez sur le coéquipier à lancer"}
+      </span>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="px-2 py-0.5 bg-purple-900 rounded text-xs hover:bg-purple-950"
+      >
+        Annuler
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -67,8 +67,10 @@ import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
 import { SetupPhasePanel } from "./components/SetupPhasePanel";
+import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
+import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -954,23 +956,13 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
         })()}
       {/* Indicateur THROW_TEAM_MATE : explique l'etape en cours */}
       {currentAction === "THROW_TEAM_MATE" && state.selectedPlayerId && (
-        <div className="fixed top-20 left-1/2 -translate-x-1/2 z-40 bg-purple-700 text-white px-4 py-2 rounded-lg shadow-lg text-sm font-semibold flex items-center gap-3">
-          <span>
-            {throwTeamMateThrownId
-              ? "Cliquez sur la case d'arrivée"
-              : "Cliquez sur le coéquipier à lancer"}
-          </span>
-          <button
-            type="button"
-            onClick={() => {
-              setThrowTeamMateThrownId(null);
-              setCurrentAction(null);
-            }}
-            className="px-2 py-0.5 bg-purple-900 rounded text-xs hover:bg-purple-950"
-          >
-            Annuler
-          </button>
-        </div>
+        <ThrowTeamMateIndicator
+          thrownPlayerId={throwTeamMateThrownId}
+          onCancel={() => {
+            setThrowTeamMateThrownId(null);
+            setCurrentAction(null);
+          }}
+        />
       )}
       {/* Bouton fin d'activation du joueur */}
       {/* Barre d'activation du joueur : PM restants + bouton terminer */}
@@ -1030,23 +1022,16 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
           chooser={state.pendingBlock.chooser}
           options={state.pendingBlock.options}
           onChoose={(result) => {
-            const move = buildBlockChooseMove(state.pendingBlock!, result);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                  if (res.gameState.lastDiceResult) setShowDicePopup(true);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                const s2 = applyMove(s, move, createRNG());
-                if (s2.lastDiceResult) setShowDicePopup(true);
-                return s2 as ExtendedGameState;
-              });
-            }
+            applyOrSubmitMove({
+              move: buildBlockChooseMove(state.pendingBlock!, result),
+              isActiveMatch,
+              submitMove,
+              setState,
+              setIsMyTurn,
+              createRNG,
+              withDicePopup: true,
+              setShowDicePopup,
+            });
           }}
           onClose={() => {}}
         />
@@ -1061,17 +1046,14 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
           }
           availableDirections={state.pendingPushChoice.availableDirections}
           onChoose={(direction) => {
-            const move = buildPushChooseMove(state.pendingPushChoice!, direction);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => s ? applyMove(s, move, createRNG()) as ExtendedGameState : null);
-            }
+            applyOrSubmitMove({
+              move: buildPushChooseMove(state.pendingPushChoice!, direction),
+              isActiveMatch,
+              submitMove,
+              setState,
+              setIsMyTurn,
+              createRNG,
+            });
           }}
           onClose={() => {}}
         />
@@ -1087,17 +1069,14 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
           targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
           targetOldPosition={state.pendingFollowUpChoice.targetOldPosition}
           onChoose={(followUp) => {
-            const move = buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => s ? applyMove(s, move, createRNG()) as ExtendedGameState : null);
-            }
+            applyOrSubmitMove({
+              move: buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp),
+              isActiveMatch,
+              submitMove,
+              setState,
+              setIsMyTurn,
+              createRNG,
+            });
           }}
           onClose={() => {}}
         />
@@ -1115,23 +1094,16 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
               : state.teamRerolls.teamB
           }
           onChoose={(useReroll) => {
-            const move = buildRerollChooseMove(useReroll);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                  if (res.gameState.lastDiceResult) setShowDicePopup(true);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                const s2 = applyMove(s, move, createRNG());
-                if (s2.lastDiceResult) setShowDicePopup(true);
-                return s2 as ExtendedGameState;
-              });
-            }
+            applyOrSubmitMove({
+              move: buildRerollChooseMove(useReroll),
+              isActiveMatch,
+              submitMove,
+              setState,
+              setIsMyTurn,
+              createRNG,
+              withDicePopup: true,
+              setShowDicePopup,
+            });
           }}
         />
       )}

--- a/apps/web/app/play/[id]/utils/apply-or-submit-move.ts
+++ b/apps/web/app/play/[id]/utils/apply-or-submit-move.ts
@@ -1,0 +1,84 @@
+/**
+ * Helper qui factorise le pattern "submit move au serveur (online) OU
+ * apply local (offline)" + dispatch state + dispatch dice popup.
+ *
+ * Utilise par les popups Block / Push / FollowUp / Reroll qui partagent
+ * tous la meme logique de soumission / dispatch d'effet (~12 lignes
+ * dupliquees x4 dans page.tsx avant ce refactor).
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0i.
+ */
+
+import { type ExtendedGameState, type Move, type RNG, applyMove } from "@bb/game-engine";
+import { normalizeState } from "./normalize-state";
+
+interface ApplyOrSubmitMoveOptions {
+  move: Move;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | {
+        success?: boolean;
+        gameState?: ExtendedGameState;
+        isMyTurn?: boolean;
+      }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  /** RNG factory pour le mode offline (apply local). */
+  createRNG: () => RNG;
+  /** Si true, declenche `setShowDicePopup(true)` quand le state final
+   *  contient `lastDiceResult`. Tous les popups de choix Block /
+   *  Reroll en ont besoin ; Push / FollowUp non. */
+  withDicePopup?: boolean;
+  setShowDicePopup?: (v: boolean) => void;
+}
+
+/**
+ * Mode online (`isActiveMatch=true`) :
+ *  - submit au serveur, normalise gameState, dispatch isMyTurn
+ *  - declenche dice popup si present et `withDicePopup`
+ * Mode offline :
+ *  - apply local via applyMove, dispatch state
+ *  - declenche dice popup si present et `withDicePopup`
+ */
+export function applyOrSubmitMove({
+  move,
+  isActiveMatch,
+  submitMove,
+  setState,
+  setIsMyTurn,
+  createRNG,
+  withDicePopup = false,
+  setShowDicePopup,
+}: ApplyOrSubmitMoveOptions): void {
+  if (isActiveMatch) {
+    submitMove(move).then((res) => {
+      if (res?.success && res.gameState) {
+        setState(normalizeState(res.gameState));
+        if (typeof res.isMyTurn === "boolean") setIsMyTurn(res.isMyTurn);
+        if (
+          withDicePopup &&
+          res.gameState.lastDiceResult &&
+          setShowDicePopup
+        ) {
+          setShowDicePopup(true);
+        }
+      }
+    });
+  } else {
+    setState((s) => {
+      if (!s) return null;
+      const s2 = applyMove(s, move, createRNG());
+      if (withDicePopup && s2.lastDiceResult && setShowDicePopup) {
+        setShowDicePopup(true);
+      }
+      return s2 as ExtendedGameState;
+    });
+  }
+}


### PR DESCRIPTION
## Resume

Neuvieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1175 a 1147 lignes** (cumul depuis le debut : 1666 -> 1147, -519 lignes).

### Extractions

#### `ThrowTeamMateIndicator` (composant UI)

Indicateur fixe en haut de l'ecran qui explique l'etape courante du flow THROW_TEAM_MATE (selectionner le coequipier puis la case d'arrivee). Deplace dans `apps/web/app/play/[id]/components/ThrowTeamMateIndicator.tsx` avec props minimales (`thrownPlayerId`, `onCancel`).

#### `applyOrSubmitMove` (helper util)

Factorise le pattern duplique **4 fois** (BlockChoice / Push / FollowUp / Reroll popups) dans `apps/web/app/play/[id]/utils/apply-or-submit-move.ts` :

- **online** (`isActiveMatch`) : `submitMove(move)` + `normalizeState(gameState)` + `setIsMyTurn` + `setShowDicePopup` conditionnel
- **offline** : `applyMove` + `setState` + `setShowDicePopup` conditionnel
- option `withDicePopup` pour distinguer Block/Reroll (`true`) vs Push/FollowUp (`false`)

Les 4 popup callsites passent de ~12 lignes chacun a 8-10 lignes appelant `applyOrSubmitMove({...})` avec le move construit + options.

### Slices restantes pour S26.0

- `handleDrop` + `onCellClick` (logique complexe deeply intertwined avec React state, necessitera probablement un hook custom)
- `ActionPickerPopup` IIFE (extractible en composant)

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0i)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que les 4 flows popups (Block / Push / FollowUp / Reroll) fonctionnent toujours en mode online et offline sur `/play/[id]`.
- [ ] Verifier que l'indicateur THROW_TEAM_MATE s'affiche bien quand `currentAction === "THROW_TEAM_MATE"` et que le bouton Annuler reset l'etat correctement.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_