### PR TITLE
feat(sim-engine): tuning iter #9 — engineVer 0.10.0 (breakthrough 14% + TV gap cap 200) — 2 matchups en cible C1

### DIFF
--- a/docs/roadmap/sprints/pro-league-gate.md
+++ b/docs/roadmap/sprints/pro-league-gate.md
@@ -17,16 +17,16 @@ complet.
 
 | Champ | Valeur |
 |---|---|
-| `engineVer` | `0.9.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
+| `engineVer` | `0.10.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
 | Snapshot bench-baseline | `2026-05-06` (3 pairings, runs=200, seed=0) |
-| Tuning iterations effectuées | 8 (race-aware → block→armor + tv → upset fix → defensive disruption → Nuffle casualty → breakthrough 8/10/12% → conditional magnitudes +40/+35/+30 → casualty rate ~93% FUMBBL) |
+| Tuning iterations effectuées | 9 (race-aware → block→armor + tv → upset fix → defensive disruption → Nuffle casualty → breakthrough 8/10/12/14% → conditional magnitudes +40/+35/+30 → TV gap cap 200 → 2 matchups en cible C1) |
 | Replays panel | 50 fichiers `replays/replay-XXX-*-seed[2026-2075].txt` (à regénérer pour engineVer 0.5.0) |
 
 ## Critères de gate
 
 | # | Critère | Cible sprint | Mesure | Statut |
 |---|---|---|---|---|
-| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _1.18 - 1.30_ | ❌ FAIL (~85% cible) |
+| C1 | Std dev TD ≥ 1.4 (lot 0.D.3) | ≥ 1.4 | _1.19 - 1.43 (2/5 pairings ✓)_ | ⚠️ partial (2 pairings dans cible) |
 | C2 | Upset rate 12-18% (lot 0.D.3) | 0.12 - 0.18 | _16.5 - 35% (Halflings vs Ogres 16.5% ✓)_ | ⚠️ 1/5 pairings DANS cible |
 | C3 | Tous matchups raciaux dans ±10% FUMBBL winrate (lot 0.E.1) | ±10% | _Iron Bears 34 vs Gold Rush 30 — parité OK ✓_ | ⚠️ partial RESOLU |
 | C4 | bench-baseline.json passe à `engineVer` cible (lot 0.D.4) | PASS | PASS | ✅ |

--- a/packages/sim-engine/CHANGELOG.md
+++ b/packages/sim-engine/CHANGELOG.md
@@ -7,6 +7,40 @@ sim engine. Used as the audit trail for sprint Pro League lots 0.D
 Each version bump matches `ENGINE_VER` in `src/types.ts` and is
 reflected in `bench/bench-baseline.json`.
 
+## 0.10.0 — 2026-05-06 (sprint task 0.E.1 iter #9)
+
+### Headline 🎯
+
+- **2 matchups passent C1** (std dev TD ≥ 1.4 ✓) :
+  - Snow Ogres vs Cheese Halflings : **1.43**
+  - Outlaws vs Storm Eagles : **1.43**
+- **TD means 2.21-2.46** (FUMBBL range OK)
+- Casualty rate stable ~92% FUMBBL (0.89-0.94)
+
+### Changes
+
+- **Breakthrough proba** : 12% → **14%** (+17%)
+- **TV gap cap to 200 max** : Dark Elves / Wood Elves / Pro Elves
+  passent 1100 → **1050**. Halflings restent 850, Ogres 900. Tous les
+  matchups TV-équilibrés ont maintenant un gap ≤ 200.
+
+### Observed deltas (200 runs / pairing, seed=0)
+
+| Matchup | TD mean | Std | Cas | C1 |
+|---|---|---|---|---|
+| Smashers vs Soaring Hawks | 2.08→**2.33** | 1.18→1.19 | .89 | ❌ |
+| Snow Ogres vs Cheese Halflings | 2.06→**2.46** | 1.28→**1.43** | .91 | **✓** |
+| Iron Bears vs Gold Rush | 1.96→**2.27** | 1.25→**1.32** | .90 | ❌ |
+| Cold Tacticians vs Tomb Cardinals | 1.99→**2.21** | 1.20→**1.26** | .93 | ❌ |
+| Outlaws vs Storm Eagles | 1.91→**2.25** | 1.30→**1.43** | .94 | **✓** |
+
+### Iter #10 plan (final iteration before pause)
+
+1. Std dev TD : breakthrough 14% → 16% pour passer C1 sur 4-5 pairings
+2. Casualty rate : pousser 0.94 → 1.0 (FUMBBL parité) — augmenter
+   `crowd_riot` à 60% ou ajouter `equipment_failure` 30%
+3. Upset rate : ajustement final pour viser 1-2/5 pairings dans cible
+
 ## 0.9.0 — 2026-05-06 (sprint task 0.E.1 iter #8)
 
 ### Headline

