### PR TITLE
docs(panel): regenerate 50 panel replays on engineVer 0.12.0

### DIFF
--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt
@@ -1,47 +1,51 @@
 === MATCH #1 — Soaring Hawks (Wood Elf) vs Frostraiders (Norse) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts min-frostraiders (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 17 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 15 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 3 — home in possession at yardline 10 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
   ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
   BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 8 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 5 — away in possession at yardline 14 (score 0-0)
+Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 1 • Turn 6 — away in possession at yardline 19 (score 0-0)
-Half 1 • Turn 7 — away in possession at yardline 23 (score 0-0)
   TURNOVER — pickup_failed.
-Half 1 • Turn 8 — home in possession at yardline 14 (score 0-0)
+Half 1 • Turn 6 — away in possession at yardline 11 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 1 • Turn 7 — away in possession at yardline 21 (score 0-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 8 — home in possession at yardline 8 (score 0-0)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-1-8 is taken off by banana_skin.
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → caught.
 
 --- HALFTIME (score 0-0) ---
 
 Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 2 • Turn 2 — home in possession at yardline 10 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — away in possession at yardline 13 (score 0-0)
+Half 2 • Turn 2 — home in possession at yardline 9 (score 0-0)
+  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+Half 2 • Turn 3 — home in possession at yardline 13 (score 0-0)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 2 • Turn 4 — away in possession at yardline 19 (score 0-0)
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-1)
-Half 2 • Turn 6 — home in possession at yardline 9 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 16 (score 0-1)
-  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 8 — away in possession at yardline 8 (score 0-1)
+Half 2 • Turn 4 — home in possession at yardline 14 (score 0-0)
+Half 2 • Turn 5 — home in possession at yardline 17 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 6 — home in possession at yardline 17 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 2 • Turn 7 — home in possession at yardline 24 (score 0-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
 
---- END OF MATCH (score 0-1) ---
+--- END OF MATCH (score 0-0) ---
 
 
-FINAL: 0 - 1 (away)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 5 | Nuffle: 4
+FINAL: 0 - 0 (draw)
+Touchdowns: 0 | Casualties: 1 | Turnovers: 6 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-002-kc-soaring-hawks-vs-no-voodoo-saints-seed2027.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-002-kc-soaring-hawks-vs-no-voodoo-saints-seed2027.txt
@@ -1,56 +1,62 @@
 === MATCH #2 — Soaring Hawks (Wood Elf) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
-Half 1 • Turn 2 — away in possession at yardline 12 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
   ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-Half 1 • Turn 3 — away in possession at yardline 18 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 4 — away in possession at yardline 21 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 15 (score 0-1)
   BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
-Half 1 • Turn 7 — away in possession at yardline 20 (score 0-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-
---- HALFTIME (score 0-2) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+Half 1 • Turn 3 — away in possession at yardline 11 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
   TURNOVER — pickup_failed.
-Half 2 • Turn 2 — away in possession at yardline 12 (score 0-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 0-2)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 16 (score 0-2)
+Half 1 • Turn 6 — away in possession at yardline 8 (score 0-2)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 7 — home in possession at yardline 10 (score 0-2)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 0-3.
+Half 1 • Turn 8 — home in possession at yardline 4 (score 0-3)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 11 (score 0-2)
-Half 2 • Turn 6 — away in possession at yardline 13 (score 0-2)
+
+--- HALFTIME (score 0-3) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-3)
+  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  CASUALTY — away-NUFFLE-2-1 is taken off by bombardier_gone_wild.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → caught.
+Half 2 • Turn 2 — home in possession at yardline 6 (score 0-3)
+  Touchdown! home crosses the line. Score is now 1-3.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 1-3)
   TURNOVER — pickup_failed.
-Half 2 • Turn 7 — home in possession at yardline 6 (score 0-2)
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-3)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 2 • Turn 5 — home in possession at yardline 9 (score 1-3)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 6 — home in possession at yardline 12 (score 1-3)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 7 — away in possession at yardline 8 (score 1-3)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 8 — away in possession at yardline 11 (score 0-2)
+Half 2 • Turn 8 — away in possession at yardline 12 (score 1-3)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  CASUALTY — home-NUFFLE-2-8 is taken off by nemesis_clash.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 1-3) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 7 | Nuffle: 8
+FINAL: 1 - 3 (away)
+Touchdowns: 4 | Casualties: 2 | Turnovers: 7 | Nuffle: 8

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-003-kc-soaring-hawks-vs-buf-snow-ogres-seed2028.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-003-kc-soaring-hawks-vs-buf-snow-ogres-seed2028.txt
@@ -1,53 +1,57 @@
 === MATCH #3 — Soaring Hawks (Wood Elf) vs Snow Ogres (Ogre) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts buf-snow-ogres (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 1 • Turn 3 — away in possession at yardline 19 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — away-NUFFLE-1-3 is taken off by tantrum_star.
+  TURNOVER — pickup_failed.
+Half 1 • Turn 4 — away in possession at yardline 9 (score 0-0)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 4 — home in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-Half 1 • Turn 5 — home in possession at yardline 14 (score 0-0)
-Half 1 • Turn 6 — home in possession at yardline 20 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — away in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 21 (score 0-0)
-  TURNOVER — pickup_failed.
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 2 • Turn 2 — away in possession at yardline 9 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
-Half 2 • Turn 3 — away in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 4 — home in possession at yardline 10 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 5 — away in possession at yardline 16 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
-Half 2 • Turn 6 — away in possession at yardline 23 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 2 • Turn 7 — away in possession at yardline 25 (score 0-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PLAYER_DOWN], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 5 — home in possession at yardline 8 (score 0-0)
+Half 1 • Turn 6 — home in possession at yardline 13 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
+Half 1 • Turn 7 — away in possession at yardline 9 (score 0-0)
+  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
 
---- END OF MATCH (score 0-1) ---
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PLAYER_DOWN], chose POW, defender_down.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 5 — home in possession at yardline 7 (score 0-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 6 — away in possession at yardline 8 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — home in possession at yardline 7 (score 0-1)
+  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  TURNOVER — pickup_failed.
+
+--- END OF MATCH (score 1-1) ---
 
 
-FINAL: 0 - 1 (away)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 7 | Nuffle: 5
+FINAL: 1 - 1 (draw)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 9 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-004-jax-swamp-lizards-vs-car-jungle-queens-seed2029.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-004-jax-swamp-lizards-vs-car-jungle-queens-seed2029.txt
@@ -1,60 +1,63 @@
 === MATCH #4 — Swamp Lizards (Lizardmen) vs Jungle Queens (Amazon) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — jax-swamp-lizards hosts car-jungle-queens (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
   BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, both_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+Half 1 • Turn 4 — home in possession at yardline 17 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0)
