### PR TITLE
docs: archive Ligues v2 optional extensions to future-ideas

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,20 +38,13 @@ prete a accueillir les phases R+).
 
 ## Backlog
 
-### Ligues v2 — restes optionnels
+### Ligues v2 — extensions reportees
 
-- [ ] **L2.C.4 — Promotion/relegation multi-tier** (Backend, L)
-  Modele `LeagueTier` (D1/D2/D3) avec `League.tierId`. Service
-  `applyPromotionRelegation(leagueId)` : top 2 montent / bottom 2
-  descendent au passage de saison. Reporte de
-  [`SPRINT-leagues-v2`](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
-  (L2.C.4) — explicitement marque optionnel. A activer si demande
-  utilisateur (ligues longues, structure pyramidale).
-
-> **Note** : L2.C.7 (Mobile parite ligues) a ete archivee dans
+> Toutes les extensions optionnelles de Ligues v2 ont ete archivees dans
 > [`docs/roadmap/backlog/future-ideas.md`](./docs/roadmap/backlog/future-ideas.md)
-> (Annexe A.1) le 2026-05-05 — priorisation Pro League avant les
-> extensions mobile ligues.
+> (annexe A) le 2026-05-05 :
+> - **A.0** : L2.C.4 Promotion/relegation multi-tier (focus acquisition/retention).
+> - **A.1** : L2.C.7 Mobile parite ligues (priorisation Pro League).
 
 ### Autres
 

--- a/TODO.md
+++ b/TODO.md
@@ -48,12 +48,10 @@ prete a accueillir les phases R+).
   (L2.C.4) — explicitement marque optionnel. A activer si demande
   utilisateur (ligues longues, structure pyramidale).
 
