### PR TITLE
feat: Add admin leagues management console (L2.C.6)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ import authRefreshRoutes from "./routes/auth-refresh";
 import matchRoutes from "./routes/match";
 import adminRoutes from "./routes/admin";
 import adminDataRoutes from "./routes/admin-data";
+import adminLeaguesRoutes from "./routes/admin-leagues";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -173,6 +174,9 @@ app.use("/leagues", leagueRoutes);
 app.use("/webhooks/kofi", kofiRoutes);
 app.use("/api/feature-flags", userFeatureFlagsRouter);
 app.use("/admin/feature-flags", adminFeatureFlagsRouter);
+// L2.C.6 — admin leagues : reservation aux admins, route distincte
+// pour ne pas polluer /admin (qui devient un sac fourre-tout).
+app.use("/admin/leagues", adminLeaguesRoutes);
 
 // Endpoint public de reset pour tests (uniquement en TEST_SQLITE=1)
 if (process.env.TEST_SQLITE === "1") {

--- a/apps/server/src/routes/admin-leagues.ts
+++ b/apps/server/src/routes/admin-leagues.ts
@@ -1,0 +1,284 @@
+/**
+ * L2.C.6 — Sprint Ligues v2 PR10 : routes admin pour la gestion
+ * globale des ligues.
+ *
+ * Reservees aux admins (authUser + adminOnly). Fournissent les
+ * leviers pour superviser et nettoyer le catalogue de ligues sans
+ * passer par l'identite du creator :
+ *   - GET  /admin/leagues : liste paginee + filtres + counts
+ *   - PATCH /admin/leagues/:id/status : force status
+ *     ("draft"|"open"|"in_progress"|"completed"|"archived")
+ *   - POST /admin/leagues/:id/archive : raccourci status=archived
+ *   - PATCH /admin/leagues/:id/creator : transferer le creator a un
+ *     autre user (ex: coach disparu)
+ *
+ * Ne deplace pas les actions saison (start / regenerate / close) :
+ * elles existent deja sous /league/seasons/:id/* gates par
+ * `requireLeagueCreator`. Pour qu'un admin force ces actions sans
+ * etre creator, il peut d'abord transferer le creator vers son
+ * propre compte.
+ */
+
+import { Router } from "express";
+import type { Response } from "express";
+import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
+import { adminOnly } from "../middleware/adminOnly";
+import { validate, validateQuery } from "../middleware/validate";
+import { prisma } from "../prisma";
+import {
+  adminLeaguesQuerySchema,
+  adminLeagueStatusSchema,
+  adminLeagueTransferSchema,
+  type AdminLeaguesQuery,
+  type AdminLeagueStatusBody,
+  type AdminLeagueTransferBody,
+} from "../schemas/admin-leagues.schemas";
+import { sendError, sendSuccess } from "../utils/api-response";
+import { serverLog } from "../utils/server-log";
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+interface AdminLeagueRow {
+  id: string;
+  name: string;
+  description: string | null;
+  ruleset: string;
+  status: string;
+  isPublic: boolean;
+  maxParticipants: number;
+  creatorId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  creator: {
+    id: string;
+    coachName: string | null;
+    email: string;
+  };
+  _count: {
+    seasons: number;
+  };
+}
+
+/**
+ * GET /admin/leagues
+ *
+ * Liste paginee des ligues. Filtres :
+ *   - status : filtre exact sur League.status
+ *   - search : substring (case-insensitive) dans le nom
+ *   - publicOnly : "true" / "false" / undefined (default : tous)
+ *   - limit / offset (pagination)
+ *
+ * Renvoie aussi le `seasonsCount` materialise pour permettre au front
+ * d'identifier rapidement les ligues vides (eligibles a l'archivage).
+ */
+export async function handleListAdminLeagues(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const query = req.query as unknown as AdminLeaguesQuery;
+  const where: Record<string, unknown> = {};
+  if (query.status) where.status = query.status;
+  if (typeof query.publicOnly === "boolean") {
+    where.isPublic = query.publicOnly;
+  }
+  if (query.search && query.search.length > 0) {
+    where.name = { contains: query.search, mode: "insensitive" };
+  }
+  const limit = Math.min(Math.max(query.limit ?? 50, 1), 100);
+  const offset = Math.max(query.offset ?? 0, 0);
+
+  try {
+    const [items, total] = await Promise.all([
+      prisma.league.findMany({
+        where,
+        orderBy: { updatedAt: "desc" },
+        take: limit,
+        skip: offset,
+        include: {
+          creator: {
+            select: { id: true, coachName: true, email: true },
+          },
+          _count: { select: { seasons: true } },
+        },
+      }),
+      prisma.league.count({ where }),
+    ]);
+    res.status(200).json({
+      success: true,
+      data: {
+        leagues: (items as AdminLeagueRow[]).map((l) => ({
+          id: l.id,
+          name: l.name,
+          description: l.description,
+          ruleset: l.ruleset,
+          status: l.status,
+          isPublic: l.isPublic,
+          maxParticipants: l.maxParticipants,
+          creatorId: l.creatorId,
+          creator: l.creator,
+          seasonsCount: l._count.seasons,
+          createdAt: l.createdAt,
+          updatedAt: l.updatedAt,
+        })),
+      },
+      meta: { total, limit, page: Math.floor(offset / limit) },
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Erreur serveur";
+    serverLog.error("[admin-leagues] list failed:", msg);
+    sendError(res, "Erreur serveur", 500);
+  }
+}
+
+/**
+ * PATCH /admin/leagues/:id/status
+ *
+ * Force le `status` d'une ligue, peu importe le creator. Utile pour :
+ *   - desarchiver une ligue (archived -> draft)
+ *   - forcer "completed" sur une ligue zombie qui n'avance plus
+ *   - re-ouvrir une ligue (in_progress -> open)
+ */
+export async function handleForceLeagueStatus(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  const body = req.body as AdminLeagueStatusBody;
+
+  const league = await prisma.league.findUnique({
+    where: { id },
+    select: { id: true, status: true },
+  });
+  if (!league) {
+    sendError(res, "Ligue introuvable", 404);
+    return;
+  }
+  if (league.status === body.status) {
+    // No-op : on retourne tel quel, idempotent.
+    sendSuccess(res, { leagueId: id, status: body.status, changed: false });
+    return;
+  }
+
+  await prisma.league.update({
+    where: { id },
+    data: { status: body.status },
+  });
+  serverLog.info(
+    `[admin-leagues] status changed: id=${id} ${league.status} -> ${body.status} by user=${req.user?.id}`,
+  );
+  sendSuccess(res, {
+    leagueId: id,
+    status: body.status,
+    changed: true,
+    previousStatus: league.status,
+  });
+}
+
+/**
+ * POST /admin/leagues/:id/archive
+ *
+ * Raccourci : passe le status a "archived". Idempotent.
+ */
+export async function handleArchiveLeague(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  const league = await prisma.league.findUnique({
+    where: { id },
+    select: { id: true, status: true },
+  });
+  if (!league) {
+    sendError(res, "Ligue introuvable", 404);
+    return;
+  }
+  if (league.status === "archived") {
+    sendSuccess(res, { leagueId: id, status: "archived", changed: false });
+    return;
+  }
+  await prisma.league.update({
+    where: { id },
+    data: { status: "archived" },
+  });
+  serverLog.info(
+    `[admin-leagues] archived: id=${id} (was ${league.status}) by user=${req.user?.id}`,
+  );
+  sendSuccess(res, {
+    leagueId: id,
+    status: "archived",
+    changed: true,
+    previousStatus: league.status,
+  });
+}
+
+/**
+ * PATCH /admin/leagues/:id/creator
+ *
+ * Transfere le creator d'une ligue a un autre user (typiquement
+ * pour reassigner une ligue dont le creator a quitte). Verifie que
+ * le user cible existe.
+ */
+export async function handleTransferLeagueCreator(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  const body = req.body as AdminLeagueTransferBody;
+
+  const [league, target] = await Promise.all([
+    prisma.league.findUnique({
+      where: { id },
+      select: { id: true, creatorId: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: body.userId },
+      select: { id: true, coachName: true },
+    }),
+  ]);
+  if (!league) {
+    sendError(res, "Ligue introuvable", 404);
+    return;
+  }
+  if (!target) {
+    sendError(res, "Utilisateur cible introuvable", 404);
+    return;
+  }
+  if (league.creatorId === body.userId) {
+    sendSuccess(res, { leagueId: id, creatorId: body.userId, changed: false });
+    return;
+  }
+  await prisma.league.update({
+    where: { id },
+    data: { creatorId: body.userId },
+  });
+  serverLog.info(
+    `[admin-leagues] creator transferred: league=${id} ${league.creatorId} -> ${body.userId} by admin=${req.user?.id}`,
+  );
+  sendSuccess(res, {
+    leagueId: id,
+    creatorId: body.userId,
+    changed: true,
+    previousCreatorId: league.creatorId,
+  });
+}
+
+router.get(
+  "/",
+  validateQuery(adminLeaguesQuerySchema),
+  handleListAdminLeagues,
+);
+router.patch(
+  "/:id/status",
+  validate(adminLeagueStatusSchema),
+  handleForceLeagueStatus,
+);
+router.post("/:id/archive", handleArchiveLeague);
+router.patch(
+  "/:id/creator",
+  validate(adminLeagueTransferSchema),
+  handleTransferLeagueCreator,
+);
+
+export default router;

--- a/apps/server/src/schemas/admin-leagues.schemas.ts
+++ b/apps/server/src/schemas/admin-leagues.schemas.ts
@@ -1,0 +1,39 @@
+/**
+ * L2.C.6 — Sprint Ligues v2 PR10 : Zod schemas pour les routes
+ * `/admin/leagues/*`.
+ */
+
+import { z } from "zod";
+
+const leagueStatus = z.enum([
+  "draft",
+  "open",
+  "in_progress",
+  "completed",
+  "archived",
+]);
+
+export const adminLeaguesQuerySchema = z.object({
+  status: leagueStatus.optional(),
+  search: z.string().trim().max(100).optional(),
+  publicOnly: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === "true")),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
+export const adminLeagueStatusSchema = z.object({
+  status: leagueStatus,
+});
+
+export const adminLeagueTransferSchema = z.object({
+  userId: z.string().min(1, "userId requis"),
+});
+
+export type AdminLeaguesQuery = z.infer<typeof adminLeaguesQuerySchema>;
+export type AdminLeagueStatusBody = z.infer<typeof adminLeagueStatusSchema>;
+export type AdminLeagueTransferBody = z.infer<
+  typeof adminLeagueTransferSchema
+>;

--- a/apps/web/app/admin/leagues/page.tsx
+++ b/apps/web/app/admin/leagues/page.tsx
@@ -1,0 +1,435 @@
+"use client";
+/**
+ * L2.C.6 — Sprint Ligues v2 PR10 : console admin pour la gestion
+ * globale des ligues.
+ *
+ * Reservee aux admins (gate cote UI via redirect /auth/me + role
+ * check ; verite finale cote serveur via adminOnly middleware).
+ *
+ * Fonctionnalites :
+ *   - liste paginee + filtre par status + recherche par nom
+ *   - badge `Vide` quand seasonsCount=0 (eligible a l'archivage)
+ *   - actions par-ligue : changer status, archive, voir detail
+ *
+ * UX volontairement minimale : scrollable list, modale legere pour
+ * choisir le nouveau status. Le transfer-creator necessite de
+ * connaitre l'userId cible — pour l'instant on expose une input
+ * texte. Une autocomplete coach pourra etre ajoutee plus tard.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { API_BASE } from "../../auth-client";
+
+type LeagueStatus =
+  | "draft"
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "archived";
+
+interface AdminLeague {
+  id: string;
+  name: string;
+  description: string | null;
+  ruleset: string;
+  status: LeagueStatus | string;
+  isPublic: boolean;
+  maxParticipants: number;
+  creatorId: string;
+  creator: {
+    id: string;
+    coachName: string | null;
+    email: string;
+  };
+  seasonsCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ListResponse {
+  data: { leagues: AdminLeague[] };
+  meta: { total: number; limit: number; page: number };
+}
+
+const STATUS_OPTIONS: ReadonlyArray<{
+  value: LeagueStatus | "all";
+  label: string;
+}> = [
+  { value: "all", label: "Tous" },
+  { value: "draft", label: "Brouillon" },
+  { value: "open", label: "Ouverte" },
+  { value: "in_progress", label: "En cours" },
+  { value: "completed", label: "Terminee" },
+  { value: "archived", label: "Archivee" },
+];
+
+async function fetchJSON<T = unknown>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const token =
+    typeof window !== "undefined"
+      ? localStorage.getItem("auth_token")
+      : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) {
+    const body = (await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export default function AdminLeaguesPage() {
+  const router = useRouter();
+  const [leagues, setLeagues] = useState<AdminLeague[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<LeagueStatus | "all">("all");
+  const [search, setSearch] = useState("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [transferTarget, setTransferTarget] = useState<{
+    leagueId: string;
+    userId: string;
+  } | null>(null);
+
+  // Auth gate cote client : redirige les non-admin vers /. Le serveur
+  // refuse de toute facon (401/403), c'est cosmetique.
+  useEffect(() => {
+    let cancelled = false;
+    async function checkAdmin() {
+      try {
+        const me = (await fetchJSON<{
+          user: { id: string; role?: string; roles?: string[] } | null;
+        }>("/auth/me")) ?? { user: null };
+        const roles =
+          me.user?.roles ??
+          (me.user?.role ? [me.user.role] : []);
+        if (cancelled) return;
+        if (!roles.includes("admin")) {
+          router.replace("/");
+        }
+      } catch {
+        if (!cancelled) router.replace("/");
+      }
+    }
+    checkAdmin();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  const reload = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const params = new URLSearchParams();
+      if (statusFilter !== "all") params.set("status", statusFilter);
+      if (search.trim().length > 0) params.set("search", search.trim());
+      const path = `/admin/leagues${
+        params.toString() ? `?${params.toString()}` : ""
+      }`;
+      const json = await fetchJSON<ListResponse>(path);
+      setLeagues(json.data.leagues ?? []);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, search]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const handleSetStatus = useCallback(
+    async (leagueId: string, status: LeagueStatus) => {
+      try {
+        setBusyId(leagueId);
+        await fetchJSON(`/admin/leagues/${leagueId}/status`, {
+          method: "PATCH",
+          body: JSON.stringify({ status }),
+        });
+        await reload();
+      } catch (e: unknown) {
+        alert(
+          e instanceof Error ? e.message : "Echec du changement de status",
+        );
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [reload],
+  );
+
+  const handleArchive = useCallback(
+    async (leagueId: string) => {
+      if (!confirm("Archiver cette ligue ?")) return;
+      try {
+        setBusyId(leagueId);
+        await fetchJSON(`/admin/leagues/${leagueId}/archive`, {
+          method: "POST",
+        });
+        await reload();
+      } catch (e: unknown) {
+        alert(e instanceof Error ? e.message : "Echec de l'archivage");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [reload],
+  );
+
+  const handleTransfer = useCallback(async () => {
+    if (!transferTarget) return;
+    if (!transferTarget.userId.trim()) return;
+    try {
+      setBusyId(transferTarget.leagueId);
+      await fetchJSON(
+        `/admin/leagues/${transferTarget.leagueId}/creator`,
+        {
+          method: "PATCH",
+          body: JSON.stringify({ userId: transferTarget.userId.trim() }),
+        },
+      );
+      setTransferTarget(null);
+      await reload();
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : "Echec du transfert");
+    } finally {
+      setBusyId(null);
+    }
+  }, [transferTarget, reload]);
+
+  const counts = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const l of leagues) {
+      out[l.status] = (out[l.status] ?? 0) + 1;
+    }
+    return out;
+  }, [leagues]);
+
+  return (
+    <div
+      data-testid="admin-leagues-page"
+      className="w-full max-w-5xl mx-auto p-4 sm:p-6 space-y-4"
+    >
+      <div>
+        <Link
+          href="/admin"
+          className="text-sm text-gray-600 hover:text-gray-800"
+        >
+          ← Admin
+        </Link>
+        <h1 className="text-2xl sm:text-3xl font-bold mt-2">
+          🛠️ Console ligues
+        </h1>
+        <p className="text-sm text-gray-600 mt-1">
+          Liste globale, force-status, archivage, transfert de creator.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-3 items-end">
+        <label className="block">
+          <span className="text-xs font-medium text-gray-700">Status</span>
+          <select
+            data-testid="admin-leagues-status-filter"
+            value={statusFilter}
+            onChange={(e) =>
+              setStatusFilter(e.target.value as LeagueStatus | "all")
+            }
+            className="mt-1 block rounded-md border border-gray-300 px-3 py-1.5 text-sm bg-white"
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+                {counts[s.value] !== undefined
+                  ? ` (${counts[s.value]})`
+                  : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block flex-1 min-w-[200px]">
+          <span className="text-xs font-medium text-gray-700">Recherche</span>
+          <input
+            data-testid="admin-leagues-search"
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Nom de ligue…"
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+          />
+        </label>
+      </div>
+
+      {error ? (
+        <div className="rounded border border-red-200 bg-red-50 text-red-700 px-3 py-2 text-sm">
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p>Chargement…</p>
+      ) : leagues.length === 0 ? (
+        <p
+          data-testid="admin-leagues-empty"
+          className="text-sm text-gray-500"
+        >
+          Aucune ligue ne correspond aux filtres.
+        </p>
+      ) : (
+        <ul
+          data-testid="admin-leagues-list"
+          className="grid grid-cols-1 gap-2"
+        >
+          {leagues.map((l) => (
+            <li
+              key={l.id}
+              data-testid={`admin-league-${l.id}`}
+              className="border border-gray-200 rounded-lg bg-white p-3 space-y-2"
+            >
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <div className="min-w-0">
+                  <Link
+                    href={`/leagues/${l.id}`}
+                    className="font-semibold text-nuffle-anthracite hover:underline"
+                  >
+                    {l.name}
+                  </Link>
+                  <span className="ml-2 text-xs uppercase tracking-wide bg-gray-100 text-gray-700 px-2 py-0.5 rounded">
+                    {l.status}
+                  </span>
+                  {l.seasonsCount === 0 ? (
+                    <span className="ml-1 text-xs uppercase tracking-wide bg-amber-100 text-amber-800 px-2 py-0.5 rounded">
+                      Vide
+                    </span>
+                  ) : (
+                    <span className="ml-1 text-xs text-gray-500">
+                      {l.seasonsCount} saison
+                      {l.seasonsCount > 1 ? "s" : ""}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {l.creator.coachName ?? l.creator.email}
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2 items-center text-xs">
+                <select
+                  data-testid={`admin-league-status-${l.id}`}
+                  value={l.status}
+                  disabled={busyId === l.id}
+                  onChange={(e) =>
+                    handleSetStatus(l.id, e.target.value as LeagueStatus)
+                  }
+                  className="rounded border border-gray-300 px-2 py-1 bg-white"
+                >
+                  {STATUS_OPTIONS.filter((s) => s.value !== "all").map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+                {l.status !== "archived" ? (
+                  <button
+                    type="button"
+                    data-testid={`admin-league-archive-${l.id}`}
+                    onClick={() => handleArchive(l.id)}
+                    disabled={busyId === l.id}
+                    className="px-2 py-1 rounded border border-gray-300 bg-white hover:bg-gray-50"
+                  >
+                    📦 Archiver
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  data-testid={`admin-league-transfer-${l.id}`}
+                  onClick={() =>
+                    setTransferTarget({ leagueId: l.id, userId: "" })
+                  }
+                  disabled={busyId === l.id}
+                  className="px-2 py-1 rounded border border-gray-300 bg-white hover:bg-gray-50"
+                >
+                  🔄 Transferer
+                </button>
+                <span className="text-gray-400">
+                  Maj{" "}
+                  {new Date(l.updatedAt).toLocaleDateString("fr-FR", {
+                    day: "2-digit",
+                    month: "short",
+                  })}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {transferTarget ? (
+        <div
+          data-testid="admin-transfer-modal"
+          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center px-4"
+          onClick={() => setTransferTarget(null)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-lg max-w-md w-full p-5 space-y-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-semibold">Transferer le creator</h2>
+            <p className="text-xs text-gray-500">
+              Coller l'identifiant utilisateur (cuid) du nouveau creator.
+            </p>
+            <input
+              data-testid="admin-transfer-userid"
+              type="text"
+              value={transferTarget.userId}
+              onChange={(e) =>
+                setTransferTarget({
+                  ...transferTarget,
+                  userId: e.target.value,
+                })
+              }
+              placeholder="user-id"
+              className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                data-testid="admin-transfer-confirm"
+                onClick={handleTransfer}
+                disabled={
+                  transferTarget.userId.trim().length === 0 ||
+                  busyId === transferTarget.leagueId
+                }
+                className="px-3 py-1.5 rounded-md bg-nuffle-gold text-white text-sm font-medium disabled:opacity-50"
+              >
+                Transferer
+              </button>
+              <button
+                type="button"
+                onClick={() => setTransferTarget(null)}
+                className="text-sm text-gray-600 hover:text-gray-800"
+              >
+                Annuler
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/tests/e2e-api/helpers/api.ts
+++ b/tests/e2e-api/helpers/api.ts
@@ -99,6 +99,25 @@ export async function rawGet(
   });
 }
 
+/**
+ * L2.C.6 — PATCH brut pour les routes admin (status / creator).
+ * Renvoie le `Response` natif sans parser, comme `rawGet` / `rawPost`.
+ */
+export async function rawPatch(
+  path: string,
+  token: string | null,
+  body: unknown,
+): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeader(token),
+    },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
 export async function put<TResponse = unknown>(
   path: string,
   token: string | null,

--- a/tests/e2e-api/specs/admin-leagues.spec.ts
+++ b/tests/e2e-api/specs/admin-leagues.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * L2.C.6 — E2E API : routes admin pour la gestion des ligues
+ * (Sprint Ligues v2 PR10).
+ *
+ * Couvre :
+ *  - Auth gates (401 sans token, 403 user non-admin).
+ *  - GET /admin/leagues : structure de reponse, filtres status,
+ *    pagination, seasonsCount.
+ *  - PATCH /admin/leagues/:id/status : force le status.
+ *  - POST /admin/leagues/:id/archive : raccourci status=archived.
+ *  - PATCH /admin/leagues/:id/creator : transfere le creator.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  get,
+  post,
+  rawGet,
+  rawPost,
+  rawPatch,
+  resetDb,
+  unwrap,
+} from "../helpers/api";
+import { seedAndLogin } from "../helpers/factories";
+
+interface AdminLeagueRow {
+  id: string;
+  name: string;
+  status: string;
+  creatorId: string;
+  seasonsCount: number;
+}
+
+interface AdminLeaguesListResponse {
+  data: { leagues: AdminLeagueRow[] };
+  meta: { total: number; limit: number; page: number };
+}
+
+interface CreatedLeague {
+  id: string;
+  status: string;
+}
+
+describe("E2E API — /admin/leagues", () => {
+  beforeEach(async () => {
+    await resetDb();
+  });
+
+  describe("auth gates", () => {
+    it("GET /admin/leagues sans token -> 401", async () => {
+      const res = await rawGet("/admin/leagues", null);
+      expect(res.status).toBe(401);
+    });
+
+    it("GET /admin/leagues avec user non-admin -> 403", async () => {
+      const { token } = await seedAndLogin(
+        "admin-leagues-user@e2e.test",
+        "pwd",
+        "Coach",
+      );
+      const res = await rawGet("/admin/leagues", token);
+      expect(res.status).toBe(403);
+    });
+
+    it("PATCH /admin/leagues/:id/status sans token -> 401", async () => {
+      const res = await rawPatch("/admin/leagues/abc/status", null, {
+        status: "archived",
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("with admin token", () => {
+    it("GET /admin/leagues retourne une enveloppe paginated avec leagues + meta", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-admin@e2e.test",
+        "pwd",
+        "AdminCoach",
+        { role: "admin" },
+      );
+      // Seed 2 ligues a partir de l'admin (le test admin user est
+      // creator).
+      await post("/leagues", admin.token, { name: "Open Cup" });
+      await post("/leagues", admin.token, {
+        name: "Closed Cup",
+        isPublic: false,
+      });
+
+      const res = await rawGet("/admin/leagues", admin.token);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as AdminLeaguesListResponse;
+      expect(json.data.leagues.length).toBeGreaterThanOrEqual(2);
+      expect(json.meta.limit).toBe(50);
+      const names = json.data.leagues.map((l) => l.name);
+      expect(names).toContain("Open Cup");
+      expect(names).toContain("Closed Cup");
+      // seasonsCount expose
+      const target = json.data.leagues.find((l) => l.name === "Open Cup");
+      expect(target?.seasonsCount).toBe(0);
+    });
+
+    it("GET /admin/leagues filtre par status", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-filter@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      await post("/leagues", admin.token, { name: "Active League" });
+
+      // Verifie default = draft.
+      const draftRes = await rawGet(
+        "/admin/leagues?status=draft",
+        admin.token,
+      );
+      const draftJson = (await draftRes.json()) as AdminLeaguesListResponse;
+      expect(
+        draftJson.data.leagues.every((l) => l.status === "draft"),
+      ).toBe(true);
+
+      // Filter on a status with no league should return empty.
+      const completedRes = await rawGet(
+        "/admin/leagues?status=completed",
+        admin.token,
+      );
+      const completedJson =
+        (await completedRes.json()) as AdminLeaguesListResponse;
+      expect(completedJson.data.leagues).toHaveLength(0);
+    });
+
+    it("PATCH /admin/leagues/:id/status passe une ligue de draft a archived", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-status@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      const league = unwrap(
+        await post<{ success: true; data: CreatedLeague }>(
+          "/leagues",
+          admin.token,
+          { name: "ToArchive" },
+        ),
+      );
+      expect(league.status).toBe("draft");
+
+      const res = await rawPatch(
+        `/admin/leagues/${league.id}/status`,
+        admin.token,
+        { status: "archived" },
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as {
+        data: { changed: boolean; status: string; previousStatus?: string };
+      };
+      expect(json.data.changed).toBe(true);
+      expect(json.data.status).toBe("archived");
+      expect(json.data.previousStatus).toBe("draft");
+
+      // Idempotence : 2e appel renvoie changed=false.
+      const res2 = await rawPatch(
+        `/admin/leagues/${league.id}/status`,
+        admin.token,
+        { status: "archived" },
+      );
+      const json2 = (await res2.json()) as { data: { changed: boolean } };
+      expect(json2.data.changed).toBe(false);
+    });
+
+    it("POST /admin/leagues/:id/archive est un raccourci", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-arch@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      const league = unwrap(
+        await post<{ success: true; data: CreatedLeague }>(
+          "/leagues",
+          admin.token,
+          { name: "QuickArchive" },
+        ),
+      );
+      const res = await rawPost(
+        `/admin/leagues/${league.id}/archive`,
+        admin.token,
+        {},
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as {
+        data: { status: string; changed: boolean };
+      };
+      expect(json.data.status).toBe("archived");
+      expect(json.data.changed).toBe(true);
+    });
+
+    it("PATCH /admin/leagues/:id/creator transfere a un autre user", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-tx@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      const target = await seedAndLogin(
+        "admin-leagues-target@e2e.test",
+        "pwd",
+        "Target",
+      );
+      const league = unwrap(
+        await post<{ success: true; data: CreatedLeague & { creatorId: string }
+        }>("/leagues", admin.token, { name: "ToTransfer" }),
+      );
+
+      const res = await rawPatch(
+        `/admin/leagues/${league.id}/creator`,
+        admin.token,
+        { userId: target.userId },
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as {
+        data: { creatorId: string; changed: boolean; previousCreatorId?: string };
+      };
+      expect(json.data.changed).toBe(true);
+      expect(json.data.creatorId).toBe(target.userId);
+    });
+
+    it("PATCH /admin/leagues/:id/creator -> 404 quand userId cible inexistant", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-tx2@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      const league = unwrap(
+        await post<{ success: true; data: CreatedLeague }>(
+          "/leagues",
+          admin.token,
+          { name: "Solo" },
+        ),
+      );
+      const res = await rawPatch(
+        `/admin/leagues/${league.id}/creator`,
+        admin.token,
+        { userId: "user-does-not-exist" },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("PATCH /admin/leagues/:id/status sur ligue inconnue -> 404", async () => {
+      const admin = await seedAndLogin(
+        "admin-leagues-404@e2e.test",
+        "pwd",
+        "Admin",
+        { role: "admin" },
+      );
+      const res = await rawPatch(
+        `/admin/leagues/missing-id/status`,
+        admin.token,
+        { status: "archived" },
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Résumé

Adds a comprehensive admin console for managing leagues globally, including:
- Paginated list with status filtering and name search
- Force status changes on any league (draft → archived, etc.)
- Quick archive action for empty leagues
- Creator transfer functionality to reassign leagues to other users

This feature is part of Sprint Ligues v2 PR10 and provides admins with tools to supervise and clean up the league catalog without needing to act as the league creator.

## Changes

### Frontend (`apps/web/app/admin/leagues/page.tsx`)
- New admin-only page with client-side auth gate (redirects non-admins to `/`)
- Displays paginated league list with:
  - Status badge and "Vide" (empty) badge for leagues with no seasons
  - Creator info (coach name or email)
  - Last updated date
- Filter controls: status dropdown and name search input
- Per-league actions:
  - Status selector dropdown
  - Archive button (hidden for already-archived leagues)
  - Transfer creator button with modal dialog
- Modal for entering target user ID when transferring creator

### Backend (`apps/server/src/routes/admin-leagues.ts`)
- Four new admin-protected endpoints:
  - `GET /admin/leagues` — List with pagination, status/search filters, season counts
  - `PATCH /admin/leagues/:id/status` — Force league status (idempotent)
  - `POST /admin/leagues/:id/archive` — Shortcut to set status=archived
  - `PATCH /admin/leagues/:id/creator` — Transfer creator to another user
- All routes require `authUser` + `adminOnly` middleware
- Includes proper error handling (404 for missing leagues/users, validation)
- Server logging for audit trail

### Schemas (`apps/server/src/schemas/admin-leagues.schemas.ts`)
- Zod validation schemas for query parameters and request bodies
- Supports status enum, search string, pagination (limit/offset)

### Tests (`tests/e2e-api/specs/admin-leagues.spec.ts`)
- Auth gate tests (401 without token, 403 for non-admin users)
- List endpoint tests (response structure, filtering, pagination, seasonsCount)
- Status change tests (idempotence, previous status tracking)
- Archive shortcut test
- Creator transfer tests (success, 404 for missing user)
- Helper function `rawPatch` added to test utilities

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (E2E API tests cover all endpoints and auth gates)
- [x] Tests e2e (264 lines of comprehensive API tests)
- [ ] Changeset ajouté (to be added by maintainer)

https://claude.ai/code/session_01Kra7z5xyDvQZGzFkhpAofq