### PR TITLE
refactor(play): extract TopStatusBanners components (S26.0l)

### DIFF
--- a/apps/web/app/play/[id]/components/TopStatusBanners.tsx
+++ b/apps/web/app/play/[id]/components/TopStatusBanners.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Bandeaux fixes en haut de l'ecran qui resument le statut courant
+ * du tour (match actif) et le statut de placement (prematch setup).
+ *
+ * Deux composants exportes :
+ *  - `TurnStatusBanner` : affiche en match actif "C'est votre tour"
+ *    / "En attente" + badges Reroll / Apothecary / Match termine.
+ *  - `PreMatchSetupBanner` : affiche en phase setup "Placez vos 11
+ *    joueurs..." / "En attente du placement de X..." avec spinner.
+ *
+ * Extraits de `play/[id]/page.tsx` dans le cadre du refactor S26.0l.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+
+interface TurnStatusBannerProps {
+  state: ExtendedGameState | null;
+  isMyTurn: boolean;
+  moveSubmitting: boolean;
+}
+
+export function TurnStatusBanner({
+  state,
+  isMyTurn,
+  moveSubmitting,
+}: TurnStatusBannerProps) {
+  return (
+    <div
+      className={`fixed top-0 left-0 right-0 z-50 text-center py-2 text-sm font-bold flex items-center justify-center gap-4 ${
+        isMyTurn ? "bg-green-500 text-white" : "bg-yellow-400 text-gray-900"
+      }`}
+    >
+      <span>
+        {moveSubmitting
+          ? "Envoi du coup..."
+          : isMyTurn
+            ? "C'est votre tour !"
+            : "En attente de l'adversaire..."}
+      </span>
+      {state && state.pendingReroll && isMyTurn && (
+        <span className="bg-orange-500 text-white px-2 py-0.5 rounded text-xs animate-pulse">
+          Relance disponible !
+        </span>
+      )}
+      {state && state.pendingApothecary && isMyTurn && (
+        <span className="bg-green-500 text-white px-2 py-0.5 rounded text-xs animate-pulse">
+          Apothicaire disponible !
+        </span>
+      )}
+      {state && state.gamePhase === "ended" && (
+        <span className="bg-gray-700 text-white px-2 py-0.5 rounded text-xs">
+          Match terminé — {state.score.teamA} - {state.score.teamB}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface PreMatchSetupBannerProps {
+  state: ExtendedGameState;
+  isMyTurn: boolean;
+}
+
+export function PreMatchSetupBanner({
+  state,
+  isMyTurn,
+}: PreMatchSetupBannerProps) {
+  return (
+    <div
+      className={`fixed top-0 left-0 right-0 z-50 text-center py-3 text-sm font-bold flex items-center justify-center gap-4 transition-colors duration-300 ${
+        isMyTurn ? "bg-green-600 text-white" : "bg-yellow-400 text-gray-900"
+      }`}
+    >
+      <span>
+        {isMyTurn
+          ? "Placez vos 11 joueurs puis cliquez Prêt !"
+          : `En attente du placement de ${
+              state.preMatch?.currentCoach === "A"
+                ? state.teamNames.teamA
+                : state.teamNames.teamB
+            }...`}
+      </span>
+      {!isMyTurn && (
+        <span className="inline-block w-4 h-4 border-2 border-gray-700 border-t-transparent rounded-full animate-spin" />
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -69,6 +69,10 @@ import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
 import { SetupPhasePanel } from "./components/SetupPhasePanel";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { PlayerActivationBar } from "./components/PlayerActivationBar";
+import {
+  TurnStatusBanner,
+  PreMatchSetupBanner,
+} from "./components/TopStatusBanners";
 import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
@@ -644,55 +648,15 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       )}
       {/* Bandeau de statut de tour (match actif) */}
       {isActiveMatch && (
-        <div
-          className={`fixed top-0 left-0 right-0 z-50 text-center py-2 text-sm font-bold flex items-center justify-center gap-4 ${
-            isMyTurn
-              ? "bg-green-500 text-white"
-              : "bg-yellow-400 text-gray-900"
-          }`}
-        >
-          <span>
-            {moveSubmitting
-              ? "Envoi du coup..."
-              : isMyTurn
-                ? "C'est votre tour !"
-                : "En attente de l'adversaire..."}
-          </span>
-          {state && state.pendingReroll && isMyTurn && (
-            <span className="bg-orange-500 text-white px-2 py-0.5 rounded text-xs animate-pulse">
-              Relance disponible !
-            </span>
-          )}
-          {state && state.pendingApothecary && isMyTurn && (
-            <span className="bg-green-500 text-white px-2 py-0.5 rounded text-xs animate-pulse">
-              Apothicaire disponible !
-            </span>
-          )}
-          {state && state.gamePhase === "ended" && (
-            <span className="bg-gray-700 text-white px-2 py-0.5 rounded text-xs">
-              Match terminé — {state.score.teamA} - {state.score.teamB}
-            </span>
-          )}
-        </div>
+        <TurnStatusBanner
+          state={state as ExtendedGameState | null}
+          isMyTurn={isMyTurn}
+          moveSubmitting={moveSubmitting}
+        />
       )}
       {/* Bandeau de statut pré-match (setup) */}
       {!isActiveMatch && matchStatus === "prematch-setup" && state?.preMatch?.phase === "setup" && (
-        <div
-          className={`fixed top-0 left-0 right-0 z-50 text-center py-3 text-sm font-bold flex items-center justify-center gap-4 transition-colors duration-300 ${
-            isMyTurn
-              ? "bg-green-600 text-white"
-              : "bg-yellow-400 text-gray-900"
-          }`}
-        >
-          <span>
-            {isMyTurn
-              ? "Placez vos 11 joueurs puis cliquez Prêt !"
-              : `En attente du placement de ${state.preMatch.currentCoach === "A" ? state.teamNames.teamA : state.teamNames.teamB}...`}
-          </span>
-          {!isMyTurn && (
-            <span className="inline-block w-4 h-4 border-2 border-gray-700 border-t-transparent rounded-full animate-spin" />
-          )}
-        </div>
+        <PreMatchSetupBanner state={state as ExtendedGameState} isMyTurn={isMyTurn} />
       )}
       {/* Wrapper pour éléments pré-match, à l'intérieur du container principal */}
       <div className="pt-32">


### PR DESCRIPTION
## Resume

Douzieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1107 a 1071 lignes** (cumul depuis le debut : 1666 -> 1071, **-595 lignes / -35.7%**).

### Extractions

2 bandeaux fixes en haut de l'ecran deplaces dans `apps/web/app/play/[id]/components/TopStatusBanners.tsx` :

- **`TurnStatusBanner`** (match actif) : "C'est votre tour" / "En attente de l'adversaire..." + badges contextuels :
  - "Relance disponible !" (orange) si `pendingReroll && isMyTurn`
  - "Apothicaire disponible !" (vert) si `pendingApothecary && isMyTurn`
  - "Match termine — A-B" (gris) si `gamePhase === "ended"`
- **`PreMatchSetupBanner`** (phase setup) : "Placez vos 11 joueurs puis cliquez Pret !" si mon tour, sinon "En attente du placement de X..." + spinner.

`page.tsx` remplace les 2 blocs JSX inline (~50 lignes total) par des appels concis aux composants.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 1071 lignes (-595, -35.7%)**.

Cible DoD : `< 600 lignes`. Encore ~470 lignes a extraire ; on est bien en dessous de la moitie maintenant.

### Slices restantes

- `handleDrop` + `onCellClick` (logique de manipulation, gros morceau, necessitera un hook custom car deeply intertwined avec React state)
- post-match SPP block (~22 lignes)
- gameLog UI / Board+sidebar JSX

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0l)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que les 2 bandeaux affichent les bons messages selon `isMyTurn` / `moveSubmitting` et les badges Reroll/Apothecary/Match termine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_