### PR TITLE
feat(server): activate Pro League sim runner cron at boot

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -590,3 +590,40 @@ if (!inTestForfeitEnv && tickMs > 0) {
     }, tickMs).unref();
   });
 }
+
+// =============================================================================
+// Pro League sim-runner cron (sprint Pro League lot 1.A.4 — activation).
+// =============================================================================
+// Pre-simule les matchs ProLeague dont scheduledAt tombe dans les
+// prochaines 24h. Persiste Replay + met a jour ProLeagueMatch.
+//
+// Tick par defaut : 10 min. Configurable via PRO_LEAGUE_SIM_RUNNER_TICK_MS.
+// Mettre = 0 pour desactiver (CI / dev local sans side-effects).
+const inTestSimRunnerEnv =
+  process.env.NODE_ENV === "test" || process.env.TEST_SQLITE === "1";
+const simRunnerTickMsEnv = Number(process.env.PRO_LEAGUE_SIM_RUNNER_TICK_MS);
+const simRunnerTickMs = Number.isFinite(simRunnerTickMsEnv)
+  ? simRunnerTickMsEnv
+  : 10 * 60 * 1000;
+if (!inTestSimRunnerEnv && simRunnerTickMs > 0) {
+  void import("./services/pro-league-sim-runner").then(
+    ({ simulateUpcomingMatches }) => {
+      const tick = async () => {
+        try {
+          const out = await simulateUpcomingMatches();
+          if (out.simulated > 0 || out.failed > 0 || out.versionMismatched > 0) {
+            serverLog.info(
+              `[pro-league-sim] tick: simulated=${out.simulated} skipped=${out.skipped} failed=${out.failed} versionMismatched=${out.versionMismatched} (inspected=${out.inspected})`,
+            );
+          }
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : "unknown";
+          serverLog.error(`[pro-league-sim] tick failed: ${msg}`);
+        }
+      };
+      setInterval(() => {
+        void tick();
+      }, simRunnerTickMs).unref();
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Active la chaîne complète **scheduler → sim-runner → DB** en prod.

Branche `simulateUpcomingMatches` (lot 1.A.4) au démarrage du serveur via `setInterval`. Pattern miroir du cron `league-forfeit` existant :

- **Tick par défaut** : 10 minutes (configurable via `PRO_LEAGUE_SIM_RUNNER_TICK_MS`)
- **Désactivé en test** : `NODE_ENV=test` ou `TEST_SQLITE=1`
- **Off switch** : `PRO_LEAGUE_SIM_RUNNER_TICK_MS=0`
- **Import dynamique** + `.unref()` (idem league-forfeit)
- **Logs** : seulement si simulated/failed/versionMismatched > 0 (sinon silence)

## Effet en prod

À chaque boot, et toutes les 10 min ensuite :
1. Charge les `ProLeagueMatch` `scheduled` avec `scheduledAt ∈ [now, now+24h]`
2. Pour chaque, simule via sim-engine (engine version pinning vérifié — lot 1.A.5)
3. Persiste `Replay` + met à jour `ProLeagueMatch` (status=ready, score, counters)

Tant qu'aucun `ProLeagueSeason` actif n'existe en DB, le cron ne fait rien (no-op silencieux). Un admin peut créer une saison via `seedProLeague` (lot 1.A.1) puis appeler `buildProLeagueSchedule` (lot 1.A.3) pour amorcer la chaîne.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] Tests existants (sim-runner, scheduler, version-policy) inchangés (déjà mockés)
- [x] Le cron est désactivé en `TEST_SQLITE=1` → pas d'impact CI

## Suite

Lot **1.B** : broadcaster SSE + spectate UI (live match streaming).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_