### PR TITLE
docs: add Pro League sprint and future ideas backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO — Nuffle Arena (Blood Bowl 3 Online)
 
-> Derniere mise a jour : 2026-05-04
+> Derniere mise a jour : 2026-05-05
 > Version actuelle : v1.73.0 (beta ouverte au public).
 >
 > La roadmap v1 (Sprints 0-23, Phases A-Q, 201 taches livrees) est
@@ -20,6 +20,18 @@ prete a accueillir les phases R+).
   calendrier auto round-robin, forfait, Jeu en Ligue post-match,
   awards de saison. Decoupe en 3 lots (MVP / Jeu en Ligue / Polish),
   ~12 jours, 7 PR planifiees. A demarrer immediatement.
+
+- [**SPRINT Pro League — Championnat virtuel + Paris MVP**](./docs/roadmap/sprints/SPRINT-pro-league.md)
+  — **P1** (post-Ligues v2) — Championnat permanent 16 equipes IA vs IA
+  (hommages NFL × races BB), matchs auto diffuses live le mardi 21h, paris
+  en Crowns, mode spectateur/fan, Nuffle Gazette LLM quotidienne. **Phase 0
+  sim foundation bloquante** (8 sem : behavior trees, profils tactiques,
+  variance Nuffle, bench harness, validation panel humain). **Phase 1 MVP**
+  (4 sem : data model, broadcaster live SSE, UI, paris, Gazette,
+  casualties, HoF light). Calendrier aligne saison NFL 2026-27 (kickoff
+  cible 5 sept 2026). Backlog idees differees (MPG-layer mercato,
+  multi-leagues, weather sync IRL...) consigne dans
+  [`docs/roadmap/backlog/future-ideas.md`](./docs/roadmap/backlog/future-ideas.md).
 
 ## Suivi qualite actif
 

