### PR TITLE
feat(server,web): Pro League hub page (sprint 1.C.1)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -28,6 +28,10 @@ import { Router, type Request, type Response } from "express";
 import type { MatchEvent } from "@bb/sim-engine";
 
 import {
+  ProLeagueNotFoundError,
+  getProLeagueHubSnapshot,
+} from "../services/pro-league-hub";
+import {
   getBroadcasterStats,
   subscribeToMatch,
 } from "../services/pro-league-match-broadcaster";
@@ -135,8 +139,32 @@ export function handleBroadcasterStats(_req: Request, res: Response): void {
   res.json(getBroadcasterStats());
 }
 
+/**
+ * Sprint 1.C.1 — Snapshot agrégé pour la page d'accueil `/pro-league`.
+ * Renvoie league + saison courante + round courant + prochains matchs
+ * + classement top 8.
+ */
+export async function handleGetCurrentSeasonHub(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const data = await getProLeagueHubSnapshot();
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProLeagueNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/seasons/current] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
 const router = Router();
 
+router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 

--- a/apps/server/src/services/pro-league-hub.test.ts
+++ b/apps/server/src/services/pro-league-hub.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Sprint Pro League lot 1.C.1 — Tests pro-league-hub service.
+ *
+ * Mocks `prisma` pour valider la sélection prio in_progress > completed,
+ * le choix du round courant, et la mise en forme des entités.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeague: { findUnique: vi.fn() },
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueRound: { findFirst: vi.fn() },
+    proLeagueMatch: { findMany: vi.fn() },
+    proLeagueStandings: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+
+import {
+  ProLeagueNotFoundError,
+  getProLeagueHubSnapshot,
+} from "./pro-league-hub";
+
+interface MockedPrisma {
+  proLeague: { findUnique: ReturnType<typeof vi.fn> };
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueRound: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+  proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getProLeagueHubSnapshot — sprint 1.C.1", () => {
+  it("throw ProLeagueNotFoundError si la ligue n'existe pas", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue(null);
+    await expect(getProLeagueHubSnapshot()).rejects.toThrow(
+      ProLeagueNotFoundError,
+    );
+  });
+
+  it("renvoie league + season=null + listes vides si pas de saison", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({
+      slug: "old-world-league",
+      name: "Old World League",
+      description: "test",
+      branding: { motto: "x" },
+    });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+
+    const out = await getProLeagueHubSnapshot();
+    expect(out.league.slug).toBe("old-world-league");
+    expect(out.season).toBeNull();
+    expect(out.currentRound).toBeNull();
+    expect(out.nextMatches).toEqual([]);
+    expect(out.standings).toEqual([]);
+  });
+
+  it("priorise une saison in_progress sur une saison completed", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({
+      slug: "old-world-league",
+      name: "Old World League",
+      description: null,
+      branding: null,
+    });
+    // Premier appel = recherche in_progress.
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      id: "s_active",
+      year: 2026,
+      status: "in_progress",
+      engineVer: "0.13.0",
+      startsAt: new Date("2026-09-01T00:00:00Z"),
+      endsAt: null,
+    });
+    mocked.proLeagueRound.findFirst.mockResolvedValueOnce(null);
+    mocked.proLeagueRound.findFirst.mockResolvedValueOnce(null);
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    mocked.proLeagueStandings.findMany.mockResolvedValue([]);
+
+    const out = await getProLeagueHubSnapshot();
+    expect(out.season?.id).toBe("s_active");
+    expect(out.season?.status).toBe("in_progress");
+    // Le 2e fallback (completed) n'est pas appelé puisque in_progress trouvé.
+    expect(mocked.proLeagueSeason.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("fallback sur saison completed si pas d'in_progress", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({
+      slug: "old-world-league",
+      name: "Old World League",
+      description: null,
+      branding: null,
+    });
+    mocked.proLeagueSeason.findFirst
+      .mockResolvedValueOnce(null) // pas d'in_progress
+      .mockResolvedValueOnce({
+        id: "s_done",
+        year: 2025,
+        status: "completed",
+        engineVer: "0.12.0",
+        startsAt: null,
+        endsAt: null,
+      });
+    mocked.proLeagueRound.findFirst.mockResolvedValue(null);
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    mocked.proLeagueStandings.findMany.mockResolvedValue([]);
+
+    const out = await getProLeagueHubSnapshot();
+    expect(out.season?.id).toBe("s_done");
+    expect(out.season?.status).toBe("completed");
+  });
+
+  it("formate les nextMatches en string ISO + slugs équipes", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({
+      slug: "old-world-league",
+      name: "Old World League",
+      description: null,
+      branding: null,
+    });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+      engineVer: "0.13.0",
+      startsAt: null,
+      endsAt: null,
+    });
+    mocked.proLeagueRound.findFirst.mockResolvedValueOnce({
+      id: "r1",
+      roundNumber: 3,
+      status: "pending",
+      scheduledAt: new Date("2026-09-15T21:00:00Z"),
+    });
+    const scheduledAt = new Date("2026-09-15T21:00:00Z");
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        status: "scheduled",
+        scheduledAt,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        round: { roundNumber: 3 },
+        homeTeam: {
+          slug: "pit-smashers",
+          name: "Smashers",
+          city: "Pittsburgh",
+          primaryColor: "#000000",
+          secondaryColor: "#FFB612",
+        },
+        awayTeam: {
+          slug: "kc-soaring-hawks",
+          name: "Soaring Hawks",
+          city: "Kansas City",
+          primaryColor: "#E31837",
+          secondaryColor: "#FFB81C",
+        },
+      },
+    ]);
+    mocked.proLeagueStandings.findMany.mockResolvedValue([]);
+
+    const out = await getProLeagueHubSnapshot();
+    expect(out.nextMatches).toHaveLength(1);
+    const m = out.nextMatches[0];
+    expect(m.id).toBe("m1");
+    expect(m.roundNumber).toBe(3);
+    expect(m.homeTeam.slug).toBe("pit-smashers");
+    expect(m.awayTeam.slug).toBe("kc-soaring-hawks");
+    expect(m.scheduledAt).toBe(scheduledAt.toISOString());
+    expect(out.currentRound?.roundNumber).toBe(3);
+  });
+
+  it("formate les standings en plat (sans nesting team)", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({
+      slug: "old-world-league",
+      name: "Old World League",
+      description: null,
+      branding: null,
+    });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+      engineVer: "0.13.0",
+      startsAt: null,
+      endsAt: null,
+    });
+    mocked.proLeagueRound.findFirst.mockResolvedValue(null);
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 5,
+        wins: 4,
+        draws: 0,
+        losses: 1,
+        points: 12,
+        tdFor: 14,
+        tdAgainst: 6,
+        team: {
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+        },
+      },
+    ]);
+
+    const out = await getProLeagueHubSnapshot();
+    expect(out.standings).toHaveLength(1);
+    const s = out.standings[0];
+    expect(s.teamSlug).toBe("buf-snow-ogres");
+    expect(s.teamName).toBe("Snow Ogres");
+    expect(s.points).toBe(12);
+    expect(s.tdFor).toBe(14);
+  });
+});

