### PR TITLE
refactor(play): extract handleSetupDrop util (S26.0o, < 1000 lignes)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -79,6 +79,7 @@ import { applyOrSubmitMove } from "./utils/apply-or-submit-move";
 import { getAvailableActions } from "./utils/available-actions";
 import { handlePlayerClick } from "./utils/handle-player-click";
 import { handleSetupDragStart } from "./utils/handle-drag-start";
+import { handleSetupDrop } from "./utils/handle-drop";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -223,74 +224,19 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
   };
 
   const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    if (!state || !draggedPlayerId || !boardRef.current) return;
-
-    const extState = state as ExtendedGameState;
-    if (extState.preMatch?.phase !== "setup") return;
-    // Bloquer si je ne suis pas le coach courant
-    if (teamNameA && teamNameB) {
-      const mySide: "A" | "B" =
-        teamNameA === extState.teamNames.teamA ? "A" : "B";
-      if (mySide !== extState.preMatch.currentCoach) {
-        setDraggedPlayerId(null);
-        showSetupError("Ce n'est pas votre tour de placer");
-        return;
-      }
-      const playerTeam = extState.players.find(
-        (p) => p.id === draggedPlayerId,
-      )?.team;
-      if (playerTeam !== mySide) {
-        setDraggedPlayerId(null);
-        showSetupError("Vous ne pouvez placer que vos joueurs");
-        return;
-      }
-    }
-
-    // Utiliser rect du canvas Pixi (pas le wrapper div qui peut être plus large)
-    const canvas = boardRef.current.querySelector('canvas');
-    const rect = (canvas || boardRef.current).getBoundingClientRect();
-    const nativeEvent = e.nativeEvent;
-    const pixelX = nativeEvent.clientX - rect.left;
-    const pixelY = nativeEvent.clientY - rect.top;
-    // pixelX → colonne (y), pixelY → ligne (x) — même logique que PixiBoard.handleStageClick
-    const gridCol = Math.floor(pixelX / currentCellSize);
-    const gridRow = Math.floor(pixelY / currentCellSize);
-
-    if (
-      gridCol >= 0 &&
-      gridCol < state.height &&
-      gridRow >= 0 &&
-      gridRow < state.width
-    ) {
-      const pos: Position = { x: gridRow, y: gridCol };
-
-      const err = validatePlacement(
-        extState,
-        draggedPlayerId,
-        pos,
-        getMySide(extState, teamNameA, teamNameB),
-      );
-      if (err) {
-        showSetupError(err);
-        setDraggedPlayerId(null);
-        return;
-      }
-
-      const result = placePlayerInSetup(extState, draggedPlayerId, pos);
-      if (!result.success) {
-        showSetupError("Placement refusé");
-        setDraggedPlayerId(null);
-        return;
-      }
-      
-      const newState = result.state;
-      setState(newState);
-      if (newState.preMatch.placedPlayers.length === 11) {
-        setDraggedPlayerId(null);
-      }
-    }
-    setDraggedPlayerId(null);
+    if (!state) return;
+    handleSetupDrop({
+      e,
+      state: state as ExtendedGameState,
+      draggedPlayerId,
+      boardEl: boardRef.current,
+      teamNameA,
+      teamNameB,
+      currentCellSize,
+      showSetupError,
+      setState,
+      setDraggedPlayerId,
+    });
   };
 
   // Kickoff handlers extracted to ./utils/kickoff-actions.ts (S26.0d).

