### PR TITLE
feat(sim-engine): cross-match PlayerForm avec decay sur 3 matchs — closes lot C (0.C.4)

### DIFF
--- a/docs/roadmap/sprints/SPRINT-pro-league.md
+++ b/docs/roadmap/sprints/SPRINT-pro-league.md
@@ -107,7 +107,7 @@ jusqu'a passer le gate.
 | 0.C.1 | Bibliotheque "Eye of Nuffle" events | Content + Backend | M | [x] | ~25-30 events scriptes avec probabilites : rookie_brilliance (3%), crowd_riot (1%), sudden_inspiration (4%), weather_shift (5%), tantrum_star (2%), banana_skin (2%), bombardier_gone_wild (1%), nemesis_clash (3%), etc. Chacun emet un `MatchEvent` type `NUFFLE` annonce par le ticker. |
 | 0.C.2 | Hooks injection Nuffle events | Backend | S | [x] | Le driver hybride invoque le rolleur Nuffle a chaque debut de tour. Effets appliques au state via PRNG seede. Events stockes en DB pour replay et alimentation Gazette. |
 | 0.C.3 | Boost variance underdog (subtil) | Backend | S | [x] | Si TV gap > 200 ou pre-match win prob < 15%, +10% sur les rolls critiques cote underdog. Non visible utilisateur. Cible : upset rate 12-18% (pas 5%). |
