### PR TITLE
feat(server): engine version policy + replay freeze (sprint 1.A.5)

### DIFF
--- a/apps/server/src/services/pro-league-engine-version.test.ts
+++ b/apps/server/src/services/pro-league-engine-version.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Sprint Pro League lot 1.A.5 — Tests engine version policy.
+ *
+ * Couvre :
+ *  - assertSimulationAllowed : OK quand current = season = match,
+ *    refus quand season ≠ current, refus quand match ≠ current.
+ *  - isReplayReadOnly : true si version replay ≠ current.
+ *  - describeVersionStatus : descripteur lisible avec flags.
+ *  - EngineVersionMismatchError : attributes (code, pinnedVersion,
+ *    currentVersion, context).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  CURRENT_ENGINE_VER,
+  EngineVersionMismatchError,
+  assertSimulationAllowed,
+  describeVersionStatus,
+  isReplayReadOnly,
+} from "./pro-league-engine-version";
+
+const OTHER_VER = "9.99.99-test";
+
+describe("assertSimulationAllowed — sprint 1.A.5", () => {
+  it("OK quand season pinned = current et match jamais simulé", () => {
+    expect(() =>
+      assertSimulationAllowed({
+        engineVer: null,
+        season: { id: "s1", engineVer: CURRENT_ENGINE_VER },
+      }),
+    ).not.toThrow();
+  });
+
+  it("OK quand season + match = current", () => {
+    expect(() =>
+      assertSimulationAllowed({
+        engineVer: CURRENT_ENGINE_VER,
+        season: { id: "s1", engineVer: CURRENT_ENGINE_VER },
+      }),
+    ).not.toThrow();
+  });
+
+  it("refuse si season pinned à une autre version", () => {
+    expect(() =>
+      assertSimulationAllowed({
+        engineVer: null,
+        season: { id: "s1", engineVer: OTHER_VER },
+      }),
+    ).toThrow(EngineVersionMismatchError);
+  });
+
+  it("refuse si match déjà simulé avec une autre version", () => {
+    expect(() =>
+      assertSimulationAllowed({
+        engineVer: OTHER_VER,
+        season: { id: "s1", engineVer: CURRENT_ENGINE_VER },
+      }),
+    ).toThrow(EngineVersionMismatchError);
+  });
+
+  it("erreur expose pinnedVersion / currentVersion / context", () => {
+    try {
+      assertSimulationAllowed({
+        engineVer: null,
+        season: { id: "s42", engineVer: OTHER_VER },
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EngineVersionMismatchError);
+      const e = err as EngineVersionMismatchError;
+      expect(e.code).toBe("ENGINE_VERSION_MISMATCH");
+      expect(e.pinnedVersion).toBe(OTHER_VER);
+      expect(e.currentVersion).toBe(CURRENT_ENGINE_VER);
+      expect(e.context).toContain("season s42");
+    }
+  });
+});
+
+describe("isReplayReadOnly — sprint 1.A.5", () => {
+  it("false quand engineVer match current", () => {
+    expect(isReplayReadOnly({ engineVer: CURRENT_ENGINE_VER })).toBe(false);
+  });
+
+  it("true quand engineVer ≠ current", () => {
+    expect(isReplayReadOnly({ engineVer: OTHER_VER })).toBe(true);
+  });
+});
+
+describe("describeVersionStatus — sprint 1.A.5", () => {
+  it("canSimulate=true + readOnly=false sur match aligned", () => {
+    const out = describeVersionStatus({
+      engineVer: null,
+      season: { id: "s1", engineVer: CURRENT_ENGINE_VER },
+    });
+    expect(out.canSimulate).toBe(true);
+    expect(out.isReplayReadOnly).toBe(false);
+    expect(out.currentEngine).toBe(CURRENT_ENGINE_VER);
+    expect(out.pinnedSeasonEngine).toBe(CURRENT_ENGINE_VER);
+    expect(out.matchEngine).toBeNull();
+  });
+
+  it("canSimulate=false + readOnly=true sur match avec ancien engineVer", () => {
+    const out = describeVersionStatus({
+      engineVer: OTHER_VER,
+      season: { id: "s1", engineVer: CURRENT_ENGINE_VER },
+    });
+    expect(out.canSimulate).toBe(false);
+    expect(out.isReplayReadOnly).toBe(true);
+    expect(out.matchEngine).toBe(OTHER_VER);
+  });
+
+  it("canSimulate=false sur saison pinnée à une autre version", () => {
+    const out = describeVersionStatus({
+      engineVer: null,
+      season: { id: "s1", engineVer: OTHER_VER },
+    });
+    expect(out.canSimulate).toBe(false);
+    // Match pas encore simulé → pas read-only
+    expect(out.isReplayReadOnly).toBe(false);
+  });
+});

--- a/apps/server/src/services/pro-league-engine-version.ts
+++ b/apps/server/src/services/pro-league-engine-version.ts
@@ -1,0 +1,145 @@
+/**
+ * Pro League — engine version policy (sprint Pro League lot 1.A.5).
+ *
+ * Garantit la cohérence entre :
+ *  - `ProLeagueSeason.engineVer` : version pinnée à la création de la
+ *    saison (lot 1.A.1, set par le service qui crée la saison).
+ *  - `ProLeagueMatch.engineVer` : version utilisée au moment de la sim
+ *    (lot 1.A.4, écrit par `simulateProMatch`).
+ *  - `ENGINE_VER` (sim-engine) : version courante du package.
+ *
+ * Règles :
+ *
+ *  1. **Pinning saison** : on ne peut simuler un match d'une saison que
+ *     si `season.engineVer === ENGINE_VER`. Si l'engine évolue en
+ *     cours de saison, les nouveaux matchs sont bloqués → lever une
+ *     `EngineVersionMismatchError`. L'admin doit alors soit créer une
+ *     nouvelle saison, soit déployer le pinned engine en production.
+ *
+ *  2. **Replay read-only** : un Replay produit avec `engineVer = X`
+ *     reste read-only pour `ENGINE_VER ≠ X`. Permet de re-jouer le
+ *     replay (consommation de payload) mais bloque la re-simulation
+ *     (qui produirait un payload différent).
+ *
+ *  3. **Fallback simulation fail** (spec sprint) : si la sim throw
+ *     pour des raisons non liées à la version (bug runtime, OOM...),
+ *     l'erreur est propagée mais le match est marqué `failed` ; un
+ *     replay "pinned" peut être reconstruit côté admin via
+ *     `regenerateReplay` (à implémenter côté admin tools — exposé via
+ *     l'interface `simulateProMatch` qui upsert le Replay).
+ *
+ * Ce service ne fait aucun I/O direct : il opère sur des records DB
+ * passés en argument. Le sim-runner (1.A.4) consomme
+ * `assertSimulationAllowed` avant chaque sim.
+ */
+
+import { ENGINE_VER as CURRENT_ENGINE_VER } from "@bb/sim-engine";
+
+export { CURRENT_ENGINE_VER };
+
+/**
+ * Levée quand on tente de simuler / re-simuler un match alors que
+ * l'engine courant ne match pas la version pinnée. Le code consommateur
+ * doit attraper cette erreur explicitement (ne pas marquer le match
+ * `failed` car ce n'est pas une erreur de simulation à proprement parler).
+ */
+export class EngineVersionMismatchError extends Error {
+  readonly code = "ENGINE_VERSION_MISMATCH";
+  constructor(
+    readonly pinnedVersion: string,
+    readonly currentVersion: string,
+    readonly context: string,
+  ) {
+    super(
+      `Engine version mismatch (${context}) : pinned='${pinnedVersion}', current='${currentVersion}'. ` +
+        `Replay/sim refused to avoid producing inconsistent payloads.`,
+    );
+    this.name = "EngineVersionMismatchError";
+  }
+}
+
+export interface SeasonVersionRef {
+  readonly id: string;
+  readonly engineVer: string;
+}
+
+export interface MatchVersionRef {
+  /** `null` si le match n'a jamais été simulé (status `scheduled`). */
+  readonly engineVer: string | null;
+  readonly season: SeasonVersionRef;
+}
+
+export interface ReplayVersionRef {
+  /** `engineVer` de la version qui a produit ce replay. */
+  readonly engineVer: string;
+}
+
+/**
+ * Vérifie qu'on peut simuler ce match avec l'engine courant.
+ * - Si `season.engineVer ≠ ENGINE_VER` : refuse (saison pinnée à une
+ *   autre version, on ne peut pas garantir la cohérence du replay).
+ * - Si `match.engineVer ≠ null` ET `≠ ENGINE_VER` : refuse aussi
+ *   (re-simulation avec une autre version produirait un replay
+ *   incohérent avec l'engineVer stocké).
+ *
+ * Utilisé par `simulateProMatch` (sim-runner 1.A.4) avant chaque sim.
+ */
+export function assertSimulationAllowed(match: MatchVersionRef): void {
+  if (match.season.engineVer !== CURRENT_ENGINE_VER) {
+    throw new EngineVersionMismatchError(
+      match.season.engineVer,
+      CURRENT_ENGINE_VER,
+      `season ${match.season.id}`,
+    );
+  }
+  if (match.engineVer !== null && match.engineVer !== CURRENT_ENGINE_VER) {
+    throw new EngineVersionMismatchError(
+      match.engineVer,
+      CURRENT_ENGINE_VER,
+      `match (already simulated with a different engine)`,
+    );
+  }
+}
+
+/**
+ * Vrai si le replay est en mode read-only pour l'engine courant.
+ * Le payload reste consommable (broadcaster pour spectate / replay UI)
+ * mais on ne doit pas tenter de le re-simuler. Tout flux qui veut
+ * "rebuild" un replay doit d'abord vérifier ce flag.
+ */
+export function isReplayReadOnly(replay: ReplayVersionRef): boolean {
+  return replay.engineVer !== CURRENT_ENGINE_VER;
+}
+
+/**
+ * Helper pour les routes admin qui exposent l'état de versioning d'un
+ * match : renvoie un descripteur lisible avec le statut versioning.
+ */
+export interface VersionStatus {
+  readonly currentEngine: string;
+  readonly pinnedSeasonEngine: string;
+  readonly matchEngine: string | null;
+  readonly canSimulate: boolean;
+  readonly isReplayReadOnly: boolean;
+}
+
+export function describeVersionStatus(match: MatchVersionRef): VersionStatus {
+  let canSimulate = true;
+  try {
+    assertSimulationAllowed(match);
+  } catch (err) {
+    if (err instanceof EngineVersionMismatchError) {
+      canSimulate = false;
+    } else {
+      throw err;
+    }
+  }
+  return {
+    currentEngine: CURRENT_ENGINE_VER,
+    pinnedSeasonEngine: match.season.engineVer,
+    matchEngine: match.engineVer,
+    canSimulate,
+    isReplayReadOnly:
+      match.engineVer !== null && match.engineVer !== CURRENT_ENGINE_VER,
+  };
+}

--- a/apps/server/src/services/pro-league-sim-runner.test.ts
+++ b/apps/server/src/services/pro-league-sim-runner.test.ts
@@ -164,6 +164,33 @@ describe("simulateProMatch — sprint 1.A.4", () => {
     expect(seed1).toBe(seed2);
   });
 
+  it("refuse de simuler si la saison est pinnée à un autre engineVer", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({ season: { id: "s1", engineVer: "9.99.99-pinned" } }),
+    );
+
+    await expect(simulateProMatch(MATCH_ID)).rejects.toThrow(
+      /Engine version mismatch/,
+    );
+    expect(mocked.replay.upsert).not.toHaveBeenCalled();
+    // Le match n'est PAS marqué `failed` — un mismatch n'est pas un
+    // échec de sim mais un refus de policy.
+    expect(mocked.proLeagueMatch.update).not.toHaveBeenCalled();
+  });
+
+  it("refuse de re-simuler un match déjà sim avec un autre engineVer", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({
+        status: "failed",
+        engineVer: "9.99.99-old",
+      }),
+    );
+
+    await expect(simulateProMatch(MATCH_ID)).rejects.toThrow(
+      /Engine version mismatch/,
+    );
+  });
+
   it("marque le match 'failed' si simulateMatch throw", async () => {
     mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
     const spy = vi
@@ -190,7 +217,13 @@ describe("simulateUpcomingMatches — sprint 1.A.4", () => {
   it("renvoie zéros si aucun match dans la fenêtre", async () => {
     mocked.proLeagueMatch.findMany.mockResolvedValue([]);
     const out = await simulateUpcomingMatches();
-    expect(out).toEqual({ simulated: 0, skipped: 0, failed: 0, inspected: 0 });
+    expect(out).toEqual({
+      simulated: 0,
+      skipped: 0,
+      failed: 0,
+      versionMismatched: 0,
+      inspected: 0,
+    });
   });
 
   it("fenêtre par défaut 24h (gte now, lte now+24h)", async () => {

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -39,6 +39,10 @@ import {
 } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import {
+  EngineVersionMismatchError,
+  assertSimulationAllowed,
+} from "./pro-league-engine-version";
 
 /** Statuts de match qui n'ont plus besoin d'être simulés. */
 const FINAL_STATUSES = new Set(["ready", "in_progress", "completed"]);
@@ -56,6 +60,9 @@ export interface SimulateUpcomingResult {
   readonly simulated: number;
   readonly skipped: number;
   readonly failed: number;
+  /** Lot 1.A.5 — matchs refusés car la version courante du sim-engine
+   *  ne match pas la version pinnée sur la saison ou le match. */
+  readonly versionMismatched: number;
   readonly inspected: number;
 }
 
@@ -104,7 +111,7 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
   const match = await prisma.proLeagueMatch.findUnique({
     where: { id: matchId },
     include: {
-      season: { select: { engineVer: true } },
+      season: { select: { id: true, engineVer: true } },
       homeTeam: { select: { slug: true, name: true } },
       awayTeam: { select: { slug: true, name: true } },
     },
@@ -116,6 +123,17 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
   if (FINAL_STATUSES.has(match.status as string)) {
     return false; // déjà simulé
   }
+
+  // Lot 1.A.5 — gating engineVer : refuse de simuler si la version
+  // courante ne match pas la version pinnée sur la saison ou (en cas
+  // de re-simulation) sur le match. Lève EngineVersionMismatchError.
+  assertSimulationAllowed({
+    engineVer: (match.engineVer as string | null) ?? null,
+    season: {
+      id: match.season.id as string,
+      engineVer: match.season.engineVer as string,
+    },
+  });
 
   const homeProfile = PRO_LEAGUE_TEAM_BY_ID[match.homeTeam.slug as string];
   const awayProfile = PRO_LEAGUE_TEAM_BY_ID[match.awayTeam.slug as string];
@@ -232,15 +250,26 @@ export async function simulateUpcomingMatches(
   let simulated = 0;
   let skipped = 0;
   let failed = 0;
+  let versionMismatched = 0;
   for (const { id } of candidates) {
     try {
       const ok = await simulateProMatch(id);
       if (ok) simulated += 1;
       else skipped += 1;
-    } catch {
-      failed += 1;
+    } catch (err) {
+      if (err instanceof EngineVersionMismatchError) {
+        versionMismatched += 1;
+      } else {
+        failed += 1;
+      }
     }
   }
 
-  return { simulated, skipped, failed, inspected: candidates.length };
+  return {
+    simulated,
+    skipped,
+    failed,
+    versionMismatched,
+    inspected: candidates.length,
+  };
 }


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.A.5** — Engine version policy + replay freeze.

🎯 **Avec ce PR, le bloc 1.A (data model + scheduler + sim runner + versioning) est complet.**

### Nouveau : `pro-league-engine-version.ts`

| API | Rôle |
|---|---|
| `assertSimulationAllowed(match)` | Refuse de simuler si saison ou match pinné à un autre `engineVer` que le courant. Lève `EngineVersionMismatchError`. |
| `isReplayReadOnly(replay)` | Helper broadcaster / admin : true si `engineVer ≠ current`. |
| `describeVersionStatus(match)` | Descripteur lisible (canSimulate, isReplayReadOnly, currentEngine, pinnedSeasonEngine, matchEngine) pour routes admin. |
| `EngineVersionMismatchError` | Erreur typée (`code='ENGINE_VERSION_MISMATCH'`, `pinnedVersion`, `currentVersion`, `context`). |

### Hardening sim-runner (1.A.4)

- `simulateProMatch` appelle `assertSimulationAllowed` **après** le check d'idempotence et **avant** la simulation. Un mismatch n'est **pas** un échec de sim → le match n'est **pas** marqué `failed`.
- `SimulateUpcomingResult` gagne un champ `versionMismatched` (séparé de `failed`) → l'ops peut distinguer mismatch policy vs bug runtime.

### Règles métier

1. **Pinning saison** : `season.engineVer` pinné à la création garantit que tous les matchs d'une saison utilisent la même version. Si l'engine évolue entre 2 saisons → 2 saisons pinnées à versions différentes.
2. **Replay read-only** : un Replay produit avec engineVer X reste consommable (broadcaster) mais bloqué en re-simulation.
3. **Fallback fail** : la policy mismatch et l'erreur runtime sont propagées **séparément** pour permettre aux ops d'identifier la cause (`EngineVersionMismatchError` vs autre).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-league-{engine-version,sim-runner,scheduler}.test.ts` → **35/35 ✓**

Couverture (10 nouveaux tests sur version policy + 2 sur sim-runner) :

| Cas | Résultat |
|---|---|
| `assertSimulationAllowed` aligned (season + match = current) | OK |
| Saison pinnée autre version | `EngineVersionMismatchError` |
| Match déjà sim avec autre version | `EngineVersionMismatchError` |
| Erreur expose `code` / `pinnedVersion` / `currentVersion` / `context` | OK |
| `isReplayReadOnly` aligned/diverged | false/true |
| `describeVersionStatus` aligned/readonly/cantSimulate | bons flags |
| `simulateProMatch` refuse si season pinned autre version | erreur propagée, match pas marqué `failed` |
| `simulateProMatch` refuse re-sim si match déjà sim autre version | erreur propagée |
| `simulateUpcomingMatches` retourne `versionMismatched` | OK |

## Bloc 1.A — récap

| Lot | PR | État |
|---|---|---|
| 1.A.1 — Prisma models | #597 | ✅ mergé |
| 1.A.2 — Replay + compression | #598 | ✅ mergé |
| 1.A.3 — Round-robin scheduler | #599 | ✅ mergé |
| 1.A.4 — Sim runner | #600 | ✅ mergé |
| 1.A.5 — Engine version policy | _this PR_ | ⏳ |

## Suite

Au choix :
- **Lot 1.B** : broadcaster SSE + spectate UI (live match streaming)
- **Lot 1.E.4** : casualties persistantes (DB layer)
- **Activation cron** : brancher `simulateUpcomingMatches` dans `index.ts` via `setInterval`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_