### PR TITLE
refactor(play): extract handlePlayerClick util (S26.0m)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -77,6 +77,7 @@ import { normalizeState } from "./utils/normalize-state";
 import * as kickoffActions from "./utils/kickoff-actions";
 import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
 import { getAvailableActions } from "./utils/available-actions";
+import { handlePlayerClick } from "./utils/handle-player-click";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -772,66 +773,17 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
                 } // Nouvelle prop
                 onPlayerClick={(playerId) => {
                   if (!state) return;
-                  const extState = state as ExtendedGameState;
-                  webLog.debug("onPlayerClick called:", {
+                  handlePlayerClick({
+                    state: state as ExtendedGameState,
                     playerId,
-                    phase: extState.preMatch?.phase,
-                    currentCoach: extState.preMatch?.currentCoach,
+                    draggedPlayerId,
+                    currentAction,
+                    setState,
+                    setCurrentAction,
+                    setThrowTeamMateThrownId,
+                    setSelectedFromReserve,
+                    onCellClick,
                   });
-
-                  if (extState.preMatch?.phase === "setup") {
-                    const player = state.players.find((p) => p.id === playerId);
-                    if (
-                      player &&
-                      player.team === extState.preMatch.currentCoach
-                    ) {
-                      // Permettre de sélectionner les joueurs déjà placés ou ceux en réserves
-                      if (!draggedPlayerId) {
-                        webLog.debug("Setting selectedFromReserve:", playerId);
-                        setSelectedFromReserve(playerId);
-                      }
-                      return;
-                    }
-                    webLog.debug("Ignoring player click in setup phase");
-                    return; // Ignore autres en setup
-                  }
-                  // Logique normale (seulement si pas en phase setup)
-                  const player = state.players.find((p) => p.id === playerId);
-                  if (!player) return;
-
-                  // Clic sur un adversaire avec une action Block/Blitz active → traiter comme un clic de cellule
-                  if (
-                    player.team !== state.currentPlayer &&
-                    state.selectedPlayerId &&
-                    (currentAction === "BLOCK" || currentAction === "BLITZ" || currentAction === "FOUL")
-                  ) {
-                    onCellClick(player.pos);
-                    return;
-                  }
-
-                  // En mode THROW_TEAM_MATE, un clic sur un coequipier doit declencher la selection (pas changer le selectedPlayerId)
-                  if (
-                    currentAction === "THROW_TEAM_MATE" &&
-                    state.selectedPlayerId &&
-                    player.team === state.currentPlayer &&
-                    player.id !== state.selectedPlayerId
-                  ) {
-                    onCellClick(player.pos);
-                    return;
-                  }
-
-                  if (
-                    player.team === state.currentPlayer &&
-                    (!extState.preMatch ||
-                      (extState.preMatch.phase as string) !== "setup")
-                  ) {
-                    setState((s) =>
-                      s ? { ...s, selectedPlayerId: player.id } : null,
-                    );
-                    setCurrentAction(null);
-                    setThrowTeamMateThrownId(null);
-                    setSelectedFromReserve(null);
-                  }
                 }}
                 onDragStart={handleDragStart}
                 boardContainerRef={boardRef}

--- a/apps/web/app/play/[id]/utils/handle-player-click.ts
+++ b/apps/web/app/play/[id]/utils/handle-player-click.ts
@@ -1,0 +1,104 @@
+/**
+ * Helper qui factorise la logique du `onPlayerClick` du board Pixi.
+ *
+ * Resoud les 3 cas :
+ *  1. Phase setup : si le joueur clique appartient au coach courant et
+ *     qu'aucun drag n'est en cours, le selectionne dans la reserve.
+ *  2. Match actif + action BLOCK / BLITZ / FOUL : un clic sur un
+ *     adversaire equivaut a un clic sur la cellule -> delegue
+ *     onCellClick.
+ *  3. Match actif + action THROW_TEAM_MATE : un clic sur un coequipier
+ *     equivaut a un clic sur la cellule.
+ *  4. Sinon : selectionne le joueur (mes joueurs uniquement).
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0m.
+ */
+
+import {
+  type ExtendedGameState,
+  type Position,
+} from "@bb/game-engine";
+import { webLog } from "../../../lib/log";
+import type { ActivationAction } from "./available-actions";
+
+interface HandlePlayerClickContext {
+  state: ExtendedGameState;
+  playerId: string;
+  draggedPlayerId: string | null;
+  currentAction: ActivationAction | null;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setCurrentAction: (a: ActivationAction | null) => void;
+  setThrowTeamMateThrownId: (id: string | null) => void;
+  setSelectedFromReserve: (id: string | null) => void;
+  onCellClick: (pos: Position) => void;
+}
+
+export function handlePlayerClick(ctx: HandlePlayerClickContext): void {
+  const {
+    state,
+    playerId,
+    draggedPlayerId,
+    currentAction,
+    setState,
+    setCurrentAction,
+    setThrowTeamMateThrownId,
+    setSelectedFromReserve,
+    onCellClick,
+  } = ctx;
+  webLog.debug("onPlayerClick called:", {
+    playerId,
+    phase: state.preMatch?.phase,
+    currentCoach: state.preMatch?.currentCoach,
+  });
+
+  if (state.preMatch?.phase === "setup") {
+    const player = state.players.find((p) => p.id === playerId);
+    if (player && player.team === state.preMatch.currentCoach) {
+      if (!draggedPlayerId) {
+        webLog.debug("Setting selectedFromReserve:", playerId);
+        setSelectedFromReserve(playerId);
+      }
+      return;
+    }
+    webLog.debug("Ignoring player click in setup phase");
+    return;
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return;
+
+  if (
+    player.team !== state.currentPlayer &&
+    state.selectedPlayerId &&
+    (currentAction === "BLOCK" ||
+      currentAction === "BLITZ" ||
+      currentAction === "FOUL")
+  ) {
+    onCellClick(player.pos);
+    return;
+  }
+
+  if (
+    currentAction === "THROW_TEAM_MATE" &&
+    state.selectedPlayerId &&
+    player.team === state.currentPlayer &&
+    player.id !== state.selectedPlayerId
+  ) {
+    onCellClick(player.pos);
+    return;
+  }
+
+  if (
+    player.team === state.currentPlayer &&
+    (!state.preMatch || (state.preMatch.phase as string) !== "setup")
+  ) {
+    setState((s) => (s ? { ...s, selectedPlayerId: player.id } : null));
+    setCurrentAction(null);
+    setThrowTeamMateThrownId(null);
+    setSelectedFromReserve(null);
+  }
+}


### PR DESCRIPTION
## Resume

Treizieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1071 a 1023 lignes** (cumul depuis le debut : 1666 -> 1023, **-643 lignes / -38.6%**).

### Extraction

Grosse closure `onPlayerClick` (~60 lignes inline dans `<GameBoardWithDugouts>`) deplacee dans `apps/web/app/play/[id]/utils/handle-player-click.ts` comme fonction pure prenant un `HandlePlayerClickContext`.

4 cas preserves a l'identique :
1. **phase setup** : selectionner le joueur dans la reserve si meme coach que `currentCoach` et pas de drag en cours.
2. **match actif + BLOCK/BLITZ/FOUL** : clic sur adversaire = clic cellule (delegue `onCellClick`).
3. **match actif + THROW_TEAM_MATE** : clic sur coequipier = clic cellule.
4. **sinon** : selectionner le joueur (mes joueurs uniquement, hors phase setup).

Le type `ActivationAction` (extrait en S26.0j) est reutilise pour typer correctement `currentAction` / `setCurrentAction` (au lieu de `string | null`).

`page.tsx` remplace la closure inline (~60 lignes) par un appel concis `handlePlayerClick({...ctx})` de 12 lignes.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 1023 lignes (-643, -38.6%)**.

Cible DoD : `< 600 lignes`. Encore ~424 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0m)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview qu'un clic sur un joueur fonctionne dans les 4 cas (setup reserve, BLOCK/BLITZ/FOUL adversaire, THROW_TEAM_MATE coequipier, selection normale).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_