### PR TITLE
feat(server,web): Pro League match detail page (sprint 1.C.3)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -40,6 +40,10 @@ import {
   getProLeagueCurrentStandings,
 } from "../services/pro-league-standings";
 import {
+  ProMatchNotFoundError,
+  getProMatchDetail,
+} from "../services/pro-league-match";
+import {
   ProTeamNotFoundError,
   getProTeamDetail,
 } from "../services/pro-league-team";
@@ -222,11 +226,40 @@ export async function handleGetTeamDetail(
   }
 }
 
+/**
+ * Sprint 1.C.3 — Détail d'un match Pro League (meta + équipes +
+ * scoreboard + highlights). NB : pour les events temps réel,
+ * utiliser `/pro-league/matches/:id/stream` (lot 1.B.2).
+ */
+export async function handleGetMatchDetail(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  if (!id || typeof id !== "string") {
+    res.status(400).json({ error: "missing-match-id" });
+    return;
+  }
+  try {
+    const data = await getProMatchDetail(id);
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProMatchNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/matches/${id}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
 router.get("/teams/:slug", handleGetTeamDetail);
+router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 

--- a/apps/server/src/services/pro-league-match.test.ts
+++ b/apps/server/src/services/pro-league-match.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn() },
+    replay: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  ProMatchNotFoundError,
+  getProMatchDetail,
+} from "./pro-league-match";
+
+interface MockedPrisma {
+  proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const MATCH_ID = "m_123";
+
+function makeMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MATCH_ID,
+    seasonId: "s1",
+    status: "completed",
+    scheduledAt: new Date("2026-09-15T21:00:00Z"),
+    simulatedAt: new Date("2026-09-14T21:00:00Z"),
+    completedAt: new Date("2026-09-15T21:08:00Z"),
+    engineVer: "0.13.0",
+    scoreHome: 3,
+    scoreAway: 1,
+    outcome: "home",
+    touchdownCount: 4,
+    casualtyCount: 2,
+    turnoverCount: 5,
+    nuffleCount: 3,
+    season: { year: 2026 },
+    round: { roundNumber: 4 },
+    homeTeam: {
+      slug: "buf-snow-ogres",
+      name: "Snow Ogres",
+      city: "Buffalo",
+      race: "Ogre",
+      nflFlavor: "Buffalo brutality",
+      primaryColor: "#00338D",
+      secondaryColor: "#C60C30",
+      baseTv: 1100,
+    },
+    awayTeam: {
+      slug: "gb-cheese-halflings",
+      name: "Cheese Halflings",
+      city: "Green Bay",
+      race: "Halfling",
+      nflFlavor: "Cheese underdogs",
+      primaryColor: "#203731",
+      secondaryColor: "#FFB612",
+      baseTv: 700,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.replay.findUnique.mockResolvedValue(null);
+});
+
+describe("getProMatchDetail — sprint 1.C.3", () => {
+  it("404 si le match n'existe pas", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expect(getProMatchDetail("unknown")).rejects.toThrow(
+      ProMatchNotFoundError,
+    );
+  });
+
+  it("formate les meta + dates ISO + équipes", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    const out = await getProMatchDetail(MATCH_ID);
+    expect(out.id).toBe(MATCH_ID);
+    expect(out.seasonYear).toBe(2026);
+    expect(out.roundNumber).toBe(4);
+    expect(out.status).toBe("completed");
+    expect(out.scheduledAt).toBe("2026-09-15T21:00:00.000Z");
+    expect(out.simulatedAt).toBe("2026-09-14T21:00:00.000Z");
+    expect(out.completedAt).toBe("2026-09-15T21:08:00.000Z");
+    expect(out.engineVer).toBe("0.13.0");
+    expect(out.homeTeam.slug).toBe("buf-snow-ogres");
+    expect(out.awayTeam.slug).toBe("gb-cheese-halflings");
+    expect(out.homeTeam.race).toBe("Ogre");
+    expect(out.homeTeam.baseTv).toBe(1100);
+    expect(out.scoreHome).toBe(3);
+    expect(out.outcome).toBe("home");
+    expect(out.casualtyCount).toBe(2);
+  });
+
+  it("renvoie replay=null si pas de Replay row", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.findUnique.mockResolvedValue(null);
+    const out = await getProMatchDetail(MATCH_ID);
+    expect(out.replay).toBeNull();
+  });
+
+  it("inclut highlights + durationMs si Replay disponible (array natif)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.findUnique.mockResolvedValue({
+      durationMs: 480_000,
+      highlights: [
+        { type: "TD", atMs: 30_000, meta: { team: "home" } },
+        { type: "CASUALTY", atMs: 60_000, meta: { causedBy: "block" } },
+      ],
+    });
+    const out = await getProMatchDetail(MATCH_ID);
+    expect(out.replay?.durationMs).toBe(480_000);
+    expect(out.replay?.highlights).toHaveLength(2);
+    expect(out.replay?.highlights[0].type).toBe("TD");
+  });
+
+  it("parse highlights depuis JSON string (sqlite mirror)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.findUnique.mockResolvedValue({
+      durationMs: 100,
+      highlights: '[{"type":"NUFFLE","atMs":5000,"meta":{"id":"x"}}]',
+    });
+    const out = await getProMatchDetail(MATCH_ID);
+    expect(out.replay?.highlights).toHaveLength(1);
+    expect(out.replay?.highlights[0].type).toBe("NUFFLE");
+  });
+
+  it("filtre les types de highlights inconnus", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(makeMatch());
+    mocked.replay.findUnique.mockResolvedValue({
+      durationMs: 100,
+      highlights: [
+        { type: "TD", atMs: 0, meta: {} },
+        { type: "BOGUS", atMs: 0, meta: {} },
+        { type: "CASUALTY", atMs: 1000 },
+      ],
+    });
+    const out = await getProMatchDetail(MATCH_ID);
+    // Filtre BOGUS, garde TD + CASUALTY (avec meta défaut {}).
+    expect(out.replay?.highlights).toHaveLength(2);
+    expect(out.replay?.highlights[1].type).toBe("CASUALTY");
+    expect(out.replay?.highlights[1].meta).toEqual({});
+  });
+
+  it("renvoie scores=null pour un match scheduled non encore simulé", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      makeMatch({
+        status: "scheduled",
+        simulatedAt: null,
+        completedAt: null,
+        engineVer: null,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        touchdownCount: null,
+        casualtyCount: null,
+        turnoverCount: null,
+        nuffleCount: null,
+      }),
+    );
+    const out = await getProMatchDetail(MATCH_ID);
+    expect(out.status).toBe("scheduled");
+    expect(out.simulatedAt).toBeNull();
+    expect(out.scoreHome).toBeNull();
+    expect(out.outcome).toBeNull();
+    expect(out.replay).toBeNull();
+  });
+});

