### PR TITLE
feat(server,web): Pro League team detail page (sprint 1.C.2)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -39,6 +39,10 @@ import {
   ProLeagueStandingsNotFoundError,
   getProLeagueCurrentStandings,
 } from "../services/pro-league-standings";
+import {
+  ProTeamNotFoundError,
+  getProTeamDetail,
+} from "../services/pro-league-team";
 import { serverLog } from "../utils/server-log";
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -191,10 +195,38 @@ export async function handleGetCurrentSeasonStandings(
   }
 }
 
+/**
+ * Sprint 1.C.2 — Détail d'une équipe Pro League : meta + record +
+ * roster + 5 prochains matchs + 5 derniers matchs.
+ */
+export async function handleGetTeamDetail(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const slug = req.params.slug;
+  if (!slug || typeof slug !== "string") {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  try {
+    const data = await getProTeamDetail(slug);
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProTeamNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/teams/${slug}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
+router.get("/teams/:slug", handleGetTeamDetail);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 

--- a/apps/server/src/services/pro-league-team.test.ts
+++ b/apps/server/src/services/pro-league-team.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn() },
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueStandings: { findUnique: vi.fn() },
+    proLeagueMatch: { findMany: vi.fn() },
+    proTeamRoster: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  ProTeamNotFoundError,
+  getProTeamDetail,
+} from "./pro-league-team";
+
+interface MockedPrisma {
+  proTeam: { findUnique: ReturnType<typeof vi.fn> };
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueStandings: { findUnique: ReturnType<typeof vi.fn> };
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+  proTeamRoster: { findMany: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const TEAM_ID = "team_buf_1";
+
+function fakeTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEAM_ID,
+    slug: "buf-snow-ogres",
+    city: "Buffalo",
+    name: "Snow Ogres",
+    race: "Ogre",
+    nflFlavor: "Buffalo snow brutality",
+    primaryColor: "#00338D",
+    secondaryColor: "#C60C30",
+    baseTv: 1100,
+    meta: { motto: "Snow over Steel" },
+    leagueId: "league_1",
+    league: { slug: "old-world-league", branding: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+  mocked.proLeagueStandings.findUnique.mockResolvedValue(null);
+  mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+  mocked.proTeamRoster.findMany.mockResolvedValue([]);
+});
+
+describe("getProTeamDetail — sprint 1.C.2", () => {
+  it("404 si l'équipe n'existe pas", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    await expect(getProTeamDetail("unknown")).rejects.toThrow(
+      ProTeamNotFoundError,
+    );
+  });
+
+  it("404 si l'équipe appartient à une autre ligue", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(
+      fakeTeam({ league: { slug: "other-league", branding: null } }),
+    );
+    await expect(getProTeamDetail("buf-snow-ogres")).rejects.toThrow(
+      ProTeamNotFoundError,
+    );
+  });
+
+  it("renvoie les meta + motto extrait de meta.motto", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.slug).toBe("buf-snow-ogres");
+    expect(out.city).toBe("Buffalo");
+    expect(out.race).toBe("Ogre");
+    expect(out.motto).toBe("Snow over Steel");
+    expect(out.baseTv).toBe(1100);
+    expect(out.seasonId).toBeNull();
+    expect(out.record).toBeNull();
+  });
+
+  it("priorise une saison in_progress sur completed", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      id: "s_active",
+      year: 2026,
+    });
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.seasonId).toBe("s_active");
+    expect(out.seasonYear).toBe(2026);
+    // 1 seul appel (pas de fallback completed)
+    expect(mocked.proLeagueSeason.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("inclut le record + form depuis standings", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      id: "s1",
+      year: 2026,
+    });
+    mocked.proLeagueStandings.findUnique.mockResolvedValue({
+      played: 4,
+      wins: 3,
+      draws: 0,
+      losses: 1,
+      points: 9,
+      tdFor: 12,
+      tdAgainst: 5,
+      form: ["W", "W", "L", "W"],
+    });
+
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.record).toEqual({
+      played: 4,
+      wins: 3,
+      draws: 0,
+      losses: 1,
+      points: 9,
+      tdFor: 12,
+      tdAgainst: 5,
+      form: ["W", "W", "L", "W"],
+    });
+  });
+
+  it("formate les matchs avec opponent + isHome", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      id: "s1",
+      year: 2026,
+    });
+    const at = new Date("2026-09-15T21:00:00Z");
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m1",
+        status: "scheduled",
+        scheduledAt: at,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        homeTeamId: TEAM_ID,
+        awayTeamId: "other-team",
+        round: { roundNumber: 4 },
+        homeTeam: {
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          primaryColor: "#00338D",
+        },
+        awayTeam: {
+          slug: "gb-cheese-halflings",
+          name: "Cheese Halflings",
+          city: "Green Bay",
+          primaryColor: "#203731",
+        },
+      },
+    ]);
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.upcomingMatches).toHaveLength(1);
+    const m = out.upcomingMatches[0];
+    expect(m.id).toBe("m1");
+    expect(m.isHome).toBe(true);
+    expect(m.opponent.slug).toBe("gb-cheese-halflings");
+    expect(m.scheduledAt).toBe(at.toISOString());
+  });
+
+  it("parse skills array natif et JSON string", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p1",
+        name: "Grim",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: ["block", "thick_skull"], // postgres native
+        status: "active",
+        form: 60,
+        niggling: 0,
+      },
+      {
+        id: "p2",
+        name: "Mox",
+        position: "Blitzer",
+        ma: 6,
+        st: 4,
+        ag: 3,
+        pa: null,
+        av: 10,
+        skills: '["dodge"]', // sqlite JSON string mirror
+        status: "injured",
+        form: 40,
+        niggling: 1,
+      },
+    ]);
+
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.roster).toHaveLength(2);
+    expect(out.roster[0].skills).toEqual(["block", "thick_skull"]);
+    expect(out.roster[1].skills).toEqual(["dodge"]);
+    expect(out.roster[1].pa).toBeNull();
+    expect(out.roster[1].niggling).toBe(1);
+  });
+});

