### PR TITLE
feat(server,web): Pro League fan follow + feed (sprint 1.C.4)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -70,6 +70,7 @@ model User {
   refreshTokens               RefreshToken[]
   eloSnapshots                EloSnapshot[]
   tutorialCompletions         TutorialCompletion[]
+  proSpectatorFollows         ProSpectatorFollow[]
 }
 
 /// S26.3l — mirror SQLite de l'historique ELO Postgres (snapshot par mise a jour).
@@ -865,6 +866,7 @@ model ProTeam {
   homeMatches ProLeagueMatch[]     @relation("ProMatchHome")
   awayMatches ProLeagueMatch[]     @relation("ProMatchAway")
   standings   ProLeagueStandings[]
+  followers   ProSpectatorFollow[]
 
   @@index([leagueId])
 }
@@ -997,4 +999,18 @@ model Replay {
   rawJsonSize Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+model ProSpectatorFollow {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  team      ProTeam  @relation(fields: [proTeamId], references: [id], onDelete: Cascade)
+  proTeamId String
+  since     DateTime @default(now())
+  createdAt DateTime @default(now())
+
+  @@unique([userId, proTeamId])
+  @@index([userId])
+  @@index([proTeamId])
 }

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -27,6 +27,15 @@ import { Router, type Request, type Response } from "express";
 
 import type { MatchEvent } from "@bb/sim-engine";
 
+import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
+import {
+  ProTeamFollowError,
+  followProTeam,
+  getMyFeed,
+  isFollowing,
+  listMyFollows,
+  unfollowProTeam,
+} from "../services/pro-league-follow";
 import {
   ProLeagueNotFoundError,
   getProLeagueHubSnapshot,
@@ -254,6 +263,124 @@ export async function handleGetMatchDetail(
   }
 }
 
+/**
+ * Sprint 1.C.4 — Suivre une équipe Pro League. Idempotent.
+ */
+export async function handleFollowTeam(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const slug = req.params.slug;
+  if (!slug) {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  try {
+    const data = await followProTeam(userId, slug);
+    res.status(200).json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProTeamFollowError && err.code === "team_not_found") {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/follow] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint 1.C.4 — Ne plus suivre. Idempotent (200 même si pas de follow).
+ */
+export async function handleUnfollowTeam(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const slug = req.params.slug;
+  if (!slug) {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  try {
+    const removed = await unfollowProTeam(userId, slug);
+    res.status(200).json({ removed });
+  } catch (err: unknown) {
+    if (err instanceof ProTeamFollowError && err.code === "team_not_found") {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/unfollow] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint 1.C.4 — Statut de suivi pour l'user courant. Pratique pour
+ * initialiser le bouton "Follow" sur la page team sans charger toute
+ * la liste.
+ */
+export async function handleIsFollowing(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const slug = req.params.slug;
+  if (!slug) {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  const following = await isFollowing(userId, slug);
+  res.json({ following });
+}
+
+/**
+ * Sprint 1.C.4 — Liste des équipes suivies par l'user courant.
+ */
+export async function handleListMyFollows(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const follows = await listMyFollows(userId);
+  res.json({ follows });
+}
+
+/**
+ * Sprint 1.C.4 — Newsfeed perso (matchs upcoming + recent des équipes
+ * suivies).
+ */
+export async function handleGetMyFeed(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const entries = await getMyFeed(userId);
+  res.json({ entries });
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
@@ -262,5 +389,12 @@ router.get("/teams/:slug", handleGetTeamDetail);
 router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
+
+// Sprint 1.C.4 — endpoints auth-protected pour le mode "fan".
+router.post("/teams/:slug/follow", authUser, handleFollowTeam);
+router.delete("/teams/:slug/follow", authUser, handleUnfollowTeam);
+router.get("/teams/:slug/follow", authUser, handleIsFollowing);
+router.get("/me/follows", authUser, handleListMyFollows);
+router.get("/me/feed", authUser, handleGetMyFeed);
 
 export default router;

--- a/apps/server/src/services/pro-league-follow.test.ts
+++ b/apps/server/src/services/pro-league-follow.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn() },
+    proSpectatorFollow: {
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    proLeagueMatch: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  ProTeamFollowError,
+  followProTeam,
+  getMyFeed,
+  isFollowing,
+  listMyFollows,
+  unfollowProTeam,
+} from "./pro-league-follow";
+
+interface MockedPrisma {
+  proTeam: { findUnique: ReturnType<typeof vi.fn> };
+  proSpectatorFollow: {
+    upsert: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const USER = "user_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("followProTeam — sprint 1.C.4", () => {
+  it("404 si la team n'existe pas", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    await expect(followProTeam(USER, "unknown")).rejects.toThrow(
+      ProTeamFollowError,
+    );
+  });
+
+  it("upsert + renvoie le summary + since ISO", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "team_1",
+      slug: "buf-snow-ogres",
+      name: "Snow Ogres",
+      city: "Buffalo",
+      race: "Ogre",
+      primaryColor: "#00338D",
+      secondaryColor: "#C60C30",
+    });
+    mocked.proSpectatorFollow.upsert.mockResolvedValue({
+      since: new Date("2026-09-01T12:00:00Z"),
+    });
+
+    const out = await followProTeam(USER, "buf-snow-ogres");
+    expect(out.proTeamId).toBe("team_1");
+    expect(out.slug).toBe("buf-snow-ogres");
+    expect(out.since).toBe("2026-09-01T12:00:00.000Z");
+  });
+
+  it("idempotent : 2 appels successifs upsertent (no-op le 2e)", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "team_1",
+      slug: "x",
+      name: "X",
+      city: "X",
+      race: "X",
+      primaryColor: null,
+      secondaryColor: null,
+    });
+    mocked.proSpectatorFollow.upsert.mockResolvedValue({
+      since: new Date(),
+    });
+    await followProTeam(USER, "x");
+    await followProTeam(USER, "x");
+    expect(mocked.proSpectatorFollow.upsert).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("unfollowProTeam — sprint 1.C.4", () => {
+  it("404 si la team n'existe pas", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    await expect(unfollowProTeam(USER, "x")).rejects.toThrow(
+      ProTeamFollowError,
+    );
+  });
+
+  it("renvoie true si suppression effective", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({ id: "t1" });
+    mocked.proSpectatorFollow.deleteMany.mockResolvedValue({ count: 1 });
+    expect(await unfollowProTeam(USER, "t1")).toBe(true);
+  });
+
+  it("renvoie false si rien à supprimer (idempotent)", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({ id: "t1" });
+    mocked.proSpectatorFollow.deleteMany.mockResolvedValue({ count: 0 });
+    expect(await unfollowProTeam(USER, "t1")).toBe(false);
+  });
+});
+
+describe("isFollowing — sprint 1.C.4", () => {
+  it("false si team inconnue", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    expect(await isFollowing(USER, "x")).toBe(false);
+  });
+
+  it("true si row existe", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({ id: "t1" });
+    mocked.proSpectatorFollow.findUnique.mockResolvedValue({ id: "f1" });
+    expect(await isFollowing(USER, "t1")).toBe(true);
+  });
+
+  it("false si row absente", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({ id: "t1" });
+    mocked.proSpectatorFollow.findUnique.mockResolvedValue(null);
+    expect(await isFollowing(USER, "t1")).toBe(false);
+  });
+});
+
+describe("listMyFollows — sprint 1.C.4", () => {
+  it("renvoie [] si aucun follow", async () => {
+    mocked.proSpectatorFollow.findMany.mockResolvedValue([]);
+    const out = await listMyFollows(USER);
+    expect(out).toEqual([]);
+  });
+
+  it("formate les rows en summary", async () => {
+    mocked.proSpectatorFollow.findMany.mockResolvedValue([
+      {
+        since: new Date("2026-09-01T00:00:00Z"),
+        team: {
+          id: "t1",
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          race: "Ogre",
+          primaryColor: "#00338D",
+          secondaryColor: "#C60C30",
+        },
+      },
+    ]);
+    const out = await listMyFollows(USER);
+    expect(out).toHaveLength(1);
+    expect(out[0].slug).toBe("buf-snow-ogres");
+    expect(out[0].since).toBe("2026-09-01T00:00:00.000Z");
+  });
+});
+
+describe("getMyFeed — sprint 1.C.4", () => {
+  it("renvoie [] si aucun follow", async () => {
+    mocked.proSpectatorFollow.findMany.mockResolvedValue([]);
+    expect(await getMyFeed(USER)).toEqual([]);
+  });
+
+  it("agrège upcoming + recent avec catégorie + isHome", async () => {
+    mocked.proSpectatorFollow.findMany.mockResolvedValue([
+      { proTeamId: "t1" },
+    ]);
+
+    const upcomingMatch = {
+      id: "m_up",
+      status: "scheduled",
+      scheduledAt: new Date("2026-09-15T21:00:00Z"),
+      scoreHome: null,
+      scoreAway: null,
+      outcome: null,
+      homeTeamId: "t1",
+      awayTeamId: "t2",
+      round: { roundNumber: 5 },
+      season: { year: 2026 },
+      homeTeam: {
+        slug: "buf-snow-ogres",
+        name: "Snow Ogres",
+        city: "Buffalo",
+        primaryColor: "#00338D",
+      },
+      awayTeam: {
+        slug: "gb-cheese-halflings",
+        name: "Cheese Halflings",
+        city: "Green Bay",
+        primaryColor: "#203731",
+      },
+    };
+    const recentMatch = {
+      id: "m_done",
+      status: "completed",
+      scheduledAt: new Date("2026-09-08T21:00:00Z"),
+      scoreHome: 1,
+      scoreAway: 3,
+      outcome: "away",
+      homeTeamId: "t3",
+      awayTeamId: "t1",
+      round: { roundNumber: 4 },
+      season: { year: 2026 },
+      homeTeam: {
+        slug: "kc-soaring-hawks",
+        name: "Soaring Hawks",
+        city: "Kansas City",
+        primaryColor: "#E31837",
+      },
+      awayTeam: {
+        slug: "buf-snow-ogres",
+        name: "Snow Ogres",
+        city: "Buffalo",
+        primaryColor: "#00338D",
+      },
+    };
+    // 1er appel : upcoming pour t1 → 1 row
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([upcomingMatch]);
+    // 2e appel : recent pour t1 → 1 row
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([recentMatch]);
+
+    const out = await getMyFeed(USER);
+    expect(out).toHaveLength(2);
+    // recent en premier (catégorie recent en haut), puis upcoming
+    expect(out[0].category).toBe("recent");
+    expect(out[0].matchId).toBe("m_done");
+    expect(out[0].isHome).toBe(false);
+    expect(out[0].followedTeam.slug).toBe("buf-snow-ogres");
+    expect(out[0].opponent.slug).toBe("kc-soaring-hawks");
+    expect(out[1].category).toBe("upcoming");
+    expect(out[1].isHome).toBe(true);
+  });
+
+  it("limite à 30 entrées max", async () => {
+    const teamIds = Array.from({ length: 16 }, (_, i) => ({
+      proTeamId: `t${i}`,
+    }));
+    mocked.proSpectatorFollow.findMany.mockResolvedValue(teamIds);
+    // Pour chaque team, on retourne 1 upcoming + 1 recent (32 total)
+    mocked.proLeagueMatch.findMany.mockImplementation(
+      async ({ where }: { where: { status?: unknown } }) => {
+        const isUpcoming =
+          typeof where.status === "object" && where.status !== null;
+        return [
+          {
+            id: `m_${Math.random()}`,
+            status: isUpcoming ? "scheduled" : "completed",
+            scheduledAt: new Date(),
+            scoreHome: null,
+            scoreAway: null,
+            outcome: null,
+            homeTeamId: "tX",
+            awayTeamId: "tY",
+            round: { roundNumber: 1 },
+            season: { year: 2026 },
+            homeTeam: {
+              slug: "x",
+              name: "X",
+              city: "X",
+              primaryColor: null,
+            },
+            awayTeam: {
+              slug: "y",
+              name: "Y",
+              city: "Y",
+              primaryColor: null,
+            },
+          },
+        ];
+      },
+    );
+
+    const out = await getMyFeed(USER);
+    expect(out.length).toBeLessThanOrEqual(30);
+  });
+});

