### PR TITLE
feat(admin): petit utilitaire admin pour simuler des paires Pro League

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,6 +23,7 @@
     "postinstall": "test -f ../../prisma/schema.prisma && prisma generate --schema ../../prisma/schema.prisma || true"
   },
   "dependencies": {
+    "@bb/sim-engine": "workspace:*",
     "@prisma/client": "^6.16.2",
     "bcryptjs": "^3.0.2",
     "body-parser": "^2.2.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import matchRoutes from "./routes/match";
 import adminRoutes from "./routes/admin";
 import adminDataRoutes from "./routes/admin-data";
 import adminLeaguesRoutes from "./routes/admin-leagues";
+import adminSimRoutes from "./routes/admin-sim";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -181,6 +182,7 @@ app.use("/admin/feature-flags", adminFeatureFlagsRouter);
 // L2.C.6 — admin leagues : reservation aux admins, route distincte
 // pour ne pas polluer /admin (qui devient un sac fourre-tout).
 app.use("/admin/leagues", adminLeaguesRoutes);
+app.use("/admin/sim", adminSimRoutes);
 
 // Endpoint public de reset pour tests (uniquement en TEST_SQLITE=1)
 if (process.env.TEST_SQLITE === "1") {

--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the `/admin/sim/*` admin utility (Phase 0 helper).
+ *
+ * Tests the handlers directly — middleware (`authUser`, `adminOnly`,
+ * `validate`) is covered by the routes that use the same pieces in
+ * production.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Request, Response } from "express";
+
+import {
+  handleListTeams,
+  handleRunSim,
+  runSimSchema,
+  type RunSimBody,
+} from "./admin-sim";
+
+function buildRes(): Response & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown };
+}
+
+describe("handleListTeams", () => {
+  it("returns the 16 Pro League teams with id/city/name/race/nflFlavor", () => {
+    const res = buildRes();
+    handleListTeams({} as Request, res);
+    const body = res.body as { teams: Array<{ id: string; city: string }> };
+    expect(body.teams).toHaveLength(16);
+    expect(body.teams.find((t) => t.id === "pit-smashers")).toBeDefined();
+    for (const team of body.teams) {
+      expect(team.id.length).toBeGreaterThan(0);
+      expect(team.city.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("handleRunSim", () => {
+  function call(body: RunSimBody): {
+    statusCode: number;
+    body: unknown;
+  } {
+    const req = { body } as unknown as Request;
+    const res = buildRes();
+    handleRunSim(req, res);
+    return res;
+  }
+
+  it("returns 200 with metrics for a valid pairing", () => {
+    const out = call({
+      teamA: "pit-smashers",
+      teamB: "kc-soaring-hawks",
+      runs: 5,
+      seed: 0,
+    });
+    expect(out.statusCode).toBe(200);
+    const body = out.body as {
+      matches: number;
+      metrics: { matches: number };
+      report: string;
+      pairing: { home: { id: string }; away: { id: string } };
+    };
+    expect(body.matches).toBe(5);
+    expect(body.metrics.matches).toBe(5);
+    expect(body.report).toContain("Smashers");
+    expect(body.pairing.home.id).toBe("pit-smashers");
+    expect(body.pairing.away.id).toBe("kc-soaring-hawks");
+  });
+
+  it("returns 400 when teamA is unknown", () => {
+    const out = call({
+      teamA: "vampire-counts",
+      teamB: "kc-soaring-hawks",
+      runs: 5,
+      seed: 0,
+    });
+    expect(out.statusCode).toBe(400);
+    expect((out.body as { error: string }).error).toContain("teamA");
+  });
+
+  it("returns 400 when teamB is unknown", () => {
+    const out = call({
+      teamA: "pit-smashers",
+      teamB: "vampire-counts",
+      runs: 5,
+      seed: 0,
+    });
+    expect(out.statusCode).toBe(400);
+    expect((out.body as { error: string }).error).toContain("teamB");
+  });
+
+  it("returns 400 when teamA === teamB", () => {
+    const out = call({
+      teamA: "pit-smashers",
+      teamB: "pit-smashers",
+      runs: 5,
+      seed: 0,
+    });
+    expect(out.statusCode).toBe(400);
+    expect((out.body as { error: string }).error).toContain("distinct");
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = call({
+      teamA: "pit-smashers",
+      teamB: "kc-soaring-hawks",
+      runs: 5,
+      seed: 42,
+    });
+    const b = call({
+      teamA: "pit-smashers",
+      teamB: "kc-soaring-hawks",
+      runs: 5,
+      seed: 42,
+    });
+    expect(b.body).toEqual(a.body);
+  });
+});
+
+describe("runSimSchema (Zod validation)", () => {
+  it("applies sane defaults on optional fields", () => {
+    const parsed = runSimSchema.parse({
+      teamA: "pit-smashers",
+      teamB: "kc-soaring-hawks",
+    });
+    expect(parsed.runs).toBe(50);
+    expect(parsed.seed).toBe(0);
+  });
+
+  it("rejects empty team ids", () => {
+    expect(() =>
+      runSimSchema.parse({ teamA: "", teamB: "kc-soaring-hawks" }),
+    ).toThrow();
+  });
+
+  it("rejects runs > 2000 (admin guardrail)", () => {
+    expect(() =>
+      runSimSchema.parse({
+        teamA: "pit-smashers",
+        teamB: "kc-soaring-hawks",
+        runs: 5000,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects negative seed", () => {
+    expect(() =>
+      runSimSchema.parse({
+        teamA: "pit-smashers",
+        teamB: "kc-soaring-hawks",
+        seed: -1,
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -1,0 +1,94 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { z } from "zod";
+import {
+  PRO_LEAGUE_TEAMS,
+  PRO_LEAGUE_TEAM_BY_ID,
+  formatBenchReport,
+  runBench,
+} from "@bb/sim-engine";
+
+import { adminOnly } from "../middleware/adminOnly";
+import { authUser } from "../middleware/authUser";
+import { validate } from "../middleware/validate";
+
+/**
+ * Petit utilitaire admin (Phase 0 — pre-Pro League UI).
+ *
+ * Permet de declencher une simulation depuis le navigateur sans passer
+ * par le CLI. Branche le `runBench` du sim-engine sur une route POST
+ * `/admin/sim/run` qui retourne le `BenchPairing` (metrics + favori +
+ * report texte).
+ *
+ * Cette route disparaitra quand la Phase 1 livrera la vraie UI Pro
+ * League (lots 1.A scheduler + 1.B broadcaster + 1.C pages).
+ */
+
+export const runSimSchema = z.object({
+  teamA: z.string().min(1),
+  teamB: z.string().min(1),
+  runs: z.number().int().positive().max(2000).default(50),
+  seed: z.number().int().min(0).default(0),
+});
+
+export type RunSimBody = z.infer<typeof runSimSchema>;
+
+/** Handler for `GET /admin/sim/teams` — list the 16 Pro League teams. */
+export function handleListTeams(_req: Request, res: Response): void {
+  res.json({
+    teams: PRO_LEAGUE_TEAMS.map((t) => ({
+      id: t.id,
+      city: t.city,
+      name: t.name,
+      race: t.race,
+      nflFlavor: t.nflFlavor,
+    })),
+  });
+}
+
+/** Handler for `POST /admin/sim/run` — runs a bench pairing. */
+export function handleRunSim(req: Request, res: Response): void {
+  const { teamA, teamB, runs, seed } = req.body as RunSimBody;
+
+  const home = PRO_LEAGUE_TEAM_BY_ID[teamA];
+  const away = PRO_LEAGUE_TEAM_BY_ID[teamB];
+  if (!home) {
+    res.status(400).json({ error: `Unknown teamA '${teamA}'` });
+    return;
+  }
+  if (!away) {
+    res.status(400).json({ error: `Unknown teamB '${teamB}'` });
+    return;
+  }
+  if (teamA === teamB) {
+    res.status(400).json({ error: "teamA and teamB must be distinct" });
+    return;
+  }
+
+  const result = runBench({
+    pairing: { home, away },
+    runs,
+    seedOffset: seed,
+  });
+  const report = formatBenchReport([result]);
+
+  res.json({
+    pairing: {
+      home: { id: home.id, name: home.name, race: home.race },
+      away: { id: away.id, name: away.name, race: away.race },
+    },
+    matches: result.matches,
+    metrics: result.metrics,
+    favorite: result.favorite,
+    report,
+  });
+}
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+router.get("/teams", handleListTeams);
+router.post("/run", validate(runSimSchema), handleRunSim);
+
+export default router;

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@bb/game-engine': resolve(__dirname, '../../packages/game-engine/src'),
+      '@bb/sim-engine': resolve(__dirname, '../../packages/sim-engine/src'),
+      '@bb/shared-types': resolve(__dirname, '../../packages/shared-types/src'),
     },
   },
 });

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -67,6 +67,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/local-matches", "Matchs Locaux", "🎯")}
               {navItem("/admin/cups", "Coupes", "🏆")}
               {navItem("/admin/feature-flags", "Feature Flags", "🚩")}
+              {navItem("/admin/sim", "Sim Pro League", "🎲")}
               {navItem("/admin/routes", "Routes", "📋")}
             </div>
 

--- a/apps/web/app/admin/sim/page.tsx
+++ b/apps/web/app/admin/sim/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+/**
+ * Petit utilitaire admin (Phase 0 — pre-Pro League UI).
+ *
+ * Permet de declencher une simulation depuis le navigateur sans passer
+ * par le CLI. Hit `POST /admin/sim/run` qui appelle `runBench` du
+ * sim-engine et retourne metrics + report texte.
+ *
+ * Cette page disparaitra quand la Phase 1 livrera la vraie UI Pro
+ * League (lots 1.A scheduler + 1.B broadcaster + 1.C pages).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { API_BASE } from "../../auth-client";
+
+interface Team {
+  id: string;
+  city: string;
+  name: string;
+  race: string;
+  nflFlavor: string;
+}
+
+interface VivacityMetrics {
+  matches: number;
+  td: { mean: number; std: number; p5: number; p95: number };
+  casualties: { mean: number; std: number };
+  turnovers: { mean: number };
+  fatTails: { highScoring: number; bloodbath: number };
+  outcomes: { home: number; away: number; draw: number; upsetRate: number };
+  meetsTargets: { stdDevTd: boolean; upsetRate: boolean };
+}
+
+interface SimRunResult {
+  pairing: {
+    home: { id: string; name: string; race: string };
+    away: { id: string; name: string; race: string };
+  };
+  matches: number;
+  metrics: VivacityMetrics;
+  favorite?: "home" | "away";
+  report: string;
+}
+
+async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+const RUN_OPTIONS = [10, 50, 200, 500, 1000];
+
+export default function AdminSimPage() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [teamA, setTeamA] = useState<string>("");
+  const [teamB, setTeamB] = useState<string>("");
+  const [runs, setRuns] = useState<number>(50);
+  const [seed, setSeed] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [running, setRunning] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SimRunResult | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await fetchJSON<{ teams: Team[] }>("/admin/sim/teams");
+        setTeams(data.teams);
+        if (data.teams.length >= 2) {
+          setTeamA(data.teams[0].id);
+          setTeamB(data.teams[1].id);
+        }
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const teamLabel = useMemo(() => {
+    const map = new Map(teams.map((t) => [t.id, `${t.city} ${t.name} (${t.race})`]));
+    return (id: string) => map.get(id) ?? id;
+  }, [teams]);
+
+  async function handleRun() {
+    if (!teamA || !teamB || teamA === teamB) {
+      setError("Choisis deux equipes differentes.");
+      return;
+    }
+    setError(null);
+    setRunning(true);
+    try {
+      const out = await fetchJSON<SimRunResult>("/admin/sim/run", {
+        method: "POST",
+        body: JSON.stringify({ teamA, teamB, runs, seed }),
+      });
+      setResult(out);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-5xl">
+      <header>
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          🎲 Simulateur Pro League
+        </h1>
+        <p className="text-sm text-gray-600">
+          Utilitaire Phase 0 : declenche une simulation deterministe et
+          affiche le rapport stat. Sera remplace par la vraie UI Pro
+          League en Phase 1 (lots 1.A / 1.B / 1.C).
+        </p>
+      </header>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          ⚠️ {error}
+        </div>
+      )}
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold mb-4">Parametres</h2>
+        {loading ? (
+          <p className="text-gray-500">Chargement des equipes…</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-gray-700">
+                Equipe domicile
+              </span>
+              <select
+                value={teamA}
+                onChange={(e) => setTeamA(e.target.value)}
+                className="border border-gray-300 rounded px-3 py-2"
+                disabled={running}
+              >
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {teamLabel(t.id)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-gray-700">
+                Equipe visiteur
+              </span>
+              <select
+                value={teamB}
+                onChange={(e) => setTeamB(e.target.value)}
+                className="border border-gray-300 rounded px-3 py-2"
+                disabled={running}
+              >
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {teamLabel(t.id)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-gray-700">
+                Nombre de matchs
+              </span>
+              <select
+                value={runs}
+                onChange={(e) => setRuns(Number.parseInt(e.target.value, 10))}
+                className="border border-gray-300 rounded px-3 py-2"
+                disabled={running}
+              >
+                {RUN_OPTIONS.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-gray-700">
+                Seed (replay deterministe)
+              </span>
+              <input
+                type="number"
+                min={0}
+                value={seed}
+                onChange={(e) =>
+                  setSeed(Math.max(0, Number.parseInt(e.target.value, 10) || 0))
+                }
+                className="border border-gray-300 rounded px-3 py-2"
+                disabled={running}
+              />
+            </label>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={handleRun}
+          disabled={loading || running || !teamA || !teamB || teamA === teamB}
+          className="mt-4 px-6 py-2 rounded-lg bg-nuffle-anthracite text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {running ? "Simulation en cours…" : "Lancer la simulation"}
+        </button>
+      </section>
+
+      {result && (
+        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
+          <header className="flex items-baseline justify-between">
+            <h2 className="text-lg font-semibold">
+              {result.pairing.home.name} vs {result.pairing.away.name}
+            </h2>
+            <span className="text-xs text-gray-500">
+              {result.matches} matchs simules
+            </span>
+          </header>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+            <Metric label="TD / match" value={result.metrics.td.mean.toFixed(2)} subtle={`std ${result.metrics.td.std.toFixed(2)}`} />
+            <Metric label="Casualties" value={result.metrics.casualties.mean.toFixed(2)} />
+            <Metric label="Turnovers" value={result.metrics.turnovers.mean.toFixed(2)} />
+            <Metric
+              label="Outcomes"
+              value={`${result.metrics.outcomes.home}–${result.metrics.outcomes.away}–${result.metrics.outcomes.draw}`}
+              subtle="V D N"
+            />
+            <Metric
+              label=">=5 TD"
+              value={`${(result.metrics.fatTails.highScoring * 100).toFixed(1)}%`}
+            />
+            <Metric
+              label=">=4 cas"
+              value={`${(result.metrics.fatTails.bloodbath * 100).toFixed(1)}%`}
+            />
+            <Metric
+              label="Upset rate"
+              value={`${(result.metrics.outcomes.upsetRate * 100).toFixed(1)}%`}
+              subtle={result.favorite ? `fav. ${result.favorite}` : "no fav."}
+            />
+            <Metric
+              label="Sprint targets"
+              value={`${result.metrics.meetsTargets.stdDevTd ? "✓" : "✗"} std / ${result.metrics.meetsTargets.upsetRate ? "✓" : "✗"} upset`}
+            />
+          </div>
+
+          <details className="bg-gray-50 rounded p-3">
+            <summary className="cursor-pointer font-medium text-sm">
+              Rapport texte (CLI-style)
+            </summary>
+            <pre className="mt-2 text-xs whitespace-pre-wrap font-mono">{result.report}</pre>
+          </details>
+
+          <details className="bg-gray-50 rounded p-3">
+            <summary className="cursor-pointer font-medium text-sm">
+              Reponse JSON brute
+            </summary>
+            <pre className="mt-2 text-xs whitespace-pre-wrap font-mono">{JSON.stringify(result, null, 2)}</pre>
+          </details>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  subtle,
+}: {
+  label: string;
+  value: string;
+  subtle?: string;
+}) {
+  return (
+    <div className="bg-gray-50 rounded p-3">
+      <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+      <div className="text-lg font-semibold text-nuffle-anthracite">{value}</div>
+      {subtle && <div className="text-xs text-gray-500">{subtle}</div>}
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@bb/sim-engine':
+        specifier: workspace:*
+        version: link:../../packages/sim-engine
       '@prisma/client':
         specifier: ^6.16.2
         version: 6.16.2(prisma@6.16.2(magicast@0.3.5)(typescript@5.9.2))(typescript@5.9.2)


### PR DESCRIPTION
## Résumé

Petit utilitaire admin **Phase 0** pour simuler une paire d'équipes Pro League depuis le navigateur, sans passer par le CLI `pnpm sim:bench`. Sera retiré quand la **Phase 1** livrera la vraie UI Pro League (lots 1.A scheduler + 1.B broadcaster + 1.C pages).

## Backend

### Nouvelle route Express `/admin/sim/*` (apps/server)
- **`GET /admin/sim/teams`** : liste les 16 équipes Pro League (id, city, name, race, NFL flavor) pour peupler le formulaire.
- **`POST /admin/sim/run`** : valide `{teamA, teamB, runs?, seed?}` via Zod (`runs ≤ 2000` garde-fou admin), appelle `runBench` du sim-engine, retourne `{pairing, matches, metrics, favorite?, report}`.

Handlers extraits (`handleListTeams`, `handleRunSim`) pour testabilité sans supertest.

### Configuration
- `apps/server/package.json` : ajoute `@bb/sim-engine: workspace:*`.
- `apps/server/vitest.config.ts` : ajoute aliases `@bb/sim-engine` et `@bb/shared-types` (mirror du `@bb/game-engine` existant).

## Frontend

### Nouvelle page `apps/web/app/admin/sim/page.tsx`

Form :
- Selects équipe domicile / visiteur (16 options chacun)
- Nombre de matchs (10/50/200/500/1000)
- Seed pour replay déterministe

Au submit → hit `POST /admin/sim/run` et affiche :
- **Headline metrics** : TD/match (+ std), casualties, turnovers, outcomes V-D-N, fat-tails, upset rate, sprint targets ✓/✗
- **Rapport texte** (CLI-style) en details collapsible
- **JSON brut** en details collapsible (debug/inspection)

### Sidebar
`apps/web/app/admin/layout.tsx` : ajoute "🎲 Sim Pro League" dans la section Administration.

## Tests (10 nouveaux)

- `handleListTeams` : retourne les 16 équipes avec champs requis
- `handleRunSim` :
  - 200 + metrics pour pairing valide
  - 400 sur teamA inconnue
  - 400 sur teamB inconnue
  - 400 sur teamA === teamB
  - Déterministe par seed (replay)
- `runSimSchema` :
  - Defaults (runs=50, seed=0)
  - Rejette empty ids, runs > 2000, seed négatif

## Checklist

- [x] Typecheck monorepo (server + web + sim-engine) vert
- [x] Tests : admin-sim **10/10**, sim-engine **249/249** (no regression)

## Usage

1. Démarrer le server : `pnpm --filter @bb/server dev`
2. Démarrer le web : `pnpm --filter @bb/web dev`
3. Ouvrir http://localhost:3000/admin/sim (login admin requis)
4. Choisir 2 équipes + nombre de matchs + seed → **Lancer la simulation**

## Suite

Une fois mergé, on peut enchaîner sur le **lot 0.E** (Tuning loop + replay sampling + panel BB experts, gate Phase 0 → Phase 1).

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_