### PR TITLE
feat(server): Pro League match broadcaster (sprint 1.B.1)

### DIFF
--- a/apps/server/src/services/pro-league-match-broadcaster.test.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Sprint Pro League lot 1.B.1 — Tests du match broadcaster.
+ *
+ * Couvre :
+ *  - subscribeToMatch : match introuvable, status non broadcastable,
+ *    replay manquant, fan-out vers N subscribers, catch-up, tick.
+ *  - preloadMatch : pré-charge sans subscriber.
+ *  - getBroadcasterStats : compteurs activeSessions / totalSubscribers.
+ *  - unsubscribe : retire le listener + auto-reap.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { compressEvents, type MatchEvent } from "@bb/sim-engine";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: {
+      findUnique: vi.fn(),
+    },
+    replay: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+
+import {
+  __resetBroadcasterForTesting,
+  getBroadcasterStats,
+  preloadMatch,
+  subscribeToMatch,
+} from "./pro-league-match-broadcaster";
+
+interface MockedPrisma {
+  proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const MATCH_ID = "match_xyz";
+
+function makeEvents(): MatchEvent[] {
+  return [
+    {
+      type: "KICKOFF",
+      displayAtMs: 0,
+      engineVer: "0.13.0",
+      seed: 1,
+      meta: { home: "h", away: "a" },
+    },
+    {
+      type: "TURN_START",
+      displayAtMs: 30_000,
+      engineVer: "0.13.0",
+      meta: { half: 1, turn: 1, drivingTeam: "home", ballYardline: 4 },
+    },
+    {
+      type: "TD",
+      displayAtMs: 60_000,
+      engineVer: "0.13.0",
+      meta: { team: "home", half: 1, turn: 2 },
+    },
+  ];
+}
+
+async function mockReplay(events: MatchEvent[]): Promise<void> {
+  const compressed = await compressEvents(events);
+  mocked.replay.findUnique.mockResolvedValue({ payload: compressed });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  __resetBroadcasterForTesting();
+});
+
+afterEach(() => {
+  __resetBroadcasterForTesting();
+});
+
+describe("subscribeToMatch — sprint 1.B.1", () => {
+  it("erreur si le match n'existe pas", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expect(
+      subscribeToMatch(MATCH_ID, () => undefined),
+    ).rejects.toThrow(/introuvable/);
+  });
+
+  it("erreur si status='scheduled' (pas encore simulé)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "scheduled" });
+    await expect(
+      subscribeToMatch(MATCH_ID, () => undefined),
+    ).rejects.toThrow(/scheduled/);
+  });
+
+  it("erreur si status='failed'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "failed" });
+    await expect(
+      subscribeToMatch(MATCH_ID, () => undefined),
+    ).rejects.toThrow(/failed/);
+  });
+
+  it("erreur si Replay introuvable", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    mocked.replay.findUnique.mockResolvedValue(null);
+    await expect(
+      subscribeToMatch(MATCH_ID, () => undefined),
+    ).rejects.toThrow(/Replay/);
+  });
+
+  it("dispatch immédiat de l'event KICKOFF (displayAtMs=0)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    vi.useFakeTimers({ now: 1_000_000_000 });
+    const received: MatchEvent[] = [];
+    const unsubscribe = await subscribeToMatch(MATCH_ID, (ev) =>
+      received.push(ev),
+    );
+
+    // Premier tick (100ms après création).
+    await vi.advanceTimersByTimeAsync(150);
+
+    // KICKOFF (displayAtMs=0) doit être dispatched.
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("KICKOFF");
+
+    unsubscribe();
+  });
+
+  it("dispatch progressif selon displayAtMs", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    vi.useFakeTimers({ now: 1_000_000_000 });
+    const received: MatchEvent[] = [];
+    const unsubscribe = await subscribeToMatch(MATCH_ID, (ev) =>
+      received.push(ev),
+    );
+
+    // T+100ms → KICKOFF (displayAtMs=0)
+    await vi.advanceTimersByTimeAsync(150);
+    expect(received.map((e) => e.type)).toEqual(["KICKOFF"]);
+
+    // T+30s → KICKOFF + TURN_START
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(received.map((e) => e.type)).toEqual(["KICKOFF", "TURN_START"]);
+
+    // T+60s → tous
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(received.map((e) => e.type)).toEqual([
+      "KICKOFF",
+      "TURN_START",
+      "TD",
+    ]);
+
+    unsubscribe();
+  });
+
+  it("catch-up : un subscriber qui rejoint après reçoit les events passés en bulk", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    vi.useFakeTimers({ now: 1_000_000_000 });
+    const a: MatchEvent[] = [];
+    const unsubA = await subscribeToMatch(MATCH_ID, (ev) => a.push(ev));
+
+    // Avance jusqu'à T+30s — A reçoit KICKOFF + TURN_START
+    await vi.advanceTimersByTimeAsync(30_500);
+    expect(a.map((e) => e.type)).toEqual(["KICKOFF", "TURN_START"]);
+
+    // Subscriber B rejoint maintenant — doit recevoir le catch-up.
+    const b: MatchEvent[] = [];
+    const unsubB = await subscribeToMatch(MATCH_ID, (ev) => b.push(ev));
+
+    // B reçoit immédiatement les 2 events dispatchés.
+    expect(b.map((e) => e.type)).toEqual(["KICKOFF", "TURN_START"]);
+
+    // Avance encore — A et B reçoivent TD.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(a.map((e) => e.type)).toEqual(["KICKOFF", "TURN_START", "TD"]);
+    expect(b.map((e) => e.type)).toEqual(["KICKOFF", "TURN_START", "TD"]);
+
+    unsubA();
+    unsubB();
+  });
+
+  it("fan-out : 3 subscribers reçoivent les mêmes events", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    vi.useFakeTimers({ now: 1_000_000_000 });
+    const a: MatchEvent[] = [];
+    const b: MatchEvent[] = [];
+    const c: MatchEvent[] = [];
+    const unA = await subscribeToMatch(MATCH_ID, (ev) => a.push(ev));
+    const unB = await subscribeToMatch(MATCH_ID, (ev) => b.push(ev));
+    const unC = await subscribeToMatch(MATCH_ID, (ev) => c.push(ev));
+
+    await vi.advanceTimersByTimeAsync(60_500);
+
+    expect(a).toHaveLength(3);
+    expect(b).toHaveLength(3);
+    expect(c).toHaveLength(3);
+    expect(a.map((e) => e.type)).toEqual(b.map((e) => e.type));
+    expect(a.map((e) => e.type)).toEqual(c.map((e) => e.type));
+
+    unA();
+    unB();
+    unC();
+  });
+
+  it("unsubscribe coupe les events futurs", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    vi.useFakeTimers({ now: 1_000_000_000 });
+    const received: MatchEvent[] = [];
+    const unsubscribe = await subscribeToMatch(MATCH_ID, (ev) =>
+      received.push(ev),
+    );
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(received).toHaveLength(1); // KICKOFF
+
+    unsubscribe();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(received).toHaveLength(1); // pas de nouveaux events
+  });
+});
+
+describe("preloadMatch — sprint 1.B.1", () => {
+  it("crée la session sans subscriber", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    expect(getBroadcasterStats().activeSessions).toBe(0);
+    await preloadMatch(MATCH_ID);
+    expect(getBroadcasterStats().activeSessions).toBe(1);
+    expect(getBroadcasterStats().totalSubscribers).toBe(0);
+  });
+});
+
+describe("getBroadcasterStats — sprint 1.B.1", () => {
+  it("compte sessions et subscribers", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    expect(getBroadcasterStats()).toEqual({
+      activeSessions: 0,
+      totalSubscribers: 0,
+    });
+
+    const un1 = await subscribeToMatch(MATCH_ID, () => undefined);
+    const un2 = await subscribeToMatch(MATCH_ID, () => undefined);
+    expect(getBroadcasterStats()).toEqual({
+      activeSessions: 1,
+      totalSubscribers: 2,
+    });
+
+    un1();
+    expect(getBroadcasterStats().totalSubscribers).toBe(1);
+    un2();
+    expect(getBroadcasterStats().totalSubscribers).toBe(0);
+  });
+});

