### PR TITLE
feat(db): Pro League Prisma models (sprint 1.A.1)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -823,3 +823,168 @@ model Feedback {
   @@index([status, createdAt])
   @@index([createdAt])
 }
+
+// =============================================================
+// Pro League — sprint Pro League lot 1.A.1 (sqlite mirror)
+// =============================================================
+// Cf. /prisma/schema.prisma pour la documentation. Ce mirror sqlite
+// remplace les colonnes `Json` par `String` (sqlite supporte JSON
+// uniquement via JSON1 module — on serialise/parse cote application
+// pour rester compatible).
+
+model ProLeague {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  name        String
+  description String?
+  branding    String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  teams   ProTeam[]
+  seasons ProLeagueSeason[]
+}
+
+model ProTeam {
+  id             String    @id @default(cuid())
+  league         ProLeague @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  leagueId       String
+  slug           String    @unique
+  city           String
+  name           String
+  race           String
+  nflFlavor      String?
+  primaryColor   String?
+  secondaryColor String?
+  baseTv         Int       @default(1000)
+  meta           String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  roster      ProTeamRoster[]
+  homeMatches ProLeagueMatch[]     @relation("ProMatchHome")
+  awayMatches ProLeagueMatch[]     @relation("ProMatchAway")
+  standings   ProLeagueStandings[]
+
+  @@index([leagueId])
+}
+
+model ProTeamRoster {
+  id          String   @id @default(cuid())
+  team        ProTeam  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId      String
+  name        String
+  position    String
+  ma          Int
+  st          Int
+  ag          Int
+  pa          Int?
+  av          Int
+  skills      String   @default("[]")
+  niggling    Int      @default(0)
+  maReduction Int      @default(0)
+  stReduction Int      @default(0)
+  agReduction Int      @default(0)
+  avReduction Int      @default(0)
+  status      String   @default("active")
+  form        Int      @default(50)
+  careerStats String   @default("{}")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([teamId, status])
+}
+
+model ProLeagueSeason {
+  id        String    @id @default(cuid())
+  league    ProLeague @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  leagueId  String
+  year      Int
+  status    String    @default("scheduled")
+  engineVer String
+  startsAt  DateTime?
+  endsAt    DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  rounds    ProLeagueRound[]
+  matches   ProLeagueMatch[]
+  standings ProLeagueStandings[]
+
+  @@unique([leagueId, year])
+  @@index([status])
+}
+
+model ProLeagueRound {
+  id          String          @id @default(cuid())
+  season      ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId    String
+  roundNumber Int
+  status      String          @default("pending")
+  scheduledAt DateTime?
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+
+  matches ProLeagueMatch[]
+
+  @@unique([seasonId, roundNumber])
+  @@index([status])
+}
+
+model ProLeagueMatch {
+  id             String          @id @default(cuid())
+  season         ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId       String
+  round          ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  roundId        String
+  homeTeam       ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
+  homeTeamId     String
+  awayTeam       ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
+  awayTeamId     String
+  status         String          @default("scheduled")
+  scheduledAt    DateTime
+  simulatedAt    DateTime?
+  completedAt    DateTime?
+  seed           BigInt?
+  engineVer      String?
+  replayId       String?         @unique
+  scoreHome      Int?
+  scoreAway      Int?
+  outcome        String?
+  touchdownCount Int?
+  casualtyCount  Int?
+  turnoverCount  Int?
+  nuffleCount    Int?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  @@index([seasonId, status])
+  @@index([roundId])
+  @@index([scheduledAt])
+  @@index([homeTeamId])
+  @@index([awayTeamId])
+}
+
+model ProLeagueStandings {
+  id                String          @id @default(cuid())
+  season            ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId          String
+  team              ProTeam         @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId            String
+  played            Int             @default(0)
+  wins              Int             @default(0)
+  draws             Int             @default(0)
+  losses            Int             @default(0)
+  points            Int             @default(0)
+  tdFor             Int             @default(0)
+  tdAgainst         Int             @default(0)
+  casualtiesFor     Int             @default(0)
+  casualtiesAgainst Int             @default(0)
+  form              String          @default("[]")
+  updatedAt         DateTime        @updatedAt
+
+  @@unique([seasonId, teamId])
+  @@index([seasonId, points, tdFor])
+}

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -24,6 +24,7 @@ import {
   LEAGUES_V2_UI_FLAG,
 } from "./services/featureFlags";
 import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
