### PR TITLE
docs: Update TODO roadmap — Ligues v2 sprint completion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO — Nuffle Arena (Blood Bowl 3 Online)
 
-> Derniere mise a jour : 2026-05-04
+> Derniere mise a jour : 2026-05-05
 > Version actuelle : v1.73.0 (beta ouverte au public).
 >
 > La roadmap v1 (Sprints 0-23, Phases A-Q, 201 taches livrees) est
@@ -15,11 +15,8 @@ prete a accueillir les phases R+).
 ## Priorite immediate
 
 - [**SPRINT Ligues v2 — Gestion complete des ligues Blood Bowl**](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
-  — **P0** — Sprint dedie a transformer l'infrastructure ligues
-  (Sprint 17 archive) en produit utilisable : creation UI, inscription,
-  calendrier auto round-robin, forfait, Jeu en Ligue post-match,
-  awards de saison. Decoupe en 3 lots (MVP / Jeu en Ligue / Polish),
-  ~12 jours, 7 PR planifiees. A demarrer immediatement.
+  — **TERMINE** (Lots A/B/C livres en PRs #535-#545). Restes optionnels
+  reportes en backlog ci-dessous.
 
 ## Suivi qualite actif
 
@@ -29,4 +26,23 @@ prete a accueillir les phases R+).
 
 ## Backlog
 
-(a definir post-Sprint Ligues v2 selon retours beta et priorites)
+### Ligues v2 — restes optionnels
+
+- [ ] **L2.C.4 — Promotion/relegation multi-tier** (Backend, L)
+  Modele `LeagueTier` (D1/D2/D3) avec `League.tierId`. Service
+  `applyPromotionRelegation(leagueId)` : top 2 montent / bottom 2
+  descendent au passage de saison. Reporte de
+  [`SPRINT-leagues-v2`](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
+  (L2.C.4) — explicitement marque optionnel. A activer si demande
+  utilisateur (ligues longues, structure pyramidale).
+
+- [ ] **L2.C.7 — Mobile parite ligues** (Mobile, L)
+  Sur l'app Expo (`apps/mobile/app/leagues/`) : liste, detail saison,
+  calendrier, classement, bouton inscription, bouton "Lancer match"
+  qui redirige vers le flow match existant. Reporte de
+  [`SPRINT-leagues-v2`](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
+  (L2.C.7). Reutilise i18n module S27.3.
+
+### Autres
+
+(a definir selon retours beta et priorites)


### PR DESCRIPTION
## Résumé

- [x] Marquer le sprint Ligues v2 comme terminé (PRs #535-#545 livrées)
- [x] Réorganiser le backlog pour isoler les tâches optionnelles reportées
- [x] Documenter les deux tâches optionnelles (L2.C.4 promotion/relégation, L2.C.7 parité mobile)
- [x] Mettre à jour la date de dernière mise à jour (2026-05-05)

## Détails

Le sprint Ligues v2 est maintenant marqué comme **TERMINE** avec les trois lots (A/B/C) livrés. Les tâches optionnelles qui n'ont pas été incluses dans le MVP sont documentées dans une nouvelle section "Ligues v2 — restes optionnels" du backlog :

- **L2.C.4** : Promotion/relégation multi-tier (modèle `LeagueTier`, service `applyPromotionRelegation`)
- **L2.C.7** : Parité mobile pour les ligues (UI Expo, intégration avec le flow match existant)

Ces tâches sont explicitement marquées comme optionnelles et peuvent être activées selon les retours utilisateurs.

## Checklist

- [x] Lint / Types OK (documentation uniquement)
- [x] Tests unitaires (N/A — changement de documentation)
- [x] Tests e2e (N/A — changement de documentation)
- [x] Changeset ajouté (N/A — mise à jour de roadmap)

https://claude.ai/code/session_01Kra7z5xyDvQZGzFkhpAofq