### PR TITLE
feat(admin): UI lecture des replays panel pour validation C6-C9

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,6 +11,7 @@ import adminRoutes from "./routes/admin";
 import adminDataRoutes from "./routes/admin-data";
 import adminLeaguesRoutes from "./routes/admin-leagues";
 import adminSimRoutes from "./routes/admin-sim";
+import adminSimReplaysRoutes from "./routes/admin-sim-replays";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -187,6 +188,12 @@ app.use("/admin/feature-flags", adminFeatureFlagsRouter);
 // pour ne pas polluer /admin (qui devient un sac fourre-tout).
 app.use("/admin/leagues", adminLeaguesRoutes);
 app.use("/admin/sim", adminSimRoutes);
+// Sprint Pro League 0.E.2 / 0.E.3 — exposition lecture seule des replays
+// panel pour la validation C6-C9 du gate Phase 0 → Phase 1 (cf.
+// docs/roadmap/sprints/pro-league-gate.md). Mountée sur un namespace
+// distinct (`/admin/sim-replays`) pour éviter la double exécution du
+// middleware d'auth qui se produirait si on imbriquait sous `/admin/sim`.
+app.use("/admin/sim-replays", adminSimReplaysRoutes);
 // Feedback public : pas d'auth, captcha + rate limiter dedies dans le router.
 app.use("/feedback", feedbackPublicRouter);
 // Console admin : auth + role admin appliques dans le router.

