### PR TITLE
feat(server): Pro League scheduler service (sprint 1.A.3)

### DIFF
--- a/apps/server/src/services/pro-league-scheduler.test.ts
+++ b/apps/server/src/services/pro-league-scheduler.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Sprint Pro League lot 1.A.3 — Tests du Pro League scheduler.
+ *
+ * Couvre :
+ *  - buildProLeagueSchedule : status invalides, < 2 équipes,
+ *    persistance rounds + matchs, basculement `in_progress`,
+ *    idempotence (no-op si déjà créé), respect de la cadence.
+ *  - regenerateProLeagueSchedule : refus si match déjà simulé,
+ *    suppression + reconstruction sinon.
+ *  - nextTuesdayKickoff : prochain mardi 21h00 UTC.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    proLeagueRound: {
+      count: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    proLeagueMatch: {
+      count: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    proTeam: {
+      findMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  buildProLeagueSchedule,
+  nextTuesdayKickoff,
+  regenerateProLeagueSchedule,
+} from "./pro-league-scheduler";
+
+interface MockedPrisma {
+  proLeagueSeason: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  proLeagueRound: {
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: {
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  proTeam: { findMany: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const SEASON_ID = "season_1";
+const LEAGUE_ID = "league_1";
+
+function makeTeams(count: number): Array<{ id: string; slug: string }> {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `team_${i + 1}`,
+    slug: `team-${i + 1}`,
+  }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default : transaction passes the same mocked tx (= prisma).
+  mocked.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+    return fn(prisma);
+  });
+});
+
+describe("buildProLeagueSchedule — sprint 1.A.3", () => {
+  it("erreur si la saison n'existe pas", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue(null);
+    await expect(buildProLeagueSchedule({ seasonId: SEASON_ID })).rejects.toThrow(
+      /introuvable/,
+    );
+  });
+
+  it("idempotent : ne touche à rien si rounds déjà créés", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "in_progress",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(15);
+    mocked.proLeagueMatch.count.mockResolvedValue(120);
+
+    const out = await buildProLeagueSchedule({ seasonId: SEASON_ID });
+    expect(out).toEqual({
+      seasonId: SEASON_ID,
+      roundsCreated: 15,
+      matchesCreated: 120,
+      idempotentSkip: true,
+    });
+    expect(mocked.proLeagueRound.create).not.toHaveBeenCalled();
+    expect(mocked.proLeagueMatch.create).not.toHaveBeenCalled();
+  });
+
+  it("erreur si status saison != 'scheduled' et aucun round existant", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "completed",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+
+    await expect(buildProLeagueSchedule({ seasonId: SEASON_ID })).rejects.toThrow(
+      /scheduled/,
+    );
+  });
+
+  it("erreur si moins de 2 équipes", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "scheduled",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+    mocked.proTeam.findMany.mockResolvedValue(makeTeams(1));
+
+    await expect(buildProLeagueSchedule({ seasonId: SEASON_ID })).rejects.toThrow(
+      /Au moins 2/,
+    );
+  });
+
+  it("crée 15 rounds + 120 matchs pour 16 équipes (round-robin classique)", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "scheduled",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+    mocked.proTeam.findMany.mockResolvedValue(makeTeams(16));
+    mocked.proLeagueRound.create.mockImplementation(async ({ data }) => ({
+      id: `round_${data.roundNumber}`,
+    }));
+    mocked.proLeagueMatch.create.mockResolvedValue({});
+    mocked.proLeagueSeason.update.mockResolvedValue({});
+
+    const out = await buildProLeagueSchedule({
+      seasonId: SEASON_ID,
+      firstRoundAt: new Date("2026-09-01T21:00:00Z"),
+    });
+
+    expect(out).toEqual({
+      seasonId: SEASON_ID,
+      roundsCreated: 15,
+      matchesCreated: 120,
+      idempotentSkip: false,
+    });
+    expect(mocked.proLeagueRound.create).toHaveBeenCalledTimes(15);
+    expect(mocked.proLeagueMatch.create).toHaveBeenCalledTimes(120);
+    // Saison passe à 'in_progress'.
+    expect(mocked.proLeagueSeason.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: SEASON_ID },
+        data: expect.objectContaining({ status: "in_progress" }),
+      }),
+    );
+  });
+
+  it("respecte la cadence : round N à firstRoundAt + (N-1)*cadence jours", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "scheduled",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+    mocked.proTeam.findMany.mockResolvedValue(makeTeams(4));
+    mocked.proLeagueRound.create.mockImplementation(async ({ data }) => ({
+      id: `round_${data.roundNumber}`,
+    }));
+    mocked.proLeagueMatch.create.mockResolvedValue({});
+    mocked.proLeagueSeason.update.mockResolvedValue({});
+
+    const baseDate = new Date("2026-09-01T21:00:00Z");
+    await buildProLeagueSchedule({
+      seasonId: SEASON_ID,
+      firstRoundAt: baseDate,
+      roundCadenceDays: 3,
+    });
+
+    const calls = mocked.proLeagueRound.create.mock.calls;
+    expect(calls).toHaveLength(3); // 4 équipes → 3 rounds
+    const round1Date = calls[0][0].data.scheduledAt as Date;
+    const round2Date = calls[1][0].data.scheduledAt as Date;
+    const round3Date = calls[2][0].data.scheduledAt as Date;
+    expect(round1Date.toISOString()).toBe("2026-09-01T21:00:00.000Z");
+    expect(round2Date.toISOString()).toBe("2026-09-04T21:00:00.000Z");
+    expect(round3Date.toISOString()).toBe("2026-09-07T21:00:00.000Z");
+  });
+
+  it("rejette une cadence négative ou nulle", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "scheduled",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+    mocked.proTeam.findMany.mockResolvedValue(makeTeams(4));
+
+    await expect(
+      buildProLeagueSchedule({ seasonId: SEASON_ID, roundCadenceDays: 0 }),
+    ).rejects.toThrow(/roundCadenceDays/);
+  });
+});
+
+describe("regenerateProLeagueSchedule — sprint 1.A.3", () => {
+  it("refuse si un match a déjà été simulé", async () => {
+    mocked.proLeagueMatch.count.mockResolvedValue(3);
+
+    await expect(
+      regenerateProLeagueSchedule({ seasonId: SEASON_ID }),
+    ).rejects.toThrow(/déjà simulé/);
+  });
+
+  it("supprime + reconstruit si aucun match joué", async () => {
+    mocked.proLeagueMatch.count
+      .mockResolvedValueOnce(0) // gating regen
+      .mockResolvedValue(0); // post-build idempotency check (avant rebuild)
+    mocked.proLeagueMatch.deleteMany.mockResolvedValue({ count: 0 });
+    mocked.proLeagueRound.deleteMany.mockResolvedValue({ count: 0 });
+    mocked.proLeagueSeason.update.mockResolvedValue({});
+    // Stub buildProLeagueSchedule path
+    mocked.proLeagueSeason.findUnique.mockResolvedValue({
+      id: SEASON_ID,
+      leagueId: LEAGUE_ID,
+      status: "scheduled",
+    });
+    mocked.proLeagueRound.count.mockResolvedValue(0);
+    mocked.proTeam.findMany.mockResolvedValue(makeTeams(4));
+    mocked.proLeagueRound.create.mockImplementation(async ({ data }) => ({
+      id: `round_${data.roundNumber}`,
+    }));
+    mocked.proLeagueMatch.create.mockResolvedValue({});
+
+    const out = await regenerateProLeagueSchedule({
+      seasonId: SEASON_ID,
+      firstRoundAt: new Date("2026-09-01T21:00:00Z"),
+    });
+
+    expect(out.idempotentSkip).toBe(false);
+    expect(mocked.proLeagueMatch.deleteMany).toHaveBeenCalled();
+    expect(mocked.proLeagueRound.deleteMany).toHaveBeenCalled();
+    // 4 équipes → 3 rounds, 6 matchs.
+    expect(out.roundsCreated).toBe(3);
+    expect(out.matchesCreated).toBe(6);
+  });
+});
+
+describe("nextTuesdayKickoff — sprint 1.A.3", () => {
+  it("renvoie le mardi 21h UTC strictement après une date donnée", () => {
+    // Lundi 2026-05-04 12:00:00 UTC → mardi 2026-05-05 21:00:00 UTC
+    const out = nextTuesdayKickoff(new Date("2026-05-04T12:00:00Z"));
+    expect(out.toISOString()).toBe("2026-05-05T21:00:00.000Z");
+  });
+
+  it("si on est mardi 21h pile, renvoie le mardi suivant", () => {
+    const out = nextTuesdayKickoff(new Date("2026-05-05T21:00:00Z"));
+    expect(out.toISOString()).toBe("2026-05-12T21:00:00.000Z");
+  });
+
+  it("si on est mardi mais avant 21h, renvoie le même mardi 21h", () => {
+    const out = nextTuesdayKickoff(new Date("2026-05-05T08:00:00Z"));
+    expect(out.toISOString()).toBe("2026-05-05T21:00:00.000Z");
+  });
+});

