### PR TITLE
feat(sim-engine): tuning iter #6 — engineVer 0.7.0 (breakthrough 8% + nemesis_clash casualty)

### DIFF
--- a/docs/roadmap/sprints/pro-league-gate.md
+++ b/docs/roadmap/sprints/pro-league-gate.md
@@ -17,18 +17,18 @@ complet.
 
 | Champ | Valeur |
 |---|---|
-| `engineVer` | `0.6.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
+| `engineVer` | `0.7.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
 | Snapshot bench-baseline | `2026-05-06` (3 pairings, runs=200, seed=0) |
-| Tuning iterations effectuées | 5 (race-aware LOS → block→armor + tv → upset metric fix + bash recalib → defensive disruption → bash /28 + breakthrough 6% + Nuffle casualty injection) |
+| Tuning iterations effectuées | 6 (race-aware → block→armor + tv → upset fix + bash → defensive disruption → Nuffle casualty injection → breakthrough 8% + nemesis_clash) |
 | Replays panel | 50 fichiers `replays/replay-XXX-*-seed[2026-2075].txt` (à regénérer pour engineVer 0.5.0) |
 
 ## Critères de gate
 
 | # | Critère | Cible sprint | Mesure | Statut |
 |---|---|---|---|---|
-| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _0.86 - 0.93_ | ❌ FAIL (progrès, iter #6 needed) |
-| C2 | Upset rate 12-18% (lot 0.D.3) | 0.12 - 0.18 | _14.5 - 32.5% (Halflings vs Ogres 14.5% ✓ cible)_ | ⚠️ 1/5 pairings DANS cible |
-| C3 | Tous matchups raciaux dans ±10% FUMBBL winrate (lot 0.E.1) | ±10% | _Iron Bears 30 vs Gold Rush 28 — parité OK ✓_ | ⚠️ partial RESOLU |
+| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _1.02 - 1.09_ | ❌ FAIL (convergence claire) |
+| C2 | Upset rate 12-18% (lot 0.D.3) | 0.12 - 0.18 | _16.5 - 35% (Halflings vs Ogres 16.5% ✓)_ | ⚠️ 1/5 pairings DANS cible |
+| C3 | Tous matchups raciaux dans ±10% FUMBBL winrate (lot 0.E.1) | ±10% | _Iron Bears 34 vs Gold Rush 30 — parité OK ✓_ | ⚠️ partial RESOLU |
 | C4 | bench-baseline.json passe à `engineVer` cible (lot 0.D.4) | PASS | PASS | ✅ |
 | C5 | Tests unitaires sim-engine ≥ 95% pass rate | 95% | 258 / 258 = 100% | ✅ |
 | C6 | Panel humain — moyenne globale ≥ 7/10 (lot 0.E.3) | ≥ 7.0 | _en attente_ | ⏳ |

--- a/packages/sim-engine/CHANGELOG.md
+++ b/packages/sim-engine/CHANGELOG.md
@@ -7,6 +7,56 @@ sim engine. Used as the audit trail for sprint Pro League lots 0.D
 Each version bump matches `ENGINE_VER` in `src/types.ts` and is
 reflected in `bench/bench-baseline.json`.
 
+## 0.7.0 — 2026-05-06 (sprint task 0.E.1 iter #6)
+
+### Headline progress
+
+- **Casualty rate +30%** : 0.47-0.53 → **0.63-0.70 / match** (FUMBBL ~1.0
+  — now ~70% de la cible).
+- **Std dev TD up** : 0.86-0.93 → **1.02-1.09** (still under 1.4 mais
+  closer).
+- **TD means up** : 0.9-1.25 → **1.26-1.54**.
+- Snow Ogres vs Halflings upset 16.5% **toujours en cible** ✓.
+
+### Changes
+
+- **`rollYards` breakthrough proba** : 6% → **8%**. ~32 yard rolls / match
+  × 8% = ~2.5 events / match.
+- **Conditional breakthrough magnitude** : `+35` yards quand defense
+  bash < 70 (offensive break vs soft D), `+30` sinon. Permet aux
+  équipes balance de scorer plus contre les non-bash.
+- **`nemesis_clash` Nuffle event** ajouté à la casualty injection
+  (25% chance casualty). Maintenant 4 events Nuffle injectent des
+  casualties (bombardier, banana, riot, nemesis).
+
+### Observed deltas (200 runs / pairing, seed=0)
+
+| Matchup | 0.6.0 H/D/A | 0.7.0 H/D/A | Cas | Upset rate | TD mean | Std |
+|---|---|---|---|---|---|---|
+| Smashers vs Soaring Hawks | 65/76/59 | 70/68/62 | .47→.63 | 32.5%→35% | 1.24→1.51 | .93→1.02 |
+| Snow Ogres vs Cheese Halflings | 103/68/29 | 103/64/33 | .52→.68 | 14.5%→**16.5%** ✓ | 1.25→1.54 | .91→1.03 |
+| Iron Bears vs Gold Rush | 61/84/55 | 68/73/59 | .47→.65 | 27.5%→29.5% | 1.04→1.34 | .89→1.05 |
+| Cold Tacticians vs Tomb Cardinals | 52/94/54 | 55/88/57 | .49→.66 | parité TV | 0.90→1.28 | .89→1.09 |
+| Outlaws vs Storm Eagles | 58/96/46 | 62/85/53 | .53→.70 | 29%→31% | 0.93→1.26 | .86→1.08 |
+
+### Gate criteria status
+
+- ⚠️ C1 std dev TD : **1.02-1.09** (vs 1.4 cible — convergence claire)
+- ⚠️ C2 upset rate : Halflings vs Ogres 16.5% en cible ✓ (1/5)
+- ⚠️ C3 Skaven > Dwarves : Iron Bears 34 / Gold Rush 30 — parité OK
+- ⚠️ Casualty rate **0.63-0.70** (~70% FUMBBL ~1.0)
+- → **Verdict : NO-GO maintenu mais convergence rapide ; iter #7 plan**
+
+### Iter #7 plan
+
+1. **Std dev TD vers 1.4** : breakthrough proba 8% → 10%, magnitude
+   +35 → +40 quand bash défense très faible (<50)
+2. **Casualty rate** : ajouter `tantrum_star` 50%, `cocky_drop` 30%
+3. **Upset rate trop haut sur autres pairings** : revoir le `tv` per
+   team — peut-être trop d'écart entre 800 et 1100 ; modérer.
+4. **C3 wider sample** : matrix 5x5 sur les races les plus
+   identifiables.
+
 ## 0.6.0 — 2026-05-06 (sprint task 0.E.1 iter #5)
 
 ### Headline wins

--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.6.0",
+  "engineVer": "0.7.0",
   "snapshotAt": "2026-05-06",
   "tolerance": 0.05,
   "pairings": [
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.235,
-        "tdStd": 0.9326172848494719,
-        "casualtyMean": 0.47,
-        "turnoverMean": 5.71,
-        "homeWinRate": 0.325,
-        "awayWinRate": 0.295,
-        "drawRate": 0.38
+        "tdMean": 1.515,
+        "tdStd": 1.0196935814253218,
+        "casualtyMean": 0.63,
+        "turnoverMean": 5.77,
+        "homeWinRate": 0.35,
+        "awayWinRate": 0.31,
+        "drawRate": 0.34
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.245,
-        "tdStd": 0.9082813440779236,
-        "casualtyMean": 0.515,
-        "turnoverMean": 6.715,
+        "tdMean": 1.54,
+        "tdStd": 1.0336343647538035,
+        "casualtyMean": 0.68,
+        "turnoverMean": 6.755,
         "homeWinRate": 0.515,
-        "awayWinRate": 0.145,
-        "drawRate": 0.34
+        "awayWinRate": 0.165,
+        "drawRate": 0.32
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.105,
-        "tdStd": 0.971583758612709,
-        "casualtyMean": 0.46,
-        "turnoverMean": 5.605,
-        "homeWinRate": 0.345,
-        "awayWinRate": 0.23,
-        "drawRate": 0.425
+        "tdMean": 1.385,
+        "tdStd": 1.0520337447059378,
+        "casualtyMean": 0.625,
+        "turnoverMean": 5.635,
+        "homeWinRate": 0.365,
+        "awayWinRate": 0.265,
+        "drawRate": 0.37
       }
     }
   ]

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -326,16 +326,17 @@ function rollYards(
   profile: TacticalProfile,
   defenseProfile: TacticalProfile
 ): number {
-  // Sprint 0.E.1 tuning iter #5 (engineVer 0.6.0) :
+  // Sprint 0.E.1 tuning iter #6 (engineVer 0.7.0) :
   //
   // - Base : 2d6+2 (mean 7).
   // - `+pace/25 - 2` : pace-based offset.
-  // - `-defense.bashIndex/28` : bash counter softened from /25 (iter #4)
-  //   to /28 — bash 90 défense → -3 yards (au lieu de -4). On préserve
-  //   le fix C3 (Skaven > Dwarves) tout en remontant les TD means.
+  // - `-defense.bashIndex/28` : bash counter unchanged from iter #5.
   // - `-defensiveDisruption` : kept (Dwarves bash + stall combo).
-  // - `+ fat-tail breakthrough/crush` : 6% +30 / 6% -10 (was 4% / 4%).
-  //   Plus d'events fat-tail → std dev TD up.
+  // - `+ fat-tail breakthrough/crush` : 8% +N / 8% -10 (was 6%).
+  //   Breakthrough magnitude conditional :
+  //     - +35 yards quand defense bash < 70 (offensive break vs soft D)
+  //     - +30 yards sinon (bash D limite la breakthrough)
+  //   Plus de fat-tails → std dev TD up.
   const dice = Math.floor(rng.next() * 6) + Math.floor(rng.next() * 6) + 2;
   const paceOffset = Math.round(profile.pace / 25) - 2;
   const bashCounter = -Math.round(defenseProfile.bashIndex / 28);
@@ -345,8 +346,11 @@ function rollYards(
   );
   const fatTail = rng.next();
   let breakthrough = 0;
-  if (fatTail < 0.06) breakthrough = 30;
-  else if (fatTail < 0.12) breakthrough = -10;
+  if (fatTail < 0.08) {
+    breakthrough = defenseProfile.bashIndex < 70 ? 35 : 30;
+  } else if (fatTail < 0.16) {
+    breakthrough = -10;
+  }
   return Math.max(0, dice + paceOffset + bashCounter + defensiveDisruption + breakthrough);
 }
 
