### PR TITLE
refactor(play): extract handleMoveClick branch (S26.0s)

### DIFF
--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -83,6 +83,7 @@ import { handleSetupDrop } from "./utils/handle-drop";
 import { handleSetupCellClick } from "./utils/handle-setup-cell-click";
 import { handleThrowTeamMateClick } from "./utils/handle-throw-team-mate-click";
 import { handleBlockClick } from "./utils/handle-block-click";
+import { handleMoveClick } from "./utils/handle-move-click";
 import { validateSetupPlacement } from "./utils/validate-setup";
 import { getMySide, validatePlacement } from "./utils/setup-validation";
 import { type LegalAction } from "./utils/legal-action";
@@ -373,46 +374,20 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
         return;
       }
 
-      const candidate = legal.find(
-        (m) =>
-          m.type === "MOVE" &&
-          m.playerId === state.selectedPlayerId &&
-          m.to.x === pos.x &&
-          m.to.y === pos.y,
-      );
-      if (
-        candidate &&
-        candidate.type === "MOVE" &&
-        (currentAction === "MOVE" ||
-          currentAction === "BLITZ" ||
-          currentAction === null)
-      ) {
-        if (isActiveMatch) {
-          // Match actif : envoyer le coup au serveur
-          submitMove(candidate).then((result) => {
-            if (result?.success && result.gameState) {
-              const ns = normalizeState(result.gameState);
-              setState(ns);
-              setIsMyTurn(result.isMyTurn);
-              const p = ns.players.find((pl) => pl.id === candidate.playerId);
-              if (!p || p.pm <= 0) setState((s) => s ? { ...s, selectedPlayerId: null } : null);
-              if (ns.lastDiceResult) setShowDicePopup(true);
-              setSelectedFromReserve(null);
-            }
-          });
-        } else {
-          // Pré-match / fallback local
-          setState((s) => {
-            if (!s) return null;
-            let s2 = applyMove(s, candidate, createRNG());
-            const p = s2.players.find((pl) => pl.id === candidate.playerId);
-            if (!p || p.pm <= 0) s2 = { ...s2, selectedPlayerId: null };
-            if (s2.lastDiceResult) setShowDicePopup(true);
-            setSelectedFromReserve(null);
-            return s2 as ExtendedGameState;
-          });
-        }
-      }
+      // Handle MOVE: clicking a cell to move the selected player (S26.0s — extracted)
+      handleMoveClick({
+        pos,
+        state: extState,
+        legal,
+        currentAction,
+        isActiveMatch,
+        submitMove,
+        setState,
+        setIsMyTurn,
+        setShowDicePopup,
+        setSelectedFromReserve,
+        createRNG,
+      });
     }
   }
 

--- a/apps/web/app/play/[id]/utils/handle-move-click.ts
+++ b/apps/web/app/play/[id]/utils/handle-move-click.ts
@@ -1,0 +1,108 @@
+/**
+ * Helper qui factorise la branche MOVE du `onCellClick` :
+ * un clic sur une cellule cible cherche un Move legal MOVE pour le
+ * joueur selectionne et l'applique. Apres l'application, deselectionne
+ * le joueur s'il n'a plus de PM.
+ *
+ * Retourne `true` si la branche a soumis un MOVE Move (caller doit
+ * `return`), `false` si aucun candidate MOVE n'existe ou que l'action
+ * courante ne permet pas un MOVE.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0s.
+ */
+
+import {
+  type ExtendedGameState,
+  type Move,
+  type Position,
+  type RNG,
+  applyMove,
+} from "@bb/game-engine";
+import type { LegalAction } from "./legal-action";
+import { normalizeState } from "./normalize-state";
+import type { ActivationAction } from "./available-actions";
+
+interface HandleMoveClickContext {
+  pos: Position;
+  state: ExtendedGameState;
+  legal: readonly LegalAction[];
+  currentAction: ActivationAction | null;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | { success?: boolean; gameState?: ExtendedGameState; isMyTurn?: boolean }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  setShowDicePopup: (v: boolean) => void;
+  setSelectedFromReserve: (id: string | null) => void;
+  createRNG: () => RNG;
+}
+
+/**
+ * @returns `true` si la branche a soumis un MOVE Move, `false` sinon.
+ */
+export function handleMoveClick(ctx: HandleMoveClickContext): boolean {
+  const {
+    pos,
+    state,
+    legal,
+    currentAction,
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    setShowDicePopup,
+    setSelectedFromReserve,
+    createRNG,
+  } = ctx;
+
+  const candidate = legal.find(
+    (m): m is Extract<Move, { type: "MOVE" }> =>
+      m.type === "MOVE" &&
+      m.playerId === state.selectedPlayerId &&
+      m.to.x === pos.x &&
+      m.to.y === pos.y,
+  );
+  if (
+    !candidate ||
+    !(
+      currentAction === "MOVE" ||
+      currentAction === "BLITZ" ||
+      currentAction === null
+    )
+  ) {
+    return false;
+  }
+
+  if (isActiveMatch) {
+    submitMove(candidate).then((result) => {
+      if (result?.success && result.gameState) {
+        const ns = normalizeState(result.gameState);
+        setState(ns);
+        if (typeof result.isMyTurn === "boolean") setIsMyTurn(result.isMyTurn);
+        const p = ns.players.find((pl) => pl.id === candidate.playerId);
+        if (!p || p.pm <= 0)
+          setState((s) => (s ? { ...s, selectedPlayerId: null } : null));
+        if (ns.lastDiceResult) setShowDicePopup(true);
+        setSelectedFromReserve(null);
+      }
+    });
+  } else {
+    setState((s) => {
+      if (!s) return null;
+      let s2 = applyMove(s, candidate, createRNG());
+      const p = s2.players.find((pl) => pl.id === candidate.playerId);
+      if (!p || p.pm <= 0) s2 = { ...s2, selectedPlayerId: null };
+      if (s2.lastDiceResult) setShowDicePopup(true);
+      setSelectedFromReserve(null);
+      return s2 as ExtendedGameState;
+    });
+  }
+  return true;
+}


### PR DESCRIPTION
## Resume

Dix-neuvieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **884 a 859 lignes** (cumul depuis le debut : 1666 -> 859, **-807 lignes / -48.4%**).

### Extraction

Branche `MOVE` du `onCellClick` (~40 lignes inline) deplacee dans `apps/web/app/play/[id]/utils/handle-move-click.ts`.

`handleMoveClick(ctx) -> boolean` retourne `true` si la branche a soumis un MOVE Move.

Logique preservee :
- Type predicate dans `find()` pour narrow `Move -> Extract<Move, { type: "MOVE" }>`
- Online : `submitMove` + `normalizeState` + `setIsMyTurn` + deselect-on-no-PM (reset `selectedPlayerId` si `pm <= 0` apres deplacement) + dice popup + reset `selectedFromReserve`
- Offline : `applyMove` + meme reset interne dans le setState updater

`onCellClick` (page.tsx) passe maintenant a 2 lignes (guard `selectedPlayerId` + appel `handleMoveClick`).

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 859 lignes (-807, -48.4%)**.

Cible DoD : `< 600 lignes`. Encore ~259 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0s)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview qu'un Move (clic cellule) fonctionne avec deselect-on-no-PM (online + offline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_