### PR TITLE
refactor(play): extract handleSetupCellClick branch (S26.0p)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -80,6 +80,7 @@ import { getAvailableActions } from "./utils/available-actions";
 import { handlePlayerClick } from "./utils/handle-player-click";
 import { handleSetupDragStart } from "./utils/handle-drag-start";
 import { handleSetupDrop } from "./utils/handle-drop";
+import { handleSetupCellClick } from "./utils/handle-setup-cell-click";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -285,48 +286,21 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
 
     // Bloquer si match actif et pas mon tour (ou soumission en cours)
     if (isActiveMatch && (!isMyTurn || moveSubmitting)) return;
-    // Bloquer les interactions setup quand ce n'est pas mon tour ou soumission en cours
-    if (extState.preMatch?.phase === "setup") {
-      const mySide = myTeamSide || getMySide(extState, teamNameA, teamNameB);
-      if (mySide && mySide !== extState.preMatch.currentCoach) return;
-      if (setupSubmitting) return;
-    }
-    if (extState.preMatch?.phase === "setup") {
-      // Mode setup : placer selectedFromReserve sur pos si légal
-      if (selectedFromReserve) {
-        const err = validatePlacement(
-          extState,
-          selectedFromReserve,
-          pos,
-          myTeamSide || getMySide(extState, teamNameA, teamNameB),
-        );
-        if (err) {
-          showSetupError(err);
-          setSelectedFromReserve(null);
-          return;
-        }
-        const result = placePlayerInSetup(extState, selectedFromReserve, pos);
-        if (!result.success) {
-          showSetupError("Placement refusé");
-          setSelectedFromReserve(null);
-          return;
-        }
-        
-        const newState = result.state;
-        setState(newState);
-        if (newState.preMatch.placedPlayers.length === 11) {
-          // TODO: Switch coach ou kickoff
-          setSelectedFromReserve(null);
-        }
-        setSelectedFromReserve(null); // Deselect après placement
-        return;
-      }
-      // Sinon, clic sur terrain vide : ignore ou deselect
-      setSelectedFromReserve(null);
-      // Réinitialiser selectedPlayerId en phase setup
-      if (state.selectedPlayerId) {
-        setState((s) => (s ? { ...s, selectedPlayerId: null } : null));
-      }
+    // Phase setup : delegue au util S26.0p
+    if (
+      handleSetupCellClick({
+        pos,
+        state: extState,
+        myTeamSide,
+        teamNameA,
+        teamNameB,
+        setupSubmitting,
+        selectedFromReserve,
+        showSetupError,
+        setState,
+        setSelectedFromReserve,
+      })
+    ) {
       return;
     }
     // Logique normale pour match en cours (seulement si pas en phase setup)

--- a/apps/web/app/play/[id]/utils/handle-setup-cell-click.ts
+++ b/apps/web/app/play/[id]/utils/handle-setup-cell-click.ts
@@ -1,0 +1,91 @@
+/**
+ * Helper qui factorise la branche "phase setup" du `onCellClick` du
+ * board. Place le `selectedFromReserve` sur la cellule cible si legal,
+ * sinon deselectionne et reset selectedPlayerId.
+ *
+ * Retourne `true` si l'evenement a ete pris en charge (caller doit
+ * sortir de onCellClick), `false` sinon.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0p.
+ */
+
+import {
+  type ExtendedGameState,
+  type Position,
+  placePlayerInSetup,
+} from "@bb/game-engine";
+import { getMySide, validatePlacement } from "./setup-validation";
+
+interface HandleSetupCellClickContext {
+  pos: Position;
+  state: ExtendedGameState;
+  myTeamSide: "A" | "B" | null;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+  setupSubmitting: boolean;
+  selectedFromReserve: string | null;
+  showSetupError: (msg: string) => void;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setSelectedFromReserve: (id: string | null) => void;
+}
+
+/**
+ * @returns `true` si la branche setup a traite l'evenement (caller doit
+ *   `return`), `false` si on n'est pas en setup ou qu'aucune action n'a
+ *   ete prise.
+ */
+export function handleSetupCellClick(
+  ctx: HandleSetupCellClickContext,
+): boolean {
+  const {
+    pos,
+    state,
+    myTeamSide,
+    teamNameA,
+    teamNameB,
+    setupSubmitting,
+    selectedFromReserve,
+    showSetupError,
+    setState,
+    setSelectedFromReserve,
+  } = ctx;
+
+  if (state.preMatch?.phase !== "setup") return false;
+
+  // Bloquer les interactions setup quand ce n'est pas mon tour ou
+  // soumission en cours.
+  const mySide = myTeamSide || getMySide(state, teamNameA, teamNameB);
+  if (mySide && mySide !== state.preMatch.currentCoach) return true;
+  if (setupSubmitting) return true;
+
+  // Mode setup : placer selectedFromReserve sur pos si legal.
+  if (selectedFromReserve) {
+    const err = validatePlacement(state, selectedFromReserve, pos, mySide);
+    if (err) {
+      showSetupError(err);
+      setSelectedFromReserve(null);
+      return true;
+    }
+    const result = placePlayerInSetup(state, selectedFromReserve, pos);
+    if (!result.success) {
+      showSetupError("Placement refusé");
+      setSelectedFromReserve(null);
+      return true;
+    }
+
+    setState(result.state as ExtendedGameState);
+    setSelectedFromReserve(null);
+    return true;
+  }
+
+  // Sinon, clic sur terrain vide : ignore ou deselect.
+  setSelectedFromReserve(null);
+  if (state.selectedPlayerId) {
+    setState((s) => (s ? { ...s, selectedPlayerId: null } : null));
+  }
+  return true;
+}


### PR DESCRIPTION
## Resume

Seizieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **959 a 933 lignes** (cumul depuis le debut : 1666 -> 933, **-733 lignes / -44%**).

### Extraction

Branche "phase setup" du `onCellClick` (~45 lignes inline) deplacee dans `apps/web/app/play/[id]/utils/handle-setup-cell-click.ts`.

`handleSetupCellClick(ctx) -> boolean` retourne `true` si la branche setup a traite le clic (caller doit `return`). Conserve tous les guards :
- `state.preMatch?.phase !== "setup"` -> retour `false` (caller continue)
- mauvais coach -> retour `true` (handled, ignore)
- `setupSubmitting` -> retour `true`
- avec `selectedFromReserve` : valide via `validatePlacement` + applique via `placePlayerInSetup`, sinon affiche `showSetupError`
- sans `selectedFromReserve` : reset `selectedPlayerId` et retourne `true`

`onCellClick` (page.tsx) appelle `handleSetupCellClick` puis `return` si traite, sinon continue avec la logique match actif (THROW_TEAM_MATE / BLOCK / MOVE).

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 933 lignes (-733, -44%)**.

Cible DoD : `< 600 lignes`. Encore ~334 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0p)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le placement par clic en phase setup fonctionne (selectionner reserve + clic cellule = place ou reject avec message).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_