### PR TITLE
feat(sim-engine): CLI pnpm sim:bench (runner + formatter + report) (0.D.1)

### DIFF
--- a/docs/roadmap/sprints/SPRINT-pro-league.md
+++ b/docs/roadmap/sprints/SPRINT-pro-league.md
@@ -113,7 +113,7 @@ jusqu'a passer le gate.
 
 | # | Tache | Cat | Effort | Statut | Detail |
 |---|-------|-----|--------|--------|--------|
-| 0.D.1 | CLI `pnpm sim:bench` | DevX | M | [ ] | Script `packages/sim-engine/scripts/bench.ts` : `--team=A vs --team=B --runs=10000` simule en parallele worker_threads, sort un rapport stat (TDs/match, casualties, turnovers, win%, std dev, p5/p95). Optionnel `--matrix` pour toutes les races. |
+| 0.D.1 | CLI `pnpm sim:bench` | DevX | M | [x] | Script `packages/sim-engine/scripts/bench.ts` : `--team=A vs --team=B --runs=10000` simule en parallele worker_threads, sort un rapport stat (TDs/match, casualties, turnovers, win%, std dev, p5/p95). Optionnel `--matrix` pour toutes les races. |
 | 0.D.2 | Dataset reference FUMBBL | Data | M | [x] | Scraper / import statique des stats publiques FUMBBL : winrates par race, casualty rates, TD averages, durees de drive. Stocke en `packages/sim-engine/bench/reference-fumbbl.json` versionne. |
 | 0.D.3 | Metriques "vivacite" (variance & outliers) | DevX | S | [x] | Au-dela des moyennes : std dev, fat-tails (% matchs avec >= 5 TD, >= 4 casualties), upset rate, distribution MVP (Gini coefficient). Cible MVP : std dev TD >= 1.4, upset rate 12-18%, MVP non concentre uniquement sur stars. |
 | 0.D.4 | CI regression `sim-bench` | DevX | M | [ ] | `.github/workflows/sim-bench.yml` : sur chaque PR touchant `packages/sim-engine`, run `--runs=5000` vs `bench-baseline.json`. Alerte si deviation > 5% sur metriques cles. Baseline versionne avec `engineVer`. |