--- a/docs/roadmap/backlog/future-ideas.md
+++ b/docs/roadmap/backlog/future-ideas.md
@@ -1,0 +1,335 @@
+# Backlog — Idees futures (Pro League & engagement async)
+
+> Derniere mise a jour : 2026-05-05
+> Statut : **idees consignees**, non scopees.
+> Ces items ont ete brainstormes lors de la conception du SPRINT Pro League
+> ([sprints/SPRINT-pro-league.md](../sprints/SPRINT-pro-league.md)) puis
+> exclus volontairement du MVP pour eviter la sur-ingenierie.
+> **Aucune de ces idees ne doit etre attaquee** tant que les KPI MVP du
+> SPRINT Pro League ne sont pas atteints (cf. section "Gate de reactivation"
+> en bas).
+
+## 0. Pourquoi ce backlog
+
+Lors de la conception du SPRINT Pro League, plusieurs directions audacieuses
+ont ete explorees (MPG-layer mercato, weather sync IRL, NFL Twin Mirror,
+Twitch auto-cast, etc.). On les a ecartees du MVP par discipline produit :
+**si le MVP ne trouve pas son audience, ces extensions n'ont pas de sens**.
+
+Ce document garde la **memoire produit** : si demain on decide d'avancer, on
+reprend la reflexion ici plutot que de tout re-explorer.
+
+## Gate de reactivation
+
+Les items de ce backlog ne sont **pas reactivables a la legere**. Pre-requis
+generiques avant d'attaquer **n'importe quel item ci-dessous** :
+
+| KPI MVP Pro League | Cible minimale |
+|--------------------|----------------|
+| Coachs uniques ayant place >=1 pari/semaine | >= 100 |
+| Spectateurs simultanes pic mardi 21h | >= 200 |
+| Retention J30 (utilisateurs revenant 30j apres 1er pari) | >= 35% |
+| NPS beta + early users | >= 40 |
+| Saison complete livree sans bug bloquant | 1 saison reussie minimum |
+
+Si ces seuils sont atteints, on peut piocher dans le backlog par ordre de ROI
+estime. Sinon, on itere sur le MVP avant tout.
+
+---
+
+## 1. MPG-layer (mercato + lineups + ligues privees) [ITEM PHARE]
+
+**Concept** : couche fantasy par-dessus la Pro League. Les coachs creent des
+**ligues privees entre amis** (6-10 membres), draftent via mercato hebdo des
+**joueurs de la Pro League**, composent leur 11 chaque journee. Le score est
+calcule a partir des perfs simulees des joueurs. Equivalent direct de MPG.
+
+**Modeles Prisma envisages** :
+```
+FantasyLeague        # ligue privee d'amis
+FantasyLeagueMember  # coach + budget mercato + roster
+FantasyRoster        # joueurs detenus
+FantasyLineup        # composition de la semaine N (titulaires, banc, capitaine)
+FantasyTransfer      # encheres mercato hebdo (Vickrey)
+PlayerWeekRating     # note 0-10 calculee depuis MatchEvents
+```
+
+**Pourquoi differe** :
+- Triple la complexite produit/UI/regles.
+- N'a de sens que si la Pro League fait deja vibrer une vraie audience.
+- L'economie Crowns du MVP (gagnees en pariant) devient le **budget mercato
+  initial** : crucial pour la peception "fair" mais necessite que le MVP
+  fasse circuler suffisamment de Crowns avant.
+
+**Gate specifique** : >= 100 utilisateurs avec >= 5000 Crowns au wallet
+(donc actifs depuis >= 1 mois) + retention J30 >= 35%.
+
+**Effort estime a la reactivation** : 6-8 semaines.
+
+## 2. Multi-leagues (Old World League #2, Gridiron League foot US flavored)
+
+**Concept** : ouvrir une 2e Pro League apres la S1 reussie.
+- **Old World League #2** : nouveau roster d'equipes (16 hommages NFL non
+  utilises au MVP : Texans, Broncos, Lions, Bengals, etc.).
+- **Gridiron League** : alternative thematique pure foot US, equipes "Steel
+  City Hammers", "Kansas Plains Flyers" sans melange races BB → un univers
+  homogene foot US fantasy.
+
+**Pourquoi differe** : multiplication de la sim engine load + complexite UI +
+risque de diluer l'audience. Pertinent uniquement avec >= 500 utilisateurs
+actifs sur OWL #1.
+
+**Effort** : 2-3 sem (reutilise infra MVP) + 1 sem tuning par nouvelle ligue.
+
+## 3. Cross-over PvP (prets joueurs, XP partagee)
+
+**Concept** : un coach actif sur le mode PvP existant peut "preter" un star
+player de son equipe Pro League favorite (suivi via SpectatorFollow) pour
+booster ses matchs PvP. Ou inversement : un joueur qui performe dans son
+equipe PvP gagne XP qui se traduit en bonus narratif Pro League.
+
+**Pourquoi differe** :
+- Risque de cassure de l'equilibre PvP existant.
+- Mecanique meta complexe a expliquer.
+- Pertinent uniquement si les deux modes ont chacun une vraie traction.
+
+**Idee design** : pret limite a 1 match, bonus mineurs (+ aura, narrative
+flair), pas de stat boost direct.
+
+## 4. Weather Sync IRL
+
+**Concept** : la meteo reelle de la ville d'une equipe influence le match.
+Pittsburgh Smashers jouent sous la pluie si Pittsburgh PA est en alerte
+meteo le jour du match.
+
+**Pourquoi audacieux et viral** : aucun jeu ne fait ca. Differenciateur
+poetique. Crea moments uniques impossibles a reproduire = partages.
+
+**Pourquoi differe** :
+- Necessite integration API meteo fiable (OpenWeather ~free, Tomorrow.io payant).
+- Risque de paraitre gimmicky si mal dose.
+- A tester en flag opt-in avant d'imposer.
+
+**Effort** : 1 sem (API integration + regles weather mapping).
+
+## 5. NFL Twin Mirror
+
+**Concept** : le coach "lie" son equipe Pro League favorite a une franchise
+NFL reelle. Si Mahomes se blesse, le QB elf de Kansas City Soaring Hawks est
+"blesse" (MNG 1 match). Trade NFL = trade fantasy auto propose.
+
+**Pourquoi audacieux** : hook fan NFL + double couverture mediatique.
+
+**Pourquoi differe** :
+- Necessite scraping/API NFL (sportsdata.io ~100 €/mois).
+- Risque deséquilibre sim si trop deterministe par evt NFL.
+- Encore plus sensible juridiquement (lien explicite NFL).
+
+**Effort** : 2 sem.
+
+## 6. Twitch Auto-Cast 24/7
+
+**Concept** : chaine Twitch officielle qui stream **en continu** des replays
+de matchs Pro League aleatoires, avec 2 commentateurs IA generes en temps
+reel (un serieux, un drunk uncle complotiste). Highlights auto-clippes vers
+TikTok/YouTube Shorts.
+
+**Pourquoi audacieux** : machine a memes + viralite = PR gratuit a vie.
+
+**Pourquoi differe** :
+- Cout transcoding Twitch.
+- Outil custom de rendering Pixi → video stream + TTS LLM = stack lourde.
+- Modeling juridique du "stream automatique" (DMCA, Twitch policies).
+
+**Effort** : 4 sem (lourd, infra-heavy).
+
+## 7. Pep Talk push (notification 2 min avant kickoff)
+
+**Concept** : push 2 min avant le match : "Tap pour parler a ton equipe". Le
+coach (s'il a une equipe en Pro League en V2 mercato) tape 3 mots-cles ou
+choisit un ton, l'IA genere un pep talk qui boost stats specifiques selon
+l'emotion detectee.
+
+**Pourquoi differe** : depend de la couche V2 mercato (item #1). Pas de sens
+au MVP ou les equipes sont 100% IA.
+
+**Effort** : 1 sem (post-V2 mercato).
+
+## 8. Conferences de presse interactives
+
+**Concept** : apres chaque match, journalistes IA posent 3 questions au
+coach. Reponses (choix multiples ou texte libre) impactent moral equipe,
+fans, rivaux. Gaffe = scandale = storyline Gazette.
+
+**Pourquoi differe** : depend de la couche V2 mercato.
+
+**Effort** : 2 sem.
+
+## 9. Promotion / relegation pyramidale
+
+**Concept** : 8+ divisions persistantes mondiales. Promotion enivrante,
+relegation traumatique. Saison de 6-8 semaines reelles.
+
+**Pourquoi differe** : necessite >= 5 ligues actives donc >= 80 equipes.
+Aucun sens au MVP a 1 ligue de 16 equipes.
+
+**Effort** : 3 sem (post-multi-leagues item #2).
+
+## 10. Insurance Brokerage P2P
+
+**Concept** : marche P2P d'assurances joueurs. Un coach vend une police "si
+ton star meurt, je te file 500 Crowns" a un autre coach. Cree derives
+financiers ludiques facon Lloyd's of London nain.
+
+**Pourquoi audacieux** : profondeur meta-economique unique.
+
+**Pourquoi differe** : necessite la couche V2 mercato (item #1) + masse
+critique d'utilisateurs (>= 200) pour avoir un marche liquide.
+
+**Effort** : 2 sem (post-V2).
+
+## 11. Survivor Pick'em hebdo
+
+**Concept** : chaque semaine, choisis 1 equipe gagnante de Pro League. Faux
+= elimine. Dernier survivant = trophee saisonnier + skin legendaire. Une
+seule equipe utilisable par saison.
+
+**Pourquoi differe** : add-on pari complementaire, mais MVP a deja >= 6
+markets par match. A reactiver si l'engagement paris est solide mais qu'on
+veut une couche FOMO additionnelle.
+
+**Effort** : 1 sem (reutilise wallet + bet infra MVP).
+
+## 12. Loan Wager (pari de star player entre coachs)
+
+**Concept** : avant un duel coach vs coach (en mode V2), chacun met en gage
+un joueur de sa fantasy team. Le perdant le prete 3 matchs au gagnant.
+Risque de blessure pendant le pret = perte seche.
+
+**Pourquoi differe** : depend de V2 mercato.
+
+**Effort** : 1 sem (post-V2).
+
+## 13. Hall of Fame eternel inter-saisons
+
+**Concept** : les joueurs qui prennent leur retraite avec une carriere
+legendaire (>= 200 TD ou >= 50 kills) entrent au HoF ETERNEL visible par
+TOUS les joueurs du monde a jamais. Statue dans la cathedrale virtuelle.
+Descendants proceduraux portant son nom emergent dans les drafts d'autres
+joueurs avec un buff "heritage".
+
+**Pourquoi differe** : item HoF "light" deja inclus au MVP. Version
+"eternelle" + descendants procedural = scope V2/V3.
+
+**Effort** : 2 sem (post-V2).
+
+## 14. Ligues thematiques limitees
+
+**Concept** : tournois flash week-end : "Coupe des Maudits" (que des morts-
+vivants), "Tournoi de Sang" (blessures permanentes activees), "Skaven Only
+League". Recompenses cosmetiques exclusives.
+
+**Pourquoi differe** : cosmetiques pas implementes au MVP. A tracer comme
+extension post-monetisation cosmetique.
+
+**Effort** : 1-2 sem.
+
+## 15. Cartes joueurs collectibles (Sorare-style sans NFT)
+
+**Concept** : chaque joueur de la Pro League a une carte avec rarete visuelle
+(Common / Rare / Super Rare / Unique). Score auto base sur perf des matchs
+auto. Possession emotionnelle d'un joueur. Galaxy brain.
+
+**Pourquoi differe** : depend de V2 mercato. Risque de complexifier si
+ajoute trop tot.
+
+**Effort** : 3 sem (post-V2).
+
+## 16. Permadeath Franchise (mode hardcore)
+
+**Concept** : mode opt-in ou si tu te fais releguer 3 saisons de suite, ta
+franchise est dissoute definitivement. Tu repars de zero, gardes 1 veteran
+qui devient ton coach legendaire. Cimetiere des franchises mortes
+consultable.
+
+**Pourquoi differe** : necessite multi-ligues + relegation (item #9). Mode
+streamer-friendly mais pas au MVP.
+
+**Effort** : 1 sem (post-#9).
+
+## 17. AR / scan figurine GW
+
+**Concept** : pointe ton telephone vers une figurine BB GW (ou peinte par
+un pote, ou un dessin) → IA scanne, genere un joueur unique dans ton roster
+avec couleurs/nom/histoire/stats equilibrees. Edition limitee : scan en
+magasin partenaire = joueur ultra-rare geolocalisé.
+
+**Pourquoi audacieux** : pont collectionneurs / digitaux, partenariat
+naturel GW.
+
+**Pourquoi differe** : tech AR + ML lourde, partenariat GW complexe,
+scope post-1.0.
+
+**Effort** : 4-6 sem.
+
+## 18. Multiverse / ligues parallel weird
+
+**Concept** : ton equipe a 6 doppelgangers dans des ligues parallles aux
+regles barrees : Underwater (sous l'eau, ralenti), Lovecraft (folie
+progressive), Disco (danse-off pour resoudre tackles), Speedrun (1 min/
+match), Inverse (perdre = gagner), Permadeath. Reliques cross-univers
+buffant l'equipe principale.
+
+**Pourquoi audacieux** : memes infinis, contenu UGC enorme.
+
+**Pourquoi differe** : meme remarque que #16, scope post-1.0 et
+necessite stack multi-ligues mature.
+
+**Effort** : 6+ sem.
+
+---
+
+## Synthese de la matrice "Quand reactiver quoi"
+
+| Item | Pre-requis | Effort | Priorite si gate atteint |
+|------|-----------|--------|--------------------------|
+| **#1 MPG-layer** | 100 users actifs + 35% retention J30 | 6-8 sem | **P0** |
+| #11 Survivor Pick'em | MVP paris stable | 1 sem | P1 (quick win) |
+| #4 Weather Sync | MVP stable | 1 sem | P1 (differenciateur facile) |
+| #2 Multi-leagues | 500 users actifs | 3 sem | P2 |
+| #6 Twitch Auto-Cast | 1000 users actifs | 4 sem | P2 (impact PR) |
+| #7 Pep Talk | Item #1 livre | 1 sem | P2 |
+| #5 NFL Twin Mirror | Item #1 livre + budget API NFL | 2 sem | P2 |
+| #15 Cartes collectibles | Item #1 livre | 3 sem | P2 |
+| #10 Insurance Brokerage | Item #1 + 200 users | 2 sem | P3 |
+| #3 Cross-over PvP | Item #1 + audit balance PvP | 3 sem | P3 |
+| #8 Conferences presse | Item #1 livre | 2 sem | P3 |
+| #12 Loan Wager | Item #1 livre | 1 sem | P3 |
+| #9 Promotion/relegation | Item #2 livre (multi-leagues) | 3 sem | P3 |
+| #13 HoF eternel + heritage | Item #1 livre | 2 sem | P3 |
+| #16 Permadeath Franchise | Items #2, #9 livres | 1 sem | P4 |
+| #14 Ligues thematiques | Cosmetiques implementes | 1-2 sem | P4 |
+| #17 AR scan figurines | Partenariat GW + ML team | 4-6 sem | P4 |
+| #18 Multiverse | Stack multi-ligues mature | 6+ sem | P4 |
+
+---
+
+## Process de reactivation
+
+Si un KPI MVP atteint son seuil et qu'un item devient pertinent :
+1. Ouvrir une issue GitHub "Reactivation backlog : <nom item>".
+2. Re-evaluer le scope a froid (les hypotheses ont 6+ mois, peuvent etre
+   obsoletes).
+3. Confronter aux donnees terrain (analytics MVP) avant scoping.
+4. Sortir un sprint dedie dans `docs/roadmap/sprints/` avec la rigueur du
+   sprint pro-league (Phase 0 testing + Phase 1 livraison).
+5. Mettre a jour ce document : marquer l'item "REACTIVE" avec lien sprint.
+
+## Sources
+
+- Audit produit + brainstorm conduit le 2026-05-05 par 5 agents en parallele
+  (game design / paris / paysage concurrentiel / architecture technique /
+  moonshots).
+- Conversation produit transcrit dans le ticket de design Pro League.
+- Inspirations : MPG (Mon Petit Gazon), Hattrick, FM, OOTP, Sorare, NFL
+  Fantasy, FUMBBL, NAF.

--- a/docs/roadmap/phases.md
+++ b/docs/roadmap/phases.md
@@ -1,6 +1,6 @@
 # Roadmap v2 — Sprints 24-27
 
-> Derniere mise a jour : 2026-04-27
+> Derniere mise a jour : 2026-05-05
 > Contexte : v1.74.0 livree (beta publique). Roadmap v1 archivee dans
 > [`archive/v1.73/`](./archive/v1.73/README.md). Cette nouvelle roadmap
 > couvre les 4 sprints suivants, derives d'un audit a 10 agents.
@@ -14,6 +14,7 @@
 | **S26** | Refactor + Retention & engagement (page.tsx prerequis, achievements, profil, ligues) | [sprints/S26-retention-engagement.md](./sprints/S26-retention-engagement.md) | TERMINE |
 | **S27** | Evolutions & confort (esport, mobile parite, S4 skeleton, audit log, B0.1 residuels) | [sprints/S27-evolutions-confort.md](./sprints/S27-evolutions-confort.md) | A faire |
 | **Ligues v2** | **PRIORITE** Gestion complete des ligues BB (creation UI, inscription, calendrier auto, forfait, Jeu en Ligue post-match, awards) | [sprints/SPRINT-leagues-v2.md](./sprints/SPRINT-leagues-v2.md) | A faire (P0) |
+| **Pro League** | Championnat virtuel 16 equipes IA vs IA (hommages NFL × races BB), matchs auto diffuses live le mardi 21h, paris en Crowns, mode spectateur/fan, Nuffle Gazette LLM. Phase 0 sim foundation bloquante (8 sem) + Phase 1 MVP (4 sem) | [sprints/SPRINT-pro-league.md](./sprints/SPRINT-pro-league.md) | A faire (P1, post-Ligues v2) |
 
 ## Suivi qualite actif
 
@@ -27,6 +28,7 @@
 | Faux positifs (deja faits) | A.9 badge connexion, I.6 specialRules star players, O.2 / O.3 audit S2/S3 |
 | Differes (non prioritaires) | Replay public sharable, OpenTelemetry full, CodeQL CI, lore par equipe, season passes / cosmetics premium |
 | Hors scope 4 sprints | E2E mobile Detox/Appium (chantier complet, 1 sprint dedie a prevoir) |
+| Backlog idees Pro League differees | MPG-layer mercato, multi-leagues, weather sync IRL, NFL Twin Mirror, Twitch auto-cast, etc. — voir [`backlog/future-ideas.md`](./backlog/future-ideas.md) |
 
 ## Source
 

--- a/docs/roadmap/sprints/SPRINT-pro-league.md
+++ b/docs/roadmap/sprints/SPRINT-pro-league.md
@@ -1,0 +1,412 @@
+# SPRINT Pro League — Championnat virtuel Blood Bowl + Paris MVP
+
+> Statut : A faire (P1, demarre apres SPRINT Ligues v2)
+> Duree cible : ~12 semaines (Phase 0 = 8 sem bloquant, Phase 1 = 4 sem MVP)
+> Theme : creer un championnat IA vs IA permanent (16 equipes hommages NFL),
+> matchs auto diffuses "live" le mardi 21h, paris en monnaie virtuelle (Crowns),
+> mode spectateur/fan, narratif quotidien (Nuffle Gazette LLM).
+> Pre-requis : SPRINT Ligues v2 livre (reutilise infra LeagueSeason / standings).
+
+## Contexte
+
+Aujourd'hui Nuffle Arena propose **uniquement du PvP synchrone** (matchs joues
+en personne). Trois constats :
+
+1. **Trou de marche BB** : aucun produit (Cyanide BB3, FUMBBL, NAF) ne propose
+   un format "saison reguliere round-robin permanente" type Ligue 1 / NFL. Tous
+   les tournois officiels sont en elimination directe ou Swiss.
+2. **Engagement async manquant** : entre deux matchs PvP, le coach n'a rien a
+   suivre, rien a anticiper, pas de second-screen.
+3. **Audience superieure aux coachs** : sur les jeux a succes (FM, Hattrick,
+   MPG), les fans/spectateurs sont 3x plus nombreux que les managers actifs.
+
+Ce sprint cree un **championnat virtuel "Old World League"** de 16 equipes
+gerees par le systeme, dont les matchs se simulent automatiquement et se
+diffusent en direct le mardi 21h. Les utilisateurs **parient en Crowns**, gagnent
+des badges, suivent leur equipe favorite, lisent une Gazette quotidienne
+generee par LLM.
+
+**Inspirations produit** : MPG (mecaniques d'enjeu hebdo, communaute), Hattrick
+(rendez-vous social fixe), Football Manager (live ticker + narratif),
+ESPN/Sorare (cartes joueurs + scoring auto). **Inspiration narrative** : NFL
+(homages reconnaissables sans utiliser les marques), univers Games Workshop
+(Blood Bowl, Spike Magazine, Nuffle).
+
+**Objectif strategique** : prouver l'engagement d'un mode async avant
+d'engager la complexite d'une couche fantasy/mercato (consignee en backlog,
+voir [`docs/roadmap/backlog/future-ideas.md`](../backlog/future-ideas.md)).
+
+## Vision MVP
+
+| Element | MVP |
+|---------|-----|
+| **Championnat** | 1 seule "Old World League", 16 equipes IA, 1 saison de 15 journees |
+| **Equipes** | Rosters fixes pre-construits, hommages NFL × races BB |
+| **Calendrier** | Round-robin simple, 2 matchs/semaine, mardi 21h heure serveur |
+| **Sim** | Hybride (drives haut niveau + key moments resolus par game-engine) |
+| **Diffusion** | "Live" SSE : sim pre-calculee T-24h, events dispatched a l'heure reelle |
+| **Paris** | 1N2 + over/under TD + MVP du match + casualty count, en Crowns gagnees uniquement |
+| **Crowns** | Monnaie 100% earned (jamais achetable, jamais cashable) |
+| **Engagement** | Leaderboards parieurs hebdo/saison, badges/titres, mode spectateur/fan, Nuffle Gazette LLM quotidienne |
+| **Casualties** | Identite BB preservee : MNG / niggling / -stat / DEAD persistants. Hall of Fame light pour les stars retires/morts |
+
+## Hors scope (consigne backlog)
+
+Tout ce qui suit est documente dans
+[`docs/roadmap/backlog/future-ideas.md`](../backlog/future-ideas.md) et **ne sera
+pas attaque** tant que les KPI MVP (volume coachs actifs, retention 30j) ne
+sont pas atteints :
+
+- Couche MPG-style (mercato, drafts, lineups, capitaine, ligues privees)
+- Multi-leagues (Old World League #2, Gridiron League foot US flavored)
+- Cross-over PvP (prets joueurs, XP partagee)
+- Weather sync IRL, NFL Twin Mirror, Twitch auto-cast
+- Pep Talk push, conferences de presse interactives
+- Promotion/relegation pyramidale (necessite >= 2 ligues)
+
+## Decoupage en phases
+
+| Phase | Theme | Objectif livrable | Duree |
+|-------|-------|-------------------|-------|
+| **0** | Sim Foundation (gate bloquant) | Sim engine credible + 16 profils tactiques + bench harness valide stat & humain | ~8 sem |
+| **1** | MVP Pro League + Paris | Saison playable, diffusion live, paris MVP, Gazette, mode fan | ~4 sem |
+
+**Gate Phase 0 → Phase 1** : si la validation humaine (panel BB experts) note
+< 6.5/10 sur "lisibilite tactique" ou si les benchs statistiques devient de
+> 10% des refs FUMBBL, **on n'attaque pas la Phase 1**. La Phase 0 boucle
+jusqu'a passer le gate.
+
+---
+
+## Phase 0 — Sim Foundation (8 sem, BLOQUANT)
+
+### Lot 0.A — Architecture sim engine (~2 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 0.A.1 | Nouveau package `packages/sim-engine` | Backend | M | [ ] | Workspace pnpm, build TS, depend de `packages/game-engine` (regles, dices, types). Interface publique : `simulateMatch(input: SimInput): SimResult`. Output : `{result, events: MatchEvent[], summary, casualties[], engineVer}`. |
+| 0.A.2 | Driver hybride (drive-level + key moments) | Backend | L | [ ] | Boucle haut niveau : kickoff → drive → resolution turn-by-turn des actions critiques (block, dodge, pass, turnover) via `game-engine` actions. Drives non-critiques resolus en proba (avancement yards + fumble chance). Garde la possibilite de basculer en `full` driver plus tard sans casser les events. |
+| 0.A.3 | Format `MatchEvent` typé partage | Types | M | [ ] | `packages/shared-types/match-event.ts` : enum `EventType` (KICKOFF / TURN_START / BLOCK / DODGE / PASS / TD / KO / CASUALTY / TURNOVER / NUFFLE / HALFTIME / END). Champs `displayAtMs` (offset depuis kickoff pour la diffusion live), `seed`, `meta`. Versionne via `engineVer`. |
+| 0.A.4 | PRNG seede + injection partout | Backend | M | [ ] | `packages/sim-engine/rng/seeded.ts` (xoroshiro). Banni `Math.random` du package via lint custom (`no-restricted-globals`). Tout consommateur recoit le PRNG en parametre. Permet replay deterministe + audit. |
+| 0.A.5 | Resolvers actions BB | Backend | L | [ ] | `resolvers/{block,dodge,pass,pickup,gfi,foul}.ts` consomment `game-engine` rules (skills, modifiers, weather) pour rester strict regle. Output : `{success, newState, events[]}`. Couverture par tests unitaires sur cas typiques + cas edge (skill stack, double-skull, etc.). |
+
+### Lot 0.B — Profils tactiques 16 equipes (~2 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 0.B.1 | Behavior tree + patterns library | Backend | XL | [ ] | `ai/strategy/` (cage-build, breakaway, defensive-screen, blitz-train, stall, foul-fest), `ai/tactics/patterns/` (cage-formation, line-grind, pass-route-deep, wedge, screen). 3 passes par tour : evaluer situation → choisir strategie → executer pattern. Garantit coherence narrative des drives. |
+| 0.B.2 | Type `TacticalProfile` + schema Zod | Types | S | [ ] | ~15 parametres : bashIndex, passingFrequency, riskAppetite, cageAffinity, blitzPriority, reroll_usage, pace, foulFrequency, stallTendency, kickReturn, etc. Validation Zod cote sim-engine. Profile stocke en JSON sur `ProTeam.tactics`. |
+| 0.B.3 | 16 profils raciaux pour les 16 equipes Pro League | Content | L | [ ] | Mapping NFL × race BB (cf. tableau "Mapping 16 equipes" plus bas). Chaque profil parametre pour refleter l'identite : Pittsburgh Smashers (Orcs, bash 85, pace measured), Kansas City Soaring Hawks (Wood Elves, passing 75, risk 70), etc. Tunable. |
+| 0.B.4 | Memoire partielle d'etat de match (momentum) | Backend | M | [ ] | Forme par joueur : `hot` apres 2+ TD ou 3+ blocks reussis (+1 confiance temporaire), `cold` apres echecs en chaine. Memoire mensuelle visible publiquement. Alimente la Gazette et les paris. |
+| 0.B.5 | Temperature IA (decisions sub-optimales controlees) | Backend | M | [ ] | Au lieu de toujours prendre l'action max-EV, sample sur top-K avec poids dependant du profil (`riskAppetite` → temperature). Genere variance entre matchs identiques sur le papier. |
+
+### Lot 0.C — Variance & Nuffle moments (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 0.C.1 | Bibliotheque "Eye of Nuffle" events | Content + Backend | M | [ ] | ~25-30 events scriptes avec probabilites : rookie_brilliance (3%), crowd_riot (1%), sudden_inspiration (4%), weather_shift (5%), tantrum_star (2%), banana_skin (2%), bombardier_gone_wild (1%), nemesis_clash (3%), etc. Chacun emet un `MatchEvent` type `NUFFLE` annonce par le ticker. |
+| 0.C.2 | Hooks injection Nuffle events | Backend | S | [ ] | Le driver hybride invoque le rolleur Nuffle a chaque debut de tour. Effets appliques au state via PRNG seede. Events stockes en DB pour replay et alimentation Gazette. |
+| 0.C.3 | Boost variance underdog (subtil) | Backend | S | [ ] | Si TV gap > 200 ou pre-match win prob < 15%, +10% sur les rolls critiques cote underdog. Non visible utilisateur. Cible : upset rate 12-18% (pas 5%). |
+| 0.C.4 | Streaks/forme cross-match | Backend | S | [ ] | Persiste `PlayerForm` (hot/normal/cold) entre matchs. Decay sur 3 matchs. Visible sur la fiche joueur publique. |
+
+### Lot 0.D — Bench harness (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 0.D.1 | CLI `pnpm sim:bench` | DevX | M | [ ] | Script `packages/sim-engine/scripts/bench.ts` : `--team=A vs --team=B --runs=10000` simule en parallele worker_threads, sort un rapport stat (TDs/match, casualties, turnovers, win%, std dev, p5/p95). Optionnel `--matrix` pour toutes les races. |
+| 0.D.2 | Dataset reference FUMBBL | Data | M | [ ] | Scraper / import statique des stats publiques FUMBBL : winrates par race, casualty rates, TD averages, durees de drive. Stocke en `packages/sim-engine/bench/reference-fumbbl.json` versionne. |
+| 0.D.3 | Metriques "vivacite" (variance & outliers) | DevX | S | [ ] | Au-dela des moyennes : std dev, fat-tails (% matchs avec >= 5 TD, >= 4 casualties), upset rate, distribution MVP (Gini coefficient). Cible MVP : std dev TD >= 1.4, upset rate 12-18%, MVP non concentre uniquement sur stars. |
+| 0.D.4 | CI regression `sim-bench` | DevX | M | [ ] | `.github/workflows/sim-bench.yml` : sur chaque PR touchant `packages/sim-engine`, run `--runs=5000` vs `bench-baseline.json`. Alerte si deviation > 5% sur metriques cles. Baseline versionne avec `engineVer`. |
+
+### Lot 0.E — Tuning loop + Human playtest gate (~2 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 0.E.1 | Iteration tuning profils | Tuning | XL | [ ] | Boucle : run bench → identifier deltas vs FUMBBL (>10%) → ajuster profils (bashIndex, riskAppetite, etc.) → re-run. Objectif : tous les matchups raciaux dans ±10% du winrate FUMBBL. Documenter ajustements dans `packages/sim-engine/CHANGELOG.md`. |
+| 0.E.2 | Replay sampling tool | DevX | M | [ ] | Script `pnpm sim:replay --random=50` qui sort 50 matchs aleatoires en format lisible (txt narratif + lien web Pixi spectate). Pour panel humain. |
+| 0.E.3 | Panel BB experts (5 testeurs) | Process | M | [ ] | Recruter 5 testeurs BB experts (FUMBBL veterans, NAF coaches, communaute). Leur fournir 50 replays aleatoires + grille notation 0-10 sur : lisibilite tactique, coherence drives, identite raciale, moments memorables. Cible >= 7/10 moyenne. |
+| 0.E.4 | Gate decision documentee | Process | S | [ ] | Document `docs/roadmap/sprints/pro-league-gate.md` : metriques stat finales, scores humains, deltas residuels, GO/NO-GO motive. Si NO-GO, retour en Lot 0.E.1 avec plan d'amelioration. |
+
+---
+
+## Phase 1 — MVP Pro League + Paris (4 sem)
+
+### Lot 1.A — Data model + scheduler + sim runner (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.A.1 | Modeles Prisma Pro League | DB | L | [ ] | `ProLeague`, `ProTeam`, `ProTeamRoster` (joueurs avec stats / forme / status), `ProLeagueSeason`, `ProLeagueRound`, `ProLeagueMatch` (status, scheduledAt, seed, engineVer, replayId), `ProLeagueStandings`. Migration + seed des 16 equipes initiales. |
+| 1.A.2 | Modele `Replay` + storage events | DB | M | [ ] | `Replay {matchId @id, payload Bytes, highlights Json, durationMs}`. Compression CBOR + gzip. Migration. Helper `compressEvents/decompressEvents` dans sim-engine. |
+| 1.A.3 | Service `pro-league-scheduler.ts` | Backend | M | [ ] | Au demarrage de saison, genere round-robin (15 journees, 2 matchs/round, soit 16 equipes / 2 = 8 matchs/round, ajuste : pour 16 eq round-robin classique = 15 rounds × 8 matchs = 120 matchs/saison sur 15 semaines). Persiste `ProLeagueRound[]` + `ProLeagueMatch[]` avec `scheduledAt` mardi 21h. Idempotent. |
+| 1.A.4 | Service `sim-runner.ts` (in-process) | Backend | M | [ ] | Cron T-24h qui pre-simule tous les matchs de la prochaine journee. Stocke `Replay.payload` + `ProLeagueMatch.result`. Pas de worker dedie au MVP — execution dans `apps/server` via `node-cron` ou setInterval simple. Preserve interface pour migration BullMQ future. |
+| 1.A.5 | Versionning IA + freeze replays | Backend | S | [ ] | `engineVer` stocke sur chaque match + replay. Replays anciens = read-only. Si simulation fail, fallback sur engine version pinnee. |
+
+### Lot 1.B — Live broadcaster SSE (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.B.1 | Service `match-broadcaster.ts` | Backend | M | [ ] | A `scheduledAt`, charge `Replay.payload`, dispatch les events via `EventEmitter` interne (ou Redis pub/sub si dispo) selon leur `displayAtMs`. Catch-up pour spectateurs en retard : leur envoie les events deja passes en bloc puis tail live. |
+| 1.B.2 | Endpoint SSE `/pro-league/matches/:id/stream` | API | M | [ ] | Route SSE qui consomme le broadcaster. Heartbeat 30s. Reconnection-friendly (Last-Event-ID). Retourne le replay complet en oneshot si le match est `done`. |
+| 1.B.3 | Mode spectate Pixi reutilise | Frontend | L | [ ] | Reutilise renderer PvP existant en mode read-only : consomme l'`EventSource`, anime le terrain selon les events. Couche `<TickerFeed/>` React au-dessus. Skip / x2 / x4 / "go to halftime". |
+| 1.B.4 | Ticker textuel mobile-friendly | Frontend | M | [ ] | Vue alternative pure texte pour mobile/low-bandwidth : timeline scrollable, badges TD/CAS/NUFFLE, score en sticky header. Auto-refresh sur SSE. |
+
+### Lot 1.C — UI Pro League + spectator/fan (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.C.1 | Page `/pro-league` (hub) | Frontend | M | [ ] | Saison en cours, journee N, prochains matchs avec compte a rebours T-21h mardi, classement live, liens fiches equipes. Header avec branding "Old World League". |
+| 1.C.2 | Page `/pro-league/teams/:slug` | Frontend | M | [ ] | Roster avec stats + forme, calendrier, historique matchs, joueurs en HoF, fans count, identite NFL homage (couleurs, devise). |
+| 1.C.3 | Page `/pro-league/matches/:id` | Frontend | M | [ ] | Pre-match : odds, lineups, hype meter. Live : Pixi spectate + ticker + chat fans. Post-match : resume, MVP, casualties, highlights, replay. |
+| 1.C.4 | Mode "Suivre cette equipe" (fan) | Frontend + Backend | M | [ ] | Modele `SpectatorFollow {userId, proTeamId, since}`. Bouton "Suivre" sur fiche equipe. Newsfeed perso `/pro-league/feed` avec actus des equipes suivies. Reset hebdo notifications. |
+| 1.C.5 | Page `/pro-league/standings` | Frontend | S | [ ] | Classement detaille : V/N/D, points, TD+/-, casualties, forme 5 derniers, badges. |
+
+### Lot 1.D — Systeme de paris + economie Crowns (~1 sem)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.D.1 | Modeles Prisma `Wallet`, `Transaction` | DB | M | [ ] | `Wallet {userId @id, crowns Int}` + `Transaction {id, walletId, type enum(BET / WIN / REWARD / DAILY / BADGE), amount Int, ref, createdAt}`. Reuse en Phase 2 (mercato). Service `wallet.ts` avec helpers atomiques (`debit`, `credit`, `transfer`). |
+| 1.D.2 | Modeles `BetMarket`, `Bet`, `BetSettlement` | DB | M | [ ] | `BetMarket {matchId, type enum(1N2 / OVER_UNDER_TD / MVP / CAS_COUNT / NUFFLE_OCCURS), config Json, status, closesAt}`. `Bet {id, userId, marketId, selection, stake, oddsAtPlace, status, payoutAmount?}`. `BetSettlement` audit. |
+| 1.D.3 | Calcul cotes dynamique | Backend | L | [ ] | Service `odds-calculator.ts` qui pre-simule N=200 matchs (sample du `engineVer` actuel) pour estimer probas, applique marge maison 5%, expose cotes via API. Re-calcul au pre-match si line-up change. Stocke `oddsAtPlace` au moment du pari pour fairness. |
+| 1.D.4 | Endpoints paris | API | M | [ ] | `GET /pro-league/matches/:id/markets` (liste markets ouverts), `POST /pro-league/bets` (placer pari : valide market open, debit wallet), `GET /me/bets` (historique). Idempotence cle `clientToken`. |
+| 1.D.5 | Settlement automatique | Backend | M | [ ] | Hook post-match : pour chaque `BetMarket` du match, evalue le `result`, met `Bet.status` a `won`/`lost`, credit le wallet pour les gagnes. Idempotent (flag `BetMarket.settled`). |
+| 1.D.6 | Daily login bonus + sources de Crowns | Backend | S | [ ] | Daily : 50 Crowns / login (max 1/24h). First-time bonus : 1000 Crowns. Pas d'achat IRL. Ratelimite. |
+| 1.D.7 | UI paris | Frontend | L | [ ] | Composants `<BetSlip/>` (panier), `<MarketsList/>` sur page match, `<MyBets/>` sur dashboard. Confirmation modale, animations win/lose. Mobile-first. |
+| 1.D.8 | Leaderboards parieurs | Frontend + Backend | M | [ ] | Vues : `/pro-league/leaderboard?period=weekly|season|all-time`. Metriques : profit Crowns, accuracy %, longest streak, biggest win. Pagination. Recompenses hebdo (top 10 = badge + bonus Crowns). |
+| 1.D.9 | Badges/titres | Backend + Content | M | [ ] | `Badge {code, name, description, criteria Json}`, `UserBadge {userId, badgeCode, earnedAt}`. Catalogue MVP : "Oracle of Nuffle" (10 pronos justes d'affilee), "Profit King" (top 1% gains saison), "Blood Reader" (90%+ accuracy prop bets violents), "Underdog Whisperer" (5 paris cote >= 5 gagnes), "First Kickoff" (1er pari saison), "Loyal Fan" (suivi 1 equipe 30j). UI sur profil. |
+
+### Lot 1.E — Nuffle Gazette + casualties + HoF light (~ inclus dans 4 sem) 
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.E.1 | Service `nuffle-gazette.ts` (LLM Claude Haiku) | Backend + Content | L | [ ] | Cron quotidien 8h : pour chaque journee jouee, genere 1 article principal (resume saison J-1) + 3 breves (transferts/blessures/dramas) + 1 edito signe par 1 des 3 personas IA recurrents (le cynique, l'enthousiaste orc, le statisticien). Prompt template avec context = events du jour + standings + storylines actives. Cache prompts (ratio 70%) pour optimiser cout. Stocke en `GazetteArticle`. |
+| 1.E.2 | Modele `GazetteArticle` + UI | DB + Frontend | M | [ ] | `GazetteArticle {id, date, persona, type enum(MAIN / BREVE / EDITO), title, body, relatedTeamIds, relatedPlayerIds}`. Page `/nuffle-gazette` (latest), `/nuffle-gazette/:date` (archive). Cards partageables (OG image generee). |
+| 1.E.3 | Detection storylines automatique | Backend | M | [ ] | Service `storyline-detector.ts` post-match : detecte rivalites (3 matchs serres entre A et B), retours (joueur revenu de blessure), records, defaites surprises. Output `Storyline {type, weight, refs}` consomme par la Gazette. |
+| 1.E.4 | Casualties persistantes | Backend | M | [ ] | `ProTeamRoster` integre permanent injuries : `dead bool, niggling int, maReduction, stReduction, etc.`. Apres chaque match, post-process applique les casualties. Joueur DEAD = retire roster + entree HoF si carriere notable. |
+| 1.E.5 | Hall of Fame light | Backend + Frontend | M | [ ] | `HallOfFameEntry {playerId, teamId, careerStats, retiredAt, cause enum(DEATH / RETIREMENT / INJURY)}`. Page `/pro-league/hall-of-fame` avec filtres. Critere d'entree : >= 30 TD ou >= 15 cas ou MVP de saison. |
+| 1.E.6 | Rookie pipeline (remplacement morts) | Backend | M | [ ] | Si une equipe perd >= 1 joueur (DEAD/MNG longue duree), draft d'urgence d'un rookie genere proceduralement (nom, stats baseline, potentiel). Annonce dans la Gazette. |
+
+### Lot 1.F — E2E + go-live (~inclus)
+
+| # | Tache | Cat | Effort | Statut | Detail |
+|---|-------|-----|--------|--------|--------|
+| 1.F.1 | Tests E2E Playwright "saison Pro League" | Tests | M | [ ] | Scenario : creation saison admin → cron sim T-24h → broadcaster live (mock T+0 accelere) → user place bet → match settle → wallet credite → badge eventuel debloque → article Gazette publie. Garde-fou anti-regression. |
+| 1.F.2 | Beta fermee 50 testeurs | Process | M | [ ] | Recrutement Discord communaute BB. Feedback structure (form + Discord channel). 2 saisons completes en accelerated mode (1 journee/jour au lieu de 1/sem) pour valider boucle complete en 2 semaines reelles. |
+| 1.F.3 | Monitoring + alerting prod | DevOps | M | [ ] | Sentry sur sim-runner / broadcaster / settlement. Dashboard Grafana : matchs simules/jour, paris places, Crowns en circulation, taux d'erreur, latence broadcaster. Alerte si match `FAILED` ou settlement bloque. |
+| 1.F.4 | Page marketing `/pro-league/about` | Frontend + Marketing | S | [ ] | Pitch produit, calendrier saison, regles paris (no real money, no cashout), FAQ. SEO ready. |
+
+---
+
+## Mapping 16 equipes Pro League (homages NFL × races BB)
+
+> **Statut juridique** : aucun nom, logo ou marque NFL n'est utilise. Les
+> equipes sont des **clins d'oeil** identifiables par les fans (ville, couleurs,
+> archetype) sans citation directe. Cf. analyse legale en section "Risques".
+
+| # | Ville | Nom propose | Race BB | Identite tactique | NFL inspiration |
+|---|-------|-------------|---------|-------------------|----------------|
+| 1 | Pittsburgh | Smashers | Orcs | Bash 85, pace measured | Steelers (blue collar, defense brutale) |
+| 2 | Dallas | Vipers | Dark Elves | Risk 70, agility 85 | Cowboys (richesse, prima donnas, etoile) |
+| 3 | Kansas City | Soaring Hawks | Wood Elves | Passing 80, risk 75 | Chiefs (jeu aerien, Mahomes-flavored) |
+| 4 | New England | Cold Tacticians | Lizardmen | Discipline 90, methodique | Patriots (froid, dynastie) |
+| 5 | San Francisco | Gold Rush | Skaven | Speed 95, gunslinger | 49ers (scrappy, west coast) |
+| 6 | Carolina | Jungle Queens | Amazons | Defense 80, tribal | Panthers (jungle, agressif) |
+| 7 | Las Vegas | Outlaws | Norse | Brutal 80, hors-la-loi | Raiders (pirate, noir/argent) |
+| 8 | New Orleans | Voodoo Saints | Undead | Necro 75, slow grind | Saints (Big Easy, voodoo) |
+| 9 | Chicago | Iron Bears | Dwarves | Tank 90, smashmouth | Bears (rugged) |
+| 10 | Philadelphia | Storm Eagles | Pro Elves | Balance 70 | Eagles (Philly, flying) |
+| 11 | Phoenix | Tomb Cardinals | Tomb Kings (Khemri) | Slow 95, undead | Cardinals (desert) |
+| 12 | Minneapolis | Frostraiders | Norse alt | Raid heavy | Vikings (purple, raids) |
+| 13 | Green Bay | Cheese Halflings | Halflings | Underdog 100 | Packers (cheese-head, ouvriers) |
+| 14 | Jacksonville | Swamp Lizards | Lizardmen alt | Variant Lizard | Jaguars (Florida jungle) |
+| 15 | Denver | Mile High Centaurs | Beastmen / Chaos | Wild West, raids | Broncos (mile high, wild) |
+| 16 | Buffalo | Snow Ogres | Ogres | Brutal 95, snow mastery | Bills (Buffalo snow, blue collar) |
+
+> A iterer au Lot 0.B.3 (tuning des profils tactiques) et avant beta. Couleurs,
+> devises, lore courte, blasons originaux a produire en parallele du dev par
+> l'agent design / illustrateur communautaire.
+
+---
+
+## Architecture technique synthese
+
+### Sim engine
+```
+packages/sim-engine/
+  src/
+    drivers/
+      hybrid.ts          # MVP : drive-level + key moments resolus
+      full.ts            # backlog : action-by-action (futur)
+    resolvers/           # block, dodge, pass, gfi, foul (consomme game-engine)
+    ai/
+      strategy/          # cage-build, breakaway, defensive-screen, blitz-train
+      tactics/patterns/  # cage-formation, line-grind, pass-route-deep
+      profiles/          # 16 profils raciaux
+    nuffle/              # bibliotheque events + injection
+    rng/                 # PRNG seede (xoroshiro)
+    events/              # MatchEvent emitter typed
+  bench/
+    reference-fumbbl.json
+    bench-baseline.json
+  scripts/
+    bench.ts             # CLI benchmark
+    replay.ts            # Sampling pour panel humain
+```
+
+### Backend
+```
+apps/server/src/
+  services/
+    pro-league-scheduler.ts   # generation calendrier saison
+    sim-runner.ts              # cron T-24h pre-simulation
+    match-broadcaster.ts       # diffusion live SSE
+    odds-calculator.ts         # pre-sim 200 matchs pour cotes
+    bet-settlement.ts          # post-match auto settlement
+    nuffle-gazette.ts          # cron quotidien LLM
+    storyline-detector.ts      # detection rivalites/dramas
+    wallet.ts                  # debit/credit/transfer atomique
+  routes/
+    pro-league.ts              # standings, matches, teams
+    pro-league-bets.ts         # markets, place, history
+    nuffle-gazette.ts          # articles
+  jobs/
+    pro-league-sim-runner.ts   # cron T-24h
+    nuffle-gazette-daily.ts    # cron 8h
+```
+
+### Frontend
+```
+apps/web/app/pro-league/
+  page.tsx                     # hub
+  teams/[slug]/page.tsx
+  matches/[id]/page.tsx        # spectate live + ticker + paris
+  standings/page.tsx
+  leaderboard/page.tsx
+  hall-of-fame/page.tsx
+  feed/page.tsx                # newsfeed fan
+apps/web/app/nuffle-gazette/
+  page.tsx
+  [date]/page.tsx
+apps/web/components/pro-league/
+  TickerFeed.tsx
+  BetSlip.tsx
+  MarketsList.tsx
+  TeamCard.tsx
+```
+
+### Diffusion live (sequencement)
+```
+T-24h    sim-runner cron    -> simulate match (~2s) -> store Replay
+T-2h     match-broadcaster prepares -> load Replay events in memory
+T-0      kickoff            -> dispatch events via SSE according to displayAtMs
+T+90min  match end          -> trigger settlement -> credit Crowns -> generate Gazette feed
+T+8h     nuffle-gazette cron-> publish daily articles
+```
+
+---
+
+## Definition of done
+
+### Phase 0 (gate bloquant)
+- [ ] Bench stat : tous les matchups raciaux dans ±10% du winrate FUMBBL.
+- [ ] Bench variance : std dev TD >= 1.4, upset rate 12-18%, % matchs >=5 TD entre 4-7%.
+- [ ] Panel humain (5 testeurs BB experts) note moyenne >= 7/10 sur 50 replays.
+- [ ] CI sim-bench passe sur baseline pinnee.
+- [ ] Doc gate `pro-league-gate.md` publiee avec metriques + GO motive.
+
+### Phase 1 (MVP)
+- [ ] Une saison Pro League peut etre creee, calendrier genere, matchs joues automatiquement.
+- [ ] Diffusion live SSE fonctionnelle un mardi 21h reel sur >= 100 spectateurs simultanes.
+- [ ] User peut placer un pari sur un match a venir, settlement automatique post-match, wallet credite.
+- [ ] >= 6 markets de pari ouverts par match (1N2, O/U TD, MVP, CAS count, NUFFLE occurs, double chance).
+- [ ] Leaderboards parieurs hebdo + saison + all-time fonctionnels avec >= 6 badges debloquables.
+- [ ] Mode "Suivre une equipe" avec newsfeed fonctionnel.
+- [ ] Nuffle Gazette publie automatiquement >= 5 articles/jour pendant 7j consecutifs.
+- [ ] Casualties persistantes appliquees au roster, joueurs DEAD remplaces par rookies.
+- [ ] Hall of Fame light avec >= 5 entrees apres 1 saison.
+- [ ] Tests E2E Playwright "saison complete" passent.
+- [ ] Beta fermee 50 testeurs validee (NPS >= 30).
+
+---
+
+## Calendrier aligne saison NFL 2026-27
+
+| Periode | Activite Pro League |
+|---------|---------------------|
+| Mai-Juin 2026 | Phase 0 — sim foundation, profils, bench, gate |
+| Juillet 2026 | Phase 1 dev (lots 1.A → 1.E) |
+| Aout 2026 | Phase 1 finalisation, beta fermee 50 testeurs, tuning final |
+| **5 sept 2026** | **Kickoff Old World League saison 1** synchrone NFL Week 1 |
+| Sept 2026 → Janv 2027 | Saison reguliere 15 journees, ~1 match/sem mardi 21h |
+| **8 fev 2027** | **"Blood Bowl Final"** — finale Old World League aligne Super Bowl LXI weekend |
+
+---
+
+## Dependances & risques
+
+### Dependances
+- **SPRINT Ligues v2 livre** : reutilise les concepts `LeagueSeason`, `LeagueRound` etendus. Si le modele `ProLeague*` doit diverger, decision a prendre au Lot 1.A.1.
+- **`packages/game-engine` stable** : la sim depend des resolvers actions BB. Aucune evolution breaking pendant Phase 0.
+- **Anthropic API key** : pour Nuffle Gazette (Claude Haiku 4.5). Cout estime `<5 €/mois` sur MVP (1 ligue, ~30 articles/jour).
+- **node-cron ou equivalent** dans `apps/server` : deja present pour les forfaits ligue (cf. SPRINT-leagues-v2 L2.A.11).
+
+### Risques
+
+- **Realisme sim insuffisant** (P1, critique) : si le panel humain note <7/10, le MVP perd toute credibilite et les paris perdent leur saveur. **Mitigation** : Phase 0 gate strict, 8 semaines de tuning prevues, 5 testeurs experts panel, possibilite de boucler en Phase 0.E.1 sans avancer en Phase 1.
+- **Variance trop forte / trop faible** : si favoris perdent 50% du temps = roulette ; si <5% = ennui. **Mitigation** : metriques `upset rate` mesuree explicitement (cible 12-18%), variance pilotable via temperature IA + Nuffle events probas.
+- **Drift game-engine ↔ sim-engine** : un patch BB Cyanide / regles GW peut invalider replays. **Mitigation** : `engineVer` strict, replays anciens read-only, freeze des matchs joues.
+- **Cout LLM** : sur 1 ligue MVP, ~5 €/mois. Si scale soudain (multi-leagues backlog) : surveille via dashboard + hard limit Anthropic. **Mitigation** : prompt caching active, batch API si non-urgent.
+- **Engagement reel insuffisant** : si <20 utilisateurs places paris regulierement apres 1 mois MVP, le mode est un echec. **Mitigation** : beta fermee 50 testeurs avant go-live, NPS >= 30 requis pour go-live public, daily bonus + first-time grace pour onboarding.
+- **Live SSE scaling** : si finale attire 1000+ spectateurs simultanes, `apps/server` peut saturer. **Mitigation MVP** : single instance suffit pour <500 ; au-dela, basculer vers Redis pub/sub (deja prevu dans architecture). Pas urgent au MVP.
+- **Determinisme casse** : un `Math.random` oublie dans `sim-engine` ou un import non-pur (`Date.now()`) casse les replays et l'audit anti-triche. **Mitigation** : lint custom `no-restricted-globals`, PRNG injecte partout, tests de reproductibilite (re-simuler 10x un meme match avec meme seed → events identiques).
+- **Statut juridique homages NFL** : un usage trop appuye (logos, noms officiels) declenche cease-and-desist NFL. **Mitigation** : noms et blasons originaux uniquement, ville + couleurs OK (faits), aucun logo/marque NFL en assets, validation legale avant beta publique. Fallback : retirer toute reference NFL et garder seulement les villes US / l'esprit "foot americain".
+- **Casualties dramatiques** : un joueur "favori" qui meurt cree frustration. **Mitigation** : DEAD reste rare (~1-2/saison sur 16 equipes), Hall of Fame transforme la mort en hommage, rookie pipeline donne immediatement un remplacant narratif.
+
+---
+
+## Migration / data
+
+- **Phase 0** : aucune migration Prisma. Seules additions code dans `packages/sim-engine` (nouveau package) + `packages/shared-types` (types `MatchEvent`, `TacticalProfile`).
+- **Phase 1** : 3 migrations Prisma sequentielles :
+  1. **PR1.A.1** : `ProLeague`, `ProTeam`, `ProTeamRoster`, `ProLeagueSeason`, `ProLeagueRound`, `ProLeagueMatch`, `Replay`, `ProLeagueStandings`. Seed 16 equipes initiales.
+  2. **PR1.D.1** : `Wallet`, `Transaction`, `BetMarket`, `Bet`, `BetSettlement`. Init wallet pour tous les users existants avec 0 Crowns.
+  3. **PR1.E.2** : `GazetteArticle`, `Storyline`, `HallOfFameEntry`, `Badge`, `UserBadge`, `SpectatorFollow`, `PlayerForm`.
+- **Seeder etendu** : ajouter les 16 equipes Pro League en seed `seed/pro-league/teams.json` avec rosters complets pre-construits.
+
+---
+
+## Ordre de livraison recommande
+
+| PR | Phase | Lots | Description | Estim |
+|----|-------|------|-------------|-------|
+| **PR0.1** | 0 | 0.A.1-0.A.5 | Sim engine fondation + driver hybride + resolvers | ~2 sem |
+| **PR0.2** | 0 | 0.B.1-0.B.5 | Behavior trees + 16 profils + temperature IA + memoire match | ~2 sem |
+| **PR0.3** | 0 | 0.C.1-0.C.4 | Variance, Nuffle events, underdog boost, streaks | ~1 sem |
+| **PR0.4** | 0 | 0.D.1-0.D.4 | Bench harness + dataset + CI regression | ~1 sem |
+| **PR0.5** | 0 | 0.E.1-0.E.4 | Tuning loop + replay sampling + panel humain + gate doc | ~2 sem |
+| **GATE** | — | — | Decision GO/NO-GO basee sur metriques + panel | — |
+| **PR1.1** | 1 | 1.A.1-1.A.5 | Modeles Prisma + scheduler + sim-runner + replay storage | ~1 sem |
+| **PR1.2** | 1 | 1.B.1-1.B.4 | Broadcaster live SSE + spectate Pixi + ticker mobile | ~1 sem |
+| **PR1.3** | 1 | 1.C.1-1.C.5 | UI Pro League (hub, teams, matches, standings, follow) | ~1 sem |
+| **PR1.4** | 1 | 1.D.1-1.D.9 | Wallet + paris MVP + cotes + leaderboards + badges | ~1.5 sem |
+| **PR1.5** | 1 | 1.E.1-1.E.6 | Nuffle Gazette LLM + storylines + casualties + HoF + rookies | ~1 sem |
+| **PR1.6** | 1 | 1.F.1-1.F.4 | E2E + monitoring + page marketing + beta fermee | ~0.5 sem |
+| **GO-LIVE** | — | — | Saison 1 kickoff 5 sept 2026 | — |
+
+---
+
+## Sources
+
+- Audit produit + architecture conduit le 2026-05-05 par 5 agents en parallele
+  (game design / paris / paysage concurrentiel / architecture technique /
+  moonshots).
+- Inspirations produit : MPG (Mon Petit Gazon), Hattrick, Football Manager,
+  OOTP Baseball, Sorare, NFL Fantasy.
+- Donnees BB : FUMBBL stats publiques, NAF tournament data, regles officielles
+  Saison 2/3 (cf. `extraction_blood_bowl.md`).
+- `packages/game-engine/` : resolvers existants block/dodge/pass/foul reutilises.
+- `apps/server/src/services/league*.ts` : modele de symetrie pour
+  `pro-league-scheduler.ts`.
+- `docs/roadmap/sprints/SPRINT-leagues-v2.md` : pre-requis (infrastructure
+  ligues consolidee).
+- `docs/roadmap/backlog/future-ideas.md` : items differes (mercato MPG-layer,
+  multi-leagues, weather sync, etc.).


### PR DESCRIPTION
## Résumé

Ajout de la documentation complète du SPRINT Pro League et du backlog des idées futures.

- [x] Documentation du SPRINT Pro League (championnat virtuel 16 équipes IA, paris en Crowns, diffusion live SSE, Nuffle Gazette LLM)
- [x] Backlog structuré des extensions futures (MPG-layer, multi-ligues, weather sync, etc.) avec gate de réactivation basé sur KPI MVP
- [x] Mise à jour des fichiers de roadmap existants (TODO.md, phases.md)

## Détails

### Fichiers ajoutés

**`docs/roadmap/sprints/SPRINT-pro-league.md`** (412 lignes)
- Vision MVP : 1 championnat "Old World League", 16 équipes IA (hommages NFL × races Blood Bowl), 15 journées round-robin
- Calendrier : matchs mardi 21h, diffusion live SSE, simulation pré-calculée T-24h
- Économie : paris en Crowns (earned only, jamais achetable), leaderboards hebdo/saison, badges
- Contenu : Nuffle Gazette quotidienne générée par LLM, Hall of Fame light, casualties persistantes
- Découpage en 2 phases :
  - **Phase 0 (8 sem, bloquant)** : Sim Foundation (engine hybride, 16 profils tactiques, variance Nuffle, bench harness)
  - **Phase 1 (4 sem)** : MVP Pro League + Paris (scheduler, broadcaster SSE, UI spectateur, settlement automatique)
- Gate Phase 0→1 : validation humaine (panel 5 experts BB) >= 7/10 sur lisibilité tactique
- Mapping détaillé des 16 équipes (Pittsburgh Smashers/Orcs, Dallas Vipers/Dark Elves, etc.)
- Architecture technique synthétisée (sim-engine, backend services, frontend routes)
- Definition of Done pour chaque phase

**`docs/roadmap/backlog/future-ideas.md`** (335 lignes)
- 18 idées futures documentées et priorisées (MPG-layer, multi-ligues, weather sync IRL, NFL Twin Mirror, Twitch auto-cast, etc.)
- Gate de réactivation : KPI MVP à atteindre avant d'attaquer le backlog (100 users actifs, 200 spectateurs pic, 35% retention J30, NPS >= 40)
- Matrice "Quand réactiver quoi" avec effort estimé et dépendances
- Process de réactivation structuré (issue GitHub, re-évaluation, sprint dédié)

### Fichiers modifiés

**`TODO.md`**
- Ajout du SPRINT Pro League dans la liste des sprints à venir (P1, post-Ligues v2)
- Mise à jour de la date (2026-05-05)

**`docs/roadmap/phases.md`**
- Mise à jour de la date (2026-05-05)

## Checklist

- [x] Lint / Types OK (fichiers Markdown)
- [x] Pas de tests unitaires applicables (documentation)
- [x] Pas de tests e2e applicables (documentation)
- [x] Changeset non applicable (documentation de roadmap)

## Notes

Cette PR est une documentation de planification produit. Elle établit le cadre pour le SPRINT Pro League (championnat virtuel + paris) et documente les extensions futures avec un gate clair basé sur les KPI MVP. Aucun code source n'est modifié.

https://claude.ai/code/session_013uZGAh3sBE6kiZzpL1dgDw