### PR TITLE
refactor(play): extract getAvailableActions util (S26.0j)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -71,6 +71,7 @@ import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
+import { getAvailableActions } from "./utils/available-actions";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -926,34 +927,24 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       {state.selectedPlayerId &&
         currentAction === null &&
         !hasPlayerActed(state, state.selectedPlayerId) &&
-        (state as ExtendedGameState).preMatch?.phase !== "setup" && (() => {
-          const sp = state.players.find((p) => p.id === state.selectedPlayerId);
-          const canThrowTM =
-            !!sp &&
-            sp.skills.some(
-              (s) => s.toLowerCase() === "throw-team-mate",
-            ) &&
-            legal.some(
-              (m) =>
-                m.type === "THROW_TEAM_MATE" &&
-                m.playerId === state.selectedPlayerId,
-            );
-          const available: Array<
-            "MOVE" | "BLOCK" | "BLITZ" | "PASS" | "HANDOFF" | "FOUL" | "THROW_TEAM_MATE"
-          > = ["MOVE", "BLOCK", "BLITZ", "PASS", "HANDOFF", "FOUL"];
-          if (canThrowTM) available.push("THROW_TEAM_MATE");
-          return (
-            <ActionPickerPopup
-              playerName={sp?.name || "Joueur"}
-              available={available}
-              onPick={(a) => {
-                setThrowTeamMateThrownId(null);
-                setCurrentAction(a);
-              }}
-              onClose={() => setCurrentAction("MOVE")}
-            />
-          );
-        })()}
+        (state as ExtendedGameState).preMatch?.phase !== "setup" && (
+          <ActionPickerPopup
+            playerName={
+              state.players.find((p) => p.id === state.selectedPlayerId)?.name ||
+              "Joueur"
+            }
+            available={getAvailableActions(
+              state as ExtendedGameState,
+              legal,
+              state.selectedPlayerId,
+            )}
+            onPick={(a) => {
+              setThrowTeamMateThrownId(null);
+              setCurrentAction(a);
+            }}
+            onClose={() => setCurrentAction("MOVE")}
+          />
+        )}
       {/* Indicateur THROW_TEAM_MATE : explique l'etape en cours */}
       {currentAction === "THROW_TEAM_MATE" && state.selectedPlayerId && (
         <ThrowTeamMateIndicator

--- a/apps/web/app/play/[id]/utils/available-actions.ts
+++ b/apps/web/app/play/[id]/utils/available-actions.ts
@@ -1,0 +1,55 @@
+/**
+ * Determine la liste des actions disponibles pour le joueur
+ * actuellement selectionne (avant qu'il choisisse). Le calcul depend
+ * notamment du skill `THROW_TEAM_MATE` et de la presence d'un Move
+ * legal correspondant.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0j.
+ */
+
+import {
+  type ExtendedGameState,
+  type GameState,
+} from "@bb/game-engine";
+import type { LegalAction } from "./legal-action";
+
+export type ActivationAction =
+  | "MOVE"
+  | "BLOCK"
+  | "BLITZ"
+  | "PASS"
+  | "HANDOFF"
+  | "FOUL"
+  | "THROW_TEAM_MATE";
+
+const BASE_ACTIONS: ActivationAction[] = [
+  "MOVE",
+  "BLOCK",
+  "BLITZ",
+  "PASS",
+  "HANDOFF",
+  "FOUL",
+];
+
+/**
+ * Retourne la liste d'actions affichables dans le `ActionPickerPopup`
+ * pour `selectedPlayerId`. Inclut THROW_TEAM_MATE quand le joueur a
+ * le skill correspondant ET qu'au moins un Move legal de ce type est
+ * disponible (ex: il y a un coequipier liftable a portee).
+ */
+export function getAvailableActions(
+  state: ExtendedGameState | GameState,
+  legal: readonly LegalAction[],
+  selectedPlayerId: string,
+): ActivationAction[] {
+  const sp = state.players.find((p) => p.id === selectedPlayerId);
+  const canThrowTM =
+    !!sp &&
+    sp.skills.some((s) => s.toLowerCase() === "throw-team-mate") &&
+    legal.some(
+      (m) => m.type === "THROW_TEAM_MATE" && m.playerId === selectedPlayerId,
+    );
+  const available: ActivationAction[] = [...BASE_ACTIONS];
+  if (canThrowTM) available.push("THROW_TEAM_MATE");
+  return available;
+}


### PR DESCRIPTION
## Resume

Dixieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1147 a 1138 lignes** (cumul depuis le debut : 1666 -> 1138, -528 lignes).

### Extraction

Logique IIFE qui calculait la liste `available` d'actions (BASE_ACTIONS + `THROW_TEAM_MATE` conditionnel selon skill du joueur + presence de Move legal `THROW_TEAM_MATE`) deplacee dans `apps/web/app/play/[id]/utils/available-actions.ts`.

`getAvailableActions(state, legal, selectedPlayerId)` retourne `ActivationAction[]` (union literal exportee : `"MOVE" | "BLOCK" | "BLITZ" | "PASS" | "HANDOFF" | "FOUL" | "THROW_TEAM_MATE"`).

Le composant `<ActionPickerPopup>` recoit directement la liste calculee — plus besoin d'IIFE inline avec destructuration de `sp`/`canThrowTM`.

### Slices restantes pour S26.0

- `handleDrop` + `onCellClick` (logique de manipulation, gros morceau, necessitera probablement un hook custom car deeply intertwined avec React state)
- post-match SPP block, gameLog UI
- player activation bar (PM restants + bouton "Terminer l'activation")

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0j)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que l'`ActionPickerPopup` s'affiche bien avec les actions de base + `THROW_TEAM_MATE` (pour les joueurs ayant le skill et un coequipier liftable).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_