-| 0.C.4 | Streaks/forme cross-match | Backend | S | [ ] | Persiste `PlayerForm` (hot/normal/cold) entre matchs. Decay sur 3 matchs. Visible sur la fiche joueur publique. |
+| 0.C.4 | Streaks/forme cross-match | Backend | S | [x] | Persiste `PlayerForm` (hot/normal/cold) entre matchs. Decay sur 3 matchs. Visible sur la fiche joueur publique. |
 
 ### Lot 0.D — Bench harness (~1 sem)
 

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -47,6 +47,15 @@ export {
   type UnderdogContext,
 } from './tactics/underdog';
 export {
+  FORM_DECAY_MATCHES,
+  applyMatchToForms,
+  decayForm,
+  getPlayerForm,
+  type FormState,
+  type FormUpdateInput,
+  type PlayerForm,
+} from './tactics/player-form';
+export {
   PATTERNS,
   PATTERN_BY_ID,
   STRATEGIES,

--- a/packages/sim-engine/src/tactics/player-form.test.ts
+++ b/packages/sim-engine/src/tactics/player-form.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PlayerMomentum } from './momentum';
+
+import {
+  FORM_DECAY_MATCHES,
+  applyMatchToForms,
+  decayForm,
+  getPlayerForm,
+  type FormState,
+  type PlayerForm,
+} from './player-form';
+
+const momentum = (
+  playerId: string,
+  state: 'hot' | 'normal' | 'cold' = 'normal'
+): PlayerMomentum => ({
+  playerId,
+  state,
+  touchdowns: state === 'hot' ? 2 : 0,
+  successfulBlocks: 0,
+  failureStreak: state === 'cold' ? 3 : 0,
+});
+
+describe('PlayerForm — sprint Pro League 0.C.4', () => {
+  it('exposes the documented decay window of 3 matches', () => {
+    expect(FORM_DECAY_MATCHES).toBe(3);
+  });
+
+  it('returns "normal" for an unknown player', () => {
+    expect(getPlayerForm([], 'ghost')).toBe<FormState>('normal');
+  });
+
+  it('promotes a player to "hot" when the match-end momentum is hot', () => {
+    const next = applyMatchToForms({ momentumSnapshot: [momentum('p1', 'hot')], prior: [] });
+    const p1 = next.find((f) => f.playerId === 'p1');
+    expect(p1?.state).toBe<FormState>('hot');
+    expect(p1?.matchesSinceReinforcement).toBe(0);
+  });
+
+  it('promotes a player to "cold" when the match-end momentum is cold', () => {
+    const next = applyMatchToForms({ momentumSnapshot: [momentum('p1', 'cold')], prior: [] });
+    expect(next.find((f) => f.playerId === 'p1')?.state).toBe<FormState>('cold');
+  });
+
+  it('a normal-momentum match increments matchesSinceReinforcement on existing forms', () => {
+    const prior: PlayerForm[] = [
+      { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 0 },
+    ];
+    const next = applyMatchToForms({
+      momentumSnapshot: [momentum('p1', 'normal')],
+      prior,
+    });
+    const p1 = next.find((f) => f.playerId === 'p1');
+    expect(p1?.state).toBe<FormState>('hot');
+    expect(p1?.matchesSinceReinforcement).toBe(1);
+  });
+
+  it('decays hot to normal after 3 matches without reinforcement', () => {
+    let forms: readonly PlayerForm[] = [
+      { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 0 },
+    ];
+    for (let i = 0; i < FORM_DECAY_MATCHES; i += 1) {
+      forms = applyMatchToForms({ momentumSnapshot: [momentum('p1', 'normal')], prior: forms });
+    }
+    expect(forms.find((f) => f.playerId === 'p1')?.state).toBe<FormState>('normal');
+  });
+
+  it('decays cold to normal after 3 matches without reinforcement', () => {
+    let forms: readonly PlayerForm[] = [
+      { playerId: 'p1', state: 'cold', matchesSinceReinforcement: 0 },
+    ];
+    for (let i = 0; i < FORM_DECAY_MATCHES; i += 1) {
+      forms = applyMatchToForms({ momentumSnapshot: [momentum('p1', 'normal')], prior: forms });
+    }
+    expect(forms.find((f) => f.playerId === 'p1')?.state).toBe<FormState>('normal');
+  });
+
+  it('reinforcing a hot player resets the decay counter', () => {
+    let forms: readonly PlayerForm[] = [
+      { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 2 },
+    ];
+    forms = applyMatchToForms({
+      momentumSnapshot: [momentum('p1', 'hot')],
+      prior: forms,
+    });
+    const p1 = forms.find((f) => f.playerId === 'p1');
+    expect(p1?.state).toBe<FormState>('hot');
+    expect(p1?.matchesSinceReinforcement).toBe(0);
+  });
+
+  it('players who did not play this match still age (decay continues)', () => {
+    const prior: PlayerForm[] = [
+      { playerId: 'absent', state: 'hot', matchesSinceReinforcement: 1 },
+    ];
+    const next = applyMatchToForms({ momentumSnapshot: [], prior });
+    expect(next.find((f) => f.playerId === 'absent')?.matchesSinceReinforcement).toBe(2);
+  });
+
+  it('hot momentum overrides a previously cold form (most recent match wins)', () => {
+    const prior: PlayerForm[] = [
+      { playerId: 'p1', state: 'cold', matchesSinceReinforcement: 0 },
+    ];
+    const next = applyMatchToForms({
+      momentumSnapshot: [momentum('p1', 'hot')],
+      prior,
+    });
+    expect(next.find((f) => f.playerId === 'p1')?.state).toBe<FormState>('hot');
+  });
+
+  it('decayForm helper : hot stays hot until the threshold then flips', () => {
+    let f: PlayerForm = { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 0 };
+    f = decayForm(f);
+    expect(f.state).toBe<FormState>('hot');
+    expect(f.matchesSinceReinforcement).toBe(1);
+    f = decayForm(f);
+    expect(f.state).toBe<FormState>('hot');
+    f = decayForm(f);
+    // After 3 cumulative aging steps, the state has decayed.
+    expect(f.state).toBe<FormState>('normal');
+  });
+
+  it('immutability : applyMatchToForms returns a fresh array (no mutation of prior)', () => {
+    const prior: PlayerForm[] = [
+      { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 0 },
+    ];
+    const before = JSON.stringify(prior);
+    applyMatchToForms({ momentumSnapshot: [momentum('p1', 'cold')], prior });
+    expect(JSON.stringify(prior)).toBe(before);
+  });
+
+  it('getPlayerForm returns the persisted state for known players', () => {
+    const forms: PlayerForm[] = [
+      { playerId: 'p1', state: 'hot', matchesSinceReinforcement: 1 },
+    ];
+    expect(getPlayerForm(forms, 'p1')).toBe<FormState>('hot');
+    expect(getPlayerForm(forms, 'p2')).toBe<FormState>('normal');
+  });
+
+  it('a momentum entry with state="normal" but high counters does not flip the form', () => {
+    const partial: PlayerMomentum = {
+      playerId: 'p1',
+      state: 'normal',
+      touchdowns: 1,
+      successfulBlocks: 2,
+      failureStreak: 1,
+    };
+    const next = applyMatchToForms({ momentumSnapshot: [partial], prior: [] });
+    expect(next.find((f) => f.playerId === 'p1')?.state).toBe<FormState>('normal');
+  });
+});

