### PR TITLE
feat(sim-engine): métriques vivacité (variance, fat-tails, Gini, upset rate) (0.D.3)

### DIFF
--- a/docs/roadmap/sprints/SPRINT-pro-league.md
+++ b/docs/roadmap/sprints/SPRINT-pro-league.md
@@ -115,7 +115,7 @@ jusqu'a passer le gate.
 |---|-------|-----|--------|--------|--------|
 | 0.D.1 | CLI `pnpm sim:bench` | DevX | M | [ ] | Script `packages/sim-engine/scripts/bench.ts` : `--team=A vs --team=B --runs=10000` simule en parallele worker_threads, sort un rapport stat (TDs/match, casualties, turnovers, win%, std dev, p5/p95). Optionnel `--matrix` pour toutes les races. |
 | 0.D.2 | Dataset reference FUMBBL | Data | M | [ ] | Scraper / import statique des stats publiques FUMBBL : winrates par race, casualty rates, TD averages, durees de drive. Stocke en `packages/sim-engine/bench/reference-fumbbl.json` versionne. |
-| 0.D.3 | Metriques "vivacite" (variance & outliers) | DevX | S | [ ] | Au-dela des moyennes : std dev, fat-tails (% matchs avec >= 5 TD, >= 4 casualties), upset rate, distribution MVP (Gini coefficient). Cible MVP : std dev TD >= 1.4, upset rate 12-18%, MVP non concentre uniquement sur stars. |
+| 0.D.3 | Metriques "vivacite" (variance & outliers) | DevX | S | [x] | Au-dela des moyennes : std dev, fat-tails (% matchs avec >= 5 TD, >= 4 casualties), upset rate, distribution MVP (Gini coefficient). Cible MVP : std dev TD >= 1.4, upset rate 12-18%, MVP non concentre uniquement sur stars. |
 | 0.D.4 | CI regression `sim-bench` | DevX | M | [ ] | `.github/workflows/sim-bench.yml` : sur chaque PR touchant `packages/sim-engine`, run `--runs=5000` vs `bench-baseline.json`. Alerte si deviation > 5% sur metriques cles. Baseline versionne avec `engineVer`. |
 
 ### Lot 0.E — Tuning loop + Human playtest gate (~2 sem)

