### PR TITLE
feat(sim-engine): tuning iter #7 — engineVer 0.8.0 (breakthrough 10% + +40 vs soft D + tantrum/cocky casualties)

### DIFF
--- a/docs/roadmap/sprints/pro-league-gate.md
+++ b/docs/roadmap/sprints/pro-league-gate.md
@@ -17,16 +17,16 @@ complet.
 
 | Champ | Valeur |
 |---|---|
-| `engineVer` | `0.7.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
+| `engineVer` | `0.8.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
 | Snapshot bench-baseline | `2026-05-06` (3 pairings, runs=200, seed=0) |
-| Tuning iterations effectuées | 6 (race-aware → block→armor + tv → upset fix + bash → defensive disruption → Nuffle casualty injection → breakthrough 8% + nemesis_clash) |
+| Tuning iterations effectuées | 7 (race-aware → block→armor + tv → upset fix + bash → defensive disruption → Nuffle casualty → breakthrough 8% → breakthrough 10% +40/+35/+30 + 6 Nuffle casualties) |
 | Replays panel | 50 fichiers `replays/replay-XXX-*-seed[2026-2075].txt` (à regénérer pour engineVer 0.5.0) |
 
 ## Critères de gate
 
 | # | Critère | Cible sprint | Mesure | Statut |
 |---|---|---|---|---|
-| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _1.02 - 1.09_ | ❌ FAIL (convergence claire) |
+| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _1.14 - 1.23_ | ❌ FAIL (convergence rapide) |
 | C2 | Upset rate 12-18% (lot 0.D.3) | 0.12 - 0.18 | _16.5 - 35% (Halflings vs Ogres 16.5% ✓)_ | ⚠️ 1/5 pairings DANS cible |
 | C3 | Tous matchups raciaux dans ±10% FUMBBL winrate (lot 0.E.1) | ±10% | _Iron Bears 34 vs Gold Rush 30 — parité OK ✓_ | ⚠️ partial RESOLU |
 | C4 | bench-baseline.json passe à `engineVer` cible (lot 0.D.4) | PASS | PASS | ✅ |

--- a/packages/sim-engine/CHANGELOG.md
+++ b/packages/sim-engine/CHANGELOG.md
@@ -7,6 +7,48 @@ sim engine. Used as the audit trail for sprint Pro League lots 0.D
 Each version bump matches `ENGINE_VER` in `src/types.ts` and is
 reflected in `bench/bench-baseline.json`.
 
+## 0.8.0 — 2026-05-06 (sprint task 0.E.1 iter #7)
+
+### Headline
+
+- **Casualty rate ~85% FUMBBL** : 0.63-0.70 → **0.83-0.90 / match**
+- **Std dev TD vers 1.4** : 1.02-1.09 → **1.14-1.23**
+- **TD means recovered** : 1.26-1.54 → **1.62-1.83** (dans la fourchette FUMBBL)
+
+### Changes
+
+- **Breakthrough proba** : 8% → **10%** (+25%)
+- **Conditional magnitude étendu** : `+40` quand bash défense <50,
+  `+35` quand 50-69, `+30` sinon
+- **Casualty Nuffle ajouts** : `tantrum_star` 50%, `cocky_drop` 30%
+  (6 events injectent maintenant des casualties)
+
+### Observed deltas (200 runs / pairing, seed=0)
+
+| Matchup | 0.7.0 cas | 0.8.0 cas | 0.7.0 TD mean / std | 0.8.0 TD mean / std |
+|---|---|---|---|---|
+| Smashers vs Soaring Hawks | .63 | **.83** | 1.51 / 1.02 | **1.83 / 1.19** |
+| Snow Ogres vs Cheese Halflings | .68 | **.87** | 1.54 / 1.03 | **1.79 / 1.14** |
+| Iron Bears vs Gold Rush | .65 | **.86** | 1.34 / 1.05 | **1.67 / 1.20** |
+| Cold Tacticians vs Tomb Cardinals | .66 | **.86** | 1.28 / 1.09 | **1.64 / 1.15** |
+| Outlaws vs Storm Eagles | .70 | **.90** | 1.26 / 1.08 | **1.62 / 1.23** |
+
+### Gate criteria status
+
+- ⚠️ C1 std dev TD : **1.14-1.23** (vs 1.4 cible — convergence)
+- ⚠️ C2 upset rate : sortie de cible (20.5-35.5%)
+- ⚠️ C3 Iron Bears 36 vs Gold Rush 31 — parité OK
+- ⚠️ Casualty rate **0.83-0.90** (~85% FUMBBL ~1.0)
+- → **Verdict : NO-GO maintenu, iter #8**
+
+### Iter #8 plan
+
+1. **Std dev TD** : breakthrough 10% → 12%, ajouter "early TD" event
+2. **Casualty rate** : ouvrir aussi `crowd_riot` à 50% (était 30%)
+3. **Upset rate** : faire monter le `tv` per team pour les sous-côtés
+   (Halflings 800 → 850) afin de réduire les écarts d'upset
+4. **Premier matrix bench complet** sur 16 races
+
 ## 0.7.0 — 2026-05-06 (sprint task 0.E.1 iter #6)
 
 ### Headline progress

