### PR TITLE
feat(web): Pro League live ticker page (sprint 1.B.4)

### DIFF
--- a/apps/web/app/lib/use-pro-league-match-stream.test.ts
+++ b/apps/web/app/lib/use-pro-league-match-stream.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Sprint Pro League lot 1.B.4 — Tests du hook
+ * `useProLeagueMatchStream`.
+ *
+ * Mocke `EventSource` globalement pour pouvoir simuler les events
+ * SSE dans jsdom.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { useProLeagueMatchStream } from "./use-pro-league-match-stream";
+
+interface MockEventSourceInstance {
+  url: string;
+  readyState: number;
+  close: ReturnType<typeof vi.fn>;
+  onopen: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  listeners: Map<string, EventListener[]>;
+  emitTyped(type: string, data: unknown): void;
+  triggerOpen(): void;
+  triggerError(): void;
+}
+
+function makeMockEventSource(): {
+  ctor: new (url: string) => MockEventSourceInstance;
+  instances: MockEventSourceInstance[];
+} {
+  const instances: MockEventSourceInstance[] = [];
+  const ctor = function (this: MockEventSourceInstance, url: string) {
+    this.url = url;
+    this.readyState = 0;
+    this.close = vi.fn();
+    this.onopen = null;
+    this.onerror = null;
+    this.onmessage = null;
+    this.listeners = new Map();
+    this.emitTyped = (type: string, data: unknown): void => {
+      const ev = {
+        data: typeof data === "string" ? data : JSON.stringify(data),
+      } as MessageEvent;
+      const ls = this.listeners.get(type) ?? [];
+      for (const l of ls) l(ev);
+    };
+    this.triggerOpen = (): void => {
+      if (this.onopen) this.onopen({} as Event);
+    };
+    this.triggerError = (): void => {
+      if (this.onerror) this.onerror({} as Event);
+    };
+    instances.push(this);
+  } as unknown as new (url: string) => MockEventSourceInstance;
+  Object.defineProperty(ctor.prototype, "addEventListener", {
+    value(this: MockEventSourceInstance, type: string, listener: EventListener) {
+      const ls = this.listeners.get(type) ?? [];
+      ls.push(listener);
+      this.listeners.set(type, ls);
+    },
+  });
+  return { ctor, instances };
+}
+
+let originalEventSource: typeof globalThis.EventSource | undefined;
+let mock: ReturnType<typeof makeMockEventSource>;
+
+beforeEach(() => {
+  mock = makeMockEventSource();
+  originalEventSource = (globalThis as { EventSource?: typeof EventSource })
+    .EventSource;
+  (globalThis as { EventSource?: unknown }).EventSource = mock.ctor;
+});
+
+afterEach(() => {
+  (globalThis as { EventSource?: unknown }).EventSource = originalEventSource;
+});
+
+describe("useProLeagueMatchStream — sprint 1.B.4", () => {
+  it("ne crée pas de connexion si matchId est null", () => {
+    const { result } = renderHook(() => useProLeagueMatchStream(null));
+    expect(mock.instances).toHaveLength(0);
+    expect(result.current.connectionState).toBe("closed");
+    expect(result.current.events).toEqual([]);
+  });
+
+  it("crée une EventSource avec l'URL attendue", () => {
+    renderHook(() => useProLeagueMatchStream("match_abc"));
+    expect(mock.instances).toHaveLength(1);
+    expect(mock.instances[0].url).toContain(
+      "/pro-league/matches/match_abc/stream",
+    );
+  });
+
+  it("connectionState=open après onopen", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].triggerOpen();
+    });
+    expect(result.current.connectionState).toBe("open");
+  });
+
+  it("accumule les events typed received", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+
+    const e1: MatchEvent = {
+      type: "KICKOFF",
+      displayAtMs: 0,
+      engineVer: "0.13.0",
+      seed: 1,
+      meta: { home: "h", away: "a" },
+    };
+    const e2: MatchEvent = {
+      type: "TURN_START",
+      displayAtMs: 30_000,
+      engineVer: "0.13.0",
+      meta: { half: 1, turn: 1, drivingTeam: "home", ballYardline: 4 },
+    };
+
+    act(() => {
+      mock.instances[0].emitTyped("KICKOFF", e1);
+      mock.instances[0].emitTyped("TURN_START", e2);
+    });
+
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[0].type).toBe("KICKOFF");
+    expect(result.current.events[1].type).toBe("TURN_START");
+  });
+
+  it("ferme la connexion quand un event END est reçu", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    const endEv: MatchEvent = {
+      type: "END",
+      displayAtMs: 480_000,
+      engineVer: "0.13.0",
+      meta: { score: { home: 2, away: 1 } },
+    };
+    act(() => {
+      mock.instances[0].emitTyped("END", endEv);
+    });
+    expect(result.current.connectionState).toBe("closed");
+    expect(mock.instances[0].close).toHaveBeenCalled();
+  });
+
+  it("connectionState=error sur onerror", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].triggerError();
+    });
+    expect(result.current.connectionState).toBe("error");
+  });
+
+  it("expose error string si JSON.parse fail", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].emitTyped("KICKOFF", "not-valid-json{{{");
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("ferme la connexion à l'unmount", () => {
+    const { unmount } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    expect(mock.instances[0].close).not.toHaveBeenCalled();
+    unmount();
+    expect(mock.instances[0].close).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/use-pro-league-match-stream.ts
+++ b/apps/web/app/lib/use-pro-league-match-stream.ts
@@ -1,0 +1,118 @@
+/**
+ * Hook React qui consomme l'endpoint SSE
+ * `/pro-league/matches/:id/stream` (sprint Pro League lot 1.B.2) et
+ * accumule les `MatchEvent[]` reçus.
+ *
+ * Sprint Pro League — lot 1.B.4 (ticker textuel mobile-friendly).
+ *
+ * Le navigateur gère nativement la reconnexion via `Last-Event-ID`
+ * tant que la `EventSource` n'est pas explicitement fermée. On expose
+ * néanmoins un état `connectionState` lisible pour permettre à l'UI
+ * d'afficher un badge "live" / "reconnecting" / "ended".
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { API_BASE } from "../auth-client";
+
+export type ConnectionState = "connecting" | "open" | "error" | "closed";
+
+export interface UseProLeagueMatchStreamResult {
+  readonly events: readonly MatchEvent[];
+  readonly connectionState: ConnectionState;
+  /** Erreur runtime (parse, fetch). null en bon état. */
+  readonly error: string | null;
+}
+
+const ENDED_EVENT_TYPES = new Set(["END"]);
+
+/**
+ * Subscribe au stream SSE d'un match Pro League. Le hook ferme
+ * automatiquement la connexion à l'unmount + lorsqu'un event `END`
+ * est reçu (le match est terminé, plus rien à streamer).
+ */
+export function useProLeagueMatchStream(
+  matchId: string | null | undefined,
+): UseProLeagueMatchStreamResult {
+  const [events, setEvents] = useState<readonly MatchEvent[]>([]);
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>("connecting");
+  const [error, setError] = useState<string | null>(null);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!matchId) {
+      setConnectionState("closed");
+      return;
+    }
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      // SSR / environnement sans EventSource : no-op.
+      return;
+    }
+
+    const url = `${API_BASE}/pro-league/matches/${encodeURIComponent(matchId)}/stream`;
+    const source = new EventSource(url);
+    sourceRef.current = source;
+    setConnectionState("connecting");
+    setError(null);
+    setEvents([]);
+
+    source.onopen = () => {
+      setConnectionState("open");
+      setError(null);
+    };
+
+    source.onerror = () => {
+      // EventSource va automatiquement retry. On expose juste l'état.
+      setConnectionState("error");
+    };
+
+    const handleEvent = (raw: MessageEvent): void => {
+      try {
+        const parsed = JSON.parse(raw.data) as MatchEvent;
+        setEvents((prev) => [...prev, parsed]);
+        if (ENDED_EVENT_TYPES.has(parsed.type)) {
+          source.close();
+          setConnectionState("closed");
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "parse failed";
+        setError(msg);
+      }
+    };
+
+    // Le serveur émet event: <TYPE> + data: <JSON>. EventSource expose
+    // `addEventListener(type, …)` par event named, ou `onmessage` pour
+    // les events sans type. On wire les types connus + un fallback.
+    const KNOWN_EVENT_TYPES = [
+      "KICKOFF",
+      "TURN_START",
+      "BLOCK",
+      "DODGE",
+      "PASS",
+      "TD",
+      "KO",
+      "CASUALTY",
+      "TURNOVER",
+      "NUFFLE",
+      "HALFTIME",
+      "END",
+    ] as const;
+    for (const t of KNOWN_EVENT_TYPES) {
+      source.addEventListener(t, handleEvent as EventListener);
+    }
+    source.onmessage = handleEvent;
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+      setConnectionState("closed");
+    };
+  }, [matchId]);
+
+  return { events, connectionState, error };
+}