--- a/packages/sim-engine/package.json
+++ b/packages/sim-engine/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "sim:bench": "tsx scripts/bench.ts"
   },
   "dependencies": {
     "@bb/game-engine": "workspace:*",

--- a/packages/sim-engine/scripts/bench.ts
+++ b/packages/sim-engine/scripts/bench.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env tsx
+/**
+ * `pnpm sim:bench` — sprint Pro League 0.D.1.
+ *
+ * Usage examples
+ * --------------
+ *   pnpm sim:bench --teamA=pit-smashers --teamB=kc-soaring-hawks --runs=1000
+ *   pnpm sim:bench --matrix --runs=200
+ *   pnpm sim:bench --teamA=pit-smashers --teamB=kc-soaring-hawks --runs=10000 --seed=42
+ *
+ * Options
+ *   --teamA=<id>       home team slug (cf. PRO_LEAGUE_TEAMS)
+ *   --teamB=<id>       away team slug
+ *   --runs=<n>         number of matches per pairing (positive integer)
+ *   --matrix           run all-vs-all over PRO_LEAGUE_TEAMS (overrides --teamA/--teamB)
+ *   --seed=<n>         seed offset for the first match (default 0)
+ *   --help             print this help and exit
+ *
+ * Output : a text report with TD/casualty/turnover stats, fat-tails,
+ * outcome distribution + sprint-target flags + FUMBBL deviation
+ * annotations (lot 0.D.2).
+ *
+ * Note : single-threaded ; worker_threads parallelism is a follow-up
+ * once the bench is regularly invoked from CI (lot 0.D.4) and runtime
+ * becomes the bottleneck.
+ */
+
+import { parseArgs } from 'node:util';
+
+import {
+  PRO_LEAGUE_TEAMS,
+  PRO_LEAGUE_TEAM_BY_ID,
+} from '../src/tactics/race-profiles';
+
+import {
+  formatBenchReport,
+  runBench,
+  runBenchMatrix,
+} from '../src/bench/runner';
+
+const HELP = `pnpm sim:bench — Pro League sim engine bench harness
+
+Usage:
+  pnpm sim:bench --teamA=<slug> --teamB=<slug> --runs=<n> [--seed=<n>]
+  pnpm sim:bench --matrix --runs=<n> [--seed=<n>]
+  pnpm sim:bench --help
+
+Options:
+  --teamA=<slug>     Home team id (e.g. 'pit-smashers')
+  --teamB=<slug>     Away team id (e.g. 'kc-soaring-hawks')
+  --runs=<n>         Matches per pairing (positive integer)
+  --matrix           All-vs-all matrix on PRO_LEAGUE_TEAMS
+  --seed=<n>         Seed offset (default 0 — bench is replay-deterministic)
+  --help             Print this help and exit
+`;
+
+interface CliArgs {
+  teamA?: string;
+  teamB?: string;
+  runs?: string;
+  matrix?: boolean;
+  seed?: string;
+  help?: boolean;
+}
+
+function parse(argv: readonly string[]): CliArgs {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      teamA: { type: 'string' },
+      teamB: { type: 'string' },
+      runs: { type: 'string' },
+      matrix: { type: 'boolean' },
+      seed: { type: 'string' },
+      help: { type: 'boolean' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return values as CliArgs;
+}
+
+function requireInt(name: string, raw: string | undefined): number {
+  if (raw === undefined) throw new Error(`Missing --${name}`);
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return n;
+}
+
+function main(argv: readonly string[]): void {
+  let args: CliArgs;
+  try {
+    args = parse(argv);
+  } catch (err: unknown) {
+    process.stderr.write(`bench: ${(err as Error).message}\n\n${HELP}`);
+    process.exit(2);
+  }
+
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const seed = args.seed !== undefined ? Number.parseInt(args.seed, 10) : 0;
+  if (!Number.isFinite(seed)) {
+    process.stderr.write('bench: --seed must be a finite integer\n');
+    process.exit(2);
+  }
+
+  if (args.matrix) {
+    const runs = requireInt('runs', args.runs);
+    const matrix = runBenchMatrix({
+      teams: PRO_LEAGUE_TEAMS,
+      runs,
+      seedOffset: seed,
+    });
+    process.stdout.write(formatBenchReport(matrix.pairings) + '\n');
+    return;
+  }
+
+  const teamAId = args.teamA;
+  const teamBId = args.teamB;
+  if (!teamAId || !teamBId) {
+    process.stderr.write('bench: --teamA and --teamB are required (or use --matrix)\n');
+    process.exit(2);
+  }
+  const runs = requireInt('runs', args.runs);
+  const home = PRO_LEAGUE_TEAM_BY_ID[teamAId];
+  const away = PRO_LEAGUE_TEAM_BY_ID[teamBId];
+  if (!home) {
+    process.stderr.write(`bench: unknown teamA '${teamAId}'\n`);
+    process.exit(2);
+  }
+  if (!away) {
+    process.stderr.write(`bench: unknown teamB '${teamBId}'\n`);
+    process.exit(2);
+  }
+
+  const out = runBench({ pairing: { home, away }, runs, seedOffset: seed });
+  process.stdout.write(formatBenchReport([out]) + '\n');
+}
+
+main(process.argv.slice(2));

--- a/packages/sim-engine/src/bench/runner.test.ts
+++ b/packages/sim-engine/src/bench/runner.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { PRO_LEAGUE_TEAMS, PRO_LEAGUE_TEAM_BY_ID } from '../tactics/race-profiles';
+
+import {
+  formatBenchReport,
+  runBench,
+  runBenchMatrix,
+  type BenchPairing,
+} from './runner';
+
+const teamA = PRO_LEAGUE_TEAM_BY_ID['pit-smashers'];
+const teamB = PRO_LEAGUE_TEAM_BY_ID['kc-soaring-hawks'];
+
+describe('runBench — sprint Pro League 0.D.1', () => {
+  it('runs the requested number of matches and aggregates metrics', () => {
+    const out = runBench({
+      pairing: { home: teamA, away: teamB },
+      runs: 12,
+      seedOffset: 0,
+    });
+    expect(out.matches).toBe(12);
+    expect(out.metrics.matches).toBe(12);
+    expect(out.pairing.home.id).toBe(teamA.id);
+  });
+
+  it('is deterministic for a given seedOffset (replay)', () => {
+    const a = runBench({ pairing: { home: teamA, away: teamB }, runs: 8, seedOffset: 1000 });
+    const b = runBench({ pairing: { home: teamA, away: teamB }, runs: 8, seedOffset: 1000 });
+    expect(b).toEqual(a);
+  });
+
+  it('different seed offsets produce different metrics distributions', () => {
+    const a = runBench({ pairing: { home: teamA, away: teamB }, runs: 10, seedOffset: 1 });
+    const b = runBench({ pairing: { home: teamA, away: teamB }, runs: 10, seedOffset: 200 });
+    // Same totals are extremely unlikely : at least one of std / mean / outcome counts differs.
+    const same =
+      a.metrics.td.mean === b.metrics.td.mean &&
+      a.metrics.outcomes.home === b.metrics.outcomes.home;
+    expect(same).toBe(false);
+  });
+
+  it('throws on runs <= 0', () => {
+    expect(() =>
+      runBench({ pairing: { home: teamA, away: teamB }, runs: 0, seedOffset: 0 })
+    ).toThrow();
+    expect(() =>
+      runBench({ pairing: { home: teamA, away: teamB }, runs: -1, seedOffset: 0 })
+    ).toThrow();
+  });
+
+  it('throws on non-integer runs', () => {
+    expect(() =>
+      runBench({ pairing: { home: teamA, away: teamB }, runs: 5.5, seedOffset: 0 })
+    ).toThrow();
+  });
+
+  it('counts home/away/draw outcomes that sum to total matches', () => {
+    const out = runBench({ pairing: { home: teamA, away: teamB }, runs: 50, seedOffset: 7 });
+    const { home, away, draw } = out.metrics.outcomes;
+    expect(home + away + draw).toBe(50);
+  });
+
+  it('annotates favorite from TV when both teams provide tv', () => {
+    const out = runBench({
+      pairing: {
+        home: { ...teamA, tv: 1500 },
+        away: { ...teamB, tv: 1000 },
+      },
+      runs: 20,
+      seedOffset: 0,
+    });
+    // upsetRate must be derivable since favorite = 'home'
+    expect(out.favorite).toBe('home');
+  });
+
+  it('omits favorite when TVs are missing', () => {
+    const out = runBench({
+      pairing: { home: teamA, away: teamB },
+      runs: 20,
+      seedOffset: 0,
+    });
+    expect(out.favorite).toBeUndefined();
+  });
+});
+
+describe('runBenchMatrix — all-vs-all', () => {
+  it('runs N(N-1)/2 unique pairings for N teams (no self-match, no duplicates)', () => {
+    const teams = PRO_LEAGUE_TEAMS.slice(0, 3);
+    const out = runBenchMatrix({ teams, runs: 4, seedOffset: 0 });
+    // 3 teams -> 3 pairings (Orc-Dark, Orc-Wood, Dark-Wood)
+    expect(out.pairings).toHaveLength(3);
+    for (const p of out.pairings) {
+      expect(p.metrics.matches).toBe(4);
+    }
+  });
+
+  it('is deterministic for a given matrix invocation', () => {
+    const teams = PRO_LEAGUE_TEAMS.slice(0, 3);
+    const a = runBenchMatrix({ teams, runs: 4, seedOffset: 0 });
+    const b = runBenchMatrix({ teams, runs: 4, seedOffset: 0 });
+    expect(b).toEqual(a);
+  });
+
+  it('throws when fewer than 2 teams are provided', () => {
+    expect(() =>
+      runBenchMatrix({ teams: PRO_LEAGUE_TEAMS.slice(0, 1), runs: 4, seedOffset: 0 })
+    ).toThrow();
+  });
+});
+
+describe('formatBenchReport — text output', () => {
+  it('renders a non-empty report with key headline numbers', () => {
+    const out = runBench({ pairing: { home: teamA, away: teamB }, runs: 10, seedOffset: 0 });
+    const report = formatBenchReport([out]);
+    expect(report).toContain(teamA.name);
+    expect(report).toContain(teamB.name);
+    expect(report).toContain('TD/match');
+    expect(report).toContain('std');
+    expect(report).toContain('upset rate');
+  });
+
+  it('renders multi-pairing summaries one section per pairing', () => {
+    const teams = PRO_LEAGUE_TEAMS.slice(0, 3);
+    const matrix = runBenchMatrix({ teams, runs: 4, seedOffset: 0 });
+    const report = formatBenchReport(matrix.pairings);
+    // 3 pairings → at least 3 home/away headers.
+    const matches = report.match(/===/g);
+    expect((matches ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('flags FUMBBL-divergent home race with an annotation', () => {
+    // Construct an artificial bench result with extreme winrate so the
+    // formatter flags the divergence.
+    const fakePairing: BenchPairing = {
+      pairing: { home: teamA, away: teamB },
+      matches: 100,
+      metrics: {
+        matches: 100,
+        td: { mean: 1, std: 0.5, p5: 0, p95: 2 },
+        casualties: { mean: 0.5, std: 0.5 },
+        turnovers: { mean: 5 },
+        fatTails: { highScoring: 0, bloodbath: 0 },
+        outcomes: { home: 100, away: 0, draw: 0, upsetRate: 0 },
+        meetsTargets: { stdDevTd: false, upsetRate: false },
+      },
+    };
+    const report = formatBenchReport([fakePairing]);
+    expect(report).toContain('OUTSIDE');
+  });
+});

--- a/packages/sim-engine/src/bench/runner.ts
+++ b/packages/sim-engine/src/bench/runner.ts
@@ -1,0 +1,187 @@
+/**
+ * Bench runner — sprint Pro League 0.D.1.
+ *
+ * Pure functions extracted from the CLI (`scripts/bench.ts`) for
+ * testability. Two entry points :
+ *
+ * - `runBench(input)` : a single home/away pairing simulé `runs` times
+ *   avec des seeds dérivés de `seedOffset`. Retourne les métriques
+ *   `VivacityMetrics` (lot 0.D.3) sur l'échantillon.
+ *
+ * - `runBenchMatrix(input)` : N(N-1)/2 pairings sur les `teams`
+ *   fournies, chacune avec `runs` matchs. Pas de self-match, pas de
+ *   duplicates.
+ *
+ * Note : la version actuelle est synchrone single-threaded. Le sprint
+ * mentionne `worker_threads` ; un follow-up pourra paralléliser via un
+ * pool quand `runs * pairings` excède un seuil de coût. Le contrat
+ * publié ici (`runBench` / `runBenchMatrix`) ne change pas ; seule
+ * l'implémentation interne est susceptible de le faire.
+ */
+
+import { simulateMatch } from '../simulate-match';
+import type { ProTeamProfile } from '../tactics/race-profiles';
+import type { SimInput, SimTeamInput } from '../types';
+
+import {
+  computeVivacityMetrics,
+  simResultToSample,
+  type VivacityMetrics,
+  type VivacitySample,
+} from './metrics';
+import { getFumbblRaceStats, isWithinFumbblTolerance } from './fumbbl-reference';
+
+export interface BenchPair {
+  home: ProTeamProfile & { tv?: number };
+  away: ProTeamProfile & { tv?: number };
+}
+
+export interface BenchInput {
+  pairing: BenchPair;
+  runs: number;
+  /** Seed of the first match. Subsequent matches get `seedOffset + i`. */
+  seedOffset: number;
+}
+
+export interface BenchPairing {
+  pairing: BenchPair;
+  matches: number;
+  metrics: VivacityMetrics;
+  /** Pre-match favorite when both teams provided a TV. */
+  favorite?: 'home' | 'away';
+}
+
+export interface BenchMatrixInput {
+  teams: readonly ProTeamProfile[];
+  runs: number;
+  seedOffset: number;
+}
+
+export interface BenchMatrixResult {
+  pairings: readonly BenchPairing[];
+}
+
+function toSimTeamInput(
+  team: ProTeamProfile & { tv?: number },
+  side: 'home' | 'away'
+): SimTeamInput {
+  return {
+    id: team.id,
+    name: team.name,
+    side,
+    tactics: team.tactics,
+    tv: team.tv,
+  };
+}
+
+function deriveFavorite(pair: BenchPair): 'home' | 'away' | undefined {
+  if (typeof pair.home.tv !== 'number' || typeof pair.away.tv !== 'number') {
+    return undefined;
+  }
+  if (pair.home.tv === pair.away.tv) return undefined;
+  return pair.home.tv > pair.away.tv ? 'home' : 'away';
+}
+
+export function runBench(input: BenchInput): BenchPairing {
+  if (!Number.isInteger(input.runs) || input.runs <= 0) {
+    throw new Error('runBench: runs must be a positive integer');
+  }
+  const favorite = deriveFavorite(input.pairing);
+  const samples: VivacitySample[] = [];
+  for (let i = 0; i < input.runs; i += 1) {
+    const seed = input.seedOffset + i;
+    const sim: SimInput = {
+      seed,
+      home: toSimTeamInput(input.pairing.home, 'home'),
+      away: toSimTeamInput(input.pairing.away, 'away'),
+    };
+    const result = simulateMatch(sim);
+    samples.push(simResultToSample(result, favorite));
+  }
+  return {
+    pairing: input.pairing,
+    matches: input.runs,
+    metrics: computeVivacityMetrics(samples),
+    favorite,
+  };
+}
+
+export function runBenchMatrix(input: BenchMatrixInput): BenchMatrixResult {
+  if (input.teams.length < 2) {
+    throw new Error('runBenchMatrix: at least 2 teams are required');
+  }
+  if (!Number.isInteger(input.runs) || input.runs <= 0) {
+    throw new Error('runBenchMatrix: runs must be a positive integer');
+  }
+
+  const pairings: BenchPairing[] = [];
+  let cursor = input.seedOffset;
+  for (let i = 0; i < input.teams.length; i += 1) {
+    for (let j = i + 1; j < input.teams.length; j += 1) {
+      const out = runBench({
+        pairing: { home: input.teams[i], away: input.teams[j] },
+        runs: input.runs,
+        seedOffset: cursor,
+      });
+      cursor += input.runs;
+      pairings.push(out);
+    }
+  }
+  return { pairings };
+}
+
+/* ------------------------------------------------------------------ */
+/* Text report formatter                                              */
+/* ------------------------------------------------------------------ */
+
+function pct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function fixed(value: number, digits = 2): string {
+  return value.toFixed(digits);
+}
+
+function compareToFumbbl(
+  raceName: string,
+  observedTd: number,
+  observedCas: number
+): string {
+  const ref = getFumbblRaceStats(raceName);
+  if (!ref) return '';
+  const tdOk = isWithinFumbblTolerance(observedTd, ref.tdAverage);
+  const casOk = isWithinFumbblTolerance(observedCas, ref.casualtyRate);
+  if (tdOk && casOk) {
+    return ` [FUMBBL ✓]`;
+  }
+  return ` [FUMBBL OUTSIDE: TD ${tdOk ? '✓' : '✗'} / CAS ${casOk ? '✓' : '✗'}]`;
+}
+
+export function formatBenchReport(pairings: readonly BenchPairing[]): string {
+  const lines: string[] = [];
+  for (const p of pairings) {
+    const m = p.metrics;
+    const fumbbl = compareToFumbbl(p.pairing.home.race, m.td.mean / 2, m.casualties.mean);
+    lines.push('');
+    lines.push(`=== ${p.pairing.home.name} (home) vs ${p.pairing.away.name} (away)${fumbbl} ===`);
+    lines.push(`  matches      : ${m.matches}`);
+    lines.push(
+      `  outcomes     : home ${m.outcomes.home} / away ${m.outcomes.away} / draw ${m.outcomes.draw}` +
+        (p.favorite ? ` | favorite=${p.favorite} | upset rate ${pct(m.outcomes.upsetRate)}` : '')
+    );
+    lines.push(
+      `  TD/match     : mean ${fixed(m.td.mean)} | std ${fixed(m.td.std)} | p5 ${fixed(m.td.p5)} | p95 ${fixed(m.td.p95)}`
+    );
+    lines.push(
+      `  casualties   : mean ${fixed(m.casualties.mean)} | std ${fixed(m.casualties.std)}`
+    );
+    lines.push(`  turnovers    : mean ${fixed(m.turnovers.mean)}`);
+    lines.push(
+      `  fat tails    : >=5 TD ${pct(m.fatTails.highScoring)} | >=4 cas ${pct(m.fatTails.bloodbath)}`
+    );
+    lines.push(
+      `  targets      : std dev TD ${m.meetsTargets.stdDevTd ? '✓' : '✗'} (>= 1.4) | upset rate ${m.meetsTargets.upsetRate ? '✓' : '✗'} (12-18%)`
+    );
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Résumé

Sprint Pro League — tâche **0.D.1** (CLI `pnpm sim:bench`).

Permet d'invoquer la bench harness contre une paire d'équipes ou en matrix all-vs-all, avec rapport texte structuré incluant les targets sprint et les annotations FUMBBL.

## Architecture

### `src/bench/runner.ts` — fonctions pures (testables sans I/O)
- **`runBench({pairing, runs, seedOffset})`** : simule N matchs avec seeds dérivés de `seedOffset`, agrège en `VivacityMetrics` (lot 0.D.3) et détecte le favori à partir des TVs (lot 0.C.3). Throws sur runs non-integer ou ≤ 0.
- **`runBenchMatrix({teams, runs, seedOffset})`** : N(N-1)/2 pairings sans self-match ni duplicates ; chaque pairing reçoit un `seedOffset` différent pour replay-déterminisme global.
- **`formatBenchReport(pairings)`** : sortie texte par pairing avec matches/outcomes/TD stats/casualties/turnovers/fat-tails/targets. Annotation `[FUMBBL OUTSIDE]` quand TD ou casualties hors ±10% (lot 0.D.2 `isWithinFumbblTolerance`).

### `scripts/bench.ts` — entrypoint CLI
- `--teamA=<id> --teamB=<id> --runs=<n>` : single pairing
- `--matrix --runs=<n>` : all-vs-all sur `PRO_LEAGUE_TEAMS` (16 teams)
- `--seed=<n>` : seed offset (default 0)
- `--help` : print usage
- `parseArgs` strict, exits 2 sur erreur

### `package.json`
Ajoute `"sim:bench": "tsx scripts/bench.ts"`.

⚠️ Note : version single-threaded. Le sprint mentionne `worker_threads`, qui devient un follow-up quand le bench tourne en CI (lot 0.D.4) sur des runs > 5000. Le contrat publié (`runBench` / `runBenchMatrix`) ne change pas avec une parallélisation interne future.

## Smoke test

```
pnpm sim:bench --teamA=pit-smashers --teamB=kc-soaring-hawks --runs=20 --seed=42

=== Smashers (home) vs Soaring Hawks (away) [FUMBBL OUTSIDE: TD ✗ / CAS ✗] ===
  matches      : 20
  outcomes     : home 7 / away 7 / draw 6
  TD/match     : mean 1.65 | std 1.19 | p5 0.00 | p95 4.00
  casualties   : mean 0.05 | std 0.22
  turnovers    : mean 5.90
  fat tails    : >=5 TD 0.0% | >=4 cas 0.0%
  targets      : std dev TD ✗ (>= 1.4) | upset rate ✗ (12-18%)
```

(Tuning des targets fait par lot 0.E.1.)

## Tests (14 nouveaux, 234 total)

### `runBench` (8)
- Agrège le bon nombre de matchs et expose `metrics.matches`
- **Déterminisme par seedOffset** (replay)
- Seed offsets différents → distributions différentes
- Throws sur runs ≤ 0 ou non-integer
- `outcomes.home + away + draw === matches`
- `favorite` dérivé du TV gap quand les deux teams en ont un
- `favorite` undefined sans TV

### `runBenchMatrix` (3)
- N(N-1)/2 pairings, pas de self-match, pas de duplicates
- **Déterminisme** matrix-level
- Throws si < 2 teams

### `formatBenchReport` (3)
- Rendu non-vide avec home/away names + TD/match, std, upset rate
- Multi-pairing : un section par pairing (≥ 3 separators `===`)
- Flag `FUMBBL OUTSIDE` annotation correctement

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **234/234** (+14)
- [x] Typecheck monorepo (4 packages) vert
- [x] CLI smoke OK : `pnpm sim:bench` produit le rapport
- [x] Sprint doc : 0.D.1 marqué `[x]`

## Suite (lot D)

- **0.D.4** — CI sim-bench regression workflow (`.github/workflows/sim-bench.yml`)

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_