### PR TITLE
feat(sim-engine): IA temperature softmax pilotée par riskAppetite (0.B.5)

### DIFF
--- a/docs/roadmap/sprints/SPRINT-pro-league.md
+++ b/docs/roadmap/sprints/SPRINT-pro-league.md
@@ -98,7 +98,7 @@ jusqu'a passer le gate.
 | 0.B.2 | Type `TacticalProfile` + schema Zod | Types | S | [x] | ~15 parametres : bashIndex, passingFrequency, riskAppetite, cageAffinity, blitzPriority, reroll_usage, pace, foulFrequency, stallTendency, kickReturn, etc. Validation Zod cote sim-engine. Profile stocke en JSON sur `ProTeam.tactics`. |
 | 0.B.3 | 16 profils raciaux pour les 16 equipes Pro League | Content | L | [x] | Mapping NFL × race BB (cf. tableau "Mapping 16 equipes" plus bas). Chaque profil parametre pour refleter l'identite : Pittsburgh Smashers (Orcs, bash 85, pace measured), Kansas City Soaring Hawks (Wood Elves, passing 75, risk 70), etc. Tunable. |
 | 0.B.4 | Memoire partielle d'etat de match (momentum) | Backend | M | [ ] | Forme par joueur : `hot` apres 2+ TD ou 3+ blocks reussis (+1 confiance temporaire), `cold` apres echecs en chaine. Memoire mensuelle visible publiquement. Alimente la Gazette et les paris. |
-| 0.B.5 | Temperature IA (decisions sub-optimales controlees) | Backend | M | [ ] | Au lieu de toujours prendre l'action max-EV, sample sur top-K avec poids dependant du profil (`riskAppetite` → temperature). Genere variance entre matchs identiques sur le papier. |
+| 0.B.5 | Temperature IA (decisions sub-optimales controlees) | Backend | M | [x] | Au lieu de toujours prendre l'action max-EV, sample sur top-K avec poids dependant du profil (`riskAppetite` → temperature). Genere variance entre matchs identiques sur le papier. |
 
 ### Lot 0.C — Variance & Nuffle moments (~1 sem)
 

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -35,6 +35,11 @@ import {
   type ResolverState,
 } from '../resolvers';
 import {
+  DEFAULT_TACTICAL_PROFILE,
+  type TacticalProfile,
+} from '../tactics/tactical-profile';
+import { riskAppetiteToTemperature, softmaxSample } from '../tactics/temperature';
+import {
   ENGINE_VER,
   type Casualty,
   type MatchOutcome,
@@ -146,22 +151,59 @@ function buildKeyMomentState(
   };
 }
 