--- a/apps/server/src/services/pro-league-match.ts
+++ b/apps/server/src/services/pro-league-match.ts
@@ -1,0 +1,214 @@
+/**
+ * Pro League match detail — sprint Pro League lot 1.C.3.
+ *
+ * Service qui agrège les données nécessaires à la page
+ * `/pro-league/matches/:id` :
+ *  - meta (status, scheduledAt, simulatedAt, completedAt, engineVer)
+ *  - équipes home/away (slug, name, city, race, palette)
+ *  - score + outcome + counters (TD/cas/turnover/nuffle)
+ *  - highlights pré-extraits depuis Replay (TD/CAS/NUFFLE)
+ *
+ * Les replays sont stockés CBOR + gzip (lot 1.A.2). On NE renvoie PAS
+ * le payload brut sur cet endpoint — pour streamer les events, utiliser
+ * `/pro-league/matches/:id/stream` (lot 1.B.2).
+ *
+ * Hors scope MVP : odds, lineups, hype meter, MVP, chat fans (lots 1.D
+ * + 1.E).
+ */
+
+import { prisma } from "../prisma";
+
+export interface ProMatchDetailTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly baseTv: number;
+}
+
+export interface ProMatchHighlight {
+  readonly type: "TD" | "CASUALTY" | "NUFFLE";
+  readonly atMs: number;
+  readonly meta: Record<string, unknown>;
+}
+
+export interface ProMatchDetail {
+  readonly id: string;
+  readonly seasonId: string;
+  readonly seasonYear: number;
+  readonly roundNumber: number;
+  /** "scheduled" | "ready" | "in_progress" | "completed" | "failed" */
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly simulatedAt: string | null;
+  readonly completedAt: string | null;
+  readonly engineVer: string | null;
+  readonly homeTeam: ProMatchDetailTeam;
+  readonly awayTeam: ProMatchDetailTeam;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  /** "home" | "away" | "draw" | null */
+  readonly outcome: string | null;
+  readonly touchdownCount: number | null;
+  readonly casualtyCount: number | null;
+  readonly turnoverCount: number | null;
+  readonly nuffleCount: number | null;
+  /** Disponible quand le replay existe (status >= ready). */
+  readonly replay: {
+    readonly durationMs: number;
+    readonly highlights: readonly ProMatchHighlight[];
+  } | null;
+}
+
+export class ProMatchNotFoundError extends Error {
+  constructor(id: string) {
+    super(`ProLeagueMatch '${id}' introuvable`);
+    this.name = "ProMatchNotFoundError";
+  }
+}
+
+function teamMeta(t: {
+  slug: unknown;
+  name: unknown;
+  city: unknown;
+  race: unknown;
+  nflFlavor?: unknown;
+  primaryColor?: unknown;
+  secondaryColor?: unknown;
+  baseTv?: unknown;
+}): ProMatchDetailTeam {
+  return {
+    slug: t.slug as string,
+    name: t.name as string,
+    city: t.city as string,
+    race: t.race as string,
+    nflFlavor: (t.nflFlavor as string | null) ?? null,
+    primaryColor: (t.primaryColor as string | null) ?? null,
+    secondaryColor: (t.secondaryColor as string | null) ?? null,
+    baseTv: (t.baseTv as number) ?? 1000,
+  };
+}
+
+function parseHighlights(raw: unknown): ProMatchHighlight[] {
+  let arr: unknown;
+  if (typeof raw === "string") {
+    try {
+      arr = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  } else {
+    arr = raw;
+  }
+  if (!Array.isArray(arr)) return [];
+  const out: ProMatchHighlight[] = [];
+  for (const h of arr) {
+    if (h && typeof h === "object") {
+      const obj = h as Record<string, unknown>;
+      const type = obj.type;
+      const atMs = obj.atMs;
+      if (
+        (type === "TD" || type === "CASUALTY" || type === "NUFFLE") &&
+        typeof atMs === "number"
+      ) {
+        out.push({
+          type,
+          atMs,
+          meta: (obj.meta as Record<string, unknown> | undefined) ?? {},
+        });
+      }
+    }
+  }
+  return out;
+}
+
+export async function getProMatchDetail(id: string): Promise<ProMatchDetail> {
+  const m = await prisma.proLeagueMatch.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      seasonId: true,
+      status: true,
+      scheduledAt: true,
+      simulatedAt: true,
+      completedAt: true,
+      engineVer: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      touchdownCount: true,
+      casualtyCount: true,
+      turnoverCount: true,
+      nuffleCount: true,
+      season: { select: { year: true } },
+      round: { select: { roundNumber: true } },
+      homeTeam: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          race: true,
+          nflFlavor: true,
+          primaryColor: true,
+          secondaryColor: true,
+          baseTv: true,
+        },
+      },
+      awayTeam: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          race: true,
+          nflFlavor: true,
+          primaryColor: true,
+          secondaryColor: true,
+          baseTv: true,
+        },
+      },
+    },
+  });
+  if (!m) {
+    throw new ProMatchNotFoundError(id);
+  }
+
+  // Charge le Replay (highlights + durationMs) si disponible.
+  let replay: ProMatchDetail["replay"] = null;
+  const replayRow = await prisma.replay.findUnique({
+    where: { matchId: id },
+    select: { durationMs: true, highlights: true },
+  });
+  if (replayRow) {
+    replay = {
+      durationMs: (replayRow.durationMs as number) ?? 0,
+      highlights: parseHighlights(replayRow.highlights),
+    };
+  }
+
+  return {
+    id: m.id as string,
+    seasonId: m.seasonId as string,
+    seasonYear: m.season.year as number,
+    roundNumber: m.round.roundNumber as number,
+    status: m.status as string,
+    scheduledAt: (m.scheduledAt as Date).toISOString(),
+    simulatedAt:
+      (m.simulatedAt as Date | null)?.toISOString() ?? null,
+    completedAt:
+      (m.completedAt as Date | null)?.toISOString() ?? null,
+    engineVer: (m.engineVer as string | null) ?? null,
+    homeTeam: teamMeta(m.homeTeam),
+    awayTeam: teamMeta(m.awayTeam),
+    scoreHome: (m.scoreHome as number | null) ?? null,
+    scoreAway: (m.scoreAway as number | null) ?? null,
+    outcome: (m.outcome as string | null) ?? null,
+    touchdownCount: (m.touchdownCount as number | null) ?? null,
+    casualtyCount: (m.casualtyCount as number | null) ?? null,
+    turnoverCount: (m.turnoverCount as number | null) ?? null,
+    nuffleCount: (m.nuffleCount as number | null) ?? null,
+    replay,
+  };
+}