+Half 1 • Turn 5 — away in possession at yardline 10 (score 0-0)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  TURNOVER — pickup_failed.
+Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
   FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 5 — home in possession at yardline 16 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 1 • Turn 6 — home in possession at yardline 25 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose STUMBLE, defender_down.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 2-1)
   FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/POW], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 8 — home in possession at yardline 15 (score 1-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 2 — home in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 23 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 13 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 2 • Turn 4 — home in possession at yardline 9 (score 2-1)
   ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 5 — home in possession at yardline 11 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 6 — home in possession at yardline 17 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
   FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 7 — home in possession at yardline 24 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+Half 2 • Turn 5 — home in possession at yardline 19 (score 2-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 7 — away in possession at yardline 5 (score 2-1)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 8 — away in possession at yardline 11 (score 1-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 8 — home in possession at yardline 8 (score 2-1)
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 7 | Nuffle: 9
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 8 | Nuffle: 9

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-005-dal-vipers-vs-chi-iron-bears-seed2030.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-005-dal-vipers-vs-chi-iron-bears-seed2030.txt
@@ -1,55 +1,54 @@
 === MATCH #5 — Vipers (Dark Elf) vs Iron Bears (Dwarf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — dal-vipers hosts chi-iron-bears (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
-Half 1 • Turn 2 — home in possession at yardline 12 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — away in possession at yardline 17 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 2 — home in possession at yardline 6 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
+Half 1 • Turn 4 — home in possession at yardline 11 (score 0-0)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 5 — home in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 6 — home in possession at yardline 17 (score 0-1)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — away in possession at yardline 14 (score 0-1)
-Half 1 • Turn 8 — away in possession at yardline 24 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 0-2.
-
---- HALFTIME (score 0-2) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — away in possession at yardline 11 (score 0-2)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 3 — away in possession at yardline 16 (score 0-2)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 12 (score 0-2)
-Half 2 • Turn 5 — home in possession at yardline 23 (score 0-2)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 6 — away in possession at yardline 16 (score 0-2)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 10 (score 0-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 7 — home in possession at yardline 7 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+Half 1 • Turn 8 — home in possession at yardline 7 (score 0-1)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — away-NUFFLE-1-8 is taken off by tantrum_star.
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
   FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 8 — home in possession at yardline 16 (score 0-2)
+Half 2 • Turn 3 — home in possession at yardline 14 (score 0-1)
+Half 2 • Turn 4 — home in possession at yardline 16 (score 0-1)
   FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+Half 2 • Turn 5 — home in possession at yardline 16 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 2 • Turn 6 — home in possession at yardline 16 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+Half 2 • Turn 7 — home in possession at yardline 16 (score 0-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-2-7 is taken off by banana_skin.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 8 — away in possession at yardline 5 (score 0-1)
+  TURNOVER — gfi_failed.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 0-1) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 5 | Nuffle: 7
+FINAL: 0 - 1 (away)
+Touchdowns: 1 | Casualties: 2 | Turnovers: 4 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-006-kc-soaring-hawks-vs-no-voodoo-saints-seed2031.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-006-kc-soaring-hawks-vs-no-voodoo-saints-seed2031.txt
@@ -1,47 +1,60 @@
 === MATCH #6 — Soaring Hawks (Wood Elf) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 3 — away in possession at yardline 21 (score 0-0)
+Half 1 • Turn 3 — away in possession at yardline 8 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — home in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 1 • Turn 5 — home in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-Half 1 • Turn 6 — home in possession at yardline 23 (score 0-0)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 7 — away in possession at yardline 10 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — away in possession at yardline 11 (score 0-0)
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-Half 2 • Turn 3 — home in possession at yardline 20 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 9 (score 0-0)
-Half 2 • Turn 6 — home in possession at yardline 18 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 6 — away in possession at yardline 12 (score 1-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 7 — home in possession at yardline 5 (score 1-0)
+Half 1 • Turn 8 — home in possession at yardline 8 (score 1-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+
+--- HALFTIME (score 1-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  TURNOVER — gfi_failed.
+Half 2 • Turn 2 — away in possession at yardline 9 (score 1-0)
+  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 4 — away in possession at yardline 10 (score 1-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 5 — home in possession at yardline 5 (score 1-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 6 — away in possession at yardline 9 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+Half 2 • Turn 7 — away in possession at yardline 17 (score 1-0)
   ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-Half 2 • Turn 8 — away in possession at yardline 12 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  CASUALTY — home-NUFFLE-2-7 is taken off by bombardier_gone_wild.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 2-0)
+  TURNOVER — pickup_failed.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-0) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 4 | Nuffle: 6
+FINAL: 2 - 0 (home)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 11 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-007-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2032.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-007-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2032.txt
@@ -1,53 +1,53 @@
 === MATCH #7 — Soaring Hawks (Wood Elf) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
   FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 3 — away in possession at yardline 15 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → caught.
-Half 1 • Turn 5 — home in possession at yardline 15 (score 0-1)
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/POW], chose POW, defender_down.
-Half 1 • Turn 7 — away in possession at yardline 6 (score 1-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 1 • Turn 8 — away in possession at yardline 10 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, defender_down.
-
---- HALFTIME (score 1-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 2 — away in possession at yardline 7 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 3 — away in possession at yardline 14 (score 1-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — home in possession at yardline 6 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 5 — home in possession at yardline 12 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
-Half 2 • Turn 6 — home in possession at yardline 25 (score 1-1)
+Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
+Half 1 • Turn 4 — home in possession at yardline 7 (score 0-0)
+Half 1 • Turn 5 — home in possession at yardline 13 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 6 — home in possession at yardline 17 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — away in possession at yardline 16 (score 1-1)
+Half 1 • Turn 7 — away in possession at yardline 7 (score 0-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+Half 1 • Turn 8 — away in possession at yardline 12 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 8 — away in possession at yardline 19 (score 1-1)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 4 — home in possession at yardline 6 (score 1-1)
+Half 2 • Turn 5 — home in possession at yardline 14 (score 1-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
+Half 2 • Turn 7 — away in possession at yardline 11 (score 2-1)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 2 • Turn 8 — away in possession at yardline 16 (score 2-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → ko).
-  KO — home-PRONE is knocked unconscious by away-LOS.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, defender_down.
+  TURNOVER — pickup_failed.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 3 | Nuffle: 4
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 4 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-008-dal-vipers-vs-phi-storm-eagles-seed2033.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-008-dal-vipers-vs-phi-storm-eagles-seed2033.txt
@@ -1,50 +1,50 @@
 === MATCH #8 — Vipers (Dark Elf) vs Storm Eagles (Pro Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — dal-vipers hosts phi-storm-eagles (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 13 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 3 — away in possession at yardline 13 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
   TURNOVER — pickup_failed.
-Half 1 • Turn 4 — home in possession at yardline 13 (score 0-0)
+Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 5 — home in possession at yardline 20 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 15 (score 1-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 1 • Turn 5 — away in possession at yardline 15 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-Half 1 • Turn 8 — away in possession at yardline 18 (score 1-0)
+Half 1 • Turn 8 — away in possession at yardline 7 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- HALFTIME (score 1-0) ---
+--- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 3 — away in possession at yardline 10 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 2 — home in possession at yardline 11 (score 1-1)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 5 — home in possession at yardline 21 (score 1-0)
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-0)
+Half 2 • Turn 3 — home in possession at yardline 15 (score 1-1)
+  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 2 • Turn 4 — home in possession at yardline 18 (score 1-1)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 5 — home in possession at yardline 20 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+Half 2 • Turn 6 — home in possession at yardline 20 (score 1-1)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 9 (score 2-0)
+  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-Half 2 • Turn 8 — home in possession at yardline 14 (score 2-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 2-1)
 
---- END OF MATCH (score 2-0) ---
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 2 - 0 (home)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 6
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-009-no-voodoo-saints-vs-phi-storm-eagles-seed2034.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-009-no-voodoo-saints-vs-phi-storm-eagles-seed2034.txt
@@ -1,49 +1,53 @@
 === MATCH #9 — Voodoo Saints (Undead) vs Storm Eagles (Pro Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — no-voodoo-saints hosts phi-storm-eagles (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 11 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 18 (score 0-0)
-Half 1 • Turn 4 — home in possession at yardline 22 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 6 — away in possession at yardline 11 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 11 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 8 — home in possession at yardline 14 (score 1-0)
+Half 1 • Turn 4 — home in possession at yardline 8 (score 0-0)
+  TURNOVER — gfi_failed.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 7 — away in possession at yardline 6 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+Half 1 • Turn 8 — away in possession at yardline 12 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+Half 2 • Turn 2 — home in possession at yardline 7 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  TURNOVER — block_attacker_down.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
+  CASUALTY — away-NUFFLE-2-3 is taken off by equipment_failure.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 6 — away in possession at yardline 10 (score 1-1)
+  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  TURNOVER — gfi_failed.
+Half 2 • Turn 7 — home in possession at yardline 7 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 8 — home in possession at yardline 9 (score 1-1)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
 
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 2 — away in possession at yardline 13 (score 1-0)
-Half 2 • Turn 3 — away in possession at yardline 20 (score 1-0)
-  ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 4 — home in possession at yardline 14 (score 1-0)
-Half 2 • Turn 5 — home in possession at yardline 19 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 6 — home in possession at yardline 20 (score 1-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 10 (score 1-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 8 — away in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 1-1) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 5 | Nuffle: 5
+FINAL: 1 - 1 (draw)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 4 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-010-chi-iron-bears-vs-lv-outlaws-seed2035.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-010-chi-iron-bears-vs-lv-outlaws-seed2035.txt
@@ -1,54 +1,67 @@
 === MATCH #10 — Iron Bears (Dwarf) vs Outlaws (Norse) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — chi-iron-bears hosts lv-outlaws (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 2 — home in possession at yardline 6 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 15 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
   BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
-Half 1 • Turn 4 — home in possession at yardline 20 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 6 — away in possession at yardline 14 (score 1-0)
+  KO — away-LOS is knocked unconscious by home-LOS.
+Half 1 • Turn 4 — home in possession at yardline 5 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/POW], chose POW, defender_down.
+Half 1 • Turn 5 — home in possession at yardline 5 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — home in possession at yardline 9 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 8 — home in possession at yardline 14 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 2 • Turn 2 — away in possession at yardline 12 (score 1-0)
-Half 2 • Turn 3 — away in possession at yardline 21 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 7 — home in possession at yardline 5 (score 2-0)
+Half 1 • Turn 8 — home in possession at yardline 5 (score 2-0)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
   PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 11 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 16 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 2 • Turn 7 — away in possession at yardline 23 (score 1-1)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  Touchdown! away crosses the line. Score is now 2-1.
+
+--- HALFTIME (score 2-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+  Touchdown! home crosses the line. Score is now 3-1.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 3-1)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 4 — home in possession at yardline 5 (score 3-1)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 3-1)
+  Touchdown! away crosses the line. Score is now 3-2.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — away in possession at yardline 8 (score 3-2)
+  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 8 — home in possession at yardline 5 (score 3-2)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 1-2) ---
+--- END OF MATCH (score 3-2) ---
 
 
-FINAL: 1 - 2 (away)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 5
+FINAL: 3 - 2 (home)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 8 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-011-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2036.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-011-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2036.txt
@@ -1,54 +1,60 @@
 === MATCH #11 — Soaring Hawks (Wood Elf) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-Half 1 • Turn 2 — home in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  CASUALTY — away-NUFFLE-1-1 is taken off by banana_skin.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
   BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-Half 1 • Turn 4 — away in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-Half 1 • Turn 5 — away in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 6 — away in possession at yardline 17 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 8 — home in possession at yardline 18 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 (fumble!) → failed.
-  TURNOVER — pass_failed.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 4 — home in possession at yardline 8 (score 1-1)
+  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
   TURNOVER — pickup_failed.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+Half 1 • Turn 5 — away in possession at yardline 8 (score 1-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
+Half 1 • Turn 6 — away in possession at yardline 11 (score 1-1)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 3 — away in possession at yardline 9 (score 1-0)
+Half 1 • Turn 7 — home in possession at yardline 7 (score 1-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 9 (score 1-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 2 • Turn 4 — away in possession at yardline 15 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — home in possession at yardline 12 (score 1-0)
-Half 2 • Turn 6 — home in possession at yardline 19 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
+Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — away in possession at yardline 12 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-Half 2 • Turn 8 — away in possession at yardline 17 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 6 — away in possession at yardline 8 (score 1-1)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
   BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/STUMBLE], chose PUSH_BACK, push_only.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  Touchdown! home crosses the line. Score is now 2-2.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 2-2)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-2) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 6 | Nuffle: 8
+FINAL: 2 - 2 (draw)
+Touchdowns: 4 | Casualties: 2 | Turnovers: 5 | Nuffle: 8

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-012-no-voodoo-saints-vs-chi-iron-bears-seed2037.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-012-no-voodoo-saints-vs-chi-iron-bears-seed2037.txt
@@ -1,56 +1,58 @@
 === MATCH #12 — Voodoo Saints (Undead) vs Iron Bears (Dwarf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — no-voodoo-saints hosts chi-iron-bears (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 1 • Turn 2 — home in possession at yardline 9 (score 0-0)
+  CASUALTY — away-NUFFLE-1-1 is taken off by nemesis_clash.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — away in possession at yardline 11 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 1 • Turn 4 — away in possession at yardline 15 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 21 (score 0-0)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 7 — home in possession at yardline 12 (score 0-1)
-Half 1 • Turn 8 — home in possession at yardline 17 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-
---- HALFTIME (score 0-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 1 • Turn 7 — away in possession at yardline 6 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 1 • Turn 8 — away in possession at yardline 6 (score 1-1)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 2 — away in possession at yardline 13 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 2 — away in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 0-1)
+  CASUALTY — home-NUFFLE-2-2 is taken off by banana_skin.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 5 — away in possession at yardline 13 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 6 — home in possession at yardline 14 (score 0-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 2 • Turn 7 — away in possession at yardline 10 (score 0-1)
+Half 2 • Turn 4 — away in possession at yardline 4 (score 1-2)
+  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — away in possession at yardline 6 (score 1-2)
   ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 8 — away in possession at yardline 16 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 8 — away in possession at yardline 12 (score 1-2)
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 1-2) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 7
+FINAL: 1 - 2 (away)
+Touchdowns: 3 | Casualties: 2 | Turnovers: 6 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-013-phx-tomb-cardinals-vs-lv-outlaws-seed2038.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-013-phx-tomb-cardinals-vs-lv-outlaws-seed2038.txt
@@ -1,58 +1,61 @@
 === MATCH #13 — Tomb Cardinals (Tomb Kings) vs Outlaws (Norse) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts lv-outlaws (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
   FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 12 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
   ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
   BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 18 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 7 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 4 — home in possession at yardline 23 (score 0-0)
+Half 1 • Turn 4 — home in possession at yardline 7 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 5 — home in possession at yardline 7 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 6 — away in possession at yardline 7 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 12 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 8 — home in possession at yardline 11 (score 1-0)
+Half 1 • Turn 7 — home in possession at yardline 8 (score 1-0)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  CASUALTY — away-NUFFLE-1-7 is taken off by cocky_drop.
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 9 (score 1-0)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
 
 --- HALFTIME (score 1-0) ---
 
 Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 2 — away in possession at yardline 13 (score 1-0)
+Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 3 — away in possession at yardline 22 (score 1-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-Half 2 • Turn 5 — home in possession at yardline 10 (score 1-1)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 6 — home in possession at yardline 14 (score 1-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 22 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 2-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+Half 2 • Turn 4 — home in possession at yardline 6 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 2-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
 
---- END OF MATCH (score 2-1) ---
+--- END OF MATCH (score 2-0) ---
 
 
-FINAL: 2 - 1 (home)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 2 | Nuffle: 9
+FINAL: 2 - 0 (home)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 4 | Nuffle: 9

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-014-min-frostraiders-vs-jax-swamp-lizards-seed2039.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-014-min-frostraiders-vs-jax-swamp-lizards-seed2039.txt
@@ -1,55 +1,68 @@
 === MATCH #14 — Frostraiders (Norse) vs Swamp Lizards (Lizardmen) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — min-frostraiders hosts jax-swamp-lizards (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-Half 1 • Turn 2 — away in possession at yardline 6 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 1 • Turn 3 — away in possession at yardline 17 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-Half 1 • Turn 4 — away in possession at yardline 23 (score 0-0)
+  CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 5 — home in possession at yardline 11 (score 0-0)
+Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
+Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 1 • Turn 6 — home in possession at yardline 20 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 6 — home in possession at yardline 14 (score 0-0)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  TURNOVER — gfi_failed.
-Half 1 • Turn 8 — home in possession at yardline 9 (score 1-0)
+  CASUALTY — home-NUFFLE-1-7 is taken off by cocky_drop.
+  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
+Half 1 • Turn 8 — away in possession at yardline 7 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! home crosses the line. Score is now 1-0.
 
 --- HALFTIME (score 1-0) ---
 
 Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — home in possession at yardline 11 (score 1-0)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 17 (score 1-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 5 — away in possession at yardline 11 (score 2-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 2 • Turn 6 — away in possession at yardline 14 (score 2-0)
+  CASUALTY — home-NUFFLE-2-2 is taken off by bombardier_gone_wild.
+  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
   PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 15 (score 2-0)
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 3-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+Half 2 • Turn 4 — home in possession at yardline 9 (score 1-0)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 5 — away in possession at yardline 7 (score 1-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+Half 2 • Turn 6 — away in possession at yardline 12 (score 1-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — home in possession at yardline 7 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 2 • Turn 8 — home in possession at yardline 8 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  Touchdown! home crosses the line. Score is now 2-0.
 
---- END OF MATCH (score 3-0) ---
+--- END OF MATCH (score 2-0) ---
 
 
-FINAL: 3 - 0 (home)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 11
+FINAL: 2 - 0 (home)
+Touchdowns: 2 | Casualties: 4 | Turnovers: 7 | Nuffle: 11

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-015-pit-smashers-vs-gb-cheese-halflings-seed2040.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-015-pit-smashers-vs-gb-cheese-halflings-seed2040.txt
@@ -1,54 +1,59 @@
 === MATCH #15 — Smashers (Orc) vs Cheese Halflings (Halfling) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — pit-smashers hosts gb-cheese-halflings (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 2 — home in possession at yardline 13 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-Half 1 • Turn 3 — home in possession at yardline 21 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 4 — away in possession at yardline 14 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 24 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — home in possession at yardline 11 (score 0-1)
+Half 1 • Turn 4 — away in possession at yardline 8 (score 1-1)
+Half 1 • Turn 5 — away in possession at yardline 13 (score 1-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 1 • Turn 6 — away in possession at yardline 19 (score 1-1)
   TURNOVER — pickup_failed.
-Half 1 • Turn 8 — away in possession at yardline 8 (score 0-1)
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 2-1)
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+Half 1 • Turn 8 — away in possession at yardline 5 (score 2-1)
   FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  TURNOVER — pickup_failed.
+  Touchdown! home crosses the line. Score is now 3-1.
 
---- HALFTIME (score 0-1) ---
+--- HALFTIME (score 3-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 2 — home in possession at yardline 13 (score 3-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — home in possession at yardline 13 (score 3-1)
+  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
   FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → ko, sent off!).
   KO — away-PRONE is knocked unconscious by home-LOS.
   TURNOVER — foul_sent_off.
-Half 2 • Turn 2 — away in possession at yardline 10 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — home in possession at yardline 13 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 19 (score 0-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 5 — home in possession at yardline 24 (score 0-1)
+  Touchdown! away crosses the line. Score is now 3-2.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 3-2)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 7 — away in possession at yardline 11 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 8 — away in possession at yardline 22 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+Half 2 • Turn 7 — home in possession at yardline 14 (score 3-2)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 8 — home in possession at yardline 24 (score 3-2)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+  Touchdown! home crosses the line. Score is now 4-2.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 4-2) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 5 | Nuffle: 3
+FINAL: 4 - 2 (home)
+Touchdowns: 6 | Casualties: 0 | Turnovers: 7 | Nuffle: 3

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-016-ne-cold-tacticians-vs-kc-soaring-hawks-seed2041.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-016-ne-cold-tacticians-vs-kc-soaring-hawks-seed2041.txt
@@ -1,46 +1,52 @@
 === MATCH #16 — Cold Tacticians (Lizardmen) vs Soaring Hawks (Wood Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — away in possession at yardline 13 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → caught.
-Half 1 • Turn 3 — away in possession at yardline 22 (score 0-0)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 3 — away in possession at yardline 10 (score 0-1)
   ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 4 — home in possession at yardline 11 (score 0-0)
-Half 1 • Turn 5 — home in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 1 • Turn 7 — away in possession at yardline 9 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 16 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → caught.
-  Touchdown! away crosses the line. Score is now 1-1.
-
---- HALFTIME (score 1-1) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 2 — home in possession at yardline 16 (score 1-1)
-Half 2 • Turn 3 — home in possession at yardline 23 (score 1-1)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 4 — away in possession at yardline 13 (score 1-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 1 • Turn 4 — away in possession at yardline 12 (score 0-1)
   DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
-Half 2 • Turn 5 — away in possession at yardline 23 (score 1-1)
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — away in possession at yardline 8 (score 1-2)
+Half 1 • Turn 5 — away in possession at yardline 16 (score 0-1)
+  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+Half 1 • Turn 6 — away in possession at yardline 23 (score 0-1)
+  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-2)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+Half 1 • Turn 8 — home in possession at yardline 7 (score 0-2)
+
+--- HALFTIME (score 0-2) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+Half 2 • Turn 2 — home in possession at yardline 11 (score 0-2)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  Touchdown! home crosses the line. Score is now 1-2.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 1-2)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → caught.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 8 — away in possession at yardline 17 (score 1-2)
+Half 2 • Turn 4 — away in possession at yardline 6 (score 1-2)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+Half 2 • Turn 5 — away in possession at yardline 13 (score 1-2)
+  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → casualty).
+  CASUALTY — home-PRONE is taken off by away-LOS.
+Half 2 • Turn 6 — away in possession at yardline 17 (score 1-2)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 7 — home in possession at yardline 6 (score 1-2)
+Half 2 • Turn 8 — home in possession at yardline 6 (score 1-2)
+  TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 1-2) ---
 
 
 FINAL: 1 - 2 (away)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 3
+Touchdowns: 3 | Casualties: 1 | Turnovers: 3 | Nuffle: 3

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-017-phx-tomb-cardinals-vs-dal-vipers-seed2042.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-017-phx-tomb-cardinals-vs-dal-vipers-seed2042.txt
@@ -1,51 +1,57 @@
 === MATCH #17 — Tomb Cardinals (Tomb Kings) vs Vipers (Dark Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts dal-vipers (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   TURNOVER — gfi_failed.
-Half 1 • Turn 2 — home in possession at yardline 16 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — away in possession at yardline 12 (score 0-0)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 4 — home in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 1 • Turn 5 — home in possession at yardline 24 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  TURNOVER — gfi_failed.
+Half 1 • Turn 3 — home in possession at yardline 11 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+Half 1 • Turn 4 — home in possession at yardline 11 (score 1-0)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 7 — away in possession at yardline 7 (score 2-0)
+  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+Half 1 • Turn 8 — away in possession at yardline 9 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+
+--- HALFTIME (score 2-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+Half 2 • Turn 2 — home in possession at yardline 9 (score 2-0)
+  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+Half 2 • Turn 3 — home in possession at yardline 12 (score 2-0)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 4 — away in possession at yardline 7 (score 2-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 2-0)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 3-0.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 3-0)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 1 • Turn 8 — home in possession at yardline 18 (score 1-0)
+Half 2 • Turn 7 — home in possession at yardline 8 (score 3-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  Touchdown! home crosses the line. Score is now 4-0.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 4-0)
+  Touchdown! away crosses the line. Score is now 4-1.
 
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 2 — away in possession at yardline 7 (score 1-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 3 — away in possession at yardline 13 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 15 (score 1-0)
-Half 2 • Turn 5 — home in possession at yardline 18 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 6 — away in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 2 • Turn 7 — away in possession at yardline 17 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — home in possession at yardline 12 (score 1-0)
-  TURNOVER — pickup_failed.
-
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 4-1) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 9 | Nuffle: 5
+FINAL: 4 - 1 (home)
+Touchdowns: 5 | Casualties: 1 | Turnovers: 5 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-018-phx-tomb-cardinals-vs-no-voodoo-saints-seed2043.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-018-phx-tomb-cardinals-vs-no-voodoo-saints-seed2043.txt
@@ -1,52 +1,53 @@
 === MATCH #18 — Tomb Cardinals (Tomb Kings) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts no-voodoo-saints (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 11 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
-Half 1 • Turn 4 — home in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 1 • Turn 5 — home in possession at yardline 18 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 1 • Turn 6 — home in possession at yardline 23 (score 0-0)
+Half 1 • Turn 3 — away in possession at yardline 6 (score 0-0)
+  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
   TURNOVER — pickup_failed.
-Half 1 • Turn 7 — away in possession at yardline 12 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 13 (score 0-0)
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 2 — away in possession at yardline 11 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 3 — away in possession at yardline 17 (score 0-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 4 — home in possession at yardline 13 (score 0-0)
-Half 2 • Turn 5 — home in possession at yardline 16 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
-Half 2 • Turn 6 — home in possession at yardline 22 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  CASUALTY — home-NUFFLE-1-4 is taken off by cocky_drop.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 6 — away in possession at yardline 6 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+Half 1 • Turn 7 — away in possession at yardline 6 (score 1-0)
+Half 1 • Turn 8 — away in possession at yardline 9 (score 1-0)
+  Touchdown! away crosses the line. Score is now 1-1.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+Half 2 • Turn 7 — away in possession at yardline 8 (score 1-1)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — home in possession at yardline 13 (score 1-0)
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
   ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 1-2) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 5 | Nuffle: 7
+FINAL: 1 - 2 (away)
+Touchdowns: 3 | Casualties: 1 | Turnovers: 4 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-019-ne-cold-tacticians-vs-car-jungle-queens-seed2044.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-019-ne-cold-tacticians-vs-car-jungle-queens-seed2044.txt
@@ -1,56 +1,60 @@
 === MATCH #19 — Cold Tacticians (Lizardmen) vs Jungle Queens (Amazon) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts car-jungle-queens (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 2 — home in possession at yardline 12 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 3 — away in possession at yardline 11 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+Half 1 • Turn 3 — home in possession at yardline 9 (score 1-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 4 — home in possession at yardline 8 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 5 — away in possession at yardline 14 (score 0-0)
-Half 1 • Turn 6 — away in possession at yardline 17 (score 0-0)
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 2-1)
+Half 1 • Turn 6 — away in possession at yardline 4 (score 2-1)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 12 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+  Touchdown! home crosses the line. Score is now 3-1.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 3-1)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  Touchdown! away crosses the line. Score is now 3-2.
+Half 1 • Turn 8 — home in possession at yardline 4 (score 3-2)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 8 — home in possession at yardline 23 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+
+--- HALFTIME (score 3-2) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 3-2)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+  Touchdown! away crosses the line. Score is now 3-3.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 3-3)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+Half 2 • Turn 3 — home in possession at yardline 9 (score 3-3)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — home in possession at yardline 10 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 3 — home in possession at yardline 17 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 4 — home in possession at yardline 21 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-0)
+Half 2 • Turn 4 — away in possession at yardline 4 (score 3-3)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 2 • Turn 5 — away in possession at yardline 7 (score 3-3)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 13 (score 1-0)
-Half 2 • Turn 7 — away in possession at yardline 21 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 6 — away in possession at yardline 9 (score 3-3)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-1)
+Half 2 • Turn 7 — away in possession at yardline 11 (score 3-3)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+Half 2 • Turn 8 — away in possession at yardline 13 (score 3-3)
   ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 3-3) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 5
+FINAL: 3 - 3 (draw)
+Touchdowns: 6 | Casualties: 0 | Turnovers: 4 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-020-pit-smashers-vs-no-voodoo-saints-seed2045.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-020-pit-smashers-vs-no-voodoo-saints-seed2045.txt
@@ -1,52 +1,55 @@
 === MATCH #20 — Smashers (Orc) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — pit-smashers hosts no-voodoo-saints (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 1 • Turn 3 — home in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 4 — home in possession at yardline 22 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 6 — home in possession at yardline 7 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
-Half 1 • Turn 7 — home in possession at yardline 13 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — home in possession at yardline 19 (score 1-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  Touchdown! home crosses the line. Score is now 2-0.
-
---- HALFTIME (score 2-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-Half 2 • Turn 2 — home in possession at yardline 11 (score 2-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 3 — away in possession at yardline 8 (score 2-0)
+Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 8 (score 0-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — away in possession at yardline 14 (score 2-0)
-Half 2 • Turn 5 — away in possession at yardline 22 (score 2-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 1-1.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1)
+Half 2 • Turn 3 — home in possession at yardline 9 (score 1-1)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
   FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  Touchdown! away crosses the line. Score is now 2-1.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 2-1)
+Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 6 — away in possession at yardline 7 (score 1-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-Half 2 • Turn 7 — home in possession at yardline 10 (score 2-1)
-Half 2 • Turn 8 — home in possession at yardline 13 (score 2-1)
+  CASUALTY — home-NUFFLE-2-6 is taken off by tantrum_star.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 7 — home in possession at yardline 10 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+Half 2 • Turn 8 — home in possession at yardline 10 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 2-1.
 
 --- END OF MATCH (score 2-1) ---
 
 
 FINAL: 2 - 1 (home)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 6
+Touchdowns: 3 | Casualties: 2 | Turnovers: 4 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-021-sf-gold-rush-vs-phx-tomb-cardinals-seed2046.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-021-sf-gold-rush-vs-phx-tomb-cardinals-seed2046.txt
@@ -1,53 +1,58 @@
 === MATCH #21 — Gold Rush (Skaven) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — sf-gold-rush hosts phx-tomb-cardinals (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 3 — away in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  TURNOVER — pickup_failed.
+Half 1 • Turn 4 — home in possession at yardline 6 (score 0-0)
   DODGE — home-LOS dodges to (13,7): needs 2+, rolled 4 → success.
-  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 4 → success.
-Half 1 • Turn 4 — home in possession at yardline 15 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 4+, rolled 5 → caught.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 6 — away in possession at yardline 8 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 7 — home in possession at yardline 9 (score 1-0)
+Half 1 • Turn 5 — home in possession at yardline 6 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 4+, rolled 6 → caught.
-Half 1 • Turn 8 — home in possession at yardline 19 (score 1-0)
+Half 1 • Turn 6 — home in possession at yardline 6 (score 0-0)
+  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 1 • Turn 7 — away in possession at yardline 5 (score 0-0)
+Half 1 • Turn 8 — away in possession at yardline 10 (score 0-0)
   ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-0.
+  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  Touchdown! away crosses the line. Score is now 0-1.
 
---- HALFTIME (score 2-0) ---
+--- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 15 (score 2-0)
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 3-0)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 2 • Turn 4 — away in possession at yardline 11 (score 3-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
-Half 2 • Turn 5 — away in possession at yardline 18 (score 3-0)
+  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 6 → success.
+Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 4+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 0-2)
+  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+  Touchdown! away crosses the line. Score is now 0-3.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 0-3)
+Half 2 • Turn 5 — home in possession at yardline 4 (score 0-3)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  Touchdown! home crosses the line. Score is now 1-3.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 1-3)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+  Touchdown! home crosses the line. Score is now 2-3.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 2-3)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 6 — home in possession at yardline 12 (score 3-0)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 21 (score 3-0)
-  Touchdown! home crosses the line. Score is now 4-0.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 4-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 2 • Turn 8 — home in possession at yardline 8 (score 2-3)
+  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 3 → success.
 
---- END OF MATCH (score 4-0) ---
+--- END OF MATCH (score 2-3) ---
 
 
-FINAL: 4 - 0 (home)
-Touchdowns: 4 | Casualties: 0 | Turnovers: 3 | Nuffle: 4
+FINAL: 2 - 3 (away)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 6 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-022-phi-storm-eagles-vs-car-jungle-queens-seed2047.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-022-phi-storm-eagles-vs-car-jungle-queens-seed2047.txt
@@ -1,51 +1,55 @@
 === MATCH #22 — Storm Eagles (Pro Elf) vs Jungle Queens (Amazon) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phi-storm-eagles hosts car-jungle-queens (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 13 (score 0-0)
-Half 1 • Turn 3 — away in possession at yardline 18 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
   ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 4 — away in possession at yardline 17 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-Half 1 • Turn 5 — home in possession at yardline 9 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 1 • Turn 6 — home in possession at yardline 16 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 15 (score 0-1)
-Half 1 • Turn 8 — away in possession at yardline 17 (score 0-1)
   FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  Touchdown! away crosses the line. Score is now 0-2.
-
---- HALFTIME (score 0-2) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 2 — home in possession at yardline 11 (score 0-2)
-Half 2 • Turn 3 — home in possession at yardline 18 (score 0-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 6 — away in possession at yardline 8 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 7 — away in possession at yardline 10 (score 0-1)
+Half 1 • Turn 8 — away in possession at yardline 10 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 0-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — home in possession at yardline 12 (score 0-2)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false, sent off!).
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
+  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 2 • Turn 6 — away in possession at yardline 11 (score 0-2)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — home in possession at yardline 11 (score 0-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 0-2)
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+Half 2 • Turn 4 — home in possession at yardline 9 (score 0-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
+  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+Half 2 • Turn 5 — home in possession at yardline 14 (score 0-1)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 6 — away in possession at yardline 5 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  TURNOVER — pickup_failed.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 1-1) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 4
+FINAL: 1 - 1 (draw)
+Touchdowns: 2 | Casualties: 2 | Turnovers: 7 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-023-lv-outlaws-vs-sf-gold-rush-seed2048.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-023-lv-outlaws-vs-sf-gold-rush-seed2048.txt
@@ -1,58 +1,62 @@
 === MATCH #23 — Outlaws (Norse) vs Gold Rush (Skaven) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — lv-outlaws hosts sf-gold-rush (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
   BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — home in possession at yardline 9 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-Half 1 • Turn 3 — home in possession at yardline 19 (score 0-0)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
   FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
   Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 5 — away in possession at yardline 12 (score 1-0)
-Half 1 • Turn 6 — away in possession at yardline 20 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 8 — home in possession at yardline 11 (score 1-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-
---- HALFTIME (score 1-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 2 — away in possession at yardline 9 (score 1-1)
-Half 2 • Turn 3 — away in possession at yardline 22 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — home in possession at yardline 12 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 5 — home in possession at yardline 20 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0)
   PASS — away-LOS attempts a short pass: needs 4+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 18 (score 2-1)
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
+Half 1 • Turn 6 — away in possession at yardline 9 (score 2-0)
+  DODGE — away-LOS dodges to (13,7): needs 2+, rolled 6 → success.
+  DODGE — away-LOS dodges to (13,7): needs 2+, rolled 2 → success.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+Half 1 • Turn 7 — away in possession at yardline 17 (score 2-0)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  PASS — away-LOS attempts a short pass: needs 4+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 8 — home in possession at yardline 12 (score 2-0)
+  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+
+--- HALFTIME (score 2-0) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+Half 2 • Turn 2 — away in possession at yardline 6 (score 2-0)
+  PASS — away-LOS attempts a short pass: needs 4+, rolled 4 → caught.
+Half 2 • Turn 3 — away in possession at yardline 15 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 2 • Turn 4 — home in possession at yardline 8 (score 2-0)
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 2-1.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 2 • Turn 6 — home in possession at yardline 6 (score 2-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — away in possession at yardline 9 (score 2-1)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 3-1.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 3-1)
+Half 2 • Turn 8 — away in possession at yardline 9 (score 2-1)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
   TURNOVER — gfi_failed.
 
---- END OF MATCH (score 3-1) ---
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 3 - 1 (home)
-Touchdowns: 4 | Casualties: 0 | Turnovers: 4 | Nuffle: 9
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 6 | Nuffle: 9

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-024-min-frostraiders-vs-phx-tomb-cardinals-seed2049.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-024-min-frostraiders-vs-phx-tomb-cardinals-seed2049.txt
@@ -1,53 +1,60 @@
 === MATCH #24 — Frostraiders (Norse) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — min-frostraiders hosts phx-tomb-cardinals (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 4 — home in possession at yardline 13 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — away in possession at yardline 10 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
   TURNOVER — pickup_failed.
-Half 1 • Turn 6 — home in possession at yardline 7 (score 0-0)
+Half 1 • Turn 5 — home in possession at yardline 8 (score 0-0)
+Half 1 • Turn 6 — home in possession at yardline 13 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 13 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 20 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
 
---- HALFTIME (score 0-0) ---
+--- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 2 — home in possession at yardline 13 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 3 — home in possession at yardline 20 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 0-0)
-Half 2 • Turn 5 — away in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 2 • Turn 6 — away in possession at yardline 25 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 7 — home in possession at yardline 9 (score 0-0)
-Half 2 • Turn 8 — home in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  CASUALTY — away-NUFFLE-2-1 is taken off by tantrum_star.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 2-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 4 — home in possession at yardline 5 (score 2-1)
   BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  KO — home-LOS is knocked unconscious by away-LOS.
   TURNOVER — block_attacker_down.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+Half 2 • Turn 6 — away in possession at yardline 5 (score 2-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  Touchdown! away crosses the line. Score is now 2-2.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 2-2)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! home crosses the line. Score is now 3-2.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 3-2)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
---- END OF MATCH (score 0-0) ---
+--- END OF MATCH (score 3-2) ---
 
 
-FINAL: 0 - 0 (draw)
-Touchdowns: 0 | Casualties: 0 | Turnovers: 8 | Nuffle: 5
+FINAL: 3 - 2 (home)
+Touchdowns: 5 | Casualties: 1 | Turnovers: 5 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-025-gb-cheese-halflings-vs-phi-storm-eagles-seed2050.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-025-gb-cheese-halflings-vs-phi-storm-eagles-seed2050.txt
@@ -1,55 +1,69 @@
 === MATCH #25 — Cheese Halflings (Halfling) vs Storm Eagles (Pro Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — gb-cheese-halflings hosts phi-storm-eagles (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
   FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
   KO — away-PRONE is knocked unconscious by home-LOS.
-Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-Half 1 • Turn 3 — home in possession at yardline 13 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 4 — home in possession at yardline 21 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+Half 1 • Turn 4 — away in possession at yardline 16 (score 0-0)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0)
+  CASUALTY — home-NUFFLE-1-4 is taken off by banana_skin.
+  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 6 — home in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
   FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 7 — away in possession at yardline 11 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 16 (score 0-0)
+Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  CASUALTY — home-NUFFLE-1-6 is taken off by nemesis_clash.
+  TURNOVER — pickup_failed.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 8 — home in possession at yardline 11 (score 0-1)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
---- HALFTIME (score 0-0) ---
+--- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 2 • Turn 2 — away in possession at yardline 15 (score 0-0)
-Half 2 • Turn 3 — away in possession at yardline 24 (score 0-0)
+Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 2 — home in possession at yardline 11 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+Half 2 • Turn 3 — home in possession at yardline 11 (score 0-1)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose STUMBLE, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
-Half 2 • Turn 5 — home in possession at yardline 16 (score 0-1)
-Half 2 • Turn 6 — home in possession at yardline 21 (score 0-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 7 — home in possession at yardline 25 (score 0-1)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
   TURNOVER — dodge_failed.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 0-1)
+Half 2 • Turn 4 — away in possession at yardline 11 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 6 — away in possession at yardline 10 (score 0-2)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  Touchdown! away crosses the line. Score is now 0-3.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 0-3)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  Touchdown! home crosses the line. Score is now 1-3.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 1-3)
+  Touchdown! away crosses the line. Score is now 1-4.
 
---- END OF MATCH (score 0-1) ---
+--- END OF MATCH (score 1-4) ---
 
 
-FINAL: 0 - 1 (away)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 4 | Nuffle: 10
+FINAL: 1 - 4 (away)
+Touchdowns: 5 | Casualties: 2 | Turnovers: 6 | Nuffle: 10

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-026-chi-iron-bears-vs-phx-tomb-cardinals-seed2051.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-026-chi-iron-bears-vs-phx-tomb-cardinals-seed2051.txt
@@ -1,47 +1,64 @@
 === MATCH #26 — Iron Bears (Dwarf) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — chi-iron-bears hosts phx-tomb-cardinals (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-Half 1 • Turn 3 — away in possession at yardline 13 (score 0-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 0-1)
   FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 1 • Turn 4 — away in possession at yardline 17 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 25 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+Half 1 • Turn 4 — away in possession at yardline 4 (score 0-1)
   BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 6 — home in possession at yardline 8 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 1-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 11 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 14 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, push_only.
-Half 2 • Turn 3 — home in possession at yardline 13 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 8 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/POW], chose POW, defender_down.
-Half 2 • Turn 5 — away in possession at yardline 14 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 6 — away in possession at yardline 20 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/POW], chose BOTH_DOWN, push_only.
-Half 2 • Turn 7 — away in possession at yardline 24 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 8 — home in possession at yardline 10 (score 0-0)
+Half 1 • Turn 6 — home in possession at yardline 6 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
   FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/POW], chose BOTH_DOWN, push_only.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 0-0) ---
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
+Half 2 • Turn 2 — home in possession at yardline 5 (score 1-1)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+Half 2 • Turn 4 — home in possession at yardline 5 (score 1-2)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+Half 2 • Turn 5 — home in possession at yardline 5 (score 1-2)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  Touchdown! home crosses the line. Score is now 2-2.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 2-2)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, push_only.
+Half 2 • Turn 7 — away in possession at yardline 9 (score 2-2)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 2-2)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! away crosses the line. Score is now 2-3.
+
+--- END OF MATCH (score 2-3) ---
 
 
-FINAL: 0 - 0 (draw)
-Touchdowns: 0 | Casualties: 0 | Turnovers: 4 | Nuffle: 3
+FINAL: 2 - 3 (away)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 7 | Nuffle: 3

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-027-jax-swamp-lizards-vs-gb-cheese-halflings-seed2052.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-027-jax-swamp-lizards-vs-gb-cheese-halflings-seed2052.txt
@@ -1,52 +1,56 @@
 === MATCH #27 — Swamp Lizards (Lizardmen) vs Cheese Halflings (Halfling) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — jax-swamp-lizards hosts gb-cheese-halflings (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 15 (score 0-0)
