### PR TITLE
refactor(play): extract handleSetupDragStart util (S26.0n)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -78,6 +78,7 @@ import * as kickoffActions from "./utils/kickoff-actions";
 import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
 import { getAvailableActions } from "./utils/available-actions";
 import { handlePlayerClick } from "./utils/handle-player-click";
+import { handleSetupDragStart } from "./utils/handle-drag-start";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -205,28 +206,17 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
     return computeBlockTargets(state.selectedPlayerId, realMoves, state.players);
   }, [state?.selectedPlayerId, legal, state?.players]);
 
-  // Ajouter handlers après onCellClick
-  const handleDragStart = (e: React.DragEvent, playerId: string) => {
-    const ext = state as ExtendedGameState | null;
-    if (!ext || ext.preMatch?.phase !== "setup") return;
-    if (setupSubmitting) return; // Bloquer pendant la soumission
-    // Autoriser uniquement le coach courant et ses joueurs
-    const isMyTeam = (() => {
-      // On déduit mon côté via teamNameA/B comparés à state.teamNames
-      if (!teamNameA || !teamNameB) return true; // fallback permissif
-      const mySide: "A" | "B" = teamNameA === ext.teamNames.teamA ? "A" : "B";
-      const playerTeam = ext.players.find((p) => p.id === playerId)?.team;
-      return mySide === ext.preMatch.currentCoach && playerTeam === mySide;
-    })();
-    if (!isMyTeam) return;
-
-    // Permettre de déplacer les joueurs déjà placés ou ceux en réserves
-    const player = ext.players.find((p) => p.id === playerId);
-    if (!player) return;
-
-    e.dataTransfer.setData("text/plain", playerId);
-    setDraggedPlayerId(playerId);
-  };
+  // Drag handlers (S26.0n — handleDragStart extracted to ./utils/handle-drag-start.ts).
+  const handleDragStart = (e: React.DragEvent, playerId: string) =>
+    handleSetupDragStart({
+      e,
+      playerId,
+      state: state as ExtendedGameState | null,
+      teamNameA,
+      teamNameB,
+      setupSubmitting,
+      setDraggedPlayerId,
+    });
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault(); // Permettre drop

--- a/apps/web/app/play/[id]/utils/handle-drag-start.ts
+++ b/apps/web/app/play/[id]/utils/handle-drag-start.ts
@@ -1,0 +1,56 @@
+/**
+ * Helper qui factorise la logique du `handleDragStart` du board en
+ * phase de setup pre-match.
+ *
+ * Bloque le drag :
+ *  - quand on n'est pas en phase setup
+ *  - pendant la soumission du placement (`setupSubmitting`)
+ *  - quand on n'est pas le coach courant ou que le joueur drag
+ *    n'appartient pas a notre equipe
+ *
+ * Sinon, ecrit le `playerId` dans le `dataTransfer` et expose le
+ * `draggedPlayerId` pour le drop handler.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0n.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+
+interface HandleDragStartContext {
+  e: React.DragEvent;
+  playerId: string;
+  state: ExtendedGameState | null;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+  setupSubmitting: boolean;
+  setDraggedPlayerId: (id: string | null) => void;
+}
+
+export function handleSetupDragStart(ctx: HandleDragStartContext): void {
+  const {
+    e,
+    playerId,
+    state,
+    teamNameA,
+    teamNameB,
+    setupSubmitting,
+    setDraggedPlayerId,
+  } = ctx;
+  if (!state || state.preMatch?.phase !== "setup") return;
+  if (setupSubmitting) return;
+
+  const isMyTeam = (() => {
+    if (!teamNameA || !teamNameB) return true; // fallback permissif
+    const mySide: "A" | "B" =
+      teamNameA === state.teamNames.teamA ? "A" : "B";
+    const playerTeam = state.players.find((p) => p.id === playerId)?.team;
+    return mySide === state.preMatch?.currentCoach && playerTeam === mySide;
+  })();
+  if (!isMyTeam) return;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return;
+
+  e.dataTransfer.setData("text/plain", playerId);
+  setDraggedPlayerId(playerId);
+}


### PR DESCRIPTION
## Resume

Quatorzieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1023 a 1013 lignes** (cumul depuis le debut : 1666 -> 1013, **-653 lignes / -39.2%**).

### Extraction

`handleDragStart` (~21 lignes inline) deplace dans `apps/web/app/play/[id]/utils/handle-drag-start.ts` comme fonction pure `handleSetupDragStart` prenant un `HandleDragStartContext`.

3 guards conserves a l'identique :
1. pas en phase setup
2. `setupSubmitting` actif (validation en cours)
3. pas le coach courant OU joueur drag pas dans mon equipe (avec fallback permissif quand `teamNameA`/`teamNameB` absents)

`page.tsx` remplace l'inline (~21 lignes) par un wrapper de 9 lignes qui binde state/teamNames/setupSubmitting/setDraggedPlayerId au handler factorise.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 1013 lignes (-653, -39.2%)**.

Cible DoD : `< 600 lignes`. Encore ~414 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0n)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le drag d'un joueur en phase setup fonctionne et que le drop est bien rejete dans les 3 cas guard (hors setup, submitting, mauvais coach).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_