### PR TITLE
feat(server,web): Pro League detailed standings page (sprint 1.C.5)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -35,6 +35,10 @@ import {
   getBroadcasterStats,
   subscribeToMatch,
 } from "../services/pro-league-match-broadcaster";
+import {
+  ProLeagueStandingsNotFoundError,
+  getProLeagueCurrentStandings,
+} from "../services/pro-league-standings";
 import { serverLog } from "../utils/server-log";
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -162,9 +166,35 @@ export async function handleGetCurrentSeasonHub(
   }
 }
 
+/**
+ * Sprint 1.C.5 — Classement détaillé de la saison courante.
+ * Renvoie 16 entrées avec V/N/D, points, TD diff, casualties diff,
+ * form (5 derniers résultats), rang.
+ */
+export async function handleGetCurrentSeasonStandings(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const data = await getProLeagueCurrentStandings();
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProLeagueStandingsNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(
+      `[pro-league/seasons/current/standings] failed: ${msg}`,
+    );
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
+router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 

--- a/apps/server/src/services/pro-league-standings.test.ts
+++ b/apps/server/src/services/pro-league-standings.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeague: { findUnique: vi.fn() },
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueStandings: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  ProLeagueStandingsNotFoundError,
+  getProLeagueCurrentStandings,
+} from "./pro-league-standings";
+
+interface MockedPrisma {
+  proLeague: { findUnique: ReturnType<typeof vi.fn> };
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
+  it("404 si la ligue n'existe pas", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue(null);
+    await expect(getProLeagueCurrentStandings()).rejects.toThrow(
+      ProLeagueStandingsNotFoundError,
+    );
+  });
+
+  it("404 si aucune saison disponible", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+    await expect(getProLeagueCurrentStandings()).rejects.toThrow(
+      /Aucune saison/i,
+    );
+  });
+
+  it("calcule le rang (1-based) et les diffs TD/cas", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 5,
+        wins: 4,
+        draws: 0,
+        losses: 1,
+        points: 12,
+        tdFor: 14,
+        tdAgainst: 6,
+        casualtiesFor: 3,
+        casualtiesAgainst: 1,
+        form: '["W","W","L","W","W"]',
+        team: {
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          race: "Ogre",
+          primaryColor: "#00338D",
+          secondaryColor: "#C60C30",
+        },
+      },
+      {
+        played: 5,
+        wins: 0,
+        draws: 1,
+        losses: 4,
+        points: 1,
+        tdFor: 4,
+        tdAgainst: 12,
+        casualtiesFor: 0,
+        casualtiesAgainst: 5,
+        form: '["L","D","L","L","L"]',
+        team: {
+          slug: "gb-cheese-halflings",
+          name: "Cheese Halflings",
+          city: "Green Bay",
+          race: "Halfling",
+          primaryColor: "#203731",
+          secondaryColor: "#FFB612",
+        },
+      },
+    ]);
+
+    const out = await getProLeagueCurrentStandings();
+    expect(out.rows).toHaveLength(2);
+    expect(out.rows[0].rank).toBe(1);
+    expect(out.rows[0].team.slug).toBe("buf-snow-ogres");
+    expect(out.rows[0].tdDiff).toBe(8);
+    expect(out.rows[0].casualtiesDiff).toBe(2);
+    expect(out.rows[0].form).toEqual(["W", "W", "L", "W", "W"]);
+    expect(out.rows[1].rank).toBe(2);
+    expect(out.rows[1].tdDiff).toBe(-8);
+    expect(out.rows[1].form).toEqual(["L", "D", "L", "L", "L"]);
+  });
+
+  it("parse form depuis array natif sqlite (mirror)", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 1,
+        wins: 1,
+        draws: 0,
+        losses: 0,
+        points: 3,
+        tdFor: 2,
+        tdAgainst: 1,
+        casualtiesFor: 1,
+        casualtiesAgainst: 0,
+        form: ["W"], // postgres JSON-natif (pas string)
+        team: {
+          slug: "pit-smashers",
+          name: "Smashers",
+          city: "Pittsburgh",
+          race: "Orc",
+          primaryColor: "#000000",
+          secondaryColor: "#FFB612",
+        },
+      },
+    ]);
+    const out = await getProLeagueCurrentStandings();
+    expect(out.rows[0].form).toEqual(["W"]);
+  });
+
+  it("retourne form=[] si la valeur est invalide ou vide", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 0,
+        wins: 0,
+        draws: 0,
+        losses: 0,
+        points: 0,
+        tdFor: 0,
+        tdAgainst: 0,
+        casualtiesFor: 0,
+        casualtiesAgainst: 0,
+        form: "garbage-not-json",
+        team: {
+          slug: "x",
+          name: "X",
+          city: "X",
+          race: "X",
+          primaryColor: null,
+          secondaryColor: null,
+        },
+      },
+    ]);
+    const out = await getProLeagueCurrentStandings();
+    expect(out.rows[0].form).toEqual([]);
+  });
+});