--- a/apps/server/src/services/pro-league-team.ts
+++ b/apps/server/src/services/pro-league-team.ts
@@ -1,0 +1,330 @@
+/**
+ * Pro League team detail — sprint Pro League lot 1.C.2.
+ *
+ * Service qui agrège les données nécessaires à la page
+ * `/pro-league/teams/:slug` :
+ *  - team meta (city, name, race, NFL flavor, palette, baseTv)
+ *  - standings entry pour la saison courante (V/N/D/points + form)
+ *  - roster (joueurs actifs avec stats + status + form)
+ *  - calendar : 5 prochains matchs + 5 derniers matchs joués
+ *
+ * Note : Hall of Fame et fan count seront branchés en 1.E.5 / 1.C.4.
+ */
+
+import { prisma } from "../prisma";
+
+import { OLD_WORLD_LEAGUE_SLUG } from "./pro-league-hub";
+
+const UPCOMING_LIMIT = 5;
+const RECENT_LIMIT = 5;
+
+export interface ProTeamDetailOpponent {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+}
+
+export interface ProTeamDetailMatch {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly homeTeamSlug: string;
+  readonly awayTeamSlug: string;
+  readonly opponent: ProTeamDetailOpponent;
+  readonly isHome: boolean;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+}
+
+export interface ProTeamRosterEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number | null;
+  readonly av: number;
+  readonly skills: readonly string[];
+  readonly status: string;
+  readonly form: number;
+  readonly niggling: number;
+}
+
+export interface ProTeamDetailRecord {
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+  readonly form: readonly ("W" | "D" | "L")[];
+}
+
+export interface ProTeamDetail {
+  readonly slug: string;
+  readonly city: string;
+  readonly name: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly baseTv: number;
+  readonly motto: string | null;
+  readonly seasonId: string | null;
+  readonly seasonYear: number | null;
+  readonly record: ProTeamDetailRecord | null;
+  readonly roster: readonly ProTeamRosterEntry[];
+  readonly upcomingMatches: readonly ProTeamDetailMatch[];
+  readonly recentMatches: readonly ProTeamDetailMatch[];
+}
+
+export class ProTeamNotFoundError extends Error {
+  constructor(slug: string) {
+    super(`ProTeam slug='${slug}' introuvable`);
+    this.name = "ProTeamNotFoundError";
+  }
+}
+
+function parseSkills(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((s): s is string => typeof s === "string");
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function parseForm(raw: unknown): ("W" | "D" | "L")[] {
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (v): v is "W" | "D" | "L" => v === "W" || v === "D" || v === "L",
+    );
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(
+          (v): v is "W" | "D" | "L" => v === "W" || v === "D" || v === "L",
+        );
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export async function getProTeamDetail(
+  slug: string,
+  leagueSlug: string = OLD_WORLD_LEAGUE_SLUG,
+): Promise<ProTeamDetail> {
+  const team = await prisma.proTeam.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      slug: true,
+      city: true,
+      name: true,
+      race: true,
+      nflFlavor: true,
+      primaryColor: true,
+      secondaryColor: true,
+      baseTv: true,
+      meta: true,
+      leagueId: true,
+      league: { select: { slug: true, branding: true } },
+    },
+  });
+  if (!team || (team.league?.slug as string) !== leagueSlug) {
+    throw new ProTeamNotFoundError(slug);
+  }
+
+  // Saison courante (in_progress > completed la plus récente).
+  const inProgress = await prisma.proLeagueSeason.findFirst({
+    where: { leagueId: team.leagueId as string, status: "in_progress" },
+    orderBy: { year: "asc" },
+    select: { id: true, year: true },
+  });
+  const season =
+    inProgress ??
+    (await prisma.proLeagueSeason.findFirst({
+      where: { leagueId: team.leagueId as string },
+      orderBy: { year: "desc" },
+      select: { id: true, year: true },
+    }));
+
+  let record: ProTeamDetailRecord | null = null;
+  let upcomingMatches: ProTeamDetailMatch[] = [];
+  let recentMatches: ProTeamDetailMatch[] = [];
+
+  if (season) {
+    const seasonId = season.id as string;
+    const standings = await prisma.proLeagueStandings.findUnique({
+      where: { seasonId_teamId: { seasonId, teamId: team.id as string } },
+      select: {
+        played: true,
+        wins: true,
+        draws: true,
+        losses: true,
+        points: true,
+        tdFor: true,
+        tdAgainst: true,
+        form: true,
+      },
+    });
+    if (standings) {
+      record = {
+        played: (standings.played as number) ?? 0,
+        wins: (standings.wins as number) ?? 0,
+        draws: (standings.draws as number) ?? 0,
+        losses: (standings.losses as number) ?? 0,
+        points: (standings.points as number) ?? 0,
+        tdFor: (standings.tdFor as number) ?? 0,
+        tdAgainst: (standings.tdAgainst as number) ?? 0,
+        form: parseForm(standings.form),
+      };
+    }
+
+    // Calendrier : matchs de la saison où l'équipe est home OU away.
+    const teamId = team.id as string;
+    const upcoming = await prisma.proLeagueMatch.findMany({
+      where: {
+        seasonId,
+        OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
+        status: { in: ["scheduled", "ready"] },
+      },
+      orderBy: { scheduledAt: "asc" },
+      take: UPCOMING_LIMIT,
+      select: matchSelect(),
+    });
+    const recent = await prisma.proLeagueMatch.findMany({
+      where: {
+        seasonId,
+        OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
+        status: "completed",
+      },
+      orderBy: { scheduledAt: "desc" },
+      take: RECENT_LIMIT,
+      select: matchSelect(),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    upcomingMatches = upcoming.map((m: any) => toDetailMatch(m, teamId));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recentMatches = recent.map((m: any) => toDetailMatch(m, teamId));
+  }
+
+  // Roster (filter status='active' par défaut, on garde tous les statuts
+  // pour permettre à l'UI de filtrer côté client).
+  const rosterRaw = await prisma.proTeamRoster.findMany({
+    where: { teamId: team.id as string },
+    orderBy: [{ position: "asc" }, { name: "asc" }],
+    select: {
+      id: true,
+      name: true,
+      position: true,
+      ma: true,
+      st: true,
+      ag: true,
+      pa: true,
+      av: true,
+      skills: true,
+      status: true,
+      form: true,
+      niggling: true,
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const roster: ProTeamRosterEntry[] = rosterRaw.map((r: any) => ({
+    id: r.id as string,
+    name: r.name as string,
+    position: r.position as string,
+    ma: r.ma as number,
+    st: r.st as number,
+    ag: r.ag as number,
+    pa: (r.pa as number | null) ?? null,
+    av: r.av as number,
+    skills: parseSkills(r.skills),
+    status: (r.status as string) ?? "active",
+    form: (r.form as number) ?? 50,
+    niggling: (r.niggling as number) ?? 0,
+  }));
+
+  const meta = (team.meta as { motto?: string } | null | undefined) ?? null;
+
+  return {
+    slug: team.slug as string,
+    city: team.city as string,
+    name: team.name as string,
+    race: team.race as string,
+    nflFlavor: (team.nflFlavor as string | null) ?? null,
+    primaryColor: (team.primaryColor as string | null) ?? null,
+    secondaryColor: (team.secondaryColor as string | null) ?? null,
+    baseTv: (team.baseTv as number) ?? 1000,
+    motto: meta?.motto ?? null,
+    seasonId: season ? (season.id as string) : null,
+    seasonYear: season ? (season.year as number) : null,
+    record,
+    roster,
+    upcomingMatches,
+    recentMatches,
+  };
+}
+
+function matchSelect() {
+  return {
+    id: true,
+    status: true,
+    scheduledAt: true,
+    scoreHome: true,
+    scoreAway: true,
+    outcome: true,
+    homeTeamId: true,
+    awayTeamId: true,
+    round: { select: { roundNumber: true } },
+    homeTeam: {
+      select: { slug: true, name: true, city: true, primaryColor: true },
+    },
+    awayTeam: {
+      select: { slug: true, name: true, city: true, primaryColor: true },
+    },
+  } as const;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toDetailMatch(m: any, teamId: string): ProTeamDetailMatch {
+  const isHome = (m.homeTeamId as string) === teamId;
+  const opp = isHome ? m.awayTeam : m.homeTeam;
+  return {
+    id: m.id as string,
+    roundNumber: m.round.roundNumber as number,
+    status: m.status as string,
+    scheduledAt: (m.scheduledAt as Date).toISOString(),
+    homeTeamSlug: m.homeTeam.slug as string,
+    awayTeamSlug: m.awayTeam.slug as string,
+    isHome,
+    opponent: {
+      slug: opp.slug as string,
+      name: opp.name as string,
+      city: opp.city as string,
+      primaryColor: (opp.primaryColor as string | null) ?? null,
+    },
+    scoreHome: (m.scoreHome as number | null) ?? null,
+    scoreAway: (m.scoreAway as number | null) ?? null,
+    outcome: (m.outcome as string | null) ?? null,
+  };
+}

--- a/apps/web/app/pro-league/teams/[slug]/page.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.test.tsx
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {},
+}));
+
+import { apiRequest } from "../../../lib/api-client";
+import ProLeagueTeamPage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeTeam(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    slug: "buf-snow-ogres",
+    city: "Buffalo",
+    name: "Snow Ogres",
+    race: "Ogre",
+    nflFlavor: "Buffalo snow brutality",
+    primaryColor: "#00338D",
+    secondaryColor: "#C60C30",
+    baseTv: 1100,
+    motto: "Snow over Steel",
+    seasonId: "s1",
+    seasonYear: 2026,
+    record: {
+      played: 4,
+      wins: 3,
+      draws: 0,
+      losses: 1,
+      points: 9,
+      tdFor: 12,
+      tdAgainst: 5,
+      form: ["W", "W", "L", "W"],
+    },
+    roster: [
+      {
+        id: "p1",
+        name: "Grim",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: ["block"],
+        status: "active",
+        form: 60,
+        niggling: 0,
+      },
+    ],
+    upcomingMatches: [
+      {
+        id: "m_up",
+        roundNumber: 5,
+        status: "scheduled",
+        scheduledAt: new Date(Date.now() + 86_400_000).toISOString(),
+        homeTeamSlug: "buf-snow-ogres",
+        awayTeamSlug: "gb-cheese-halflings",
+        opponent: {
+          slug: "gb-cheese-halflings",
+          name: "Cheese Halflings",
+          city: "Green Bay",
+          primaryColor: "#203731",
+        },
+        isHome: true,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+      },
+    ],
+    recentMatches: [
+      {
+        id: "m_done",
+        roundNumber: 4,
+        status: "completed",
+        scheduledAt: new Date(Date.now() - 86_400_000).toISOString(),
+        homeTeamSlug: "kc-soaring-hawks",
+        awayTeamSlug: "buf-snow-ogres",
+        opponent: {
+          slug: "kc-soaring-hawks",
+          name: "Soaring Hawks",
+          city: "Kansas City",
+          primaryColor: "#E31837",
+        },
+        isHome: false,
+        scoreHome: 1,
+        scoreAway: 3,
+        outcome: "away",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProLeagueTeamPage — sprint 1.C.2", () => {
+  it("affiche 'Chargement…' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche le banner avec city, race, motto, NFL flavor", async () => {
+    mockedApi.mockResolvedValue(makeTeam());
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("team-banner")).toBeTruthy();
+    });
+    expect(screen.getByText("Snow Ogres")).toBeTruthy();
+    expect(screen.getByText("Buffalo")).toBeTruthy();
+    expect(screen.getAllByText(/Ogre/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Snow over Steel/)).toBeTruthy();
+    expect(screen.getByText(/Buffalo snow brutality/)).toBeTruthy();
+  });
+
+  it("affiche le record + points + form", async () => {
+    mockedApi.mockResolvedValue(makeTeam());
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("team-record")).toBeTruthy();
+    });
+    expect(screen.getByText(/3V 0N 1D/)).toBeTruthy();
+    expect(screen.getByText(/12.5/)).toBeTruthy(); // td for-against
+    const formBadges = screen.getByTestId("form-badges");
+    expect(formBadges.children.length).toBe(4);
+  });
+
+  it("affiche le roster", async () => {
+    mockedApi.mockResolvedValue(makeTeam());
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Grim")).toBeTruthy();
+    expect(screen.getByText("Lineman")).toBeTruthy();
+    expect(screen.getByText("block")).toBeTruthy();
+  });
+
+  it("affiche placeholder roster si vide", async () => {
+    mockedApi.mockResolvedValue(makeTeam({ roster: [] }));
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Roster non encore peuplé/i)).toBeTruthy();
+    });
+  });
+
+  it("affiche les prochains et derniers matchs", async () => {
+    mockedApi.mockResolvedValue(makeTeam());
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("match-row");
+      expect(rows.length).toBe(2);
+    });
+    expect(screen.getByText("Cheese Halflings")).toBeTruthy();
+    expect(screen.getByText("Soaring Hawks")).toBeTruthy();
+  });
+
+  it("affiche message d'erreur si API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("not-found"));
+    render(<ProLeagueTeamPage params={{ slug: "unknown" }} />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("not-found");
+  });
+});

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../lib/api-client";
+
+/**
+ * Page détail d'une équipe Pro League — sprint Pro League lot 1.C.2.
+ *
+ * Affiche :
+ * - Banner branding (couleur primaire, ville + race + NFL flavor + motto)
+ * - Record + form (badges 5 derniers résultats)
+ * - Roster (table compacte avec stats BB)
+ * - Calendrier : prochains matchs + derniers matchs joués
+ *
+ * Public, pas d'auth.
+ */
+
+type FormChar = "W" | "D" | "L";
+
+interface Opponent {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+}
+
+interface DetailMatch {
+  readonly id: string;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly homeTeamSlug: string;
+  readonly awayTeamSlug: string;
+  readonly opponent: Opponent;
+  readonly isHome: boolean;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+}
+
+interface RosterEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number | null;
+  readonly av: number;
+  readonly skills: readonly string[];
+  readonly status: string;
+  readonly form: number;
+  readonly niggling: number;
+}
+
+interface DetailRecord {
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly tdFor: number;
+  readonly tdAgainst: number;
+  readonly form: readonly FormChar[];
+}
+
+interface TeamDetail {
+  readonly slug: string;
+  readonly city: string;
+  readonly name: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly baseTv: number;
+  readonly motto: string | null;
+  readonly seasonId: string | null;
+  readonly seasonYear: number | null;
+  readonly record: DetailRecord | null;
+  readonly roster: readonly RosterEntry[];
+  readonly upcomingMatches: readonly DetailMatch[];
+  readonly recentMatches: readonly DetailMatch[];
+}
+
+const FORM_BADGE_STYLES: Record<FormChar, string> = {
+  W: "bg-emerald-700 text-emerald-50",
+  D: "bg-slate-600 text-slate-50",
+  L: "bg-rose-700 text-rose-50",
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-emerald-700/30 text-emerald-200",
+  injured: "bg-amber-700/30 text-amber-200",
+  dead: "bg-rose-900/40 text-rose-200",
+  retired: "bg-slate-700/30 text-slate-300",
+};
+
+function FormBadges({ form }: { form: readonly FormChar[] }): JSX.Element {
+  if (form.length === 0) {
+    return <span className="text-xs text-slate-600">—</span>;
+  }
+  return (
+    <div className="flex gap-0.5" data-testid="form-badges">
+      {form.map((c, i) => (
+        <span
+          key={i}
+          className={`flex h-5 w-5 items-center justify-center rounded text-xs font-bold font-mono ${FORM_BADGE_STYLES[c]}`}
+        >
+          {c}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function MatchRow({ match }: { match: DetailMatch }): JSX.Element {
+  const at = new Date(match.scheduledAt);
+  const formattedDate = at.toLocaleString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const finished = match.status === "completed";
+  const won =
+    finished &&
+    ((match.isHome && match.outcome === "home") ||
+      (!match.isHome && match.outcome === "away"));
+  const drew = finished && match.outcome === "draw";
+  const resultClass = finished
+    ? won
+      ? "text-emerald-300"
+      : drew
+        ? "text-slate-300"
+        : "text-rose-300"
+    : "text-slate-400";
+
+  return (
+    <Link
+      href={`/pro-league/matches/${match.id}/live`}
+      className="flex items-center justify-between rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm hover:bg-slate-800"
+      data-testid="match-row"
+    >
+      <div className="flex flex-col">
+        <span className="text-xs uppercase text-slate-500">
+          R{match.roundNumber} · {match.isHome ? "Home" : "Away"}
+        </span>
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block h-3 w-3 rounded-full ring-1 ring-slate-700"
+            style={{ background: match.opponent.primaryColor ?? "#475569" }}
+          />
+          <span className="font-medium text-slate-100">
+            {match.opponent.name}
+          </span>
+          <span className="text-xs text-slate-500">{match.opponent.city}</span>
+        </div>
+      </div>
+      <div className="flex flex-col items-end">
+        {finished ? (
+          <span className={`font-mono ${resultClass}`}>
+            {match.scoreHome}–{match.scoreAway}
+          </span>
+        ) : (
+          <span className="font-mono text-xs text-slate-500">{match.status}</span>
+        )}
+        <span className="text-xs text-slate-500">{formattedDate}</span>
+      </div>
+    </Link>
+  );
+}
+
+function RosterTable({
+  rows,
+}: {
+  rows: readonly RosterEntry[];
+}): JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">
+        Roster non encore peuplé. Les joueurs sont générés à la création
+        de la saison (lot 1.E.6).
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded border border-slate-800">
+      <table data-testid="roster-table" className="w-full text-sm">
+        <thead className="bg-slate-900 text-xs uppercase text-slate-400">
+          <tr>
+            <th className="px-2 py-2 text-left">Nom</th>
+            <th className="px-2 py-2 text-left">Position</th>
+            <th className="w-10 px-2 py-2 text-center">MA</th>
+            <th className="w-10 px-2 py-2 text-center">ST</th>
+            <th className="w-10 px-2 py-2 text-center">AG</th>
+            <th className="w-10 px-2 py-2 text-center">PA</th>
+            <th className="w-10 px-2 py-2 text-center">AV</th>
+            <th className="px-2 py-2 text-left">Skills</th>
+            <th className="w-20 px-2 py-2 text-center">Status</th>
+            <th className="w-12 px-2 py-2 text-center">Forme</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr
+              key={r.id}
+              className="border-t border-slate-800 hover:bg-slate-900"
+            >
+              <td className="px-2 py-2 font-medium text-slate-100">
+                {r.name}
+              </td>
+              <td className="px-2 py-2 text-slate-300">{r.position}</td>
+              <td className="px-2 py-2 text-center font-mono text-slate-300">
+                {r.ma}
+              </td>
+              <td className="px-2 py-2 text-center font-mono text-slate-300">
+                {r.st}
+              </td>
+              <td className="px-2 py-2 text-center font-mono text-slate-300">
+                {r.ag}
+              </td>
+              <td className="px-2 py-2 text-center font-mono text-slate-300">
+                {r.pa ?? "—"}
+              </td>
+              <td className="px-2 py-2 text-center font-mono text-slate-300">
+                {r.av}
+              </td>
+              <td className="px-2 py-2 text-xs text-slate-400">
+                {r.skills.length === 0 ? "—" : r.skills.join(", ")}
+              </td>
+              <td className="px-2 py-2 text-center">
+                <span
+                  className={`inline-block rounded px-2 py-0.5 text-xs ${STATUS_STYLES[r.status] ?? STATUS_STYLES.active}`}
+                >
+                  {r.status}
+                </span>
+              </td>
+              <td className="px-2 py-2 text-center font-mono text-slate-400">
+                {r.form}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface TeamPageProps {
+  readonly params: { slug: string };
+}
+
+export default function ProLeagueTeamPage({
+  params,
+}: TeamPageProps): JSX.Element {
+  const [data, setData] = useState<TeamDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<TeamDetail>(
+      `/pro-league/teams/${encodeURIComponent(params.slug)}`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.slug]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col bg-slate-950 text-slate-100">
+      {loading ? (
+        <p className="px-4 py-6 text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="m-4 rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !data ? (
+        <p className="px-4 py-6 text-sm text-slate-400">Équipe inconnue.</p>
+      ) : (
+        <>
+          <header
+            data-testid="team-banner"
+            className="flex flex-col gap-1 border-b-4 px-4 py-6"
+            style={{
+              background: `linear-gradient(135deg, ${data.primaryColor ?? "#1e293b"} 0%, ${data.secondaryColor ?? "#0f172a"} 100%)`,
+              borderBottomColor: data.secondaryColor ?? "#0f172a",
+            }}
+          >
+            <div className="flex items-center justify-between">
+              <Link
+                href="/pro-league"
+                className="rounded border border-white/30 px-2 py-1 text-xs text-white/90 hover:bg-white/10"
+              >
+                ← Hub
+              </Link>
+              <span className="font-mono text-xs text-white/70">
+                {data.race} · TV {data.baseTv}
+              </span>
+            </div>
+            <h1 className="text-3xl font-black tracking-wide text-white drop-shadow-md">
+              {data.name}
+            </h1>
+            <p className="text-sm text-white/80">{data.city}</p>
+            {data.motto ? (
+              <p className="mt-1 text-sm italic text-white/70">
+                "{data.motto}"
+              </p>
+            ) : null}
+            {data.nflFlavor ? (
+              <p className="mt-2 text-xs text-white/60">{data.nflFlavor}</p>
+            ) : null}
+          </header>
+
+          <div className="px-4 py-6">
+            {data.record ? (
+              <section
+                data-testid="team-record"
+                className="mb-6 flex flex-wrap items-center gap-4 rounded border border-slate-800 bg-slate-900 px-4 py-3"
+              >
+                <div className="flex flex-col">
+                  <span className="text-xs uppercase text-slate-500">
+                    Record
+                  </span>
+                  <span className="font-mono text-lg font-bold text-slate-100">
+                    {data.record.wins}V {data.record.draws}N {data.record.losses}D
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs uppercase text-slate-500">
+                    Points
+                  </span>
+                  <span className="font-mono text-lg font-bold text-slate-100">
+                    {data.record.points}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs uppercase text-slate-500">TD</span>
+                  <span className="font-mono text-lg font-bold text-slate-100">
+                    {data.record.tdFor}–{data.record.tdAgainst}
+                  </span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-xs uppercase text-slate-500">
+                    Forme
+                  </span>
+                  <FormBadges form={data.record.form} />
+                </div>
+              </section>
+            ) : null}
+
+            <section className="mb-6">
+              <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                Roster
+              </h2>
+              <RosterTable rows={data.roster} />
+            </section>
+
+            <section className="mb-6">
+              <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                Prochains matchs
+              </h2>
+              {data.upcomingMatches.length === 0 ? (
+                <p className="text-sm text-slate-500">
+                  Aucun match programmé.
+                </p>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {data.upcomingMatches.map((m) => (
+                    <MatchRow key={m.id} match={m} />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                Derniers matchs
+              </h2>
+              {data.recentMatches.length === 0 ? (
+                <p className="text-sm text-slate-500">
+                  Aucun match joué.
+                </p>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {data.recentMatches.map((m) => (
+                    <MatchRow key={m.id} match={m} />
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.C.2** — Page détail équipe `/pro-league/teams/[slug]`.

### Backend

| Fichier | Rôle |
|---|---|
| `services/pro-league-team.ts` | `getProTeamDetail(slug)` — agrège team + record + roster + calendrier |
| `routes/pro-league.ts` | Nouveau handler `GET /pro-league/teams/:slug` |

**Détails :**
- 404 typé `ProTeamNotFoundError` (slug inconnu **OU** team appartenant à une autre ligue).
- Saison courante : `in_progress` > fallback `completed` (la plus récente).
- Calendrier : 5 prochains matchs (`scheduled`/`ready`) + 5 derniers (`completed`).
- Roster trié par `position asc, name asc`.
- Helpers `parseSkills` / `parseForm` qui acceptent **array natif** (postgres JSON) OU **string JSON** (sqlite mirror).

### Frontend `/pro-league/teams/[slug]`

- **Banner branding** : gradient `primaryColor → secondaryColor`, border-bottom secondaire. Affiche city, race, baseTv, motto (italique), NFL flavor.
- **Section record** : V/N/D, points, TD for-against, badges forme 5 derniers (W vert, D slate, L rose).
- **Roster table** scroll-x mobile : nom, position, MA/ST/AG/PA/AV, skills (csv), status (badge coloré : active/injured/dead/retired), forme.
- **Calendar 2-cols** : prochains matchs + derniers matchs. Cards avec couleur opponent + score outcome coloré (vert win, slate draw, rose loss). Liens vers `/pro-league/matches/[id]/live`.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-league-team` (backend) → **7/7 ✓**
- [x] `npx vitest run app/pro-league/teams` (frontend) → **7/7 ✓**

Couverture totale : **14 tests**.

## Suite

Au choix : **1.C.3** (match detail page) ou **1.C.4** (suivre une équipe).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_