--- a/apps/server/src/routes/admin-sim-replays.test.ts
+++ b/apps/server/src/routes/admin-sim-replays.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests pour `/admin/sim/replays`. On teste les handlers
+ * directement (pas Express) avec un dossier temporaire qui contient
+ * un panel de fixtures replays — ça évite de dépendre du repo réel
+ * (qui peut bouger/régénérer les fichiers panel) et garantit que les
+ * tests sont déterministes.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Request, Response } from "express";
+
+import { handleGetReplay, handleListReplays } from "./admin-sim-replays";
+
+const FIXTURE_REPLAY = `=== MATCH #1 — Soaring Hawks (Wood Elf) vs Frostraiders (Norse) ===
+engine 0.12.0
+
+KICKOFF — kc-soaring-hawks hosts min-frostraiders.
+Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+
+--- END OF MATCH (score 2-1) ---
+
+
+FINAL: 2 - 1 (home win)
+Touchdowns: 3 | Casualties: 1 | Turnovers: 5 | Nuffle: 2
+`;
+
+const FIXTURE_REPLAY_2 = `=== MATCH #2 — Iron Bears (Dwarf) vs Vipers (Skaven) ===
+engine 0.12.0
+
+FINAL: 0 - 0 (draw)
+Touchdowns: 0 | Casualties: 4 | Turnovers: 8 | Nuffle: 6
+`;
+
+function buildRes(): Response & { statusCode: number; body: unknown } {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown };
+}
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(tmpdir(), "replays-test-"));
+  process.env.PRO_LEAGUE_REPLAYS_DIR = tmpDir;
+});
+
+afterEach(async () => {
+  delete process.env.PRO_LEAGUE_REPLAYS_DIR;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("handleListReplays", () => {
+  it("returns parsed summaries for all replay-*.txt files", async () => {
+    await writeFile(
+      path.join(
+        tmpDir,
+        "replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt",
+      ),
+      FIXTURE_REPLAY,
+    );
+    await writeFile(
+      path.join(tmpDir, "replay-002-iron-bears-vs-vipers-seed2027.txt"),
+      FIXTURE_REPLAY_2,
+    );
+    // Bruit qui doit être ignoré (filtre isValidReplayFilename).
+    await writeFile(path.join(tmpDir, "README.md"), "ignore me");
+
+    const res = buildRes();
+    await handleListReplays({} as Request, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      replays: Array<{
+        filename: string;
+        index: string;
+        seed: number;
+        parsed: { homeName: string; outcome: string };
+      }>;
+      missing: boolean;
+    };
+    expect(body.missing).toBe(false);
+    expect(body.replays).toHaveLength(2);
+    // Ordre alphabétique = ordre des index padded.
+    expect(body.replays[0].filename).toContain("replay-001");
+    expect(body.replays[0].seed).toBe(2026);
+    expect(body.replays[0].parsed.homeName).toBe("Soaring Hawks");
+    expect(body.replays[0].parsed.outcome).toBe("home");
+    expect(body.replays[1].parsed.outcome).toBe("draw");
+  });
+
+  it("returns missing=true when the directory does not exist", async () => {
+    process.env.PRO_LEAGUE_REPLAYS_DIR = path.join(tmpDir, "does-not-exist");
+    const res = buildRes();
+    await handleListReplays({} as Request, res);
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { replays: unknown[]; missing: boolean };
+    expect(body.missing).toBe(true);
+    expect(body.replays).toEqual([]);
+  });
+});
+
+describe("handleGetReplay", () => {
+  it("returns content + parsed metadata for a valid file", async () => {
+    const filename =
+      "replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt";
+    await writeFile(path.join(tmpDir, filename), FIXTURE_REPLAY);
+
+    const res = buildRes();
+    await handleGetReplay(
+      { params: { filename } } as unknown as Request,
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      content: string;
+      parsed: { homeScore: number; awayScore: number };
+      file: { seed: number };
+    };
+    expect(body.content).toContain("=== MATCH #1");
+    expect(body.parsed.homeScore).toBe(2);
+    expect(body.parsed.awayScore).toBe(1);
+    expect(body.file.seed).toBe(2026);
+  });
+
+  it("returns 400 for filenames that fail validation", async () => {
+    const res = buildRes();
+    await handleGetReplay(
+      { params: { filename: "../etc/passwd" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 for filenames missing the canonical pattern", async () => {
+    const res = buildRes();
+    await handleGetReplay(
+      { params: { filename: "README.md" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 404 when the file is not on disk", async () => {
+    const res = buildRes();
+    await handleGetReplay(
+      {
+        params: {
+          filename:
+            "replay-999-foo-vs-bar-seed1.txt",
+        },
+      } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/server/src/routes/admin-sim-replays.ts
+++ b/apps/server/src/routes/admin-sim-replays.ts
@@ -1,0 +1,155 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { adminOnly } from "../middleware/adminOnly";
+import { authUser } from "../middleware/authUser";
+import {
+  isValidReplayFilename,
+  parseReplayContent,
+  parseReplayFilename,
+  type ParsedReplay,
+  type ReplayFileMetadata,
+} from "../utils/replay-parser";
+import { serverLog } from "../utils/server-log";
+
+/**
+ * Admin endpoints qui exposent les replays panel BB (sprint Pro League
+ * 0.E.2 / 0.E.3) pour la validation C6-C9 du gate Phase 0 → Phase 1
+ * (cf. `docs/roadmap/sprints/pro-league-gate.md`).
+ *
+ * Les fichiers `.txt` vivent dans
+ * `docs/roadmap/sprints/pro-league-panel/replays/` à la racine du repo.
+ * On les lit en lecture seule, on parse les méta-données (header,
+ * scores, totaux) pour permettre à l'UI admin de :
+ *  - lister les 50 replays avec un résumé tableau,
+ *  - filtrer/trier (race, score, touchdowns, casualties),
+ *  - afficher le contenu narratif complet d'un replay donné.
+ *
+ * Aucun écriture, aucun side-effect : ce sont les fichiers source du
+ * kit panel, pas une donnée applicative.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Chemin vers le dossier des replays. Override possible via env
+ * `PRO_LEAGUE_REPLAYS_DIR` (utile pour les tests + déploiements
+ * exotiques où le repo n'est pas mounted en entier).
+ *
+ * Le fallback grimpe depuis `apps/server/src/routes/` jusqu'à la
+ * racine du repo (4 niveaux), puis pointe sur le sous-dossier panel.
+ */
+const DEFAULT_REPLAYS_DIR = path.resolve(
+  __dirname,
+  "../../../..",
+  "docs/roadmap/sprints/pro-league-panel/replays",
+);
+
+export function getReplaysDir(): string {
+  return process.env.PRO_LEAGUE_REPLAYS_DIR ?? DEFAULT_REPLAYS_DIR;
+}
+
+/** Résumé d'un replay listé (méta-fichier + parsing rapide du contenu). */
+export interface ReplaySummary extends ReplayFileMetadata {
+  parsed: ParsedReplay;
+  /** Taille du fichier en octets (info utile en UI). */
+  sizeBytes: number;
+}
+
+async function listReplayFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir);
+  return entries.filter(isValidReplayFilename).sort();
+}
+
+/** Handler `GET /admin/sim/replays` — liste + parsing résumé. */
+export async function handleListReplays(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const dir = getReplaysDir();
+  let filenames: string[];
+  try {
+    filenames = await listReplayFiles(dir);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      res.json({ replays: [], dir, missing: true });
+      return;
+    }
+    serverLog.error("[admin-sim-replays] readdir failed", err);
+    res.status(500).json({ error: "Failed to read replays directory" });
+    return;
+  }
+
+  const replays: ReplaySummary[] = await Promise.all(
+    filenames.map(async (filename) => {
+      const fullPath = path.join(dir, filename);
+      const [content, stat] = await Promise.all([
+        fs.readFile(fullPath, "utf8"),
+        fs.stat(fullPath),
+      ]);
+      return {
+        ...parseReplayFilename(filename),
+        parsed: parseReplayContent(content),
+        sizeBytes: stat.size,
+      };
+    }),
+  );
+
+  res.json({ replays, dir, missing: false });
+}
+
+/** Handler `GET /admin/sim/replays/:filename` — texte brut + parsing. */
+export async function handleGetReplay(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const filename = req.params.filename ?? "";
+  if (!isValidReplayFilename(filename)) {
+    res.status(400).json({ error: "Invalid replay filename" });
+    return;
+  }
+
+  const dir = getReplaysDir();
+  const fullPath = path.join(dir, filename);
+  // Defense-in-depth : s'assurer que le chemin résolu reste sous `dir`
+  // même si une regex pathologique laissait passer un nom hostile.
+  const resolved = path.resolve(fullPath);
+  if (!resolved.startsWith(path.resolve(dir) + path.sep)) {
+    res.status(400).json({ error: "Invalid replay filename" });
+    return;
+  }
+
+  let content: string;
+  try {
+    content = await fs.readFile(resolved, "utf8");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      res.status(404).json({ error: "Replay not found" });
+      return;
+    }
+    serverLog.error("[admin-sim-replays] readFile failed", err);
+    res.status(500).json({ error: "Failed to read replay" });
+    return;
+  }
+
+  res.json({
+    file: parseReplayFilename(filename),
+    parsed: parseReplayContent(content),
+    content,
+  });
+}
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+router.get("/", handleListReplays);
+router.get("/:filename", handleGetReplay);
+
+export default router;

--- a/apps/server/src/utils/replay-parser.test.ts
+++ b/apps/server/src/utils/replay-parser.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isValidReplayFilename,
+  parseReplayContent,
+  parseReplayFilename,
+} from "./replay-parser";
+
+const SAMPLE_REPLAY = `=== MATCH #1 — Soaring Hawks (Wood Elf) vs Frostraiders (Norse) ===
+engine 0.12.0
+
+KICKOFF — kc-soaring-hawks hosts min-frostraiders (weather: nice, away receives).
+Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+Half 1 • Turn 2 — away in possession at yardline 15 (score 0-0)
+  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+
+--- HALFTIME (score 0-0) ---
+
+Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+
+--- END OF MATCH (score 2-1) ---
+
+
+FINAL: 2 - 1 (home win)
+Touchdowns: 3 | Casualties: 2 | Turnovers: 6 | Nuffle: 4
+`;
+
+describe("parseReplayContent", () => {
+  it("extracts header (match index, names, races)", () => {
+    const parsed = parseReplayContent(SAMPLE_REPLAY);
+    expect(parsed.matchIndex).toBe(1);
+    expect(parsed.homeName).toBe("Soaring Hawks");
+    expect(parsed.homeRace).toBe("Wood Elf");
+    expect(parsed.awayName).toBe("Frostraiders");
+    expect(parsed.awayRace).toBe("Norse");
+  });
+
+  it("extracts engine version line", () => {
+    const parsed = parseReplayContent(SAMPLE_REPLAY);
+    expect(parsed.engineVer).toBe("0.12.0");
+  });
+
+  it("extracts FINAL score and explicit outcome annotation", () => {
+    const parsed = parseReplayContent(SAMPLE_REPLAY);
+    expect(parsed.homeScore).toBe(2);
+    expect(parsed.awayScore).toBe(1);
+    expect(parsed.outcome).toBe("home");
+  });
+
+  it("derives outcome from score when annotation missing (legacy file)", () => {
+    const legacy = SAMPLE_REPLAY.replace("FINAL: 2 - 1 (home win)", "FINAL: 1 - 3");
+    const parsed = parseReplayContent(legacy);
+    expect(parsed.outcome).toBe("away");
+  });
+
+  it("returns 'draw' when scores are tied", () => {
+    const tied = SAMPLE_REPLAY.replace("FINAL: 2 - 1 (home win)", "FINAL: 0 - 0 (draw)");
+    const parsed = parseReplayContent(tied);
+    expect(parsed.outcome).toBe("draw");
+  });
+
+  it("extracts the totals footer (TD / cas / TO / Nuffle)", () => {
+    const parsed = parseReplayContent(SAMPLE_REPLAY);
+    expect(parsed.totals).toEqual({
+      touchdowns: 3,
+      casualties: 2,
+      turnovers: 6,
+      nuffle: 4,
+    });
+  });
+
+  it("counts total lines for UI hints", () => {
+    const parsed = parseReplayContent(SAMPLE_REPLAY);
+    expect(parsed.totalLines).toBeGreaterThan(10);
+  });
+
+  it("returns nulls gracefully when replay is empty / malformed", () => {
+    const parsed = parseReplayContent("");
+    expect(parsed.matchIndex).toBeNull();
+    expect(parsed.homeScore).toBeNull();
+    expect(parsed.totals.touchdowns).toBeNull();
+    expect(parsed.outcome).toBeNull();
+  });
+
+  it("does not throw on a single-line garbage input", () => {
+    expect(() => parseReplayContent("garbage line")).not.toThrow();
+  });
+});
+
+describe("parseReplayFilename", () => {
+  it("decomposes a canonical replay filename", () => {
+    const meta = parseReplayFilename(
+      "replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt",
+    );
+    expect(meta.index).toBe("001");
+    expect(meta.homeId).toBe("kc-soaring-hawks");
+    expect(meta.awayId).toBe("min-frostraiders");
+    expect(meta.seed).toBe(2026);
+  });
+
+  it("returns nulls for non-matching files (not a panel replay)", () => {
+    const meta = parseReplayFilename("some-other-file.txt");
+    expect(meta.index).toBeNull();
+    expect(meta.homeId).toBeNull();
+    expect(meta.awayId).toBeNull();
+    expect(meta.seed).toBeNull();
+  });
+});
+
+describe("isValidReplayFilename (path-traversal guard)", () => {
+  it("accepts canonical filenames", () => {
+    expect(
+      isValidReplayFilename(
+        "replay-050-pit-smashers-vs-kc-soaring-hawks-seed2075.txt",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects path-traversal attempts", () => {
+    expect(isValidReplayFilename("../etc/passwd")).toBe(false);
+    expect(isValidReplayFilename("replay-001-../../../etc-vs-passwd-seed1.txt")).toBe(false);
+    expect(isValidReplayFilename("/etc/passwd")).toBe(false);
+  });
+
+  it("rejects files outside the replay naming convention", () => {
+    expect(isValidReplayFilename("README.md")).toBe(false);
+    expect(isValidReplayFilename("replay-1-foo-vs-bar-seed1.txt")).toBe(false); // index pas padded
+    expect(isValidReplayFilename("replay-001-foo-vs-bar.txt")).toBe(false); // pas de seed
+  });
+});

--- a/apps/server/src/utils/replay-parser.ts
+++ b/apps/server/src/utils/replay-parser.ts
@@ -1,0 +1,209 @@
+/**
+ * Parser pour les replays narratifs Pro League (sprint 0.E.2).
+ *
+ * Les fichiers replays sont produits par `pnpm sim:replay` (cf.
+ * `packages/sim-engine/scripts/replay.ts`) et stockes dans
+ * `docs/roadmap/sprints/pro-league-panel/replays/`. Format texte plat,
+ * voir un exemple dans le meme dossier (header `=== MATCH ... ===`,
+ * lignes `Half X • Turn Y`, ligne finale `FINAL: H - A` + ligne de
+ * compteurs `Touchdowns | Casualties | Turnovers | Nuffle`).
+ *
+ * On expose un parser pur (entree string, sortie objet) pour pouvoir
+ * fournir aux interfaces admin une vue indexable (tri, recherche,
+ * filtres) sans refaire ce travail cote frontend.
+ */
+
+const HEADER_REGEX =
+  /^===\s*MATCH\s*#(\d+)\s*—\s*(.+?)\s*\((.+?)\)\s*vs\s*(.+?)\s*\((.+?)\)\s*===$/;
+
+const FINAL_SCORE_REGEX = /^FINAL:\s*(\d+)\s*-\s*(\d+)(?:\s*\((draw|home win|away win)\))?/i;
+
+const TOTALS_REGEX =
+  /^Touchdowns:\s*(\d+)\s*\|\s*Casualties:\s*(\d+)\s*\|\s*Turnovers:\s*(\d+)\s*\|\s*Nuffle:\s*(\d+)/;
+
+const ENGINE_REGEX = /^engine\s+(\S+)/;
+
+// Restreint aux caractères que `slugForFile` (cf.
+// `packages/sim-engine/scripts/replay.ts`) émet : `[a-z0-9-]`. Cela
+// élimine d'office les segments `..` ou les séparateurs de chemin.
+const FILENAME_REGEX = /^replay-(\d{3})-([a-z0-9-]+)-vs-([a-z0-9-]+)-seed(\d+)\.txt$/;
+
+/**
+ * Champs structurés extraits d'un replay narratif.
+ *
+ * - `matchIndex` : numéro affiché dans le header (1..N).
+ * - `homeName` / `awayName` : nom commercial (ex: "Soaring Hawks").
+ * - `homeRace` / `awayRace` : race BB (ex: "Wood Elf").
+ * - `engineVer` : version sim-engine (ex: "0.12.0").
+ * - `homeScore` / `awayScore` : touchdowns finaux.
+ * - `outcome` : "home" si home gagne, "away" si away gagne, "draw" sinon.
+ *   Calculé sur les TDs si l'annotation `(draw|home win|away win)`
+ *   manque (legacy).
+ * - `totals` : compteurs récapitulatifs en fin de match.
+ * - `totalLines` : taille du replay en nombre de lignes (utile pour
+ *   l'UI : afficher un badge "court / long").
+ */
+export interface ParsedReplay {
+  matchIndex: number | null;
+  homeName: string | null;
+  homeRace: string | null;
+  awayName: string | null;
+  awayRace: string | null;
+  engineVer: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  outcome: "home" | "away" | "draw" | null;
+  totals: {
+    touchdowns: number | null;
+    casualties: number | null;
+    turnovers: number | null;
+    nuffle: number | null;
+  };
+  totalLines: number;
+}
+
+/**
+ * Champs déduits du nom de fichier (fallback quand le contenu ne donne
+ * pas l'info, et clé de tri dans la liste).
+ */
+export interface ReplayFileMetadata {
+  filename: string;
+  /** Index padded sur 3 chiffres (ex: "001"). */
+  index: string | null;
+  /** Slug équipe domicile (ex: "kc-soaring-hawks"). */
+  homeId: string | null;
+  /** Slug équipe visiteur (ex: "min-frostraiders"). */
+  awayId: string | null;
+  /** Seed PRNG utilisée pour reproduire le match. */
+  seed: number | null;
+}
+
+function deriveOutcome(
+  homeScore: number | null,
+  awayScore: number | null,
+): "home" | "away" | "draw" | null {
+  if (homeScore === null || awayScore === null) return null;
+  if (homeScore > awayScore) return "home";
+  if (awayScore > homeScore) return "away";
+  return "draw";
+}
+
+function normalizeOutcome(
+  raw: string | undefined,
+  homeScore: number | null,
+  awayScore: number | null,
+): "home" | "away" | "draw" | null {
+  if (raw) {
+    const lower = raw.toLowerCase();
+    if (lower === "draw") return "draw";
+    if (lower === "home win") return "home";
+    if (lower === "away win") return "away";
+  }
+  return deriveOutcome(homeScore, awayScore);
+}
+
+/**
+ * Extrait les méta-données structurées d'un replay narratif. Tolerant :
+ * une ligne manquante n'invalide pas le parsing — les champs absents
+ * sortent à `null`.
+ */
+export function parseReplayContent(content: string): ParsedReplay {
+  const lines = content.split(/\r?\n/);
+
+  const result: ParsedReplay = {
+    matchIndex: null,
+    homeName: null,
+    homeRace: null,
+    awayName: null,
+    awayRace: null,
+    engineVer: null,
+    homeScore: null,
+    awayScore: null,
+    outcome: null,
+    totals: {
+      touchdowns: null,
+      casualties: null,
+      turnovers: null,
+      nuffle: null,
+    },
+    totalLines: lines.length,
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const headerMatch = HEADER_REGEX.exec(trimmed);
+    if (headerMatch && result.matchIndex === null) {
+      result.matchIndex = Number.parseInt(headerMatch[1], 10);
+      result.homeName = headerMatch[2];
+      result.homeRace = headerMatch[3];
+      result.awayName = headerMatch[4];
+      result.awayRace = headerMatch[5];
+      continue;
+    }
+
+    const engineMatch = ENGINE_REGEX.exec(trimmed);
+    if (engineMatch && result.engineVer === null) {
+      result.engineVer = engineMatch[1];
+      continue;
+    }
+
+    const finalMatch = FINAL_SCORE_REGEX.exec(trimmed);
+    if (finalMatch) {
+      result.homeScore = Number.parseInt(finalMatch[1], 10);
+      result.awayScore = Number.parseInt(finalMatch[2], 10);
+      result.outcome = normalizeOutcome(
+        finalMatch[3],
+        result.homeScore,
+        result.awayScore,
+      );
+      continue;
+    }
+
+    const totalsMatch = TOTALS_REGEX.exec(trimmed);
+    if (totalsMatch) {
+      result.totals = {
+        touchdowns: Number.parseInt(totalsMatch[1], 10),
+        casualties: Number.parseInt(totalsMatch[2], 10),
+        turnovers: Number.parseInt(totalsMatch[3], 10),
+        nuffle: Number.parseInt(totalsMatch[4], 10),
+      };
+      continue;
+    }
+  }
+
+  if (result.outcome === null) {
+    result.outcome = deriveOutcome(result.homeScore, result.awayScore);
+  }
+  return result;
+}
+
+/**
+ * Décompose le nom de fichier `replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt`
+ * pour récupérer les méta-données qui n'apparaissent pas toujours dans
+ * le contenu (notamment la seed et les ids slug).
+ */
+export function parseReplayFilename(filename: string): ReplayFileMetadata {
+  const match = FILENAME_REGEX.exec(filename);
+  if (!match) {
+    return { filename, index: null, homeId: null, awayId: null, seed: null };
+  }
+  const [, index, homeId, awayId, seed] = match;
+  return {
+    filename,
+    index,
+    homeId,
+    awayId,
+    seed: Number.parseInt(seed, 10),
+  };
+}
+
+/**
+ * Vérifie qu'un nom de fichier est un replay panel valide. Sert de
+ * garde-fou anti path-traversal côté API : on n'accepte que des noms
+ * matchant strictement le pattern.
+ */
+export function isValidReplayFilename(filename: string): boolean {
+  return FILENAME_REGEX.test(filename);
+}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -25,6 +25,11 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
     if (path === "/admin") {
       return pathname === "/admin";
     }
+    // /admin/sim et /admin/sim/replays partagent un préfixe : forcer la
+    // comparaison exacte sur /admin/sim pour éviter le double highlight.
+    if (path === "/admin/sim") {
+      return pathname === "/admin/sim";
+    }
     return pathname?.startsWith(path);
   };
 
@@ -72,6 +77,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/cups", "Coupes", "🏆")}
               {navItem("/admin/feature-flags", "Feature Flags", "🚩")}
               {navItem("/admin/sim", "Sim Pro League", "🎲")}
+              {navItem("/admin/sim/replays", "Replays Panel", "📜")}
               {navItem("/admin/feedback", "Feedback", "💬")}
               {navItem("/admin/routes", "Routes", "📋")}
             </div>

--- a/apps/web/app/admin/sim/replays/page.tsx
+++ b/apps/web/app/admin/sim/replays/page.tsx
@@ -1,0 +1,449 @@
+"use client";
+
+/**
+ * Console admin — lecture des 50 replays panel BB experts (sprint
+ * Pro League 0.E.2 / 0.E.3).
+ *
+ * Sert de support à la validation **C6-C9** du gate Phase 0 → Phase 1
+ * (cf. `docs/roadmap/sprints/pro-league-gate.md`) :
+ *   C6 — moyenne globale ≥ 7/10
+ *   C7 — pas de note < 6.5 sur lisibilité tactique
+ *   C8 — pas de note < 6.5 sur cohérence des drives
+ *   C9 — ≥ 4/5 testeurs recommandent Phase 1
+ *
+ * Permet à un admin (sprint owner / tech lead / game designer) de :
+ *  - parcourir le set de 50 replays sans CLI ni clone du repo,
+ *  - filtrer par race / résultat / score / casualties,
+ *  - ouvrir le contenu narratif complet d'un replay côté droit,
+ *  - copier rapidement le nom du fichier pour citation dans
+ *    `pro-league-panel/score-synthesis.md`.
+ *
+ * Lecture seule : cette page n'écrit aucun état serveur.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+interface ReplaySummary {
+  filename: string;
+  index: string | null;
+  homeId: string | null;
+  awayId: string | null;
+  seed: number | null;
+  sizeBytes: number;
+  parsed: {
+    matchIndex: number | null;
+    homeName: string | null;
+    homeRace: string | null;
+    awayName: string | null;
+    awayRace: string | null;
+    engineVer: string | null;
+    homeScore: number | null;
+    awayScore: number | null;
+    outcome: "home" | "away" | "draw" | null;
+    totals: {
+      touchdowns: number | null;
+      casualties: number | null;
+      turnovers: number | null;
+      nuffle: number | null;
+    };
+    totalLines: number;
+  };
+}
+
+interface ListResponse {
+  replays: ReplaySummary[];
+  dir: string;
+  missing: boolean;
+}
+
+interface DetailResponse {
+  file: ReplaySummary["parsed"] & { filename: string };
+  parsed: ReplaySummary["parsed"];
+  content: string;
+}
+
+type OutcomeFilter = "all" | "home" | "away" | "draw";
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+  });
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(err.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+function formatScore(r: ReplaySummary): string {
+  const { homeScore, awayScore } = r.parsed;
+  if (homeScore === null || awayScore === null) return "—";
+  return `${homeScore}-${awayScore}`;
+}
+
+function outcomeBadge(outcome: ReplaySummary["parsed"]["outcome"]): {
+  label: string;
+  className: string;
+} {
+  switch (outcome) {
+    case "home":
+      return { label: "Home", className: "bg-emerald-100 text-emerald-700" };
+    case "away":
+      return { label: "Away", className: "bg-sky-100 text-sky-700" };
+    case "draw":
+      return { label: "Draw", className: "bg-gray-100 text-gray-700" };
+    default:
+      return { label: "?", className: "bg-gray-100 text-gray-500" };
+  }
+}
+
+export default function AdminReplaysPage() {
+  const [replays, setReplays] = useState<ReplaySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [missing, setMissing] = useState(false);
+  const [dir, setDir] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
+  const [raceFilter, setRaceFilter] = useState<string>("all");
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const [detail, setDetail] = useState<DetailResponse | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchJSON<ListResponse>("/admin/sim-replays/");
+        setReplays(data.replays);
+        setMissing(data.missing);
+        setDir(data.dir);
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!selected) {
+      setDetail(null);
+      setDetailError(null);
+      return;
+    }
+    setDetailLoading(true);
+    setDetailError(null);
+    (async () => {
+      try {
+        const data = await fetchJSON<DetailResponse>(
+          `/admin/sim-replays/${encodeURIComponent(selected)}`,
+        );
+        setDetail(data);
+      } catch (e) {
+        setDetailError((e as Error).message);
+      } finally {
+        setDetailLoading(false);
+      }
+    })();
+  }, [selected]);
+
+  const races = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of replays) {
+      if (r.parsed.homeRace) set.add(r.parsed.homeRace);
+      if (r.parsed.awayRace) set.add(r.parsed.awayRace);
+    }
+    return Array.from(set).sort();
+  }, [replays]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return replays.filter((r) => {
+      if (outcomeFilter !== "all" && r.parsed.outcome !== outcomeFilter) {
+        return false;
+      }
+      if (raceFilter !== "all") {
+        if (
+          r.parsed.homeRace !== raceFilter &&
+          r.parsed.awayRace !== raceFilter
+        ) {
+          return false;
+        }
+      }
+      if (q) {
+        const hay = [
+          r.filename,
+          r.parsed.homeName,
+          r.parsed.awayName,
+          r.parsed.homeRace,
+          r.parsed.awayRace,
+          r.homeId,
+          r.awayId,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [replays, outcomeFilter, raceFilter, search]);
+
+  const aggregate = useMemo(() => {
+    if (replays.length === 0) {
+      return { td: 0, cas: 0, to: 0, nuffle: 0, draws: 0 };
+    }
+    let td = 0;
+    let cas = 0;
+    let to = 0;
+    let nuffle = 0;
+    let draws = 0;
+    for (const r of replays) {
+      td += r.parsed.totals.touchdowns ?? 0;
+      cas += r.parsed.totals.casualties ?? 0;
+      to += r.parsed.totals.turnovers ?? 0;
+      nuffle += r.parsed.totals.nuffle ?? 0;
+      if (r.parsed.outcome === "draw") draws += 1;
+    }
+    return {
+      td: td / replays.length,
+      cas: cas / replays.length,
+      to: to / replays.length,
+      nuffle: nuffle / replays.length,
+      draws,
+    };
+  }, [replays]);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          📜 Replays panel — validation C6-C9
+        </h1>
+        <p className="text-sm text-gray-600">
+          Visualisation des 50 replays{" "}
+          <code className="text-xs bg-gray-100 px-1 rounded">
+            pro-league-panel/replays/
+          </code>{" "}
+          utilisés pour la validation gate Phase 0 → Phase 1 (cf.{" "}
+          <code className="text-xs bg-gray-100 px-1 rounded">
+            docs/roadmap/sprints/pro-league-gate.md
+          </code>
+          ). Lecture seule : aucune écriture serveur.
+        </p>
+      </header>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          ⚠️ {error}
+        </div>
+      )}
+
+      {missing && !loading && !error && (
+        <div className="p-4 bg-amber-50 border border-amber-200 rounded-lg text-amber-700 text-sm">
+          ⚠️ Le dossier <code>{dir}</code> est introuvable côté serveur.
+          Régénère les replays avec{" "}
+          <code className="bg-white px-1 rounded">
+            pnpm --filter @bb/sim-engine sim:replay --random=50 --seed=2026
+            --out=docs/roadmap/sprints/pro-league-panel/replays
+          </code>
+          .
+        </div>
+      )}
+
+      {!loading && !missing && replays.length > 0 && (
+        <section className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+            <Stat label="Replays" value={String(replays.length)} />
+            <Stat label="Ø TD / match" value={aggregate.td.toFixed(2)} />
+            <Stat label="Ø Cas / match" value={aggregate.cas.toFixed(2)} />
+            <Stat label="Ø TO / match" value={aggregate.to.toFixed(2)} />
+            <Stat label="Nuls" value={`${aggregate.draws} / ${replays.length}`} />
+          </div>
+        </section>
+      )}
+
+      <section className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-gray-500">
+              Recherche
+            </span>
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="équipe, race, fichier…"
+              className="border border-gray-300 rounded px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-gray-500">
+              Résultat
+            </span>
+            <select
+              value={outcomeFilter}
+              onChange={(e) =>
+                setOutcomeFilter(e.target.value as OutcomeFilter)
+              }
+              className="border border-gray-300 rounded px-3 py-2 text-sm"
+            >
+              <option value="all">Tous</option>
+              <option value="home">Victoire domicile</option>
+              <option value="away">Victoire visiteur</option>
+              <option value="draw">Match nul</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wide text-gray-500">
+              Race impliquée
+            </span>
+            <select
+              value={raceFilter}
+              onChange={(e) => setRaceFilter(e.target.value)}
+              className="border border-gray-300 rounded px-3 py-2 text-sm"
+            >
+              <option value="all">Toutes</option>
+              {races.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Liste */}
+        <section className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden">
+          <header className="px-4 py-2 border-b border-gray-200 text-xs text-gray-500 uppercase tracking-wide bg-gray-50 flex items-center justify-between">
+            <span>
+              {filtered.length} / {replays.length} replays
+            </span>
+            {loading && <span>Chargement…</span>}
+          </header>
+          <ul className="divide-y divide-gray-100 max-h-[60vh] overflow-y-auto">
+            {filtered.map((r) => {
+              const badge = outcomeBadge(r.parsed.outcome);
+              const isSelected = r.filename === selected;
+              return (
+                <li key={r.filename}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(r.filename)}
+                    className={`w-full text-left px-4 py-3 hover:bg-gray-50 transition-colors ${
+                      isSelected ? "bg-nuffle-gold/10" : ""
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-nuffle-anthracite truncate">
+                          #{r.parsed.matchIndex ?? r.index ?? "?"}{" "}
+                          — {r.parsed.homeName ?? r.homeId} vs{" "}
+                          {r.parsed.awayName ?? r.awayId}
+                        </div>
+                        <div className="text-xs text-gray-500 truncate">
+                          {r.parsed.homeRace ?? "?"} vs{" "}
+                          {r.parsed.awayRace ?? "?"} · seed {r.seed ?? "?"} ·
+                          engine {r.parsed.engineVer ?? "?"}
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end gap-1 shrink-0">
+                        <span className="text-base font-mono font-semibold text-nuffle-anthracite">
+                          {formatScore(r)}
+                        </span>
+                        <span
+                          className={`text-[10px] uppercase font-bold tracking-wide px-2 py-0.5 rounded ${badge.className}`}
+                        >
+                          {badge.label}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-gray-500">
+                      <span>cas {r.parsed.totals.casualties ?? "?"}</span>
+                      <span>to {r.parsed.totals.turnovers ?? "?"}</span>
+                      <span>nuffle {r.parsed.totals.nuffle ?? "?"}</span>
+                      <span>{r.parsed.totalLines} lignes</span>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+            {!loading && filtered.length === 0 && (
+              <li className="px-4 py-8 text-center text-sm text-gray-500">
+                Aucun replay ne matche les filtres courants.
+              </li>
+            )}
+          </ul>
+        </section>
+
+        {/* Détail */}
+        <section className="rounded-xl border border-gray-200 bg-white shadow-sm overflow-hidden flex flex-col">
+          <header className="px-4 py-2 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+            <div className="text-xs text-gray-500 uppercase tracking-wide">
+              {selected ? "Replay" : "Sélectionne un replay"}
+            </div>
+            {selected && (
+              <button
+                type="button"
+                onClick={() => navigator.clipboard?.writeText(selected)}
+                className="text-xs px-2 py-1 rounded border border-gray-300 hover:bg-gray-100"
+                title="Copier le nom du fichier (utile pour citer dans score-synthesis.md)"
+              >
+                📋 {selected}
+              </button>
+            )}
+          </header>
+          <div className="flex-1 max-h-[60vh] overflow-y-auto">
+            {!selected && (
+              <p className="px-4 py-8 text-sm text-gray-500 text-center">
+                Choisis un replay dans la liste pour afficher son contenu
+                narratif complet.
+              </p>
+            )}
+            {selected && detailLoading && (
+              <p className="px-4 py-8 text-sm text-gray-500 text-center">
+                Chargement…
+              </p>
+            )}
+            {selected && detailError && (
+              <p className="px-4 py-8 text-sm text-red-600 text-center">
+                ⚠️ {detailError}
+              </p>
+            )}
+            {detail && (
+              <pre className="px-4 py-3 text-xs whitespace-pre-wrap font-mono text-gray-800 leading-relaxed">
+                {detail.content}
+              </pre>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-gray-50 rounded p-3">
+      <div className="text-[11px] uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div className="text-base font-semibold text-nuffle-anthracite">
+        {value}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Sprint Pro League 0.E.2 / 0.E.3 — outillage admin pour la validation
gate Phase 0 → Phase 1 (cf. docs/roadmap/sprints/pro-league-gate.md
critères C6-C9 : moyenne globale ≥ 7/10, lisibilité ≥ 6.5,
cohérence ≥ 6.5, ≥ 4/5 testeurs recommandent).

- Backend `/admin/sim-replays` (admin-only, lecture seule) :
  GET `/`            → liste les 50 replays avec parsing résumé
  GET `/:filename`   → renvoie le narratif complet + métadonnées

  Garde-fou anti path-traversal : regex stricte
  `replay-NNN-<slug>-vs-<slug>-seedNNN.txt` + vérification du chemin
  résolu sous le dossier panel. Override env `PRO_LEAGUE_REPLAYS_DIR`
  pour les tests.

- Parser pur (`replay-parser.ts`) : extrait header, engine version,
  scores, totals (TD/cas/TO/Nuffle) — tolérant aux replays incomplets.

- UI `/admin/sim/replays` : liste filtrable (race / résultat /
  recherche), agrégats globaux (Ø TD/cas/TO, nuls), panneau de
  contenu narratif côté droit, copie en un clic du nom de fichier
  pour citation dans `pro-league-panel/score-synthesis.md`.

- Lien navigation ajouté dans `/admin/layout.tsx` ("📜 Replays
  Panel"). Fix `isActive` pour éviter le double highlight avec
  `/admin/sim`.

Tests : 14 unit tests parser + 6 tests handler (fixtures isolées en
tmpdir, indépendantes du repo réel). Suite serveur : 1462 / 1462 ✓.