### PR TITLE
refactor(play): extract MatchLogAndSpp section (S26.0w, ~46 lignes restantes)

### DIFF
--- a/apps/web/app/play/[id]/components/MatchLogAndSpp.tsx
+++ b/apps/web/app/play/[id]/components/MatchLogAndSpp.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Section affichee sous le board pendant et apres le match :
+ *  - `GameLog` : journal des actions (toujours visible si non vide)
+ *  - `PostMatchSPP` : visible quand le match est termine, affiche
+ *    les SPP par joueur avec match stats / result.
+ *
+ * Extrait de `play/[id]/page.tsx` dans le cadre du refactor S26.0w.
+ */
+
+import { type ExtendedGameState } from "@bb/game-engine";
+import { GameLog } from "@bb/ui";
+import PostMatchSPP from "../../../components/PostMatchSPP";
+
+interface MatchLogAndSppProps {
+  state: ExtendedGameState;
+  teamNameA: string | null | undefined;
+  teamNameB: string | null | undefined;
+}
+
+export function MatchLogAndSpp({
+  state,
+  teamNameA,
+  teamNameB,
+}: MatchLogAndSppProps) {
+  return (
+    <>
+      {state.gameLog && state.gameLog.length > 0 && (
+        <div className="mt-2 w-full max-w-5xl mx-auto">
+          <GameLog logEntries={state.gameLog} />
+        </div>
+      )}
+
+      {state.gamePhase === "ended" &&
+        state.matchStats &&
+        Object.keys(state.matchStats).length > 0 &&
+        state.matchResult &&
+        state.players && (
+          <div className="mt-6">
+            <PostMatchSPP
+              matchStats={state.matchStats}
+              matchResult={state.matchResult}
+              players={state.players.map((p) => ({
+                id: p.id,
+                team: p.team,
+                name: p.name,
+                number: p.number ?? 0,
+                position: p.position ?? "",
+              }))}
+              teamAName={teamNameA || state.teamNames?.teamA || "Équipe A"}
+              teamBName={teamNameB || state.teamNames?.teamB || "Équipe B"}
+            />
+          </div>
+        )}
+    </>
+  );
+}

--- a/apps/web/app/play/[id]/page.tsx
+++ b/apps/web/app/play/[id]/page.tsx
@@ -4,7 +4,6 @@ import {
   DiceResultPopup,
   GameScoreboard,
   ActionPickerPopup,
-  GameLog,
   ToastProvider,
 } from "@bb/ui";
 import {
@@ -28,7 +27,6 @@ import { useGameState } from "./hooks/useGameState";
 import {
   computeBlockTargets,
 } from "./hooks/useBlockPopups";
-import PostMatchSPP from "../../components/PostMatchSPP";
 import MatchEndScreen from "../../components/MatchEndScreen";
 import PreMatchSummary from "../../components/PreMatchSummary";
 import HalftimeTransition from "../../components/HalftimeTransition";
@@ -36,6 +34,7 @@ import { InducementsPhaseUI } from "./components/InducementsPhaseUI";
 import { PreMatchPanel } from "./components/PreMatchPanel";
 import { ChoicePopups } from "./components/ChoicePopups";
 import { BoardSection } from "./components/BoardSection";
+import { MatchLogAndSpp } from "./components/MatchLogAndSpp";
 import { ThrowTeamMateIndicator } from "./components/ThrowTeamMateIndicator";
 import { PlayerActivationBar } from "./components/PlayerActivationBar";
 import {
@@ -554,35 +553,12 @@ export default function PlayByIdPage({ params }: { params: { id: string } }) {
             onCellSizeChange={setCurrentCellSize}
           />
 
-          {/* Match log below the game board */}
-          {state.gameLog && state.gameLog.length > 0 && (
-            <div className="mt-2 w-full max-w-5xl mx-auto">
-              <GameLog logEntries={state.gameLog} />
-            </div>
-          )}
-
-          {/* Post-match SPP display when game has ended */}
-          {state.gamePhase === "ended" &&
-            state.matchStats &&
-            Object.keys(state.matchStats).length > 0 &&
-            state.matchResult &&
-            state.players && (
-            <div className="mt-6">
-              <PostMatchSPP
-                matchStats={state.matchStats}
-                matchResult={state.matchResult}
-                players={state.players.map((p) => ({
-                  id: p.id,
-                  team: p.team,
-                  name: p.name,
-                  number: p.number ?? 0,
-                  position: p.position ?? "",
-                }))}
-                teamAName={teamNameA || state.teamNames?.teamA || "Équipe A"}
-                teamBName={teamNameB || state.teamNames?.teamB || "Équipe B"}
-              />
-            </div>
-          )}
+          {/* Match log + post-match SPP (S26.0w — extracted) */}
+          <MatchLogAndSpp
+            state={state as ExtendedGameState}
+            teamNameA={teamNameA}
+            teamNameB={teamNameB}
+          />
         </div>
       </div>
       {showDicePopup && state.lastDiceResult && (


### PR DESCRIPTION
## Resume

Vingt-troisieme tranche du refactor **S26.0** — `play/[id]/page.tsx` passe de **670 a 646 lignes** (cumul depuis le debut : 1666 -> 646, **-1020 lignes / -61.2%**). Encore ~46 lignes a extraire pour atteindre la cible DoD `< 600 lignes`.

### Extraction

Section "match log + post-match SPP" (~30 lignes JSX) deplacee dans `apps/web/app/play/[id]/components/MatchLogAndSpp.tsx`.

Le composant rend :
- `<GameLog logEntries={state.gameLog} />` quand `gameLog` non vide (visible pendant et apres le match)
- `<PostMatchSPP>` quand `gamePhase === "ended"` ET `matchStats` non vide ET `matchResult` present, mappe les `players` au format attendu et hydrate les noms d'equipes (fallback `state.teamNames` puis `"Equipe A/B"`)

### Cleanup imports

`page.tsx` perd 2 imports : `GameLog` (utilise dans le composant) et `PostMatchSPP` (deplace dans le composant).

### Progression

Cumul depuis le debut de S26.0 : **1666 -> 646 lignes (-1020, -61.2%)**.

Cible DoD : `< 600 lignes`. Encore ~46 lignes.

## Tache roadmap

Sprint S26, tache S26.0 (slice S26.0w)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

## Plan de test

- [x] `pnpm --filter @bb/web test` — 607 tests passes (aucune regression).
- [x] `pnpm --filter @bb/web build` OK.
- [x] `pnpm --filter @bb/web typecheck` — pas de nouvelle erreur (erreurs feature-flags pre-existantes uniquement).
- [ ] Verifier en preview que le `<GameLog>` apparait sous le board, et que le `<PostMatchSPP>` s'affiche en fin de match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bgk5QHFhMhtWoPVhKKCRdT)_