@@ -431,16 +435,14 @@ function processTurn(
       })
     );
     m.nuffleEvents += 1;
-    // Sprint 0.E.1 iter #5 (engineVer 0.6.0) : certains Nuffle events
-    // injectent une casualty pour pousser le rate vers FUMBBL ~1.0.
-    // Sélection :
-    //   - bombardier_gone_wild → friendly fire casualty (1 par event)
-    //   - banana_skin → KD + chance armor break (50% casualty)
-    //   - crowd_riot → 1 random player stunned, 30% casualty
+    // Sprint 0.E.1 iter #6 (engineVer 0.7.0) : élargi les Nuffle
+    // events qui injectent une casualty pour pousser le rate vers
+    // FUMBBL ~1.0. Ajout de `nemesis_clash` 25%.
     if (
       nuffleEvent.id === 'bombardier_gone_wild' ||
       (nuffleEvent.id === 'banana_skin' && rngs.luck.next() < 0.5) ||
-      (nuffleEvent.id === 'crowd_riot' && rngs.luck.next() < 0.3)
+      (nuffleEvent.id === 'crowd_riot' && rngs.luck.next() < 0.3) ||
+      (nuffleEvent.id === 'nemesis_clash' && rngs.luck.next() < 0.25)
     ) {
       const victimSide: Side = otherSide(m.state.drive.drivingTeam);
       const victimId = `${victimSide}-NUFFLE-${m.state.half}-${m.state.turn}`;

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.6.0';
+export const ENGINE_VER = '0.7.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Résumé

Sprint Pro League — **sixth tuning iteration**. Bump engineVer **0.6.0 → 0.7.0**.

Convergence rapide : casualty rate +30%, std dev TD +13%, TD means recovered. Halflings vs Ogres reste **dans la cible upset rate** (16.5%).

## Changes

### `rollYards`
- **Breakthrough proba** : 6% → **8%**. ~32 yard rolls / match × 8% = ~2.5 events / match.
- **Conditional magnitude** : +35 yards quand defense bash < 70 (offensive break vs soft D), +30 sinon. Permet aux teams balance de scorer plus contre les non-bash.

### Nuffle casualty injection
- `nemesis_clash` ajouté (25% chance). Maintenant 4 events injectent des casualties.

## Résultats observés (200 runs / pairing, seed=0)

| Matchup | 0.6.0 | 0.7.0 | Cas | Upset rate | TD mean | Std |
|---|---|---|---|---|---|---|
| Smashers vs Soaring Hawks | 65/76/59 | 70/68/62 | .47→**.63** | 32.5%→35% | 1.24→**1.51** | .93→**1.02** |
| Snow Ogres vs Cheese Halflings | 103/68/29 | 103/64/33 | .52→**.68** | 14.5%→**16.5%** ✓ | 1.25→**1.54** | .91→**1.03** |
| Iron Bears vs Gold Rush | 61/84/55 | 68/73/59 | .47→**.65** | 27.5%→29.5% | 1.04→**1.34** | .89→**1.05** |
| Cold Tacticians vs Tomb Cardinals | 52/94/54 | 55/88/57 | .49→**.66** | parité TV | 0.90→**1.28** | .89→**1.09** |
| Outlaws vs Storm Eagles | 58/96/46 | 62/85/53 | .53→**.70** | 29%→31% | 0.93→**1.26** | .86→**1.08** |

## Gate criteria status

| Critère | iter #5 | iter #6 | Trend |
|---|---|---|---|
| C1 std dev TD ≥ 1.4 | 0.86-0.93 | **1.02-1.09** | ↗ (cible 1.4) |
| C2 upset rate 12-18% | 14.5-32.5% (1/5 cible) | 16.5-35% (1/5 cible) | ≈ |
| C3 ±10% FUMBBL Skaven/Dwarves | 61/55 | **68/59** | ≈ parité OK |
| Casualty rate ~1.0 | 0.47-0.53 | **0.63-0.70** | ↗ (~70% cible) |

→ **Verdict : NO-GO maintenu, convergence rapide. Iter #7 plan**

## Iter #7 plan

1. **Std dev TD** : breakthrough 8% → 10%, magnitude +40 quand bash défense très faible
2. **Casualty rate** : ajouter `tantrum_star` 50%, `cocky_drop` 30%
3. **Upset rate** : modérer les écarts `tv` per team
4. **C3 wider sample** : matrix 5×5 races identifiables

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **258/258** (no regression)
- [x] `bench:ci` PASS au baseline 0.7.0
- [x] CHANGELOG.md mis à jour avec audit trail iter #6
- [x] `pro-league-gate.md` mis à jour

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_