--- a/apps/server/src/services/pro-league-follow.ts
+++ b/apps/server/src/services/pro-league-follow.ts
@@ -1,0 +1,333 @@
+/**
+ * Pro League fan follow — sprint Pro League lot 1.C.4.
+ *
+ * Service qui gère :
+ *  - `followProTeam(userId, slug)` : crée un follow idempotent.
+ *  - `unfollowProTeam(userId, slug)` : supprime le follow si présent.
+ *  - `listMyFollows(userId)` : liste des équipes suivies par l'user.
+ *  - `getMyFeed(userId)` : newsfeed (matchs récents + à venir des
+ *    équipes suivies, avec un ordre cohérent).
+ *
+ * Toutes les opérations sont auth-required côté route — ce service ne
+ * fait pas de check d'auth, c'est le caller qui doit fournir un userId
+ * validé.
+ */
+
+import { prisma } from "../prisma";
+
+const FEED_UPCOMING_PER_TEAM = 1;
+const FEED_RECENT_PER_TEAM = 1;
+const FEED_MAX_TOTAL = 30;
+
+export interface ProTeamFollowSummary {
+  readonly proTeamId: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly since: string;
+}
+
+export interface FeedTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+}
+
+export interface FeedEntry {
+  readonly matchId: string;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly roundNumber: number;
+  readonly seasonYear: number;
+  /** Équipe suivie qui motive cette entrée (= follow). */
+  readonly followedTeam: FeedTeam;
+  /** Adversaire dans le match. */
+  readonly opponent: FeedTeam;
+  /** True si la team suivie joue à domicile dans ce match. */
+  readonly isHome: boolean;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  /** "home" | "away" | "draw" | null */
+  readonly outcome: string | null;
+  /** Catégorie pour l'UI : "upcoming" (à venir) ou "recent" (joué). */
+  readonly category: "upcoming" | "recent";
+}
+
+export class ProTeamFollowError extends Error {
+  constructor(
+    readonly code: "team_not_found" | "user_not_found",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProTeamFollowError";
+  }
+}
+
+export async function followProTeam(
+  userId: string,
+  slug: string,
+): Promise<ProTeamFollowSummary> {
+  const team = await prisma.proTeam.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      city: true,
+      race: true,
+      primaryColor: true,
+      secondaryColor: true,
+    },
+  });
+  if (!team) {
+    throw new ProTeamFollowError(
+      "team_not_found",
+      `ProTeam slug='${slug}' introuvable`,
+    );
+  }
+
+  const created = await prisma.proSpectatorFollow.upsert({
+    where: {
+      userId_proTeamId: {
+        userId,
+        proTeamId: team.id as string,
+      },
+    },
+    create: {
+      userId,
+      proTeamId: team.id as string,
+    },
+    update: {},
+    select: { since: true },
+  });
+
+  return {
+    proTeamId: team.id as string,
+    slug: team.slug as string,
+    name: team.name as string,
+    city: team.city as string,
+    race: team.race as string,
+    primaryColor: (team.primaryColor as string | null) ?? null,
+    secondaryColor: (team.secondaryColor as string | null) ?? null,
+    since: (created.since as Date).toISOString(),
+  };
+}
+
+/** Renvoie true si un follow a été supprimé, false si rien à supprimer. */
+export async function unfollowProTeam(
+  userId: string,
+  slug: string,
+): Promise<boolean> {
+  const team = await prisma.proTeam.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!team) {
+    throw new ProTeamFollowError(
+      "team_not_found",
+      `ProTeam slug='${slug}' introuvable`,
+    );
+  }
+  const result = await prisma.proSpectatorFollow.deleteMany({
+    where: { userId, proTeamId: team.id as string },
+  });
+  return ((result.count as number) ?? 0) > 0;
+}
+
+export async function listMyFollows(
+  userId: string,
+): Promise<ProTeamFollowSummary[]> {
+  const rows = await prisma.proSpectatorFollow.findMany({
+    where: { userId },
+    orderBy: { since: "desc" },
+    select: {
+      since: true,
+      team: {
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          city: true,
+          race: true,
+          primaryColor: true,
+          secondaryColor: true,
+        },
+      },
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((r: any) => ({
+    proTeamId: r.team.id as string,
+    slug: r.team.slug as string,
+    name: r.team.name as string,
+    city: r.team.city as string,
+    race: r.team.race as string,
+    primaryColor: (r.team.primaryColor as string | null) ?? null,
+    secondaryColor: (r.team.secondaryColor as string | null) ?? null,
+    since: (r.since as Date).toISOString(),
+  }));
+}
+
+export async function isFollowing(
+  userId: string,
+  slug: string,
+): Promise<boolean> {
+  const team = await prisma.proTeam.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (!team) return false;
+  const row = await prisma.proSpectatorFollow.findUnique({
+    where: {
+      userId_proTeamId: {
+        userId,
+        proTeamId: team.id as string,
+      },
+    },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+interface FeedRawMatch {
+  id: string;
+  status: string;
+  scheduledAt: Date;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  homeTeamId: string;
+  awayTeamId: string;
+  round: { roundNumber: number };
+  season: { year: number };
+  homeTeam: {
+    slug: string;
+    name: string;
+    city: string;
+    primaryColor: string | null;
+  };
+  awayTeam: {
+    slug: string;
+    name: string;
+    city: string;
+    primaryColor: string | null;
+  };
+}
+
+function toFeedEntry(
+  m: FeedRawMatch,
+  followedTeamId: string,
+  category: "upcoming" | "recent",
+): FeedEntry {
+  const isHome = m.homeTeamId === followedTeamId;
+  const followed = isHome ? m.homeTeam : m.awayTeam;
+  const opp = isHome ? m.awayTeam : m.homeTeam;
+  return {
+    matchId: m.id,
+    status: m.status,
+    scheduledAt: m.scheduledAt.toISOString(),
+    roundNumber: m.round.roundNumber,
+    seasonYear: m.season.year,
+    followedTeam: {
+      slug: followed.slug,
+      name: followed.name,
+      city: followed.city,
+      primaryColor: followed.primaryColor ?? null,
+    },
+    opponent: {
+      slug: opp.slug,
+      name: opp.name,
+      city: opp.city,
+      primaryColor: opp.primaryColor ?? null,
+    },
+    isHome,
+    scoreHome: m.scoreHome ?? null,
+    scoreAway: m.scoreAway ?? null,
+    outcome: m.outcome ?? null,
+    category,
+  };
+}
+
+const matchSelectForFeed = {
+  id: true,
+  status: true,
+  scheduledAt: true,
+  scoreHome: true,
+  scoreAway: true,
+  outcome: true,
+  homeTeamId: true,
+  awayTeamId: true,
+  round: { select: { roundNumber: true } },
+  season: { select: { year: true } },
+  homeTeam: {
+    select: { slug: true, name: true, city: true, primaryColor: true },
+  },
+  awayTeam: {
+    select: { slug: true, name: true, city: true, primaryColor: true },
+  },
+} as const;
+
+/**
+ * Newsfeed perso de l'user. Pour chaque équipe suivie :
+ *  - 1 match à venir (le plus proche)
+ *  - 1 match récent (le plus récent joué)
+ *
+ * Toutes les entrées sont fusionnées + triées par `scheduledAt asc` pour
+ * les upcoming et `scheduledAt desc` pour les recent ; le résultat
+ * final est : recent (récents en haut) + upcoming (les plus proches
+ * ensuite). Limité à 30 entrées max au total.
+ */
+export async function getMyFeed(userId: string): Promise<FeedEntry[]> {
+  const follows = await prisma.proSpectatorFollow.findMany({
+    where: { userId },
+    select: { proTeamId: true },
+  });
+  if (follows.length === 0) return [];
+
+  const teamIds = follows.map((f: { proTeamId: unknown }) => f.proTeamId as string);
+  const upcoming: FeedEntry[] = [];
+  const recent: FeedEntry[] = [];
+
+  for (const teamId of teamIds) {
+    const upcomingRows = (await prisma.proLeagueMatch.findMany({
+      where: {
+        OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
+        status: { in: ["scheduled", "ready"] },
+      },
+      orderBy: { scheduledAt: "asc" },
+      take: FEED_UPCOMING_PER_TEAM,
+      select: matchSelectForFeed,
+    })) as FeedRawMatch[];
+    for (const m of upcomingRows) {
+      upcoming.push(toFeedEntry(m, teamId, "upcoming"));
+    }
+
+    const recentRows = (await prisma.proLeagueMatch.findMany({
+      where: {
+        OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
+        status: "completed",
+      },
+      orderBy: { scheduledAt: "desc" },
+      take: FEED_RECENT_PER_TEAM,
+      select: matchSelectForFeed,
+    })) as FeedRawMatch[];
+    for (const m of recentRows) {
+      recent.push(toFeedEntry(m, teamId, "recent"));
+    }
+  }
+
+  recent.sort(
+    (a, b) =>
+      new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime(),
+  );
+  upcoming.sort(
+    (a, b) =>
+      new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime(),
+  );
+
+  return [...recent, ...upcoming].slice(0, FEED_MAX_TOTAL);
+}

--- a/apps/web/app/pro-league/feed/page.test.tsx
+++ b/apps/web/app/pro-league/feed/page.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../lib/api-client", () => {
+  class FakeApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    apiRequest: vi.fn(),
+    ApiClientError: FakeApiError,
+  };
+});
+
+import { ApiClientError, apiRequest } from "../../lib/api-client";
+import ProLeagueFeedPage from "./page";
+
+const FakeApiError = ApiClientError as unknown as new (
+  msg: string,
+  status?: number,
+) => Error & { status?: number };
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeFeed(extras: Record<string, unknown>[] = []): unknown {
+  return {
+    entries: [
+      {
+        matchId: "m_done",
+        status: "completed",
+        scheduledAt: new Date("2026-09-08T21:00:00Z").toISOString(),
+        roundNumber: 4,
+        seasonYear: 2026,
+        followedTeam: {
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          primaryColor: "#00338D",
+        },
+        opponent: {
+          slug: "kc-soaring-hawks",
+          name: "Soaring Hawks",
+          city: "Kansas City",
+          primaryColor: "#E31837",
+        },
+        isHome: false,
+        scoreHome: 1,
+        scoreAway: 3,
+        outcome: "away",
+        category: "recent",
+      },
+      {
+        matchId: "m_up",
+        status: "scheduled",
+        scheduledAt: new Date("2026-09-15T21:00:00Z").toISOString(),
+        roundNumber: 5,
+        seasonYear: 2026,
+        followedTeam: {
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          primaryColor: "#00338D",
+        },
+        opponent: {
+          slug: "gb-cheese-halflings",
+          name: "Cheese Halflings",
+          city: "Green Bay",
+          primaryColor: "#203731",
+        },
+        isHome: true,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        category: "upcoming",
+      },
+      ...extras,
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProLeagueFeedPage — sprint 1.C.4", () => {
+  it("affiche 'Chargement…' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<ProLeagueFeedPage />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche la liste recent + upcoming", async () => {
+    mockedApi.mockResolvedValue(makeFeed());
+    render(<ProLeagueFeedPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("feed-recent")).toBeTruthy();
+    });
+    expect(screen.getByTestId("feed-upcoming")).toBeTruthy();
+    const rows = screen.getAllByTestId("feed-row");
+    expect(rows.length).toBe(2);
+    expect(screen.getByText(/Soaring Hawks/)).toBeTruthy();
+    expect(screen.getByText(/Cheese Halflings/)).toBeTruthy();
+  });
+
+  it("affiche un message si aucune équipe suivie", async () => {
+    mockedApi.mockResolvedValue({ entries: [] });
+    render(<ProLeagueFeedPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-feed")).toBeTruthy();
+    });
+  });
+
+  it("affiche le message auth-required si 401", async () => {
+    mockedApi.mockRejectedValue(new FakeApiError("auth", 401));
+    render(<ProLeagueFeedPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-required")).toBeTruthy();
+    });
+  });
+
+  it("affiche message d'erreur générique si autre erreur", async () => {
+    mockedApi.mockRejectedValue(new Error("boom"));
+    render(<ProLeagueFeedPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+});

--- a/apps/web/app/pro-league/feed/page.tsx
+++ b/apps/web/app/pro-league/feed/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { ApiClientError, apiRequest } from "../../lib/api-client";
+
+/**
+ * Newsfeed perso Pro League — sprint 1.C.4.
+ *
+ * Liste les matchs upcoming + recent des équipes suivies par l'user.
+ * Auth-required (401 → message "se connecter").
+ */
+
+interface FeedTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly primaryColor: string | null;
+}
+
+interface FeedEntry {
+  readonly matchId: string;
+  readonly status: string;
+  readonly scheduledAt: string;
+  readonly roundNumber: number;
+  readonly seasonYear: number;
+  readonly followedTeam: FeedTeam;
+  readonly opponent: FeedTeam;
+  readonly isHome: boolean;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+  readonly category: "upcoming" | "recent";
+}
+
+function FeedRow({ entry }: { entry: FeedEntry }): JSX.Element {
+  const at = new Date(entry.scheduledAt);
+  const formatted = at.toLocaleString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const finished = entry.category === "recent";
+  const won =
+    finished &&
+    ((entry.isHome && entry.outcome === "home") ||
+      (!entry.isHome && entry.outcome === "away"));
+  const drew = finished && entry.outcome === "draw";
+  const resultClass = finished
+    ? won
+      ? "text-emerald-300"
+      : drew
+        ? "text-slate-300"
+        : "text-rose-300"
+    : "text-emerald-200";
+
+  return (
+    <Link
+      href={`/pro-league/matches/${entry.matchId}/live`}
+      data-testid="feed-row"
+      className="flex items-center justify-between gap-3 rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm hover:bg-slate-800"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className="inline-block h-3 w-3 rounded-full ring-1 ring-slate-700"
+          style={{ background: entry.followedTeam.primaryColor ?? "#475569" }}
+        />
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2 text-slate-100">
+            <span className="font-medium">{entry.followedTeam.name}</span>
+            <span className="text-xs text-slate-500">
+              {entry.isHome ? "vs" : "@"}
+            </span>
+            <span>{entry.opponent.name}</span>
+          </div>
+          <span className="text-xs text-slate-500">
+            R{entry.roundNumber} · saison {entry.seasonYear}
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col items-end">
+        {finished ? (
+          <span className={`font-mono ${resultClass}`}>
+            {entry.scoreHome}–{entry.scoreAway}
+          </span>
+        ) : (
+          <span className={`font-mono text-xs uppercase ${resultClass}`}>
+            {entry.status}
+          </span>
+        )}
+        <span className="text-xs text-slate-500">{formatted}</span>
+      </div>
+    </Link>
+  );
+}
+
+export default function ProLeagueFeedPage(): JSX.Element {
+  const [entries, setEntries] = useState<readonly FeedEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [needsAuth, setNeedsAuth] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setNeedsAuth(false);
+    apiRequest<{ entries: readonly FeedEntry[] }>("/pro-league/me/feed")
+      .then((d) => {
+        if (cancelled) return;
+        setEntries(d.entries);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiClientError && e.status === 401) {
+          setNeedsAuth(true);
+          return;
+        }
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const recent = entries?.filter((e) => e.category === "recent") ?? [];
+  const upcoming = entries?.filter((e) => e.category === "upcoming") ?? [];
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+          Mon feed
+        </h1>
+        <Link
+          href="/pro-league"
+          className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+        >
+          ← Hub
+        </Link>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : needsAuth ? (
+        <p
+          data-testid="auth-required"
+          className="rounded border border-amber-700 bg-amber-950 px-3 py-2 text-sm text-amber-200"
+        >
+          Connecte-toi pour suivre tes équipes Pro League préférées et
+          consulter ton feed personnalisé.
+        </p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : entries && entries.length === 0 ? (
+        <p
+          data-testid="empty-feed"
+          className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
+        >
+          Tu ne suis aucune équipe pour l'instant. Explore les fiches
+          équipes et clique sur "+ Suivre" pour personnaliser ton feed.
+        </p>
+      ) : (
+        <>
+          {recent.length > 0 ? (
+            <section data-testid="feed-recent" className="mb-6">
+              <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                Derniers résultats
+              </h2>
+              <div className="flex flex-col gap-2">
+                {recent.map((e) => (
+                  <FeedRow key={`r-${e.matchId}`} entry={e} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+          {upcoming.length > 0 ? (
+            <section data-testid="feed-upcoming">
+              <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                À venir
+              </h2>
+              <div className="flex flex-col gap-2">
+                {upcoming.map((e) => (
+                  <FeedRow key={`u-${e.matchId}`} entry={e} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -253,12 +253,92 @@ interface TeamPageProps {
   readonly params: { slug: string };
 }
 
+function FollowButton({
+  slug,
+  initiallyFollowing,
+  onChange,
+}: {
+  slug: string;
+  initiallyFollowing: boolean;
+  onChange: (next: boolean) => void;
+}): JSX.Element {
+  const [following, setFollowing] = useState(initiallyFollowing);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFollowing(initiallyFollowing);
+  }, [initiallyFollowing]);
+
+  const toggle = async (): Promise<void> => {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    const next = !following;
+    try {
+      await apiRequest(
+        `/pro-league/teams/${encodeURIComponent(slug)}/follow`,
+        { method: next ? "POST" : "DELETE" },
+      );
+      setFollowing(next);
+      onChange(next);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "fetch error";
+      setError(msg);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        data-testid="follow-button"
+        onClick={() => {
+          void toggle();
+        }}
+        disabled={pending}
+        className={`rounded px-3 py-1 text-xs font-semibold transition disabled:opacity-50 ${
+          following
+            ? "bg-white/20 text-white hover:bg-white/30"
+            : "bg-white text-slate-900 hover:bg-slate-100"
+        }`}
+      >
+        {pending
+          ? "..."
+          : following
+            ? "✓ Suivi"
+            : "+ Suivre"}
+      </button>
+      {error ? (
+        <span className="text-xs text-rose-200" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+interface FollowState {
+  readonly authChecked: boolean;
+  readonly authed: boolean;
+  readonly following: boolean;
+}
+
+const INITIAL_FOLLOW: FollowState = {
+  authChecked: false,
+  authed: false,
+  following: false,
+};
+
 export default function ProLeagueTeamPage({
   params,
 }: TeamPageProps): JSX.Element {
   const [data, setData] = useState<TeamDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [followState, setFollowState] = useState<FollowState>(INITIAL_FOLLOW);
 
   useEffect(() => {
     let cancelled = false;
@@ -278,6 +358,34 @@ export default function ProLeagueTeamPage({
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.slug]);
+
+  // Charge le statut de follow (auth-required ; 401 silencieux pour
+  // les visiteurs anonymes — le bouton ne s'affichera pas).
+  useEffect(() => {
+    let cancelled = false;
+    apiRequest<{ following: boolean }>(
+      `/pro-league/teams/${encodeURIComponent(params.slug)}/follow`,
+    )
+      .then((r) => {
+        if (cancelled) return;
+        setFollowState({
+          authChecked: true,
+          authed: true,
+          following: !!r.following,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFollowState({
+          authChecked: true,
+          authed: false,
+          following: false,
+        });
       });
     return () => {
       cancelled = true;
@@ -314,9 +422,20 @@ export default function ProLeagueTeamPage({
               >
                 ← Hub
               </Link>
-              <span className="font-mono text-xs text-white/70">
-                {data.race} · TV {data.baseTv}
-              </span>
+              <div className="flex items-center gap-3">
+                {followState.authChecked && followState.authed ? (
+                  <FollowButton
+                    slug={data.slug}
+                    initiallyFollowing={followState.following}
+                    onChange={(next) =>
+                      setFollowState((s) => ({ ...s, following: next }))
+                    }
+                  />
+                ) : null}
+                <span className="font-mono text-xs text-white/70">
+                  {data.race} · TV {data.baseTv}
+                </span>
+              </div>
             </div>
             <h1 className="text-3xl font-black tracking-wide text-white drop-shadow-md">
               {data.name}

--- a/prisma/migrations/20260506120000_add_pro_spectator_follow/migration.sql
+++ b/prisma/migrations/20260506120000_add_pro_spectator_follow/migration.sql
@@ -1,0 +1,31 @@
+-- Pro League fan follow (sprint 1.C.4).
+
+-- CreateTable: ProSpectatorFollow
+CREATE TABLE "public"."ProSpectatorFollow" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "proTeamId" TEXT NOT NULL,
+    "since" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProSpectatorFollow_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProSpectatorFollow_userId_proTeamId_key"
+  ON "public"."ProSpectatorFollow"("userId", "proTeamId");
+
+CREATE INDEX "ProSpectatorFollow_userId_idx"
+  ON "public"."ProSpectatorFollow"("userId");
+
+CREATE INDEX "ProSpectatorFollow_proTeamId_idx"
+  ON "public"."ProSpectatorFollow"("proTeamId");
+
+ALTER TABLE "public"."ProSpectatorFollow"
+  ADD CONSTRAINT "ProSpectatorFollow_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "public"."User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProSpectatorFollow"
+  ADD CONSTRAINT "ProSpectatorFollow_proTeamId_fkey"
+  FOREIGN KEY ("proTeamId") REFERENCES "public"."ProTeam"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model User {
   refreshTokens               RefreshToken[]
   eloSnapshots                EloSnapshot[]
   tutorialCompletions         TutorialCompletion[]
+  proSpectatorFollows         ProSpectatorFollow[]
 }
 
 /// S26.3l — Historique ELO du coach. Une ligne par mise a jour ELO (donc 2
@@ -1131,6 +1132,7 @@ model ProTeam {
   homeMatches ProLeagueMatch[]     @relation("ProMatchHome")
   awayMatches ProLeagueMatch[]     @relation("ProMatchAway")
   standings   ProLeagueStandings[]
+  followers   ProSpectatorFollow[]
 
   @@index([leagueId])
 }
@@ -1320,4 +1322,26 @@ model Replay {
   rawJsonSize Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+}
+
+/// Sprint Pro League lot 1.C.4 — Fan follow.
+/// Permet à un user de suivre une ProTeam pour recevoir un newsfeed
+/// personnalisé sur /pro-league/feed.
+///
+/// Une seule entrée par couple (userId, proTeamId) garantie par
+/// l'@@unique. `since` permet de filtrer le feed à partir de la date
+/// d'abonnement (rétro-coverage des matchs ne sert à rien — un fan
+/// suit ce qui se passe à partir d'aujourd'hui).
+model ProSpectatorFollow {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  team      ProTeam  @relation(fields: [proTeamId], references: [id], onDelete: Cascade)
+  proTeamId String
+  since     DateTime @default(now())
+  createdAt DateTime @default(now())
+
+  @@unique([userId, proTeamId])
+  @@index([userId])
+  @@index([proTeamId])
 }


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.C.4** — Mode "fan" (follow team + newsfeed).

🎯 **Avec ce PR, le lot 1.C est complet** (1.C.1 → 1.C.5 livrés).

### Backend

| Fichier | Rôle |
|---|---|
| `prisma/schema.prisma` + sqlite mirror | Modèle `ProSpectatorFollow {userId, proTeamId, since}` avec unique composite |
| `prisma/migrations/.../migration.sql` | Migration SQL postgres |
| `services/pro-league-follow.ts` | Service follow / unfollow / isFollowing / listMyFollows / getMyFeed |
| `routes/pro-league.ts` | 5 endpoints auth-required |

**Logique du feed** : 1 upcoming + 1 recent par équipe suivie, mergés et triés (recent récents en haut, upcoming proches ensuite), cap à 30 entrées max.

### Endpoints (auth-required)

| Method + URL | Rôle |
|---|---|
| `POST /pro-league/teams/:slug/follow` | Suivre une équipe (idempotent) |
| `DELETE /pro-league/teams/:slug/follow` | Ne plus suivre (idempotent) |
| `GET /pro-league/teams/:slug/follow` | Statut de follow |
| `GET /pro-league/me/follows` | Liste équipes suivies |
| `GET /pro-league/me/feed` | Newsfeed perso |

### Frontend

**Bouton Follow** sur `/pro-league/teams/[slug]` :
- Visible **uniquement aux users authentifiés** (401 silencieux pour visiteurs)
- State 3 étapes : init via GET → toggle via POST/DELETE
- Variants : `+ Suivre` (CTA blanc) / `✓ Suivi` (passive)
- Disabled pendant requête, error inline

**Page `/pro-league/feed`** :
- Sections "Derniers résultats" + "À venir"
- Cards avec couleur équipe, `vs`/`@` selon home/away, score coloré (vert win, slate draw, rose loss)
- Liens vers `/matches/[id]/live`
- États gérés : loading / **401 → message auth-required** / empty (pas de follows) / error / OK

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-league-follow` (backend) → **14/14 ✓**
- [x] `npx vitest run app/pro-league/feed` (frontend) → **5/5 ✓**
- [x] `npx vitest run app/pro-league/teams` (regression) → 7/7 ✓

Couverture totale : **19 nouveaux tests**.

## Lot 1.C — récap final

| Lot | PR | État |
|---|---|---|
| 1.C.1 — Hub page | #609 | ✅ |
| 1.C.2 — Team detail | #611 | ✅ |
| 1.C.3 — Match detail | #612 | ✅ |
| 1.C.4 — Follow + feed | _this PR_ | ⏳ |
| 1.C.5 — Standings detail | #610 | ✅ |

## Suite

Au choix :
- **Lot 1.D** : paris + économie Crowns (~1 sem effort) — feature impactante "fan engagement"
- **Lot 1.E** : Nuffle Gazette + casualties persistantes + HoF light (LLM Claude Haiku) — narratif/storyline

Hors scope cette PR : reset hebdo notifications (à brancher quand on aura le système de notifications transverse).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_