-function pickKeyMoment(rng: Rng, drive: DriveState): KeyMomentKind | null {
-  const r = rng.next();
+function pickKeyMoment(
+  rng: Rng,
+  drive: DriveState,
+  profile: TacticalProfile
+): KeyMomentKind | null {
+  const temperature = riskAppetiteToTemperature(profile.riskAppetite);
+
+  // Score each candidate from the team's tactical fingerprint. Scores
+  // are on the same [0, 1] scale (param / 100) so the softmax remains
+  // numerically tame across all 16 race profiles.
+  const score = (param: keyof TacticalProfile): number => profile[param] / 100;
+
   if (!drive.hasPossession) {
-    return r < 0.6 ? 'pickup' : 'block';
+    // Loose ball : pickup vs hustle-block. Pickup demand is roughly
+    // anti-correlated with bash (a bash team prefers cracking heads).
+    return softmaxSample(
+      rng,
+      [
+        { value: 'pickup' as KeyMomentKind, score: 1 - score('bashIndex') * 0.5 },
+        { value: 'block' as KeyMomentKind, score: score('bashIndex') },
+      ],
+      temperature
+    );
   }
+
   if (drive.ballYardline >= FIELD_YARDS - 4) {
-    if (r < 0.55) return 'block';
-    if (r < 0.85) return 'dodge';
-    return 'gfi';
+    // Red-zone : push for TD via bash / dodge / GFI chains.
+    return softmaxSample(
+      rng,
+      [
+        { value: 'block' as KeyMomentKind, score: score('bashIndex') + 0.3 },
+        { value: 'dodge' as KeyMomentKind, score: score('breakawayInstinct') + 0.2 },
+        { value: 'gfi' as KeyMomentKind, score: score('gfiTolerance') },
+      ],
+      temperature
+    );
   }
-  if (r < 0.35) return 'block';
-  if (r < 0.55) return 'dodge';
-  if (r < 0.7) return 'pass';
-  if (r < 0.8) return 'gfi';
-  if (r < 0.92) return 'foul';
-  return null;
+
+  // Open-field decision. The `null` ("nothing scripted, just yards")
+  // branch ties down a baseline tempo so high-pace teams skip more
+  // scripted moments.
+  return softmaxSample(
+    rng,
+    [
+      { value: 'block' as KeyMomentKind, score: score('bashIndex') },
+      { value: 'dodge' as KeyMomentKind, score: score('breakawayInstinct') * 0.8 + 0.2 },
+      { value: 'pass' as KeyMomentKind, score: score('passingFrequency') },
+      { value: 'gfi' as KeyMomentKind, score: score('gfiTolerance') * 0.6 },
+      { value: 'foul' as KeyMomentKind, score: score('foulFrequency') },
+      { value: null as unknown as KeyMomentKind, score: 1 - score('pace') * 0.5 },
+    ],
+    temperature
+  );
 }
 
 interface KeyMomentOutcome {
@@ -304,14 +346,17 @@ function emitTd(m: MutableMatch, scoringTeam: Side): void {
 function processTurn(
   m: MutableMatch,
   rngs: DriverRng,
-  weather: ResolverState['weather']
+  weather: ResolverState['weather'],
+  homeProfile: TacticalProfile,
+  awayProfile: TacticalProfile
 ): void {
   emitTurnStart(m);
 
   // 1-2 key moments per turn driven by the strategic stream.
   const momentCount = m.state.turn % 3 === 0 ? 2 : 1;
+  const activeProfile = m.state.drive.drivingTeam === 'home' ? homeProfile : awayProfile;
   for (let i = 0; i < momentCount; i += 1) {
-    const moment = pickKeyMoment(rngs.strategic, m.state.drive);
+    const moment = pickKeyMoment(rngs.strategic, m.state.drive, activeProfile);
     if (moment === null) continue;
 
     const { events: keyEvents, turnover } = runKeyMoment(
@@ -376,6 +421,11 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
 
   const initialReceiver: Side = rngs.strategic.next() < 0.5 ? 'home' : 'away';
 
+  // Tactical fingerprints. Default to the neutral baseline when a team
+  // input does not provide one (e.g. ad-hoc test seeds).
+  const homeProfile: TacticalProfile = input.home.tactics ?? DEFAULT_TACTICAL_PROFILE;
+  const awayProfile: TacticalProfile = input.away.tactics ?? DEFAULT_TACTICAL_PROFILE;
+
   const m: MutableMatch = {
     state: {
       half: 1,
@@ -406,7 +456,7 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
 
   // First half.
   while (m.state.turn <= TURNS_PER_HALF) {
-    processTurn(m, rngs, weather);
+    processTurn(m, rngs, weather, homeProfile, awayProfile);
   }
 
   // Halftime.
@@ -426,7 +476,7 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
 
   // Second half.
   while (m.state.turn <= TURNS_PER_HALF) {
-    processTurn(m, rngs, weather);
+    processTurn(m, rngs, weather, homeProfile, awayProfile);
   }
 
   m.events.push({

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -24,6 +24,11 @@ export {
   type ProTeamProfile,
 } from './tactics/race-profiles';
 export {
+  riskAppetiteToTemperature,
+  softmaxSample,
+  type WeightedCandidate,
+} from './tactics/temperature';
+export {
   ENGINE_VER,
   type Casualty,
   type EngineVersion,

--- a/packages/sim-engine/src/tactics/temperature.test.ts
+++ b/packages/sim-engine/src/tactics/temperature.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRng } from '../rng/seeded';
+
+import {
+  riskAppetiteToTemperature,
+  softmaxSample,
+  type WeightedCandidate,
+} from './temperature';
+
+describe('riskAppetiteToTemperature — sprint Pro League 0.B.5', () => {
+  it('riskAppetite 0 → temperature 0 (always pick max-EV / argmax)', () => {
+    expect(riskAppetiteToTemperature(0)).toBe(0);
+  });
+
+  it('riskAppetite 50 → temperature ~1.0 (neutral baseline)', () => {
+    const t = riskAppetiteToTemperature(50);
+    expect(t).toBeGreaterThan(0.8);
+    expect(t).toBeLessThan(1.5);
+  });
+
+  it('riskAppetite 100 → high temperature (>= 2.0, near-uniform)', () => {
+    expect(riskAppetiteToTemperature(100)).toBeGreaterThanOrEqual(2);
+  });
+
+  it('temperature is monotonically non-decreasing in riskAppetite', () => {
+    let prev = -1;
+    for (let r = 0; r <= 100; r += 5) {
+      const t = riskAppetiteToTemperature(r);
+      expect(t).toBeGreaterThanOrEqual(prev);
+      prev = t;
+    }
+  });
+
+  it('clamps inputs outside [0, 100]', () => {
+    expect(riskAppetiteToTemperature(-50)).toBe(riskAppetiteToTemperature(0));
+    expect(riskAppetiteToTemperature(200)).toBe(riskAppetiteToTemperature(100));
+  });
+});
+
+describe('softmaxSample — sprint Pro League 0.B.5', () => {
+  type Action = 'block' | 'dodge' | 'pass';
+
+  const candidates = (): readonly WeightedCandidate<Action>[] => [
+    { value: 'block', score: 1.0 },
+    { value: 'dodge', score: 0.5 },
+    { value: 'pass', score: 0.2 },
+  ];
+
+  it('temperature 0 always returns the argmax candidate (deterministic)', () => {
+    const rng = createRng(1);
+    for (let i = 0; i < 50; i += 1) {
+      const picked = softmaxSample(rng, candidates(), 0);
+      expect(picked).toBe('block');
+    }
+  });
+
+  it('temperature 0 still requires at least one candidate', () => {
+    const rng = createRng(1);
+    expect(() => softmaxSample(rng, [], 0)).toThrow();
+  });
+
+  it('high temperature (3.0) produces variety across draws (>= 2 distinct)', () => {
+    const rng = createRng(7);
+    const seen = new Set<Action>();
+    for (let i = 0; i < 200; i += 1) {
+      seen.add(softmaxSample(rng, candidates(), 3));
+    }
+    expect(seen.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('determinism : same seed + same temperature reproduces the sequence', () => {
+    const draws = (seed: number) => {
+      const rng = createRng(seed);
+      const values: Action[] = [];
+      for (let i = 0; i < 32; i += 1) {
+        values.push(softmaxSample(rng, candidates(), 1.0));
+      }
+      return values;
+    };
+    expect(draws(99)).toEqual(draws(99));
+  });
+
+  it('higher temperature shifts mass away from the argmax', () => {
+    // Empirical: count argmax frequency for each temperature.
+    function pickFrequency(temperature: number): number {
+      const rng = createRng(2024);
+      let argmax = 0;
+      const N = 2000;
+      for (let i = 0; i < N; i += 1) {
+        if (softmaxSample(rng, candidates(), temperature) === 'block') argmax += 1;
+      }
+      return argmax / N;
+    }
+    const cold = pickFrequency(0.5);
+    const hot = pickFrequency(3.0);
+    expect(cold).toBeGreaterThan(hot);
+  });
+
+  it('rejects negative temperature', () => {
+    const rng = createRng(1);
+    expect(() => softmaxSample(rng, candidates(), -1)).toThrow();
+  });
+
+  it('rejects non-finite scores', () => {
+    const rng = createRng(1);
+    const bad: readonly WeightedCandidate<Action>[] = [
+      { value: 'block', score: Number.POSITIVE_INFINITY },
+      { value: 'dodge', score: 0.5 },
+    ];
+    expect(() => softmaxSample(rng, bad, 1)).toThrow();
+  });
+
+  it('handles a single candidate by always returning it', () => {
+    const rng = createRng(3);
+    const only: readonly WeightedCandidate<Action>[] = [{ value: 'pass', score: 0.1 }];
+    for (let i = 0; i < 20; i += 1) {
+      expect(softmaxSample(rng, only, 1)).toBe('pass');
+    }
+  });
+
+  it('treats negative scores correctly via softmax stability', () => {
+    const rng = createRng(5);
+    const withNeg: readonly WeightedCandidate<Action>[] = [
+      { value: 'block', score: -2 },
+      { value: 'dodge', score: -1 },
+      { value: 'pass', score: 0 },
+    ];
+    // T=0 should still pick the argmax (score=0 → 'pass').
+    expect(softmaxSample(rng, withNeg, 0)).toBe('pass');
+  });
+});

--- a/packages/sim-engine/src/tactics/temperature.ts
+++ b/packages/sim-engine/src/tactics/temperature.ts
@@ -1,0 +1,106 @@
+/**
+ * IA temperature — sprint Pro League 0.B.5.
+ *
+ * Au lieu de toujours prendre l'action max-EV (deterministe et tres
+ * previsible), le driver hybride (0.A.2) sample sur les top-K candidats
+ * via un softmax dont la temperature est pilotee par le `riskAppetite`
+ * du `TacticalProfile` (0.B.2). Cela genere de la variance entre matchs
+ * theoriquement identiques (par exemple deux Pittsburgh-vs-Chicago
+ * lances avec le meme TV mais des seeds differents).
+ *
+ * Reference : softmax stable (Vigna/StackExchange) — soustraction du
+ * max avant exp pour eviter l'overflow numerique.
+ */
+
+import type { Rng } from '../rng/seeded';
+
+/** Candidate avec un score brut (EV / heuristique / weight). Le score
+ *  peut etre negatif ou positif ; seules les *differences* comptent. */
+export interface WeightedCandidate<T> {
+  value: T;
+  score: number;
+}
+
+/**
+ * Mappe `riskAppetite` (0..100) vers une temperature softmax :
+ * - 0 → 0 (argmax pur, IA glaciale)
+ * - 50 → ~1.0 (baseline neutre, distribution balancee)
+ * - 100 → ~2.5 (IA brulante, presque uniforme)
+ *
+ * Choix d'une fonction lineaire `risk / 40` sur [0, 100], donne :
+ * - risk=0 → T=0
+ * - risk=50 → T=1.25
+ * - risk=100 → T=2.5
+ *
+ * Volontairement simple — la tuning loop (lot 0.E.1) pourra basculer
+ * vers une courbe non-lineaire si besoin sans casser l'API.
+ */
+export function riskAppetiteToTemperature(riskAppetite: number): number {
+  if (!Number.isFinite(riskAppetite)) return 0;
+  const clamped = Math.max(0, Math.min(100, riskAppetite));
+  return clamped / 40;
+}
+
+/**
+ * Sample un candidat selon une distribution softmax stabilisee.
+ * - `temperature === 0` -> argmax deterministe (premier max si egalites).
+ * - `temperature > 0` -> probabilite `exp(score_i / T) / sum(exp(score_j / T))`.
+ *
+ * Throws sur input vide, scores non-finis, temperature negative.
+ */
+export function softmaxSample<T>(
+  rng: Pick<Rng, 'next'>,
+  candidates: readonly WeightedCandidate<T>[],
+  temperature: number
+): T {
+  if (candidates.length === 0) {
+    throw new Error('softmaxSample: candidates list must be non-empty');
+  }
+  if (!Number.isFinite(temperature) || temperature < 0) {
+    throw new Error('softmaxSample: temperature must be a non-negative finite number');
+  }
+  for (const c of candidates) {
+    if (!Number.isFinite(c.score)) {
+      throw new Error('softmaxSample: each candidate score must be a finite number');
+    }
+  }
+
+  if (candidates.length === 1) return candidates[0].value;
+
+  if (temperature === 0) {
+    // Argmax (first occurrence wins on ties).
+    let bestIdx = 0;
+    let bestScore = candidates[0].score;
+    for (let i = 1; i < candidates.length; i += 1) {
+      if (candidates[i].score > bestScore) {
+        bestScore = candidates[i].score;
+        bestIdx = i;
+      }
+    }
+    return candidates[bestIdx].value;
+  }
+
+  // Stable softmax : subtract max score to avoid exp overflow.
+  let maxScore = candidates[0].score;
+  for (let i = 1; i < candidates.length; i += 1) {
+    if (candidates[i].score > maxScore) maxScore = candidates[i].score;
+  }
+
+  const weights: number[] = new Array(candidates.length);
+  let totalWeight = 0;
+  for (let i = 0; i < candidates.length; i += 1) {
+    const w = Math.exp((candidates[i].score - maxScore) / temperature);
+    weights[i] = w;
+    totalWeight += w;
+  }
+
+  // Inverse-CDF sampling.
+  const draw = rng.next() * totalWeight;
+  let acc = 0;
+  for (let i = 0; i < candidates.length; i += 1) {
+    acc += weights[i];
+    if (draw < acc) return candidates[i].value;
+  }
+  // Floating-point fallback : return the last candidate.
+  return candidates[candidates.length - 1].value;
+}


### PR DESCRIPTION
## Résumé

Sprint Pro League — tâche **0.B.5** (Température IA, décisions sub-optimales contrôlées).

Au lieu que le driver hybride (0.A.2) prenne toujours l'action max-EV (déterministe et prévisible), il sample désormais sur les top-K candidats via un **softmax** dont la **température** est pilotée par le `riskAppetite` du `TacticalProfile` (0.B.2). Cela génère de la variance entre matchs théoriquement identiques (mêmes TVs, mêmes adversaires).

## Livrables

### `src/tactics/temperature.ts`
- **`riskAppetiteToTemperature(0..100)`** :
  - `riskAppetite=0` → T=0 (argmax pur, IA glaciale)
  - `riskAppetite=50` → T=1.25 (baseline neutre)
  - `riskAppetite=100` → T=2.5 (presque uniforme, IA brûlante)
  - Linéaire `risk / 40` ; la tuning loop (0.E.1) pourra basculer non-linéaire sans casser l'API.
- **`softmaxSample<T>(rng, candidates, temperature)`** :
  - Softmax **numériquement stable** (subtraction du max avant exp).
  - `T=0` → argmax déterministe (premier max sur égalités).
  - `T>0` → probabilité `exp(score_i / T) / sum(exp(score_j / T))`, tirage par inverse-CDF.
  - Throws sur input vide, scores non-finis, T < 0.
- **`WeightedCandidate<T>`** interface publique.

### Wiring driver hybride
- `pickKeyMoment` réécrit : prend désormais le `TacticalProfile` de l'équipe active et dérive les scores des dimensions 0.B.2 :
  - **Loose ball** : `pickup ~ 1 - bashIndex/2`, `block ~ bashIndex`
  - **Red zone** : `block ~ bashIndex+0.3`, `dodge ~ breakawayInstinct+0.2`, `gfi ~ gfiTolerance`
  - **Open field** : block/dodge/pass/gfi/foul/null pondérés par `bashIndex`, `breakawayInstinct`, `passingFrequency`, `gfiTolerance`, `foulFrequency`, `pace`
- `processTurn` reçoit les profils home/away et passe le profil de l'équipe en attaque.
- Défaut `DEFAULT_TACTICAL_PROFILE` quand un team input n'a pas déclaré `tactics`.

## Tests (14 nouveaux, 102 total)

### `riskAppetiteToTemperature`
- 0 → T=0, 50 → T∈[0.8, 1.5], 100 → T≥2.0
- Monotone non-décroissant
- Clamp `<0` et `>100`

### `softmaxSample`
- `T=0` retourne l'argmax déterministe (50 itérations)
- `T=3.0` sur 200 draws → ≥ 2 valeurs distinctes
- Même seed + même T reproduit la séquence
- **Higher T déplace la masse hors de l'argmax** (test empirique 2000 draws)
- Rejette `T<0`, scores non-finis, candidates vides
- Single-candidate toujours retourné
- Scores négatifs gérés correctement (softmax stable)

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **102/102** (+14)
- [x] Typecheck monorepo (4 packages) vert
- [x] Sprint doc : 0.B.5 marqué `[x]`

## Suite (lot B)

- **0.B.4** — Mémoire momentum (hot/cold) inter-match
- **0.B.1** — Behavior tree + patterns library

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_