--- a/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Sprint Pro League lot 1.B.4 — Tests page live ticker.
+ *
+ * Mocke le hook `useProLeagueMatchStream` pour contrôler les events.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+vi.mock("../../../../lib/use-pro-league-match-stream", () => ({
+  useProLeagueMatchStream: vi.fn(),
+}));
+
+import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
+import LiveProMatchPage from "./page";
+
+const mockedHook = vi.mocked(useProLeagueMatchStream);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LiveProMatchPage — sprint 1.B.4", () => {
+  it("affiche '0 – 0' + 'En attente du kickoff' quand pas d'events", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "connecting",
+      error: null,
+    });
+
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+
+    expect(screen.getByTestId("score-display").textContent).toContain("0");
+    expect(screen.getByText(/En attente/i)).toBeTruthy();
+    expect(screen.getByTestId("connection-badge").textContent).toMatch(
+      /connecting/i,
+    );
+  });
+
+  it("affiche le badge LIVE quand connecté", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByTestId("connection-badge").textContent).toMatch(/LIVE/);
+  });
+
+  it("calcule le score à partir des events TD", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: { home: "h", away: "a" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 30_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 60_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 90_000,
+        engineVer: "0.13.0",
+        meta: { team: "away" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByTestId("score-display").textContent).toContain("2");
+    expect(screen.getByTestId("score-display").textContent).toContain("1");
+  });
+
+  it("affiche '2nd half' après HALFTIME et 'FT' après END", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: {},
+      },
+      {
+        type: "HALFTIME",
+        displayAtMs: 240_000,
+        engineVer: "0.13.0",
+        meta: { score: { home: 1, away: 1 } },
+      },
+    ];
+    mockedHook.mockReturnValueOnce({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    const { rerender } = render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText(/2nd half/i)).toBeTruthy();
+
+    mockedHook.mockReturnValue({
+      events: [
+        ...events,
+        {
+          type: "END",
+          displayAtMs: 480_000,
+          engineVer: "0.13.0",
+          meta: { score: { home: 2, away: 1 } },
+        },
+      ],
+      connectionState: "closed",
+      error: null,
+    });
+    rerender(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText("FT")).toBeTruthy();
+  });
+
+  it("liste les events avec les badges et l'horloge", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "TD",
+        displayAtMs: 75_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText("TD")).toBeTruthy();
+    expect(screen.getByText("1:15")).toBeTruthy();
+    expect(screen.getByText(/TOUCHDOWN HOME/i)).toBeTruthy();
+  });
+
+  it("ordre inverse : event le plus récent en haut", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: {},
+      },
+      {
+        type: "TD",
+        displayAtMs: 30_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    const items = screen.getByTestId("event-feed").querySelectorAll("li");
+    expect(items.length).toBe(2);
+    // Premier li = event le plus récent (TD).
+    expect(items[0].textContent).toContain("TD");
+    expect(items[1].textContent).toContain("KICKOFF");
+  });
+
+  it("affiche le message d'erreur si error retourné par le hook", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "error",
+      error: "boom-parse",
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByRole("alert").textContent).toContain("boom-parse");
+  });
+});

