### PR TITLE
refactor(play): extract ChoicePopups (5 popups, -121 lignes) (S26.0u)

### DIFF
--- a/apps/web/app/play/[id]/components/ChoicePopups.tsx
+++ b/apps/web/app/play/[id]/components/ChoicePopups.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * Composant qui groupe les 5 popups de choix declenches par le moteur
+ * pendant un match : Block / Push / FollowUp / Reroll / Apothecary.
+ *
+ * Toutes les soumissions de Move passent par applyOrSubmitMove
+ * (factorise en S26.0i) ; les popups ne s'occupent que des donnees
+ * d'affichage (noms, options).
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0u.
+ */
+
+import {
+  type ExtendedGameState,
+  type Move,
+  type RNG,
+} from "@bb/game-engine";
+import {
+  buildBlockChooseMove,
+  buildPushChooseMove,
+  buildFollowUpChooseMove,
+  buildRerollChooseMove,
+  buildApothecaryChooseMove,
+  shouldShowBlockPopup,
+  shouldShowPushPopup,
+  shouldShowFollowUpPopup,
+  shouldShowRerollPopup,
+} from "../hooks/useBlockPopups";
+import {
+  BlockChoicePopup,
+  PushChoicePopup,
+  FollowUpChoicePopup,
+  RerollChoicePopup,
+  ApothecaryChoicePopup,
+} from "@bb/ui";
+import { applyOrSubmitMove } from "../utils/apply-or-submit-move";
+
+interface ChoicePopupsProps {
+  state: ExtendedGameState;
+  isMyTurn: boolean;
+  myTeamSide: "A" | "B" | null;
+  isActiveMatch: boolean;
+  submitMove: (move: Move) => Promise<
+    | { success?: boolean; gameState?: ExtendedGameState; isMyTurn?: boolean }
+    | null
+    | undefined
+  >;
+  setState: (
+    s:
+      | ExtendedGameState
+      | ((prev: ExtendedGameState | null) => ExtendedGameState | null),
+  ) => void;
+  setIsMyTurn: (v: boolean) => void;
+  setShowDicePopup: (v: boolean) => void;
+  createRNG: () => RNG;
+}
+
+export function ChoicePopups({
+  state,
+  isMyTurn,
+  myTeamSide,
+  isActiveMatch,
+  submitMove,
+  setState,
+  setIsMyTurn,
+  setShowDicePopup,
+  createRNG,
+}: ChoicePopupsProps) {
+  const submitOptions = {
+    isActiveMatch,
+    submitMove,
+    setState,
+    setIsMyTurn,
+    createRNG,
+  };
+
+  return (
+    <>
+      {shouldShowBlockPopup(state) && state.pendingBlock && (
+        <BlockChoicePopup
+          attackerName={
+            state.players.find((p) => p.id === state.pendingBlock!.attackerId)
+              ?.name || "Attaquant"
+          }
+          defenderName={
+            state.players.find((p) => p.id === state.pendingBlock!.targetId)
+              ?.name || "Défenseur"
+          }
+          chooser={state.pendingBlock.chooser}
+          options={state.pendingBlock.options}
+          onChoose={(result) => {
+            applyOrSubmitMove({
+              ...submitOptions,
+              move: buildBlockChooseMove(state.pendingBlock!, result),
+              withDicePopup: true,
+              setShowDicePopup,
+            });
+          }}
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowPushPopup(state) && state.pendingPushChoice && (
+        <PushChoicePopup
+          attackerName={
+            state.players.find(
+              (p) => p.id === state.pendingPushChoice!.attackerId,
+            )?.name || "Attaquant"
+          }
+          targetName={
+            state.players.find(
+              (p) => p.id === state.pendingPushChoice!.targetId,
+            )?.name || "Défenseur"
+          }
+          availableDirections={state.pendingPushChoice.availableDirections}
+          onChoose={(direction) => {
+            applyOrSubmitMove({
+              ...submitOptions,
+              move: buildPushChooseMove(state.pendingPushChoice!, direction),
+            });
+          }}
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowFollowUpPopup(state) && state.pendingFollowUpChoice && (
+        <FollowUpChoicePopup
+          attackerName={
+            state.players.find(
+              (p) => p.id === state.pendingFollowUpChoice!.attackerId,
+            )?.name || "Attaquant"
+          }
+          targetName={
+            state.players.find(
+              (p) => p.id === state.pendingFollowUpChoice!.targetId,
+            )?.name || "Défenseur"
+          }
+          targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
+          targetOldPosition={state.pendingFollowUpChoice.targetOldPosition}
+          onChoose={(followUp) => {
+            applyOrSubmitMove({
+              ...submitOptions,
+              move: buildFollowUpChooseMove(
+                state.pendingFollowUpChoice!,
+                followUp,
+              ),
+            });
+          }}
+          onClose={() => {}}
+        />
+      )}
+      {shouldShowRerollPopup(state) && state.pendingReroll && isMyTurn && (
+        <RerollChoicePopup
+          rollType={state.pendingReroll.rollType}
+          playerName={
+            state.players.find((p) => p.id === state.pendingReroll!.playerId)
+              ?.name || "Joueur"
+          }
+          teamRerollsLeft={
+            myTeamSide === "A"
+              ? state.teamRerolls.teamA
+              : state.teamRerolls.teamB
+          }
+          onChoose={(useReroll) => {
+            applyOrSubmitMove({
+              ...submitOptions,
+              move: buildRerollChooseMove(useReroll),
+              withDicePopup: true,
+              setShowDicePopup,
+            });
+          }}
+        />
+      )}
+      {state.pendingApothecary && isMyTurn && (
+        <ApothecaryChoicePopup
+          playerName={
+            state.players.find((p) => p.id === state.pendingApothecary!.playerId)
+              ?.name || "Joueur"
+          }
+          injuryType={state.pendingApothecary.injuryType}
+          casualtyOutcome={state.pendingApothecary.originalCasualtyOutcome}
+          onChoose={(useApothecary) => {
+            applyOrSubmitMove({
+              ...submitOptions,
+              move: buildApothecaryChooseMove(useApothecary),
+            });
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -5,11 +5,6 @@ import {
   DiceResultPopup,
   GameScoreboard,
   ActionPickerPopup,
-  BlockChoicePopup,
-  PushChoicePopup,
-  FollowUpChoicePopup,
-  RerollChoicePopup,
-  ApothecaryChoicePopup,
   GameLog,
   ToastProvider,
   type TerrainSkinId,
@@ -49,15 +44,6 @@ import { useGameMoves } from "./hooks/useGameMoves";
 // useGameSocket is now called only inside useGameState to avoid duplicate connections
 import { useGameState } from "./hooks/useGameState";
 import {
-  shouldShowBlockPopup,
-  shouldShowPushPopup,
-  shouldShowFollowUpPopup,
-  shouldShowRerollPopup,
-  buildBlockChooseMove,
-  buildPushChooseMove,
-  buildFollowUpChooseMove,
-  buildRerollChooseMove,
-  buildApothecaryChooseMove,
   computeBlockTargets,
 } from "./hooks/useBlockPopups";
 import PostMatchSPP from "../../components/PostMatchSPP";
@@ -66,6 +52,7 @@ import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { PreMatchPanel } from "./components/PreMatchPanel";
+import { ChoicePopups } from "./components/ChoicePopups";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { PlayerActivationBar } from "./components/PlayerActivationBar";
 import {
@@ -693,101 +680,18 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             createRNG={createRNG}
           />
         )}
-      {/* Block/Push/FollowUp decision popups */}
-      {state && shouldShowBlockPopup(state) && state.pendingBlock && (
-        <BlockChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingBlock!.attackerId)?.name || "Attaquant"
-          }
-          defenderName={
-            state.players.find((p) => p.id === state.pendingBlock!.targetId)?.name || "Défenseur"
-          }
-          chooser={state.pendingBlock.chooser}
-          options={state.pendingBlock.options}
-          onChoose={(result) => {
-            applyOrSubmitMove({
-              move: buildBlockChooseMove(state.pendingBlock!, result),
-              isActiveMatch,
-              submitMove,
-              setState,
-              setIsMyTurn,
-              createRNG,
-              withDicePopup: true,
-              setShowDicePopup,
-            });
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {state && shouldShowPushPopup(state) && state.pendingPushChoice && (
-        <PushChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingPushChoice!.attackerId)?.name || "Attaquant"
-          }
-          targetName={
-            state.players.find((p) => p.id === state.pendingPushChoice!.targetId)?.name || "Défenseur"
-          }
-          availableDirections={state.pendingPushChoice.availableDirections}
-          onChoose={(direction) => {
-            applyOrSubmitMove({
-              move: buildPushChooseMove(state.pendingPushChoice!, direction),
-              isActiveMatch,
-              submitMove,
-              setState,
-              setIsMyTurn,
-              createRNG,
-            });
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {state && shouldShowFollowUpPopup(state) && state.pendingFollowUpChoice && (
-        <FollowUpChoicePopup
-          attackerName={
-            state.players.find((p) => p.id === state.pendingFollowUpChoice!.attackerId)?.name || "Attaquant"
-          }
-          targetName={
-            state.players.find((p) => p.id === state.pendingFollowUpChoice!.targetId)?.name || "Défenseur"
-          }
-          targetNewPosition={state.pendingFollowUpChoice.targetNewPosition}
-          targetOldPosition={state.pendingFollowUpChoice.targetOldPosition}
-          onChoose={(followUp) => {
-            applyOrSubmitMove({
-              move: buildFollowUpChooseMove(state.pendingFollowUpChoice!, followUp),
-              isActiveMatch,
-              submitMove,
-              setState,
-              setIsMyTurn,
-              createRNG,
-            });
-          }}
-          onClose={() => {}}
-        />
-      )}
-      {/* Reroll decision popup */}
-      {state && shouldShowRerollPopup(state) && state.pendingReroll && isMyTurn && (
-        <RerollChoicePopup
-          rollType={state.pendingReroll.rollType}
-          playerName={
-            state.players.find((p) => p.id === state.pendingReroll!.playerId)?.name || "Joueur"
-          }
-          teamRerollsLeft={
-            myTeamSide === "A"
-              ? state.teamRerolls.teamA
-              : state.teamRerolls.teamB
-          }
-          onChoose={(useReroll) => {
-            applyOrSubmitMove({
-              move: buildRerollChooseMove(useReroll),
-              isActiveMatch,
-              submitMove,
-              setState,
-              setIsMyTurn,
-              createRNG,
-              withDicePopup: true,
-              setShowDicePopup,
-            });
-          }}
+      {/* All choice popups: Block / Push / FollowUp / Reroll / Apothecary (S26.0u — extracted) */}
+      {state && (
+        <ChoicePopups
+          state={state as ExtendedGameState}
+          isMyTurn={isMyTurn}
+          myTeamSide={myTeamSide}
+          isActiveMatch={isActiveMatch}
+          submitMove={submitMove}
+          setState={setState}
+          setIsMyTurn={setIsMyTurn}
+          setShowDicePopup={setShowDicePopup}
+          createRNG={createRNG}
         />
       )}
       {/* In-game chat */}
@@ -798,32 +702,7 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
           currentUserId={currentUserId}
         />
       )}
-      {/* Apothecary decision popup */}
-      {state && state.pendingApothecary && isMyTurn && (
-        <ApothecaryChoicePopup
-          playerName={
-            state.players.find((p) => p.id === state.pendingApothecary!.playerId)?.name || "Joueur"
-          }
-          injuryType={state.pendingApothecary.injuryType}
-          casualtyOutcome={state.pendingApothecary.originalCasualtyOutcome}
-          onChoose={(useApothecary) => {
-            const move = buildApothecaryChooseMove(useApothecary);
-            if (isActiveMatch) {
-              submitMove(move).then((res) => {
-                if (res?.success && res.gameState) {
-                  setState(normalizeState(res.gameState));
-                  setIsMyTurn(res.isMyTurn);
-                }
-              });
-            } else {
-              setState((s) => {
-                if (!s) return null;
-                return applyMove(s, move, createRNG()) as ExtendedGameState;
-              });
-            }
-          }}
-        />
-      )}
+      {/* Apothecary popup is now in ChoicePopups (S26.0u) */}
     </div>
     </ToastProvider>
   );


### PR DESCRIPTION
## Resume

Vingt-et-unieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **830 a 709 lignes**. **GROS GAIN : 121 lignes en une slice.** (cumul depuis le debut : 1666 -> 709, **-957 lignes / -57.4%**).

### Extraction

Cree `apps/web/app/play/[id]/components/ChoicePopups.tsx` qui groupe les 5 popups de choix declenches par le moteur :

| Popup | Trigger | applyOrSubmitMove dicePopup |
|-------|---------|----|
| `BlockChoicePopup` | Block dice chooser | ✅ |
| `PushChoicePopup` | push direction | ❌ |
| `FollowUpChoicePopup` | follow-up apres push | ❌ |
| `RerollChoicePopup` | use team reroll y/n | ✅ |
| `ApothecaryChoicePopup` | use apothecary y/n | ❌ |

Toutes les soumissions de Move passent par `applyOrSubmitMove` (extrait en S26.0i). Le popup Apothecary qui restait avec son inline submit/apply est maintenant aussi factorise.

### Cleanup imports

`page.tsx` perd **10 imports** inutilises : 5 popup components (`BlockChoicePopup`, `PushChoicePopup`, `FollowUpChoicePopup`, `RerollChoicePopup`, `ApothecaryChoicePopup`) + 5 helpers (`shouldShowBlockPopup`, `shouldShowPushPopup`, `shouldShowFollowUpPopup`, `shouldShowRerollPopup`, `buildXxxChooseMove`). Tout est consomme dans `ChoicePopups`.

`page.tsx` remplace ~140 lignes inline par `<ChoicePopups />` de 12 lignes.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 709 lignes (-957, -57.4%)**.

Cible DoD : `< 600 lignes`. Encore ~109 lignes a extraire.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0u)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que les 5 popups (Block / Push / FollowUp / Reroll / Apothecary) declenchent bien et soumettent les Move correctement (online + offline).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_