--- a/apps/web/app/pro-league/matches/[id]/page.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/page.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {},
+}));
+
+import { apiRequest } from "../../../lib/api-client";
+import ProLeagueMatchDetailPage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeMatch(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    id: "m_1",
+    seasonId: "s1",
+    seasonYear: 2026,
+    roundNumber: 4,
+    status: "completed",
+    scheduledAt: new Date("2026-09-15T21:00:00Z").toISOString(),
+    simulatedAt: new Date("2026-09-14T21:00:00Z").toISOString(),
+    completedAt: new Date("2026-09-15T21:08:00Z").toISOString(),
+    engineVer: "0.13.0",
+    homeTeam: {
+      slug: "buf-snow-ogres",
+      name: "Snow Ogres",
+      city: "Buffalo",
+      race: "Ogre",
+      nflFlavor: null,
+      primaryColor: "#00338D",
+      secondaryColor: "#C60C30",
+      baseTv: 1100,
+    },
+    awayTeam: {
+      slug: "gb-cheese-halflings",
+      name: "Cheese Halflings",
+      city: "Green Bay",
+      race: "Halfling",
+      nflFlavor: null,
+      primaryColor: "#203731",
+      secondaryColor: "#FFB612",
+      baseTv: 700,
+    },
+    scoreHome: 3,
+    scoreAway: 1,
+    outcome: "home",
+    touchdownCount: 4,
+    casualtyCount: 2,
+    turnoverCount: 5,
+    nuffleCount: 3,
+    replay: {
+      durationMs: 480_000,
+      highlights: [
+        { type: "TD", atMs: 30_000, meta: { team: "home" } },
+        { type: "CASUALTY", atMs: 60_000, meta: { causedBy: "block" } },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProLeagueMatchDetailPage — sprint 1.C.3", () => {
+  it("affiche 'Chargement…' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche le banner avec les noms d'équipes + saison + round", async () => {
+    mockedApi.mockResolvedValue(makeMatch());
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-banner")).toBeTruthy();
+    });
+    expect(screen.getByTestId("home-team-name").textContent).toBe(
+      "Snow Ogres",
+    );
+    expect(screen.getByTestId("away-team-name").textContent).toBe(
+      "Cheese Halflings",
+    );
+    expect(screen.getByText(/Saison 2026/)).toBeTruthy();
+    expect(screen.getByText(/R4/)).toBeTruthy();
+  });
+
+  it("post-match : affiche le score + counters + highlights", async () => {
+    mockedApi.mockResolvedValue(makeMatch());
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("scoreboard")).toBeTruthy();
+    });
+    expect(screen.getByTestId("scoreboard").textContent).toContain("3");
+    expect(screen.getByTestId("scoreboard").textContent).toContain("1");
+    expect(screen.getByTestId("post-match-stats")).toBeTruthy();
+    expect(screen.getByTestId("post-match-highlights")).toBeTruthy();
+    expect(screen.getByText(/TOUCHDOWN HOME/i)).toBeTruthy();
+  });
+
+  it("post-match : pas de section highlights si aucun", async () => {
+    mockedApi.mockResolvedValue(
+      makeMatch({ replay: { durationMs: 100, highlights: [] } }),
+    );
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("post-match-stats")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("post-match-highlights")).toBeNull();
+  });
+
+  it("pre-match scheduled : affiche le card avec compte à rebours", async () => {
+    mockedApi.mockResolvedValue(
+      makeMatch({
+        status: "scheduled",
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        replay: null,
+        touchdownCount: null,
+        casualtyCount: null,
+        turnoverCount: null,
+        nuffleCount: null,
+        scheduledAt: new Date(Date.now() + 90 * 60_000).toISOString(),
+      }),
+    );
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("pre-match-card")).toBeTruthy();
+    });
+    expect(screen.getByText(/Suivre en direct/i)).toBeTruthy();
+    expect(screen.getByTestId("scoreboard").textContent).toContain("vs");
+  });
+
+  it("ready : affiche le card pré-simulation", async () => {
+    mockedApi.mockResolvedValue(
+      makeMatch({
+        status: "ready",
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+      }),
+    );
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("pre-match-card")).toBeTruthy();
+    });
+    expect(screen.getByText(/Pré-simulation faite/i)).toBeTruthy();
+  });
+
+  it("in_progress : affiche le card live", async () => {
+    mockedApi.mockResolvedValue(makeMatch({ status: "in_progress" }));
+    render(<ProLeagueMatchDetailPage params={{ id: "m_1" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("live-card")).toBeTruthy();
+    });
+    expect(screen.getByText(/Match en cours/i)).toBeTruthy();
+  });
+
+  it("affiche message d'erreur si API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("not-found"));
+    render(<ProLeagueMatchDetailPage params={{ id: "x" }} />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("not-found");
+  });
+});