--- a/apps/web/app/play/[id]/utils/handle-drop.ts
+++ b/apps/web/app/play/[id]/utils/handle-drop.ts
@@ -1,0 +1,122 @@
+/**
+ * Helper qui factorise la logique du `handleDrop` du board en phase
+ * de setup pre-match.
+ *
+ * Etapes :
+ *  1. Bloque si pas en setup ou si on n'est pas le coach courant
+ *     (sinon affiche showSetupError et reset draggedPlayerId).
+ *  2. Convertit la position pixel du drop -> coordonnee grid via le
+ *     rect du canvas Pixi (pas le wrapper div qui peut etre plus large).
+ *  3. Valide le placement via validatePlacement (LOS, wide zones,
+ *     max 11, doublons).
+ *  4. Applique le placement via placePlayerInSetup (engine).
+ *  5. Reset draggedPlayerId quand 11 joueurs sont places ou apres
+ *     le drop.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0o.
+ */
+
+import {
+  type ExtendedGameState,
+  type Position,
+  placePlayerInSetup,
+} from "@bb/game-engine";
+import { getMySide, validatePlacement } from "./setup-validation";
+
+interface HandleDropContext {
+  e: React.DragEvent;
+  state: ExtendedGameState;
+  draggedPlayerId: string | null;
+  boardEl: HTMLElement | null;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+  currentCellSize: number;
+  showSetupError: (msg: string) => void;
+  setState: (s: ExtendedGameState) => void;
+  setDraggedPlayerId: (id: string | null) => void;
+}
+
+export function handleSetupDrop(ctx: HandleDropContext): void {
+  const {
+    e,
+    state,
+    draggedPlayerId,
+    boardEl,
+    teamNameA,
+    teamNameB,
+    currentCellSize,
+    showSetupError,
+    setState,
+    setDraggedPlayerId,
+  } = ctx;
+  e.preventDefault();
+  if (!state || !draggedPlayerId || !boardEl) return;
+
+  if (state.preMatch?.phase !== "setup") return;
+
+  // Bloquer si je ne suis pas le coach courant ou que le joueur drag
+  // n'appartient pas a mon equipe.
+  if (teamNameA && teamNameB) {
+    const mySide: "A" | "B" =
+      teamNameA === state.teamNames.teamA ? "A" : "B";
+    if (mySide !== state.preMatch.currentCoach) {
+      setDraggedPlayerId(null);
+      showSetupError("Ce n'est pas votre tour de placer");
+      return;
+    }
+    const playerTeam = state.players.find((p) => p.id === draggedPlayerId)
+      ?.team;
+    if (playerTeam !== mySide) {
+      setDraggedPlayerId(null);
+      showSetupError("Vous ne pouvez placer que vos joueurs");
+      return;
+    }
+  }
+
+  // Utiliser rect du canvas Pixi (pas le wrapper div qui peut etre
+  // plus large et fausser la conversion pixel -> cellule).
+  const canvas = boardEl.querySelector("canvas");
+  const rect = (canvas || boardEl).getBoundingClientRect();
+  const nativeEvent = e.nativeEvent;
+  const pixelX = nativeEvent.clientX - rect.left;
+  const pixelY = nativeEvent.clientY - rect.top;
+  // pixelX -> colonne (y), pixelY -> ligne (x) — meme logique que
+  // PixiBoard.handleStageClick.
+  const gridCol = Math.floor(pixelX / currentCellSize);
+  const gridRow = Math.floor(pixelY / currentCellSize);
+
+  if (
+    gridCol >= 0 &&
+    gridCol < state.height &&
+    gridRow >= 0 &&
+    gridRow < state.width
+  ) {
+    const pos: Position = { x: gridRow, y: gridCol };
+
+    const err = validatePlacement(
+      state,
+      draggedPlayerId,
+      pos,
+      getMySide(state, teamNameA, teamNameB),
+    );
+    if (err) {
+      showSetupError(err);
+      setDraggedPlayerId(null);
+      return;
+    }
+
+    const result = placePlayerInSetup(state, draggedPlayerId, pos);
+    if (!result.success) {
+      showSetupError("Placement refusé");
+      setDraggedPlayerId(null);
+      return;
+    }
+
+    const newState = result.state;
+    setState(newState as ExtendedGameState);
+    if ((newState as ExtendedGameState).preMatch?.placedPlayers.length === 11) {
+      setDraggedPlayerId(null);
+    }
+  }
+  setDraggedPlayerId(null);
+}


### PR DESCRIPTION
## Resume

Quinzieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **1013 a 959 lignes**. **Passe sous la barre des 1000 lignes !** (cumul depuis le debut : 1666 -> 959, **-707 lignes / -42.4%**).

### Extraction

`handleDrop` (~70 lignes inline) deplace dans `apps/web/app/play/[id]/utils/handle-drop.ts` comme fonction pure `handleSetupDrop` prenant un `HandleDropContext`.

Etapes preservees a l'identique :
1. Guards : pas en setup, mauvais coach, joueur drag pas dans mon equipe (avec showSetupError approprie)
2. Conversion pixel -> grid via le `rect` du canvas Pixi (pas le wrapper div qui peut etre plus large et fausser la conversion)
3. Validation via `validatePlacement` (LOS, wide zones, max 11, doublons)
4. Application via `placePlayerInSetup` (engine)
5. Reset `draggedPlayerId` quand 11 joueurs places ou apres drop

`page.tsx` remplace la closure inline (~70 lignes) par un wrapper de 14 lignes qui binde state/draggedPlayerId/boardEl/etc. au handler factorise.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 959 lignes (-707, -42.4%)**.

Cible DoD : `< 600 lignes`. Encore ~360 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0o)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le drop d'un joueur en phase setup fonctionne (placement valide accepte, invalide rejete avec showSetupError, drag bloque si mauvais coach).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_