### PR TITLE
feat(db): Pro League bet markets + bets + settlements (sprint 1.D.2)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -72,6 +72,7 @@ model User {
   tutorialCompletions         TutorialCompletion[]
   proSpectatorFollows         ProSpectatorFollow[]
   proWallet                   ProWallet?
+  proBets                     ProBet[]
 }
 
 /// S26.3l — mirror SQLite de l'historique ELO Postgres (snapshot par mise a jour).
@@ -963,6 +964,8 @@ model ProLeagueMatch {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
 
+  betMarkets ProBetMarket[]
+
   @@index([seasonId, status])
   @@index([roundId])
   @@index([scheduledAt])
@@ -1037,4 +1040,53 @@ model ProTransaction {
 
   @@index([walletId, createdAt])
   @@index([type])
+}
+
+model ProBetMarket {
+  id        String         @id @default(cuid())
+  match     ProLeagueMatch @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  matchId   String
+  type      String
+  config    String
+  status    String         @default("open")
+  closesAt  DateTime
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+
+  bets       ProBet[]
+  settlement ProBetSettlement?
+
+  @@unique([matchId, type])
+  @@index([status, closesAt])
+}
+
+model ProBet {
+  id           String       @id @default(cuid())
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  market       ProBetMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  marketId     String
+  selection    String
+  stake        Int
+  oddsAtPlace  Float
+  status       String       @default("pending")
+  payoutAmount Int?
+  clientToken  String       @unique
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([marketId, status])
+  @@index([status])
+}
+
+model ProBetSettlement {
+  id               String       @id @default(cuid())
+  market           ProBetMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  marketId         String       @unique
+  winningSelection String
+  totalStake       Int          @default(0)
+  totalPayout      Int          @default(0)
+  betCount         Int          @default(0)
+  settledAt        DateTime     @default(now())
 }

--- a/prisma/migrations/20260506140000_add_pro_bet_models/migration.sql
+++ b/prisma/migrations/20260506140000_add_pro_bet_models/migration.sql
@@ -1,0 +1,86 @@
+-- Pro League bet markets + bets + settlements (sprint 1.D.2).
+
+-- CreateTable: ProBetMarket
+CREATE TABLE "public"."ProBetMarket" (
+    "id"        TEXT NOT NULL,
+    "matchId"   TEXT NOT NULL,
+    "type"      TEXT NOT NULL,
+    "config"    JSONB NOT NULL,
+    "status"    TEXT NOT NULL DEFAULT 'open',
+    "closesAt"  TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProBetMarket_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProBetMarket_matchId_type_key"
+  ON "public"."ProBetMarket"("matchId", "type");
+
+CREATE INDEX "ProBetMarket_status_closesAt_idx"
+  ON "public"."ProBetMarket"("status", "closesAt");
+
+ALTER TABLE "public"."ProBetMarket"
+  ADD CONSTRAINT "ProBetMarket_matchId_fkey"
+  FOREIGN KEY ("matchId") REFERENCES "public"."ProLeagueMatch"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProBet
+CREATE TABLE "public"."ProBet" (
+    "id"           TEXT NOT NULL,
+    "userId"       TEXT NOT NULL,
+    "marketId"     TEXT NOT NULL,
+    "selection"    TEXT NOT NULL,
+    "stake"        INTEGER NOT NULL,
+    "oddsAtPlace"  DOUBLE PRECISION NOT NULL,
+    "status"       TEXT NOT NULL DEFAULT 'pending',
+    "payoutAmount" INTEGER,
+    "clientToken"  TEXT NOT NULL,
+    "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"    TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProBet_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProBet_clientToken_key"
+  ON "public"."ProBet"("clientToken");
+
+CREATE INDEX "ProBet_userId_createdAt_idx"
+  ON "public"."ProBet"("userId", "createdAt");
+
+CREATE INDEX "ProBet_marketId_status_idx"
+  ON "public"."ProBet"("marketId", "status");
+
+CREATE INDEX "ProBet_status_idx"
+  ON "public"."ProBet"("status");
+
+ALTER TABLE "public"."ProBet"
+  ADD CONSTRAINT "ProBet_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "public"."User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."ProBet"
+  ADD CONSTRAINT "ProBet_marketId_fkey"
+  FOREIGN KEY ("marketId") REFERENCES "public"."ProBetMarket"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: ProBetSettlement
+CREATE TABLE "public"."ProBetSettlement" (
+    "id"               TEXT NOT NULL,
+    "marketId"         TEXT NOT NULL,
+    "winningSelection" TEXT NOT NULL,
+    "totalStake"       INTEGER NOT NULL DEFAULT 0,
+    "totalPayout"      INTEGER NOT NULL DEFAULT 0,
+    "betCount"         INTEGER NOT NULL DEFAULT 0,
+    "settledAt"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProBetSettlement_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProBetSettlement_marketId_key"
+  ON "public"."ProBetSettlement"("marketId");
+
+ALTER TABLE "public"."ProBetSettlement"
+  ADD CONSTRAINT "ProBetSettlement_marketId_fkey"
+  FOREIGN KEY ("marketId") REFERENCES "public"."ProBetMarket"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model User {
   tutorialCompletions         TutorialCompletion[]
   proSpectatorFollows         ProSpectatorFollow[]
   proWallet                   ProWallet?
+  proBets                     ProBet[]
 }
 
 /// S26.3l — Historique ELO du coach. Une ligne par mise a jour ELO (donc 2
@@ -1262,6 +1263,8 @@ model ProLeagueMatch {
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
 
+  betMarkets ProBetMarket[]
+
   @@index([seasonId, status])
   @@index([roundId])
   @@index([scheduledAt])
@@ -1394,4 +1397,91 @@ model ProTransaction {
 
   @@index([walletId, createdAt])
   @@index([type])
+}
+
+/// Sprint Pro League lot 1.D.2 — Marche de pari sur un match.
+///
+/// Un BetMarket regroupe les paris d'un type donne (`type`) sur un
+/// match. Les cotes sont stockees dans `config` (Json) ; la forme
+/// depend du type :
+///   - ONE_X_TWO       : { homeOdds, drawOdds, awayOdds }
+///   - OVER_UNDER_TD   : { line, overOdds, underOdds }
+///   - CAS_COUNT       : { line, overOdds, underOdds }
+///   - NUFFLE_OCCURS   : { yesOdds, noOdds }
+///   - MVP             : { selections: [{key, label, odds}, ...] }
+///
+/// Les cotes sont calculees lot 1.D.3 (odds-calculator) au pre-match
+/// puis mises a jour si le line-up change. Le lot 1.D.5 (settlement)
+/// passe le market a `settled` et evalue les bets.
+model ProBetMarket {
+  id        String         @id @default(cuid())
+  match     ProLeagueMatch @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  matchId   String
+  /// 'ONE_X_TWO' | 'OVER_UNDER_TD' | 'CAS_COUNT' | 'NUFFLE_OCCURS' | 'MVP'
+  type      String
+  config    Json
+  /// 'open' | 'closed' | 'settled'
+  status    String         @default("open")
+  /// Apres ce timestamp, plus aucun pari n'est accepte.
+  closesAt  DateTime
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+
+  bets       ProBet[]
+  settlement ProBetSettlement?
+
+  @@unique([matchId, type])
+  @@index([status, closesAt])
+}
+
+/// Sprint Pro League lot 1.D.2 — Pari pose par un user.
+///
+/// La cote (`oddsAtPlace`) est figee au moment de la pose (fairness :
+/// l'utilisateur sait exactement combien il peut gagner). Le `stake`
+/// est en Crowns. Au settlement (lot 1.D.5), `status` passe a `won`/
+/// `lost`/`void` et `payoutAmount` est rempli pour les gagnants
+/// (= round(stake * oddsAtPlace)).
+///
+/// `clientToken` permet l'idempotence : 2 requetes POST avec le meme
+/// token (par exemple un retry reseau) ne creent qu'un seul Bet.
+model ProBet {
+  id           String       @id @default(cuid())
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  market       ProBetMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  marketId     String
+  /// Selection serialisee selon le type de market (cf. ProBetMarket.type).
+  selection    String
+  stake        Int
+  oddsAtPlace  Float
+  /// 'pending' | 'won' | 'lost' | 'void'
+  status       String       @default("pending")
+  /// Gain net (round(stake * oddsAtPlace)) si won. null sinon.
+  payoutAmount Int?
+  /// Cle d'idempotence cote client (cuid genere au submit).
+  clientToken  String       @unique
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([marketId, status])
+  @@index([status])
+}
+
+/// Sprint Pro League lot 1.D.2 — Audit de settlement d'un market.
+///
+/// Cree au settlement (lot 1.D.5) ; 1-1 avec ProBetMarket via @unique.
+/// `winningSelection` est la selection gagnante ("home"/"draw"/"away"
+/// pour 1X2, "over"/"under" pour over/under, etc.).
+/// `totalStake` / `totalPayout` / `betCount` : metriques agregees
+/// utiles pour les leaderboards (1.D.8) sans rejoindre les bets.
+model ProBetSettlement {
+  id               String       @id @default(cuid())
+  market           ProBetMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  marketId         String       @unique
+  winningSelection String
+  totalStake       Int          @default(0)
+  totalPayout      Int          @default(0)
+  betCount         Int          @default(0)
+  settledAt        DateTime     @default(now())
 }


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.2** — Modèles Prisma pour les paris.

### `ProBetMarket`

| Champ | Rôle |
|---|---|
| `id` (cuid) | PK |
| `matchId` | FK ProLeagueMatch |
| `type` | `ONE_X_TWO` / `OVER_UNDER_TD` / `CAS_COUNT` / `NUFFLE_OCCURS` / `MVP` |
| `config` (Json) | Cotes selon le type |
| `status` | `open` / `closed` / `settled` |
| `closesAt` | Date au-delà → plus aucun pari accepté |

`@@unique([matchId, type])` : un seul market par couple. `@@index([status, closesAt])` pour le settlement automatique.

**Forme de `config`** :
- `ONE_X_TWO` : `{homeOdds, drawOdds, awayOdds}`
- `OVER_UNDER_TD` / `CAS_COUNT` : `{line, overOdds, underOdds}`
- `NUFFLE_OCCURS` : `{yesOdds, noOdds}`
- `MVP` : `{selections: [{key, label, odds}, ...]}`

### `ProBet`

| Champ | Rôle |
|---|---|
| `id` (cuid) | PK |
| `userId` | FK User |
| `marketId` | FK ProBetMarket |
| `selection` | Selection sérialisée selon le type market |
| `stake` (Int) | Mise en Crowns |
| `oddsAtPlace` (Float) | Cote figée à la pose (fairness) |
| `status` | `pending` / `won` / `lost` / `void` |
| `payoutAmount` (Int?) | Gain net = `round(stake * oddsAtPlace)` ; rempli au settlement |
| `clientToken` (unique) | Idempotence client (retry réseau ne dupli pas) |

### `ProBetSettlement`

1-1 avec `ProBetMarket` via `marketId @unique`. Métriques agrégées (`totalStake`, `totalPayout`, `betCount`) pour leaderboards (1.D.8) sans rejoindre tous les bets.

### Postgres + sqlite mirror + migration

Back-relations ajoutées :
- `User.proBets : ProBet[]`
- `ProLeagueMatch.betMarkets : ProBetMarket[]`

`config` est `Json` côté postgres / `String` côté sqlite (parsé/serialisé côté service ultérieurement).

## Test plan

- [x] `prisma format` postgres + sqlite → OK
- [x] `prisma validate` postgres + sqlite → both valid
- [x] `pnpm --filter @bb/server typecheck` → clean

## Suite (lot 1.D)

- **1.D.3** : odds-calculator (pré-sim 200 matchs + marge maison 5%)
- **1.D.4** : endpoints paris (`GET /markets`, `POST /bets`, `GET /me/bets`)
- **1.D.5** : settlement automatique post-match


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_