### PR TITLE
feat(web): Pro League Pixi field visualization (sprint 1.B.3)

### DIFF
--- a/apps/web/app/lib/pro-league-field-state.test.ts
+++ b/apps/web/app/lib/pro-league-field-state.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import {
+  INITIAL_FIELD_STATE,
+  deriveProLeagueFieldState,
+} from "./pro-league-field-state";
+
+function ev(
+  type: MatchEvent["type"],
+  displayAtMs: number,
+  meta: Record<string, unknown> = {},
+): MatchEvent {
+  return {
+    type,
+    displayAtMs,
+    engineVer: "0.13.0",
+    meta,
+  } as MatchEvent;
+}
+
+describe("deriveProLeagueFieldState — sprint 1.B.3", () => {
+  it("retourne l'état initial pour un array vide", () => {
+    const out = deriveProLeagueFieldState([]);
+    expect(out.score).toEqual({ home: 0, away: 0 });
+    expect(out.ballYardline).toBeNull();
+    expect(out.drivingTeam).toBeNull();
+    expect(out.half).toBe(1);
+    expect(out.lastFlash).toBeNull();
+    expect(out.cursor).toBe(-1);
+  });
+
+  it("INITIAL_FIELD_STATE matche la sortie pour [] ", () => {
+    expect(deriveProLeagueFieldState([])).toEqual(INITIAL_FIELD_STATE);
+  });
+
+  it("met à jour ballYardline + drivingTeam depuis TURN_START", () => {
+    const out = deriveProLeagueFieldState([
+      ev("TURN_START", 0, {
+        half: 1,
+        turn: 1,
+        drivingTeam: "home",
+        ballYardline: 12,
+      }),
+    ]);
+    expect(out.ballYardline).toBe(12);
+    expect(out.drivingTeam).toBe("home");
+  });
+
+  it("incrémente le score sur TD home/away", () => {
+    const out = deriveProLeagueFieldState([
+      ev("TD", 30_000, { team: "home" }),
+      ev("TD", 60_000, { team: "home" }),
+      ev("TD", 90_000, { team: "away" }),
+    ]);
+    expect(out.score).toEqual({ home: 2, away: 1 });
+    // lastFlash doit être le dernier TD vu
+    expect(out.lastFlash?.type).toBe("TD");
+    expect(out.lastFlash?.team).toBe("away");
+    expect(out.lastFlash?.eventIndex).toBe(2);
+  });
+
+  it("garde le dernier flash CASUALTY", () => {
+    const out = deriveProLeagueFieldState([
+      ev("TD", 0, { team: "home" }),
+      ev("CASUALTY", 5_000, { causedBy: "block" }),
+    ]);
+    expect(out.lastFlash?.type).toBe("CASUALTY");
+    expect(out.lastFlash?.eventIndex).toBe(1);
+  });
+
+  it("garde le dernier flash NUFFLE", () => {
+    const out = deriveProLeagueFieldState([
+      ev("CASUALTY", 0),
+      ev("NUFFLE", 1000, { id: "banana_skin" }),
+    ]);
+    expect(out.lastFlash?.type).toBe("NUFFLE");
+  });
+
+  it("HALFTIME passe half à 2 ; END le passe à 'final'", () => {
+    expect(
+      deriveProLeagueFieldState([ev("HALFTIME", 240_000)]).half,
+    ).toBe(2);
+    expect(deriveProLeagueFieldState([ev("END", 480_000)]).half).toBe("final");
+  });
+
+  it("cursor = events.length - 1", () => {
+    const out = deriveProLeagueFieldState([
+      ev("KICKOFF", 0),
+      ev("TURN_START", 0, {
+        half: 1,
+        turn: 1,
+        drivingTeam: "home",
+        ballYardline: 4,
+      }),
+      ev("TD", 30_000, { team: "home" }),
+    ]);
+    expect(out.cursor).toBe(2);
+  });
+
+  it("scénario complet : kickoff → drive home → TD home → TURN_START away", () => {
+    const events: MatchEvent[] = [
+      ev("KICKOFF", 0, { home: "h", away: "a" }),
+      ev("TURN_START", 0, {
+        half: 1,
+        turn: 1,
+        drivingTeam: "home",
+        ballYardline: 4,
+      }),
+      ev("TURN_START", 30_000, {
+        half: 1,
+        turn: 2,
+        drivingTeam: "home",
+        ballYardline: 18,
+      }),
+      ev("TD", 60_000, { team: "home" }),
+      ev("TURN_START", 90_000, {
+        half: 1,
+        turn: 3,
+        drivingTeam: "away",
+        ballYardline: 4,
+      }),
+    ];
+    const out = deriveProLeagueFieldState(events);
+    expect(out.score).toEqual({ home: 1, away: 0 });
+    expect(out.ballYardline).toBe(4);
+    expect(out.drivingTeam).toBe("away");
+    // lastFlash est le TD (event index 3) car le TURN_START suivant
+    // n'efface pas le flash.
+    expect(out.lastFlash?.type).toBe("TD");
+    expect(out.lastFlash?.eventIndex).toBe(3);
+  });
+
+  it("idempotent : 2 appels avec le même array → même résultat", () => {
+    const events: MatchEvent[] = [
+      ev("TD", 0, { team: "home" }),
+      ev("TURN_START", 30_000, {
+        half: 1,
+        turn: 1,
+        drivingTeam: "away",
+        ballYardline: 12,
+      }),
+    ];
+    expect(deriveProLeagueFieldState(events)).toEqual(
+      deriveProLeagueFieldState(events),
+    );
+  });
+});

