### PR TITLE
refactor(play): extract handleBlockClick branch (S26.0r)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -82,6 +82,7 @@ import { handleSetupDragStart } from "./utils/handle-drag-start";
 import { handleSetupDrop } from "./utils/handle-drop";
 import { handleSetupCellClick } from "./utils/handle-setup-cell-click";
 import { handleThrowTeamMateClick } from "./utils/handle-throw-team-mate-click";
+import { handleBlockClick } from "./utils/handle-block-click";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -354,40 +355,22 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
         return;
       }
 
-      // Handle BLOCK action: clicking an opponent to initiate a block
-      const target = state.players.find(
-        (p) =>
-          p.team !== state.currentPlayer &&
-          p.pos.x === pos.x &&
-          p.pos.y === pos.y,
-      );
-      if (target && (currentAction === "BLOCK" || currentAction === "BLITZ")) {
-        const blockMove = legal.find(
-          (m): m is Extract<Move, { type: "BLOCK" }> =>
-            m.type === "BLOCK" &&
-            m.playerId === state.selectedPlayerId &&
-            m.targetId === target.id,
-        );
-        if (blockMove) {
-          if (isActiveMatch) {
-            submitMove(blockMove).then((result) => {
-              if (result?.success && result.gameState) {
-                const ns = normalizeState(result.gameState);
-                setState(ns);
-                setIsMyTurn(result.isMyTurn);
-                if (ns.lastDiceResult) setShowDicePopup(true);
-              }
-            });
-          } else {
-            setState((s) => {
-              if (!s) return null;
-              const s2 = applyMove(s, blockMove, createRNG());
-              if (s2.lastDiceResult) setShowDicePopup(true);
-              return s2 as ExtendedGameState;
-            });
-          }
-          return;
-        }
+      // Handle BLOCK action: clicking an opponent to initiate a block (S26.0r — extracted)
+      if (
+        handleBlockClick({
+          pos,
+          state: extState,
+          legal,
+          currentAction,
+          isActiveMatch,
+          submitMove,
+          setState,
+          setIsMyTurn,
+          setShowDicePopup,
+          createRNG,
+        })
+      ) {
+        return;
       }
 
       const candidate = legal.find(

--- a/apps/web/app/play/[id]/utils/handle-block-click.ts
+++ b/apps/web/app/play/[id]/utils/handle-block-click.ts
@@ -1,0 +1,88 @@
+/**
+ * Helper qui factorise la branche BLOCK / BLITZ du `onCellClick` :
+ * un clic sur un adversaire avec une action BLOCK ou BLITZ active
+ * declenche le bloc.
+ *
+ * Retourne `true` si la branche a traite le clic (caller doit
+ * `return`), `false` si on n'est pas sur un adversaire ou qu'aucun
+ * Move BLOCK legal n'existe pour la cible.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0r.
+ */
+
+import {
+  type ExtendedGameState,
+  type Move,
+  type Position,
+  type RNG,
+} from "@bb/game-engine";
+import type { LegalAction } from "./legal-action";
+import { applyOrSubmitMove } from "./apply-or-submit-move";
+import type { ActivationAction } from "./available-actions";
+
+interface HandleBlockClickContext {
+  pos: Position;
+  state: ExtendedGameState;
+  legal: readonly LegalAction[];
+  currentAction: ActivationAction | null;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | { success?: boolean; gameState?: ExtendedGameState; isMyTurn?: boolean }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  setShowDicePopup: (v: boolean) => void;
+  createRNG: () => RNG;
+}
+
+/**
+ * @returns `true` si la branche a soumis un BLOCK Move, `false` sinon.
+ */
+export function handleBlockClick(ctx: HandleBlockClickContext): boolean {
+  const {
+    pos,
+    state,
+    legal,
+    currentAction,
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    setShowDicePopup,
+    createRNG,
+  } = ctx;
+
+  const target = state.players.find(
+    (p) =>
+      p.team !== state.currentPlayer && p.pos.x === pos.x && p.pos.y === pos.y,
+  );
+  if (!target || (currentAction !== "BLOCK" && currentAction !== "BLITZ")) {
+    return false;
+  }
+
+  const blockMove = legal.find(
+    (m): m is Extract<Move, { type: "BLOCK" }> =>
+      m.type === "BLOCK" &&
+      m.playerId === state.selectedPlayerId &&
+      m.targetId === target.id,
+  );
+  if (!blockMove) return false;
+
+  applyOrSubmitMove({
+    move: blockMove,
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    createRNG,
+    withDicePopup: true,
+    setShowDicePopup,
+  });
+  return true;
+}


### PR DESCRIPTION
## Resume

Dix-huitieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **901 a 884 lignes** (cumul depuis le debut : 1666 -> 884, **-782 lignes / -47%**).

### Extraction

Branche `BLOCK / BLITZ` du `onCellClick` (~38 lignes inline) deplacee dans `apps/web/app/play/[id]/utils/handle-block-click.ts`.

`handleBlockClick(ctx) -> boolean` retourne `true` si la branche a soumis un BLOCK Move pour l'adversaire clique.

Logique preservee :
- Trouve un adversaire a la position cliquee (`p.team !== currentPlayer`)
- Si action `BLOCK` ou `BLITZ`, cherche un Move BLOCK legal matching `playerId + targetId`
- Soumet via `applyOrSubmitMove` (S26.0i) avec `withDicePopup=true`

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 884 lignes (-782, -47%)**.

Cible DoD : `< 600 lignes`. Encore ~284 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0r)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview qu'un block (BLOCK ou BLITZ) sur un adversaire fonctionne en cliquant sur sa cellule (online + offline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_