--- a/apps/web/app/pro-league/matches/[id]/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/page.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../lib/api-client";
+
+/**
+ * Page détail d'un match Pro League — sprint Pro League lot 1.C.3.
+ *
+ * 3 modes d'affichage selon `match.status` :
+ *  - **scheduled / ready** (pré-match) : bandeau équipes, kickoff,
+ *    compte à rebours, lien vers /live.
+ *  - **in_progress** (en direct) : redirige immédiatement vers /live.
+ *  - **completed** (post-match) : score final, summary
+ *    (TD/cas/turnover/nuffle), highlights pré-extraits, replay link.
+ *
+ * Hors scope MVP : odds (1.D.3), MVP automatique (1.E), chat fans
+ * (1.E).
+ */
+
+interface DetailTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly baseTv: number;
+}
+
+interface Highlight {
+  readonly type: "TD" | "CASUALTY" | "NUFFLE";
+  readonly atMs: number;
+  readonly meta: Record<string, unknown>;
+}
+
+interface MatchDetail {
+  readonly id: string;
+  readonly seasonId: string;
+  readonly seasonYear: number;
+  readonly roundNumber: number;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly simulatedAt: string | null;
+  readonly completedAt: string | null;
+  readonly engineVer: string | null;
+  readonly homeTeam: DetailTeam;
+  readonly awayTeam: DetailTeam;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+  readonly touchdownCount: number | null;
+  readonly casualtyCount: number | null;
+  readonly turnoverCount: number | null;
+  readonly nuffleCount: number | null;
+  readonly replay: {
+    readonly durationMs: number;
+    readonly highlights: readonly Highlight[];
+  } | null;
+}
+
+const HIGHLIGHT_BADGE_STYLES: Record<Highlight["type"], string> = {
+  TD: "bg-emerald-700 text-emerald-50",
+  CASUALTY: "bg-rose-700 text-rose-50",
+  NUFFLE: "bg-purple-700 text-purple-50",
+};
+
+function formatRelative(target: Date, now: Date): string {
+  const diffMs = target.getTime() - now.getTime();
+  if (diffMs < 0) return "en cours";
+  const days = Math.floor(diffMs / 86_400_000);
+  const hours = Math.floor((diffMs % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((diffMs % 3_600_000) / 60_000);
+  if (days >= 1) return `J-${days}j ${hours}h`;
+  if (hours >= 1) return `T-${hours}h${minutes.toString().padStart(2, "0")}`;
+  return `T-${minutes}min`;
+}
+
+function formatClock(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function summarizeHighlight(h: Highlight): string {
+  switch (h.type) {
+    case "TD": {
+      const team = String(h.meta.team ?? "");
+      return `Touchdown ${team.toUpperCase()}`;
+    }
+    case "CASUALTY": {
+      const cause = h.meta.causedBy ? ` (${String(h.meta.causedBy)})` : "";
+      return `Casualty${cause}`;
+    }
+    case "NUFFLE":
+      return `Nuffle: ${String(h.meta.id ?? h.meta.eventId ?? "?")}`;
+  }
+}
+
+function TeamPanel({
+  team,
+  alignRight = false,
+}: {
+  team: DetailTeam;
+  alignRight?: boolean;
+}): JSX.Element {
+  return (
+    <div
+      className={`flex flex-1 flex-col gap-1 ${alignRight ? "items-end text-right" : ""}`}
+    >
+      <span className="text-xs uppercase text-white/70">{team.race}</span>
+      <h2
+        className="text-2xl font-black leading-tight text-white drop-shadow"
+        data-testid={alignRight ? "away-team-name" : "home-team-name"}
+      >
+        {team.name}
+      </h2>
+      <span className="text-sm text-white/80">{team.city}</span>
+      <span className="font-mono text-xs text-white/60">TV {team.baseTv}</span>
+      <Link
+        href={`/pro-league/teams/${encodeURIComponent(team.slug)}`}
+        className="mt-1 inline-block rounded border border-white/30 px-2 py-0.5 text-xs text-white/90 hover:bg-white/10"
+      >
+        Voir l'équipe
+      </Link>
+    </div>
+  );
+}
+
+function ScoreboardBanner({
+  match,
+}: {
+  match: MatchDetail;
+}): JSX.Element {
+  const home = match.homeTeam;
+  const away = match.awayTeam;
+  return (
+    <header
+      data-testid="match-banner"
+      className="flex flex-col gap-3 px-4 py-6"
+      style={{
+        background: `linear-gradient(135deg, ${home.primaryColor ?? "#1e293b"} 0%, ${away.primaryColor ?? "#0f172a"} 100%)`,
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <Link
+          href="/pro-league"
+          className="rounded border border-white/30 px-2 py-1 text-xs text-white/90 hover:bg-white/10"
+        >
+          ← Hub
+        </Link>
+        <span className="font-mono text-xs text-white/70">
+          Saison {match.seasonYear} · R{match.roundNumber}
+        </span>
+      </div>
+      <div className="flex items-center gap-4">
+        <TeamPanel team={home} />
+        <div
+          data-testid="scoreboard"
+          className="flex flex-col items-center font-mono text-white"
+        >
+          {match.scoreHome !== null && match.scoreAway !== null ? (
+            <span className="text-4xl font-black drop-shadow">
+              {match.scoreHome} – {match.scoreAway}
+            </span>
+          ) : (
+            <span className="text-2xl font-bold text-white/70">vs</span>
+          )}
+          <span className="mt-1 text-xs uppercase text-white/70">
+            {match.status}
+          </span>
+        </div>
+        <TeamPanel team={away} alignRight />
+      </div>
+    </header>
+  );
+}
+
+function PreMatchCard({
+  match,
+  now,
+}: {
+  match: MatchDetail;
+  now: Date;
+}): JSX.Element {
+  const at = new Date(match.scheduledAt);
+  const formattedDate = at.toLocaleString("fr-FR", {
+    weekday: "long",
+    day: "2-digit",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const isReady = match.status === "ready";
+  return (
+    <section
+      data-testid="pre-match-card"
+      className="rounded border border-slate-800 bg-slate-900 px-4 py-3"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <span className="text-xs uppercase text-slate-500">Kickoff</span>
+          <span className="text-sm text-slate-200">{formattedDate}</span>
+        </div>
+        <span className="font-mono text-lg text-emerald-300">
+          {formatRelative(at, now)}
+        </span>
+      </div>
+      <p className="mt-3 text-xs text-slate-400">
+        {isReady
+          ? "Pré-simulation faite — le match sera streamé en direct au kickoff."
+          : "La pré-simulation aura lieu T-24h avant le kickoff."}
+      </p>
+      <Link
+        href={`/pro-league/matches/${match.id}/live`}
+        className="mt-3 inline-block rounded bg-emerald-700 px-3 py-1.5 text-sm text-emerald-50 hover:bg-emerald-600"
+      >
+        Suivre en direct →
+      </Link>
+    </section>
+  );
+}
+
+function StatBox({
+  label,
+  value,
+}: {
+  label: string;
+  value: number | null;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col items-center rounded border border-slate-800 bg-slate-900 px-3 py-2">
+      <span className="text-xs uppercase text-slate-500">{label}</span>
+      <span className="font-mono text-xl font-bold text-slate-100">
+        {value ?? "—"}
+      </span>
+    </div>
+  );
+}
+
+function PostMatchCard({ match }: { match: MatchDetail }): JSX.Element {
+  return (
+    <>
+      <section
+        data-testid="post-match-stats"
+        className="mb-6 grid grid-cols-2 gap-2 sm:grid-cols-4"
+      >
+        <StatBox label="Touchdowns" value={match.touchdownCount} />
+        <StatBox label="Casualties" value={match.casualtyCount} />
+        <StatBox label="Turnovers" value={match.turnoverCount} />
+        <StatBox label="Nuffle" value={match.nuffleCount} />
+      </section>
+
+      {match.replay && match.replay.highlights.length > 0 ? (
+        <section
+          data-testid="post-match-highlights"
+          className="mb-6 rounded border border-slate-800 bg-slate-900 px-4 py-3"
+        >
+          <h2 className="mb-2 text-lg font-semibold text-slate-100">
+            Highlights
+          </h2>
+          <ol className="flex flex-col gap-1">
+            {match.replay.highlights.map((h, i) => (
+              <li
+                key={i}
+                className="flex items-center gap-3 text-sm text-slate-200"
+              >
+                <span className="font-mono text-xs text-slate-500">
+                  {formatClock(h.atMs)}
+                </span>
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-mono ${HIGHLIGHT_BADGE_STYLES[h.type]}`}
+                >
+                  {h.type}
+                </span>
+                <span className="flex-1">{summarizeHighlight(h)}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : null}
+
+      <Link
+        href={`/pro-league/matches/${match.id}/live`}
+        className="inline-block rounded bg-slate-800 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700"
+      >
+        Revoir le replay →
+      </Link>
+    </>
+  );
+}
+
+interface MatchDetailPageProps {
+  readonly params: { id: string };
+}
+
+export default function ProLeagueMatchDetailPage({
+  params,
+}: MatchDetailPageProps): JSX.Element {
+  const [data, setData] = useState<MatchDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<MatchDetail>(
+      `/pro-league/matches/${encodeURIComponent(params.id)}`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.id]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 text-slate-100">
+      {loading ? (
+        <p className="px-4 py-6 text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="m-4 rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !data ? (
+        <p className="px-4 py-6 text-sm text-slate-400">Match inconnu.</p>
+      ) : (
+        <>
+          <ScoreboardBanner match={data} />
+          <div className="px-4 py-6">
+            {data.status === "scheduled" || data.status === "ready" ? (
+              <PreMatchCard match={data} now={now} />
+            ) : data.status === "in_progress" ? (
+              <section
+                data-testid="live-card"
+                className="rounded border border-emerald-700 bg-emerald-950 px-4 py-3"
+              >
+                <p className="text-sm text-emerald-200">
+                  Match en cours — suivez les events en direct.
+                </p>
+                <Link
+                  href={`/pro-league/matches/${data.id}/live`}
+                  className="mt-3 inline-block rounded bg-emerald-700 px-3 py-1.5 text-sm text-emerald-50 hover:bg-emerald-600"
+                >
+                  Voir le live →
+                </Link>
+              </section>
+            ) : data.status === "completed" ? (
+              <PostMatchCard match={data} />
+            ) : (
+              <p className="text-sm text-rose-300">
+                Match en erreur (status="{data.status}"). Contactez l'admin.
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.C.3** — Page détail match `/pro-league/matches/[id]`.

🎯 **Avec ce PR, le lot 1.C est complet** (1.C.1 → 1.C.5 livrés sauf 1.C.4 "follow team" en attente).

### Backend

| Fichier | Rôle |
|---|---|
| `services/pro-league-match.ts` | `getProMatchDetail(id)` — agrège meta + équipes + scoreboard + counters + highlights |
| `routes/pro-league.ts` | Nouveau handler `GET /pro-league/matches/:id` |

**Détails :**
- 404 typé `ProMatchNotFoundError`.
- Helper `parseHighlights` accepte array natif (postgres) OU JSON string (sqlite mirror) et filtre les types inconnus pour défense en profondeur.
- Replay row chargée séparément ; renvoie `replay: null` si non disponible (match non simulé).

### Frontend `/pro-league/matches/[id]`

**3 modes selon `match.status` :**

| Status | Affichage |
|---|---|
| `scheduled` / `ready` | Card pré-match avec kickoff + compte à rebours T-Xh + bouton "Suivre en direct" |
| `in_progress` | Card emerald avec "Match en cours" + lien vers `/live` |
| `completed` | Grid stats 2x2/4x1 (TD/cas/turnover/nuffle) + highlights timeline + bouton "Revoir le replay" |

**Banner universel** : gradient `homePrimary × awayPrimary`, scoreboard central (score `3 – 1` si dispo, sinon "vs"), ratio TV par équipe, liens vers les pages teams.

**Highlights** avec horloge `M:SS` + badges colorés (TD vert, CASUALTY rose, NUFFLE violet) + résumé humanisé.

**Hors scope MVP** : odds (1.D.3), MVP automatique (1.E), chat fans, lineups.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-league-match` (backend) → **7/7 ✓**
- [x] `npx vitest run app/pro-league/matches/[id]` (frontend) → **8/8 ✓**

Couverture totale : **15 tests**.

## Lot 1.C — récap

| Lot | PR | État |
|---|---|---|
| 1.C.1 — Hub page | #609 | ✅ |
| 1.C.2 — Team detail | #611 | ✅ |
| 1.C.3 — Match detail | _this PR_ | ⏳ |
| 1.C.4 — Follow team | — | ⏸️ TODO |
| 1.C.5 — Standings detail | #610 | ✅ |

## Suite

Au choix :
- **1.C.4** : suivre une équipe (modèle DB `SpectatorFollow` + bouton + newsfeed)
- **Lot 1.D** : paris + Crowns
- **Lot 1.E** : Nuffle Gazette + casualties + HoF


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_