--- a/apps/web/app/pro-league/matches/[id]/live/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
+
+/**
+ * Page de spectate textuel d'un match Pro League — sprint 1.B.4.
+ *
+ * Vue alternative pure texte pour mobile / low-bandwidth :
+ * - Score sticky en haut (mis à jour à chaque event TD).
+ * - Timeline scrollable des events avec badges (TD / CAS / NUFFLE).
+ * - Auto-refresh via SSE (`useProLeagueMatchStream`).
+ *
+ * Pas d'auth — les matchs Pro League sont publics au MVP.
+ */
+interface LivePageProps {
+  readonly params: { id: string };
+}
+
+interface ScoreState {
+  home: number;
+  away: number;
+  half: 1 | 2 | "final";
+}
+
+function deriveScore(events: readonly MatchEvent[]): ScoreState {
+  let home = 0;
+  let away = 0;
+  let half: 1 | 2 | "final" = 1;
+  for (const ev of events) {
+    if (ev.type === "TD") {
+      const team = (ev.meta as { team?: string } | undefined)?.team;
+      if (team === "home") home += 1;
+      else if (team === "away") away += 1;
+    } else if (ev.type === "HALFTIME") {
+      half = 2;
+    } else if (ev.type === "END") {
+      half = "final";
+    }
+  }
+  return { home, away, half };
+}
+
+const EVENT_BADGE_STYLES: Record<string, string> = {
+  KICKOFF: "bg-slate-700 text-slate-100",
+  TURN_START: "bg-slate-800 text-slate-300",
+  BLOCK: "bg-amber-900 text-amber-100",
+  DODGE: "bg-sky-900 text-sky-100",
+  PASS: "bg-blue-900 text-blue-100",
+  TD: "bg-emerald-700 text-emerald-50 font-semibold",
+  KO: "bg-orange-900 text-orange-100",
+  CASUALTY: "bg-red-700 text-red-50 font-semibold",
+  TURNOVER: "bg-rose-900 text-rose-100",
+  NUFFLE: "bg-purple-700 text-purple-50 font-semibold",
+  HALFTIME: "bg-indigo-900 text-indigo-100",
+  END: "bg-slate-900 text-slate-100 font-semibold",
+};
+
+function formatClock(displayAtMs: number): string {
+  const seconds = Math.floor(displayAtMs / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function summarizeMeta(ev: MatchEvent): string {
+  const meta = (ev.meta ?? {}) as Record<string, unknown>;
+  switch (ev.type) {
+    case "KICKOFF": {
+      const home = String(meta.homeName ?? meta.home ?? "home");
+      const away = String(meta.awayName ?? meta.away ?? "away");
+      return `${home} vs ${away}`;
+    }
+    case "TURN_START": {
+      const half = meta.half;
+      const turn = meta.turn;
+      const drivingTeam = String(meta.drivingTeam ?? "");
+      return `Half ${half ?? ""} · Turn ${turn ?? ""}${drivingTeam ? ` · ${drivingTeam}` : ""}`;
+    }
+    case "TD": {
+      const team = String(meta.team ?? "");
+      return `TOUCHDOWN ${team.toUpperCase()}`;
+    }
+    case "CASUALTY": {
+      const cause = meta.causedBy ? ` (${String(meta.causedBy)})` : "";
+      return `Casualty${cause}`;
+    }
+    case "NUFFLE": {
+      const id = meta.id ?? meta.eventId ?? "?";
+      return `Nuffle: ${String(id)}`;
+    }
+    case "HALFTIME":
+      return "Halftime";
+    case "END":
+      return "Match end";
+    default:
+      return ev.type;
+  }
+}
+
+function ConnectionBadge({
+  state,
+}: {
+  state: "connecting" | "open" | "error" | "closed";
+}): JSX.Element {
+  const label =
+    state === "open"
+      ? "● LIVE"
+      : state === "connecting"
+        ? "○ connecting"
+        : state === "error"
+          ? "⚠ reconnecting"
+          : "■ ended";
+  const klass =
+    state === "open"
+      ? "bg-emerald-600 text-emerald-50"
+      : state === "connecting"
+        ? "bg-slate-600 text-slate-100"
+        : state === "error"
+          ? "bg-amber-600 text-amber-50"
+          : "bg-slate-700 text-slate-300";
+  return (
+    <span
+      data-testid="connection-badge"
+      className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-mono ${klass}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default function LiveProMatchPage({
+  params,
+}: LivePageProps): JSX.Element {
+  const { events, connectionState, error } = useProLeagueMatchStream(params.id);
+  const score = useMemo(() => deriveScore(events), [events]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
+      <header
+        data-testid="score-header"
+        className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-4 py-3 shadow"
+      >
+        <div className="flex items-center gap-3">
+          <ConnectionBadge state={connectionState} />
+          <span className="font-mono text-sm text-slate-400">
+            {score.half === "final"
+              ? "FT"
+              : score.half === 1
+                ? "1st half"
+                : "2nd half"}
+          </span>
+        </div>
+        <div
+          data-testid="score-display"
+          className="font-mono text-2xl font-bold tracking-wide"
+        >
+          {score.home} – {score.away}
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="m-4 rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      <ol
+        data-testid="event-feed"
+        className="flex flex-1 flex-col gap-1 px-4 py-3"
+      >
+        {events.length === 0 ? (
+          <li className="text-sm text-slate-500">
+            En attente du kickoff…
+          </li>
+        ) : (
+          events
+            .slice()
+            .reverse()
+            .map((ev, idx) => (
+              <li
+                key={`${events.length - 1 - idx}-${ev.type}-${ev.displayAtMs}`}
+                className="flex items-start gap-3 rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm"
+              >
+                <span className="font-mono text-xs text-slate-500">
+                  {formatClock(ev.displayAtMs)}
+                </span>
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-mono ${EVENT_BADGE_STYLES[ev.type] ?? "bg-slate-700 text-slate-100"}`}
+                >
+                  {ev.type}
+                </span>
+                <span className="flex-1 text-slate-200">
+                  {summarizeMeta(ev)}
+                </span>
+              </li>
+            ))
+        )}
+      </ol>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.B.4** — Vue spectate textuelle mobile-friendly d'un match Pro League. Consomme l'endpoint SSE `/pro-league/matches/:id/stream` (lot 1.B.2) et affiche les events en temps réel.

### Hook `useProLeagueMatchStream(matchId)`

`apps/web/app/lib/use-pro-league-match-stream.ts`

- Crée une `EventSource` sur l'endpoint SSE.
- Accumule les events (`MatchEvent[]`).
- Retourne `{events, connectionState, error}`.
- Auto-close à l'event `END`.
- Reconnexion native du browser via `Last-Event-ID`.
- SSR-safe (no-op si window/EventSource undefined).

### Page `/pro-league/matches/[id]/live`

`apps/web/app/pro-league/matches/[id]/live/page.tsx`

- **Sticky header** : badge connexion (LIVE / connecting / reconnecting / ended) + indicateur 1st half / 2nd half / FT + score.
- **Score dérivé** des events TD (pas besoin de loader REST séparé).
- **Timeline scrollable** des events (ordre inverse, plus récent en haut). Badges colorés par type : KICKOFF, TURN_START, BLOCK, DODGE, PASS, TD, KO, CASUALTY, TURNOVER, NUFFLE, HALFTIME, END.
- **Horloge** au format M:SS depuis le kickoff.
- **Résumés humanisés** par event.
- **Tailwind responsive** (max-w-2xl), mobile-first.

## Décision sprint : pourquoi 1.B.4 avant 1.B.3 (Pixi)

Le sprint listait 1.B.3 (Pixi spectate read-only) avant 1.B.4 (ticker texte). Le renderer Pixi PvP attend `ExtendedGameState` (positions joueurs) alors que la sim Pro League est **hybride yards-level** — il faudrait dériver des "scènes" depuis `MatchEvent[]`, travail non trivial qui mérite une session dédiée de design.

Je livre 1.B.4 d'abord car ticker textuel est la représentation **naturelle** de `MatchEvent[]` et donne tout de suite une expérience spectate utilisable. 1.B.3 reste à faire.

## Test plan

- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run app/lib/use-pro-league-match-stream.test.ts app/pro-league` → **15/15 ✓**

Couverture hook (8) :
| Cas | Résultat |
|---|---|
| Pas de connexion si matchId null | OK |
| URL correcte | `/pro-league/matches/<id>/stream` |
| `connectionState=open` après onopen | OK |
| Accumulation des events typed | OK |
| Close auto sur event END | OK |
| `connectionState=error` sur onerror | OK |
| Erreur exposée si JSON.parse fail | OK |
| Close à l'unmount | OK |

Couverture page (7) :
| Cas | Résultat |
|---|---|
| État vide | "0 – 0" + "En attente du kickoff" |
| Badge LIVE | présent quand connecté |
| Score dérivé des TD | "2 – 1" après 3 TDs |
| Half indicator | 1st / 2nd / FT selon HALFTIME / END |
| Liste avec badges + horloge | "TD" / "1:15" / "TOUCHDOWN HOME" |
| Ordre inverse | Plus récent en haut |
| Affichage erreur | render `role="alert"` |

## Suite

Au choix :
- **1.B.3 Pixi** (à concevoir : adaptation `MatchEvent[]` → animation field)
- **Lot 1.C** (UI Pro League hub + team pages + match detail) — plus impactant côté produit


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_