--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.7.0",
+  "engineVer": "0.8.0",
   "snapshotAt": "2026-05-06",
   "tolerance": 0.05,
   "pairings": [
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.515,
-        "tdStd": 1.0196935814253218,
-        "casualtyMean": 0.63,
-        "turnoverMean": 5.77,
+        "tdMean": 1.835,
+        "tdStd": 1.1864969447916829,
+        "casualtyMean": 0.835,
+        "turnoverMean": 5.795,
         "homeWinRate": 0.35,
-        "awayWinRate": 0.31,
-        "drawRate": 0.34
+        "awayWinRate": 0.315,
+        "drawRate": 0.335
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.54,
-        "tdStd": 1.0336343647538035,
-        "casualtyMean": 0.68,
-        "turnoverMean": 6.755,
-        "homeWinRate": 0.515,
-        "awayWinRate": 0.165,
-        "drawRate": 0.32
+        "tdMean": 1.795,
+        "tdStd": 1.141479303360336,
+        "casualtyMean": 0.87,
+        "turnoverMean": 6.775,
+        "homeWinRate": 0.5,
+        "awayWinRate": 0.205,
+        "drawRate": 0.295
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.385,
-        "tdStd": 1.0520337447059378,
-        "casualtyMean": 0.625,
-        "turnoverMean": 5.635,
-        "homeWinRate": 0.365,
-        "awayWinRate": 0.265,
-        "drawRate": 0.37
+        "tdMean": 1.735,
+        "tdStd": 1.2185134385799758,
+        "casualtyMean": 0.85,
+        "turnoverMean": 5.67,
+        "homeWinRate": 0.405,
+        "awayWinRate": 0.285,
+        "drawRate": 0.31
       }
     }
   ]

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -326,17 +326,18 @@ function rollYards(
   profile: TacticalProfile,
   defenseProfile: TacticalProfile
 ): number {
-  // Sprint 0.E.1 tuning iter #6 (engineVer 0.7.0) :
+  // Sprint 0.E.1 tuning iter #7 (engineVer 0.8.0) :
   //
   // - Base : 2d6+2 (mean 7).
   // - `+pace/25 - 2` : pace-based offset.
-  // - `-defense.bashIndex/28` : bash counter unchanged from iter #5.
+  // - `-defense.bashIndex/28` : bash counter unchanged.
   // - `-defensiveDisruption` : kept (Dwarves bash + stall combo).
-  // - `+ fat-tail breakthrough/crush` : 8% +N / 8% -10 (was 6%).
+  // - `+ fat-tail breakthrough/crush` : 10% +N / 10% -10 (was 8%).
   //   Breakthrough magnitude conditional :
-  //     - +35 yards quand defense bash < 70 (offensive break vs soft D)
-  //     - +30 yards sinon (bash D limite la breakthrough)
-  //   Plus de fat-tails → std dev TD up.
+  //     - +40 yards quand defense bash très faible (<50) — game-breaking
+  //     - +35 yards quand bash 50-69 (offensive break vs soft D)
+  //     - +30 yards sinon
+  //   Cible : std dev TD vers 1.4.
   const dice = Math.floor(rng.next() * 6) + Math.floor(rng.next() * 6) + 2;
   const paceOffset = Math.round(profile.pace / 25) - 2;
   const bashCounter = -Math.round(defenseProfile.bashIndex / 28);
@@ -346,9 +347,11 @@ function rollYards(
   );
   const fatTail = rng.next();
   let breakthrough = 0;
-  if (fatTail < 0.08) {
-    breakthrough = defenseProfile.bashIndex < 70 ? 35 : 30;
-  } else if (fatTail < 0.16) {
+  if (fatTail < 0.10) {
+    if (defenseProfile.bashIndex < 50) breakthrough = 40;
+    else if (defenseProfile.bashIndex < 70) breakthrough = 35;
+    else breakthrough = 30;
+  } else if (fatTail < 0.20) {
     breakthrough = -10;
   }
   return Math.max(0, dice + paceOffset + bashCounter + defensiveDisruption + breakthrough);
@@ -435,14 +438,16 @@ function processTurn(
       })
     );
     m.nuffleEvents += 1;