+import { seedProLeague, OLD_WORLD_LEAGUE_NAME } from "./seeders/pro-league";
 import { serverLog } from "./utils/server-log";
 
 async function main() {
@@ -2028,6 +2029,11 @@ async function main() {
     serverLog.log("   ⚠️  Admin introuvable, seeder des ligues ignoré");
   }
   serverLog.log("✅ Ligues par défaut terminées\n");
+
+  // Sprint Pro League lot 1.A.1 — Pro League singleton + 16 équipes
+  serverLog.log("🏈 Seed de la Pro League...");
+  await seedProLeague();
+  serverLog.log(`   ✅ Pro League '${OLD_WORLD_LEAGUE_NAME}' + 16 équipes seedées\n`);
 }
 
 main()
@@ -2041,6 +2047,7 @@ main()
     serverLog.log("   - Les comptes par défaut sont prêts");
     serverLog.log("   - La coupe 'Test 1' et un match local ont été créés");
     serverLog.log(`   - La ligue '${DEFAULT_LEAGUE_NAME}' est prête`);
+    serverLog.log(`   - La Pro League '${OLD_WORLD_LEAGUE_NAME}' est seedée (16 équipes)`);
   })
   .catch(async (e) => {
     serverLog.error("❌ Erreur lors du seed:", e);

--- a/apps/server/src/seeders/pro-league.ts
+++ b/apps/server/src/seeders/pro-league.ts
@@ -1,0 +1,100 @@
+/**
+ * Pro League — sprint Pro League lot 1.A.1 seeder.
+ *
+ * Amorce la `ProLeague` "Old World League" et ses 16 `ProTeam` officielles.
+ * Source de verite des profils tactiques + TVs : `PRO_LEAGUE_TEAMS` dans
+ * `packages/sim-engine/src/tactics/race-profiles.ts`. La DB ne stocke que
+ * les meta d'affichage (city, race, NFL flavor, branding) ; le TV est
+ * materialise pour lectures rapides.
+ *
+ * Contrats :
+ * - Idempotent : relancer `pnpm db:seed` ne duplique pas la ligue ni les
+ *   equipes ; les TVs et flavors sont mis a jour si la source change.
+ * - Le slug `old-world-league` est la cle naturelle de la singleton ligue.
+ * - Les slugs ProTeam matchent exactement `PRO_LEAGUE_TEAMS[i].id` pour
+ *   permettre au sim-engine de remonter le profil tactique a partir d'un
+ *   record DB.
+ *
+ * Le roster joueur (ProTeamRoster) reste vide au seed — sera populé par
+ * la generation procedurale post-MVP (lot 1.E.6 rookie pipeline).
+ */
+
+import { PRO_LEAGUE_TEAMS } from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+export const OLD_WORLD_LEAGUE_SLUG = "old-world-league";
+export const OLD_WORLD_LEAGUE_NAME = "Old World League";
+
+interface ProTeamBranding {
+  primaryColor: string;
+  secondaryColor: string;
+}
+
+/**
+ * Palettes inspirees des homages NFL × races BB du sprint. Les couleurs
+ * restent generiques (pas de marque NFL utilisee) ; cf. SPRINT-pro-league.md
+ * section "Statut juridique".
+ */
+const TEAM_BRANDING: Record<string, ProTeamBranding> = {
+  "pit-smashers": { primaryColor: "#000000", secondaryColor: "#FFB612" },
+  "dal-vipers": { primaryColor: "#003594", secondaryColor: "#869397" },
+  "kc-soaring-hawks": { primaryColor: "#E31837", secondaryColor: "#FFB81C" },
+  "ne-cold-tacticians": { primaryColor: "#002244", secondaryColor: "#C60C30" },
+  "sf-gold-rush": { primaryColor: "#AA0000", secondaryColor: "#B3995D" },
+  "car-jungle-queens": { primaryColor: "#0085CA", secondaryColor: "#101820" },
+  "lv-outlaws": { primaryColor: "#000000", secondaryColor: "#A5ACAF" },
+  "no-voodoo-saints": { primaryColor: "#D3BC8D", secondaryColor: "#101820" },
+  "chi-iron-bears": { primaryColor: "#0B162A", secondaryColor: "#C83803" },
+  "phi-storm-eagles": { primaryColor: "#004C54", secondaryColor: "#A5ACAF" },
+  "phx-tomb-cardinals": { primaryColor: "#97233F", secondaryColor: "#000000" },
+  "min-frostraiders": { primaryColor: "#4F2683", secondaryColor: "#FFC62F" },
+  "gb-cheese-halflings": { primaryColor: "#203731", secondaryColor: "#FFB612" },
+  "jax-swamp-lizards": { primaryColor: "#101820", secondaryColor: "#D7A22A" },
+  "den-mile-high-centaurs": { primaryColor: "#FB4F14", secondaryColor: "#002244" },
+  "buf-snow-ogres": { primaryColor: "#00338D", secondaryColor: "#C60C30" },
+};
+
+export async function seedProLeague(): Promise<void> {
+  const league = await prisma.proLeague.upsert({
+    where: { slug: OLD_WORLD_LEAGUE_SLUG },
+    create: {
+      slug: OLD_WORLD_LEAGUE_SLUG,
+      name: OLD_WORLD_LEAGUE_NAME,
+      description:
+        "Ligue simulee a 16 equipes (homages NFL × races Blood Bowl). " +
+        "15 journees round-robin, mardi 21h, simulation engine BB-like.",
+      branding: { motto: "Where Legends Are Smashed" },
+    },
+    update: {
+      name: OLD_WORLD_LEAGUE_NAME,
+    },
+  });
+
+  for (const team of PRO_LEAGUE_TEAMS) {
+    const branding = TEAM_BRANDING[team.id];
+    await prisma.proTeam.upsert({
+      where: { slug: team.id },
+      create: {
+        leagueId: league.id,
+        slug: team.id,
+        city: team.city,
+        name: team.name,
+        race: team.race,
+        nflFlavor: team.nflFlavor,
+        primaryColor: branding?.primaryColor,
+        secondaryColor: branding?.secondaryColor,
+        baseTv: team.tv,
+      },
+      update: {
+        city: team.city,
+        name: team.name,
+        race: team.race,
+        nflFlavor: team.nflFlavor,
+        primaryColor: branding?.primaryColor,
+        secondaryColor: branding?.secondaryColor,
+        baseTv: team.tv,
+      },
+    });
+  }
+}

--- a/prisma/migrations/20260506100000_add_pro_league/migration.sql
+++ b/prisma/migrations/20260506100000_add_pro_league/migration.sql
@@ -1,0 +1,202 @@
+-- Pro League — sprint Pro League lot 1.A.1.
+-- Modèles dédiés à la Pro League simulée (16 équipes, 15 journées).
+-- Cf. prisma/schema.prisma sections "Pro League" pour la sémantique
+-- complète des champs.
+
+-- CreateTable: ProLeague (singleton league)
+CREATE TABLE "public"."ProLeague" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "branding" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProLeague_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProLeague_slug_key" ON "public"."ProLeague"("slug");
+
+-- CreateTable: ProTeam (16 fixed teams)
+CREATE TABLE "public"."ProTeam" (
+    "id" TEXT NOT NULL,
+    "leagueId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "race" TEXT NOT NULL,
+    "nflFlavor" TEXT,
+    "primaryColor" TEXT,
+    "secondaryColor" TEXT,
+    "baseTv" INTEGER NOT NULL DEFAULT 1000,
+    "meta" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProTeam_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProTeam_slug_key" ON "public"."ProTeam"("slug");
+CREATE INDEX "ProTeam_leagueId_idx" ON "public"."ProTeam"("leagueId");
+
+ALTER TABLE "public"."ProTeam" ADD CONSTRAINT "ProTeam_leagueId_fkey"
+    FOREIGN KEY ("leagueId") REFERENCES "public"."ProLeague"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProTeamRoster
+CREATE TABLE "public"."ProTeamRoster" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "position" TEXT NOT NULL,
+    "ma" INTEGER NOT NULL,
+    "st" INTEGER NOT NULL,
+    "ag" INTEGER NOT NULL,
+    "pa" INTEGER,
+    "av" INTEGER NOT NULL,
+    "skills" JSONB NOT NULL,
+    "niggling" INTEGER NOT NULL DEFAULT 0,
+    "maReduction" INTEGER NOT NULL DEFAULT 0,
+    "stReduction" INTEGER NOT NULL DEFAULT 0,
+    "agReduction" INTEGER NOT NULL DEFAULT 0,
+    "avReduction" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "form" INTEGER NOT NULL DEFAULT 50,
+    "careerStats" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProTeamRoster_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProTeamRoster_teamId_status_idx" ON "public"."ProTeamRoster"("teamId", "status");
+
+ALTER TABLE "public"."ProTeamRoster" ADD CONSTRAINT "ProTeamRoster_teamId_fkey"
+    FOREIGN KEY ("teamId") REFERENCES "public"."ProTeam"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProLeagueSeason
+CREATE TABLE "public"."ProLeagueSeason" (
+    "id" TEXT NOT NULL,
+    "leagueId" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "engineVer" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3),
+    "endsAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProLeagueSeason_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProLeagueSeason_leagueId_year_key" ON "public"."ProLeagueSeason"("leagueId", "year");
+CREATE INDEX "ProLeagueSeason_status_idx" ON "public"."ProLeagueSeason"("status");
+
+ALTER TABLE "public"."ProLeagueSeason" ADD CONSTRAINT "ProLeagueSeason_leagueId_fkey"
+    FOREIGN KEY ("leagueId") REFERENCES "public"."ProLeague"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProLeagueRound
+CREATE TABLE "public"."ProLeagueRound" (
+    "id" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "roundNumber" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "scheduledAt" TIMESTAMP(3),
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProLeagueRound_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProLeagueRound_seasonId_roundNumber_key" ON "public"."ProLeagueRound"("seasonId", "roundNumber");
+CREATE INDEX "ProLeagueRound_status_idx" ON "public"."ProLeagueRound"("status");
+
+ALTER TABLE "public"."ProLeagueRound" ADD CONSTRAINT "ProLeagueRound_seasonId_fkey"
+    FOREIGN KEY ("seasonId") REFERENCES "public"."ProLeagueSeason"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProLeagueMatch
+CREATE TABLE "public"."ProLeagueMatch" (
+    "id" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "roundId" TEXT NOT NULL,
+    "homeTeamId" TEXT NOT NULL,
+    "awayTeamId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "simulatedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "seed" BIGINT,
+    "engineVer" TEXT,
+    "replayId" TEXT,
+    "scoreHome" INTEGER,
+    "scoreAway" INTEGER,
+    "outcome" TEXT,
+    "touchdownCount" INTEGER,
+    "casualtyCount" INTEGER,
+    "turnoverCount" INTEGER,
+    "nuffleCount" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProLeagueMatch_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProLeagueMatch_replayId_key" ON "public"."ProLeagueMatch"("replayId");
+CREATE INDEX "ProLeagueMatch_seasonId_status_idx" ON "public"."ProLeagueMatch"("seasonId", "status");
+CREATE INDEX "ProLeagueMatch_roundId_idx" ON "public"."ProLeagueMatch"("roundId");
+CREATE INDEX "ProLeagueMatch_scheduledAt_idx" ON "public"."ProLeagueMatch"("scheduledAt");
+CREATE INDEX "ProLeagueMatch_homeTeamId_idx" ON "public"."ProLeagueMatch"("homeTeamId");
+CREATE INDEX "ProLeagueMatch_awayTeamId_idx" ON "public"."ProLeagueMatch"("awayTeamId");
+
+ALTER TABLE "public"."ProLeagueMatch" ADD CONSTRAINT "ProLeagueMatch_seasonId_fkey"
+    FOREIGN KEY ("seasonId") REFERENCES "public"."ProLeagueSeason"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProLeagueMatch" ADD CONSTRAINT "ProLeagueMatch_roundId_fkey"
+    FOREIGN KEY ("roundId") REFERENCES "public"."ProLeagueRound"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProLeagueMatch" ADD CONSTRAINT "ProLeagueMatch_homeTeamId_fkey"
+    FOREIGN KEY ("homeTeamId") REFERENCES "public"."ProTeam"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProLeagueMatch" ADD CONSTRAINT "ProLeagueMatch_awayTeamId_fkey"
+    FOREIGN KEY ("awayTeamId") REFERENCES "public"."ProTeam"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProLeagueStandings
+CREATE TABLE "public"."ProLeagueStandings" (
+    "id" TEXT NOT NULL,
+    "seasonId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "played" INTEGER NOT NULL DEFAULT 0,
+    "wins" INTEGER NOT NULL DEFAULT 0,
+    "draws" INTEGER NOT NULL DEFAULT 0,
+    "losses" INTEGER NOT NULL DEFAULT 0,
+    "points" INTEGER NOT NULL DEFAULT 0,
+    "tdFor" INTEGER NOT NULL DEFAULT 0,
+    "tdAgainst" INTEGER NOT NULL DEFAULT 0,
+    "casualtiesFor" INTEGER NOT NULL DEFAULT 0,
+    "casualtiesAgainst" INTEGER NOT NULL DEFAULT 0,
+    "form" JSONB NOT NULL DEFAULT '[]',
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProLeagueStandings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProLeagueStandings_seasonId_teamId_key" ON "public"."ProLeagueStandings"("seasonId", "teamId");
+CREATE INDEX "ProLeagueStandings_seasonId_points_tdFor_idx" ON "public"."ProLeagueStandings"("seasonId", "points", "tdFor");
+
+ALTER TABLE "public"."ProLeagueStandings" ADD CONSTRAINT "ProLeagueStandings_seasonId_fkey"
+    FOREIGN KEY ("seasonId") REFERENCES "public"."ProLeagueSeason"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProLeagueStandings" ADD CONSTRAINT "ProLeagueStandings_teamId_fkey"
+    FOREIGN KEY ("teamId") REFERENCES "public"."ProTeam"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1065,3 +1065,228 @@ model Feedback {
   @@index([status, createdAt])
   @@index([createdAt])
 }
+
+// =============================================================
+// Pro League — sprint Pro League lot 1.A.1
+// =============================================================
+//
+// Modeles dedies a la Pro League simulee (16 equipes round-robin,
+// 15 journees par saison). Distincts des modeles `League*` (ligues
+// joueur-vs-joueur).
+//
+// Le sim-engine reste source de verite pour les *profils tactiques*
+// et les *team values*. Cote DB on materialise uniquement l'etat
+// observable : equipes, rosters, calendrier, scores, classements.
+// Le replay binaire (events compresses) sera ajoute en 1.A.2.
+
+/// La Pro League elle-meme. Singleton au MVP ("Old World League").
+/// Le modele permet plusieurs ligues a terme (divisions, cross-leagues)
+/// via le slug unique.
+model ProLeague {
+  id          String   @id @default(cuid())
+  /// Slug stable, e.g. "old-world-league". Sert de cle naturelle
+  /// pour les URLs publiques /pro-league/...
+  slug        String   @unique
+  name        String
+  description String?
+  /// Branding optionnel (logo, devise, palette). JSON pour souplesse.
+  /// Exemple: { "motto": "Stand Firm", "primaryColor": "#7A1F1F" }
+  branding    Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  teams   ProTeam[]
+  seasons ProLeagueSeason[]
+}
+
+/// Une des 16 equipes Pro League (homages NFL x races BB).
+/// Cf. `packages/sim-engine/src/tactics/race-profiles.ts` pour la liste
+/// canonique. Le profil tactique (bashIndex, pace, etc.) reste dans le
+/// code (versionne avec engineVer) ; la DB stocke seulement les meta
+/// d'affichage et les pointeurs vers le sim.
+model ProTeam {
+  id             String    @id @default(cuid())
+  league         ProLeague @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  leagueId       String
+  /// Slug stable matchant `PRO_LEAGUE_TEAMS[i].id` dans race-profiles.ts.
+  /// Ex: "pit-smashers", "buf-snow-ogres", "gb-cheese-halflings".
+  slug           String    @unique
+  city           String
+  name           String
+  /// Nom de race BB lisible ("Orc", "Wood Elf", "Halfling", etc.).
+  race           String
+  /// Inspiration NFL pour le branding/storytelling.
+  nflFlavor      String?
+  primaryColor   String?
+  secondaryColor String?
+  /// Team value de base (gold pieces). Source de verite : race-profiles.ts.
+  /// Materialise ici pour lectures rapides + drift saisonnier.
+  baseTv         Int       @default(1000)
+  /// Meta libre (devises, headlines templates, fanbase size, etc.).
+  meta           Json?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  roster      ProTeamRoster[]
+  homeMatches ProLeagueMatch[]     @relation("ProMatchHome")
+  awayMatches ProLeagueMatch[]     @relation("ProMatchAway")
+  standings   ProLeagueStandings[]
+
+  @@index([leagueId])
+}
+
+/// Un joueur du roster d'une ProTeam. Couvre stats permanentes, forme
+/// courante, et casualties persistantes (lot 1.E.4 etendra).
+model ProTeamRoster {
+  id          String   @id @default(cuid())
+  team        ProTeam  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId      String
+  name        String
+  /// Position BB ("Lineman", "Blitzer", "Thrower", etc.).
+  position    String
+  /// Stats BB de base.
+  ma          Int
+  st          Int
+  ag          Int
+  /// PA optionnel (BB3 only ; nullable pour rosters Season 2).
+  pa          Int?
+  av          Int
+  /// Skills (slugs). JSON array de strings, ex: ["block","dodge"].
+  skills      Json
+  /// Lot 1.E.4 — casualties persistantes.
+  niggling    Int      @default(0)
+  maReduction Int      @default(0)
+  stReduction Int      @default(0)
+  agReduction Int      @default(0)
+  avReduction Int      @default(0)
+  /// Status : "active" | "injured" | "dead" | "retired".
+  status      String   @default("active")
+  /// Forme 0-100. Updated post-match.
+  form        Int      @default(50)
+  /// Stats carriere (TD, casualties, MVPs). JSON pour souplesse.
+  careerStats Json     @default("{}")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([teamId, status])
+}
+
+/// Une saison instancie une ProLeague pour une annee donnee. engineVer
+/// est gele a la creation pour garantir replay-determinisme.
+model ProLeagueSeason {
+  id        String    @id @default(cuid())
+  league    ProLeague @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  leagueId  String
+  year      Int
+  /// Status : "scheduled" | "in_progress" | "completed" | "archived".
+  status    String    @default("scheduled")
+  /// engineVer pinne a la creation. Tous les matches de cette saison
+  /// utilisent cette version pour la deterministe replay (lot 1.A.5).
+  engineVer String
+  startsAt  DateTime?
+  endsAt    DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  rounds    ProLeagueRound[]
+  matches   ProLeagueMatch[]
+  standings ProLeagueStandings[]
+
+  @@unique([leagueId, year])
+  @@index([status])
+}
+
+/// Une journee (matchday). 16 equipes round-robin = 15 journees x 8
+/// matchs/journee = 120 matches/saison.
+model ProLeagueRound {
+  id          String          @id @default(cuid())
+  season      ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId    String
+  /// 1..15 pour un round-robin classique.
+  roundNumber Int
+  /// Status : "pending" | "in_progress" | "completed".
+  status      String          @default("pending")
+  /// Date programmee (typiquement mardi 21h00).
+  scheduledAt DateTime?
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+
+  matches ProLeagueMatch[]
+
+  @@unique([seasonId, roundNumber])
+  @@index([status])
+}
+
+/// Un match Pro League. Le sim-engine produit un SimResult complet ;
+/// on materialise ici les champs queryables (status, score, outcome,
+/// counters) et on pointe vers `Replay` (lot 1.A.2) pour le payload
+/// binaire compresse.
+model ProLeagueMatch {
+  id             String          @id @default(cuid())
+  season         ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId       String
+  round          ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  roundId        String
+  homeTeam       ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
+  homeTeamId     String
+  awayTeam       ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
+  awayTeamId     String
+  /// Status : "scheduled" | "ready" | "in_progress" | "completed" | "failed".
+  /// "ready" = pre-simule, en attente du broadcaster (lot 1.B.1).
+  status         String          @default("scheduled")
+  scheduledAt    DateTime
+  simulatedAt    DateTime?
+  completedAt    DateTime?
+  /// Seed sim-engine + engineVer pinne au moment de la simulation.
+  /// Permet de rejouer le match a l'identique tant que engineVer matche.
+  seed           BigInt?
+  engineVer      String?
+  /// Pointeur vers `Replay.matchId` (lot 1.A.2). Pas de FK ici tant que
+  /// le modele Replay n'existe pas — sera converti en relation 1.A.2.
+  replayId       String?         @unique
+  /// Score cache pour listings rapides sans charger le replay.
+  scoreHome      Int?
+  scoreAway      Int?
+  /// Outcome : "home" | "away" | "draw".
+  outcome        String?
+  /// Compteurs caches issus de MatchSummary.
+  touchdownCount Int?
+  casualtyCount  Int?
+  turnoverCount  Int?
+  nuffleCount    Int?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+
+  @@index([seasonId, status])
+  @@index([roundId])
+  @@index([scheduledAt])
+  @@index([homeTeamId])
+  @@index([awayTeamId])
+}
+
+/// Classement par equipe / saison. Mis a jour atomiquement post-match.
+model ProLeagueStandings {
+  id                String          @id @default(cuid())
+  season            ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId          String
+  team              ProTeam         @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  teamId            String
+  played            Int             @default(0)
+  wins              Int             @default(0)
+  draws             Int             @default(0)
+  losses            Int             @default(0)
+  /// Points BB-style : 3W / 1D / 0L. Configurable par ligue (Phase 2).
+  points            Int             @default(0)
+  tdFor             Int             @default(0)
+  tdAgainst         Int             @default(0)
+  casualtiesFor     Int             @default(0)
+  casualtiesAgainst Int             @default(0)
+  /// Forme (5 derniers matchs). JSON array : ["W","D","L","W","W"].
+  form              Json            @default("[]")
+  updatedAt         DateTime        @updatedAt
+
+  @@unique([seasonId, teamId])
+  @@index([seasonId, points, tdFor])
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.A.1** — Prisma models pour la Pro League simulée.

### Modèles ajoutés

| Modèle | Rôle |
|---|---|
| `ProLeague` | Singleton "Old World League" + branding |
| `ProTeam` | 16 équipes (slug stable matchant `PRO_LEAGUE_TEAMS` du sim-engine), city, race, NFL flavor, palette couleurs, baseTv |
| `ProTeamRoster` | Joueurs avec stats BB (ma/st/ag/pa/av), skills, niggling/reductions persistantes (lot 1.E.4), forme, careerStats |
| `ProLeagueSeason` | Saison annuelle, engineVer pinné pour déterminisme replay (lot 1.A.5) |
| `ProLeagueRound` | Journées 1..15 du round-robin |
| `ProLeagueMatch` | Status, scheduledAt, seed, engineVer, replayId, scores cachés + counters (TD/cas/turnover/nuffle) |
| `ProLeagueStandings` | V/N/D/points/TD/cas par saison-équipe + form (5 derniers) |

### Fichiers modifiés

- `prisma/schema.prisma` : schéma postgres principal (+ 220 lignes)
- `apps/server/prisma/sqlite/schema.prisma` : mirror sqlite (Json → String)
- `prisma/migrations/20260506100000_add_pro_league/migration.sql` : migration SQL
- `apps/server/src/seeders/pro-league.ts` : seeder idempotent qui amorce les 16 équipes depuis `PRO_LEAGUE_TEAMS` (sim-engine = source de vérité pour TVs et profils tactiques)
- `apps/server/src/seed.ts` : branchement du seeder Pro League dans le seed principal

### Décisions de design

- **Slug stable** sur `ProTeam.slug` matchant `PRO_LEAGUE_TEAMS[i].id` (`pit-smashers`, `buf-snow-ogres`, etc.) → permet au sim-engine de remonter le profil tactique depuis un record DB.
- **Profils tactiques restent dans le code** (versionnés avec engineVer). La DB ne stocke que les meta d'affichage et les pointeurs.
- **engineVer pinné par saison** (`ProLeagueSeason.engineVer`) → garantie de déterminisme replay même si le sim-engine évolue.
- **`replayId` sans FK ici** (lot 1.A.2 introduira le modèle `Replay`).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm test` (server) → 1407/1407 ✓
- [x] `pnpm --filter @bb/sim-engine test` → 258/258 ✓
- [x] `pnpm lint` → 0 errors (warnings préexistants)
- [x] `prisma validate` postgres + sqlite → both valid
- [x] `prisma format` postgres + sqlite

## Suite

Lot 1.A.2 : modèle `Replay` + storage events compressé (CBOR + gzip).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_