--- a/apps/server/src/services/pro-league-standings.ts
+++ b/apps/server/src/services/pro-league-standings.ts
@@ -1,0 +1,187 @@
+/**
+ * Pro League standings — sprint Pro League lot 1.C.5.
+ *
+ * Service dédié au classement détaillé d'une saison : 16 entrées
+ * complètes (V/N/D, points, TD diff, casualties, forme 5 derniers,
+ * place actuelle).
+ *
+ * Distinct du `pro-league-hub.ts` (qui ne renvoie que le top 8 +
+ * d'autres données agrégées).
+ */
+
+import { prisma } from "../prisma";
+
+import { OLD_WORLD_LEAGUE_SLUG } from "./pro-league-hub";
+
+export interface ProLeagueStandingsTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+}
+
+export interface ProLeagueStandingsRow {
+  /** Place dans le classement (1-based). */
+  readonly rank: number;
+  readonly team: ProLeagueStandingsTeam;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+  readonly tdDiff: number;
+  readonly casualtiesFor: number;
+  readonly casualtiesAgainst: number;
+  readonly casualtiesDiff: number;
+  /** Tableau des 5 derniers résultats (W/D/L), ordre du plus ancien
+   *  au plus récent. Vide si aucun match joué. */
+  readonly form: readonly ("W" | "D" | "L")[];
+}
+
+export interface ProLeagueStandingsSnapshot {
+  readonly leagueSlug: string;
+  readonly seasonId: string;
+  readonly seasonYear: number;
+  readonly seasonStatus: string;
+  readonly rows: readonly ProLeagueStandingsRow[];
+}
+
+export class ProLeagueStandingsNotFoundError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "ProLeagueStandingsNotFoundError";
+  }
+}
+
+function parseForm(raw: unknown): ("W" | "D" | "L")[] {
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(
+          (v): v is "W" | "D" | "L" =>
+            v === "W" || v === "D" || v === "L",
+        );
+      }
+    } catch {
+      return [];
+    }
+  }
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (v): v is "W" | "D" | "L" => v === "W" || v === "D" || v === "L",
+    );
+  }
+  return [];
+}
+
+/**
+ * Renvoie le classement complet de la saison courante. Le rang est
+ * calculé depuis l'ordre Prisma (points desc, tdFor desc) — fiable
+ * car la table `ProLeagueStandings` contient une seule entrée par
+ * (seasonId, teamId).
+ */
+export async function getProLeagueCurrentStandings(
+  leagueSlug: string = OLD_WORLD_LEAGUE_SLUG,
+): Promise<ProLeagueStandingsSnapshot> {
+  const league = await prisma.proLeague.findUnique({
+    where: { slug: leagueSlug },
+    select: { slug: true },
+  });
+  if (!league) {
+    throw new ProLeagueStandingsNotFoundError(
+      `ProLeague slug='${leagueSlug}' introuvable`,
+    );
+  }
+
+  // Saison courante : in_progress > completed (la plus récente).
+  const inProgress = await prisma.proLeagueSeason.findFirst({
+    where: { league: { slug: leagueSlug }, status: "in_progress" },
+    orderBy: { year: "asc" },
+    select: { id: true, year: true, status: true },
+  });
+  const season =
+    inProgress ??
+    (await prisma.proLeagueSeason.findFirst({
+      where: { league: { slug: leagueSlug } },
+      orderBy: { year: "desc" },
+      select: { id: true, year: true, status: true },
+    }));
+
+  if (!season) {
+    throw new ProLeagueStandingsNotFoundError(
+      "Aucune saison disponible pour cette ligue",
+    );
+  }
+
+  const rowsRaw = await prisma.proLeagueStandings.findMany({
+    where: { seasonId: season.id as string },
+    orderBy: [
+      { points: "desc" },
+      { tdFor: "desc" },
+    ],
+    select: {
+      played: true,
+      wins: true,
+      draws: true,
+      losses: true,
+      points: true,
+      tdFor: true,
+      tdAgainst: true,
+      casualtiesFor: true,
+      casualtiesAgainst: true,
+      form: true,
+      team: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          race: true,
+          primaryColor: true,
+          secondaryColor: true,
+        },
+      },
+    },
+  });
+
+  return {
+    leagueSlug: league.slug as string,
+    seasonId: season.id as string,
+    seasonYear: season.year as number,
+    seasonStatus: season.status as string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rows: rowsRaw.map((s: any, index: number) => {
+      const tdFor = (s.tdFor as number) ?? 0;
+      const tdAgainst = (s.tdAgainst as number) ?? 0;
+      const casFor = (s.casualtiesFor as number) ?? 0;
+      const casAgainst = (s.casualtiesAgainst as number) ?? 0;
+      return {
+        rank: index + 1,
+        team: {
+          slug: s.team.slug as string,
+          name: s.team.name as string,
+          city: s.team.city as string,
+          race: s.team.race as string,
+          primaryColor: (s.team.primaryColor as string | null) ?? null,
+          secondaryColor: (s.team.secondaryColor as string | null) ?? null,
+        },
+        played: (s.played as number) ?? 0,
+        wins: (s.wins as number) ?? 0,
+        draws: (s.draws as number) ?? 0,
+        losses: (s.losses as number) ?? 0,
+        points: (s.points as number) ?? 0,
+        tdFor,
+        tdAgainst,
+        tdDiff: tdFor - tdAgainst,
+        casualtiesFor: casFor,
+        casualtiesAgainst: casAgainst,
+        casualtiesDiff: casFor - casAgainst,
+        form: parseForm(s.form),
+      };
+    }),
+  };
+}