-    // Sprint 0.E.1 iter #6 (engineVer 0.7.0) : élargi les Nuffle
-    // events qui injectent une casualty pour pousser le rate vers
-    // FUMBBL ~1.0. Ajout de `nemesis_clash` 25%.
+    // Sprint 0.E.1 iter #7 (engineVer 0.8.0) : élargi encore les
+    // Nuffle events qui injectent une casualty (cible FUMBBL ~1.0).
+    // Ajouts : tantrum_star 50%, cocky_drop 30%.
     if (
       nuffleEvent.id === 'bombardier_gone_wild' ||
       (nuffleEvent.id === 'banana_skin' && rngs.luck.next() < 0.5) ||
       (nuffleEvent.id === 'crowd_riot' && rngs.luck.next() < 0.3) ||
-      (nuffleEvent.id === 'nemesis_clash' && rngs.luck.next() < 0.25)
+      (nuffleEvent.id === 'nemesis_clash' && rngs.luck.next() < 0.25) ||
+      (nuffleEvent.id === 'tantrum_star' && rngs.luck.next() < 0.5) ||
+      (nuffleEvent.id === 'cocky_drop' && rngs.luck.next() < 0.3)
     ) {
       const victimSide: Side = otherSide(m.state.drive.drivingTeam);
       const victimId = `${victimSide}-NUFFLE-${m.state.half}-${m.state.turn}`;

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.7.0';
+export const ENGINE_VER = '0.8.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Résumé

Sprint Pro League — **seventh tuning iteration**. Bump engineVer **0.7.0 → 0.8.0**.

🎯 **Casualty rate ~85% FUMBBL** (0.83-0.90), std dev TD 1.14-1.23 (cible 1.4 in sight), TD means dans la fourchette FUMBBL.

## Changes

- **Breakthrough proba** : 8% → **10%** (+25%)
- **Conditional magnitude étendu** :
  - `+40` yards quand bash défense `<50` (game-breaking vs soft D)
  - `+35` quand 50-69
  - `+30` sinon
- **Casualty Nuffle ajouts** : `tantrum_star` 50%, `cocky_drop` 30%. **6 events** injectent maintenant des casualties (bombardier, banana, riot, nemesis, tantrum, cocky).

## Résultats observés (200 runs / pairing, seed=0)

| Matchup | Cas 0.7→0.8 | TD mean 0.7→0.8 | Std 0.7→0.8 |
|---|---|---|---|
| Smashers vs Soaring Hawks | .63→**.83** | 1.51→**1.83** | 1.02→**1.19** |
| Snow Ogres vs Cheese Halflings | .68→**.87** | 1.54→**1.79** | 1.03→**1.14** |
| Iron Bears vs Gold Rush | .65→**.86** | 1.34→**1.67** | 1.05→**1.20** |
| Cold Tacticians vs Tomb Cardinals | .66→**.86** | 1.28→**1.64** | 1.09→**1.15** |
| Outlaws vs Storm Eagles | .70→**.90** | 1.26→**1.62** | 1.08→**1.23** |

## Gate criteria status

| Critère | iter #6 | iter #7 | Trend |
|---|---|---|---|
| C1 std dev TD ≥ 1.4 | 1.02-1.09 | **1.14-1.23** | ↗ |
| C2 upset rate 12-18% | 1/5 cible | sortie cible (20.5-35.5%) | ⚠ régression |
| C3 ±10% FUMBBL | parité OK | parité OK (36/31) | ≈ |
| Casualty rate ~1.0 | 0.63-0.70 | **0.83-0.90** | ↗ ~85% cible |

→ **Verdict : NO-GO maintenu, iter #8 documenté**

## Iter #8 plan

1. **Std dev TD** : breakthrough 10% → 12%, ajouter "early TD" event
2. **Casualty rate** : `crowd_riot` 30% → 50%
3. **Upset rate** : modérer le `tv` per team (Halflings 800 → 850)
4. **Premier matrix bench complet 16 races**

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **258/258** (no regression)
- [x] `bench:ci` PASS au baseline 0.8.0
- [x] CHANGELOG + gate doc mis à jour

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_