### PR TITLE
refactor(play): extract PreMatchPanel composite (S26.0t, > 50% reduction)

### DIFF
--- a/apps/web/app/play/[id]/components/PreMatchPanel.tsx
+++ b/apps/web/app/play/[id]/components/PreMatchPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * Panneau qui resume la phase pre-match courante quand `half === 0`
+ * (avant le premier coup d'envoi). Affiche le coin toss puis delegue
+ * a `KickoffSequencePanel` ou `SetupPhasePanel` selon la phase.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0t.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+import { KickoffSequencePanel } from "./KickoffSequencePanel";
+import { SetupPhasePanel } from "./SetupPhasePanel";
+
+interface PreMatchPanelProps {
+  state: ExtendedGameState;
+  myTeamSide: "A" | "B" | null;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+  setupError: string | null;
+  setupSubmitting: boolean;
+  onValidatePlacement: () => void | Promise<void>;
+  onCalculateDeviation: () => void | Promise<void>;
+  onResolveKickoffEvent: () => void | Promise<void>;
+}
+
+export function PreMatchPanel({
+  state,
+  myTeamSide,
+  teamNameA,
+  teamNameB,
+  setupError,
+  setupSubmitting,
+  onValidatePlacement,
+  onCalculateDeviation,
+  onResolveKickoffEvent,
+}: PreMatchPanelProps) {
+  return (
+    <div className="text-center text-sm text-gray-600 bg-white border border-gray-200 shadow-sm p-4 rounded-lg w-full max-w-md">
+      {/* Resume du coin toss */}
+      {state.preMatch?.kickingTeam && state.preMatch?.receivingTeam && (
+        <div className="mb-3 pb-3 border-b border-gray-200">
+          <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">
+            Coin Toss
+          </div>
+          <div className="flex justify-center gap-4 text-xs">
+            <span className="px-2 py-1 bg-blue-50 text-blue-700 rounded">
+              Frappe :{" "}
+              {state.preMatch.kickingTeam === "A"
+                ? state.teamNames.teamA
+                : state.teamNames.teamB}
+            </span>
+            <span className="px-2 py-1 bg-green-50 text-green-700 rounded">
+              Recoit :{" "}
+              {state.preMatch.receivingTeam === "A"
+                ? state.teamNames.teamA
+                : state.teamNames.teamB}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {state.preMatch?.phase === "kickoff" ||
+      state.preMatch?.phase === "kickoff-sequence" ? (
+        <KickoffSequencePanel
+          state={state}
+          myTeamSide={myTeamSide}
+          onCalculateDeviation={onCalculateDeviation}
+          onResolveKickoffEvent={onResolveKickoffEvent}
+        />
+      ) : state.preMatch?.phase === "setup" ? (
+        <SetupPhasePanel
+          state={state}
+          myTeamSide={myTeamSide}
+          teamNameA={teamNameA}
+          teamNameB={teamNameB}
+          setupError={setupError}
+          setupSubmitting={setupSubmitting}
+          onValidatePlacement={onValidatePlacement}
+        />
+      ) : (
+        <div>
+          <div className="text-gray-500">Phase pré-match en cours...</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -65,8 +65,7 @@ import MatchEndScreen from "../../components/MatchEndScreen";
 import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
-import { KickoffSequencePanel } from "./components/KickoffSequencePanel";
-import { SetupPhasePanel } from "./components/SetupPhasePanel";
+import { PreMatchPanel } from "./components/PreMatchPanel";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { PlayerActivationBar } from "./components/PlayerActivationBar";
 import {
@@ -532,45 +531,17 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             )}
             {/* Statut pré-match (si half=0) */}
             {state && state.half === 0 && stateSource === "server" && state.preMatch?.phase !== "inducements" && (
-              <div className="text-center text-sm text-gray-600 bg-white border border-gray-200 shadow-sm p-4 rounded-lg w-full max-w-md">
-                {/* Résumé du coin toss */}
-                {state.preMatch?.kickingTeam && state.preMatch?.receivingTeam && (
-                  <div className="mb-3 pb-3 border-b border-gray-200">
-                    <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Coin Toss</div>
-                    <div className="flex justify-center gap-4 text-xs">
-                      <span className="px-2 py-1 bg-blue-50 text-blue-700 rounded">
-                        Frappe : {state.preMatch.kickingTeam === "A" ? state.teamNames.teamA : state.teamNames.teamB}
-                      </span>
-                      <span className="px-2 py-1 bg-green-50 text-green-700 rounded">
-                        Recoit : {state.preMatch.receivingTeam === "A" ? state.teamNames.teamA : state.teamNames.teamB}
-                      </span>
-                    </div>
-                  </div>
-                )}
-
-                {state.preMatch?.phase === "kickoff" || state.preMatch?.phase === "kickoff-sequence" ? (
-                  <KickoffSequencePanel
-                    state={state as ExtendedGameState}
-                    myTeamSide={myTeamSide}
-                    onCalculateDeviation={handleCalculateDeviation}
-                    onResolveKickoffEvent={handleResolveKickoffEvent}
-                  />
-                ) : state.preMatch?.phase === "setup" ? (
-                  <SetupPhasePanel
-                    state={state as ExtendedGameState}
-                    myTeamSide={myTeamSide}
-                    teamNameA={teamNameA}
-                    teamNameB={teamNameB}
-                    setupError={setupError}
-                    setupSubmitting={setupSubmitting}
-                    onValidatePlacement={handleValidatePlacement}
-                  />
-                ) : (
-                  <div>
-                    <div className="text-gray-500">Phase pré-match en cours...</div>
-                  </div>
-                )}
-              </div>
+              <PreMatchPanel
+                state={state as ExtendedGameState}
+                myTeamSide={myTeamSide}
+                teamNameA={teamNameA}
+                teamNameB={teamNameB}
+                setupError={setupError}
+                setupSubmitting={setupSubmitting}
+                onValidatePlacement={handleValidatePlacement}
+                onCalculateDeviation={handleCalculateDeviation}
+                onResolveKickoffEvent={handleResolveKickoffEvent}
+              />
             )}
             {/* Phase idle: le serveur gère la transition vers setup automatiquement */}
             {/* Compteur si setup */}


### PR DESCRIPTION
## Resume

Vingtieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **859 a 830 lignes**. **Plus de 50% de reduction depuis le debut !** (cumul : 1666 -> 830, **-836 lignes / -50.2%**).

### Extraction

Panneau de statut pre-match (~42 lignes JSX inline) deplace dans `apps/web/app/play/[id]/components/PreMatchPanel.tsx`.

Composant composite qui :
- Affiche le **coin toss summary** (Frappe / Recoit) en header
- Delegue a `<KickoffSequencePanel>` (`phase === "kickoff"` ou `kickoff-sequence`) ou `<SetupPhasePanel>` (`phase === "setup"`) selon la phase
- Fallback "Phase pre-match en cours..." pour les phases idle / autres

`page.tsx` remplace le bloc inline (~42 lignes) par `<PreMatchPanel />` de 11 lignes. Les composants enfants (`KickoffSequencePanel`, `SetupPhasePanel`) ne sont plus importes directement dans page.tsx — encapsules dans `PreMatchPanel`.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 830 lignes (-836, -50.2%)**.

Cible DoD : `< 600 lignes`. Encore ~230 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0t)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le pre-match panel s'affiche bien (coin toss + kickoff sequence + setup) sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_