-Half 1 • Turn 3 — away in possession at yardline 19 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  TURNOVER — gfi_failed.
+Half 1 • Turn 3 — home in possession at yardline 12 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 5 — home in possession at yardline 12 (score 0-1)
   TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 11 (score 0-1)
+Half 1 • Turn 5 — home in possession at yardline 12 (score 1-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 2-1)
   TURNOVER — pickup_failed.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 8 — home in possession at yardline 20 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+  Touchdown! home crosses the line. Score is now 3-1.
 
---- HALFTIME (score 0-1) ---
+--- HALFTIME (score 3-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1)
+Half 2 • Turn 2 — home in possession at yardline 11 (score 3-1)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
   FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 13 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — home in possession at yardline 24 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 12 (score 0-1)
+Half 2 • Turn 3 — home in possession at yardline 21 (score 3-1)
+  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+  Touchdown! home crosses the line. Score is now 4-1.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 4-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 5 — home in possession at yardline 15 (score 4-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 6 — home in possession at yardline 23 (score 4-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 7 — away in possession at yardline 5 (score 4-1)
   FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 2 • Turn 6 — home in possession at yardline 13 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 7 — home in possession at yardline 16 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 8 — home in possession at yardline 23 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 8 — home in possession at yardline 7 (score 4-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 4-1) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 4 | Nuffle: 4
+FINAL: 4 - 1 (home)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 7 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-028-buf-snow-ogres-vs-dal-vipers-seed2053.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-028-buf-snow-ogres-vs-dal-vipers-seed2053.txt
@@ -1,55 +1,56 @@
 === MATCH #28 — Snow Ogres (Ogre) vs Vipers (Dark Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — buf-snow-ogres hosts dal-vipers (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 14 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/BOTH_DOWN], chose POW, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 22 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN/PUSH_BACK], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 1 • Turn 5 — away in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 6 — away in possession at yardline 19 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — home in possession at yardline 12 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 20 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-0.
-
---- HALFTIME (score 2-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 11 (score 2-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 3 — home in possession at yardline 20 (score 2-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK/PLAYER_DOWN], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 3-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   TURNOVER — gfi_failed.
-Half 2 • Turn 5 — home in possession at yardline 13 (score 3-0)
-Half 2 • Turn 6 — home in possession at yardline 19 (score 3-0)
+Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 1 • Turn 4 — away in possession at yardline 13 (score 0-0)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0)
+  ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  TURNOVER — gfi_failed.
+Half 1 • Turn 8 — home in possession at yardline 6 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 2 — away in possession at yardline 8 (score 1-1)
+Half 2 • Turn 3 — away in possession at yardline 8 (score 1-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 2 • Turn 5 — home in possession at yardline 10 (score 1-2)
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+Half 2 • Turn 6 — home in possession at yardline 12 (score 1-2)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 7 — home in possession at yardline 23 (score 3-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 4-0.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 4-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 7 — away in possession at yardline 7 (score 1-2)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 8 — away in possession at yardline 12 (score 1-2)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
 
---- END OF MATCH (score 4-0) ---
+--- END OF MATCH (score 1-2) ---
 
 
-FINAL: 4 - 0 (home)
-Touchdowns: 4 | Casualties: 0 | Turnovers: 3 | Nuffle: 6
+FINAL: 1 - 2 (away)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 6 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-029-no-voodoo-saints-vs-kc-soaring-hawks-seed2054.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-029-no-voodoo-saints-vs-kc-soaring-hawks-seed2054.txt
@@ -1,55 +1,63 @@
 === MATCH #29 — Voodoo Saints (Undead) vs Soaring Hawks (Wood Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — no-voodoo-saints hosts kc-soaring-hawks (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, both_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — home in possession at yardline 13 (score 0-0)
-Half 1 • Turn 4 — home in possession at yardline 22 (score 0-0)
+Half 1 • Turn 4 — home in possession at yardline 6 (score 0-0)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
+Half 1 • Turn 5 — home in possession at yardline 6 (score 0-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-1-7 is taken off by banana_skin.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 6 — home in possession at yardline 9 (score 1-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
-Half 1 • Turn 7 — home in possession at yardline 13 (score 1-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — home in possession at yardline 17 (score 1-0)
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 1-0)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 3 — away in possession at yardline 11 (score 1-0)
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 2 — away in possession at yardline 9 (score 0-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 3 — home in possession at yardline 13 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 5 — away in possession at yardline 8 (score 1-1)
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 7 — away in possession at yardline 7 (score 1-2)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 2 (fumble!) → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 4 — home in possession at yardline 12 (score 1-0)
-Half 2 • Turn 5 — home in possession at yardline 23 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 5 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 7 — away in possession at yardline 18 (score 1-0)
-Half 2 • Turn 8 — away in possession at yardline 25 (score 1-0)
+Half 2 • Turn 8 — home in possession at yardline 11 (score 1-2)
   ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! home crosses the line. Score is now 2-2.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-2) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 6 | Nuffle: 7
+FINAL: 2 - 2 (draw)
+Touchdowns: 4 | Casualties: 2 | Turnovers: 9 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-030-dal-vipers-vs-kc-soaring-hawks-seed2055.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-030-dal-vipers-vs-kc-soaring-hawks-seed2055.txt
@@ -1,57 +1,54 @@
 === MATCH #30 — Vipers (Dark Elf) vs Soaring Hawks (Wood Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — dal-vipers hosts kc-soaring-hawks (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 11 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 4 — home in possession at yardline 22 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
+Half 1 • Turn 4 — home in possession at yardline 16 (score 0-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
   Touchdown! home crosses the line. Score is now 1-0.
 Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 6 — home in possession at yardline 17 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 1 • Turn 7 — home in possession at yardline 25 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, both_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 6 — home in possession at yardline 13 (score 1-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
   Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 2-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 8 — away in possession at yardline 8 (score 2-0)
+  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
 
 --- HALFTIME (score 2-0) ---
 
 Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
   ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 2-0)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 21 (score 2-0)
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 3-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 2 • Turn 5 — away in possession at yardline 9 (score 3-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 6 — home in possession at yardline 13 (score 3-0)
   TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 9 (score 3-0)
+Half 2 • Turn 2 — away in possession at yardline 13 (score 2-0)
+Half 2 • Turn 3 — away in possession at yardline 20 (score 2-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 4 — home in possession at yardline 6 (score 2-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 5 — away in possession at yardline 7 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+Half 2 • Turn 6 — away in possession at yardline 14 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 7 — home in possession at yardline 9 (score 2-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-Half 2 • Turn 8 — away in possession at yardline 19 (score 3-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! away crosses the line. Score is now 3-1.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 2 • Turn 8 — home in possession at yardline 12 (score 2-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
---- END OF MATCH (score 3-1) ---
+--- END OF MATCH (score 2-0) ---
 
 
-FINAL: 3 - 1 (home)
-Touchdowns: 4 | Casualties: 0 | Turnovers: 5 | Nuffle: 5
+FINAL: 2 - 0 (home)
+Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-031-ne-cold-tacticians-vs-buf-snow-ogres-seed2056.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-031-ne-cold-tacticians-vs-buf-snow-ogres-seed2056.txt
@@ -1,55 +1,67 @@
 === MATCH #31 — Cold Tacticians (Lizardmen) vs Snow Ogres (Ogre) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — away in possession at yardline 14 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 10 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 4 — home in possession at yardline 20 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 6 — away in possession at yardline 7 (score 1-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 17 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
   TURNOVER — pickup_failed.
-Half 1 • Turn 8 — home in possession at yardline 11 (score 1-0)
+Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 7 — home in possession at yardline 7 (score 0-1)
   FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+Half 1 • Turn 8 — home in possession at yardline 8 (score 0-1)
   FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 2 — home in possession at yardline 10 (score 1-0)
-Half 2 • Turn 3 — home in possession at yardline 20 (score 1-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
   BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 1-0)
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+Half 2 • Turn 3 — away in possession at yardline 6 (score 0-1)
+  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 0-2)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 5 — away in possession at yardline 5 (score 0-2)
   TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 7 (score 1-0)
-Half 2 • Turn 6 — home in possession at yardline 16 (score 1-0)
+Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
   ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
   FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 19 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — away in possession at yardline 7 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  Touchdown! home crosses the line. Score is now 1-2.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  KO — home-LOS is knocked unconscious by away-LOS.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 1-2)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  TURNOVER — pickup_failed.
+  Touchdown! home crosses the line. Score is now 2-2.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-2) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 5 | Nuffle: 9
+FINAL: 2 - 2 (draw)
+Touchdowns: 4 | Casualties: 2 | Turnovers: 7 | Nuffle: 9

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-032-phx-tomb-cardinals-vs-den-mile-high-centaurs-seed2057.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-032-phx-tomb-cardinals-vs-den-mile-high-centaurs-seed2057.txt
@@ -1,53 +1,56 @@
 === MATCH #32 — Tomb Cardinals (Tomb Kings) vs Mile High Centaurs (Beastmen) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts den-mile-high-centaurs (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 1 • Turn 3 — home in possession at yardline 12 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — home in possession at yardline 22 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+Half 1 • Turn 4 — home in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 1 • Turn 6 — away in possession at yardline 13 (score 1-0)
+Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — home in possession at yardline 17 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
-Half 1 • Turn 8 — away in possession at yardline 9 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — away in possession at yardline 11 (score 1-0)
+Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
+Half 1 • Turn 8 — away in possession at yardline 4 (score 0-0)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 3 — away in possession at yardline 21 (score 1-0)
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  CASUALTY — home-NUFFLE-2-1 is taken off by nemesis_clash.
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+Half 2 • Turn 3 — away in possession at yardline 8 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 5 — home in possession at yardline 14 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 6 — home in possession at yardline 16 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 20 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 2-1)
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 5 — away in possession at yardline 7 (score 0-1)
+Half 2 • Turn 6 — away in possession at yardline 7 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 0-1)
+Half 2 • Turn 8 — home in possession at yardline 6 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
---- END OF MATCH (score 2-1) ---
+--- END OF MATCH (score 0-1) ---
 
 
-FINAL: 2 - 1 (home)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 2 | Nuffle: 5
+FINAL: 0 - 1 (away)
+Touchdowns: 1 | Casualties: 1 | Turnovers: 3 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-033-ne-cold-tacticians-vs-kc-soaring-hawks-seed2058.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-033-ne-cold-tacticians-vs-kc-soaring-hawks-seed2058.txt
@@ -1,54 +1,65 @@
 === MATCH #33 — Cold Tacticians (Lizardmen) vs Soaring Hawks (Wood Elf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 13 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+Half 1 • Turn 3 — home in possession at yardline 16 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+  BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0)
   TURNOVER — gfi_failed.
-Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 20 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 7 — home in possession at yardline 11 (score 0-1)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-Half 1 • Turn 8 — home in possession at yardline 17 (score 0-1)
   FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
   CASUALTY — away-PRONE is taken off by home-LOS.
-
---- HALFTIME (score 0-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — home in possession at yardline 13 (score 0-1)
+Half 1 • Turn 7 — away in possession at yardline 8 (score 1-0)
+  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 8 — home in possession at yardline 10 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+
+--- HALFTIME (score 1-0) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+Half 2 • Turn 2 — away in possession at yardline 9 (score 1-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 3 — home in possession at yardline 20 (score 0-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 3 — home in possession at yardline 11 (score 1-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
+  CASUALTY — away-NUFFLE-2-3 is taken off by cocky_drop.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 4 — away in possession at yardline 11 (score 1-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 2 • Turn 5 — away in possession at yardline 12 (score 1-1)
-Half 2 • Turn 6 — away in possession at yardline 21 (score 1-1)
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 12 (score 1-1)
+Half 2 • Turn 5 — away in possession at yardline 11 (score 1-0)
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+Half 2 • Turn 6 — away in possession at yardline 15 (score 1-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 2-0)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 8 — home in possession at yardline 19 (score 1-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  Touchdown! away crosses the line. Score is now 2-1.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 2-1)
   ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
   TURNOVER — dodge_failed.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 1 | Turnovers: 4 | Nuffle: 9
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 2 | Turnovers: 7 | Nuffle: 9

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-034-chi-iron-bears-vs-pit-smashers-seed2059.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-034-chi-iron-bears-vs-pit-smashers-seed2059.txt
@@ -1,51 +1,51 @@
 === MATCH #34 — Iron Bears (Dwarf) vs Smashers (Orc) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — chi-iron-bears hosts pit-smashers (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
   TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 11 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
   ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — home in possession at yardline 19 (score 0-0)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
   ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-Half 1 • Turn 5 — home in possession at yardline 23 (score 0-0)
+Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
   FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
   KO — away-PRONE is knocked unconscious by home-LOS.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 7 — away in possession at yardline 12 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 8 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+Half 1 • Turn 6 — home in possession at yardline 6 (score 0-0)
+Half 1 • Turn 7 — home in possession at yardline 7 (score 0-0)
   BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — home in possession at yardline 6 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 16 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
+Half 1 • Turn 8 — home in possession at yardline 9 (score 0-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  CASUALTY — away-NUFFLE-1-8 is taken off by nemesis_clash.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 4 — home in possession at yardline 24 (score 1-0)
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+Half 2 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  KO — away-LOS is knocked unconscious by home-LOS.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
-Half 2 • Turn 6 — away in possession at yardline 8 (score 2-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, push_only.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 9 (score 2-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 8 — home in possession at yardline 14 (score 2-0)
+Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
 
---- END OF MATCH (score 2-0) ---
+--- END OF MATCH (score 1-1) ---
 
 
-FINAL: 2 - 0 (home)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 3 | Nuffle: 6
+FINAL: 1 - 1 (draw)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 2 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-035-chi-iron-bears-vs-sf-gold-rush-seed2060.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-035-chi-iron-bears-vs-sf-gold-rush-seed2060.txt
@@ -1,52 +1,56 @@
 === MATCH #35 — Iron Bears (Dwarf) vs Gold Rush (Skaven) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — chi-iron-bears hosts sf-gold-rush (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — away in possession at yardline 15 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-Half 1 • Turn 3 — away in possession at yardline 20 (score 0-0)
+  CASUALTY — home-NUFFLE-1-2 is taken off by tantrum_star.
   BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — home in possession at yardline 14 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
   TURNOVER — pickup_failed.
-Half 1 • Turn 5 — away in possession at yardline 8 (score 0-0)
+Half 1 • Turn 7 — away in possession at yardline 11 (score 1-1)
+Half 1 • Turn 8 — away in possession at yardline 16 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose PUSH_BACK, push_only.
   PASS — away-LOS attempts a short pass: needs 4+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — home in possession at yardline 16 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
 
---- HALFTIME (score 1-0) ---
+--- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 2 — home in possession at yardline 13 (score 1-0)
-Half 2 • Turn 3 — home in possession at yardline 22 (score 1-0)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
+Half 2 • Turn 2 — home in possession at yardline 8 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 3 — home in possession at yardline 8 (score 1-1)
   ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK/POW], chose POW, defender_down.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 4 — home in possession at yardline 24 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
-  DODGE — away-LOS dodges to (13,7): needs 2+, rolled 5 → success.
-Half 2 • Turn 6 — away in possession at yardline 16 (score 2-0)
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 4 → caught.
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 4 → caught.
-  Touchdown! away crosses the line. Score is now 2-1.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 2-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — away in possession at yardline 7 (score 1-1)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 5 — home in possession at yardline 8 (score 1-1)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 8 — home in possession at yardline 10 (score 2-1)
+Half 2 • Turn 6 — home in possession at yardline 8 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  TURNOVER — gfi_failed.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 8 — home in possession at yardline 8 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 2-1) ---
+--- END OF MATCH (score 1-1) ---
 
 
-FINAL: 2 - 1 (home)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 3
+FINAL: 1 - 1 (draw)
+Touchdowns: 2 | Casualties: 1 | Turnovers: 7 | Nuffle: 3

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-036-gb-cheese-halflings-vs-chi-iron-bears-seed2061.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-036-gb-cheese-halflings-vs-chi-iron-bears-seed2061.txt
@@ -1,57 +1,58 @@
 === MATCH #36 — Cheese Halflings (Halfling) vs Iron Bears (Dwarf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — gb-cheese-halflings hosts chi-iron-bears (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 10 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 4 — home in possession at yardline 20 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 5 — home in possession at yardline 24 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 6 — away in possession at yardline 15 (score 0-0)
-Half 1 • Turn 7 — away in possession at yardline 22 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN/POW], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  CASUALTY — away-NUFFLE-1-5 is taken off by nemesis_clash.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
   PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+Half 1 • Turn 7 — home in possession at yardline 6 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 6 (score 1-1)
 
---- HALFTIME (score 0-1) ---
+--- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-Half 2 • Turn 2 — away in possession at yardline 8 (score 0-1)
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+Half 2 • Turn 2 — away in possession at yardline 11 (score 1-1)
   ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 2 • Turn 3 — away in possession at yardline 15 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN/POW], chose POW, defender_down.
+Half 2 • Turn 3 — away in possession at yardline 17 (score 1-1)
   ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 4 — home in possession at yardline 11 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 5 — away in possession at yardline 12 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE/PUSH_BACK], chose STUMBLE, defender_down.
-Half 2 • Turn 6 — away in possession at yardline 22 (score 0-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/STUMBLE/PUSH_BACK], chose STUMBLE, defender_down.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 0-2)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 0-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 6 — away in possession at yardline 10 (score 1-1)
+  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  CASUALTY — home-NUFFLE-2-6 is taken off by cocky_drop.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 1-1)
+  Touchdown! home crosses the line. Score is now 2-1.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 2-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  Touchdown! away crosses the line. Score is now 2-2.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 2-2) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 6 | Nuffle: 4
+FINAL: 2 - 2 (draw)
+Touchdowns: 4 | Casualties: 2 | Turnovers: 5 | Nuffle: 4
+Underdog boosts triggered: 2

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-037-ne-cold-tacticians-vs-buf-snow-ogres-seed2062.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-037-ne-cold-tacticians-vs-buf-snow-ogres-seed2062.txt
@@ -1,55 +1,62 @@
 === MATCH #37 — Cold Tacticians (Lizardmen) vs Snow Ogres (Ogre) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 12 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 3 — home in possession at yardline 20 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 1 • Turn 4 — home in possession at yardline 25 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → casualty, sent off!).
-  CASUALTY — away-PRONE is taken off by home-LOS.
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 5 — away in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-Half 1 • Turn 6 — away in possession at yardline 19 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 25 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/STUMBLE], chose BOTH_DOWN, attacker_down.
+Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
+Half 1 • Turn 3 — away in possession at yardline 7 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 4 — away in possession at yardline 7 (score 0-0)
+Half 1 • Turn 5 — away in possession at yardline 10 (score 0-0)
+  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+Half 1 • Turn 6 — away in possession at yardline 10 (score 0-0)
+  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 7 — away in possession at yardline 11 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 1 • Turn 8 — away in possession at yardline 11 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! away crosses the line. Score is now 0-1.
 
 --- HALFTIME (score 0-1) ---
 
 Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-Half 2 • Turn 2 — away in possession at yardline 10 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 2 • Turn 3 — away in possession at yardline 15 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 4 — home in possession at yardline 6 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 3 — home in possession at yardline 5 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 4 — home in possession at yardline 5 (score 0-1)
   ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
-Half 2 • Turn 5 — home in possession at yardline 10 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 6 — home in possession at yardline 16 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — away in possession at yardline 9 (score 0-1)
-Half 2 • Turn 8 — away in possession at yardline 20 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → casualty, sent off!).
+  CASUALTY — away-PRONE is taken off by home-LOS.
+  TURNOVER — foul_sent_off.
   Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 0-2)
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  Touchdown! away crosses the line. Score is now 0-3.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 0-3)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 0-3) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 1 | Turnovers: 4 | Nuffle: 6
+FINAL: 0 - 3 (away)
+Touchdowns: 3 | Casualties: 1 | Turnovers: 5 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-038-buf-snow-ogres-vs-pit-smashers-seed2063.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-038-buf-snow-ogres-vs-pit-smashers-seed2063.txt
@@ -1,50 +1,57 @@
 === MATCH #38 — Snow Ogres (Ogre) vs Smashers (Orc) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — buf-snow-ogres hosts pit-smashers (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 4 — home in possession at yardline 19 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+Half 1 • Turn 4 — away in possession at yardline 5 (score 1-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 1 • Turn 5 — home in possession at yardline 23 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
+  CASUALTY — away-PRONE is taken off by home-LOS.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
+  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+Half 1 • Turn 7 — home in possession at yardline 9 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, push_only.
+
+--- HALFTIME (score 1-0) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 3 — home in possession at yardline 6 (score 1-0)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 6 — away in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 8 — home in possession at yardline 15 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-
---- HALFTIME (score 0-0) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — away in possession at yardline 16 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 3 — home in possession at yardline 11 (score 0-0)
-Half 2 • Turn 4 — home in possession at yardline 20 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, push_only.
-Half 2 • Turn 6 — away in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+Half 2 • Turn 4 — away in possession at yardline 8 (score 1-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 12 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 8 — home in possession at yardline 19 (score 1-0)
-  Touchdown! home crosses the line. Score is now 2-0.
+Half 2 • Turn 5 — home in possession at yardline 6 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+Half 2 • Turn 6 — home in possession at yardline 6 (score 1-0)
+  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
+Half 2 • Turn 7 — home in possession at yardline 6 (score 1-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 8 — home in possession at yardline 10 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
---- END OF MATCH (score 2-0) ---
+--- END OF MATCH (score 1-0) ---
 
 
-FINAL: 2 - 0 (home)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 5 | Nuffle: 4
+FINAL: 1 - 0 (home)
+Touchdowns: 1 | Casualties: 1 | Turnovers: 5 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-039-chi-iron-bears-vs-buf-snow-ogres-seed2064.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-039-chi-iron-bears-vs-buf-snow-ogres-seed2064.txt
@@ -1,50 +1,57 @@
 === MATCH #39 — Iron Bears (Dwarf) vs Snow Ogres (Ogre) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — chi-iron-bears hosts buf-snow-ogres (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 14 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0)
+  TURNOVER — pickup_failed.
+Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
-Half 1 • Turn 4 — home in possession at yardline 14 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 5 — home in possession at yardline 23 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 14 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
+Half 1 • Turn 7 — away in possession at yardline 5 (score 0-0)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 18 (score 1-0)
+Half 1 • Turn 8 — away in possession at yardline 5 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 2 — home in possession at yardline 5 (score 0-0)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  KO — home-LOS is knocked unconscious by away-LOS.
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+Half 2 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 1-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
   TURNOVER — pickup_failed.
 
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — home in possession at yardline 13 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 2 • Turn 3 — home in possession at yardline 20 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 2-0)
-Half 2 • Turn 5 — away in possession at yardline 12 (score 2-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 6 — home in possession at yardline 10 (score 2-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 11 (score 2-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 8 — away in possession at yardline 17 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-
---- END OF MATCH (score 2-0) ---
+--- END OF MATCH (score 1-0) ---
 
 
-FINAL: 2 - 0 (home)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 4 | Nuffle: 4
+FINAL: 1 - 0 (home)
+Touchdowns: 1 | Casualties: 0 | Turnovers: 6 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-040-dal-vipers-vs-pit-smashers-seed2065.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-040-dal-vipers-vs-pit-smashers-seed2065.txt
@@ -1,46 +1,48 @@
 === MATCH #40 — Vipers (Dark Elf) vs Smashers (Orc) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — dal-vipers hosts pit-smashers (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 3 — away in possession at yardline 19 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
   FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+Half 1 • Turn 3 — away in possession at yardline 18 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+Half 1 • Turn 4 — away in possession at yardline 19 (score 0-0)
   Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
-Half 1 • Turn 5 — home in possession at yardline 12 (score 0-1)
-Half 1 • Turn 6 — home in possession at yardline 21 (score 0-1)
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
+Half 1 • Turn 6 — home in possession at yardline 8 (score 0-1)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 1 • Turn 7 — home in possession at yardline 15 (score 0-1)
   TURNOVER — pickup_failed.
-Half 1 • Turn 8 — home in possession at yardline 10 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
+Half 1 • Turn 8 — away in possession at yardline 7 (score 0-1)
+  TURNOVER — pickup_failed.
 
---- HALFTIME (score 1-1) ---
+--- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1)
   TURNOVER — pickup_failed.
-Half 2 • Turn 2 — away in possession at yardline 15 (score 1-1)
+Half 2 • Turn 3 — away in possession at yardline 8 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+Half 2 • Turn 4 — away in possession at yardline 10 (score 0-1)
   TURNOVER — pickup_failed.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 1-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 11 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 5 — away in possession at yardline 15 (score 1-1)
+Half 2 • Turn 5 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
-Half 2 • Turn 6 — away in possession at yardline 22 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 7 — home in possession at yardline 10 (score 1-1)
-Half 2 • Turn 8 — home in possession at yardline 14 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 7 — home in possession at yardline 13 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+Half 2 • Turn 8 — home in possession at yardline 13 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
 
---- END OF MATCH (score 1-1) ---
+--- END OF MATCH (score 0-1) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 5 | Nuffle: 4
+FINAL: 0 - 1 (away)
+Touchdowns: 1 | Casualties: 0 | Turnovers: 4 | Nuffle: 4

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-041-ne-cold-tacticians-vs-no-voodoo-saints-seed2066.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-041-ne-cold-tacticians-vs-no-voodoo-saints-seed2066.txt
@@ -1,54 +1,56 @@
 === MATCH #41 — Cold Tacticians (Lizardmen) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 13 (score 0-0)
-Half 1 • Turn 3 — away in possession at yardline 19 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
   Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-Half 1 • Turn 5 — home in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 6 — home in possession at yardline 18 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 4 — home in possession at yardline 5 (score 0-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — away in possession at yardline 18 (score 0-1)
-  Touchdown! away crosses the line. Score is now 0-2.
-
---- HALFTIME (score 0-2) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 2 — home in possession at yardline 12 (score 0-2)
-Half 2 • Turn 3 — home in possession at yardline 17 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 4 — away in possession at yardline 10 (score 0-2)
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 5 — home in possession at yardline 15 (score 0-2)
+Half 1 • Turn 5 — away in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — home-NUFFLE-1-5 is taken off by tantrum_star.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  TURNOVER — pass_failed.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1)
   ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
   BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 6 — home in possession at yardline 25 (score 0-2)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 13 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+Half 2 • Turn 2 — home in possession at yardline 7 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+Half 2 • Turn 3 — home in possession at yardline 11 (score 0-1)
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 1-2.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — away in possession at yardline 6 (score 0-1)
+Half 2 • Turn 5 — away in possession at yardline 10 (score 0-1)
+  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
   BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 8 — away in possession at yardline 9 (score 1-2)
+Half 2 • Turn 6 — away in possession at yardline 10 (score 0-1)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 0-1)
 
---- END OF MATCH (score 1-2) ---
+--- END OF MATCH (score 0-1) ---
 
 
-FINAL: 1 - 2 (away)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 3 | Nuffle: 6
+FINAL: 0 - 1 (away)
+Touchdowns: 1 | Casualties: 1 | Turnovers: 6 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-042-car-jungle-queens-vs-gb-cheese-halflings-seed2067.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-042-car-jungle-queens-vs-gb-cheese-halflings-seed2067.txt
@@ -1,58 +1,64 @@
 === MATCH #42 — Jungle Queens (Amazon) vs Cheese Halflings (Halfling) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — car-jungle-queens hosts gb-cheese-halflings (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
-Half 1 • Turn 4 — away in possession at yardline 13 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 5 — away in possession at yardline 17 (score 0-0)
-Half 1 • Turn 6 — away in possession at yardline 24 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 4 — away in possession at yardline 9 (score 0-0)
   PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 1 • Turn 7 — home in possession at yardline 8 (score 0-0)
-Half 1 • Turn 8 — home in possession at yardline 16 (score 0-0)
+Half 1 • Turn 5 — home in possession at yardline 8 (score 0-0)
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-1-6 is taken off by banana_skin.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+Half 1 • Turn 7 — home in possession at yardline 13 (score 0-1)
+Half 1 • Turn 8 — home in possession at yardline 21 (score 0-1)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 2 • Turn 2 — away in possession at yardline 13 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+
+--- HALFTIME (score 0-1) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+Half 2 • Turn 2 — home in possession at yardline 11 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 3 — home in possession at yardline 15 (score 1-0)
+  Touchdown! away crosses the line. Score is now 0-2.
+Half 2 • Turn 3 — home in possession at yardline 4 (score 0-2)
   PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 2 • Turn 4 — away in possession at yardline 11 (score 1-0)
+Half 2 • Turn 4 — away in possession at yardline 4 (score 0-2)
   ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 5 — away in possession at yardline 17 (score 1-0)
+Half 2 • Turn 5 — away in possession at yardline 10 (score 0-2)
   ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — home in possession at yardline 12 (score 1-0)
+  CASUALTY — home-NUFFLE-2-5 is taken off by cocky_drop.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 6 — away in possession at yardline 13 (score 0-2)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 7 — home in possession at yardline 10 (score 0-2)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  CASUALTY — away-NUFFLE-2-7 is taken off by banana_skin.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+Half 2 • Turn 8 — home in possession at yardline 21 (score 0-2)
+  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  CASUALTY — away-NUFFLE-2-8 is taken off by tantrum_star.
   PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 8 — home in possession at yardline 11 (score 1-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  Touchdown! away crosses the line. Score is now 0-3.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 0-3) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 9 | Nuffle: 5
+FINAL: 0 - 3 (away)
+Touchdowns: 3 | Casualties: 4 | Turnovers: 9 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-043-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2068.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-043-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2068.txt
@@ -1,51 +1,61 @@
 === MATCH #43 — Tomb Cardinals (Tomb Kings) vs Cold Tacticians (Lizardmen) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-Half 1 • Turn 2 — home in possession at yardline 14 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — away in possession at yardline 8 (score 0-0)
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 4 — home in possession at yardline 10 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 5 — away in possession at yardline 11 (score 0-0)
-Half 1 • Turn 6 — away in possession at yardline 18 (score 0-0)
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 8 — away in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-
---- HALFTIME (score 0-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-Half 2 • Turn 2 — away in possession at yardline 11 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 0-1)
+  CASUALTY — away-NUFFLE-1-3 is taken off by nemesis_clash.
   BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 4 — home in possession at yardline 16 (score 0-1)
+Half 1 • Turn 4 — home in possession at yardline 7 (score 1-0)
   TURNOVER — pickup_failed.
-Half 2 • Turn 5 — away in possession at yardline 14 (score 0-1)
+Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 1 • Turn 8 — home in possession at yardline 6 (score 1-1)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+
+--- HALFTIME (score 1-1) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 3 — away in possession at yardline 9 (score 1-1)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 6 — away in possession at yardline 25 (score 0-1)
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  TURNOVER — pass_failed.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 1-2)
+  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+Half 2 • Turn 6 — away in possession at yardline 5 (score 1-2)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 0-2)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 8 — away in possession at yardline 7 (score 0-2)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 8 — home in possession at yardline 6 (score 1-2)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 1-2) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 7 | Nuffle: 3
+FINAL: 1 - 2 (away)
+Touchdowns: 3 | Casualties: 1 | Turnovers: 8 | Nuffle: 3

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-044-lv-outlaws-vs-pit-smashers-seed2069.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-044-lv-outlaws-vs-pit-smashers-seed2069.txt
@@ -1,50 +1,64 @@
 === MATCH #44 — Outlaws (Norse) vs Smashers (Orc) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — lv-outlaws hosts pit-smashers (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 15 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 20 (score 0-0)
+Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 3 — away in possession at yardline 7 (score 0-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — home in possession at yardline 9 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 6 — away in possession at yardline 9 (score 1-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 7 — away in possession at yardline 21 (score 1-0)
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 1-1)
+Half 1 • Turn 4 — away in possession at yardline 13 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
+  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+Half 1 • Turn 6 — home in possession at yardline 11 (score 0-0)
+  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+Half 1 • Turn 7 — home in possession at yardline 11 (score 0-0)
+  FOUL — home-LOS fouls away-PRONE (armor=12, broken=true → casualty, sent off!).
+  CASUALTY — away-PRONE is taken off by home-LOS.
+  TURNOVER — foul_sent_off.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  Touchdown! home crosses the line. Score is now 1-1.
 
 --- HALFTIME (score 1-1) ---
 
 Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 2 — away in possession at yardline 7 (score 1-1)
-Half 2 • Turn 3 — away in possession at yardline 19 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
   BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — home in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 5 — home in possession at yardline 19 (score 1-1)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+Half 2 • Turn 3 — home in possession at yardline 11 (score 1-1)
+  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
   TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 8 (score 1-1)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-Half 2 • Turn 7 — away in possession at yardline 16 (score 1-1)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-Half 2 • Turn 8 — away in possession at yardline 23 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+Half 2 • Turn 4 — away in possession at yardline 6 (score 1-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
   Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 6 — away in possession at yardline 8 (score 1-2)
+  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → stunned, sent off!).
+  TURNOVER — foul_sent_off.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 1-3.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 1-3)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  Touchdown! home crosses the line. Score is now 2-3.
 
---- END OF MATCH (score 1-2) ---
+--- END OF MATCH (score 2-3) ---
 
 
-FINAL: 1 - 2 (away)
-Touchdowns: 3 | Casualties: 0 | Turnovers: 4 | Nuffle: 7
+FINAL: 2 - 3 (away)
+Touchdowns: 5 | Casualties: 1 | Turnovers: 8 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-045-gb-cheese-halflings-vs-phx-tomb-cardinals-seed2070.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-045-gb-cheese-halflings-vs-phx-tomb-cardinals-seed2070.txt
@@ -1,50 +1,56 @@
 === MATCH #45 — Cheese Halflings (Halfling) vs Tomb Cardinals (Tomb Kings) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — gb-cheese-halflings hosts phx-tomb-cardinals (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 1 • Turn 3 — away in possession at yardline 13 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 1 • Turn 4 — away in possession at yardline 19 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 5 — away in possession at yardline 25 (score 0-0)
   BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 3 — away in possession at yardline 22 (score 0-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 5 — away in possession at yardline 12 (score 0-0)
+Half 1 • Turn 6 — away in possession at yardline 18 (score 0-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
   Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-1)
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 19 (score 0-1)
+  CASUALTY — away-NUFFLE-1-7 is taken off by nemesis_clash.
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
 --- HALFTIME (score 0-1) ---
 
 Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
   ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 2 — away in possession at yardline 10 (score 0-1)
+Half 2 • Turn 2 — home in possession at yardline 5 (score 0-1)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 3 — away in possession at yardline 14 (score 0-1)
-Half 2 • Turn 4 — away in possession at yardline 21 (score 0-1)
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 6 — away in possession at yardline 8 (score 0-2)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 14 (score 0-2)
-Half 2 • Turn 8 — home in possession at yardline 24 (score 0-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+  TURNOVER — pickup_failed.
+Half 2 • Turn 3 — away in possession at yardline 7 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 4 — away in possession at yardline 17 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  TURNOVER — pickup_failed.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 6 — away in possession at yardline 12 (score 1-1)
+Half 2 • Turn 7 — away in possession at yardline 18 (score 1-1)
+  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
 
---- END OF MATCH (score 0-2) ---
+--- END OF MATCH (score 1-2) ---
 
 
-FINAL: 0 - 2 (away)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 4 | Nuffle: 5
+FINAL: 1 - 2 (away)
+Touchdowns: 3 | Casualties: 1 | Turnovers: 4 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-046-phx-tomb-cardinals-vs-min-frostraiders-seed2071.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-046-phx-tomb-cardinals-vs-min-frostraiders-seed2071.txt
@@ -1,56 +1,63 @@
 === MATCH #46 — Tomb Cardinals (Tomb Kings) vs Frostraiders (Norse) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts min-frostraiders (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
   FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0)
   ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 3 — home in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-Half 1 • Turn 5 — away in possession at yardline 17 (score 0-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 1 • Turn 6 — away in possession at yardline 25 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
   PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
   TURNOVER — pass_fumble.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 8 — home in possession at yardline 19 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  Touchdown! home crosses the line. Score is now 1-0.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 2 — home in possession at yardline 11 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 17 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 22 (score 1-0)
+Half 1 • Turn 4 — home in possession at yardline 9 (score 1-0)
+  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
   BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 5 — home in possession at yardline 10 (score 1-0)
+  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+Half 1 • Turn 6 — home in possession at yardline 10 (score 1-0)
+  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+Half 1 • Turn 7 — home in possession at yardline 10 (score 1-0)
+  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
   Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
-Half 2 • Turn 6 — away in possession at yardline 16 (score 2-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+Half 1 • Turn 8 — away in possession at yardline 4 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+
+--- HALFTIME (score 2-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 2 — away in possession at yardline 5 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
   FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → ko, sent off!).
   KO — home-PRONE is knocked unconscious by away-LOS.
   TURNOVER — foul_sent_off.
-Half 2 • Turn 7 — home in possession at yardline 11 (score 2-0)
-Half 2 • Turn 8 — home in possession at yardline 19 (score 2-0)
+  Touchdown! home crosses the line. Score is now 3-0.
+Half 2 • Turn 3 — away in possession at yardline 4 (score 3-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — home in possession at yardline 7 (score 3-0)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 5 — away in possession at yardline 4 (score 3-0)
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+  Touchdown! away crosses the line. Score is now 3-1.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 3-1)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
   TURNOVER — gfi_failed.
+Half 2 • Turn 7 — away in possession at yardline 6 (score 3-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 2 • Turn 8 — away in possession at yardline 12 (score 3-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  TURNOVER — dodge_failed.
+  Touchdown! home crosses the line. Score is now 4-1.
 
---- END OF MATCH (score 2-0) ---
+--- END OF MATCH (score 4-1) ---
 
 
-FINAL: 2 - 0 (home)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 5 | Nuffle: 7
+FINAL: 4 - 1 (home)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 8 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-047-ne-cold-tacticians-vs-no-voodoo-saints-seed2072.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-047-ne-cold-tacticians-vs-no-voodoo-saints-seed2072.txt
@@ -1,53 +1,58 @@
 === MATCH #47 — Cold Tacticians (Lizardmen) vs Voodoo Saints (Undead) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
   FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
-Half 1 • Turn 3 — away in possession at yardline 16 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 4 — away in possession at yardline 24 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
   FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 5 — home in possession at yardline 12 (score 0-0)
+  Touchdown! home crosses the line. Score is now 2-0.
+Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
   ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  FOUL — home-LOS fouls away-PRONE (armor=3, broken=false).
-Half 1 • Turn 6 — home in possession at yardline 21 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 15 (score 1-0)
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
   TURNOVER — dodge_failed.
-
---- HALFTIME (score 1-0) ---
-
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — home in possession at yardline 9 (score 1-0)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 3 — away in possession at yardline 14 (score 1-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 2 • Turn 4 — away in possession at yardline 19 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 5 — away in possession at yardline 23 (score 1-0)
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 10 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
   BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
   TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — away in possession at yardline 13 (score 1-1)
+Half 1 • Turn 8 — away in possession at yardline 5 (score 2-0)
+  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
 
---- END OF MATCH (score 1-1) ---
+--- HALFTIME (score 2-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+Half 2 • Turn 2 — home in possession at yardline 4 (score 2-0)
+Half 2 • Turn 3 — home in possession at yardline 4 (score 2-0)
+  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  TURNOVER — gfi_failed.
+  Touchdown! away crosses the line. Score is now 2-1.
+Half 2 • Turn 4 — home in possession at yardline 4 (score 2-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 5 — away in possession at yardline 11 (score 2-1)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 2-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
+  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 8 — home in possession at yardline 5 (score 2-1)
+
+--- END OF MATCH (score 2-1) ---
 
 
-FINAL: 1 - 1 (draw)
-Touchdowns: 2 | Casualties: 0 | Turnovers: 4 | Nuffle: 5
+FINAL: 2 - 1 (home)
+Touchdowns: 3 | Casualties: 0 | Turnovers: 9 | Nuffle: 5

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-048-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2073.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-048-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2073.txt
@@ -1,60 +1,66 @@
 === MATCH #48 — Tomb Cardinals (Tomb Kings) vs Cold Tacticians (Lizardmen) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, away receives).
 Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 11 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 1 • Turn 3 — away in possession at yardline 19 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — away in possession at yardline 23 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 8 (score 0-1)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 7 — home in possession at yardline 13 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 8 — away in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0)
   DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
   TURNOVER — dodge_failed.
+Half 1 • Turn 3 — home in possession at yardline 7 (score 0-0)
+  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  TURNOVER — pickup_failed.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+Half 1 • Turn 6 — home in possession at yardline 8 (score 0-0)
+  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  TURNOVER — pass_fumble.
+  Touchdown! away crosses the line. Score is now 0-1.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 8 — home in possession at yardline 6 (score 0-1)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  TURNOVER — pickup_failed.
 
 --- HALFTIME (score 0-1) ---
 
 Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 2 — home in possession at yardline 10 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 16 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 2 • Turn 3 — home in possession at yardline 7 (score 0-1)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 4 — away in possession at yardline 14 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 5 — home in possession at yardline 14 (score 0-1)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 6 — home in possession at yardline 20 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+Half 2 • Turn 4 — home in possession at yardline 7 (score 0-1)
+  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 5 — away in possession at yardline 8 (score 0-1)
+  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  TURNOVER — block_attacker_down.
+Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 13 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 8 — home in possession at yardline 13 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
+  CASUALTY — away-NUFFLE-2-6 is taken off by banana_skin.
+  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+Half 2 • Turn 7 — home in possession at yardline 7 (score 0-1)
+  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  TURNOVER — foul_sent_off.
+Half 2 • Turn 8 — away in possession at yardline 6 (score 0-1)
+  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
 
 --- END OF MATCH (score 0-1) ---
 
 
 FINAL: 0 - 1 (away)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 9 | Nuffle: 7
+Touchdowns: 1 | Casualties: 1 | Turnovers: 10 | Nuffle: 7

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-049-min-frostraiders-vs-chi-iron-bears-seed2074.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-049-min-frostraiders-vs-chi-iron-bears-seed2074.txt
@@ -1,53 +1,61 @@
 === MATCH #49 — Frostraiders (Norse) vs Iron Bears (Dwarf) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — min-frostraiders hosts chi-iron-bears (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
   ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
   DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 2 — home in possession at yardline 14 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 3 — home in possession at yardline 25 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 10 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 17 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-Half 1 • Turn 6 — away in possession at yardline 22 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 7 — away in possession at yardline 25 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/POW], chose POW, defender_down.
+Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0)
+  TURNOVER — pickup_failed.
   Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-
---- HALFTIME (score 0-1) ---
-
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! home crosses the line. Score is now 1-1.
+Half 1 • Turn 4 — away in possession at yardline 4 (score 1-1)
+  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 1 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  Touchdown! home crosses the line. Score is now 2-2.
+Half 1 • Turn 6 — away in possession at yardline 4 (score 2-2)
   FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 2 • Turn 2 — away in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+  Touchdown! away crosses the line. Score is now 2-3.
+Half 1 • Turn 7 — home in possession at yardline 4 (score 2-3)
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
   TURNOVER — pass_failed.
-Half 2 • Turn 3 — home in possession at yardline 10 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 14 (score 0-1)
+Half 1 • Turn 8 — away in possession at yardline 6 (score 2-3)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/POW], chose POW, defender_down.
+
+--- HALFTIME (score 2-3) ---
+
+Half 2 • Turn 1 — away in possession at yardline 4 (score 2-3)
+  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  Touchdown! away crosses the line. Score is now 2-4.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 2-4)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+Half 2 • Turn 3 — home in possession at yardline 10 (score 2-4)
+  TURNOVER — pickup_failed.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 2-4)
+  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
   BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
-Half 2 • Turn 5 — away in possession at yardline 24 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — home in possession at yardline 5 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 7 — home in possession at yardline 17 (score 0-1)
+  CASUALTY — home-LOS is taken off by away-LOS.
+Half 2 • Turn 5 — away in possession at yardline 10 (score 2-4)
+Half 2 • Turn 6 — away in possession at yardline 14 (score 2-4)
+  Touchdown! away crosses the line. Score is now 2-5.
+Half 2 • Turn 7 — home in possession at yardline 4 (score 2-5)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 8 — away in possession at yardline 8 (score 0-1)
+  CASUALTY — away-NUFFLE-2-7 is taken off by banana_skin.
+  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  Touchdown! home crosses the line. Score is now 3-5.
+Half 2 • Turn 8 — away in possession at yardline 4 (score 3-5)
   ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
 
---- END OF MATCH (score 0-1) ---
+--- END OF MATCH (score 3-5) ---
 
 
-FINAL: 0 - 1 (away)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 5 | Nuffle: 6
+FINAL: 3 - 5 (away)
+Touchdowns: 8 | Casualties: 2 | Turnovers: 3 | Nuffle: 6

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-050-min-frostraiders-vs-car-jungle-queens-seed2075.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-050-min-frostraiders-vs-car-jungle-queens-seed2075.txt
@@ -1,54 +1,60 @@
 === MATCH #50 — Frostraiders (Norse) vs Jungle Queens (Amazon) ===
-engine 0.2.0
+engine 0.12.0
 
 KICKOFF — min-frostraiders hosts car-jungle-queens (weather: nice, home receives).
 Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 10 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 14 (score 0-0)
+  Touchdown! home crosses the line. Score is now 1-0.
+Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  Touchdown! away crosses the line. Score is now 1-1.
+Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
   ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 1 • Turn 5 — away in possession at yardline 21 (score 0-0)
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 4 — home in possession at yardline 13 (score 1-1)
+  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+Half 1 • Turn 5 — home in possession at yardline 14 (score 1-1)
   ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+Half 1 • Turn 6 — home in possession at yardline 18 (score 1-1)
+  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  TURNOVER — dodge_failed.
+Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+Half 1 • Turn 8 — away in possession at yardline 10 (score 1-1)
+  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
   FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
   TURNOVER — foul_sent_off.
-Half 1 • Turn 6 — home in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — home in possession at yardline 20 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
 
---- HALFTIME (score 1-0) ---
+--- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — away in possession at yardline 13 (score 1-0)
+Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  Touchdown! away crosses the line. Score is now 1-2.
+Half 2 • Turn 2 — home in possession at yardline 4 (score 1-2)
   ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
-Half 2 • Turn 3 — away in possession at yardline 23 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
   TURNOVER — dodge_failed.
-Half 2 • Turn 4 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 12 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 6 — home in possession at yardline 11 (score 1-0)
+Half 2 • Turn 3 — away in possession at yardline 7 (score 1-2)
+  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
   TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 13 (score 1-0)
+  Touchdown! home crosses the line. Score is now 2-2.
+Half 2 • Turn 4 — away in possession at yardline 4 (score 2-2)
+  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
   TURNOVER — gfi_failed.
-Half 2 • Turn 8 — home in possession at yardline 8 (score 1-0)
+Half 2 • Turn 5 — home in possession at yardline 7 (score 2-2)
+  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  TURNOVER — pickup_failed.
+  Touchdown! away crosses the line. Score is now 2-3.
+Half 2 • Turn 6 — home in possession at yardline 4 (score 2-3)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 7 — away in possession at yardline 9 (score 2-3)
+  TURNOVER — gfi_failed.
+Half 2 • Turn 8 — home in possession at yardline 5 (score 2-3)
   ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
+  TURNOVER — pickup_failed.
 
---- END OF MATCH (score 1-0) ---
+--- END OF MATCH (score 2-3) ---
 
 
-FINAL: 1 - 0 (home)
-Touchdowns: 1 | Casualties: 0 | Turnovers: 7 | Nuffle: 8
+FINAL: 2 - 3 (away)
+Touchdowns: 5 | Casualties: 0 | Turnovers: 9 | Nuffle: 8

--- a/packages/sim-engine/scripts/replay.ts
+++ b/packages/sim-engine/scripts/replay.ts
@@ -152,6 +152,7 @@ function toSimTeamInput(team: ProTeamProfile, side: 'home' | 'away'): SimTeamInp
     name: team.name,
     side,
     tactics: team.tactics,
+    tv: team.tv,
   };
 }
 


### PR DESCRIPTION
## Summary

- Régénération des 50 replays panel BB experts (seeds 2026-2075) sur **engineVer 0.12.0** (post iter #11 — breakthrough 18% + TV delta bonus + casualty rate ~98% FUMBBL).
- Fix mineur dans `scripts/replay.ts` : `toSimTeamInput` propage désormais `tv` au simulator, pour que les replays reflètent le TV delta bonus introduit en iter #11.

## Test plan

- [x] `pnpm sim:replay --random=50 --seed=2026 --out=docs/.../replays` → 50 fichiers générés
- [x] Replays lisibles dans le panel kit
- [x] Engine version 0.12.0 dans tous les replays

## Next steps

Les replays sont prêts à être envoyés aux 5 testeurs panel BB experts pour notation C6-C9 (cf. `docs/roadmap/sprints/pro-league-panel/notation-grille.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_