### PR TITLE
Track user last login timestamp

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -49,6 +49,8 @@ model User {
   privateProfile Boolean  @default(false)
   /// Pré-alpha gate côté Postgres ; en SQLite tous les comptes sont valides.
   valid     Boolean  @default(true)
+  /// Date de la dernière connexion réussie de l'utilisateur.
+  lastLoginAt DateTime?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   matches   Match[]

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -69,6 +69,7 @@ router.get("/users", validateQuery(adminUsersQuerySchema), async (req, res) => {
         roles: true,
         patreon: true,
         valid: true,
+        lastLoginAt: true,
         createdAt: true,
         updatedAt: true,
         _count: {
@@ -120,6 +121,7 @@ router.get("/users/:id", async (req, res) => {
         roles: true,
         patreon: true,
         valid: true,
+        lastLoginAt: true,
         createdAt: true,
         updatedAt: true,
         teams: {

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -177,6 +177,11 @@ router.post("/login", validate(loginSchema), async (req, res) => {
       serverLog.error("[login] kofi post-login hooks failed:", kofiErr);
     }
 
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+
     const roles = normalizeRoles((user as any).roles ?? user.role);
     const primaryRole = roles[0];
 

--- a/apps/web/app/admin/users/page.tsx
+++ b/apps/web/app/admin/users/page.tsx
@@ -10,6 +10,7 @@ type User = {
   roles?: string[];
   patreon?: boolean;
   valid?: boolean;
+  lastLoginAt?: string | null;
   createdAt: string;
   updatedAt: string;
   _count: {
@@ -358,6 +359,14 @@ export default function AdminUsersPage() {
                     Créé le <SortIcon column="createdAt" />
                   </div>
                 </th>
+                <th
+                  className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider cursor-pointer hover:bg-nuffle-gold/20 transition-colors"
+                  onClick={() => handleSort("lastLoginAt")}
+                >
+                  <div className="flex items-center gap-2">
+                    Dernière connexion <SortIcon column="lastLoginAt" />
+                  </div>
+                </th>
                 <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                   Actions
                 </th>
@@ -417,6 +426,15 @@ export default function AdminUsersPage() {
                       month: "short",
                       day: "numeric",
                     })}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-600">
+                    {u.lastLoginAt
+                      ? new Date(u.lastLoginAt).toLocaleDateString("fr-FR", {
+                          year: "numeric",
+                          month: "short",
+                          day: "numeric",
+                        })
+                      : <span className="text-gray-400 italic">Jamais</span>}
                   </td>
                   <td className="px-6 py-4" onClick={(e) => e.stopPropagation()}>
                     <div className="flex gap-2 flex-wrap">
@@ -625,6 +643,12 @@ export default function AdminUsersPage() {
                   <div>
                     <span className="text-gray-600">Modifié le:</span>{" "}
                     {new Date(userDetails.updatedAt).toLocaleString("fr-FR")}
+                  </div>
+                  <div>
+                    <span className="text-gray-600">Dernière connexion:</span>{" "}
+                    {userDetails.lastLoginAt
+                      ? new Date(userDetails.lastLoginAt).toLocaleString("fr-FR")
+                      : <span className="text-gray-400 italic">Jamais</span>}
                   </div>
                 </div>
               </div>

--- a/prisma/migrations/20260429130000_add_last_login_at/migration.sql
+++ b/prisma/migrations/20260429130000_add_last_login_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "lastLoginAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,8 @@ model User {
   /// `true` = profil retire de la lookup publique et du sitemap.
   privateProfile      Boolean         @default(false)
   valid               Boolean         @default(false)
+  /// Date de la dernière connexion réussie de l'utilisateur.
+  lastLoginAt         DateTime?
   createdAt           DateTime        @default(now())
   updatedAt           DateTime        @updatedAt
   matches             Match[]


### PR DESCRIPTION
## Résumé

- [x] Ajouter le suivi de la date de dernière connexion réussie des utilisateurs
  - Ajout du champ `lastLoginAt` au modèle User (Prisma)
  - Mise à jour du timestamp lors de chaque connexion réussie
  - Affichage de la dernière connexion dans l'interface admin (tableau et détails utilisateur)
  - Tri par dernière connexion disponible dans le tableau admin

## Détails des changements

### Backend
- **Prisma Schema**: Ajout du champ `lastLoginAt` (DateTime nullable) au modèle User
- **Migration**: Création de la migration pour ajouter la colonne à la base de données
- **Auth Route**: Mise à jour du timestamp `lastLoginAt` après une connexion réussie
- **Admin Route**: Inclusion du champ `lastLoginAt` dans les réponses API

### Frontend
- **Type User**: Ajout du champ `lastLoginAt` au type
- **Tableau Admin**: 
  - Nouvelle colonne "Dernière connexion" avec tri disponible
  - Affichage formaté en français (ex: "29 avr. 2025") ou "Jamais" si aucune connexion
- **Détails Utilisateur**: Affichage de la dernière connexion dans le panneau de détails

## Checklist

- [ ] Lint / Types OK
- [ ] Tests unitaires
- [ ] (si applicable) Tests e2e
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01R1u6VMrwWJFZ3ChPuPtTzS