--- a/apps/server/src/services/pro-league-scheduler.ts
+++ b/apps/server/src/services/pro-league-scheduler.ts
@@ -1,0 +1,209 @@
+/**
+ * Pro League scheduler — sprint Pro League lot 1.A.3.
+ *
+ * Au démarrage d'une saison Pro League, génère le calendrier
+ * round-robin entre les 16 `ProTeam` de la ligue. Avec N=16 (pair) le
+ * round-robin "Berger" produit :
+ *   - 15 rounds (`ProLeagueRound`)
+ *   - 8 matchs/round (`ProLeagueMatch`)
+ *   - 120 matchs au total
+ *
+ * Cadence par défaut : 1 round par semaine, mardi 21h00 (heure UTC) ;
+ * paramétrable via `roundCadenceDays` (1 = quotidien pour beta testers).
+ *
+ * Contrats :
+ *  - Idempotent : si la saison contient déjà des rounds + matchs, le
+ *    service les conserve et ne crée rien (utiliser `regenerateSchedule`
+ *    pour reconstruire de zéro tant qu'aucun match n'est joué).
+ *  - Atomique : tout est créé en une seule transaction Prisma. Si la
+ *    transaction échoue, la base reste cohérente.
+ *  - Status saison : doit être `scheduled` au moment de l'appel ; après
+ *    succès la saison passe à `in_progress`.
+ *
+ * Le service ne touche pas au sim-engine — il prépare uniquement le
+ * calendrier. Le pré-sim (lot 1.A.4) consommera ces matchs.
+ */
+
+import { prisma } from "../prisma";
+import { generateRoundRobin } from "./league-schedule";
+
+/** Cadence par défaut entre deux rounds (jours). */
+export const DEFAULT_ROUND_CADENCE_DAYS = 7;
+
+/** Heure par défaut du kickoff (UTC). Mardi 21h00 = 21:00. */
+export const DEFAULT_KICKOFF_HOUR_UTC = 21;
+
+export interface BuildProLeagueScheduleInput {
+  readonly seasonId: string;
+  /** Date du round 1. Si null, prend "now() arrondi au prochain mardi 21h". */
+  readonly firstRoundAt?: Date | null;
+  /** Cadence en jours entre rounds. Default 7 (1/semaine). */
+  readonly roundCadenceDays?: number;
+}
+
+export interface BuildProLeagueScheduleResult {
+  readonly seasonId: string;
+  readonly roundsCreated: number;
+  readonly matchesCreated: number;
+  readonly idempotentSkip: boolean;
+}
+
+/**
+ * Renvoie le prochain mardi 21h00 UTC strictement après `from`. Utilisé
+ * comme défaut pour `firstRoundAt` quand le caller ne précise pas.
+ */
+export function nextTuesdayKickoff(from: Date): Date {
+  const d = new Date(from.getTime());
+  d.setUTCHours(DEFAULT_KICKOFF_HOUR_UTC, 0, 0, 0);
+  // 0 = dimanche, 1 = lundi, 2 = mardi, ...
+  const targetDow = 2;
+  let delta = (targetDow - d.getUTCDay() + 7) % 7;
+  // Si on est mardi 21h00 pile, on glisse au mardi suivant.
+  if (delta === 0 && d.getTime() <= from.getTime()) delta = 7;
+  d.setUTCDate(d.getUTCDate() + delta);
+  return d;
+}
+
+/**
+ * Construit le calendrier complet d'une saison Pro League. Idempotent.
+ */
+export async function buildProLeagueSchedule(
+  input: BuildProLeagueScheduleInput,
+): Promise<BuildProLeagueScheduleResult> {
+  const { seasonId } = input;
+
+  const season = await prisma.proLeagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { id: true, leagueId: true, status: true },
+  });
+  if (!season) {
+    throw new Error(`ProLeagueSeason '${seasonId}' introuvable`);
+  }
+
+  // Idempotency : si déjà des rounds + matchs, ne touche à rien.
+  const existing = await prisma.proLeagueRound.count({ where: { seasonId } });
+  if (existing > 0) {
+    const matchesCreated = await prisma.proLeagueMatch.count({
+      where: { seasonId },
+    });
+    return {
+      seasonId,
+      roundsCreated: existing,
+      matchesCreated,
+      idempotentSkip: true,
+    };
+  }
+
+  if (season.status !== "scheduled") {
+    throw new Error(
+      `La saison '${seasonId}' n'est pas en status 'scheduled' (actuel: '${season.status}')`,
+    );
+  }
+
+  const teams = await prisma.proTeam.findMany({
+    where: { leagueId: season.leagueId },
+    select: { id: true, slug: true },
+    orderBy: { slug: "asc" },
+  });
+
+  if (teams.length < 2) {
+    throw new Error(
+      `Au moins 2 équipes requises pour générer un calendrier (trouvé : ${teams.length})`,
+    );
+  }
+
+  const cadence = input.roundCadenceDays ?? DEFAULT_ROUND_CADENCE_DAYS;
+  if (!Number.isInteger(cadence) || cadence <= 0) {
+    throw new Error(`roundCadenceDays doit être un entier > 0 (reçu: ${cadence})`);
+  }
+
+  const baseDate =
+    input.firstRoundAt ?? nextTuesdayKickoff(new Date());
+
+  const rrRounds = generateRoundRobin({
+    participantIds: teams.map((t: { id: string }) => t.id),
+    doubleRoundRobin: false,
+  });
+
+  let roundsCreated = 0;
+  let matchesCreated = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    for (const rr of rrRounds) {
+      const scheduledAt = new Date(baseDate.getTime());
+      scheduledAt.setUTCDate(
+        baseDate.getUTCDate() + (rr.roundNumber - 1) * cadence,
+      );
+
+      const round = await tx.proLeagueRound.create({
+        data: {
+          seasonId,
+          roundNumber: rr.roundNumber,
+          status: "pending",
+          scheduledAt,
+        },
+        select: { id: true },
+      });
+      roundsCreated += 1;
+
+      for (const pairing of rr.pairings) {
+        await tx.proLeagueMatch.create({
+          data: {
+            seasonId,
+            roundId: round.id,
+            homeTeamId: pairing.home,
+            awayTeamId: pairing.away,
+            status: "scheduled",
+            scheduledAt,
+          },
+        });
+        matchesCreated += 1;
+      }
+    }
+
+    await tx.proLeagueSeason.update({
+      where: { id: seasonId },
+      data: { status: "in_progress", startsAt: baseDate },
+    });
+  });
+
+  return {
+    seasonId,
+    roundsCreated,
+    matchesCreated,
+    idempotentSkip: false,
+  };
+}
+
+/**
+ * Reconstruit le calendrier d'une saison déjà schedulée. Refuse si
+ * un match a déjà été simulé (status != 'scheduled') pour éviter
+ * d'effacer des résultats.
+ */
+export async function regenerateProLeagueSchedule(
+  input: BuildProLeagueScheduleInput,
+): Promise<BuildProLeagueScheduleResult> {
+  const { seasonId } = input;
+
+  const playedCount = await prisma.proLeagueMatch.count({
+    where: { seasonId, NOT: { status: "scheduled" } },
+  });
+  if (playedCount > 0) {
+    throw new Error(
+      `Impossible de régénérer le calendrier : ${playedCount} match(s) déjà simulé(s) ou en cours`,
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    await tx.proLeagueMatch.deleteMany({ where: { seasonId } });
+    await tx.proLeagueRound.deleteMany({ where: { seasonId } });
+    await tx.proLeagueSeason.update({
+      where: { id: seasonId },
+      data: { status: "scheduled" },
+    });
+  });
+
+  return buildProLeagueSchedule(input);
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.A.3** — Round-robin scheduler service.

### `apps/server/src/services/pro-league-scheduler.ts`

| Fonction | Rôle |
|---|---|
| `buildProLeagueSchedule(seasonId, opts)` | Génère 15 rounds × 8 matchs (round-robin Berger) pour les 16 ProTeam d'une saison. Idempotent + atomique. |
| `regenerateProLeagueSchedule(seasonId, opts)` | Reconstruit depuis zéro (refuse si match déjà simulé). |
| `nextTuesdayKickoff(from)` | Helper : prochain mardi 21h00 UTC strictement après `from`. |

### Décisions de design

- **Réutilise `generateRoundRobin`** (L.4) — fonction pure existante (méthode des cercles Berger).
- **Cadence configurable** (`roundCadenceDays`, default 7) → permet beta accélérée (1 round/jour).
- **Status saison gating** : doit être `scheduled` au démarrage, passe à `in_progress` post-succès.
- **Idempotency** : si rounds + matchs déjà présents, skip silencieux (renvoie comptes existants).
- **Atomicité** via `prisma.$transaction` — tout ou rien.

### Couverture tests (12/12 ✓)

| Cas | Résultat attendu |
|---|---|
| Saison inexistante | erreur "introuvable" |
| Status saison ≠ `scheduled` | erreur "scheduled" |
| < 2 équipes | erreur "Au moins 2" |
| Cadence ≤ 0 | erreur "roundCadenceDays" |
| 16 équipes, premier appel | 15 rounds + 120 matchs créés, saison → `in_progress` |
| 16 équipes, rappel | no-op (idempotentSkip) |
| Cadence 3 jours | round N à T0 + (N-1)×3j |
| Regenerate avec match simulé | refus |
| Regenerate sans match simulé | delete + rebuild |
| `nextTuesdayKickoff` lundi | renvoie mardi 21h UTC |
| `nextTuesdayKickoff` mardi 21h pile | renvoie mardi suivant |
| `nextTuesdayKickoff` mardi avant 21h | renvoie même mardi 21h |

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-league-scheduler.test.ts` → 12/12 ✓

## Suite

Lot 1.A.4 : `sim-runner.ts` — cron T-24h qui pré-simule les matchs de la prochaine journée et persiste `Replay`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_