### PR TITLE
L2.B.8 & L2.B.9: Bagarreurs Brutaux SPP override + post-match sequence

### DIFF
--- a/apps/server/src/services/move-processor.ts
+++ b/apps/server/src/services/move-processor.ts
@@ -2,7 +2,7 @@ import { prisma } from "../prisma";
 import { applyMove, makeRNG, isMatchEnded } from "@bb/game-engine";
 import type { Move, ExtendedGameState } from "@bb/game-engine";
 import { getUserTeamSide } from "./turn-ownership";
-import { persistMatchSPP } from "./spp-tracking";
+import { persistMatchSPP, loadLeagueSPPContext } from "./spp-tracking";
 import { persistPlayerDeaths } from "./player-death";
 import { persistPermanentInjuries } from "./permanent-injuries";
 import { broadcastGameState, broadcastMatchEnd } from "./game-broadcast";
@@ -196,7 +196,41 @@ export async function processMove(
     if (teamAId && teamBId) {
       try {
         if (newState.matchStats) {
-          await persistMatchSPP(prisma as any, newState, teamAId, teamBId);
+          // L2.B.8 — charge le contexte ligue (rosters + regles speciales)
+          // pour appliquer l'override "Bagarreurs Brutaux" sur le calcul
+          // de SPP. En match amical / cup / IA, isLeagueMatch=false ->
+          // contexte neutre = vanilla rules.
+          let leagueContext;
+          try {
+            const matchInfo = await prisma.match.findUnique({
+              where: { id: matchId },
+              select: { leagueSeasonId: true },
+            });
+            const teams = await prisma.team.findMany({
+              where: { id: { in: [teamAId, teamBId] } },
+              select: { id: true, roster: true },
+            });
+            const rosterA =
+              teams.find((t: { id: string }) => t.id === teamAId)?.roster ??
+              "";
+            const rosterB =
+              teams.find((t: { id: string }) => t.id === teamBId)?.roster ??
+              "";
+            leagueContext = await loadLeagueSPPContext(prisma as any, {
+              isLeagueMatch: !!matchInfo?.leagueSeasonId,
+              teamARoster: rosterA,
+              teamBRoster: rosterB,
+            });
+          } catch {
+            leagueContext = undefined;
+          }
+          await persistMatchSPP(
+            prisma as any,
+            newState,
+            teamAId,
+            teamBId,
+            leagueContext,
+          );
         }
       } catch {
         // SPP persistence error — non-blocking

--- a/apps/server/src/services/post-match-league-integration.test.ts
+++ b/apps/server/src/services/post-match-league-integration.test.ts
@@ -1,0 +1,427 @@
+/**
+ * L2.B.9 — Integration test : flux post-match Jeu en Ligue end-to-end
+ * (Sprint Ligues v2 PR6).
+ *
+ * Different des unit tests `post-match-league-sequence.test.ts` (qui
+ * isolent chaque service avec un mock prisma vierge), ce spec
+ * partage *un seul* etat mock entre tous les services pour verifier
+ * leurs interactions sequentielles :
+ *
+ *   runPostMatchLeagueSequence (cree la sequence + identifie 1 choice)
+ *     -> applyAdvancementChoice (decremente SPP, push advancement)
+ *     -> markSequenceCompletedIfDone (ferme la sequence)
+ *
+ * Et verifie l'idempotence :
+ *   runPostMatchLeagueSequence rejoue -> already-exists.
+ *
+ * Et le cas Bagarreurs Brutaux :
+ *   un joueur de roster ayant la regle qui marque 2 TD + 0 cas
+ *   gagne 4 PSP (au lieu de 6 en vanilla) — cf. spp-tracking.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Shared mock state across all the services under test.
+interface PlayerRow {
+  id: string;
+  teamId: string;
+  name: string;
+  spp: number;
+  skills: string;
+  advancements: string;
+  dead: boolean;
+}
+
+interface SequenceRow {
+  id: string;
+  matchId: string;
+  seasonId: string;
+  status: string;
+  pendingChoices: string;
+  winningsApplied: boolean;
+  lastingInjuriesApplied: boolean;
+  advancementsResolved: boolean;
+  treasuryDeltaA: number;
+  treasuryDeltaB: number;
+  fanFactorDeltaA: number;
+  fanFactorDeltaB: number;
+  completedAt: Date | null;
+}
+
+interface MatchRow {
+  id: string;
+  leagueSeasonId: string | null;
+  leagueScoredAt: Date | null;
+  leaguePostMatchSequence: { id: string; status: string } | null;
+  teamSelections: Array<{ teamId: string }>;
+}
+
+interface TeamRow {
+  id: string;
+  currentValue: number;
+}
+
+const state: {
+  players: PlayerRow[];
+  sequences: SequenceRow[];
+  matches: MatchRow[];
+  teams: TeamRow[];
+  nextSeqId: number;
+} = {
+  players: [],
+  sequences: [],
+  matches: [],
+  teams: [],
+  nextSeqId: 1,
+};
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    teamPlayer: {
+      findMany: vi.fn(async (args: { where: { teamId: string; dead?: boolean } }) =>
+        state.players.filter(
+          (p) =>
+            p.teamId === args.where.teamId &&
+            (args.where.dead === undefined || p.dead === args.where.dead),
+        ),
+      ),
+      findUnique: vi.fn(async (args: { where: { id: string } }) =>
+        state.players.find((p) => p.id === args.where.id) ?? null,
+      ),
+      update: vi.fn(
+        async (args: {
+          where: { id: string };
+          data: Record<string, unknown>;
+        }) => {
+          const idx = state.players.findIndex((p) => p.id === args.where.id);
+          if (idx < 0) throw new Error("player not found");
+          const player = state.players[idx];
+          const data = args.data as Record<string, any>;
+          const next = { ...player };
+          if (data.spp?.decrement) next.spp -= data.spp.decrement;
+          if (typeof data.advancements === "string") {
+            next.advancements = data.advancements;
+          }
+          if (typeof data.skills === "string") next.skills = data.skills;
+          state.players[idx] = next;
+          return next;
+        },
+      ),
+    },
+    team: {
+      update: vi.fn(
+        async (args: {
+          where: { id: string };
+          data: { currentValue: { increment: number } };
+        }) => {
+          const idx = state.teams.findIndex((t) => t.id === args.where.id);
+          if (idx >= 0) {
+            state.teams[idx] = {
+              ...state.teams[idx],
+              currentValue:
+                state.teams[idx].currentValue +
+                (args.data.currentValue?.increment ?? 0),
+            };
+          }
+        },
+      ),
+      findUnique: vi.fn(async (args: { where: { id: string } }) =>
+        state.teams.find((t) => t.id === args.where.id) ?? null,
+      ),
+    },
+    match: {
+      findUnique: vi.fn(
+        async (args: {
+          where: { id: string };
+          select?: Record<string, unknown>;
+        }) => {
+          const m = state.matches.find((mr) => mr.id === args.where.id);
+          if (!m) return null;
+          // Return everything we have; the service ignores fields it
+          // didn't ask for.
+          return m;
+        },
+      ),
+    },
+    leaguePostMatchSequence: {
+      findUnique: vi.fn(async (args: { where: { id: string } }) =>
+        state.sequences.find((s) => s.id === args.where.id) ?? null,
+      ),
+      findFirst: vi.fn(async () =>
+        state.sequences.find((s) => s.status === "awaiting_choices") ?? null,
+      ),
+      create: vi.fn(
+        async (args: {
+          data: Record<string, unknown>;
+          select?: unknown;
+        }) => {
+          const id = `seq-${state.nextSeqId++}`;
+          const data = args.data as any;
+          const row: SequenceRow = {
+            id,
+            matchId: data.matchId,
+            seasonId: data.seasonId,
+            status: data.status,
+            pendingChoices: data.pendingChoices,
+            winningsApplied: data.winningsApplied ?? false,
+            lastingInjuriesApplied: data.lastingInjuriesApplied ?? false,
+            advancementsResolved: data.advancementsResolved ?? false,
+            treasuryDeltaA: data.treasuryDeltaA ?? 0,
+            treasuryDeltaB: data.treasuryDeltaB ?? 0,
+            fanFactorDeltaA: data.fanFactorDeltaA ?? 0,
+            fanFactorDeltaB: data.fanFactorDeltaB ?? 0,
+            completedAt: data.completedAt ?? null,
+          };
+          state.sequences.push(row);
+          // Update the linked match so subsequent runPostMatchLeagueSequence
+          // sees `leaguePostMatchSequence: {id, status}` and skips.
+          const matchIdx = state.matches.findIndex(
+            (m) => m.id === row.matchId,
+          );
+          if (matchIdx >= 0) {
+            state.matches[matchIdx] = {
+              ...state.matches[matchIdx],
+              leaguePostMatchSequence: { id: row.id, status: row.status },
+            };
+          }
+          return { id: row.id, status: row.status };
+        },
+      ),
+      update: vi.fn(
+        async (args: {
+          where: { id: string };
+          data: Record<string, unknown>;
+        }) => {
+          const idx = state.sequences.findIndex(
+            (s) => s.id === args.where.id,
+          );
+          if (idx >= 0) {
+            const data = args.data as any;
+            state.sequences[idx] = {
+              ...state.sequences[idx],
+              ...(typeof data.status === "string"
+                ? { status: data.status }
+                : {}),
+              ...(typeof data.advancementsResolved === "boolean"
+                ? { advancementsResolved: data.advancementsResolved }
+                : {}),
+              ...(data.completedAt instanceof Date
+                ? { completedAt: data.completedAt }
+                : {}),
+            };
+          }
+        },
+      ),
+    },
+  },
+}));
+
+import {
+  runPostMatchLeagueSequence,
+  applyAdvancementChoice,
+  markSequenceCompletedIfDone,
+} from "./post-match-league-sequence";
+
+function resetState() {
+  state.players = [];
+  state.sequences = [];
+  state.matches = [];
+  state.teams = [];
+  state.nextSeqId = 1;
+}
+
+beforeEach(() => {
+  resetState();
+  vi.clearAllMocks();
+});
+
+describe("L2.B.9 — Integration : runPostMatchLeagueSequence -> applyAdvancement -> markCompleted", () => {
+  it("happy path : creates sequence, applies advancement, closes sequence", async () => {
+    state.players = [
+      {
+        id: "player-A1",
+        teamId: "team-A",
+        name: "Alice's Star",
+        spp: 8, // suffit pour primary (6) ou random-primary (3)
+        skills: "block",
+        advancements: "[]",
+        dead: false,
+      },
+    ];
+    state.teams = [
+      { id: "team-A", currentValue: 1000000 },
+      { id: "team-B", currentValue: 1000000 },
+    ];
+    state.matches = [
+      {
+        id: "match-1",
+        leagueSeasonId: "season-1",
+        leagueScoredAt: new Date(),
+        leaguePostMatchSequence: null,
+        teamSelections: [{ teamId: "team-A" }, { teamId: "team-B" }],
+      },
+    ];
+
+    // Step 1 : run sequence -> 1 pendingChoice (Alice's Star).
+    const seqOut = await runPostMatchLeagueSequence({ matchId: "match-1" });
+    if (!("created" in seqOut)) throw new Error("expected created");
+    expect(seqOut.status).toBe("awaiting_choices");
+    expect(seqOut.pendingChoices).toHaveLength(1);
+    expect(seqOut.pendingChoices[0].playerName).toBe("Alice's Star");
+
+    // Step 2 : apply primary advancement (cost 6). Pas le moins cher,
+    // mais on choisit explicitement.
+    const applyOut = await applyAdvancementChoice({
+      teamId: "team-A",
+      playerId: "player-A1",
+      type: "primary",
+      skillSlug: "dodge",
+    });
+    if (!("applied" in applyOut)) throw new Error("expected applied");
+    expect(applyOut.applied).toBe(true);
+    expect(applyOut.newSpp).toBe(2); // 8 - 6 = 2
+    expect(applyOut.newAdvancementCount).toBe(1);
+    expect(applyOut.addedSkill).toBe("dodge");
+    // currentValue : 1_000_000 + 20_000 (surcharge primary) = 1_020_000
+    expect(applyOut.currentValue).toBe(1020000);
+
+    // Verifie l'etat partage.
+    expect(state.players[0].spp).toBe(2);
+    expect(state.players[0].skills).toBe("block,dodge");
+    expect(JSON.parse(state.players[0].advancements)).toHaveLength(1);
+
+    // Step 3 : ferme la sequence (le seul pendingChoice est resolu).
+    const closure = await markSequenceCompletedIfDone(seqOut.sequenceId);
+    expect(closure.closed).toBe(true);
+    expect(closure.status).toBe("completed");
+    expect(state.sequences[0].status).toBe("completed");
+  });
+
+  it("idempotence : re-running runPostMatchLeagueSequence on the same match returns already-exists", async () => {
+    state.players = [
+      {
+        id: "p1",
+        teamId: "team-A",
+        name: "Solo",
+        spp: 0,
+        skills: "",
+        advancements: "[]",
+        dead: false,
+      },
+    ];
+    state.matches = [
+      {
+        id: "match-2",
+        leagueSeasonId: "season-2",
+        leagueScoredAt: new Date(),
+        leaguePostMatchSequence: null,
+        teamSelections: [{ teamId: "team-A" }, { teamId: "team-B" }],
+      },
+    ];
+
+    const first = await runPostMatchLeagueSequence({ matchId: "match-2" });
+    if (!("created" in first)) throw new Error("expected created");
+    expect(first.status).toBe("completed"); // 0 SPP -> aucun choice
+
+    // Re-run : le mock match a maintenant un leaguePostMatchSequence
+    // attache (cf. `create` ci-dessus). Le service skip.
+    const second = await runPostMatchLeagueSequence({ matchId: "match-2" });
+    if (!("skipped" in second)) throw new Error("expected skipped");
+    expect(second.reason).toBe("already-exists");
+    expect(second.sequenceId).toBe(first.sequenceId);
+    // Aucune nouvelle sequence creee.
+    expect(state.sequences).toHaveLength(1);
+  });
+
+  it("dead players are excluded from pendingChoices even with high SPP", async () => {
+    state.players = [
+      {
+        id: "ghost",
+        teamId: "team-A",
+        name: "Ghost",
+        spp: 99, // largement assez
+        skills: "",
+        advancements: "[]",
+        dead: true,
+      },
+    ];
+    state.matches = [
+      {
+        id: "match-3",
+        leagueSeasonId: "season-3",
+        leagueScoredAt: new Date(),
+        leaguePostMatchSequence: null,
+        teamSelections: [{ teamId: "team-A" }, { teamId: "team-B" }],
+      },
+    ];
+
+    const out = await runPostMatchLeagueSequence({ matchId: "match-3" });
+    if (!("created" in out)) throw new Error("expected created");
+    expect(out.pendingChoices).toHaveLength(0);
+    expect(out.status).toBe("completed");
+  });
+
+  it("markSequenceCompletedIfDone keeps sequence open when at least one player has not advanced", async () => {
+    state.players = [
+      {
+        id: "alpha",
+        teamId: "team-A",
+        name: "Alpha",
+        spp: 6,
+        skills: "",
+        advancements: "[]",
+        dead: false,
+      },
+      {
+        id: "beta",
+        teamId: "team-A",
+        name: "Beta",
+        spp: 6,
+        skills: "",
+        advancements: "[]",
+        dead: false,
+      },
+    ];
+    state.teams = [
+      { id: "team-A", currentValue: 1000000 },
+      { id: "team-B", currentValue: 1000000 },
+    ];
+    state.matches = [
+      {
+        id: "match-4",
+        leagueSeasonId: "season-4",
+        leagueScoredAt: new Date(),
+        leaguePostMatchSequence: null,
+        teamSelections: [{ teamId: "team-A" }, { teamId: "team-B" }],
+      },
+    ];
+
+    const out = await runPostMatchLeagueSequence({ matchId: "match-4" });
+    if (!("created" in out)) throw new Error("expected created");
+    expect(out.pendingChoices).toHaveLength(2);
+
+    // Apply advancement to only Alpha.
+    await applyAdvancementChoice({
+      teamId: "team-A",
+      playerId: "alpha",
+      type: "primary",
+      skillSlug: "block",
+    });
+
+    // Sequence not yet closeable : Beta has not advanced.
+    const closureAttempt = await markSequenceCompletedIfDone(out.sequenceId);
+    expect(closureAttempt.closed).toBe(false);
+    expect(closureAttempt.status).toBe("awaiting_choices");
+
+    // Apply Beta -> sequence becomes closeable.
+    await applyAdvancementChoice({
+      teamId: "team-A",
+      playerId: "beta",
+      type: "primary",
+      skillSlug: "dodge",
+    });
+    const closureFinal = await markSequenceCompletedIfDone(out.sequenceId);
+    expect(closureFinal.closed).toBe(true);
+    expect(closureFinal.status).toBe("completed");
+  });
+});

--- a/apps/server/src/services/spp-tracking.test.ts
+++ b/apps/server/src/services/spp-tracking.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import {
   calculatePlayerSPP,
   persistMatchSPP,
+  loadLeagueSPPContext,
   type PlayerMatchStats,
   type GameStateForSPP,
+  type LeagueSPPContext,
 } from "./spp-tracking";
 
 describe("calculatePlayerSPP", () => {
@@ -212,5 +214,245 @@ describe("persistMatchSPP", () => {
       totalInterceptions: { increment: 0 },
       totalMvpAwards: { increment: 1 },
     });
+  });
+});
+
+describe("L2.B.8 — Bagarreurs Brutaux override", () => {
+  it("calculatePlayerSPP defaults to vanilla when no modifier provided", () => {
+    const stats: PlayerMatchStats = {
+      touchdowns: 1,
+      casualties: 1,
+      completions: 0,
+      interceptions: 0,
+      mvp: false,
+    };
+    expect(calculatePlayerSPP(stats)).toBe(5); // 3 TD + 2 cas
+  });
+
+  it("calculatePlayerSPP swaps TD/casualty values when bagarreursBrutaux=true", () => {
+    const stats: PlayerMatchStats = {
+      touchdowns: 1,
+      casualties: 1,
+      completions: 0,
+      interceptions: 0,
+      mvp: false,
+    };
+    // 2 TD + 3 cas = 5 (same total but inverted)
+    expect(
+      calculatePlayerSPP(stats, { bagarreursBrutaux: true }),
+    ).toBe(5);
+  });
+
+  it("Bagarreurs override differs from vanilla when TD != casualties", () => {
+    const stats: PlayerMatchStats = {
+      touchdowns: 2,
+      casualties: 0,
+      completions: 0,
+      interceptions: 0,
+      mvp: false,
+    };
+    expect(calculatePlayerSPP(stats)).toBe(6); // 2*3
+    expect(
+      calculatePlayerSPP(stats, { bagarreursBrutaux: true }),
+    ).toBe(4); // 2*2
+
+    const allCasualties: PlayerMatchStats = {
+      touchdowns: 0,
+      casualties: 3,
+      completions: 0,
+      interceptions: 0,
+      mvp: false,
+    };
+    expect(calculatePlayerSPP(allCasualties)).toBe(6); // 3*2
+    expect(
+      calculatePlayerSPP(allCasualties, { bagarreursBrutaux: true }),
+    ).toBe(9); // 3*3
+  });
+
+  it("override does not change completion / interception / MVP values", () => {
+    const stats: PlayerMatchStats = {
+      touchdowns: 0,
+      casualties: 0,
+      completions: 5,
+      interceptions: 2,
+      mvp: true,
+    };
+    const expected = 5 * 1 + 2 * 1 + 4; // 11
+    expect(calculatePlayerSPP(stats)).toBe(expected);
+    expect(
+      calculatePlayerSPP(stats, { bagarreursBrutaux: true }),
+    ).toBe(expected);
+  });
+
+  it("persistMatchSPP applies per-team override (only team A has bagarreurs)", async () => {
+    const mockPrisma = {
+      teamPlayer: {
+        findMany: vi.fn(),
+        update: vi.fn(),
+      },
+      $transaction: vi.fn(async (ops: unknown[]) =>
+        Promise.all(ops as Promise<unknown>[]),
+      ),
+    } as any;
+
+    mockPrisma.teamPlayer.findMany
+      .mockResolvedValueOnce([{ id: "a-1", number: 1 }])
+      .mockResolvedValueOnce([{ id: "b-1", number: 1 }]);
+
+    const gameState: GameStateForSPP = {
+      players: [
+        { id: "A1", team: "A", number: 1 },
+        { id: "B1", team: "B", number: 1 },
+      ],
+      matchStats: {
+        A1: { touchdowns: 1, casualties: 1, completions: 0, interceptions: 0, mvp: false },
+        B1: { touchdowns: 1, casualties: 1, completions: 0, interceptions: 0, mvp: false },
+      },
+    };
+
+    const context: LeagueSPPContext = {
+      isLeagueMatch: true,
+      teamA: { bagarreursBrutaux: true },
+      teamB: { bagarreursBrutaux: false },
+    };
+
+    await persistMatchSPP(mockPrisma, gameState, "team-A", "team-B", context);
+
+    const updates = mockPrisma.teamPlayer.update.mock.calls.map(
+      (c: unknown[]) => c[0],
+    ) as Array<{ where: { id: string }; data: Record<string, unknown> }>;
+    const a1 = updates.find((u) => u.where.id === "a-1");
+    const b1 = updates.find((u) => u.where.id === "b-1");
+
+    // Player A1 (Bagarreurs) : 1 TD * 2 + 1 cas * 3 = 5
+    expect((a1?.data.spp as { increment: number }).increment).toBe(5);
+    // Player B1 (vanilla) : 1 TD * 3 + 1 cas * 2 = 5
+    // (same total here but the breakdown is different)
+    expect((b1?.data.spp as { increment: number }).increment).toBe(5);
+  });
+
+  it("persistMatchSPP applies override consistently when only team B has the rule", async () => {
+    const mockPrisma = {
+      teamPlayer: {
+        findMany: vi.fn(),
+        update: vi.fn(),
+      },
+      $transaction: vi.fn(async (ops: unknown[]) =>
+        Promise.all(ops as Promise<unknown>[]),
+      ),
+    } as any;
+
+    mockPrisma.teamPlayer.findMany
+      .mockResolvedValueOnce([{ id: "a-1", number: 1 }])
+      .mockResolvedValueOnce([{ id: "b-1", number: 1 }]);
+
+    const gameState: GameStateForSPP = {
+      players: [
+        { id: "A1", team: "A", number: 1 },
+        { id: "B1", team: "B", number: 1 },
+      ],
+      matchStats: {
+        A1: { touchdowns: 2, casualties: 0, completions: 0, interceptions: 0, mvp: false },
+        B1: { touchdowns: 0, casualties: 3, completions: 0, interceptions: 0, mvp: false },
+      },
+    };
+
+    await persistMatchSPP(mockPrisma, gameState, "team-A", "team-B", {
+      isLeagueMatch: true,
+      teamA: { bagarreursBrutaux: false },
+      teamB: { bagarreursBrutaux: true },
+    });
+
+    const updates = mockPrisma.teamPlayer.update.mock.calls.map(
+      (c: unknown[]) => c[0],
+    ) as Array<{ where: { id: string }; data: Record<string, unknown> }>;
+    const a1 = updates.find((u) => u.where.id === "a-1");
+    const b1 = updates.find((u) => u.where.id === "b-1");
+
+    // A1 vanilla : 2 TD * 3 = 6
+    expect((a1?.data.spp as { increment: number }).increment).toBe(6);
+    // B1 Bagarreurs : 3 cas * 3 = 9
+    expect((b1?.data.spp as { increment: number }).increment).toBe(9);
+  });
+});
+
+describe("loadLeagueSPPContext", () => {
+  function makePrisma(rosters?: Array<{ slug: string; specialRules: string | null }>) {
+    return {
+      roster: {
+        findMany: vi.fn().mockResolvedValue(rosters ?? []),
+      },
+    } as any;
+  }
+
+  it("returns neutral context when isLeagueMatch=false", async () => {
+    const ctx = await loadLeagueSPPContext(makePrisma(), {
+      isLeagueMatch: false,
+      teamARoster: "skaven",
+      teamBRoster: "lizardmen",
+    });
+    expect(ctx.isLeagueMatch).toBe(false);
+    expect(ctx.teamA.bagarreursBrutaux).toBe(false);
+    expect(ctx.teamB.bagarreursBrutaux).toBe(false);
+  });
+
+  it("detects bagarreurs_brutaux on the roster CSV (team A only)", async () => {
+    const ctx = await loadLeagueSPPContext(
+      makePrisma([
+        { slug: "black_orcs", specialRules: "bagarreurs_brutaux,deferlement" },
+        { slug: "skaven", specialRules: "" },
+      ]),
+      {
+        isLeagueMatch: true,
+        teamARoster: "black_orcs",
+        teamBRoster: "skaven",
+      },
+    );
+    expect(ctx.teamA.bagarreursBrutaux).toBe(true);
+    expect(ctx.teamB.bagarreursBrutaux).toBe(false);
+  });
+
+  it("detects on team B only", async () => {
+    const ctx = await loadLeagueSPPContext(
+      makePrisma([
+        { slug: "skaven", specialRules: null },
+        { slug: "norse", specialRules: "bagarreurs_brutaux" },
+      ]),
+      {
+        isLeagueMatch: true,
+        teamARoster: "skaven",
+        teamBRoster: "norse",
+      },
+    );
+    expect(ctx.teamA.bagarreursBrutaux).toBe(false);
+    expect(ctx.teamB.bagarreursBrutaux).toBe(true);
+  });
+
+  it("falls back to neutral when prisma throws", async () => {
+    const failingPrisma = {
+      roster: { findMany: vi.fn().mockRejectedValue(new Error("no roster table")) },
+    } as any;
+    const ctx = await loadLeagueSPPContext(failingPrisma, {
+      isLeagueMatch: true,
+      teamARoster: "skaven",
+      teamBRoster: "norse",
+    });
+    expect(ctx.isLeagueMatch).toBe(false);
+    expect(ctx.teamA.bagarreursBrutaux).toBe(false);
+  });
+
+  it("tolerates whitespace + casing variations in specialRules CSV", async () => {
+    const ctx = await loadLeagueSPPContext(
+      makePrisma([
+        { slug: "black_orcs", specialRules: " Bagarreurs_Brutaux , deferlement" },
+        { slug: "skaven", specialRules: "" },
+      ]),
+      {
+        isLeagueMatch: true,
+        teamARoster: "black_orcs",
+        teamBRoster: "skaven",
+      },
+    );
+    expect(ctx.teamA.bagarreursBrutaux).toBe(true);
   });
 });

--- a/apps/server/src/services/spp-tracking.ts
+++ b/apps/server/src/services/spp-tracking.ts
@@ -16,6 +16,17 @@ const SPP_VALUES = {
   mvp: 4,
 } as const;
 
+/**
+ * L2.B.8 — Sprint Ligues v2 PR6 : override "Bagarreurs Brutaux".
+ * En Jeu en Ligue uniquement, une equipe avec la regle speciale
+ * `bagarreurs_brutaux` gagne 3 PSP (au lieu de 2) par Elimination
+ * et 2 PSP (au lieu de 3) par Touchdown.
+ */
+const BAGARREURS_BRUTAUX_OVERRIDE = {
+  touchdown: 2,
+  casualty: 3,
+} as const;
+
 export interface PlayerMatchStats {
   touchdowns: number;
   casualties: number;
@@ -34,16 +45,101 @@ export interface GameStateForSPP {
 }
 
 /**
- * Calculate SPP earned by a player from their match stats.
+ * L2.B.8 — Per-team SPP modifier. `bagarreursBrutaux=true` implique
+ * que la team a la regle speciale et que le match est en Jeu en
+ * Ligue (les modifs ne s'appliquent qu'en ligue, pas en match
+ * amical).
  */
-export function calculatePlayerSPP(stats: PlayerMatchStats): number {
+export interface TeamSPPModifier {
+  readonly bagarreursBrutaux: boolean;
+}
+
+/**
+ * L2.B.8 — Contexte SPP pour un match. `isLeagueMatch=false` desactive
+ * tous les overrides (les regles s'appliquent uniquement en ligue
+ * d'apres les regles BB officielles). Pour un match amical / cup, on
+ * ignore `teamA/B.bagarreursBrutaux` meme si la regle est presente.
+ */
+export interface LeagueSPPContext {
+  readonly isLeagueMatch: boolean;
+  readonly teamA: TeamSPPModifier;
+  readonly teamB: TeamSPPModifier;
+}
+
+const NEUTRAL_MODIFIER: TeamSPPModifier = { bagarreursBrutaux: false };
+const NEUTRAL_CONTEXT: LeagueSPPContext = {
+  isLeagueMatch: false,
+  teamA: NEUTRAL_MODIFIER,
+  teamB: NEUTRAL_MODIFIER,
+};
+
+/**
+ * Calculate SPP earned by a player from their match stats. Applies
+ * the per-team override `modifier` (default neutral = vanilla rules).
+ */
+export function calculatePlayerSPP(
+  stats: PlayerMatchStats,
+  modifier: TeamSPPModifier = NEUTRAL_MODIFIER,
+): number {
+  const useBagarreurs = modifier.bagarreursBrutaux;
+  const tdValue = useBagarreurs
+    ? BAGARREURS_BRUTAUX_OVERRIDE.touchdown
+    : SPP_VALUES.touchdown;
+  const casValue = useBagarreurs
+    ? BAGARREURS_BRUTAUX_OVERRIDE.casualty
+    : SPP_VALUES.casualty;
   return (
-    stats.touchdowns * SPP_VALUES.touchdown +
-    stats.casualties * SPP_VALUES.casualty +
+    stats.touchdowns * tdValue +
+    stats.casualties * casValue +
     stats.completions * SPP_VALUES.completion +
     stats.interceptions * SPP_VALUES.interception +
     (stats.mvp ? SPP_VALUES.mvp : 0)
   );
+}
+
+/**
+ * L2.B.8 — Helper qui charge `Roster.specialRules` (CSV de slugs)
+ * pour les rosters de deux teams, et construit un `LeagueSPPContext`
+ * exploitable par `persistMatchSPP`. Si la lecture echoue (ex:
+ * SQLite test client sans modele Roster), on retourne le contexte
+ * neutre (vanilla rules).
+ */
+export async function loadLeagueSPPContext(
+  prisma: PrismaClient,
+  args: {
+    isLeagueMatch: boolean;
+    teamARoster: string;
+    teamBRoster: string;
+  },
+): Promise<LeagueSPPContext> {
+  if (!args.isLeagueMatch) return NEUTRAL_CONTEXT;
+  try {
+    const rosters = await prisma.roster.findMany({
+      where: { slug: { in: [args.teamARoster, args.teamBRoster] } },
+      select: { slug: true, specialRules: true },
+    });
+    const bySlug = new Map(rosters.map((r) => [r.slug, r.specialRules ?? ""]));
+    return {
+      isLeagueMatch: true,
+      teamA: rosterToModifier(bySlug.get(args.teamARoster) ?? ""),
+      teamB: rosterToModifier(bySlug.get(args.teamBRoster) ?? ""),
+    };
+  } catch {
+    return NEUTRAL_CONTEXT;
+  }
+}
+
+function rosterToModifier(specialRulesText: string): TeamSPPModifier {
+  if (!specialRulesText) return NEUTRAL_MODIFIER;
+  // Tolerant parsing : split on `,` (CSV) ou tout whitespace pour
+  // accommoder les formats existants en base. Trim + lowercase.
+  const parts = specialRulesText
+    .split(/[,\s]+/g)
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  return {
+    bagarreursBrutaux: parts.includes("bagarreurs_brutaux"),
+  };
 }
 
 /**
@@ -63,6 +159,14 @@ export async function persistMatchSPP(
   gameState: GameStateForSPP,
   teamAId: string,
   teamBId: string,
+  /**
+   * L2.B.8 — Contexte SPP de match. Default = neutre (vanilla rules)
+   * pour preserver la retro-compat avec tous les call-sites
+   * existants (matchs amicaux, cups, AI practice). Le caller passe
+   * un contexte non-neutre uniquement pour les matchs de ligue
+   * dont une equipe a la regle "Bagarreurs Brutaux".
+   */
+  context: LeagueSPPContext = NEUTRAL_CONTEXT,
 ): Promise<number> {
   const { matchStats, players } = gameState;
 
@@ -83,23 +187,26 @@ export async function persistMatchSPP(
   ]);
 
   // Build lookup: game engine player ID -> database TeamPlayer ID
-  const playerIdMap = new Map<string, string>();
+  // + side ('A' or 'B') so we can apply the per-team modifier.
+  const playerIdMap = new Map<string, { dbId: string; side: "A" | "B" }>();
   for (const dbPlayer of teamAPlayers) {
-    playerIdMap.set(`A${dbPlayer.number}`, dbPlayer.id);
+    playerIdMap.set(`A${dbPlayer.number}`, { dbId: dbPlayer.id, side: "A" });
   }
   for (const dbPlayer of teamBPlayers) {
-    playerIdMap.set(`B${dbPlayer.number}`, dbPlayer.id);
+    playerIdMap.set(`B${dbPlayer.number}`, { dbId: dbPlayer.id, side: "B" });
   }
 
   // Build one update per player: increment matchesPlayed + SPP stats if any
   const updates: Promise<unknown>[] = [];
 
   for (const gamePlayer of players) {
-    const dbPlayerId = playerIdMap.get(gamePlayer.id);
-    if (!dbPlayerId) continue;
+    const found = playerIdMap.get(gamePlayer.id);
+    if (!found) continue;
+    const { dbId: dbPlayerId, side } = found;
+    const modifier = side === "A" ? context.teamA : context.teamB;
 
     const stats = matchStats[gamePlayer.id];
-    const earnedSPP = stats ? calculatePlayerSPP(stats) : 0;
+    const earnedSPP = stats ? calculatePlayerSPP(stats, modifier) : 0;
 
     updates.push(
       prisma.teamPlayer.update({


### PR DESCRIPTION
## Résumé

Implémente deux features du Sprint Ligues v2 PR6 :

- **L2.B.8** : Override SPP "Bagarreurs Brutaux" — en Jeu en Ligue, les équipes avec la règle spéciale `bagarreurs_brutaux` gagnent 3 PSP par élimination (au lieu de 2) et 2 PSP par TD (au lieu de 3).
- **L2.B.9** : Intégration end-to-end du flux post-match (`runPostMatchLeagueSequence` → `applyAdvancementChoice` → `markSequenceCompletedIfDone`) avec test d'intégration complet.

### Changements clés

**spp-tracking.ts** :
- Ajoute `TeamSPPModifier` et `LeagueSPPContext` pour encapsuler les modifieurs SPP par équipe
- `calculatePlayerSPP()` accepte maintenant un `modifier` optionnel qui inverse les valeurs TD/casualty si `bagarreursBrutaux=true`
- Nouvelle fonction `loadLeagueSPPContext()` qui charge les rosters depuis la DB et détecte la règle spéciale dans `specialRules` (CSV)
- Fallback gracieux vers contexte neutre (vanilla rules) si la lecture échoue

**move-processor.ts** :
- Charge le contexte ligue avant d'appeler `persistMatchSPP()` en fin de match
- Détecte si c'est un match de ligue (`leagueSeasonId` présent) et charge les rosters des deux équipes
- Passe le contexte à `persistMatchSPP()` pour appliquer l'override par équipe

**spp-tracking.test.ts** :
- Tests unitaires pour `calculatePlayerSPP()` avec et sans override
- Tests pour `persistMatchSPP()` avec contexte ligue (team A vs team B avec règles différentes)
- Tests pour `loadLeagueSPPContext()` : détection de la règle, tolérance whitespace/casing, fallback en cas d'erreur

**post-match-league-integration.test.ts** (nouveau) :
- Test d'intégration complet du flux post-match avec état mock partagé entre les trois services
- Vérifie la création de séquence, l'application d'advancement, et la fermeture de séquence
- Teste l'idempotence : re-run sur le même match retourne `already-exists`
- Cas limites : joueurs morts exclus, séquence reste ouverte si un joueur n'a pas avancé

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (spp-tracking.test.ts + post-match-league-integration.test.ts)
- [x] Changeset ajouté

https://claude.ai/code/session_01Kra7z5xyDvQZGzFkhpAofq