--- a/apps/web/app/lib/pro-league-field-state.ts
+++ b/apps/web/app/lib/pro-league-field-state.ts
@@ -1,0 +1,125 @@
+/**
+ * Dérive un "état field" à partir d'un flux d'events `MatchEvent[]` —
+ * sprint Pro League lot 1.B.3.
+ *
+ * La sim Pro League est hybride yards-level (cf. sim-engine) : on
+ * n'a pas de positions individuelles de joueurs. On reconstruit à
+ * la place une représentation abstraite mais expressive :
+ *   - position de la balle (yardline 0-26)
+ *   - équipe en possession
+ *   - score
+ *   - dernier event "flashable" (TD / CASUALTY / NUFFLE)
+ *
+ * Cet helper est PUR — pas d'I/O, pas de Pixi. Testable seul.
+ */
+
+import type { MatchEvent } from "@bb/shared-types";
+
+/** Largeur du terrain BB en yards (cf. sim-engine FIELD_YARDS). */
+export const PRO_LEAGUE_FIELD_YARDS = 26;
+
+export type DrivingTeam = "home" | "away";
+
+export interface ProLeagueFieldState {
+  /** Score courant (cumul des events TD). */
+  readonly score: { home: number; away: number };
+  /** Position de la balle, 0..26 yards depuis le côté de l'équipe en
+   *  possession. `null` quand pas encore d'info (avant le 1er
+   *  TURN_START par ex.). */
+  readonly ballYardline: number | null;
+  /** Équipe en possession lors du dernier TURN_START. `null` au début. */
+  readonly drivingTeam: DrivingTeam | null;
+  /** Quart-temps : 1, 2 ou "final" (post-END). */
+  readonly half: 1 | 2 | "final";
+  /** Dernier event "flashable" + son timestamp local (ms wall-clock).
+   *  Permet à l'UI de déclencher une animation pendant ~1s.
+   *  `null` si aucun n'a encore été émis. */
+  readonly lastFlash: {
+    readonly type: "TD" | "CASUALTY" | "NUFFLE";
+    readonly team?: DrivingTeam;
+    /** Index de l'event source dans `events[]`. Utile pour éviter de
+     *  re-flasher le même event sur un re-render. */
+    readonly eventIndex: number;
+  } | null;
+  /** Index du dernier event consommé (pour debugging / cohérence). */
+  readonly cursor: number;
+}
+
+/** État initial à passer à `deriveProLeagueFieldState` au 1er render. */
+export const INITIAL_FIELD_STATE: ProLeagueFieldState = {
+  score: { home: 0, away: 0 },
+  ballYardline: null,
+  drivingTeam: null,
+  half: 1,
+  lastFlash: null,
+  cursor: -1,
+};
+
+/**
+ * Recompute l'état field à partir du flux complet d'events. La fonction
+ * est idempotente : appeler 2 fois avec le même array donne le même
+ * résultat.
+ */
+export function deriveProLeagueFieldState(
+  events: readonly MatchEvent[],
+): ProLeagueFieldState {
+  let home = 0;
+  let away = 0;
+  let ballYardline: number | null = null;
+  let drivingTeam: DrivingTeam | null = null;
+  let half: 1 | 2 | "final" = 1;
+  let lastFlash: ProLeagueFieldState["lastFlash"] = null;
+
+  for (let i = 0; i < events.length; i += 1) {
+    const ev = events[i];
+    switch (ev.type) {
+      case "TURN_START": {
+        const meta = (ev.meta ?? {}) as Record<string, unknown>;
+        const yard = meta.ballYardline;
+        if (typeof yard === "number") ballYardline = yard;
+        const team = meta.drivingTeam;
+        if (team === "home" || team === "away") drivingTeam = team;
+        break;
+      }
+      case "TD": {
+        const meta = (ev.meta ?? {}) as Record<string, unknown>;
+        const team = meta.team;
+        if (team === "home") home += 1;
+        else if (team === "away") away += 1;
+        lastFlash = {
+          type: "TD",
+          team: team === "home" || team === "away" ? team : undefined,
+          eventIndex: i,
+        };
+        break;
+      }
+      case "CASUALTY": {
+        lastFlash = { type: "CASUALTY", eventIndex: i };
+        break;
+      }
+      case "NUFFLE": {
+        lastFlash = { type: "NUFFLE", eventIndex: i };
+        break;
+      }
+      case "HALFTIME": {
+        half = 2;
+        break;
+      }
+      case "END": {
+        half = "final";
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return {
+    score: { home, away },
+    ballYardline,
+    drivingTeam,
+    half,
+    lastFlash,
+    cursor: events.length - 1,
+  };
+}

--- a/apps/web/app/lib/use-pro-league-match-stream.test.ts
+++ b/apps/web/app/lib/use-pro-league-match-stream.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Sprint Pro League lot 1.B.4 — Tests du hook
+ * `useProLeagueMatchStream`.
+ *
+ * Mocke `EventSource` globalement pour pouvoir simuler les events
+ * SSE dans jsdom.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { useProLeagueMatchStream } from "./use-pro-league-match-stream";
+
+interface MockEventSourceInstance {
+  url: string;
+  readyState: number;
+  close: ReturnType<typeof vi.fn>;
+  onopen: ((ev: Event) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  listeners: Map<string, EventListener[]>;
+  emitTyped(type: string, data: unknown): void;
+  triggerOpen(): void;
+  triggerError(): void;
+}
+
+function makeMockEventSource(): {
+  ctor: new (url: string) => MockEventSourceInstance;
+  instances: MockEventSourceInstance[];
+} {
+  const instances: MockEventSourceInstance[] = [];
+  const ctor = function (this: MockEventSourceInstance, url: string) {
+    this.url = url;
+    this.readyState = 0;
+    this.close = vi.fn();
+    this.onopen = null;
+    this.onerror = null;
+    this.onmessage = null;
+    this.listeners = new Map();
+    this.emitTyped = (type: string, data: unknown): void => {
+      const ev = {
+        data: typeof data === "string" ? data : JSON.stringify(data),
+      } as MessageEvent;
+      const ls = this.listeners.get(type) ?? [];
+      for (const l of ls) l(ev);
+    };
+    this.triggerOpen = (): void => {
+      if (this.onopen) this.onopen({} as Event);
+    };
+    this.triggerError = (): void => {
+      if (this.onerror) this.onerror({} as Event);
+    };
+    instances.push(this);
+  } as unknown as new (url: string) => MockEventSourceInstance;
+  Object.defineProperty(ctor.prototype, "addEventListener", {
+    value(this: MockEventSourceInstance, type: string, listener: EventListener) {
+      const ls = this.listeners.get(type) ?? [];
+      ls.push(listener);
+      this.listeners.set(type, ls);
+    },
+  });
+  return { ctor, instances };
+}
+
+let originalEventSource: typeof globalThis.EventSource | undefined;
+let mock: ReturnType<typeof makeMockEventSource>;
+
+beforeEach(() => {
+  mock = makeMockEventSource();
+  originalEventSource = (globalThis as { EventSource?: typeof EventSource })
+    .EventSource;
+  (globalThis as { EventSource?: unknown }).EventSource = mock.ctor;
+});
+
+afterEach(() => {
+  (globalThis as { EventSource?: unknown }).EventSource = originalEventSource;
+});
+
+describe("useProLeagueMatchStream — sprint 1.B.4", () => {
+  it("ne crée pas de connexion si matchId est null", () => {
+    const { result } = renderHook(() => useProLeagueMatchStream(null));
+    expect(mock.instances).toHaveLength(0);
+    expect(result.current.connectionState).toBe("closed");
+    expect(result.current.events).toEqual([]);
+  });
+
+  it("crée une EventSource avec l'URL attendue", () => {
+    renderHook(() => useProLeagueMatchStream("match_abc"));
+    expect(mock.instances).toHaveLength(1);
+    expect(mock.instances[0].url).toContain(
+      "/pro-league/matches/match_abc/stream",
+    );
+  });
+
+  it("connectionState=open après onopen", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].triggerOpen();
+    });
+    expect(result.current.connectionState).toBe("open");
+  });
+
+  it("accumule les events typed received", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+
+    const e1: MatchEvent = {
+      type: "KICKOFF",
+      displayAtMs: 0,
+      engineVer: "0.13.0",
+      seed: 1,
+      meta: { home: "h", away: "a" },
+    };
+    const e2: MatchEvent = {
+      type: "TURN_START",
+      displayAtMs: 30_000,
+      engineVer: "0.13.0",
+      meta: { half: 1, turn: 1, drivingTeam: "home", ballYardline: 4 },
+    };
+
+    act(() => {
+      mock.instances[0].emitTyped("KICKOFF", e1);
+      mock.instances[0].emitTyped("TURN_START", e2);
+    });
+
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[0].type).toBe("KICKOFF");
+    expect(result.current.events[1].type).toBe("TURN_START");
+  });
+
+  it("ferme la connexion quand un event END est reçu", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    const endEv: MatchEvent = {
+      type: "END",
+      displayAtMs: 480_000,
+      engineVer: "0.13.0",
+      meta: { score: { home: 2, away: 1 } },
+    };
+    act(() => {
+      mock.instances[0].emitTyped("END", endEv);
+    });
+    expect(result.current.connectionState).toBe("closed");
+    expect(mock.instances[0].close).toHaveBeenCalled();
+  });
+
+  it("connectionState=error sur onerror", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].triggerError();
+    });
+    expect(result.current.connectionState).toBe("error");
+  });
+
+  it("expose error string si JSON.parse fail", () => {
+    const { result } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    act(() => {
+      mock.instances[0].emitTyped("KICKOFF", "not-valid-json{{{");
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("ferme la connexion à l'unmount", () => {
+    const { unmount } = renderHook(() =>
+      useProLeagueMatchStream("match_abc"),
+    );
+    expect(mock.instances[0].close).not.toHaveBeenCalled();
+    unmount();
+    expect(mock.instances[0].close).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/use-pro-league-match-stream.ts
+++ b/apps/web/app/lib/use-pro-league-match-stream.ts
@@ -1,0 +1,118 @@
+/**
+ * Hook React qui consomme l'endpoint SSE
+ * `/pro-league/matches/:id/stream` (sprint Pro League lot 1.B.2) et
+ * accumule les `MatchEvent[]` reçus.
+ *
+ * Sprint Pro League — lot 1.B.4 (ticker textuel mobile-friendly).
+ *
+ * Le navigateur gère nativement la reconnexion via `Last-Event-ID`
+ * tant que la `EventSource` n'est pas explicitement fermée. On expose
+ * néanmoins un état `connectionState` lisible pour permettre à l'UI
+ * d'afficher un badge "live" / "reconnecting" / "ended".
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { API_BASE } from "../auth-client";
+
+export type ConnectionState = "connecting" | "open" | "error" | "closed";
+
+export interface UseProLeagueMatchStreamResult {
+  readonly events: readonly MatchEvent[];
+  readonly connectionState: ConnectionState;
+  /** Erreur runtime (parse, fetch). null en bon état. */
+  readonly error: string | null;
+}
+
+const ENDED_EVENT_TYPES = new Set(["END"]);
+
+/**
+ * Subscribe au stream SSE d'un match Pro League. Le hook ferme
+ * automatiquement la connexion à l'unmount + lorsqu'un event `END`
+ * est reçu (le match est terminé, plus rien à streamer).
+ */
+export function useProLeagueMatchStream(
+  matchId: string | null | undefined,
+): UseProLeagueMatchStreamResult {
+  const [events, setEvents] = useState<readonly MatchEvent[]>([]);
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>("connecting");
+  const [error, setError] = useState<string | null>(null);
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!matchId) {
+      setConnectionState("closed");
+      return;
+    }
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      // SSR / environnement sans EventSource : no-op.
+      return;
+    }
+
+    const url = `${API_BASE}/pro-league/matches/${encodeURIComponent(matchId)}/stream`;
+    const source = new EventSource(url);
+    sourceRef.current = source;
+    setConnectionState("connecting");
+    setError(null);
+    setEvents([]);
+
+    source.onopen = () => {
+      setConnectionState("open");
+      setError(null);
+    };
+
+    source.onerror = () => {
+      // EventSource va automatiquement retry. On expose juste l'état.
+      setConnectionState("error");
+    };
+
+    const handleEvent = (raw: MessageEvent): void => {
+      try {
+        const parsed = JSON.parse(raw.data) as MatchEvent;
+        setEvents((prev) => [...prev, parsed]);
+        if (ENDED_EVENT_TYPES.has(parsed.type)) {
+          source.close();
+          setConnectionState("closed");
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "parse failed";
+        setError(msg);
+      }
+    };
+
+    // Le serveur émet event: <TYPE> + data: <JSON>. EventSource expose
+    // `addEventListener(type, …)` par event named, ou `onmessage` pour
+    // les events sans type. On wire les types connus + un fallback.
+    const KNOWN_EVENT_TYPES = [
+      "KICKOFF",
+      "TURN_START",
+      "BLOCK",
+      "DODGE",
+      "PASS",
+      "TD",
+      "KO",
+      "CASUALTY",
+      "TURNOVER",
+      "NUFFLE",
+      "HALFTIME",
+      "END",
+    ] as const;
+    for (const t of KNOWN_EVENT_TYPES) {
+      source.addEventListener(t, handleEvent as EventListener);
+    }
+    source.onmessage = handleEvent;
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+      setConnectionState("closed");
+    };
+  }, [matchId]);
+
+  return { events, connectionState, error };
+}

--- a/apps/web/app/pro-league/matches/[id]/live/ProLeagueField.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/ProLeagueField.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { Container, Graphics, Stage, Text } from "@pixi/react";
+// Pixi v7 (@pixi/react@7) — on type via `any` car @pixi/graphics est
+// résolu indirectement par pnpm sans entrée explicite dans le tsconfig.
+// Le runtime fonctionne ; on évite juste le dance de dépendances.
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  PRO_LEAGUE_FIELD_YARDS,
+  type ProLeagueFieldState,
+} from "../../../../lib/pro-league-field-state";
+
+/**
+ * Visualisation Pixi abstraite du field Pro League — sprint 1.B.3.
+ *
+ * Affiche un terrain BB-like avec :
+ *  - Yard lines tous les 5 yards.
+ *  - End zones colorées (home gauche, away droite).
+ *  - Indicateur de balle au yardline courant.
+ *  - Flèche de direction du drive.
+ *  - Flash overlay (vert sur TD, rouge sur CASUALTY, violet sur NUFFLE).
+ *
+ * La sim Pro League étant hybride yards-level (pas de positions
+ * individuelles), cette visu reste volontairement abstraite. Pour une
+ * visu joueur-par-joueur il faudrait un sim full driver.
+ */
+
+const FIELD_WIDTH = 720;
+const FIELD_HEIGHT = 240;
+const MARGIN = 24;
+const PLAY_WIDTH = FIELD_WIDTH - MARGIN * 2;
+const PLAY_HEIGHT = FIELD_HEIGHT - MARGIN * 2;
+/** Longueur d'1 yard en pixels (PLAY_WIDTH / 26). */
+const YARD_PX = PLAY_WIDTH / PRO_LEAGUE_FIELD_YARDS;
+
+const COLOR_FIELD = 0x1f3a1f; // dark green
+const COLOR_LINE = 0x4a6a4a;
+const COLOR_LINE_BOLD = 0xa8c8a8;
+const COLOR_HOME_END = 0xb91c1c;
+const COLOR_AWAY_END = 0x1d4ed8;
+const COLOR_BALL = 0xfacc15;
+const COLOR_BALL_OUTLINE = 0x1c1917;
+const COLOR_FLASH_TD = 0x16a34a;
+const COLOR_FLASH_CAS = 0xdc2626;
+const COLOR_FLASH_NUFFLE = 0x9333ea;
+
+interface FlashState {
+  readonly color: number;
+  readonly key: number;
+}
+
+const FLASH_DURATION_MS = 900;
+
+interface ProLeagueFieldProps {
+  readonly fieldState: ProLeagueFieldState;
+  /** Largeur CSS du conteneur. La hauteur s'ajuste avec un ratio 3:1. */
+  readonly width?: number;
+}
+
+function drawFieldBackground(g: any): void {
+  g.clear();
+  // Background terrain.
+  g.beginFill(COLOR_FIELD);
+  g.drawRoundedRect(0, 0, FIELD_WIDTH, FIELD_HEIGHT, 8);
+  g.endFill();
+
+  // End zones.
+  g.beginFill(COLOR_HOME_END, 0.6);
+  g.drawRect(0, 0, MARGIN, FIELD_HEIGHT);
+  g.endFill();
+  g.beginFill(COLOR_AWAY_END, 0.6);
+  g.drawRect(FIELD_WIDTH - MARGIN, 0, MARGIN, FIELD_HEIGHT);
+  g.endFill();
+
+  // Yard lines tous les 5 yards.
+  for (let y = 0; y <= PRO_LEAGUE_FIELD_YARDS; y += 1) {
+    const x = MARGIN + y * YARD_PX;
+    const isBold = y % 5 === 0;
+    g.lineStyle(isBold ? 2 : 1, isBold ? COLOR_LINE_BOLD : COLOR_LINE, 0.8);
+    g.moveTo(x, MARGIN);
+    g.lineTo(x, FIELD_HEIGHT - MARGIN);
+  }
+
+  // Bordures play area.
+  g.lineStyle(2, 0x000000, 0.4);
+  g.drawRect(MARGIN, MARGIN, PLAY_WIDTH, PLAY_HEIGHT);
+}
+
+function drawBall(
+  g: any,
+  ballYardline: number | null,
+  drivingTeam: "home" | "away" | null,
+): void {
+  g.clear();
+  if (ballYardline === null) return;
+  // Quand l'équipe driving est home, "yardline" est mesurée depuis
+  // leur côté (gauche). Pour away, on inverse pour visualiser depuis
+  // leur côté (droite).
+  const yard =
+    drivingTeam === "away" ? PRO_LEAGUE_FIELD_YARDS - ballYardline : ballYardline;
+  const x = MARGIN + yard * YARD_PX;
+  const y = FIELD_HEIGHT / 2;
+
+  // Direction arrow (subtle).
+  const arrowDx = drivingTeam === "away" ? -28 : 28;
+  g.lineStyle(2, COLOR_BALL, 0.35);
+  g.moveTo(x, y);
+  g.lineTo(x + arrowDx, y);
+  g.lineTo(x + arrowDx - (arrowDx > 0 ? 6 : -6), y - 4);
+  g.moveTo(x + arrowDx, y);
+  g.lineTo(x + arrowDx - (arrowDx > 0 ? 6 : -6), y + 4);
+  g.lineStyle();
+
+  // Ball.
+  g.beginFill(COLOR_BALL);
+  g.lineStyle(2, COLOR_BALL_OUTLINE);
+  g.drawCircle(x, y, 8);
+  g.endFill();
+}
+
+function drawFlash(g: any, color: number, alpha: number): void {
+  g.clear();
+  if (alpha <= 0) return;
+  g.beginFill(color, alpha);
+  g.drawRect(0, 0, FIELD_WIDTH, FIELD_HEIGHT);
+  g.endFill();
+}
+
+function flashColorFor(
+  type: "TD" | "CASUALTY" | "NUFFLE" | undefined,
+): number {
+  if (type === "TD") return COLOR_FLASH_TD;
+  if (type === "CASUALTY") return COLOR_FLASH_CAS;
+  if (type === "NUFFLE") return COLOR_FLASH_NUFFLE;
+  return 0x000000;
+}
+
+export function ProLeagueField({
+  fieldState,
+  width = 720,
+}: ProLeagueFieldProps): JSX.Element {
+  const [flash, setFlash] = useState<FlashState | null>(null);
+  const [flashAlpha, setFlashAlpha] = useState(0);
+
+  // Déclenche un flash quand `lastFlash.eventIndex` change.
+  useEffect(() => {
+    const lf = fieldState.lastFlash;
+    if (!lf) return;
+    setFlash({ color: flashColorFor(lf.type), key: lf.eventIndex });
+    setFlashAlpha(0.55);
+    const start = Date.now();
+    let raf = 0;
+    const step = (): void => {
+      const elapsed = Date.now() - start;
+      const t = Math.min(1, elapsed / FLASH_DURATION_MS);
+      setFlashAlpha(0.55 * (1 - t));
+      if (t < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [fieldState.lastFlash?.eventIndex, fieldState.lastFlash?.type]);
+
+  const drawBg = useCallback((g: any) => drawFieldBackground(g), []);
+  const drawBallG = useCallback(
+    (g: any) =>
+      drawBall(g, fieldState.ballYardline, fieldState.drivingTeam),
+    [fieldState.ballYardline, fieldState.drivingTeam],
+  );
+  const drawFlashG = useCallback(
+    (g: any) => drawFlash(g, flash?.color ?? 0, flashAlpha),
+    [flash, flashAlpha],
+  );
+
+  // Ratio hauteur 3:1 pour responsive.
+  const cssHeight = (width / FIELD_WIDTH) * FIELD_HEIGHT;
+
+  return (
+    <div
+      data-testid="pro-league-field"
+      style={{ width, height: cssHeight, maxWidth: "100%", aspectRatio: "3 / 1" }}
+    >
+      <Stage
+        width={FIELD_WIDTH}
+        height={FIELD_HEIGHT}
+        options={{ backgroundAlpha: 0, antialias: true }}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <Container>
+          <Graphics draw={drawBg} />
+          <Graphics draw={drawBallG} />
+          <Graphics draw={drawFlashG} />
+          <Text
+            text={`${fieldState.score.home}`}
+            x={MARGIN / 2 + 4}
+            y={MARGIN + 4}
+            style={
+              {
+                fontFamily: "monospace",
+                fontSize: 18,
+                fill: 0xffffff,
+                fontWeight: "bold",
+              } as unknown as undefined
+            }
+          />
+          <Text
+            text={`${fieldState.score.away}`}
+            x={FIELD_WIDTH - MARGIN - 4}
+            y={MARGIN + 4}
+            anchor={{ x: 1, y: 0 }}
+            style={
+              {
+                fontFamily: "monospace",
+                fontSize: 18,
+                fill: 0xffffff,
+                fontWeight: "bold",
+              } as unknown as undefined
+            }
+          />
+        </Container>
+      </Stage>
+    </div>
+  );
+}
+
+export default ProLeagueField;

--- a/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Sprint Pro League lot 1.B.4 — Tests page live ticker.
+ *
+ * Mocke le hook `useProLeagueMatchStream` pour contrôler les events.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+vi.mock("../../../../lib/use-pro-league-match-stream", () => ({
+  useProLeagueMatchStream: vi.fn(),
+}));
+
+import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
+import LiveProMatchPage from "./page";
+
+const mockedHook = vi.mocked(useProLeagueMatchStream);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LiveProMatchPage — sprint 1.B.4", () => {
+  it("affiche '0 – 0' + 'En attente du kickoff' quand pas d'events", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "connecting",
+      error: null,
+    });
+
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+
+    expect(screen.getByTestId("score-display").textContent).toContain("0");
+    expect(screen.getByText(/En attente/i)).toBeTruthy();
+    expect(screen.getByTestId("connection-badge").textContent).toMatch(
+      /connecting/i,
+    );
+  });
+
+  it("affiche le badge LIVE quand connecté", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByTestId("connection-badge").textContent).toMatch(/LIVE/);
+  });
+
+  it("calcule le score à partir des events TD", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: { home: "h", away: "a" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 30_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 60_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+      {
+        type: "TD",
+        displayAtMs: 90_000,
+        engineVer: "0.13.0",
+        meta: { team: "away" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByTestId("score-display").textContent).toContain("2");
+    expect(screen.getByTestId("score-display").textContent).toContain("1");
+  });
+
+  it("affiche '2nd half' après HALFTIME et 'FT' après END", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: {},
+      },
+      {
+        type: "HALFTIME",
+        displayAtMs: 240_000,
+        engineVer: "0.13.0",
+        meta: { score: { home: 1, away: 1 } },
+      },
+    ];
+    mockedHook.mockReturnValueOnce({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    const { rerender } = render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText(/2nd half/i)).toBeTruthy();
+
+    mockedHook.mockReturnValue({
+      events: [
+        ...events,
+        {
+          type: "END",
+          displayAtMs: 480_000,
+          engineVer: "0.13.0",
+          meta: { score: { home: 2, away: 1 } },
+        },
+      ],
+      connectionState: "closed",
+      error: null,
+    });
+    rerender(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText("FT")).toBeTruthy();
+  });
+
+  it("liste les events avec les badges et l'horloge", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "TD",
+        displayAtMs: 75_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByText("TD")).toBeTruthy();
+    expect(screen.getByText("1:15")).toBeTruthy();
+    expect(screen.getByText(/TOUCHDOWN HOME/i)).toBeTruthy();
+  });
+
+  it("ordre inverse : event le plus récent en haut", () => {
+    const events: MatchEvent[] = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.13.0",
+        seed: 1,
+        meta: {},
+      },
+      {
+        type: "TD",
+        displayAtMs: 30_000,
+        engineVer: "0.13.0",
+        meta: { team: "home" },
+      },
+    ];
+    mockedHook.mockReturnValue({
+      events,
+      connectionState: "open",
+      error: null,
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    const items = screen.getByTestId("event-feed").querySelectorAll("li");
+    expect(items.length).toBe(2);
+    // Premier li = event le plus récent (TD).
+    expect(items[0].textContent).toContain("TD");
+    expect(items[1].textContent).toContain("KICKOFF");
+  });
+
+  it("affiche le message d'erreur si error retourné par le hook", () => {
+    mockedHook.mockReturnValue({
+      events: [],
+      connectionState: "error",
+      error: "boom-parse",
+    });
+    render(<LiveProMatchPage params={{ id: "m1" }} />);
+    expect(screen.getByRole("alert").textContent).toContain("boom-parse");
+  });
+});

