### PR TITLE
docs(roadmap): S26 termine

### DIFF
--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -11,7 +11,7 @@
 |--------|-------|---------|------|
 | **S24** | Stabilite & DX core (fix P0 + securite + hot-reload dev) | [sprints/S24-stabilite-securite.md](./sprints/S24-stabilite-securite.md) | TERMINE |
 | **S25** | Observabilite, perf & qualite (logs, metrics, tests, bundle) | [sprints/S25-observabilite-qualite.md](./sprints/S25-observabilite-qualite.md) | TERMINE |
-| **S26** | Refactor + Retention & engagement (page.tsx prerequis, achievements, profil, ligues) | [sprints/S26-retention-engagement.md](./sprints/S26-retention-engagement.md) | A faire |
+| **S26** | Refactor + Retention & engagement (page.tsx prerequis, achievements, profil, ligues) | [sprints/S26-retention-engagement.md](./sprints/S26-retention-engagement.md) | TERMINE |
 | **S27** | Evolutions & confort (esport, mobile parite, S4 skeleton, audit log, B0.1 residuels) | [sprints/S27-evolutions-confort.md](./sprints/S27-evolutions-confort.md) | A faire |
 
 ## Suivi qualite actif


### PR DESCRIPTION
## Resume

Met à jour `docs/roadmap/phases.md` : Sprint S26 passe de `A faire` → `TERMINE`.

Toutes les tâches du sprint S26 sont désormais cochées `[x]` dans `sprints/S26-retention-engagement.md` :
- S26.0 — Refactor `play/[id]/page.tsx`
- S26.1 — Tutoriel onboarding
- S26.2 — Notifications achievement unlock
- S26.3 — Profil coach `/coach/{slug}` + courbe ELO + export PDF
- S26.4 — Système d'amis par `@username`
- S26.5 — Notifications ami démarre un match
- S26.6 — Ligues thématiques saisonnières (catalogue, endpoints, UI calendrier, badges champion, hook clôture)

## Plan de test

non termine
- [x] Pas de code touché. Diff strictement documentaire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbtvefqfJQqDQ3edAWhTku)_