### PR TITLE
feat(achievements): expose newlyUnlocked slugs on lazy read (S26.2a)

### DIFF
--- a/apps/server/src/services/achievements.test.ts
+++ b/apps/server/src/services/achievements.test.ts
@@ -346,4 +346,66 @@ describe("getUserAchievements (lazy evaluation)", () => {
     expect(unlocked).toContain("first-win");
     expect(unlocked).toContain("roster-skaven");
   });
+
+  it("surfaces newlyUnlocked slugs only for this read (S26.2a)", async () => {
+    // No prior unlocks
+    mockPrisma.userAchievement.findMany.mockResolvedValueOnce([]);
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      {
+        id: "s-1",
+        userId: "user-1",
+        teamRef: { roster: "skaven" },
+        match: {
+          id: "m-1",
+          status: "ended",
+          turns: [
+            {
+              payload: {
+                gameState: {
+                  score: { teamA: 2, teamB: 0 },
+                  players: [],
+                  matchStats: {},
+                },
+              },
+            },
+          ],
+          teamSelections: [
+            { id: "s-1", userId: "user-1" },
+            { id: "s-2", userId: "user-x" },
+          ],
+        },
+      },
+    ]);
+    mockPrisma.friendship.count.mockResolvedValue(0);
+    mockPrisma.userAchievement.createMany.mockResolvedValue({ count: 3 });
+    mockPrisma.userAchievement.findMany.mockResolvedValueOnce([
+      { slug: "first-match", unlockedAt: new Date() },
+      { slug: "first-win", unlockedAt: new Date() },
+      { slug: "roster-skaven", unlockedAt: new Date() },
+    ]);
+
+    const result = await getUserAchievements("user-1");
+
+    expect(Array.isArray(result.newlyUnlocked)).toBe(true);
+    expect(result.newlyUnlocked).toContain("first-match");
+    expect(result.newlyUnlocked).toContain("first-win");
+    expect(result.newlyUnlocked).toContain("roster-skaven");
+  });
+
+  it("returns empty newlyUnlocked when nothing changed (S26.2a)", async () => {
+    mockPrisma.userAchievement.findMany.mockResolvedValue([
+      {
+        userId: "user-1",
+        slug: "first-match",
+        unlockedAt: new Date("2026-04-20"),
+      },
+    ]);
+    mockPrisma.teamSelection.findMany.mockResolvedValue([]);
+    mockPrisma.friendship.count.mockResolvedValue(0);
+    mockPrisma.userAchievement.createMany.mockResolvedValue({ count: 0 });
+
+    const result = await getUserAchievements("user-1");
+
+    expect(result.newlyUnlocked).toEqual([]);
+  });
 });

--- a/apps/server/src/services/achievements.ts
+++ b/apps/server/src/services/achievements.ts
@@ -65,6 +65,11 @@ export interface UserAchievementsResult {
     winsByRoster: Record<string, number>;
   };
   achievements: AchievementView[];
+  /**
+   * S26.2a — Slugs unlocked during this read. Empty when nothing changed.
+   * Consumed by the client to fire toast notifications in real time.
+   */
+  newlyUnlocked: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -436,5 +441,6 @@ export async function getUserAchievements(
       winsByRoster: Object.fromEntries(stats.winsByRoster),
     },
     achievements,
+    newlyUnlocked: newly,
   };
 }


### PR DESCRIPTION
## Resume

Fondation backend pour **S26.2** (notifications temps-reel achievement unlock). `getUserAchievements` deverrouille deja les achievements satisfaits a la lecture, mais ne signalait pas lesquels venaient d'etre debloques *pendant cet appel* : le client n'avait aucun moyen de declencher un toast cible apres un match.

### Changes

- Ajout du champ `newlyUnlocked: string[]` dans `UserAchievementsResult` (slugs unlock pendant ce read, vide sinon).
- `getUserAchievements` reutilise simplement le tableau retourne par `evaluateAchievements` — pas de calcul supplementaire, pas de query additionnelle.

### Compat

Champ additionnel non-breaking : les consommateurs existants (`/me/achievements`, e2e specs) ignorent le champ jusqu'a ce que la slice **S26.2b** (toast UI in-game + redirect au clic) le consomme.

### Tests

- `newlyUnlocked` contient les slugs nouvellement deverouilles lors du premier read (first-match, first-win, roster-skaven).
- `newlyUnlocked` est vide quand rien ne change.

## Tache roadmap

Sprint S26, tache S26.2 (slice S26.2a)
Source : `docs/roadmap/sprints/S26-retention-engagement.md`

S26.2 reste `[ ]` — sera cochee a la fin de la slice S26.2b (toast UI + redirect) qui consomme `newlyUnlocked`.

## Plan de test

- [x] `pnpm --filter @bb/server test` — 968 tests passes (incluant 2 nouveaux pour `newlyUnlocked`).
- [x] `pnpm --filter @bb/server typecheck` OK.
- [x] `pnpm --filter @bb/server lint` OK.
- [ ] Verifier en preview que `GET /achievements` renvoie `newlyUnlocked: []` lorsque l'utilisateur n'a rien debloque, et un tableau de slugs apres un match qui unlock un nouveau succes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDKVPU7HzapwrPShMpdz4a)_