--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.9.0",
+  "engineVer": "0.10.0",
   "snapshotAt": "2026-05-06",
   "tolerance": 0.05,
   "pairings": [
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 2.085,
-        "tdStd": 1.1780386241545733,
+        "tdMean": 2.33,
+        "tdStd": 1.1878973019583816,
         "casualtyMean": 0.89,
-        "turnoverMean": 5.77,
-        "homeWinRate": 0.35,
-        "awayWinRate": 0.355,
-        "drawRate": 0.295
+        "turnoverMean": 5.725,
+        "homeWinRate": 0.355,
+        "awayWinRate": 0.345,
+        "drawRate": 0.3
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 2.065,
-        "tdStd": 1.284824890792516,
-        "casualtyMean": 0.925,
-        "turnoverMean": 6.655,
-        "homeWinRate": 0.495,
-        "awayWinRate": 0.23,
-        "drawRate": 0.275
+        "tdMean": 2.46,
+        "tdStd": 1.427725463805979,
+        "casualtyMean": 0.905,
+        "turnoverMean": 6.615,
+        "homeWinRate": 0.53,
+        "awayWinRate": 0.235,
+        "drawRate": 0.235
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 2.075,
-        "tdStd": 1.2959070182694428,
-        "casualtyMean": 0.91,
-        "turnoverMean": 5.66,
-        "homeWinRate": 0.405,
-        "awayWinRate": 0.34,
-        "drawRate": 0.255
+        "tdMean": 2.325,
+        "tdStd": 1.3414078425296307,
+        "casualtyMean": 0.905,
+        "turnoverMean": 5.695,
+        "homeWinRate": 0.41,
+        "awayWinRate": 0.295,
+        "drawRate": 0.295
       }
     }
   ]

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -326,14 +326,12 @@ function rollYards(
   profile: TacticalProfile,
   defenseProfile: TacticalProfile
 ): number {
-  // Sprint 0.E.1 tuning iter #8 (engineVer 0.9.0) :
+  // Sprint 0.E.1 tuning iter #9 (engineVer 0.10.0) :
   //
   // - Base : 2d6+2 (mean 7).
   // - bash counter / disruption / pace offset : unchanged.
-  // - Breakthrough proba : 10% → 12%. Magnitude unchanged.
-  // - +Pair-fluide bonus : `(Math.abs(rng.next() - 0.5) > 0.45) → ±2 yards
-  //   extra` — pousse plus d'extrême sur les rolls. Petit boost de
-  //   variance sans dépendre du fat-tail uniquement.
+  // - Breakthrough proba : 12% → 14%. Magnitudes unchanged.
+  //   Cible : std dev TD 1.4.
   const dice = Math.floor(rng.next() * 6) + Math.floor(rng.next() * 6) + 2;
   const paceOffset = Math.round(profile.pace / 25) - 2;
   const bashCounter = -Math.round(defenseProfile.bashIndex / 28);
@@ -343,11 +341,11 @@ function rollYards(
   );
   const fatTail = rng.next();
   let breakthrough = 0;
-  if (fatTail < 0.12) {
+  if (fatTail < 0.14) {
     if (defenseProfile.bashIndex < 50) breakthrough = 40;
     else if (defenseProfile.bashIndex < 70) breakthrough = 35;
     else breakthrough = 30;
-  } else if (fatTail < 0.24) {
+  } else if (fatTail < 0.28) {
     breakthrough = -10;
   }
   return Math.max(0, dice + paceOffset + bashCounter + defensiveDisruption + breakthrough);

--- a/packages/sim-engine/src/tactics/race-profiles.ts
+++ b/packages/sim-engine/src/tactics/race-profiles.ts
@@ -88,7 +88,7 @@ export const PRO_LEAGUE_TEAMS: readonly ProTeamProfile[] = Object.freeze([
       blitzPriority: 65,
       patience: 45,
     }),
-    tv: 1100,
+    tv: 1050,
   },
   // 3. Kansas City Soaring Hawks — Wood Elves / Chiefs (aerial Mahomes-flavor).
   {
@@ -107,7 +107,7 @@ export const PRO_LEAGUE_TEAMS: readonly ProTeamProfile[] = Object.freeze([
       cageAffinity: 30,
       patience: 40,
     }),
-    tv: 1100,
+    tv: 1050,
   },
   // 4. New England Cold Tacticians — Lizardmen / Patriots (cold dynasty).
   {
@@ -239,7 +239,7 @@ export const PRO_LEAGUE_TEAMS: readonly ProTeamProfile[] = Object.freeze([
       pressingDefense: 55,
       cageAffinity: 50,
     }),
-    tv: 1100,
+    tv: 1050,
   },
   // 11. Phoenix Tomb Cardinals — Tomb Kings (Khemri) / Cardinals (desert slow).
   {

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.9.0';
+export const ENGINE_VER = '0.10.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Résumé

Sprint Pro League — **ninth tuning iteration**. Bump engineVer **0.9.0 → 0.10.0**.

🎯 **2 matchups passent C1** (std dev TD ≥ 1.4) — premier en cible !
- Snow Ogres vs Cheese Halflings : **1.43**
- Outlaws vs Storm Eagles : **1.43**

## Changes

- **Breakthrough proba** : 12% → **14%** (+17%)
- **TV gap cap to 200 max** : Dark Elves / Wood Elves / Pro Elves 1100 → **1050**. Halflings 850, Ogres 900, Outlaws 950. Tous matchups TV-équilibrés ont gap ≤ 200.

## Résultats observés (200 runs / pairing, seed=0)

| Matchup | TD mean | Std | Cas | C1 |
|---|---|---|---|---|
| Smashers vs Soaring Hawks | 2.08→**2.33** | 1.18→1.19 | .89 | ❌ |
| Snow Ogres vs Cheese Halflings | 2.06→**2.46** | 1.28→**1.43** | .91 | **✓** |
| Iron Bears vs Gold Rush | 1.96→**2.27** | 1.25→**1.32** | .90 | ❌ |
| Cold Tacticians vs Tomb Cardinals | 1.99→**2.21** | 1.20→**1.26** | .93 | ❌ |
| Outlaws vs Storm Eagles | 1.91→**2.25** | 1.30→**1.43** | .94 | **✓** |

## Iter #10 plan (final iteration before user review)

1. Std dev TD : breakthrough 14% → 16% pour 4-5 pairings en cible
2. Casualty rate : pousser 0.94 → 1.0 (FUMBBL parité)
3. Upset rate : ajustement final

## Checklist

- [x] Lint / typecheck / build verts
- [x] Tests : sim-engine **258/258** (no regression)
- [x] `bench:ci` PASS au baseline 0.10.0
- [x] CHANGELOG + gate doc mis à jour

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_