--- a/packages/sim-engine/src/tactics/player-form.ts
+++ b/packages/sim-engine/src/tactics/player-form.ts
@@ -1,0 +1,117 @@
+/**
+ * Cross-match `PlayerForm` — sprint Pro League 0.C.4.
+ *
+ * Persiste un état "hot / normal / cold" entre matchs avec un decay sur
+ * 3 matchs sans renforcement (sprint table). Visible sur la fiche
+ * joueur publique (lot 1.C.2) et alimente la Nuffle Gazette LLM
+ * (lot 1.E.1) + le calcul des cotes (lot 1.D.3).
+ *
+ * Architecture
+ * ------------
+ * Le sim-engine n'a pas de couche de persistence : ces helpers sont
+ * purs et travaillent sur des `readonly PlayerForm[]` que le serveur
+ * (apps/server) lit depuis sa table Prisma `PlayerForm`, applique a
+ * chaque match termine via `applyMatchToForms`, puis re-persiste.
+ *
+ * Le pont avec lot 0.B.4 : `applyMatchToForms` consomme le snapshot
+ * `MomentumTracker` du SimResult (`summary.momentum`).
+ */
+
+import type { PlayerMomentum } from './momentum';
+
+export type FormState = 'hot' | 'normal' | 'cold';
+
+export interface PlayerForm {
+  playerId: string;
+  state: FormState;
+  /** Number of consecutive matches without state-reinforcement. Reset
+   *  to 0 each time the match-end momentum confirms the current state. */
+  matchesSinceReinforcement: number;
+}
+
+export interface FormUpdateInput {
+  /** Per-player momentum snapshot at end of match (lot 0.B.4). */
+  momentumSnapshot: readonly PlayerMomentum[];
+  /** Existing forms entering the match (server DB). */
+  prior: readonly PlayerForm[];
+}
+
+/** Decay window — sprint table: "decay sur 3 matchs". After 3 consecutive
+ *  matches with no reinforcing match-end momentum, the form returns to
+ *  `normal`. */
+export const FORM_DECAY_MATCHES = 3;
+
+/**
+ * Convenience helper : age a single form by one match without taking
+ * any reinforcement signal. Returns a fresh object (no mutation).
+ */
+export function decayForm(form: PlayerForm): PlayerForm {
+  if (form.state === 'normal') {
+    return { ...form, matchesSinceReinforcement: 0 };
+  }
+  const next = form.matchesSinceReinforcement + 1;
+  if (next >= FORM_DECAY_MATCHES) {
+    return { ...form, state: 'normal', matchesSinceReinforcement: 0 };
+  }
+  return { ...form, matchesSinceReinforcement: next };
+}
+
+/**
+ * Folds the end-of-match momentum into the persisted forms.
+ *
+ * For each player listed in the momentum snapshot :
+ * - `state === 'hot'` or `'cold'` overrides the persisted form (most-recent
+ *   match wins) and resets `matchesSinceReinforcement` to 0.
+ * - `state === 'normal'` ages the existing form by one match.
+ *
+ * For each player in `prior` who did NOT appear in the momentum snapshot
+ * (didn't play this match), their form is also aged by one match — the
+ * decay window represents calendar matches, not personal participation.
+ */
+export function applyMatchToForms(input: FormUpdateInput): readonly PlayerForm[] {
+  const out = new Map<string, PlayerForm>();
+  // Seed with priors so we don't drop entries for non-playing veterans.
+  for (const f of input.prior) {
+    out.set(f.playerId, { ...f });
+  }
+
+  const seenInMatch = new Set<string>();
+  for (const m of input.momentumSnapshot) {
+    seenInMatch.add(m.playerId);
+    if (m.state === 'hot' || m.state === 'cold') {
+      out.set(m.playerId, {
+        playerId: m.playerId,
+        state: m.state,
+        matchesSinceReinforcement: 0,
+      });
+    } else {
+      const existing = out.get(m.playerId);
+      if (!existing) {
+        // Fresh player with normal momentum — record at normal so the
+        // Gazette can list them (avoids "ghost" players never persisted).
+        out.set(m.playerId, {
+          playerId: m.playerId,
+          state: 'normal',
+          matchesSinceReinforcement: 0,
+        });
+      } else {
+        out.set(m.playerId, decayForm(existing));
+      }
+    }
+  }
+
+  // Age players who did not appear in this match (calendar-time decay).
+  for (const [id, form] of out) {
+    if (!seenInMatch.has(id)) {
+      out.set(id, decayForm(form));
+    }
+  }
+
+  return Array.from(out.values());
+}
+
+/** Read-only lookup. Returns `'normal'` for unknown players. */
+export function getPlayerForm(forms: readonly PlayerForm[], playerId: string): FormState {
+  const f = forms.find((x) => x.playerId === playerId);
+  return f ? f.state : 'normal';
+}