-- [ ] **L2.C.7 — Mobile parite ligues** (Mobile, L)
-  Sur l'app Expo (`apps/mobile/app/leagues/`) : liste, detail saison,
-  calendrier, classement, bouton inscription, bouton "Lancer match"
-  qui redirige vers le flow match existant. Reporte de
-  [`SPRINT-leagues-v2`](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
-  (L2.C.7). Reutilise i18n module S27.3.
+> **Note** : L2.C.7 (Mobile parite ligues) a ete archivee dans
+> [`docs/roadmap/backlog/future-ideas.md`](./docs/roadmap/backlog/future-ideas.md)
+> (Annexe A.1) le 2026-05-05 — priorisation Pro League avant les
+> extensions mobile ligues.
 
 ### Autres
 

--- a/docs/roadmap/backlog/future-ideas.md
+++ b/docs/roadmap/backlog/future-ideas.md
@@ -289,6 +289,37 @@ necessite stack multi-ligues mature.
 
 ---
 
+## Annexe — Reports hors Pro League
+
+### A.1 Mobile parite ligues (ex L2.C.7)
+
+**Concept** : portage de l'experience ligues sur l'app Expo
+(`apps/mobile/app/leagues/`) — liste des ligues, detail saison, calendrier,
+classement, bouton inscription, bouton "Lancer match" qui redirige vers le
+flow match existant. Reutilise i18n module S27.3.
+
+**Source** : reporte du `SPRINT-leagues-v2` (L2.C.7), categorie Mobile,
+effort L. Initialement deja dans le backlog "restes optionnels" du TODO.md,
+deplace ici le 2026-05-05 par decision produit (priorisation Pro League
+avant extensions Ligues v2).
+
+**Pourquoi differe** :
+- Les fonctionnalites ligues web sont stables et testees ; l'usage mobile
+  pour de la gestion de ligue async n'est pas un cas d'usage prioritaire
+  (creation/inscription/lancement match restent confortables sur web).
+- L'effort L (semaines) est mieux investi dans Pro League MVP qui apportera
+  une boucle d'engagement plus differenciante.
+
+**Pre-requis de reactivation** :
+- Pro League MVP livre et stabilise.
+- Demande utilisateur explicite (analytics : >= 30% des coachs ligues actifs
+  ouvrent l'app mobile au moins 1x/semaine) OU itinerance reseau
+  (deplacements) prouvee comme cas d'usage frequent en beta.
+
+**Effort** : L (~1-2 sem).
+
+---
+
 ## Synthese de la matrice "Quand reactiver quoi"
 
 | Item | Pre-requis | Effort | Priorite si gate atteint |

--- a/docs/roadmap/backlog/future-ideas.md
+++ b/docs/roadmap/backlog/future-ideas.md
@@ -291,6 +291,37 @@ necessite stack multi-ligues mature.
 
 ## Annexe — Reports hors Pro League
 
+### A.0 Promotion/relegation multi-tier (ex L2.C.4)
+
+**Concept** : modele `LeagueTier` (D1/D2/D3) avec `League.tierId`. Service
+`applyPromotionRelegation(leagueId)` au passage de saison : top 2 montent,
+bottom 2 descendent vers le tier voisin.
+
+**Source** : reporte du `SPRINT-leagues-v2` (L2.C.4), categorie Backend,
+effort L. Initialement deja dans le backlog "restes optionnels" du TODO.md,
+deplace ici le 2026-05-05 par decision produit (focus acquisition/retention
+plutot qu'extensions structurelles ligues).
+
+**Pourquoi differe** :
+- Aucun sens tant qu'on n'a pas >= 5-8 ligues groupees en pyramide (donc
+  >= 80 equipes inscrites). Probleme d'offre avant probleme de structure.
+- La Pro League apporte deja une boucle d'engagement plus forte qu'un
+  systeme de divisions : pas besoin de complexifier les ligues prive.
+- Risque de collision migrations Prisma avec les 3 migrations sequentielles
+  de la Phase 1 Pro League (Match/Bet/SpectatorFollow).
+- Item #9 du present backlog ("Promotion/relegation pyramidale 8+ divisions
+  mondiales") couvre la version "audacieuse" du concept ; A.0 etait la
+  version "petite" intra-ligue, redondante a long terme.
+
+**Pre-requis de reactivation** :
+- >= 80 equipes inscrites en ligues actives sur 30 jours glissants OU
+- Demande utilisateur explicite (top 5 dans le NPS qualitatif).
+- Pro League MVP livre et stabilise.
+
+**Effort** : L (~1-2 sem).
+
+---
+
 ### A.1 Mobile parite ligues (ex L2.C.7)
 
 **Concept** : portage de l'experience ligues sur l'app Expo


### PR DESCRIPTION
## Résumé

- [x] Archiver les extensions optionnelles de Ligues v2 (L2.C.4 et L2.C.7) dans `future-ideas.md` avec justification et pré-requis de réactivation
- [x] Mettre à jour `TODO.md` pour pointer vers la nouvelle annexe A

## Détails

Déplace deux items du backlog optionnel de Ligues v2 vers une section dédiée dans `docs/roadmap/backlog/future-ideas.md` :

**A.0 — Promotion/relegation multi-tier** (L2.C.4)
- Modèle `LeagueTier` avec promotion/relégation au passage de saison
- Reporté : nécessite ≥80 équipes en pyramide (problème d'offre avant structure)
- Effort : L (~1-2 sem)

**A.1 — Mobile parité ligues** (L2.C.7)
- Portage expérience ligues sur app Expo
- Reporté : priorisation Pro League MVP, usage mobile non critique pour gestion async
- Effort : L (~1-2 sem)

Chaque item inclut :
- Concept et source (sprint d'origine)
- Justification du report (contexte produit, risques, redondances)
- Pré-requis de réactivation explicites
- Effort estimé

`TODO.md` simplifié avec référence centralisée vers l'annexe A.

## Checklist

- [x] Lint / Types OK (documentation uniquement)
- [x] Tests unitaires — N/A
- [x] Tests e2e — N/A
- [x] Changeset ajouté — N/A (documentation)

https://claude.ai/code/session_017JkaGQje9b95Wy9GZGKwjQ