--- a/apps/server/src/services/pro-league-match-broadcaster.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.ts
@@ -1,0 +1,219 @@
+/**
+ * Pro League match broadcaster — sprint Pro League lot 1.B.1.
+ *
+ * Stream le replay binaire d'un `ProLeagueMatch` event-par-event vers
+ * un ou plusieurs subscribers (consommé par l'endpoint SSE 1.B.2 et
+ * le mode spectate Pixi 1.B.3).
+ *
+ * Architecture
+ * ------------
+ * - Une instance `MatchSession` par match actif. Chargée lazy à la
+ *   première subscription.
+ * - Décompresse `Replay.payload` (CBOR + gzip via sim-engine 1.A.2)
+ *   en mémoire au démarrage de la session.
+ * - Tick loop interne (`setInterval`, default 100ms) qui dispatch les
+ *   events selon leur `displayAtMs` relatif à `startedAt` (wall-clock).
+ * - `EventEmitter` interne pour fan-out vers N subscribers.
+ * - Catch-up automatique : un subscriber qui rejoint après le T0
+ *   reçoit en bulk tous les events déjà dispatchés, puis tail live.
+ * - Auto-cleanup : quand tous les events sont dispatchés ET tous les
+ *   subscribers ont disconnect, la session est libérée.
+ *
+ * Pas de Redis pub/sub au MVP — `EventEmitter` in-process suffit pour
+ * un seul serveur. Le sprint mentionne Redis "si dispo", on le branchera
+ * en Phase 2 si scaling horizontal devient nécessaire.
+ *
+ * Contrats
+ * --------
+ * - `subscribe(matchId, listener) → Promise<unsubscribe>` :
+ *     * Charge la session si nécessaire (lazy).
+ *     * Émet en bulk synchronously les events passés (catch-up).
+ *     * Branche le listener sur l'emitter pour les events futurs.
+ *     * Retourne une fonction `unsubscribe()` à appeler au cleanup.
+ *
+ * - Erreur si `Replay` introuvable (match jamais simulé) ou si le
+ *   match a `status='failed'`.
+ */
+
+import { EventEmitter } from "node:events";
+
+import { decompressEvents, type MatchEvent } from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+/** Fréquence du tick interne (ms). 100ms = précision visuelle suffisante. */
+const TICK_INTERVAL_MS = 100;
+
+/** Statuts de match qui empêchent le broadcast. */
+const NON_BROADCASTABLE_STATUSES = new Set(["scheduled", "failed"]);
+
+/** Event listener type — le subscriber reçoit chaque MatchEvent. */
+export type MatchEventListener = (event: MatchEvent) => void;
+
+interface MatchSession {
+  readonly matchId: string;
+  readonly events: readonly MatchEvent[];
+  /** Wall-clock when the broadcast started. */
+  readonly startedAt: number;
+  /** Index of the next event to dispatch. */
+  nextIndex: number;
+  readonly emitter: EventEmitter;
+  /** Number of currently-attached subscribers. */
+  subscribers: number;
+  timer?: NodeJS.Timeout;
+}
+
+const sessions = new Map<string, MatchSession>();
+
+/**
+ * Charge la session d'un match si elle n'existe pas encore. Décompresse
+ * le replay et démarre le tick loop. Idempotent.
+ */
+async function ensureSession(matchId: string): Promise<MatchSession> {
+  const existing = sessions.get(matchId);
+  if (existing) return existing;
+
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: { status: true },
+  });
+  if (!match) {
+    throw new Error(`ProLeagueMatch '${matchId}' introuvable`);
+  }
+  if (NON_BROADCASTABLE_STATUSES.has(match.status as string)) {
+    throw new Error(
+      `ProLeagueMatch '${matchId}' status='${match.status}' n'est pas broadcastable`,
+    );
+  }
+
+  const replay = await prisma.replay.findUnique({
+    where: { matchId },
+    select: { payload: true },
+  });
+  if (!replay) {
+    throw new Error(`Replay '${matchId}' introuvable (match jamais simulé)`);
+  }
+
+  const events = await decompressEvents(replay.payload as Buffer);
+  // Tri stable par displayAtMs (les events compressés sont déjà ordonnés
+  // par construction du sim-engine — ce tri est défensif).
+  const sorted = [...events].sort((a, b) => a.displayAtMs - b.displayAtMs);
+
+  const session: MatchSession = {
+    matchId,
+    events: sorted,
+    startedAt: Date.now(),
+    nextIndex: 0,
+    emitter: new EventEmitter(),
+    subscribers: 0,
+  };
+  // Permet beaucoup de listeners (par défaut 10) — on cap à 1024.
+  session.emitter.setMaxListeners(1024);
+  sessions.set(matchId, session);
+
+  startTickLoop(session);
+  return session;
+}
+
+/**
+ * Boucle interne qui dispatch les events selon leur `displayAtMs`
+ * relatif à `session.startedAt`. Auto-stop quand tous les events
+ * sont dispatchés.
+ */
+function startTickLoop(session: MatchSession): void {
+  const tick = (): void => {
+    const elapsed = Date.now() - session.startedAt;
+    while (
+      session.nextIndex < session.events.length &&
+      session.events[session.nextIndex].displayAtMs <= elapsed
+    ) {
+      const ev = session.events[session.nextIndex];
+      session.emitter.emit("event", ev);
+      session.nextIndex += 1;
+    }
+    if (session.nextIndex >= session.events.length && session.timer) {
+      clearInterval(session.timer);
+      session.timer = undefined;
+      maybeReap(session);
+    }
+  };
+  session.timer = setInterval(tick, TICK_INTERVAL_MS);
+  // Permet au process Node d'exit même si le tick tourne encore.
+  session.timer.unref();
+}
+
+/**
+ * Si plus de subscribers ET tous les events dispatchés → free la session
+ * pour libérer la mémoire.
+ */
+function maybeReap(session: MatchSession): void {
+  if (
+    session.subscribers === 0 &&
+    session.nextIndex >= session.events.length &&
+    !session.timer
+  ) {
+    sessions.delete(session.matchId);
+  }
+}
+
+/**
+ * Subscribe à un match. Renvoie une fonction `unsubscribe()` à appeler
+ * au cleanup (déconnexion SSE par ex.). Le listener reçoit en bulk les
+ * events déjà dispatchés (catch-up) puis chaque nouvel event en live.
+ */
+export async function subscribeToMatch(
+  matchId: string,
+  listener: MatchEventListener,
+): Promise<() => void> {
+  const session = await ensureSession(matchId);
+
+  // Catch-up : envoie tous les events déjà dispatchés (index < nextIndex).
+  for (let i = 0; i < session.nextIndex; i += 1) {
+    listener(session.events[i]);
+  }
+
+  session.emitter.on("event", listener);
+  session.subscribers += 1;
+
+  return () => {
+    session.emitter.off("event", listener);
+    session.subscribers -= 1;
+    maybeReap(session);
+  };
+}
+
+/**
+ * Helper pour les routes admin / tests : force le démarrage d'une
+ * session sans subscriber. Utile pour pré-warmer une session juste
+ * avant un kickoff.
+ */
+export async function preloadMatch(matchId: string): Promise<void> {
+  await ensureSession(matchId);
+}
+
+/**
+ * Helper de test : libère toutes les sessions actives. À ne PAS exposer
+ * aux routes — réservé aux tests qui veulent isoler des cas.
+ */
+export function __resetBroadcasterForTesting(): void {
+  for (const session of sessions.values()) {
+    if (session.timer) clearInterval(session.timer);
+    session.emitter.removeAllListeners();
+  }
+  sessions.clear();
+}
+
+/**
+ * Helper de monitoring : nombre de sessions actives + subscribers
+ * total. Sert au lot 1.F.3 (Sentry / Grafana).
+ */
+export function getBroadcasterStats(): {
+  activeSessions: number;
+  totalSubscribers: number;
+} {
+  let totalSubscribers = 0;
+  for (const session of sessions.values()) {
+    totalSubscribers += session.subscribers;
+  }
+  return { activeSessions: sessions.size, totalSubscribers };
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.B.1** — Match broadcaster service (premier maillon du live stream).

### `apps/server/src/services/pro-league-match-broadcaster.ts`

Stream le replay binaire d'un `ProLeagueMatch` event-par-event vers N subscribers.

| API | Rôle |
|---|---|
| `subscribeToMatch(matchId, listener)` | Subscribe + catch-up. Renvoie `Promise<unsubscribe>`. Consommée par endpoint SSE 1.B.2. |
| `preloadMatch(matchId)` | Pré-warm sans subscriber (admin tools). |
| `getBroadcasterStats()` | Compteurs activeSessions / totalSubscribers pour Sentry/Grafana (1.F.3). |

### Architecture

- **Une `MatchSession` en mémoire** par match actif (lazy-load à la première subscription).
- **Décompresse `Replay.payload`** (CBOR + gzip via sim-engine 1.A.2).
- **Tick interne** : `setInterval(100ms).unref()` qui dispatch les events selon `displayAtMs` relatif à `startedAt` (wall-clock).
- **EventEmitter interne** : fan-out vers jusqu'à 1024 listeners simultanés.
- **Catch-up automatique** : un subscriber qui rejoint après T0 reçoit en bulk synchronously tous les events déjà dispatchés, puis tail live.
- **Auto-cleanup** : quand events all-dispatched ET subscribers=0 → free la session pour libérer mémoire.

### Erreurs gérées

| Cas | Résultat |
|---|---|
| Match introuvable | `throw "introuvable"` |
| Status `scheduled` (pas encore simulé) | `throw "scheduled"` |
| Status `failed` | `throw "failed"` |
| Replay manquant | `throw "Replay introuvable"` |

### Décisions de design

- **Pas de Redis pub/sub** au MVP — `EventEmitter` in-process suffit pour un serveur unique. Le sprint mentionne Redis "si dispo" → branchement en Phase 2 si scaling horizontal devient nécessaire.
- **Tri défensif des events** par `displayAtMs` (déjà ordonnés par construction du sim-engine, mais on tri quand même).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-league-match-broadcaster.test.ts` → **11/11 ✓**

Couverture :
- Erreurs : match introuvable, status scheduled/failed, replay manquant
- Dispatch immédiat KICKOFF (displayAtMs=0)
- Dispatch progressif selon displayAtMs (KICKOFF→TURN_START→TD)
- Catch-up : subscriber retardataire reçoit events passés en bulk
- Fan-out : 3 subscribers reçoivent mêmes events
- Unsubscribe coupe les events futurs
- preloadMatch crée session sans subscriber
- getBroadcasterStats compte sessions + subscribers

## Suite

Lot **1.B.2** : endpoint SSE `/pro-league/matches/:id/stream` consommant ce broadcaster.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_