### PR TITLE
refactor(play): extract BoardSection (S26.0v, ~70 lignes restantes vers 600)

### DIFF
--- a/apps/web/app/play/[id]/components/BoardSection.tsx
+++ b/apps/web/app/play/[id]/components/BoardSection.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * Section principale "board" — wrap `<GameBoardWithDugouts>` (Pixi.js)
+ * avec ses 12 props injectees. Calcule en interne :
+ *  - `legalMoves` : positions legales pour le drag setup ou le move
+ *    courant
+ *  - `placedPlayers` : depuis preMatch.placedPlayers
+ *  - `isSetupPhase` : depuis preMatch.phase
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0v.
+ */
+
+import dynamic from "next/dynamic";
+import {
+  type ExtendedGameState,
+  type Position,
+} from "@bb/game-engine";
+import { type TerrainSkinId } from "@bb/ui";
+
+// GameBoardWithDugouts pulls in the entire Pixi.js + @pixi/react bundle.
+// It uses Canvas APIs that don't exist on the server, so disable SSR and
+// let Next.js emit it as a separate chunk that only ships when the user
+// actually opens an online match.
+const GameBoardWithDugouts = dynamic(
+  () => import("@bb/ui").then((m) => m.GameBoardWithDugouts),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="w-full aspect-[2/1] bg-gray-900 text-gray-400 flex items-center justify-center rounded-lg">
+        Chargement du plateau…
+      </div>
+    ),
+  },
+);
+
+interface BoardSectionProps {
+  state: ExtendedGameState;
+  onCellClick: (pos: Position) => void;
+  movesForSelected: Position[];
+  blockTargets: Position[];
+  draggedPlayerId: string | null;
+  selectedFromReserve: string | null;
+  onPlayerClick: (playerId: string) => void;
+  onDragStart: (e: React.DragEvent, playerId: string) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  boardContainerRef: React.RefObject<HTMLDivElement>;
+  onCellSizeChange: (size: number) => void;
+}
+
+export function BoardSection({
+  state,
+  onCellClick,
+  movesForSelected,
+  blockTargets,
+  draggedPlayerId,
+  selectedFromReserve,
+  onPlayerClick,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  boardContainerRef,
+  onCellSizeChange,
+}: BoardSectionProps) {
+  return (
+    <div
+      className="flex flex-col lg:flex-row items-start gap-6 mb-6"
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      {/* Board et sidebar */}
+      <div className="flex-1 flex justify-center">
+        <GameBoardWithDugouts
+          state={state}
+          onCellClick={onCellClick}
+          legalMoves={
+            draggedPlayerId && state.preMatch?.phase === "setup"
+              ? state.preMatch.legalSetupPositions
+              : movesForSelected
+          }
+          blockTargets={blockTargets}
+          selectedPlayerId={state.selectedPlayerId || undefined}
+          selectedForRepositioning={selectedFromReserve}
+          placedPlayers={state.preMatch?.placedPlayers || []}
+          onPlayerClick={onPlayerClick}
+          onDragStart={onDragStart}
+          boardContainerRef={boardContainerRef}
+          onDragOver={onDragOver}
+          onDrop={onDrop}
+          onCellSizeChange={onCellSizeChange}
+          isSetupPhase={state.preMatch?.phase === "setup"}
+          initialTerrainSkin={state.terrainSkin as TerrainSkinId | undefined}
+        />
+      </div>
+      {/* PlayerDetails is now integrated in GameBoardWithDugouts */}
+    </div>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -1,30 +1,12 @@
 "use client";
 import { useMemo, useState, useRef, useCallback, useEffect } from "react";
-import dynamic from "next/dynamic";
 import {
   DiceResultPopup,
   GameScoreboard,
   ActionPickerPopup,
   GameLog,
   ToastProvider,
-  type TerrainSkinId,
 } from "@bb/ui";
-
-// GameBoardWithDugouts pulls in the entire Pixi.js + @pixi/react bundle.
-// It uses Canvas APIs that don't exist on the server, so disable SSR and
-// let Next.js emit it as a separate chunk that only ships when the user
-// actually opens an online match.
-const GameBoardWithDugouts = dynamic(
-  () => import("@bb/ui").then((m) => m.GameBoardWithDugouts),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="w-full aspect-[2/1] bg-gray-900 text-gray-400 flex items-center justify-center rounded-lg">
-        Chargement du plateau…
-      </div>
-    ),
-  },
-);
 import {
   getLegalMoves,
   applyMove,
@@ -53,6 +35,7 @@ import HalftimeTransition from "../../components/HalftimeTransition";
 import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { PreMatchPanel } from "./components/PreMatchPanel";
 import { ChoicePopups } from "./components/ChoicePopups";
+import { BoardSection } from "./components/BoardSection";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { PlayerActivationBar } from "./components/PlayerActivationBar";
 import {
@@ -543,55 +526,33 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             {/* Le kick-off est géré automatiquement par le backend après validation des deux placements */}
           </div>
 
-          <div
-            className="flex flex-col lg:flex-row items-start gap-6 mb-6"
+          <BoardSection
+            state={state as ExtendedGameState}
+            onCellClick={onCellClick}
+            movesForSelected={movesForSelected}
+            blockTargets={blockTargets}
+            draggedPlayerId={draggedPlayerId}
+            selectedFromReserve={selectedFromReserve}
+            onPlayerClick={(playerId) => {
+              if (!state) return;
+              handlePlayerClick({
+                state: state as ExtendedGameState,
+                playerId,
+                draggedPlayerId,
+                currentAction,
+                setState,
+                setCurrentAction,
+                setThrowTeamMateThrownId,
+                setSelectedFromReserve,
+                onCellClick,
+              });
+            }}
+            onDragStart={handleDragStart}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-          >
-            {/* Board et sidebar */}
-            <div className="flex-1 flex justify-center">
-              <GameBoardWithDugouts
-                state={state}
-                onCellClick={onCellClick}
-                legalMoves={
-                  draggedPlayerId &&
-                  (state as ExtendedGameState).preMatch?.phase === "setup"
-                    ? (state as ExtendedGameState).preMatch.legalSetupPositions
-                    : movesForSelected
-                }
-                blockTargets={blockTargets}
-                selectedPlayerId={state.selectedPlayerId || undefined}
-                selectedForRepositioning={selectedFromReserve}
-                placedPlayers={
-                  (state as ExtendedGameState).preMatch?.placedPlayers || []
-                } // Nouvelle prop
-                onPlayerClick={(playerId) => {
-                  if (!state) return;
-                  handlePlayerClick({
-                    state: state as ExtendedGameState,
-                    playerId,
-                    draggedPlayerId,
-                    currentAction,
-                    setState,
-                    setCurrentAction,
-                    setThrowTeamMateThrownId,
-                    setSelectedFromReserve,
-                    onCellClick,
-                  });
-                }}
-                onDragStart={handleDragStart}
-                boardContainerRef={boardRef}
-                onDragOver={handleDragOver}
-                onDrop={handleDrop}
-                onCellSizeChange={setCurrentCellSize}
-                isSetupPhase={
-                  (state as ExtendedGameState).preMatch?.phase === "setup"
-                }
-                initialTerrainSkin={(state as ExtendedGameState).terrainSkin as TerrainSkinId | undefined}
-              />
-            </div>
-            {/* PlayerDetails is now integrated in GameBoardWithDugouts */}
-          </div>
+            boardContainerRef={boardRef}
+            onCellSizeChange={setCurrentCellSize}
+          />
 
           {/* Match log below the game board */}
           {state.gameLog && state.gameLog.length > 0 && (


### PR DESCRIPTION
## Resume

Vingt-deuxieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **709 a 670 lignes** (cumul depuis le debut : 1666 -> 670, **-996 lignes / -59.8%**). Encore ~70 lignes a extraire pour atteindre la cible DoD `< 600 lignes`.

### Extraction

Wrapper `<GameBoardWithDugouts>` + ses 12 props inlines (~50 lignes JSX) deplace dans `apps/web/app/play/[id]/components/BoardSection.tsx`.

Le composant `BoardSection` :
- Calcule en interne `legalMoves` (drag setup vs move courant)
- Calcule `placedPlayers` depuis `state.preMatch?.placedPlayers`
- Calcule `isSetupPhase` depuis `state.preMatch?.phase === "setup"`
- Cast `terrainSkin as TerrainSkinId | undefined`

Le **`dynamic` import du Pixi.js bundle** est deplace dans le composant — `page.tsx` n'a plus besoin de connaitre les details du chargement Canvas SSR-disabled.

### Cleanup imports

`page.tsx` perd 3 imports inutilises : `dynamic` (next/dynamic), `TerrainSkinId` (@bb/ui), et le bloc complet `const GameBoardWithDugouts = dynamic(...)`.

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 670 lignes (-996, -59.8%)**.

Cible DoD : `< 600 lignes`. Encore ~70 lignes a extraire pour atteindre l'objectif.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0v)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le board `<BoardSection>` s'affiche bien (move/legal moves/block targets/setup placedPlayers/terrainSkin) sur `/play/[id]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_