--- a/apps/server/src/services/pro-league-hub.ts
+++ b/apps/server/src/services/pro-league-hub.ts
@@ -1,0 +1,318 @@
+/**
+ * Pro League hub service — sprint Pro League lot 1.C.1.
+ *
+ * Agrège les données nécessaires à la page d'accueil
+ * `/pro-league` : league + saison courante + round courant + prochains
+ * matchs + classement top 8.
+ *
+ * "Saison courante" = première saison `in_progress` (ordre d'année
+ * croissant), ou à défaut la dernière saison `completed`. Si aucune
+ * saison n'existe pour la ligue, renvoie `season: null`.
+ *
+ * "Round courant" = premier round `in_progress` ou `pending` (ordre
+ * `roundNumber` croissant). À défaut, le dernier round `completed`.
+ *
+ * "Prochains matchs" = 8 prochains matchs `scheduled` ou `ready`
+ * triés par `scheduledAt` croissant. Inclut les infos minimales
+ * d'équipe (slug, name, city, primaryColor) pour l'affichage du card.
+ *
+ * "Classement" = top 8 par points (desc), tdFor (desc).
+ *
+ * Pas d'auth — la Pro League est publique au MVP.
+ */
+
+import { prisma } from "../prisma";
+
+export const OLD_WORLD_LEAGUE_SLUG = "old-world-league";
+const STANDINGS_LIMIT = 8;
+const NEXT_MATCHES_LIMIT = 8;
+
+export interface ProLeagueHubLeague {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly branding: unknown;
+}
+
+export interface ProLeagueHubSeason {
+  readonly id: string;
+  readonly year: number;
+  readonly status: string;
+  readonly engineVer: string;
+  readonly startsAt: string | null;
+  readonly endsAt: string | null;
+}
+
+export interface ProLeagueHubRound {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string | null;
+}
+
+export interface ProLeagueHubTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+}
+
+export interface ProLeagueHubMatch {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly homeTeam: ProLeagueHubTeam;
+  readonly awayTeam: ProLeagueHubTeam;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+}
+
+export interface ProLeagueHubStandingsEntry {
+  readonly teamSlug: string;
+  readonly teamName: string;
+  readonly teamCity: string;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+}
+
+export interface ProLeagueHubData {
+  readonly league: ProLeagueHubLeague;
+  readonly season: ProLeagueHubSeason | null;
+  readonly currentRound: ProLeagueHubRound | null;
+  readonly nextMatches: readonly ProLeagueHubMatch[];
+  readonly standings: readonly ProLeagueHubStandingsEntry[];
+}
+
+export class ProLeagueNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`ProLeague slug='${slug}' introuvable`);
+    this.name = "ProLeagueNotFoundError";
+  }
+}
+
+/**
+ * Retourne le snapshot agrégé pour le hub.
+ *
+ * @param leagueSlug défaut: `old-world-league` (singleton MVP).
+ */
+export async function getProLeagueHubSnapshot(
+  leagueSlug: string = OLD_WORLD_LEAGUE_SLUG,
+): Promise<ProLeagueHubData> {
+  const league = await prisma.proLeague.findUnique({
+    where: { slug: leagueSlug },
+    select: {
+      slug: true,
+      name: true,
+      description: true,
+      branding: true,
+    },
+  });
+  if (!league) {
+    throw new ProLeagueNotFoundError(leagueSlug);
+  }
+
+  // Saison courante : in_progress > completed (la plus récente).
+  const inProgress = await prisma.proLeagueSeason.findFirst({
+    where: { league: { slug: leagueSlug }, status: "in_progress" },
+    orderBy: { year: "asc" },
+    select: {
+      id: true,
+      year: true,
+      status: true,
+      engineVer: true,
+      startsAt: true,
+      endsAt: true,
+    },
+  });
+  const season =
+    inProgress ??
+    (await prisma.proLeagueSeason.findFirst({
+      where: { league: { slug: leagueSlug } },
+      orderBy: [{ year: "desc" }],
+      select: {
+        id: true,
+        year: true,
+        status: true,
+        engineVer: true,
+        startsAt: true,
+        endsAt: true,
+      },
+    }));
+
+  if (!season) {
+    return {
+      league: {
+        slug: league.slug as string,
+        name: league.name as string,
+        description: (league.description as string | null) ?? null,
+        branding: league.branding,
+      },
+      season: null,
+      currentRound: null,
+      nextMatches: [],
+      standings: [],
+    };
+  }
+
+  const seasonId = season.id as string;
+
+  // Round courant : pending/in_progress avec le plus petit roundNumber ;
+  // sinon, le dernier completed.
+  const currentRound =
+    (await prisma.proLeagueRound.findFirst({
+      where: { seasonId, status: { in: ["pending", "in_progress"] } },
+      orderBy: { roundNumber: "asc" },
+      select: {
+        id: true,
+        roundNumber: true,
+        status: true,
+        scheduledAt: true,
+      },
+    })) ??
+    (await prisma.proLeagueRound.findFirst({
+      where: { seasonId, status: "completed" },
+      orderBy: { roundNumber: "desc" },
+      select: {
+        id: true,
+        roundNumber: true,
+        status: true,
+        scheduledAt: true,
+      },
+    })) ??
+    null;
+
+  // Prochains matchs (scheduled / ready), 8 max.
+  const nextMatchesRaw = await prisma.proLeagueMatch.findMany({
+    where: {
+      seasonId,
+      status: { in: ["scheduled", "ready"] },
+    },
+    orderBy: [{ scheduledAt: "asc" }],
+    take: NEXT_MATCHES_LIMIT,
+    select: {
+      id: true,
+      status: true,
+      scheduledAt: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      round: { select: { roundNumber: true } },
+      homeTeam: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          primaryColor: true,
+          secondaryColor: true,
+        },
+      },
+      awayTeam: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          primaryColor: true,
+          secondaryColor: true,
+        },
+      },
+    },
+  });
+
+  // Standings top N.
+  const standingsRaw = await prisma.proLeagueStandings.findMany({
+    where: { seasonId },
+    orderBy: [
+      { points: "desc" },
+      { tdFor: "desc" },
+    ],
+    take: STANDINGS_LIMIT,
+    select: {
+      played: true,
+      wins: true,
+      draws: true,
+      losses: true,
+      points: true,
+      tdFor: true,
+      tdAgainst: true,
+      team: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+        },
+      },
+    },
+  });
+
+  return {
+    league: {
+      slug: league.slug as string,
+      name: league.name as string,
+      description: (league.description as string | null) ?? null,
+      branding: league.branding,
+    },
+    season: {
+      id: season.id as string,
+      year: season.year as number,
+      status: season.status as string,
+      engineVer: season.engineVer as string,
+      startsAt:
+        (season.startsAt as Date | null)?.toISOString() ?? null,
+      endsAt: (season.endsAt as Date | null)?.toISOString() ?? null,
+    },
+    currentRound: currentRound
+      ? {
+          id: currentRound.id as string,
+          roundNumber: currentRound.roundNumber as number,
+          status: currentRound.status as string,
+          scheduledAt:
+            (currentRound.scheduledAt as Date | null)?.toISOString() ?? null,
+        }
+      : null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    nextMatches: nextMatchesRaw.map((m: any) => ({
+      id: m.id as string,
+      roundNumber: m.round.roundNumber as number,
+      status: m.status as string,
+      scheduledAt: (m.scheduledAt as Date).toISOString(),
+      scoreHome: (m.scoreHome as number | null) ?? null,
+      scoreAway: (m.scoreAway as number | null) ?? null,
+      outcome: (m.outcome as string | null) ?? null,
+      homeTeam: {
+        slug: m.homeTeam.slug as string,
+        name: m.homeTeam.name as string,
+        city: m.homeTeam.city as string,
+        primaryColor: (m.homeTeam.primaryColor as string | null) ?? null,
+        secondaryColor: (m.homeTeam.secondaryColor as string | null) ?? null,
+      },
+      awayTeam: {
+        slug: m.awayTeam.slug as string,
+        name: m.awayTeam.name as string,
+        city: m.awayTeam.city as string,
+        primaryColor: (m.awayTeam.primaryColor as string | null) ?? null,
+        secondaryColor: (m.awayTeam.secondaryColor as string | null) ?? null,
+      },
+    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    standings: standingsRaw.map((s: any) => ({
+      teamSlug: s.team.slug as string,
+      teamName: s.team.name as string,
+      teamCity: s.team.city as string,
+      played: s.played as number,
+      wins: s.wins as number,
+      draws: s.draws as number,
+      losses: s.losses as number,
+      points: s.points as number,
+      tdFor: s.tdFor as number,
+      tdAgainst: s.tdAgainst as number,
+    })),
+  };
+}

--- a/apps/web/app/pro-league/page.test.tsx
+++ b/apps/web/app/pro-league/page.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Sprint Pro League lot 1.C.1 — Tests page hub.
+ *
+ * Mocke `apiRequest` pour contrôler la donnée injectée et valider
+ * les états (loading, erreur, pas de saison, hub complet).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {},
+}));
+
+import { apiRequest } from "../lib/api-client";
+import ProLeagueHubPage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeHubData(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    league: {
+      slug: "old-world-league",
+      name: "Old World League",
+      description: null,
+      branding: { motto: "Where Legends Are Smashed" },
+    },
+    season: {
+      id: "s_2026",
+      year: 2026,
+      status: "in_progress",
+      engineVer: "0.13.0",
+      startsAt: null,
+      endsAt: null,
+    },
+    currentRound: {
+      id: "r_3",
+      roundNumber: 3,
+      status: "pending",
+      scheduledAt: new Date(Date.now() + 3_600_000).toISOString(),
+    },
+    nextMatches: [
+      {
+        id: "m_1",
+        roundNumber: 3,
+        status: "scheduled",
+        scheduledAt: new Date(Date.now() + 3_600_000).toISOString(),
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        homeTeam: {
+          slug: "pit-smashers",
+          name: "Smashers",
+          city: "Pittsburgh",
+          primaryColor: "#000000",
+          secondaryColor: "#FFB612",
+        },
+        awayTeam: {
+          slug: "kc-soaring-hawks",
+          name: "Soaring Hawks",
+          city: "Kansas City",
+          primaryColor: "#E31837",
+          secondaryColor: "#FFB81C",
+        },
+      },
+    ],
+    standings: [
+      {
+        teamSlug: "buf-snow-ogres",
+        teamName: "Snow Ogres",
+        teamCity: "Buffalo",
+        played: 3,
+        wins: 3,
+        draws: 0,
+        losses: 0,
+        points: 9,
+        tdFor: 8,
+        tdAgainst: 2,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProLeagueHubPage — sprint 1.C.1", () => {
+  it("affiche 'Chargement…' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<ProLeagueHubPage />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche le titre + motto une fois la donnée chargée", async () => {
+    mockedApi.mockResolvedValue(makeHubData());
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Old World League")).toBeTruthy();
+    });
+    expect(
+      screen.getByText(/Where Legends Are Smashed/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/Saison 2026/i)).toBeTruthy();
+  });
+
+  it("affiche le current round", async () => {
+    mockedApi.mockResolvedValue(makeHubData());
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("current-round")).toBeTruthy();
+    });
+    // "Round 3" apparaît à la fois dans le current-round et dans une
+    // match card → on attend ≥1 match.
+    expect(screen.getAllByText(/Round 3/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("affiche les match cards avec noms équipes", async () => {
+    mockedApi.mockResolvedValue(makeHubData());
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-card")).toBeTruthy();
+    });
+    expect(screen.getByText("Smashers")).toBeTruthy();
+    expect(screen.getByText("Soaring Hawks")).toBeTruthy();
+  });
+
+  it("affiche le classement avec points", async () => {
+    mockedApi.mockResolvedValue(makeHubData());
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("standings-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Snow Ogres")).toBeTruthy();
+    expect(screen.getByText("9")).toBeTruthy();
+  });
+
+  it("affiche un message si aucune saison active", async () => {
+    mockedApi.mockResolvedValue(
+      makeHubData({ season: null, currentRound: null, nextMatches: [], standings: [] }),
+    );
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Aucune saison active/i)).toBeTruthy();
+    });
+  });
+
+  it("affiche un message d'erreur si l'API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("boom"));
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+
+  it("affiche un placeholder dans la table de classement si vide", async () => {
+    mockedApi.mockResolvedValue(makeHubData({ standings: [] }));
+    render(<ProLeagueHubPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/classement apparaîtra/i),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/pro-league/page.tsx
+++ b/apps/web/app/pro-league/page.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { apiRequest } from "../lib/api-client";
+
+/**
+ * Page d'accueil Pro League — sprint Pro League lot 1.C.1.
+ *
+ * Affiche :
+ * - Header branding "Old World League"
+ * - Saison courante (statut, year)
+ * - Round courant + compte à rebours T-21h mardi pour le prochain match
+ * - Cards "Prochains matchs" avec couleurs équipe
+ * - Top 8 du classement live
+ *
+ * Pas d'auth — public.
+ */
+
+interface HubLeague {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly branding: unknown;
+}
+
+interface HubSeason {
+  readonly id: string;
+  readonly year: number;
+  readonly status: string;
+  readonly engineVer: string;
+  readonly startsAt: string | null;
+  readonly endsAt: string | null;
+}
+
+interface HubRound {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string | null;
+}
+
+interface HubTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+}
+
+interface HubMatch {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly homeTeam: HubTeam;
+  readonly awayTeam: HubTeam;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+}
+
+interface HubStandingsEntry {
+  readonly teamSlug: string;
+  readonly teamName: string;
+  readonly teamCity: string;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+}
+
+interface HubData {
+  readonly league: HubLeague;
+  readonly season: HubSeason | null;
+  readonly currentRound: HubRound | null;
+  readonly nextMatches: readonly HubMatch[];
+  readonly standings: readonly HubStandingsEntry[];
+}
+
+function formatRelativeTo(target: Date, now: Date): string {
+  const diffMs = target.getTime() - now.getTime();
+  if (diffMs < 0) return "en cours";
+  const diffSec = Math.floor(diffMs / 1000);
+  const days = Math.floor(diffSec / 86_400);
+  const hours = Math.floor((diffSec % 86_400) / 3600);
+  const minutes = Math.floor((diffSec % 3600) / 60);
+  if (days >= 1) return `J-${days}j ${hours}h`;
+  if (hours >= 1) return `T-${hours}h${minutes.toString().padStart(2, "0")}`;
+  return `T-${minutes}min`;
+}
+
+function MatchCard({ match, now }: { match: HubMatch; now: Date }): JSX.Element {
+  const at = new Date(match.scheduledAt);
+  const formatted = at.toLocaleString("fr-FR", {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return (
+    <Link
+      href={`/pro-league/matches/${match.id}/live`}
+      className="flex flex-col gap-1 rounded border border-slate-800 bg-slate-900 p-3 transition hover:bg-slate-800"
+      data-testid="match-card"
+    >
+      <div className="flex items-center justify-between text-xs text-slate-400">
+        <span>Round {match.roundNumber}</span>
+        <span className="font-mono">{formatRelativeTo(at, now)}</span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <TeamPill team={match.homeTeam} />
+        <span className="font-mono text-xs text-slate-500">vs</span>
+        <TeamPill team={match.awayTeam} alignRight />
+      </div>
+      <div className="mt-1 text-xs text-slate-500">{formatted}</div>
+    </Link>
+  );
+}
+
+function TeamPill({
+  team,
+  alignRight = false,
+}: {
+  team: HubTeam;
+  alignRight?: boolean;
+}): JSX.Element {
+  return (
+    <div
+      className={`flex flex-1 items-center gap-2 ${alignRight ? "flex-row-reverse text-right" : ""}`}
+    >
+      <span
+        aria-hidden
+        className="inline-block h-3 w-3 rounded-full ring-1 ring-slate-700"
+        style={{ background: team.primaryColor ?? "#475569" }}
+      />
+      <div className={alignRight ? "flex flex-col items-end" : "flex flex-col"}>
+        <span className="text-sm font-semibold text-slate-100">
+          {team.name}
+        </span>
+        <span className="text-xs text-slate-500">{team.city}</span>
+      </div>
+    </div>
+  );
+}
+
+function StandingsTable({
+  rows,
+}: {
+  rows: readonly HubStandingsEntry[];
+}): JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">
+        Le classement apparaîtra après la première journée.
+      </p>
+    );
+  }
+  return (
+    <table
+      data-testid="standings-table"
+      className="w-full table-fixed text-sm"
+    >
+      <thead>
+        <tr className="text-left text-xs uppercase text-slate-500">
+          <th className="w-8 py-1">#</th>
+          <th className="py-1">Équipe</th>
+          <th className="w-10 py-1 text-center">J</th>
+          <th className="w-10 py-1 text-center">Pts</th>
+          <th className="w-12 py-1 text-center">TD</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((s, i) => (
+          <tr
+            key={s.teamSlug}
+            className="border-t border-slate-800 hover:bg-slate-900"
+          >
+            <td className="py-1 font-mono text-slate-400">{i + 1}</td>
+            <td className="py-1">
+              <span className="font-medium text-slate-100">{s.teamName}</span>
+              <span className="ml-1 text-xs text-slate-500">{s.teamCity}</span>
+            </td>
+            <td className="py-1 text-center font-mono text-slate-400">
+              {s.played}
+            </td>
+            <td className="py-1 text-center font-mono font-semibold text-slate-100">
+              {s.points}
+            </td>
+            <td className="py-1 text-center font-mono text-slate-400">
+              {s.tdFor}-{s.tdAgainst}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default function ProLeagueHubPage(): JSX.Element {
+  const [data, setData] = useState<HubData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => new Date());
+
+  // Refresh "now" toutes les 60s pour que le compte à rebours bouge.
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<HubData>("/pro-league/seasons/current")
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const motto = useMemo(() => {
+    const branding = data?.league.branding as
+      | { motto?: string }
+      | null
+      | undefined;
+    return branding?.motto ?? null;
+  }, [data?.league.branding]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header data-testid="hub-header" className="mb-6">
+        <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+          {data?.league.name ?? "Pro League"}
+        </h1>
+        {motto ? (
+          <p className="mt-1 text-sm italic text-slate-400">"{motto}"</p>
+        ) : null}
+        {data?.season ? (
+          <p className="mt-2 text-sm text-slate-300">
+            Saison {data.season.year} · {data.season.status} · engine{" "}
+            <span className="font-mono">{data.season.engineVer}</span>
+          </p>
+        ) : null}
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !data?.season ? (
+        <p className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400">
+          Aucune saison active pour le moment. La prochaine kickoff sera
+          annoncée bientôt.
+        </p>
+      ) : (
+        <>
+          {data.currentRound ? (
+            <section
+              data-testid="current-round"
+              className="mb-6 rounded border border-slate-800 bg-slate-900 px-4 py-3"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-100">
+                    Round {data.currentRound.roundNumber}
+                  </h2>
+                  <p className="text-xs uppercase text-slate-500">
+                    {data.currentRound.status}
+                  </p>
+                </div>
+                {data.currentRound.scheduledAt ? (
+                  <span className="font-mono text-sm text-emerald-300">
+                    {formatRelativeTo(
+                      new Date(data.currentRound.scheduledAt),
+                      now,
+                    )}
+                  </span>
+                ) : null}
+              </div>
+            </section>
+          ) : null}
+
+          <section data-testid="next-matches" className="mb-6">
+            <h2 className="mb-2 text-lg font-semibold text-slate-100">
+              Prochains matchs
+            </h2>
+            {data.nextMatches.length === 0 ? (
+              <p className="text-sm text-slate-500">
+                Aucun match programmé.
+              </p>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2">
+                {data.nextMatches.map((m) => (
+                  <MatchCard key={m.id} match={m} now={now} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section data-testid="standings">
+            <h2 className="mb-2 text-lg font-semibold text-slate-100">
+              Classement
+            </h2>
+            <StandingsTable rows={data.standings} />
+          </section>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.C.1** — Page d'accueil `/pro-league` (hub) + endpoint API associé.

### Backend

| Fichier | Rôle |
|---|---|
| `services/pro-league-hub.ts` | Service qui agrège league + saison + round + matchs + standings |
| `routes/pro-league.ts` | Nouveau handler `GET /pro-league/seasons/current` |

**Logique de sélection :**
- Saison courante : `in_progress` (year asc) → fallback `completed` (year desc)
- Round courant : `pending`/`in_progress` (roundNumber asc) → fallback `completed` (roundNumber desc)
- Prochains matchs : 8 max, status `scheduled`/`ready`, ordre `scheduledAt asc`
- Standings : top 8, ordre `points desc, tdFor desc`

`404 ProLeagueNotFoundError` si la ligue (`slug=old-world-league`) n'existe pas. Sinon JSON complet (avec `season: null` si la ligue est seedée mais aucune saison créée).

### Frontend `/pro-league`

- **Header branding** : "Old World League" + motto (italique) + saison/engineVer
- **Round courant** : numéro + statut + compte à rebours T-Xh ou J-Xj (refresh 60s)
- **Cards matchs** : grid 1col mobile / 2col desktop, pastilles colorées équipes (`primaryColor`), date formatée fr-FR, lien vers `/pro-league/matches/[id]/live`
- **Classement top 8** : rang, équipe + ville, J / Pts / TD+/-
- États **loading / error / saison absente** gérés proprement

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-league-hub.test.ts` → **6/6 ✓**
- [x] `npx vitest run app/pro-league/page.test.tsx` → **8/8 ✓**

Couverture totale : 14 tests.

## Suite

Au choix : **1.C.5** (page `/pro-league/standings` détaillée), **1.C.2** (team pages `/pro-league/teams/:slug`), ou **1.C.3** (match detail page).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_