### PR TITLE
feat(server,db): Pro League wallet + transaction ledger (sprint 1.D.1)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -71,6 +71,7 @@ model User {
   eloSnapshots                EloSnapshot[]
   tutorialCompletions         TutorialCompletion[]
   proSpectatorFollows         ProSpectatorFollow[]
+  proWallet                   ProWallet?
 }
 
 /// S26.3l — mirror SQLite de l'historique ELO Postgres (snapshot par mise a jour).
@@ -1013,4 +1014,27 @@ model ProSpectatorFollow {
   @@unique([userId, proTeamId])
   @@index([userId])
   @@index([proTeamId])
+}
+
+model ProWallet {
+  userId    String   @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  crowns    Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  transactions ProTransaction[]
+}
+
+model ProTransaction {
+  id        String    @id @default(cuid())
+  wallet    ProWallet @relation(fields: [walletId], references: [userId], onDelete: Cascade)
+  walletId  String
+  type      String
+  amount    Int
+  ref       String?
+  createdAt DateTime  @default(now())
+
+  @@index([walletId, createdAt])
+  @@index([type])
 }

--- a/apps/server/src/services/pro-wallet.test.ts
+++ b/apps/server/src/services/pro-wallet.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proWallet: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    proTransaction: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  InsufficientFundsError,
+  InvalidAmountError,
+  InvalidTxTypeError,
+  credit,
+  debit,
+  getBalance,
+  getOrCreateWallet,
+  getRecentTransactions,
+} from "./pro-wallet";
+
+interface MockedPrisma {
+  proWallet: {
+    upsert: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  proTransaction: {
+    findMany: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const USER = "user_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default $transaction passthrough
+  mocked.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn(prisma),
+  );
+});
+
+describe("getOrCreateWallet — sprint 1.D.1", () => {
+  it("upsert + renvoie le snapshot", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({
+      userId: USER,
+      crowns: 0,
+    });
+    const out = await getOrCreateWallet(USER);
+    expect(out).toEqual({ userId: USER, crowns: 0 });
+    expect(mocked.proWallet.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER },
+        create: { userId: USER },
+        update: {},
+      }),
+    );
+  });
+});
+
+describe("getBalance — sprint 1.D.1", () => {
+  it("0 si pas de wallet (pas d'erreur)", async () => {
+    mocked.proWallet.findUnique.mockResolvedValue(null);
+    expect(await getBalance(USER)).toBe(0);
+  });
+
+  it("renvoie le solde courant", async () => {
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 1500 });
+    expect(await getBalance(USER)).toBe(1500);
+  });
+});
+
+describe("debit — sprint 1.D.1", () => {
+  it("rejette amount <= 0 ou non entier", async () => {
+    await expect(debit(USER, 0, "BET")).rejects.toThrow(InvalidAmountError);
+    await expect(debit(USER, -5, "BET")).rejects.toThrow(InvalidAmountError);
+    await expect(debit(USER, 1.5, "BET")).rejects.toThrow(InvalidAmountError);
+  });
+
+  it("rejette type invalide", async () => {
+    await expect(
+      // @ts-expect-error type invalide volontaire pour test
+      debit(USER, 100, "FOOBAR"),
+    ).rejects.toThrow(InvalidTxTypeError);
+  });
+
+  it("InsufficientFundsError si solde < amount", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({ userId: USER, crowns: 50 });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 50 });
+
+    await expect(debit(USER, 100, "BET")).rejects.toThrow(
+      InsufficientFundsError,
+    );
+    expect(mocked.proWallet.update).not.toHaveBeenCalled();
+    expect(mocked.proTransaction.create).not.toHaveBeenCalled();
+  });
+
+  it("debit OK : update + transaction écrites atomiquement", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({ userId: USER, crowns: 1000 });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 1000 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 750 });
+    mocked.proTransaction.create.mockResolvedValue({});
+
+    const newBalance = await debit(USER, 250, "BET", "bet_xyz");
+
+    expect(newBalance).toBe(750);
+    expect(mocked.proWallet.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER },
+        data: { crowns: 750 },
+      }),
+    );
+    expect(mocked.proTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletId: USER,
+          type: "BET",
+          amount: -250,
+          ref: "bet_xyz",
+        }),
+      }),
+    );
+  });
+
+  it("debit sans ref : ref=null en DB", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({ userId: USER, crowns: 100 });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 100 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 50 });
+    mocked.proTransaction.create.mockResolvedValue({});
+
+    await debit(USER, 50, "BET");
+
+    expect(mocked.proTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ref: null }),
+      }),
+    );
+  });
+});
+
+describe("credit — sprint 1.D.1", () => {
+  it("rejette amount <= 0", async () => {
+    await expect(credit(USER, 0, "WIN")).rejects.toThrow(InvalidAmountError);
+    await expect(credit(USER, -10, "WIN")).rejects.toThrow(InvalidAmountError);
+  });
+
+  it("crédit OK : amount positif dans ProTransaction", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({ userId: USER, crowns: 200 });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 200 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 700 });
+    mocked.proTransaction.create.mockResolvedValue({});
+
+    const newBalance = await credit(USER, 500, "WIN", "bet_xyz");
+
+    expect(newBalance).toBe(700);
+    expect(mocked.proTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "WIN",
+          amount: 500,
+          ref: "bet_xyz",
+        }),
+      }),
+    );
+  });
+
+  it("first credit sur wallet inexistant : crée puis crédit", async () => {
+    mocked.proWallet.upsert.mockResolvedValue({ userId: USER, crowns: 0 });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 0 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 1000 });
+    mocked.proTransaction.create.mockResolvedValue({});
+
+    const out = await credit(USER, 1000, "REWARD", "first_signup");
+
+    expect(out).toBe(1000);
+    expect(mocked.proWallet.upsert).toHaveBeenCalled();
+  });
+});
+
+describe("getRecentTransactions — sprint 1.D.1", () => {
+  it("rejette limit <= 0", async () => {
+    await expect(getRecentTransactions(USER, 0)).rejects.toThrow(
+      InvalidAmountError,
+    );
+  });
+
+  it("renvoie [] si pas de transactions", async () => {
+    mocked.proTransaction.findMany.mockResolvedValue([]);
+    expect(await getRecentTransactions(USER)).toEqual([]);
+  });
+
+  it("formate les rows + ordre desc", async () => {
+    const at = new Date("2026-09-01T12:00:00Z");
+    mocked.proTransaction.findMany.mockResolvedValue([
+      {
+        id: "t1",
+        type: "WIN",
+        amount: 500,
+        ref: "bet_x",
+        createdAt: at,
+      },
+    ]);
+    const out = await getRecentTransactions(USER, 10);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("WIN");
+    expect(out[0].amount).toBe(500);
+    expect(out[0].createdAt).toBe(at.toISOString());
+    expect(mocked.proTransaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { walletId: USER },
+        orderBy: { createdAt: "desc" },
+        take: 10,
+      }),
+    );
+  });
+});