--- a/apps/web/app/pro-league/standings/page.test.tsx
+++ b/apps/web/app/pro-league/standings/page.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {},
+}));
+
+import { apiRequest } from "../../lib/api-client";
+import ProLeagueStandingsPage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeData(rows: number = 2): unknown {
+  const all = [
+    {
+      rank: 1,
+      team: {
+        slug: "buf-snow-ogres",
+        name: "Snow Ogres",
+        city: "Buffalo",
+        race: "Ogre",
+        primaryColor: "#00338D",
+        secondaryColor: "#C60C30",
+      },
+      played: 5,
+      wins: 4,
+      draws: 0,
+      losses: 1,
+      points: 12,
+      tdFor: 14,
+      tdAgainst: 6,
+      tdDiff: 8,
+      casualtiesFor: 3,
+      casualtiesAgainst: 1,
+      casualtiesDiff: 2,
+      form: ["W", "W", "L", "W", "W"],
+    },
+    {
+      rank: 2,
+      team: {
+        slug: "gb-cheese-halflings",
+        name: "Cheese Halflings",
+        city: "Green Bay",
+        race: "Halfling",
+        primaryColor: "#203731",
+        secondaryColor: "#FFB612",
+      },
+      played: 5,
+      wins: 0,
+      draws: 1,
+      losses: 4,
+      points: 1,
+      tdFor: 4,
+      tdAgainst: 12,
+      tdDiff: -8,
+      casualtiesFor: 0,
+      casualtiesAgainst: 5,
+      casualtiesDiff: -5,
+      form: ["L", "D", "L", "L", "L"],
+    },
+  ];
+  return {
+    leagueSlug: "old-world-league",
+    seasonId: "s1",
+    seasonYear: 2026,
+    seasonStatus: "in_progress",
+    rows: all.slice(0, rows),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProLeagueStandingsPage — sprint 1.C.5", () => {
+  it("affiche 'Chargement…' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<ProLeagueStandingsPage />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche le titre et la saison", async () => {
+    mockedApi.mockResolvedValue(makeData());
+    render(<ProLeagueStandingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Saison 2026/i)).toBeTruthy();
+    });
+  });
+
+  it("affiche les rangs + équipes + points + diff TD", async () => {
+    mockedApi.mockResolvedValue(makeData());
+    render(<ProLeagueStandingsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("standings-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Snow Ogres")).toBeTruthy();
+    expect(screen.getByText("Cheese Halflings")).toBeTruthy();
+    // Diff +8 et -8
+    expect(screen.getByText("+8")).toBeTruthy();
+    expect(screen.getByText("-8")).toBeTruthy();
+  });
+
+  it("affiche la forme avec 5 badges", async () => {
+    mockedApi.mockResolvedValue(makeData());
+    render(<ProLeagueStandingsPage />);
+    await waitFor(() => {
+      const badges = screen.getAllByTestId("form-badges");
+      expect(badges.length).toBe(2);
+    });
+    const ogresBadges = screen.getAllByTestId("form-badges")[0];
+    // 5 chars W/L/D
+    expect(ogresBadges.children.length).toBe(5);
+  });
+
+  it("affiche placeholder si rows vide", async () => {
+    mockedApi.mockResolvedValue(makeData(0));
+    render(<ProLeagueStandingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Pas encore de matchs/i)).toBeTruthy();
+    });
+  });
+
+  it("affiche message d'erreur si API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("boom"));
+    render(<ProLeagueStandingsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+});

