### PR TITLE
refactor(play): extract PlayerActivationBar component (S26.0k)

### DIFF
--- a/apps/web/app/play/[id]/components/PlayerActivationBar.tsx
+++ b/apps/web/app/play/[id]/components/PlayerActivationBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Barre flottante d'activation du joueur (en bas de l'ecran).
+ *
+ * Affiche les PM restants (cap MA + GFI bonus) et un bouton
+ * "Terminer l'activation" quand le joueur a deja agi (a un Move
+ * dans `playerActions`).
+ *
+ * Le clic sur le bouton soumet un move END_PLAYER_TURN via le helper
+ * applyOrSubmitMove (factorise online/offline).
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0k.
+ */
+
+import { type ExtendedGameState, type Move, type RNG } from "@bb/game-engine";
+import { applyOrSubmitMove } from "../utils/apply-or-submit-move";
+
+interface PlayerActivationBarProps {
+  state: ExtendedGameState;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | { success?: boolean; gameState?: ExtendedGameState; isMyTurn?: boolean }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  createRNG: () => RNG;
+}
+
+export function PlayerActivationBar({
+  state,
+  isActiveMatch,
+  submitMove,
+  setState,
+  setIsMyTurn,
+  createRNG,
+}: PlayerActivationBarProps) {
+  const selectedPlayerId = state.selectedPlayerId;
+  if (!selectedPlayerId) return null;
+  const selectedPlayer = state.players.find((p) => p.id === selectedPlayerId);
+  if (!selectedPlayer) return null;
+  const hasActed = !!state.playerActions?.[selectedPlayerId];
+
+  return (
+    <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3">
+      {/* Compteur de mouvements restants */}
+      <div className="bg-gray-900/90 text-white px-3 py-2 rounded-lg shadow-lg text-sm font-mono flex items-center gap-2">
+        <span className="text-xs text-gray-400">PM</span>
+        <span
+          className={`font-bold ${selectedPlayer.pm > 0 ? "text-green-400" : "text-red-400"}`}
+        >
+          {selectedPlayer.pm}/{selectedPlayer.ma}
+        </span>
+        {(selectedPlayer.gfiUsed ?? 0) < 2 && selectedPlayer.pm <= 0 && (
+          <span className="text-xs text-yellow-400 ml-1">
+            +{2 - (selectedPlayer.gfiUsed ?? 0)} GFI
+          </span>
+        )}
+      </div>
+
+      {/* Bouton terminer l'activation */}
+      {hasActed && (
+        <button
+          onClick={() => {
+            applyOrSubmitMove({
+              move: { type: "END_PLAYER_TURN", playerId: selectedPlayerId },
+              isActiveMatch,
+              submitMove,
+              setState,
+              setIsMyTurn,
+              createRNG,
+            });
+          }}
+          className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-lg shadow-lg transition-all text-sm"
+        >
+          Terminer l&apos;activation
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -68,6 +68,7 @@ import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
 import { SetupPhasePanel } from "./components/SetupPhasePanel";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
+import { PlayerActivationBar } from "./components/PlayerActivationBar";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
@@ -959,48 +960,16 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       {/* Barre d'activation du joueur : PM restants + bouton terminer */}
       {state && state.selectedPlayerId && isMyTurn &&
         (state as ExtendedGameState).preMatch?.phase !== "setup" &&
-        !state.pendingBlock && !state.pendingPushChoice && !state.pendingFollowUpChoice && (() => {
-          const selectedPlayer = state.players.find(p => p.id === state.selectedPlayerId);
-          const hasActed = !!state.playerActions?.[state.selectedPlayerId!];
-          if (!selectedPlayer) return null;
-          return (
-            <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3">
-              {/* Compteur de mouvements restants */}
-              <div className="bg-gray-900/90 text-white px-3 py-2 rounded-lg shadow-lg text-sm font-mono flex items-center gap-2">
-                <span className="text-xs text-gray-400">PM</span>
-                <span className={`font-bold ${selectedPlayer.pm > 0 ? 'text-green-400' : 'text-red-400'}`}>
-                  {selectedPlayer.pm}/{selectedPlayer.ma}
-                </span>
-                {(selectedPlayer.gfiUsed ?? 0) < 2 && selectedPlayer.pm <= 0 && (
-                  <span className="text-xs text-yellow-400 ml-1">
-                    +{2 - (selectedPlayer.gfiUsed ?? 0)} GFI
-                  </span>
-                )}
-              </div>
-              {/* Bouton terminer l'activation */}
-              {hasActed && (
-                <button
-                  onClick={() => {
-                    const move = { type: 'END_PLAYER_TURN' as const, playerId: state.selectedPlayerId! };
-                    if (isActiveMatch) {
-                      submitMove(move).then((res) => {
-                        if (res?.success && res.gameState) {
-                          setState(normalizeState(res.gameState));
-                          setIsMyTurn(res.isMyTurn);
-                        }
-                      });
-                    } else {
-                      setState((s) => s ? applyMove(s, move, createRNG()) as ExtendedGameState : null);
-                    }
-                  }}
-                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-lg shadow-lg transition-all text-sm"
-                >
-                  Terminer l&apos;activation
-                </button>
-              )}
-            </div>
-          );
-        })()}
+        !state.pendingBlock && !state.pendingPushChoice && !state.pendingFollowUpChoice && (
+          <PlayerActivationBar
+            state={state as ExtendedGameState}
+            isActiveMatch={isActiveMatch}
+            submitMove={submitMove}
+            setState={setState}
+            setIsMyTurn={setIsMyTurn}
+            createRNG={createRNG}
+          />
+        )}
       {/* Block/Push/FollowUp decision popups */}
       {state && shouldShowBlockPopup(state) && state.pendingBlock && (
         <BlockChoicePopup


### PR DESCRIPTION
## Resume

Onzieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1138 a 1107 lignes** (cumul depuis le debut : 1666 -> 1107, -559 lignes).

### Extraction

Barre flottante d'activation du joueur (~44 lignes IIFE) deplacee dans `apps/web/app/play/[id]/components/PlayerActivationBar.tsx` avec interface props nommee `PlayerActivationBarProps`.

Le composant gere :
- Compteur **PM / MA** + bonus GFI (jusqu'a +2 si pas encore consomme et `pm <= 0`)
- Bouton **"Terminer l'activation"** (visible uniquement quand le joueur a deja agi via `playerActions[selectedPlayerId]`)

Le clic sur le bouton utilise **`applyOrSubmitMove`** (extrait en S26.0i) pour soumettre `END_PLAYER_TURN` en mode online/offline. Plus de duplication de logique submit-vs-apply.

`page.tsx` remplace l'IIFE inline par un `<PlayerActivationBar />` de 9 lignes.

### Slices restantes pour S26.0

- `handleDrop` + `onCellClick` (logique de manipulation, gros morceau, necessitera un hook custom)
- post-match SPP block, gameLog UI
- bandeau de statut de tour (turn status banner)

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0k)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que la `PlayerActivationBar` s'affiche bien (PM/MA + GFI bonus correct, bouton "Terminer l'activation" cliquable apres action).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_