### PR DESCRIPTION
## Résumé

Sprint Pro League — tâche **0.C.4** (cross-match PlayerForm). **Closes lot C.**

Persiste un état **`hot / normal / cold`** entre matchs avec **decay sur 3 matchs** sans renforcement (sprint table). Visible sur la fiche joueur publique (lot 1.C.2) et alimente la Nuffle Gazette LLM (lot 1.E.1) + le calcul des cotes (lot 1.D.3).

## Architecture

Le sim-engine n'a pas de couche persistence : les helpers sont **purs** et travaillent sur des `readonly PlayerForm[]` que le serveur (apps/server) lit depuis sa table Prisma `PlayerForm` (lot 1.A.1), applique à chaque match terminé via `applyMatchToForms`, puis re-persiste.

**Pont avec lot 0.B.4** : `applyMatchToForms` consomme le snapshot `MomentumTracker` du `SimResult` (`summary.momentum`).

## Livrables

### `src/tactics/player-form.ts`
- `FormState = 'hot' | 'normal' | 'cold'`
- `PlayerForm { playerId, state, matchesSinceReinforcement }`
- `FORM_DECAY_MATCHES = 3` (sprint table)
- `decayForm(form)` — âge d'un match (pure, no mutation)
- `applyMatchToForms({momentumSnapshot, prior})` :
  - `momentum.state = hot/cold` → override la forme + reset counter
  - `momentum.state = normal` → âge la forme existante
  - Players absents du match → âgent aussi (calendar-time decay)
  - Retourne un fresh array (immutable, no mutation des priors)
- `getPlayerForm(forms, playerId)` — `'normal'` pour inconnu

## Tests (14 nouveaux, 181 total)

- `FORM_DECAY_MATCHES === 3`
- `getPlayerForm` : `'normal'` pour joueur inconnu, état persiste pour connu
- **Promote** : hot momentum → hot form, cold momentum → cold form
- Normal momentum + prior hot → increment counter, state preserved
- **Decay strict** : 3 matchs sans renforcement → hot/cold revient à normal
- **Reinforcement** : hot momentum sur prior hot reset counter
- **Absent player** : counter increment aussi (calendar decay)
- **Override** : hot momentum bat prior cold (most-recent wins)
- `decayForm` helper : hot stays hot 3x puis flips à normal
- **Immutabilité** : prior n'est pas muté par `applyMatchToForms`
- Normal momentum avec compteurs hauts ne flip pas la forme

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **181/181** (+14)
- [x] Typecheck monorepo (4 packages) vert
- [x] Sprint doc : 0.C.4 marqué `[x]`

## Lot C — bilan

Cette PR clôt le lot **0.C — Variance & Nuffle moments** :

| # | Tâche | PR |
|---|-------|----|
| 0.C.1 | Bibliothèque Eye of Nuffle (28 events scriptés) | #563 ✅ |
| 0.C.2 | Hooks injection Nuffle dans le driver | #568 ✅ |
| 0.C.3 | Underdog variance boost (TV gap > 200, +10%) | #569 ✅ |
| **0.C.4** | **Cross-match PlayerForm avec decay sur 3 matchs** | **cette PR** |

## Suite (lots D+)

- 0.D — Bench harness + dataset FUMBBL + CI sim-bench
- 0.E — Tuning loop + panel BB experts (gate Phase 0 → Phase 1)

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_