--- a/apps/web/app/pro-league/standings/page.tsx
+++ b/apps/web/app/pro-league/standings/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+/**
+ * Page classement détaillé Pro League — sprint Pro League lot 1.C.5.
+ *
+ * Affiche les 16 équipes triées par points (desc), tdFor (desc) avec :
+ * - rang, équipe (couleur primaire), city, race
+ * - V/N/D, points
+ * - TD+/-/diff, casualties+/-/diff
+ * - Forme : 5 derniers résultats (badges colorés)
+ *
+ * Public, pas d'auth.
+ */
+
+type FormChar = "W" | "D" | "L";
+
+interface StandingsTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+}
+
+interface StandingsRow {
+  readonly rank: number;
+  readonly team: StandingsTeam;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+  readonly tdDiff: number;
+  readonly casualtiesFor: number;
+  readonly casualtiesAgainst: number;
+  readonly casualtiesDiff: number;
+  readonly form: readonly FormChar[];
+}
+
+interface StandingsSnapshot {
+  readonly leagueSlug: string;
+  readonly seasonId: string;
+  readonly seasonYear: number;
+  readonly seasonStatus: string;
+  readonly rows: readonly StandingsRow[];
+}
+
+const FORM_BADGE_STYLES: Record<FormChar, string> = {
+  W: "bg-emerald-700 text-emerald-50",
+  D: "bg-slate-600 text-slate-50",
+  L: "bg-rose-700 text-rose-50",
+};
+
+function FormBadges({ form }: { form: readonly FormChar[] }): JSX.Element {
+  if (form.length === 0) {
+    return <span className="text-xs text-slate-600">—</span>;
+  }
+  return (
+    <div className="flex gap-0.5" data-testid="form-badges">
+      {form.map((c, i) => (
+        <span
+          key={i}
+          className={`flex h-4 w-4 items-center justify-center rounded text-[10px] font-bold font-mono ${FORM_BADGE_STYLES[c]}`}
+          title={c === "W" ? "Win" : c === "D" ? "Draw" : "Loss"}
+        >
+          {c}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function formatDiff(d: number): string {
+  if (d > 0) return `+${d}`;
+  return `${d}`;
+}
+
+function diffColorClass(d: number): string {
+  if (d > 0) return "text-emerald-300";
+  if (d < 0) return "text-rose-300";
+  return "text-slate-400";
+}
+
+export default function ProLeagueStandingsPage(): JSX.Element {
+  const [data, setData] = useState<StandingsSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<StandingsSnapshot>("/pro-league/seasons/current/standings")
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+            Classement
+          </h1>
+          {data ? (
+            <p className="mt-1 text-sm text-slate-400">
+              Saison {data.seasonYear} · {data.seasonStatus}
+            </p>
+          ) : null}
+        </div>
+        <Link
+          href="/pro-league"
+          className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+        >
+          ← Hub
+        </Link>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !data || data.rows.length === 0 ? (
+        <p className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400">
+          Pas encore de matchs joués cette saison — le classement
+          apparaîtra après la première journée.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded border border-slate-800">
+          <table
+            data-testid="standings-table"
+            className="w-full text-sm"
+          >
+            <thead className="bg-slate-900 text-xs uppercase text-slate-400">
+              <tr>
+                <th className="w-10 px-2 py-2 text-left">#</th>
+                <th className="px-2 py-2 text-left">Équipe</th>
+                <th className="w-10 px-2 py-2 text-center">J</th>
+                <th className="w-10 px-2 py-2 text-center">V</th>
+                <th className="w-10 px-2 py-2 text-center">N</th>
+                <th className="w-10 px-2 py-2 text-center">D</th>
+                <th className="w-12 px-2 py-2 text-center">Pts</th>
+                <th className="w-20 px-2 py-2 text-center">TD</th>
+                <th className="w-12 px-2 py-2 text-center">+/-</th>
+                <th className="w-20 px-2 py-2 text-center">Cas</th>
+                <th className="w-12 px-2 py-2 text-center">+/-</th>
+                <th className="w-24 px-2 py-2 text-center">Forme</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rows.map((r) => (
+                <tr
+                  key={r.team.slug}
+                  className="border-t border-slate-800 hover:bg-slate-900"
+                >
+                  <td className="px-2 py-2 font-mono text-slate-400">
+                    {r.rank}
+                  </td>
+                  <td className="px-2 py-2">
+                    <div className="flex items-center gap-2">
+                      <span
+                        aria-hidden
+                        className="inline-block h-3 w-3 flex-none rounded-full ring-1 ring-slate-700"
+                        style={{
+                          background: r.team.primaryColor ?? "#475569",
+                        }}
+                      />
+                      <div className="flex flex-col">
+                        <span className="font-medium text-slate-100">
+                          {r.team.name}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          {r.team.city} · {r.team.race}
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-400">
+                    {r.played}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-emerald-300">
+                    {r.wins}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-300">
+                    {r.draws}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-rose-300">
+                    {r.losses}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono font-bold text-slate-50">
+                    {r.points}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-300">
+                    {r.tdFor}–{r.tdAgainst}
+                  </td>
+                  <td
+                    className={`px-2 py-2 text-center font-mono ${diffColorClass(r.tdDiff)}`}
+                  >
+                    {formatDiff(r.tdDiff)}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-300">
+                    {r.casualtiesFor}–{r.casualtiesAgainst}
+                  </td>
+                  <td
+                    className={`px-2 py-2 text-center font-mono ${diffColorClass(r.casualtiesDiff)}`}
+                  >
+                    {formatDiff(r.casualtiesDiff)}
+                  </td>
+                  <td className="px-2 py-2">
+                    <div className="flex justify-center">
+                      <FormBadges form={r.form} />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.C.5** — Page classement détaillé `/pro-league/standings` + endpoint API associé.

### Backend

| Fichier | Rôle |
|---|---|
| `services/pro-league-standings.ts` | `getProLeagueCurrentStandings()` — renvoie 16 entrées avec V/N/D, points, TD diff, casualties diff, forme |
| `routes/pro-league.ts` | Nouveau handler `GET /pro-league/seasons/current/standings` |

**Particularités :**
- Helper `parseForm()` accepte string JSON (sqlite mirror) ou array natif (postgres JSON). Garbage → form vide.
- Rang 1-based dérivé de l'ordre Prisma (`points desc, tdFor desc`).
- 404 typé `ProLeagueStandingsNotFoundError` (ligue ou saison absente).

### Frontend `/pro-league/standings`

Tableau scroll-x mobile-friendly :
- Rang
- **Équipe** (pastille couleur + city + race)
- **V/N/D** colorés (vert / slate / rose)
- **Points** en gras
- **TD** : `for–against` + diff `+8` / `-8` coloré
- **Casualties** : idem
- **Forme** : 5 badges colorés (W vert, D slate, L rose)

Lien retour vers `/pro-league` hub. États **loading / error / empty** gérés.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-league-standings` (backend) → **5/5 ✓**
- [x] `npx vitest run app/pro-league/standings` (frontend) → **6/6 ✓**

Couverture totale : **11 tests**.

## Suite

Au choix : **1.C.2** (team pages `/pro-league/teams/:slug`) ou **1.C.3** (match detail `/pro-league/matches/:id`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_