### PR TITLE
feat(server): Pro League sim runner service (sprint 1.A.4)

### DIFF
--- a/apps/server/src/services/pro-league-sim-runner.test.ts
+++ b/apps/server/src/services/pro-league-sim-runner.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Sprint Pro League lot 1.A.4 — Tests du Pro League sim runner.
+ *
+ * Couvre :
+ *  - simulateProMatch : match introuvable, idempotence sur statuts
+ *    finaux, ProTeam slug invalide, simulation OK + persist Replay,
+ *    erreur sim → status `failed`.
+ *  - simulateUpcomingMatches : aucun match → 0/0, fenêtre 24h
+ *    respectée, agrégation des compteurs simulated/skipped/failed,
+ *    isolation des erreurs (un fail n'arrête pas le batch).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      findMany: vi.fn(),
+    },
+    replay: {
+      upsert: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@bb/sim-engine", async () => {
+  const actual = await vi.importActual<typeof import("@bb/sim-engine")>(
+    "@bb/sim-engine",
+  );
+  return {
+    ...actual,
+    // simulateMatch sera mocké individuellement par test ; default
+    // utilise la vraie implémentation pour vérifier le pipe complet.
+  };
+});
+
+import { prisma } from "../prisma";
+import * as simEngine from "@bb/sim-engine";
+
+import {
+  simulateProMatch,
+  simulateUpcomingMatches,
+} from "./pro-league-sim-runner";
+
+interface MockedPrisma {
+  proLeagueMatch: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  replay: { upsert: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const MATCH_ID = "match_abc123";
+
+function makeMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MATCH_ID,
+    status: "scheduled",
+    homeTeam: { slug: "pit-smashers", name: "Smashers" },
+    awayTeam: { slug: "kc-soaring-hawks", name: "Soaring Hawks" },
+    season: { engineVer: "0.13.0" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn(prisma),
+  );
+});
+
+describe("simulateProMatch — sprint 1.A.4", () => {
+  it("erreur si le match n'existe pas", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expect(simulateProMatch(MATCH_ID)).rejects.toThrow(/introuvable/);
+  });
+
+  it("idempotent : skip si status = 'ready'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({ status: "ready" }),
+    );
+    const out = await simulateProMatch(MATCH_ID);
+    expect(out).toBe(false);
+    expect(mocked.replay.upsert).not.toHaveBeenCalled();
+    expect(mocked.proLeagueMatch.update).not.toHaveBeenCalled();
+  });
+
+  it("idempotent : skip si status = 'completed'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({ status: "completed" }),
+    );
+    const out = await simulateProMatch(MATCH_ID);
+    expect(out).toBe(false);
+  });
+
+  it("erreur si slug ProTeam introuvable dans race-profiles", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({
+        homeTeam: { slug: "unknown-slug", name: "Foo" },
+      }),
+    );
+    await expect(simulateProMatch(MATCH_ID)).rejects.toThrow(/race-profiles/);
+  });
+
+  it("simule + persiste Replay + update Match (pipeline complet)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.upsert.mockResolvedValue({});
+    mocked.proLeagueMatch.update.mockResolvedValue({});
+
+    const out = await simulateProMatch(MATCH_ID);
+
+    expect(out).toBe(true);
+    expect(mocked.replay.upsert).toHaveBeenCalledTimes(1);
+    expect(mocked.proLeagueMatch.update).toHaveBeenCalledTimes(1);
+
+    // Vérifie quelques champs clés du upsert Replay.
+    const replayCall = mocked.replay.upsert.mock.calls[0][0];
+    expect(replayCall.where.matchId).toBe(MATCH_ID);
+    expect(replayCall.create.matchId).toBe(MATCH_ID);
+    expect(Buffer.isBuffer(replayCall.create.payload)).toBe(true);
+    expect(replayCall.create.durationMs).toBeGreaterThan(0);
+    expect(replayCall.create.rawJsonSize).toBeGreaterThan(0);
+    expect(Array.isArray(replayCall.create.highlights)).toBe(true);
+
+    // Vérifie le update du match.
+    const updateCall = mocked.proLeagueMatch.update.mock.calls[0][0];
+    expect(updateCall.where.id).toBe(MATCH_ID);
+    expect(updateCall.data.status).toBe("ready");
+    expect(updateCall.data.replayId).toBe(MATCH_ID);
+    expect(updateCall.data.engineVer).toBe("0.13.0");
+    expect(typeof updateCall.data.seed).toBe("bigint");
+    expect(["home", "away", "draw"]).toContain(updateCall.data.outcome);
+    expect(typeof updateCall.data.scoreHome).toBe("number");
+    expect(typeof updateCall.data.scoreAway).toBe("number");
+  });
+
+  it("seed déterministe : 2 appels successifs produisent le même résultat", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.upsert.mockResolvedValue({});
+    mocked.proLeagueMatch.update.mockResolvedValue({});
+
+    await simulateProMatch(MATCH_ID);
+    const seed1 = mocked.proLeagueMatch.update.mock.calls[0][0].data.seed;
+
+    vi.clearAllMocks();
+    mocked.$transaction.mockImplementation(
+      async (fn: (tx: unknown) => unknown) => fn(prisma),
+    );
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.upsert.mockResolvedValue({});
+    mocked.proLeagueMatch.update.mockResolvedValue({});
+
+    await simulateProMatch(MATCH_ID);
+    const seed2 = mocked.proLeagueMatch.update.mock.calls[0][0].data.seed;
+
+    expect(seed1).toBe(seed2);
+  });
+
+  it("marque le match 'failed' si simulateMatch throw", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    const spy = vi
+      .spyOn(simEngine, "simulateMatch")
+      .mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+    mocked.proLeagueMatch.update.mockResolvedValue({});
+
+    await expect(simulateProMatch(MATCH_ID)).rejects.toThrow(/boom/);
+
+    expect(mocked.proLeagueMatch.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: MATCH_ID },
+        data: expect.objectContaining({ status: "failed" }),
+      }),
+    );
+    expect(mocked.replay.upsert).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("simulateUpcomingMatches — sprint 1.A.4", () => {
+  it("renvoie zéros si aucun match dans la fenêtre", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const out = await simulateUpcomingMatches();
+    expect(out).toEqual({ simulated: 0, skipped: 0, failed: 0, inspected: 0 });
+  });
+
+  it("fenêtre par défaut 24h (gte now, lte now+24h)", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const now = new Date("2026-09-08T12:00:00Z");
+    await simulateUpcomingMatches({ now });
+
+    const where = mocked.proLeagueMatch.findMany.mock.calls[0][0].where;
+    expect(where.status).toBe("scheduled");
+    expect(where.scheduledAt.gte).toEqual(now);
+    expect(where.scheduledAt.lte).toEqual(new Date("2026-09-09T12:00:00Z"));
+  });
+
+  it("agrège correctement simulated / skipped / failed", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      { id: "m1" },
+      { id: "m2" },
+      { id: "m3" },
+    ]);
+    // m1 : déjà ready (skip)
+    // m2 : sim OK
+    // m3 : sim throw → failed
+    mocked.proLeagueMatch.findUnique.mockImplementation(({ where }) => {
+      if (where.id === "m1") {
+        return Promise.resolve(makeMatch({ id: "m1", status: "ready" }));
+      }
+      return Promise.resolve(makeMatch({ id: where.id }));
+    });
+    mocked.replay.upsert.mockResolvedValue({});
+    mocked.proLeagueMatch.update.mockResolvedValue({});
+
+    let simCallIdx = 0;
+    const spy = vi
+      .spyOn(simEngine, "simulateMatch")
+      .mockImplementation((input) => {
+        simCallIdx += 1;
+        if (simCallIdx === 2) {
+          throw new Error("boom on m3");
+        }
+        // m2 : passe par la vraie sim.
+        const real = vi.importActual<typeof import("@bb/sim-engine")>(
+          "@bb/sim-engine",
+        );
+        // sync fallback pour le test : juste retourner un faux résultat.
+        return {
+          result: "home",
+          events: [],
+          summary: {
+            outcome: "home",
+            score: { home: 2, away: 1 },
+            turnoverCount: 5,
+            touchdownCount: 3,
+            nuffleCount: 1,
+            underdogBoostCount: 0,
+            durationMs: 480_000,
+            momentum: [],
+          },
+          casualties: [],
+          engineVer: "0.13.0",
+        };
+      });
+
+    const out = await simulateUpcomingMatches();
+
+    expect(out.inspected).toBe(3);
+    expect(out.skipped).toBe(1);
+    expect(out.simulated).toBe(1);
+    expect(out.failed).toBe(1);
+    spy.mockRestore();
+  });
+
+  it("respecte maxBatchSize", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await simulateUpcomingMatches({ maxBatchSize: 5 });
+    const args = mocked.proLeagueMatch.findMany.mock.calls[0][0];
+    expect(args.take).toBe(5);
+  });
+});

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -1,0 +1,246 @@
+/**
+ * Pro League sim runner — sprint Pro League lot 1.A.4.
+ *
+ * Orchestre la pré-simulation des matchs `ProLeagueMatch` à T-24h :
+ *
+ *   1. Charge les matchs `scheduled` dont `scheduledAt < now + 24h`.
+ *   2. Pour chaque match, calcule un seed déterministe + invoke
+ *      `simulateMatch` (sim-engine).
+ *   3. Compresse les events via `compressEvents` (CBOR + gzip).
+ *   4. Persiste le `Replay` (upsert par `matchId`).
+ *   5. Met à jour `ProLeagueMatch` avec status `ready`, scores cachés,
+ *      counters, replayId, engineVer.
+ *
+ * Pas de worker dédié au MVP — exécuté in-process via `setInterval` à
+ * partir de `apps/server/src/index.ts` (cf. lot 1.A.4 sprint spec).
+ * L'interface (`simulateUpcomingMatches`, `simulateProMatch`) reste
+ * stable pour migration BullMQ ultérieure.
+ *
+ * Contrats :
+ *  - Idempotent : un match déjà `ready` / `in_progress` / `completed`
+ *    est skip.
+ *  - Erreur par match isolée : si la sim throw, le match passe à
+ *    `failed` avec `outcome=null` ; les autres matchs continuent.
+ *  - Le seed est dérivé du `matchId` (cuid) via un hash FNV1a 32-bit
+ *    pour rester déterministe et reproductible.
+ *  - `engineVer` est lu de `season.engineVer` (pinné lot 1.A.5) ou,
+ *    en fallback, de la version courante du sim-engine.
+ */
+
+import {
+  ENGINE_VER as CURRENT_ENGINE_VER,
+  PRO_LEAGUE_TEAM_BY_ID,
+  compressEvents,
+  computeCompressionStats,
+  simulateMatch,
+  type MatchEvent,
+  type SimInput,
+  type SimResult,
+} from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+/** Statuts de match qui n'ont plus besoin d'être simulés. */
+const FINAL_STATUSES = new Set(["ready", "in_progress", "completed"]);
+
+export interface SimulateUpcomingOptions {
+  /** Fenêtre temporelle à pré-simuler (ms). Default 24h. */
+  readonly windowMs?: number;
+  /** Si fourni, override de `now()`. Pratique pour tests. */
+  readonly now?: Date;
+  /** Limite max de matchs traités par appel (anti-runaway). Default 50. */
+  readonly maxBatchSize?: number;
+}
+
+export interface SimulateUpcomingResult {
+  readonly simulated: number;
+  readonly skipped: number;
+  readonly failed: number;
+  readonly inspected: number;
+}
+
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_BATCH = 50;
+
+/**
+ * Hash FNV1a 32-bit pour dériver un seed numérique d'un cuid string.
+ * Pas cryptographique — juste déterministe et bien distribué pour seeds.
+ */
+function hashSeed(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0; // unsigned 32-bit
+}
+
+/** Highlight pré-extrait pour Replay.highlights (lot 1.A.4 + UI 1.C.3). */
+interface ReplayHighlight {
+  readonly type: "TD" | "CASUALTY" | "NUFFLE";
+  readonly atMs: number;
+  readonly meta: Record<string, unknown>;
+}
+
+function extractHighlights(events: readonly MatchEvent[]): ReplayHighlight[] {
+  const out: ReplayHighlight[] = [];
+  for (const ev of events) {
+    if (ev.type === "TD" || ev.type === "CASUALTY" || ev.type === "NUFFLE") {
+      out.push({
+        type: ev.type,
+        atMs: ev.displayAtMs,
+        meta: (ev.meta as Record<string, unknown> | undefined) ?? {},
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Simule un seul match Pro League et persiste le résultat. Idempotent
+ * si le match est déjà `ready` ou plus avancé — renvoie alors `false`.
+ */
+export async function simulateProMatch(matchId: string): Promise<boolean> {
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    include: {
+      season: { select: { engineVer: true } },
+      homeTeam: { select: { slug: true, name: true } },
+      awayTeam: { select: { slug: true, name: true } },
+    },
+  });
+  if (!match) {
+    throw new Error(`ProLeagueMatch '${matchId}' introuvable`);
+  }
+
+  if (FINAL_STATUSES.has(match.status as string)) {
+    return false; // déjà simulé
+  }
+
+  const homeProfile = PRO_LEAGUE_TEAM_BY_ID[match.homeTeam.slug as string];
+  const awayProfile = PRO_LEAGUE_TEAM_BY_ID[match.awayTeam.slug as string];
+  if (!homeProfile || !awayProfile) {
+    throw new Error(
+      `ProTeam slug introuvable dans race-profiles : home='${match.homeTeam.slug}' away='${match.awayTeam.slug}'`,
+    );
+  }
+
+  const seed = hashSeed(matchId);
+  const engineVer = (match.season.engineVer as string) || CURRENT_ENGINE_VER;
+
+  const input: SimInput = {
+    seed,
+    home: {
+      id: homeProfile.id,
+      name: homeProfile.name,
+      side: "home",
+      tactics: homeProfile.tactics,
+      tv: homeProfile.tv,
+    },
+    away: {
+      id: awayProfile.id,
+      name: awayProfile.name,
+      side: "away",
+      tactics: awayProfile.tactics,
+      tv: awayProfile.tv,
+    },
+  };
+
+  let result: SimResult;
+  try {
+    result = simulateMatch(input);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    await prisma.proLeagueMatch.update({
+      where: { id: matchId },
+      data: { status: "failed", simulatedAt: new Date() },
+    });
+    throw new Error(`Sim failed for match '${matchId}': ${msg}`);
+  }
+
+  const compressed = await compressEvents(result.events);
+  const stats = computeCompressionStats(result.events, compressed);
+  const highlights = extractHighlights(result.events);
+
+  // Upsert Replay puis MAJ ProLeagueMatch en transaction pour cohérence.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    await tx.replay.upsert({
+      where: { matchId },
+      create: {
+        matchId,
+        payload: compressed,
+        highlights,
+        durationMs: result.summary.durationMs,
+        rawJsonSize: stats.rawJsonSize,
+      },
+      update: {
+        payload: compressed,
+        highlights,
+        durationMs: result.summary.durationMs,
+        rawJsonSize: stats.rawJsonSize,
+      },
+    });
+
+    await tx.proLeagueMatch.update({
+      where: { id: matchId },
+      data: {
+        status: "ready",
+        simulatedAt: new Date(),
+        seed: BigInt(seed),
+        engineVer,
+        replayId: matchId,
+        scoreHome: result.summary.score.home,
+        scoreAway: result.summary.score.away,
+        outcome: result.summary.outcome,
+        touchdownCount: result.summary.touchdownCount,
+        casualtyCount: result.casualties.length,
+        turnoverCount: result.summary.turnoverCount,
+        nuffleCount: result.summary.nuffleCount,
+      },
+    });
+  });
+
+  return true;
+}
+
+/**
+ * Simule tous les matchs `scheduled` dont `scheduledAt` tombe dans la
+ * fenêtre `[now, now + windowMs]`. Anti-runaway : limité à
+ * `maxBatchSize` matchs par appel.
+ *
+ * Erreur par match isolée : un échec ne bloque pas le batch.
+ */
+export async function simulateUpcomingMatches(
+  options: SimulateUpcomingOptions = {},
+): Promise<SimulateUpcomingResult> {
+  const now = options.now ?? new Date();
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const maxBatch = options.maxBatchSize ?? DEFAULT_MAX_BATCH;
+  const horizon = new Date(now.getTime() + windowMs);
+
+  const candidates = await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "scheduled",
+      scheduledAt: { gte: now, lte: horizon },
+    },
+    select: { id: true },
+    orderBy: { scheduledAt: "asc" },
+    take: maxBatch,
+  });
+
+  let simulated = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const { id } of candidates) {
+    try {
+      const ok = await simulateProMatch(id);
+      if (ok) simulated += 1;
+      else skipped += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+
+  return { simulated, skipped, failed, inspected: candidates.length };
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.A.4** — In-process sim runner service.

### `apps/server/src/services/pro-league-sim-runner.ts`

| Fonction | Rôle |
|---|---|
| `simulateProMatch(matchId)` | Simule **un** match : sim-engine → compressEvents → upsert Replay → update Match. Idempotent (skip si déjà `ready`+). Renvoie `true` si simulé, `false` si skip. |
| `simulateUpcomingMatches(opts)` | Simule **un batch** : trouve les matchs `scheduled` dans la fenêtre `[now, now+24h]` et appelle `simulateProMatch` sur chacun. Erreur par match isolée. |

### Pipeline par match (5 étapes)

1. **findUnique** : charge match + season.engineVer + slugs des équipes
2. **simulateMatch** (sim-engine) : seed FNV1a déterministe du matchId, profils tactiques + TVs résolus depuis `PRO_LEAGUE_TEAM_BY_ID`
3. **compressEvents** : CBOR + gzip → `Buffer`
4. **replay.upsert** : Replay { matchId, payload, highlights, durationMs, rawJsonSize } (atomique)
5. **proLeagueMatch.update** : status=`ready`, simulatedAt, seed, engineVer, replayId, scoreHome, scoreAway, outcome, counters

Étapes 4-5 dans une seule `$transaction` pour garantir cohérence Replay ↔ Match.

### Highlights

`Replay.highlights` est pré-extrait au moment de la persistance — sous-ensemble JSON compact (TD, CAS, NUFFLE) consommable par l'UI sans décompresser le payload binaire.

### Idempotence + erreurs

- Match déjà `ready` / `in_progress` / `completed` → skip silencieux (renvoie `false`)
- `simulateMatch` throw → match passe à `failed`, l'erreur est propagée
- `simulateUpcomingMatches` : un fail isolé ne bloque pas le batch (compteurs `simulated` / `skipped` / `failed`)

### Boot integration

Pas activé au boot dans cette PR — l'interface est prête pour intégration via `setInterval` dans `index.ts` (pattern existant déjà utilisé par `league-forfeit`). Activation séparée pour rester conservateur (le seed-only de la PR ne déclenche pas de simulations en prod).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-league-sim-runner.test.ts` → **11/11 ✓**

Couverture :
| Cas | Résultat |
|---|---|
| Match introuvable | erreur "introuvable" |
| Status `ready` / `completed` | skip (false) |
| Slug invalide | erreur "race-profiles" |
| Pipeline OK | upsert + update appelés, champs corrects |
| Seed déterministe | 2 appels → même seed |
| `simulateMatch` throw | match `failed`, erreur propagée |
| `simulateUpcoming` batch vide | 0/0/0/0 |
| Fenêtre 24h | `gte: now`, `lte: now+24h` |
| Mix skipped/simulated/failed | comptage correct |
| `maxBatchSize` | propagé à findMany.take |

## Suite

Lot 1.A.5 : `engineVer` freeze + replay versioning policy (read-only sur replays anciens, fallback engine version pinnée si simulation fail).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_