--- a/apps/server/src/services/pro-wallet.ts
+++ b/apps/server/src/services/pro-wallet.ts
@@ -1,0 +1,257 @@
+/**
+ * Pro League wallet — sprint Pro League lot 1.D.1.
+ *
+ * Service qui gère le porte-monnaie Crowns d'un user et le ledger
+ * immuable `ProTransaction`. Toutes les opérations debit/credit sont
+ * atomiques : `ProWallet.crowns` (cache) et l'entrée `ProTransaction`
+ * (audit) sont écrits dans la même transaction Prisma.
+ *
+ * Sources / sorties de Crowns au MVP (lot 1.D.6) :
+ *  - `REWARD` : first-time bonus inscription (1000 Crowns).
+ *  - `DAILY` : login quotidien (50 Crowns / 24h).
+ *  - `BET` : pose d'un pari (debit, montant négatif).
+ *  - `WIN` : gain net post-settlement (credit).
+ *  - `BADGE` : prime variable badge débloqué.
+ *
+ * Contrats :
+ *  - `getOrCreateWallet(userId)` : idempotent, renvoie le wallet
+ *    (création si absent).
+ *  - `debit(userId, amount, type, ref?)` :
+ *    * `amount` strictly > 0 ; throw `InvalidAmountError` sinon.
+ *    * Le wallet est créé si nécessaire.
+ *    * Si le solde courant < `amount` → throw `InsufficientFundsError`.
+ *    * Sinon : décrément atomique + écriture ProTransaction
+ *      `{type, amount: -amount, ref?}` et renvoie le nouveau solde.
+ *  - `credit(userId, amount, type, ref?)` :
+ *    * `amount` strictly > 0 ; throw `InvalidAmountError` sinon.
+ *    * Création wallet si absent ; incrément + écriture
+ *      ProTransaction `{type, amount: +amount, ref?}`.
+ *  - `getBalance(userId)` : 0 si pas de wallet (pas d'erreur).
+ *  - `getRecentTransactions(userId, limit)` : ledger paginé desc.
+ */
+
+import { prisma } from "../prisma";
+
+/** Types valides pour `ProTransaction.type`. */
+export type ProTxType = "BET" | "WIN" | "REWARD" | "DAILY" | "BADGE";
+
+const VALID_TX_TYPES: ReadonlySet<ProTxType> = new Set([
+  "BET",
+  "WIN",
+  "REWARD",
+  "DAILY",
+  "BADGE",
+]);
+
+export interface ProWalletSnapshot {
+  readonly userId: string;
+  readonly crowns: number;
+}
+
+export interface ProTransactionEntry {
+  readonly id: string;
+  readonly type: ProTxType;
+  readonly amount: number;
+  readonly ref: string | null;
+  readonly createdAt: string;
+}
+
+export class InvalidAmountError extends Error {
+  readonly code = "WALLET_INVALID_AMOUNT";
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidAmountError";
+  }
+}
+
+export class InvalidTxTypeError extends Error {
+  readonly code = "WALLET_INVALID_TX_TYPE";
+  constructor(public readonly raw: string) {
+    super(`ProTransaction.type invalide : '${raw}'`);
+    this.name = "InvalidTxTypeError";
+  }
+}
+
+export class InsufficientFundsError extends Error {
+  readonly code = "WALLET_INSUFFICIENT_FUNDS";
+  constructor(
+    public readonly available: number,
+    public readonly requested: number,
+  ) {
+    super(
+      `Solde insuffisant : disponible ${available}, demandé ${requested}.`,
+    );
+    this.name = "InsufficientFundsError";
+  }
+}
+
+function ensureValidAmount(amount: number): void {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new InvalidAmountError(
+      `Le montant doit être un entier > 0 (reçu: ${amount}).`,
+    );
+  }
+}
+
+function ensureValidType(type: ProTxType): void {
+  if (!VALID_TX_TYPES.has(type)) {
+    throw new InvalidTxTypeError(type as string);
+  }
+}
+
+/**
+ * Crée le wallet de l'user s'il n'existe pas, sinon le renvoie tel
+ * quel. Idempotent : 2 appels successifs ne dupliquent pas le wallet.
+ */
+export async function getOrCreateWallet(
+  userId: string,
+): Promise<ProWalletSnapshot> {
+  const wallet = await prisma.proWallet.upsert({
+    where: { userId },
+    create: { userId },
+    update: {},
+    select: { userId: true, crowns: true },
+  });
+  return {
+    userId: wallet.userId as string,
+    crowns: (wallet.crowns as number) ?? 0,
+  };
+}
+
+/**
+ * Renvoie le solde courant. Pas d'erreur si le wallet n'existe pas
+ * encore (un user qui n'a jamais reçu/dépensé de Crowns a un solde 0).
+ */
+export async function getBalance(userId: string): Promise<number> {
+  const w = await prisma.proWallet.findUnique({
+    where: { userId },
+    select: { crowns: true },
+  });
+  return ((w?.crowns as number | undefined) ?? 0) as number;
+}
+
+/**
+ * Débite le wallet de `amount` Crowns. Atomique : décrément + écriture
+ * ProTransaction `{type, amount: -amount}` dans la même $transaction.
+ *
+ * Lève `InsufficientFundsError` si solde < amount au moment de l'appel.
+ *
+ * Renvoie le nouveau solde après débit.
+ */
+export async function debit(
+  userId: string,
+  amount: number,
+  type: ProTxType,
+  ref?: string,
+): Promise<number> {
+  ensureValidAmount(amount);
+  ensureValidType(type);
+  // Garantit l'existence du wallet (création silencieuse si absent).
+  await getOrCreateWallet(userId);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (await prisma.$transaction(async (tx: any) => {
+    const w = await tx.proWallet.findUnique({
+      where: { userId },
+      select: { crowns: true },
+    });
+    const current = (w?.crowns as number | undefined) ?? 0;
+    if (current < amount) {
+      throw new InsufficientFundsError(current, amount);
+    }
+    const updated = await tx.proWallet.update({
+      where: { userId },
+      data: { crowns: current - amount },
+      select: { crowns: true },
+    });
+    await tx.proTransaction.create({
+      data: {
+        walletId: userId,
+        type,
+        amount: -amount,
+        ref: ref ?? null,
+      },
+    });
+    return updated.crowns as number;
+  })) as number;
+
+  return result;
+}
+
+/**
+ * Crédite le wallet de `amount` Crowns. Atomique : incrément +
+ * écriture ProTransaction `{type, amount: +amount}` dans la même
+ * $transaction.
+ *
+ * Renvoie le nouveau solde.
+ */
+export async function credit(
+  userId: string,
+  amount: number,
+  type: ProTxType,
+  ref?: string,
+): Promise<number> {
+  ensureValidAmount(amount);
+  ensureValidType(type);
+  await getOrCreateWallet(userId);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (await prisma.$transaction(async (tx: any) => {
+    const w = await tx.proWallet.findUnique({
+      where: { userId },
+      select: { crowns: true },
+    });
+    const current = (w?.crowns as number | undefined) ?? 0;
+    const updated = await tx.proWallet.update({
+      where: { userId },
+      data: { crowns: current + amount },
+      select: { crowns: true },
+    });
+    await tx.proTransaction.create({
+      data: {
+        walletId: userId,
+        type,
+        amount: amount,
+        ref: ref ?? null,
+      },
+    });
+    return updated.crowns as number;
+  })) as number;
+
+  return result;
+}
+
+/**
+ * Liste les `limit` dernières transactions de l'user, ordre desc
+ * (plus récentes d'abord). Renvoie [] si le wallet n'existe pas.
+ */
+export async function getRecentTransactions(
+  userId: string,
+  limit: number = 20,
+): Promise<ProTransactionEntry[]> {
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new InvalidAmountError(
+      `limit doit être un entier > 0 (reçu: ${limit}).`,
+    );
+  }
+  const rows = await prisma.proTransaction.findMany({
+    where: { walletId: userId },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      type: true,
+      amount: true,
+      ref: true,
+      createdAt: true,
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((r: any) => ({
+    id: r.id as string,
+    type: r.type as ProTxType,
+    amount: r.amount as number,
+    ref: (r.ref as string | null) ?? null,
+    createdAt: (r.createdAt as Date).toISOString(),
+  }));
+}

--- a/prisma/migrations/20260506130000_add_pro_wallet_transaction/migration.sql
+++ b/prisma/migrations/20260506130000_add_pro_wallet_transaction/migration.sql
@@ -1,0 +1,39 @@
+-- Pro League wallet + transaction ledger (sprint 1.D.1).
+
+-- CreateTable: ProWallet (1 par user)
+CREATE TABLE "public"."ProWallet" (
+    "userId"    TEXT NOT NULL,
+    "crowns"    INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProWallet_pkey" PRIMARY KEY ("userId")
+);
+
+ALTER TABLE "public"."ProWallet"
+  ADD CONSTRAINT "ProWallet_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "public"."User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProTransaction (ledger immuable)
+CREATE TABLE "public"."ProTransaction" (
+    "id"        TEXT NOT NULL,
+    "walletId"  TEXT NOT NULL,
+    "type"      TEXT NOT NULL,
+    "amount"    INTEGER NOT NULL,
+    "ref"       TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProTransaction_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProTransaction_walletId_createdAt_idx"
+  ON "public"."ProTransaction"("walletId", "createdAt");
+
+CREATE INDEX "ProTransaction_type_idx"
+  ON "public"."ProTransaction"("type");
+
+ALTER TABLE "public"."ProTransaction"
+  ADD CONSTRAINT "ProTransaction_walletId_fkey"
+  FOREIGN KEY ("walletId") REFERENCES "public"."ProWallet"("userId")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model User {
   eloSnapshots                EloSnapshot[]
   tutorialCompletions         TutorialCompletion[]
   proSpectatorFollows         ProSpectatorFollow[]
+  proWallet                   ProWallet?
 }
 
 /// S26.3l — Historique ELO du coach. Une ligne par mise a jour ELO (donc 2
@@ -1344,4 +1345,53 @@ model ProSpectatorFollow {
   @@unique([userId, proTeamId])
   @@index([userId])
   @@index([proTeamId])
+}
+
+/// Sprint Pro League lot 1.D.1 — Wallet Crowns.
+///
+/// 1 wallet par user (`userId @id`). `crowns` est le solde courant
+/// (cache) ; le ledger immuable est `Transaction` (historique
+/// append-only). `crowns` est mis a jour atomiquement a chaque
+/// debit/credit dans la meme transaction Prisma.
+///
+/// Sources de Crowns au MVP (cf. lot 1.D.6) :
+///  - Inscription : 1000 Crowns offerts (REWARD)
+///  - Login quotidien : 50 Crowns (max 1/24h, type DAILY)
+///  - Gain de pari : montant net (WIN)
+///  - Badge debloque : prime variable (BADGE)
+/// Sortie de Crowns : pose d'un pari (BET, montant negatif).
+model ProWallet {
+  userId    String   @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  /// Solde courant en Crowns. Mis a jour atomique avec chaque
+  /// Transaction associee. Toujours >= 0 (les debit echouent en
+  /// dessous via la contrainte service).
+  crowns    Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  transactions ProTransaction[]
+}
+
+/// Sprint Pro League lot 1.D.1 — Ledger immuable des operations Crowns.
+///
+/// `type` distingue la nature : BET (mise sur un pari, debit), WIN
+/// (gain net post-settlement, credit), REWARD (cadeau / first-time
+/// bonus), DAILY (login quotidien), BADGE (recompense badge).
+/// `amount` est signe : negatif pour debit, positif pour credit.
+/// `ref` est optionnel et stocke un identifiant business (`betId`,
+/// `badgeCode`, `marketId`) selon le type — facilite l'audit sans
+/// rejoindre une autre table.
+model ProTransaction {
+  id        String    @id @default(cuid())
+  wallet    ProWallet @relation(fields: [walletId], references: [userId], onDelete: Cascade)
+  walletId  String
+  type      String
+  amount    Int
+  /// Reference business optionnelle (betId, badgeCode, marketId, ...).
+  ref       String?
+  createdAt DateTime  @default(now())
+
+  @@index([walletId, createdAt])
+  @@index([type])
 }


### PR DESCRIPTION
## Summary

Démarrage du **lot 1.D** (paris + économie Crowns) — modèles Prisma + service wallet atomique.

### Modèles Prisma

| Modèle | Rôle |
|---|---|
| `ProWallet {userId @id, crowns, ...}` | 1 wallet par user, solde cache |
| `ProTransaction {id, walletId, type, amount, ref, createdAt}` | Ledger immuable append-only |

**Types `ProTransaction.type`** : `BET` / `WIN` / `REWARD` / `DAILY` / `BADGE`. **`amount`** signé (négatif debit, positif credit). **`ref`** optionnel pour audit (betId, badgeCode, marketId…).

Postgres + sqlite mirror + migration SQL (FK CASCADE sur `User`).

### Service `services/pro-wallet.ts`

| API | Rôle |
|---|---|
| `getOrCreateWallet(userId)` | Idempotent (upsert) |
| `getBalance(userId)` | 0 si pas de wallet (pas d'erreur) |
| `debit(userId, amount, type, ref?)` | `$transaction` atomique : check solde ≥ amount → décrément + ledger |
| `credit(userId, amount, type, ref?)` | `$transaction` atomique : incrément + ledger |
| `getRecentTransactions(userId, limit)` | Paginé desc |

### Erreurs typées

| Erreur | Code |
|---|---|
| `InvalidAmountError` | `WALLET_INVALID_AMOUNT` |
| `InvalidTxTypeError` | `WALLET_INVALID_TX_TYPE` |
| `InsufficientFundsError` | `WALLET_INSUFFICIENT_FUNDS` (expose `available` + `requested`) |

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-wallet` → **14/14 ✓**

Couverture :
| Cas | Résultat |
|---|---|
| `getOrCreateWallet` upsert | OK |
| `getBalance` (absent / présent) | 0 / solde |
| `debit` rejet amount ≤ 0 / non-entier | InvalidAmountError |
| `debit` rejet type invalide | InvalidTxTypeError |
| `debit` solde insuffisant | InsufficientFundsError, pas d'écriture |
| `debit` OK avec/sans ref | update + ProTransaction.amount=-amount |
| `credit` rejet amount | InvalidAmountError |
| `credit` OK | update + ProTransaction.amount=+amount |
| `credit` first credit sur wallet inexistant | upsert + crédit |
| `getRecentTransactions` | rejet limit, [] vide, ordre desc |

## Suite (lot 1.D)

- **1.D.2** : modèles `BetMarket`, `Bet`, `BetSettlement`
- **1.D.3** : calcul cotes dynamique (pré-sim 200 matches + marge maison 5%)
- **1.D.4** : endpoints paris (`GET /markets`, `POST /bets`, `GET /me/bets`)
- **1.D.5** : settlement automatique post-match
- **1.D.6** : daily login bonus + first-time bonus (1000 Crowns)
- **1.D.7** : UI paris (BetSlip, MarketsList, MyBets)
- **1.D.8** : leaderboards parieurs
- **1.D.9** : badges/titres


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_