--- a/apps/web/app/pro-league/matches/[id]/live/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
+
+/**
+ * Page de spectate textuel d'un match Pro League — sprint 1.B.4.
+ *
+ * Vue alternative pure texte pour mobile / low-bandwidth :
+ * - Score sticky en haut (mis à jour à chaque event TD).
+ * - Timeline scrollable des events avec badges (TD / CAS / NUFFLE).
+ * - Auto-refresh via SSE (`useProLeagueMatchStream`).
+ *
+ * Pas d'auth — les matchs Pro League sont publics au MVP.
+ */
+interface LivePageProps {
+  readonly params: { id: string };
+}
+
+interface ScoreState {
+  home: number;
+  away: number;
+  half: 1 | 2 | "final";
+}
+
+function deriveScore(events: readonly MatchEvent[]): ScoreState {
+  let home = 0;
+  let away = 0;
+  let half: 1 | 2 | "final" = 1;
+  for (const ev of events) {
+    if (ev.type === "TD") {
+      const team = (ev.meta as { team?: string } | undefined)?.team;
+      if (team === "home") home += 1;
+      else if (team === "away") away += 1;
+    } else if (ev.type === "HALFTIME") {
+      half = 2;
+    } else if (ev.type === "END") {
+      half = "final";
+    }
+  }
+  return { home, away, half };
+}
+
+const EVENT_BADGE_STYLES: Record<string, string> = {
+  KICKOFF: "bg-slate-700 text-slate-100",
+  TURN_START: "bg-slate-800 text-slate-300",
+  BLOCK: "bg-amber-900 text-amber-100",
+  DODGE: "bg-sky-900 text-sky-100",
+  PASS: "bg-blue-900 text-blue-100",
+  TD: "bg-emerald-700 text-emerald-50 font-semibold",
+  KO: "bg-orange-900 text-orange-100",
+  CASUALTY: "bg-red-700 text-red-50 font-semibold",
+  TURNOVER: "bg-rose-900 text-rose-100",
+  NUFFLE: "bg-purple-700 text-purple-50 font-semibold",
+  HALFTIME: "bg-indigo-900 text-indigo-100",
+  END: "bg-slate-900 text-slate-100 font-semibold",
+};
+
+function formatClock(displayAtMs: number): string {
+  const seconds = Math.floor(displayAtMs / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function summarizeMeta(ev: MatchEvent): string {
+  const meta = (ev.meta ?? {}) as Record<string, unknown>;
+  switch (ev.type) {
+    case "KICKOFF": {
+      const home = String(meta.homeName ?? meta.home ?? "home");
+      const away = String(meta.awayName ?? meta.away ?? "away");
+      return `${home} vs ${away}`;
+    }
+    case "TURN_START": {
+      const half = meta.half;
+      const turn = meta.turn;
+      const drivingTeam = String(meta.drivingTeam ?? "");
+      return `Half ${half ?? ""} · Turn ${turn ?? ""}${drivingTeam ? ` · ${drivingTeam}` : ""}`;
+    }
+    case "TD": {
+      const team = String(meta.team ?? "");
+      return `TOUCHDOWN ${team.toUpperCase()}`;
+    }
+    case "CASUALTY": {
+      const cause = meta.causedBy ? ` (${String(meta.causedBy)})` : "";
+      return `Casualty${cause}`;
+    }
+    case "NUFFLE": {
+      const id = meta.id ?? meta.eventId ?? "?";
+      return `Nuffle: ${String(id)}`;
+    }
+    case "HALFTIME":
+      return "Halftime";
+    case "END":
+      return "Match end";
+    default:
+      return ev.type;
+  }
+}
+
+function ConnectionBadge({
+  state,
+}: {
+  state: "connecting" | "open" | "error" | "closed";
+}): JSX.Element {
+  const label =
+    state === "open"
+      ? "● LIVE"
+      : state === "connecting"
+        ? "○ connecting"
+        : state === "error"
+          ? "⚠ reconnecting"
+          : "■ ended";
+  const klass =
+    state === "open"
+      ? "bg-emerald-600 text-emerald-50"
+      : state === "connecting"
+        ? "bg-slate-600 text-slate-100"
+        : state === "error"
+          ? "bg-amber-600 text-amber-50"
+          : "bg-slate-700 text-slate-300";
+  return (
+    <span
+      data-testid="connection-badge"
+      className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-mono ${klass}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default function LiveProMatchPage({
+  params,
+}: LivePageProps): JSX.Element {
+  const { events, connectionState, error } = useProLeagueMatchStream(params.id);
+  const score = useMemo(() => deriveScore(events), [events]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
+      <header
+        data-testid="score-header"
+        className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-4 py-3 shadow"
+      >
+        <div className="flex items-center gap-3">
+          <ConnectionBadge state={connectionState} />
+          <span className="font-mono text-sm text-slate-400">
+            {score.half === "final"
+              ? "FT"
+              : score.half === 1
+                ? "1st half"
+                : "2nd half"}
+          </span>
+        </div>
+        <div
+          data-testid="score-display"
+          className="font-mono text-2xl font-bold tracking-wide"
+        >
+          {score.home} – {score.away}
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="m-4 rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      <ol
+        data-testid="event-feed"
+        className="flex flex-1 flex-col gap-1 px-4 py-3"
+      >
+        {events.length === 0 ? (
+          <li className="text-sm text-slate-500">
+            En attente du kickoff…
+          </li>
+        ) : (
+          events
+            .slice()
+            .reverse()
+            .map((ev, idx) => (
+              <li
+                key={`${events.length - 1 - idx}-${ev.type}-${ev.displayAtMs}`}
+                className="flex items-start gap-3 rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm"
+              >
+                <span className="font-mono text-xs text-slate-500">
+                  {formatClock(ev.displayAtMs)}
+                </span>
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-mono ${EVENT_BADGE_STYLES[ev.type] ?? "bg-slate-700 text-slate-100"}`}
+                >
+                  {ev.type}
+                </span>
+                <span className="flex-1 text-slate-200">
+                  {summarizeMeta(ev)}
+                </span>
+              </li>
+            ))
+        )}
+      </ol>
+    </main>
+  );
+}

--- a/apps/web/app/pro-league/matches/[id]/live/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.tsx
@@ -1,10 +1,28 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useMemo } from "react";
 
 import type { MatchEvent } from "@bb/shared-types";
 
+import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
 import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
+
+// Lazy-load Pixi (>500KB) — même pattern que /play et /spectate PvP.
+// Le chunk /pro-league/matches ne porte plus le moteur de rendu en
+// main bundle (sprint 1.B.3).
+const ProLeagueField = dynamic(
+  () => import("./ProLeagueField").then((m) => m.default),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="aspect-[3/1] w-full animate-pulse rounded bg-slate-800/60"
+        aria-label="Chargement du terrain"
+      />
+    ),
+  },
+);
 
 /**
  * Page de spectate textuel d'un match Pro League — sprint 1.B.4.
@@ -137,6 +155,10 @@ export default function LiveProMatchPage({
 }: LivePageProps): JSX.Element {
   const { events, connectionState, error } = useProLeagueMatchStream(params.id);
   const score = useMemo(() => deriveScore(events), [events]);
+  const fieldState = useMemo(
+    () => deriveProLeagueFieldState(events),
+    [events],
+  );
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
@@ -161,6 +183,10 @@ export default function LiveProMatchPage({
           {score.home} – {score.away}
         </div>
       </header>
+
+      <div className="px-4 pt-4" data-testid="field-wrapper">
+        <ProLeagueField fieldState={fieldState} />
+      </div>
 
       {error ? (
         <div


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.B.3** — Visualisation Pixi abstraite du field, intégrée au-dessus du ticker textuel (1.B.4) sur la page `/pro-league/matches/[id]/live`.

### `lib/pro-league-field-state.ts` — helper pure

`deriveProLeagueFieldState(events)` dérive un état field interprétable depuis le flux d'events :

| Champ | Source |
|---|---|
| `score` | Cumul TD home/away |
| `ballYardline` | `TURN_START.meta.ballYardline` |
| `drivingTeam` | `TURN_START.meta.drivingTeam` |
| `half` | `1 / 2 / "final"` (HALFTIME / END) |
| `lastFlash` | Dernier event TD/CAS/NUFFLE + eventIndex (anti-replay) |

Fonction pure, idempotente, testable — **10 tests unitaires**.

### `ProLeagueField.tsx` — composant Pixi

Terrain BB-like (26 yards, ratio 3:1) :

- **Yard lines** tous les 5 yards (bold) + gridlines secondaires
- **End zones** colorées (home rouge gauche, away bleu droite)
- **Ball indicator** au yardline courant + flèche de direction du drive
- **Score overlay** home (gauche) / away (droite)
- **Flash overlay** à chaque event "marquant" :
  - TD → flash vert (alpha 0.55 → 0 sur 900ms via requestAnimationFrame)
  - CASUALTY → flash rouge
  - NUFFLE → flash violet

Stage Pixi 720×240, responsive via `aspect-ratio: 3/1`.

### Pourquoi abstraite (pas de joueurs)

La sim Pro League est **hybride yards-level** — pas de positions individuelles. Cette visu reflète fidèlement le modèle. Pour une visu joueur-par-joueur il faudrait un sim full driver (post-MVP).

### Intégration page /live

`<ProLeagueField fieldState={...} />` entre le score header et la timeline ticker. **Lazy-loaded** via `dynamic(import(...), {ssr: false})` pour ne pas alourdir le main bundle (Pixi >500KB).

## Test plan

- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run` (helper + hook + page) → **25/25 ✓**

## Dépendance

⚠️ Ce PR est branché sur #606 (live ticker page). À merger **après** #606 — sinon le diff inclura aussi ce dernier. Une fois #606 mergée, je rebase sur main si nécessaire.

## Suite

Lot **1.C** : Pro League hub UI (`/pro-league` page d'accueil + team pages + match detail).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_