### PR TITLE
refactor(play): extract handleThrowTeamMateClick branch (S26.0q)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -81,6 +81,7 @@ import { handlePlayerClick } from "./utils/handle-player-click";
 import { handleSetupDragStart } from "./utils/handle-drag-start";
 import { handleSetupDrop } from "./utils/handle-drop";
 import { handleSetupCellClick } from "./utils/handle-setup-cell-click";
+import { handleThrowTeamMateClick } from "./utils/handle-throw-team-mate-click";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -332,57 +333,24 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
       state.selectedPlayerId &&
       (!extState.preMatch || (extState.preMatch.phase as string) !== "setup")
     ) {
-      // Handle THROW_TEAM_MATE: 2-click flow (1) coequipier a lancer, (2) case cible
-      if (currentAction === "THROW_TEAM_MATE") {
-        const clickedPlayer = state.players.find(
-          (p) => p.pos.x === pos.x && p.pos.y === pos.y,
-        );
-        if (!throwTeamMateThrownId) {
-          // Phase 1 : selectionner un coequipier lancable
-          if (
-            clickedPlayer &&
-            clickedPlayer.team === state.currentPlayer &&
-            clickedPlayer.id !== state.selectedPlayerId &&
-            legal.some(
-              (m) =>
-                m.type === "THROW_TEAM_MATE" &&
-                m.playerId === state.selectedPlayerId &&
-                m.thrownPlayerId === clickedPlayer.id,
-            )
-          ) {
-            setThrowTeamMateThrownId(clickedPlayer.id);
-          }
-          return;
-        }
-        // Phase 2 : selectionner la position cible
-        const move = legal.find(
-          (m): m is Extract<Move, { type: "THROW_TEAM_MATE" }> =>
-            m.type === "THROW_TEAM_MATE" &&
-            m.playerId === state.selectedPlayerId &&
-            m.thrownPlayerId === throwTeamMateThrownId &&
-            m.targetPos.x === pos.x &&
-            m.targetPos.y === pos.y,
-        );
-        if (!move) return; // hors portee : ignore
-        if (isActiveMatch) {
-          submitMove(move).then((result) => {
-            if (result?.success && result.gameState) {
-              const ns = normalizeState(result.gameState);
-              setState(ns);
-              setIsMyTurn(result.isMyTurn);
-              if (ns.lastDiceResult) setShowDicePopup(true);
-            }
-          });
-        } else {
-          setState((s) => {
-            if (!s) return null;
-            const s2 = applyMove(s, move, createRNG());
-            if (s2.lastDiceResult) setShowDicePopup(true);
-            return s2 as ExtendedGameState;
-          });
-        }
-        setThrowTeamMateThrownId(null);
-        setCurrentAction(null);
+      // Handle THROW_TEAM_MATE: 2-click flow (S26.0q — extracted)
+      if (
+        handleThrowTeamMateClick({
+          pos,
+          state: extState,
+          legal,
+          currentAction,
+          throwTeamMateThrownId,
+          isActiveMatch,
+          submitMove,
+          setState,
+          setIsMyTurn,
+          setShowDicePopup,
+          setThrowTeamMateThrownId,
+          setCurrentAction,
+          createRNG,
+        })
+      ) {
         return;
       }
 

--- a/apps/web/app/play/[id]/utils/handle-throw-team-mate-click.ts
+++ b/apps/web/app/play/[id]/utils/handle-throw-team-mate-click.ts
@@ -1,0 +1,122 @@
+/**
+ * Helper qui factorise la branche THROW_TEAM_MATE du `onCellClick`.
+ *
+ * Flow 2-clics :
+ *  1. Premier clic sur un coequipier lancable -> set
+ *     `throwTeamMateThrownId`.
+ *  2. Second clic sur une case cible -> trouve le Move legal et
+ *     applique via applyOrSubmitMove, reset les states de tracking.
+ *
+ * Retourne `true` si la branche a traite le clic (caller doit
+ * `return`), `false` si on n'est pas en flow THROW_TEAM_MATE.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0q.
+ */
+
+import {
+  type ExtendedGameState,
+  type Move,
+  type Position,
+  type RNG,
+} from "@bb/game-engine";
+import type { LegalAction } from "./legal-action";
+import { applyOrSubmitMove } from "./apply-or-submit-move";
+import type { ActivationAction } from "./available-actions";
+
+interface HandleThrowTeamMateClickContext {
+  pos: Position;
+  state: ExtendedGameState;
+  legal: readonly LegalAction[];
+  currentAction: ActivationAction | null;
+  throwTeamMateThrownId: string | null;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | { success?: boolean; gameState?: ExtendedGameState; isMyTurn?: boolean }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  setShowDicePopup: (v: boolean) => void;
+  setThrowTeamMateThrownId: (id: string | null) => void;
+  setCurrentAction: (a: ActivationAction | null) => void;
+  createRNG: () => RNG;
+}
+
+/**
+ * @returns `true` si la branche a traite le clic, `false` sinon.
+ */
+export function handleThrowTeamMateClick(
+  ctx: HandleThrowTeamMateClickContext,
+): boolean {
+  const {
+    pos,
+    state,
+    legal,
+    currentAction,
+    throwTeamMateThrownId,
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    setShowDicePopup,
+    setThrowTeamMateThrownId,
+    setCurrentAction,
+    createRNG,
+  } = ctx;
+
+  if (currentAction !== "THROW_TEAM_MATE" || !state.selectedPlayerId) {
+    return false;
+  }
+
+  const clickedPlayer = state.players.find(
+    (p) => p.pos.x === pos.x && p.pos.y === pos.y,
+  );
+
+  if (!throwTeamMateThrownId) {
+    // Phase 1 : selectionner un coequipier lancable.
+    if (
+      clickedPlayer &&
+      clickedPlayer.team === state.currentPlayer &&
+      clickedPlayer.id !== state.selectedPlayerId &&
+      legal.some(
+        (m) =>
+          m.type === "THROW_TEAM_MATE" &&
+          m.playerId === state.selectedPlayerId &&
+          m.thrownPlayerId === clickedPlayer.id,
+      )
+    ) {
+      setThrowTeamMateThrownId(clickedPlayer.id);
+    }
+    return true;
+  }
+
+  // Phase 2 : selectionner la position cible.
+  const move = legal.find(
+    (m): m is Extract<Move, { type: "THROW_TEAM_MATE" }> =>
+      m.type === "THROW_TEAM_MATE" &&
+      m.playerId === state.selectedPlayerId &&
+      m.thrownPlayerId === throwTeamMateThrownId &&
+      m.targetPos.x === pos.x &&
+      m.targetPos.y === pos.y,
+  );
+  if (!move) return true; // hors portee : ignore le clic mais sort du flow
+
+  applyOrSubmitMove({
+    move,
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    createRNG,
+    withDicePopup: true,
+    setShowDicePopup,
+  });
+  setThrowTeamMateThrownId(null);
+  setCurrentAction(null);
+  return true;
+}


### PR DESCRIPTION
## Resume

Dix-septieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **933 a 901 lignes** (cumul depuis le debut : 1666 -> 901, **-765 lignes / -45.9%**).

### Extraction

Branche `THROW_TEAM_MATE` du `onCellClick` (~52 lignes inline) deplacee dans `apps/web/app/play/[id]/utils/handle-throw-team-mate-click.ts`.

`handleThrowTeamMateClick(ctx) -> boolean` retourne `true` si la branche a traite le clic.

Flow 2-clics preserve a l'identique :
1. **Phase 1** : selectionner un coequipier lancable (verifie `legal.some(THROW_TEAM_MATE matching playerId+thrownPlayerId)`)
2. **Phase 2** : selectionner la position cible -> trouve le Move legal (avec type predicate `Extract<Move, { type: "THROW_TEAM_MATE" }>`) et applique via `applyOrSubmitMove` (extrait en S26.0i, `withDicePopup=true`)
3. Reset `throwTeamMateThrownId` + `currentAction` apres soumission

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 901 lignes (-765, -45.9%)**.

Cible DoD : `< 600 lignes`. Encore ~302 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0q)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview qu'un Throw Team Mate fonctionne en 2 clics : selection coequipier + selection case cible (online + offline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_