--- a/packages/sim-engine/src/bench/metrics.test.ts
+++ b/packages/sim-engine/src/bench/metrics.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeVivacityMetrics,
+  giniCoefficient,
+  mean,
+  quantile,
+  simResultToSample,
+  stdDev,
+  variance,
+  type VivacitySample,
+} from './metrics';
+
+describe('Pure statistics helpers — sprint Pro League 0.D.3', () => {
+  it('mean of an empty array is 0', () => {
+    expect(mean([])).toBe(0);
+  });
+
+  it('mean computes the arithmetic mean', () => {
+    expect(mean([1, 2, 3, 4, 5])).toBeCloseTo(3, 10);
+    expect(mean([0, 0, 0])).toBe(0);
+  });
+
+  it('variance of a single value is 0', () => {
+    expect(variance([42])).toBe(0);
+  });
+
+  it('variance of [1, 2, 3, 4, 5] is 2.5 (population variance)', () => {
+    // pop var = sum((x - mean)^2) / n with mean=3 → (4+1+0+1+4)/5 = 2
+    expect(variance([1, 2, 3, 4, 5])).toBeCloseTo(2, 10);
+  });
+
+  it('stdDev = sqrt(variance)', () => {
+    expect(stdDev([1, 2, 3, 4, 5])).toBeCloseTo(Math.sqrt(2), 10);
+  });
+
+  it('quantile : p=0 returns min, p=1 returns max, p=0.5 returns median (linear)', () => {
+    expect(quantile([1, 2, 3, 4, 5], 0)).toBe(1);
+    expect(quantile([1, 2, 3, 4, 5], 1)).toBe(5);
+    expect(quantile([1, 2, 3, 4, 5], 0.5)).toBeCloseTo(3, 10);
+  });
+
+  it('quantile : p=0.05 / 0.95 on a sorted array', () => {
+    const xs = Array.from({ length: 101 }, (_, i) => i); // 0..100
+    expect(quantile(xs, 0.05)).toBeCloseTo(5, 10);
+    expect(quantile(xs, 0.95)).toBeCloseTo(95, 10);
+  });
+
+  it('quantile : empty array returns 0', () => {
+    expect(quantile([], 0.5)).toBe(0);
+  });
+});
+
+describe('giniCoefficient — MVP distribution sanity', () => {
+  it('a perfectly uniform distribution has Gini ~0', () => {
+    const out = giniCoefficient([5, 5, 5, 5, 5, 5]);
+    expect(out).toBeLessThan(0.01);
+  });
+
+  it('a one-player-wins-all distribution has Gini approaching 1', () => {
+    const out = giniCoefficient([0, 0, 0, 0, 0, 100]);
+    expect(out).toBeGreaterThan(0.7);
+    expect(out).toBeLessThanOrEqual(1);
+  });
+
+  it('a moderately unequal distribution sits in (0, 1)', () => {
+    const out = giniCoefficient([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(out).toBeGreaterThan(0);
+    expect(out).toBeLessThan(1);
+  });
+
+  it('empty / all-zero arrays return 0', () => {
+    expect(giniCoefficient([])).toBe(0);
+    expect(giniCoefficient([0, 0, 0])).toBe(0);
+  });
+
+  it('single value returns 0 (no inequality with one player)', () => {
+    expect(giniCoefficient([42])).toBe(0);
+  });
+});
+
+describe('computeVivacityMetrics — sprint targets', () => {
+  const sample = (overrides: Partial<VivacitySample> = {}): VivacitySample => ({
+    totalTd: 3,
+    outcome: 'home',
+    casualties: 1,
+    turnovers: 4,
+    ...overrides,
+  });
+
+  it('returns zero counts on an empty sample list', () => {
+    const out = computeVivacityMetrics([]);
+    expect(out.matches).toBe(0);
+    expect(out.td.mean).toBe(0);
+    expect(out.outcomes.home).toBe(0);
+  });
+
+  it('aggregates basic counts and rates', () => {
+    const samples: VivacitySample[] = [
+      sample({ totalTd: 2, outcome: 'home', casualties: 0, turnovers: 3 }),
+      sample({ totalTd: 4, outcome: 'away', casualties: 2, turnovers: 5 }),
+      sample({ totalTd: 0, outcome: 'draw', casualties: 1, turnovers: 6 }),
+      sample({ totalTd: 6, outcome: 'home', casualties: 4, turnovers: 4 }),
+    ];
+    const out = computeVivacityMetrics(samples);
+    expect(out.matches).toBe(4);
+    expect(out.td.mean).toBeCloseTo((2 + 4 + 0 + 6) / 4, 10);
+    expect(out.outcomes.home).toBe(2);
+    expect(out.outcomes.away).toBe(1);
+    expect(out.outcomes.draw).toBe(1);
+  });
+
+  it('flags fat-tail matches : >= 5 TD or >= 4 casualties', () => {
+    const samples: VivacitySample[] = [
+      sample({ totalTd: 6, casualties: 0 }), // high scoring
+      sample({ totalTd: 1, casualties: 5 }), // bloodbath
+      sample({ totalTd: 7, casualties: 4 }), // both
+      sample({ totalTd: 1, casualties: 1 }), // neither
+    ];
+    const out = computeVivacityMetrics(samples);
+    expect(out.fatTails.highScoring).toBe(2 / 4); // 50%
+    expect(out.fatTails.bloodbath).toBe(2 / 4); // 50%
+  });
+
+  it('upset rate counts matches where outcome != favorite', () => {
+    const samples: VivacitySample[] = [
+      sample({ outcome: 'home', favorite: 'home' }), // not upset
+      sample({ outcome: 'away', favorite: 'home' }), // upset
+      sample({ outcome: 'draw', favorite: 'home' }), // upset (favorite did not win)
+      sample({ outcome: 'home', favorite: 'home' }), // not upset
+    ];
+    const out = computeVivacityMetrics(samples);
+    expect(out.outcomes.upsetRate).toBeCloseTo(2 / 4, 10);
+  });
+
+  it('upsetRate is 0 when no favorite is annotated on any match', () => {
+    const samples: VivacitySample[] = [
+      sample({ outcome: 'home' }),
+      sample({ outcome: 'away' }),
+    ];
+    expect(computeVivacityMetrics(samples).outcomes.upsetRate).toBe(0);
+  });
+
+  it('meetsTargets reflects sprint thresholds (std dev TD >= 1.4, upset rate 12-18%)', () => {
+    // Construct synthetic samples with explicit TDs to control std dev.
+    const samples: VivacitySample[] = [];
+    // Pad with high-variance TDs : alternating 0 and 6 → mean=3, std=3.
+    for (let i = 0; i < 20; i += 1) {
+      samples.push(sample({ totalTd: i % 2 === 0 ? 0 : 6 }));
+    }
+    // Add 3 favorite-home upsets out of 20 (15% upset rate).
+    for (let i = 0; i < 17; i += 1) samples[i] = { ...samples[i], favorite: 'home', outcome: 'home' };
+    for (let i = 17; i < 20; i += 1) samples[i] = { ...samples[i], favorite: 'home', outcome: 'away' };
+    const out = computeVivacityMetrics(samples);
+    expect(out.meetsTargets.stdDevTd).toBe(true);
+    expect(out.meetsTargets.upsetRate).toBe(true);
+  });
+
+  it('meetsTargets.stdDevTd is false when variance is too low', () => {
+    const samples: VivacitySample[] = Array.from({ length: 10 }, () => sample({ totalTd: 3 }));
+    const out = computeVivacityMetrics(samples);
+    expect(out.meetsTargets.stdDevTd).toBe(false);
+  });
+});
+
+describe('simResultToSample — convenience wrapper', () => {
+  it('extracts totalTd / outcome / casualties / turnovers from a SimResult-like input', () => {
+    const fakeResult = {
+      result: 'home' as const,
+      events: [],
+      summary: {
+        outcome: 'home' as const,
+        score: { home: 2, away: 1 },
+        turnoverCount: 5,
+        touchdownCount: 3,
+        nuffleCount: 0,
+        underdogBoostCount: 0,
+        durationMs: 0,
+        momentum: [],
+      },
+      casualties: [{ playerId: 'a' }, { playerId: 'b' }],
+      engineVer: '0.1.0',
+    };
+    const sample = simResultToSample(fakeResult, 'home');
+    expect(sample.totalTd).toBe(3);
+    expect(sample.outcome).toBe('home');
+    expect(sample.casualties).toBe(2);
+    expect(sample.turnovers).toBe(5);
+    expect(sample.favorite).toBe('home');
+  });
+});

--- a/packages/sim-engine/src/bench/metrics.ts
+++ b/packages/sim-engine/src/bench/metrics.ts
@@ -1,0 +1,215 @@
+/**
+ * Métriques "vivacité" — sprint Pro League 0.D.3.
+ *
+ * Au-delà des moyennes, le bench harness (lot 0.D.1) doit valider que
+ * la simulation produit assez de variance pour rester intéressante :
+ * - std dev TD >= 1.4 (pas tous les matchs à 3-3)
+ * - upset rate 12-18% (les outsiders gagnent parfois)
+ * - distribution MVP non concentrée sur les stars (Gini coefficient)
+ * - fat-tails : % de matchs avec >= 5 TD, >= 4 casualties
+ *
+ * Toutes les fonctions sont pures et n'allouent aucun side-effect ; le
+ * harness CLI (0.D.1) et la baseline CI (0.D.4) consomment cette API.
+ */
+
+import type { Casualty, MatchOutcome, SimResult } from '../types';
+
+/** Sprint targets — flagged in `meetsTargets`. Tunable later via 0.E. */
+export const TARGET_STD_DEV_TD = 1.4;
+export const TARGET_UPSET_RATE_MIN = 0.12;
+export const TARGET_UPSET_RATE_MAX = 0.18;
+
+/** Match-level data point consumed by the metrics aggregator. */
+export interface VivacitySample {
+  /** SimResult.summary.touchdownCount. */
+  totalTd: number;
+  /** SimResult.result. */
+  outcome: MatchOutcome;
+  /** Optional pre-match favorite — when set, an outcome != favorite
+   *  counts as an upset. Set by the bench harness from TV gap or
+   *  pre-sim odds (lot 1.D.3). */
+  favorite?: 'home' | 'away';
+  /** Number of casualties in the match. */
+  casualties: number;
+  /** Total turnovers. */
+  turnovers: number;
+}
+
+export interface VivacityMetrics {
+  matches: number;
+  td: { mean: number; std: number; p5: number; p95: number };
+  casualties: { mean: number; std: number };
+  turnovers: { mean: number };
+  fatTails: {
+    /** Fraction of matches with >= 5 TDs. */
+    highScoring: number;
+    /** Fraction of matches with >= 4 casualties. */
+    bloodbath: number;
+  };
+  outcomes: {
+    home: number;
+    away: number;
+    draw: number;
+    /** Fraction of matches where outcome != favorite. 0 when no
+     *  favorite is annotated on any match. */
+    upsetRate: number;
+  };
+  meetsTargets: {
+    stdDevTd: boolean;
+    /** True when upset rate is in `[TARGET_UPSET_RATE_MIN,
+     *  TARGET_UPSET_RATE_MAX]`. */
+    upsetRate: boolean;
+  };
+}
+
+const HIGH_SCORING_TD_THRESHOLD = 5;
+const BLOODBATH_CASUALTY_THRESHOLD = 4;
+
+export function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}
+
+export function variance(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const m = mean(values);
+  let acc = 0;
+  for (const v of values) {
+    const d = v - m;
+    acc += d * d;
+  }
+  return acc / values.length;
+}
+
+export function stdDev(values: readonly number[]): number {
+  return Math.sqrt(variance(values));
+}
+
+/**
+ * Linear-interpolation quantile (R type-7). `p` in `[0, 1]`. Returns 0
+ * for an empty array (never throws — bench code consumes degenerate
+ * inputs during smoke tests).
+ */
+export function quantile(values: readonly number[], p: number): number {
+  if (values.length === 0) return 0;
+  if (values.length === 1) return values[0];
+  const sorted = [...values].sort((a, b) => a - b);
+  const clamped = Math.max(0, Math.min(1, p));
+  const idx = clamped * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  const frac = idx - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+/**
+ * Gini coefficient over a non-negative distribution (typically MVP
+ * scores per player across N matches). Returns `0` for perfectly
+ * uniform / empty / all-zero inputs ; approaches `1` when one player
+ * captures all the value.
+ */
+export function giniCoefficient(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  let sum = 0;
+  let weightedSum = 0;
+  for (let i = 0; i < n; i += 1) {
+    const v = sorted[i];
+    if (v < 0) {
+      throw new Error('giniCoefficient: values must be non-negative');
+    }
+    sum += v;
+    weightedSum += (i + 1) * v;
+  }
+  if (sum === 0) return 0;
+  // G = (2 * sum_i i*x_i) / (n * sum) - (n + 1) / n
+  return (2 * weightedSum) / (n * sum) - (n + 1) / n;
+}
+
+/** Convenience helper : extract a `VivacitySample` from a `SimResult`. */
+export function simResultToSample(
+  result: Pick<SimResult, 'result' | 'summary' | 'casualties'>,
+  favorite?: 'home' | 'away'
+): VivacitySample {
+  return {
+    totalTd: result.summary.touchdownCount,
+    outcome: result.result,
+    favorite,
+    casualties: (result.casualties as readonly Casualty[]).length,
+    turnovers: result.summary.turnoverCount,
+  };
+}
+
+export function computeVivacityMetrics(
+  samples: readonly VivacitySample[]
+): VivacityMetrics {
+  if (samples.length === 0) {
+    return {
+      matches: 0,
+      td: { mean: 0, std: 0, p5: 0, p95: 0 },
+      casualties: { mean: 0, std: 0 },
+      turnovers: { mean: 0 },
+      fatTails: { highScoring: 0, bloodbath: 0 },
+      outcomes: { home: 0, away: 0, draw: 0, upsetRate: 0 },
+      meetsTargets: { stdDevTd: false, upsetRate: false },
+    };
+  }
+
+  const tds = samples.map((s) => s.totalTd);
+  const cas = samples.map((s) => s.casualties);
+  const tos = samples.map((s) => s.turnovers);
+
+  let home = 0;
+  let away = 0;
+  let draw = 0;
+  let highScoring = 0;
+  let bloodbath = 0;
+  let upsetCount = 0;
+  let withFavorite = 0;
+  for (const s of samples) {
+    if (s.outcome === 'home') home += 1;
+    else if (s.outcome === 'away') away += 1;
+    else draw += 1;
+    if (s.totalTd >= HIGH_SCORING_TD_THRESHOLD) highScoring += 1;
+    if (s.casualties >= BLOODBATH_CASUALTY_THRESHOLD) bloodbath += 1;
+    if (s.favorite !== undefined) {
+      withFavorite += 1;
+      if (s.outcome !== s.favorite) upsetCount += 1;
+    }
+  }
+  const upsetRate = withFavorite > 0 ? upsetCount / withFavorite : 0;
+  const tdStd = stdDev(tds);
+
+  return {
+    matches: samples.length,
+    td: {
+      mean: mean(tds),
+      std: tdStd,
+      p5: quantile(tds, 0.05),
+      p95: quantile(tds, 0.95),
+    },
+    casualties: { mean: mean(cas), std: stdDev(cas) },
+    turnovers: { mean: mean(tos) },
+    fatTails: {
+      highScoring: highScoring / samples.length,
+      bloodbath: bloodbath / samples.length,
+    },
+    outcomes: {
+      home,
+      away,
+      draw,
+      upsetRate,
+    },
+    meetsTargets: {
+      stdDevTd: tdStd >= TARGET_STD_DEV_TD,
+      upsetRate:
+        withFavorite > 0 &&
+        upsetRate >= TARGET_UPSET_RATE_MIN &&
+        upsetRate <= TARGET_UPSET_RATE_MAX,
+    },
+  };
+}

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -56,6 +56,20 @@ export {
   type PlayerForm,
 } from './tactics/player-form';
 export {
+  TARGET_STD_DEV_TD,
+  TARGET_UPSET_RATE_MAX,
+  TARGET_UPSET_RATE_MIN,
+  computeVivacityMetrics,
+  giniCoefficient,
+  mean,
+  quantile,
+  simResultToSample,
+  stdDev,
+  variance,
+  type VivacityMetrics,
+  type VivacitySample,
+} from './bench/metrics';
+export {
   PATTERNS,
   PATTERN_BY_ID,
   STRATEGIES,


### PR DESCRIPTION
## Résumé

Sprint Pro League — tâche **0.D.3** (métriques "vivacité"). Foundation du lot 0.D (bench harness).

Fournit des helpers stats **purs** et un agrégateur `computeVivacityMetrics` qui valide les cibles sprint :
- **std dev TD ≥ 1.4** (variance non dégénérée)
- **upset rate 12-18%** (les outsiders gagnent parfois)
- distribution MVP non concentrée (Gini coefficient)
- fat-tails : % matchs avec ≥ 5 TD ou ≥ 4 casualties

## Livrables

### `src/bench/metrics.ts`

**Helpers stats purs** :
- `mean`, `variance`, `stdDev`
- `quantile` — interpolation linéaire (R type-7)
- `giniCoefficient` — borne `[0, 1]`, throws sur valeurs négatives

**Aggregat** :
- `VivacitySample { totalTd, outcome, favorite?, casualties, turnovers }` — data point par match
- `VivacityMetrics` :
  - `td.{mean, std, p5, p95}`
  - `casualties.{mean, std}`
  - `fatTails.{highScoring, bloodbath}`
  - `outcomes.{home, away, draw, upsetRate}`
  - `meetsTargets.{stdDevTd, upsetRate}`
- `computeVivacityMetrics(samples)` — O(N) + sort pour les quantiles
- `simResultToSample(result, favorite?)` — wrapper qui convertit un `SimResult` en `VivacitySample`

**Constantes publiques** dérivées du sprint table :
- `TARGET_STD_DEV_TD = 1.4`
- `TARGET_UPSET_RATE_MIN = 0.12`
- `TARGET_UPSET_RATE_MAX = 0.18`

## Tests (21 nouveaux, 202 total)

### Stats purs (8)
- `mean` : empty, typical, zeros
- `variance` : single value, `[1..5]` = 2 (population)
- `stdDev = sqrt(variance)`
- `quantile` : p=0/1/0.5, p=0.05/0.95 sur 0..100, empty → 0

### Gini (5)
- Distribution uniforme → ~0
- One-wins-all → ~1
- Modéré → (0, 1)
- Empty / all-zero → 0
- Single value → 0

### Agrégat (8)
- Empty → zeros
- Aggregation basique (counts, rates)
- **Fat-tails** : ≥ 5 TD / ≥ 4 casualties bins correctement
- **Upset rate** : outcome != favorite count, draw vs favorite = upset
- `upsetRate = 0` si aucun favori annoté
- `meetsTargets` reflète les seuils sprint
- `meetsTargets.stdDevTd = false` si variance trop basse
- `simResultToSample` wrapper extrait correctement les champs

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **202/202** (+21)
- [x] Typecheck monorepo (4 packages) vert
- [x] Sprint doc : 0.D.3 marqué `[x]`

## Suite (lot D)

- **0.D.2** — Dataset référence FUMBBL (winrates, casualty rates par race)
- **0.D.1** — CLI `pnpm sim:bench` (worker_threads, --runs, rapport stat)
- **0.D.4** — CI sim-bench regression (`.github/workflows/sim-bench.yml`)

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_