### PR TITLE
feat(server): Pro League odds calculator (sprint 1.D.3)

### DIFF
--- a/apps/server/src/services/pro-bet-odds-calculator.test.ts
+++ b/apps/server/src/services/pro-bet-odds-calculator.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn() },
+    proBetMarket: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@bb/sim-engine", async () => {
+  const actual = await vi.importActual<typeof import("@bb/sim-engine")>(
+    "@bb/sim-engine",
+  );
+  return {
+    ...actual,
+    simulateMatch: vi.fn(),
+  };
+});
+
+import { prisma } from "../prisma";
+import * as simEngine from "@bb/sim-engine";
+
+import {
+  ProMatchNotReadyForOddsError,
+  computeMarketsForMatch,
+  createOrRefreshMarketsForMatch,
+} from "./pro-bet-odds-calculator";
+
+interface MockedPrisma {
+  proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
+  proBetMarket: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const MATCH_ID = "m_1";
+
+const FAKE_MATCH = {
+  id: MATCH_ID,
+  scheduledAt: new Date("2026-09-15T21:00:00Z"),
+  status: "scheduled",
+  homeTeam: { slug: "pit-smashers", name: "Smashers" },
+  awayTeam: { slug: "kc-soaring-hawks", name: "Soaring Hawks" },
+};
+
+function buildSimResult(overrides: {
+  outcome: "home" | "away" | "draw";
+  td?: number;
+  cas?: number;
+  nuffle?: number;
+}): unknown {
+  return {
+    result: overrides.outcome,
+    events: [],
+    summary: {
+      outcome: overrides.outcome,
+      score: { home: 0, away: 0 },
+      turnoverCount: 0,
+      touchdownCount: overrides.td ?? 2,
+      nuffleCount: overrides.nuffle ?? 0,
+      underdogBoostCount: 0,
+      durationMs: 1000,
+      momentum: [],
+    },
+    casualties: Array(overrides.cas ?? 0).fill({
+      playerId: "x",
+      team: "A",
+      outcome: "badly_hurt",
+    }),
+    engineVer: "0.13.0",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proLeagueMatch.findUnique.mockResolvedValue(FAKE_MATCH);
+});
+
+describe("computeMarketsForMatch — sprint 1.D.3", () => {
+  it("rejette runs <= 0", async () => {
+    await expect(
+      computeMarketsForMatch(MATCH_ID, { runs: 0 }),
+    ).rejects.toThrow(/runs/);
+    await expect(
+      computeMarketsForMatch(MATCH_ID, { runs: -5 }),
+    ).rejects.toThrow(/runs/);
+  });
+
+  it("erreur si match introuvable", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expect(computeMarketsForMatch(MATCH_ID)).rejects.toThrow(
+      ProMatchNotReadyForOddsError,
+    );
+  });
+
+  it("calcule 4 markets : 1X2 + OU TD + CAS + NUFFLE", async () => {
+    // Deterministic sim : 60% home win, 20% draw, 20% away win
+    let i = 0;
+    vi.spyOn(simEngine, "simulateMatch").mockImplementation(() => {
+      i += 1;
+      const o: "home" | "away" | "draw" =
+        i <= 60 ? "home" : i <= 80 ? "draw" : "away";
+      return buildSimResult({
+        outcome: o,
+        td: 3, // > 2.5 → over
+        cas: 1, // > 0.5 → over
+        nuffle: 1, // ≥1 → yes
+      }) as ReturnType<typeof simEngine.simulateMatch>;
+    });
+
+    const out = await computeMarketsForMatch(MATCH_ID, {
+      runs: 100,
+      houseMargin: 0,
+    });
+
+    expect(out).toHaveLength(4);
+    expect(out[0].type).toBe("ONE_X_TWO");
+    expect(out[1].type).toBe("OVER_UNDER_TD");
+    expect(out[2].type).toBe("CAS_COUNT");
+    expect(out[3].type).toBe("NUFFLE_OCCURS");
+
+    // Avec marge 0 et p_home=0.6 → cote home ≈ 1/0.6 = 1.667
+    const oneXTwo = out[0].config as {
+      homeOdds: number;
+      drawOdds: number;
+      awayOdds: number;
+    };
+    expect(oneXTwo.homeOdds).toBeCloseTo(1.67, 1);
+    expect(oneXTwo.drawOdds).toBeCloseTo(5, 0);
+    expect(oneXTwo.awayOdds).toBeCloseTo(5, 0);
+
+    // 100% over (td=3 > 2.5 partout) → odds over = MIN_DECIMAL_ODDS (1.05)
+    const ou = out[1].config as { line: number; overOdds: number; underOdds: number };
+    expect(ou.line).toBe(2.5);
+    expect(ou.overOdds).toBe(1.05);
+
+    // 100% nuffle yes
+    const nuffle = out[3].config as { yesOdds: number; noOdds: number };
+    expect(nuffle.yesOdds).toBe(1.05);
+  });
+
+  it("respecte les options tdLine + casLine + houseMargin", async () => {
+    vi.spyOn(simEngine, "simulateMatch").mockImplementation(
+      () =>
+        buildSimResult({
+          outcome: "home",
+          td: 1, // sous 0.5 et sous 1.5
+          cas: 0,
+          nuffle: 0,
+        }) as ReturnType<typeof simEngine.simulateMatch>,
+    );
+
+    const out = await computeMarketsForMatch(MATCH_ID, {
+      runs: 50,
+      tdLine: 0.5,
+      casLine: 0.5,
+    });
+
+    const ou = out[1].config as { line: number };
+    expect(ou.line).toBe(0.5);
+    const cas = out[2].config as { line: number };
+    expect(cas.line).toBe(0.5);
+  });
+});
+
+describe("createOrRefreshMarketsForMatch — sprint 1.D.3", () => {
+  beforeEach(() => {
+    vi.spyOn(simEngine, "simulateMatch").mockImplementation(
+      () =>
+        buildSimResult({
+          outcome: "home",
+          td: 2,
+          cas: 1,
+          nuffle: 0,
+        }) as ReturnType<typeof simEngine.simulateMatch>,
+    );
+  });
+
+  it("erreur si match completed", async () => {
+    mocked.proLeagueMatch.findUnique
+      .mockResolvedValueOnce({ ...FAKE_MATCH, status: "completed" });
+    await expect(
+      createOrRefreshMarketsForMatch(MATCH_ID),
+    ).rejects.toThrow(/status/);
+  });
+
+  it("crée 4 markets si rien n'existe", async () => {
+    mocked.proBetMarket.findUnique.mockResolvedValue(null);
+    mocked.proBetMarket.create.mockResolvedValue({});
+
+    const out = await createOrRefreshMarketsForMatch(MATCH_ID, { runs: 5 });
+    expect(out.created).toBe(4);
+    expect(out.updated).toBe(0);
+    expect(mocked.proBetMarket.create).toHaveBeenCalledTimes(4);
+  });
+
+  it("update les markets existants", async () => {
+    mocked.proBetMarket.findUnique.mockResolvedValue({
+      id: "existing",
+      status: "open",
+    });
+    mocked.proBetMarket.update.mockResolvedValue({});
+
+    const out = await createOrRefreshMarketsForMatch(MATCH_ID, { runs: 5 });
+    expect(out.created).toBe(0);
+    expect(out.updated).toBe(4);
+  });
+
+  it("skip les markets settled (audit immutable)", async () => {
+    mocked.proBetMarket.findUnique.mockResolvedValue({
+      id: "settled1",
+      status: "settled",
+    });
+    mocked.proBetMarket.update.mockResolvedValue({});
+    mocked.proBetMarket.create.mockResolvedValue({});
+
+    const out = await createOrRefreshMarketsForMatch(MATCH_ID, { runs: 5 });
+    expect(out.created).toBe(0);
+    expect(out.updated).toBe(0);
+    expect(mocked.proBetMarket.update).not.toHaveBeenCalled();
+    expect(mocked.proBetMarket.create).not.toHaveBeenCalled();
+  });
+
+  it("closesAt = scheduledAt du match", async () => {
+    mocked.proBetMarket.findUnique.mockResolvedValue(null);
+    mocked.proBetMarket.create.mockResolvedValue({});
+
+    await createOrRefreshMarketsForMatch(MATCH_ID, { runs: 5 });
+
+    const call = mocked.proBetMarket.create.mock.calls[0][0];
+    expect(call.data.closesAt).toEqual(FAKE_MATCH.scheduledAt);
+    expect(call.data.matchId).toBe(MATCH_ID);
+    expect(call.data.status).toBe("open");
+  });
+});

--- a/apps/server/src/services/pro-bet-odds-calculator.ts
+++ b/apps/server/src/services/pro-bet-odds-calculator.ts
@@ -1,0 +1,308 @@
+/**
+ * Pro League odds calculator — sprint Pro League lot 1.D.3.
+ *
+ * Pré-simule N matchs (default 200) entre les 2 équipes d'un
+ * `ProLeagueMatch` via le sim-engine, agrège les outcomes par type de
+ * market, applique la marge maison (5%) et retourne les configs
+ * sérialisables vers `ProBetMarket.config`.
+ *
+ * Usage typique :
+ *   1. Appelé par `createMarketsForMatch(matchId)` au pre-match (lot
+ *      1.D.4) : calcule les 5 markets standards (1X2, OU TD, OU CAS,
+ *      NUFFLE_OCCURS, MVP) et upsert les rows ProBetMarket.
+ *   2. Re-callable si line-up change (admin / lot 1.E pour casualties
+ *      persistantes) — l'upsert garantit que les odds sont rafraîchies
+ *      sans dupliquer le market.
+ *
+ * Performance : 200 sim → ~1-2s sur le pairing moyen. Acceptable pour
+ * une route admin / cron T-24h. Pour des odds re-calculés en live,
+ * cache + déduplication seront nécessaires (lot 1.D.x optimisation).
+ *
+ * Cotes décimales (convention bookmaker européen) : `payout = stake *
+ * odds`. La cote est figée au moment de la pose (`oddsAtPlace` sur
+ * `ProBet`) pour fairness — un changement post-pose n'impacte pas le
+ * gain d'un pari déjà placé.
+ */
+
+import {
+  PRO_LEAGUE_TEAM_BY_ID,
+  simulateMatch,
+  type SimInput,
+  type SimResult,
+} from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+import {
+  DEFAULT_HOUSE_MARGIN,
+  computeNuffleOccursProbabilities,
+  computeOneXTwoProbabilities,
+  computeOverUnderProbabilities,
+  probabilityToDecimalOdds,
+} from "./pro-bet-odds-math";
+
+/** Types de markets supportés. */
+export type ProMarketType =
+  | "ONE_X_TWO"
+  | "OVER_UNDER_TD"
+  | "CAS_COUNT"
+  | "NUFFLE_OCCURS";
+
+/** Lines par défaut pour les markets over/under (convention .5 pour
+ *  éviter les égalités). Les lines sont choisis pour donner des
+ *  probabilités proches de 50/50 sur le sample FUMBBL de référence. */
+export const DEFAULT_TD_LINE = 2.5;
+export const DEFAULT_CAS_LINE = 0.5;
+
+/** Nombre de simulations par défaut pour estimer les probas. */
+export const DEFAULT_RUNS = 200;
+
+interface OneXTwoConfig {
+  readonly homeOdds: number;
+  readonly drawOdds: number;
+  readonly awayOdds: number;
+}
+
+interface OverUnderConfig {
+  readonly line: number;
+  readonly overOdds: number;
+  readonly underOdds: number;
+}
+
+interface NuffleOccursConfig {
+  readonly yesOdds: number;
+  readonly noOdds: number;
+}
+
+export type ProMarketConfig =
+  | { type: "ONE_X_TWO"; config: OneXTwoConfig }
+  | { type: "OVER_UNDER_TD"; config: OverUnderConfig }
+  | { type: "CAS_COUNT"; config: OverUnderConfig }
+  | { type: "NUFFLE_OCCURS"; config: NuffleOccursConfig };
+
+export class ProMatchNotReadyForOddsError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "ProMatchNotReadyForOddsError";
+  }
+}
+
+/** Hash FNV1a 32-bit pour seeds déterministes (cohérent avec sim-runner). */
+function hashSeed(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Pré-simule N matchs entre les 2 équipes d'un `ProLeagueMatch` et
+ * agrège les compteurs nécessaires aux différents markets.
+ *
+ * Renvoie l'agrégat brut — l'application de la marge maison + la
+ * conversion en cotes se fait dans `computeMarketsForMatch`.
+ */
+async function gatherSamples(
+  matchId: string,
+  runs: number,
+): Promise<{
+  oneXTwoCounts: { home: number; draws: number; away: number };
+  tdCounts: number[];
+  casCounts: number[];
+  nuffleCounts: number[];
+}> {
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: {
+      homeTeam: { select: { slug: true, name: true } },
+      awayTeam: { select: { slug: true, name: true } },
+    },
+  });
+  if (!match) {
+    throw new ProMatchNotReadyForOddsError(
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  const homeProfile = PRO_LEAGUE_TEAM_BY_ID[match.homeTeam.slug as string];
+  const awayProfile = PRO_LEAGUE_TEAM_BY_ID[match.awayTeam.slug as string];
+  if (!homeProfile || !awayProfile) {
+    throw new ProMatchNotReadyForOddsError(
+      `Slugs ProTeam introuvables : home='${match.homeTeam.slug}' away='${match.awayTeam.slug}'`,
+    );
+  }
+
+  const baseSeed = hashSeed(`odds:${matchId}`);
+  const oneXTwoCounts = { home: 0, draws: 0, away: 0 };
+  const tdCounts: number[] = [];
+  const casCounts: number[] = [];
+  const nuffleCounts: number[] = [];
+
+  for (let i = 0; i < runs; i += 1) {
+    const seed = (baseSeed + i) >>> 0;
+    const sim: SimInput = {
+      seed,
+      home: {
+        id: homeProfile.id,
+        name: homeProfile.name,
+        side: "home",
+        tactics: homeProfile.tactics,
+        tv: homeProfile.tv,
+      },
+      away: {
+        id: awayProfile.id,
+        name: awayProfile.name,
+        side: "away",
+        tactics: awayProfile.tactics,
+        tv: awayProfile.tv,
+      },
+    };
+    const result: SimResult = simulateMatch(sim);
+    if (result.summary.outcome === "home") oneXTwoCounts.home += 1;
+    else if (result.summary.outcome === "away") oneXTwoCounts.away += 1;
+    else oneXTwoCounts.draws += 1;
+    tdCounts.push(result.summary.touchdownCount);
+    casCounts.push(result.casualties.length);
+    nuffleCounts.push(result.summary.nuffleCount);
+  }
+
+  return { oneXTwoCounts, tdCounts, casCounts, nuffleCounts };
+}
+
+interface ComputeMarketsOptions {
+  readonly runs?: number;
+  readonly houseMargin?: number;
+  readonly tdLine?: number;
+  readonly casLine?: number;
+}
+
+/**
+ * Renvoie la liste des markets `{type, config}` calculés pour un match,
+ * sans les persister. Useful for testing + admin previews.
+ */
+export async function computeMarketsForMatch(
+  matchId: string,
+  options: ComputeMarketsOptions = {},
+): Promise<ProMarketConfig[]> {
+  const runs = options.runs ?? DEFAULT_RUNS;
+  const houseMargin = options.houseMargin ?? DEFAULT_HOUSE_MARGIN;
+  const tdLine = options.tdLine ?? DEFAULT_TD_LINE;
+  const casLine = options.casLine ?? DEFAULT_CAS_LINE;
+
+  if (!Number.isInteger(runs) || runs <= 0) {
+    throw new Error(`computeMarketsForMatch: runs must be > 0 (got ${runs})`);
+  }
+
+  const samples = await gatherSamples(matchId, runs);
+
+  const oneXTwoP = computeOneXTwoProbabilities(samples.oneXTwoCounts);
+  const tdP = computeOverUnderProbabilities(samples.tdCounts, tdLine);
+  const casP = computeOverUnderProbabilities(samples.casCounts, casLine);
+  const nuffleP = computeNuffleOccursProbabilities(samples.nuffleCounts);
+
+  return [
+    {
+      type: "ONE_X_TWO",
+      config: {
+        homeOdds: probabilityToDecimalOdds(oneXTwoP.home, houseMargin),
+        drawOdds: probabilityToDecimalOdds(oneXTwoP.draw, houseMargin),
+        awayOdds: probabilityToDecimalOdds(oneXTwoP.away, houseMargin),
+      },
+    },
+    {
+      type: "OVER_UNDER_TD",
+      config: {
+        line: tdLine,
+        overOdds: probabilityToDecimalOdds(tdP.over, houseMargin),
+        underOdds: probabilityToDecimalOdds(tdP.under, houseMargin),
+      },
+    },
+    {
+      type: "CAS_COUNT",
+      config: {
+        line: casLine,
+        overOdds: probabilityToDecimalOdds(casP.over, houseMargin),
+        underOdds: probabilityToDecimalOdds(casP.under, houseMargin),
+      },
+    },
+    {
+      type: "NUFFLE_OCCURS",
+      config: {
+        yesOdds: probabilityToDecimalOdds(nuffleP.yes, houseMargin),
+        noOdds: probabilityToDecimalOdds(nuffleP.no, houseMargin),
+      },
+    },
+  ];
+}
+
+export interface UpsertMarketsResult {
+  readonly matchId: string;
+  readonly created: number;
+  readonly updated: number;
+  readonly markets: ProMarketConfig[];
+}
+
+/**
+ * Upsert les markets calculés pour un match. Idempotent. `closesAt`
+ * est calé sur `ProLeagueMatch.scheduledAt` (pas de paris après le
+ * kickoff). Ne touche pas aux markets `settled` (audit).
+ */
+export async function createOrRefreshMarketsForMatch(
+  matchId: string,
+  options: ComputeMarketsOptions = {},
+): Promise<UpsertMarketsResult> {
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: { id: true, scheduledAt: true, status: true },
+  });
+  if (!match) {
+    throw new ProMatchNotReadyForOddsError(
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  if (match.status === "completed" || match.status === "failed") {
+    throw new ProMatchNotReadyForOddsError(
+      `ProLeagueMatch status='${match.status}' — markets ne sont plus rafraîchissables`,
+    );
+  }
+
+  const markets = await computeMarketsForMatch(matchId, options);
+  const closesAt = match.scheduledAt as Date;
+  let created = 0;
+  let updated = 0;
+
+  for (const m of markets) {
+    const existing = await prisma.proBetMarket.findUnique({
+      where: { matchId_type: { matchId, type: m.type } },
+      select: { id: true, status: true },
+    });
+    if (existing && existing.status === "settled") {
+      // Audit : on ne réécrit pas un settled.
+      continue;
+    }
+    if (existing) {
+      await prisma.proBetMarket.update({
+        where: { id: existing.id as string },
+        data: {
+          config: m.config as unknown as object,
+          closesAt,
+        },
+      });
+      updated += 1;
+    } else {
+      await prisma.proBetMarket.create({
+        data: {
+          matchId,
+          type: m.type,
+          config: m.config as unknown as object,
+          status: "open",
+          closesAt,
+        },
+      });
+      created += 1;
+    }
+  }
+
+  return { matchId, created, updated, markets };
+}

--- a/apps/server/src/services/pro-bet-odds-math.test.ts
+++ b/apps/server/src/services/pro-bet-odds-math.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HOUSE_MARGIN,
+  MAX_DECIMAL_ODDS,
+  MIN_DECIMAL_ODDS,
+  computeNuffleOccursProbabilities,
+  computeOneXTwoProbabilities,
+  computeOverUnderProbabilities,
+  impliedProbability,
+  probabilityToDecimalOdds,
+} from "./pro-bet-odds-math";
+
+describe("probabilityToDecimalOdds — sprint 1.D.3", () => {
+  it("p=0.5, marge 0 → cote 2.0", () => {
+    expect(probabilityToDecimalOdds(0.5, 0)).toBe(2);
+  });
+
+  it("p=0.5, marge 5% → cote ~1.90 (round 2dp)", () => {
+    expect(probabilityToDecimalOdds(0.5, 0.05)).toBeCloseTo(1.9, 2);
+  });
+
+  it("p=0.25, marge 5% → cote ~3.81", () => {
+    // (1/0.25) / 1.05 = 4 / 1.05 = 3.809... → round 3.81
+    expect(probabilityToDecimalOdds(0.25, 0.05)).toBeCloseTo(3.81, 2);
+  });
+
+  it("p=0 → MAX_DECIMAL_ODDS (cap)", () => {
+    expect(probabilityToDecimalOdds(0)).toBe(MAX_DECIMAL_ODDS);
+  });
+
+  it("p=1 → MIN_DECIMAL_ODDS (cap)", () => {
+    expect(probabilityToDecimalOdds(1)).toBe(MIN_DECIMAL_ODDS);
+  });
+
+  it("p très haut (favori extrême) → clamp MIN", () => {
+    expect(probabilityToDecimalOdds(0.99)).toBe(MIN_DECIMAL_ODDS);
+  });
+
+  it("p très bas (outsider extrême) → clamp MAX", () => {
+    expect(probabilityToDecimalOdds(0.001)).toBe(MAX_DECIMAL_ODDS);
+  });
+
+  it("rejette houseMargin négative", () => {
+    expect(() => probabilityToDecimalOdds(0.5, -0.05)).toThrow(/houseMargin/);
+  });
+
+  it("rejette inputs non-finite", () => {
+    expect(() => probabilityToDecimalOdds(Number.NaN)).toThrow();
+    expect(() => probabilityToDecimalOdds(0.5, Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  it("DEFAULT_HOUSE_MARGIN = 5%", () => {
+    expect(DEFAULT_HOUSE_MARGIN).toBe(0.05);
+  });
+});
+
+describe("impliedProbability — sprint 1.D.3", () => {
+  it("inverse de odds → 1/odds", () => {
+    expect(impliedProbability(2.0)).toBe(0.5);
+    expect(impliedProbability(4.0)).toBe(0.25);
+  });
+
+  it("rejette odds invalides", () => {
+    expect(() => impliedProbability(0)).toThrow();
+    expect(() => impliedProbability(1.0)).toThrow();
+    expect(() => impliedProbability(Number.NaN)).toThrow();
+  });
+});
+
+describe("computeOneXTwoProbabilities — sprint 1.D.3", () => {
+  it("probabilités somment à 1", () => {
+    const out = computeOneXTwoProbabilities({
+      home: 60,
+      draws: 25,
+      away: 15,
+    });
+    expect(out.home + out.draw + out.away).toBeCloseTo(1, 5);
+    expect(out.home).toBeCloseTo(0.6, 5);
+    expect(out.draw).toBeCloseTo(0.25, 5);
+    expect(out.away).toBeCloseTo(0.15, 5);
+  });
+
+  it("renvoie 1/3 partout pour échantillon vide", () => {
+    const out = computeOneXTwoProbabilities({ home: 0, draws: 0, away: 0 });
+    expect(out.home).toBeCloseTo(1 / 3, 5);
+    expect(out.draw).toBeCloseTo(1 / 3, 5);
+    expect(out.away).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe("computeOverUnderProbabilities — sprint 1.D.3", () => {
+  it("strictement > line", () => {
+    // line=2.5, valeurs [0,1,2,3,4] → 2 valeurs > 2.5 → over = 0.4
+    const out = computeOverUnderProbabilities([0, 1, 2, 3, 4], 2.5);
+    expect(out.over).toBeCloseTo(0.4, 5);
+    expect(out.under).toBeCloseTo(0.6, 5);
+  });
+
+  it("toutes valeurs sous le line → over=0", () => {
+    const out = computeOverUnderProbabilities([0, 1, 2], 5.5);
+    expect(out.over).toBe(0);
+    expect(out.under).toBe(1);
+  });
+
+  it("échantillon vide → 50/50", () => {
+    const out = computeOverUnderProbabilities([], 2.5);
+    expect(out.over).toBe(0.5);
+    expect(out.under).toBe(0.5);
+  });
+});
+
+describe("computeNuffleOccursProbabilities — sprint 1.D.3", () => {
+  it("yes = au moins 1 event", () => {
+    // [0, 0, 2, 3, 0] → 2 occurrences (≥1) sur 5 = 0.4
+    const out = computeNuffleOccursProbabilities([0, 0, 2, 3, 0]);
+    expect(out.yes).toBeCloseTo(0.4, 5);
+    expect(out.no).toBeCloseTo(0.6, 5);
+  });
+
+  it("zéros partout → yes=0", () => {
+    const out = computeNuffleOccursProbabilities([0, 0, 0]);
+    expect(out.yes).toBe(0);
+    expect(out.no).toBe(1);
+  });
+
+  it("au moins 1 partout → yes=1", () => {
+    const out = computeNuffleOccursProbabilities([1, 2, 3]);
+    expect(out.yes).toBe(1);
+    expect(out.no).toBe(0);
+  });
+
+  it("échantillon vide → 50/50", () => {
+    const out = computeNuffleOccursProbabilities([]);
+    expect(out.yes).toBe(0.5);
+    expect(out.no).toBe(0.5);
+  });
+});

--- a/apps/server/src/services/pro-bet-odds-math.ts
+++ b/apps/server/src/services/pro-bet-odds-math.ts
@@ -1,0 +1,125 @@
+/**
+ * Math helpers — sprint Pro League lot 1.D.3 (odds calculator).
+ *
+ * Fonctions pures, sans I/O, testables seules. Conversions
+ * probabilités → cotes décimales et application d'une marge maison.
+ *
+ * Convention :
+ *  - "probability" ∈ [0, 1] : fraction des cas favorables.
+ *  - "decimal odds" ≥ 1.01 : ce qui revient au parieur pour 1 Crown
+ *    misé. Ex : odds 2.50 ⇒ stake 100 ⇒ payout 250.
+ *
+ * Marge maison ("house margin") : la somme des proba implicites des
+ * cotes affichées dépasse 1, l'écart = marge captée par la "maison".
+ * On applique en multipliant la proba estimée par (1 + margin) avant
+ * inversion, puis on clamp.
+ */
+
+/** Marge maison par défaut (5%). */
+export const DEFAULT_HOUSE_MARGIN = 0.05;
+
+/** Cote min publiable (sécurité contre les "favoris extrêmes"). */
+export const MIN_DECIMAL_ODDS = 1.05;
+
+/** Cote max publiable (sécurité contre les events ultra-rares qui
+ *  exploseraient un gain unique). */
+export const MAX_DECIMAL_ODDS = 99.0;
+
+/**
+ * Convertit une probabilité en cote décimale en appliquant la marge
+ * maison. Clamp dans [MIN_DECIMAL_ODDS, MAX_DECIMAL_ODDS].
+ *
+ * Logique : si p est la proba "vraie", la cote équitable est 1/p.
+ * On ajoute la marge en réduisant la proba implicite : la cote
+ * publiée est `(1 / p) / (1 + margin)`.
+ */
+export function probabilityToDecimalOdds(
+  probability: number,
+  houseMargin: number = DEFAULT_HOUSE_MARGIN,
+): number {
+  if (!Number.isFinite(probability) || !Number.isFinite(houseMargin)) {
+    throw new Error("probabilityToDecimalOdds: invalid inputs");
+  }
+  if (houseMargin < 0) {
+    throw new Error("probabilityToDecimalOdds: houseMargin must be ≥ 0");
+  }
+  if (probability <= 0) return MAX_DECIMAL_ODDS;
+  if (probability >= 1) return MIN_DECIMAL_ODDS;
+  const fairOdds = 1 / probability;
+  const odds = fairOdds / (1 + houseMargin);
+  if (odds < MIN_DECIMAL_ODDS) return MIN_DECIMAL_ODDS;
+  if (odds > MAX_DECIMAL_ODDS) return MAX_DECIMAL_ODDS;
+  // Round to 2 decimal places — convention bookmaker.
+  return Math.round(odds * 100) / 100;
+}
+
+/**
+ * Inverse de `probabilityToDecimalOdds` (pour les tests + l'audit) :
+ * récupère la proba implicite affichée par une cote décimale.
+ */
+export function impliedProbability(odds: number): number {
+  if (!Number.isFinite(odds) || odds < MIN_DECIMAL_ODDS) {
+    throw new Error("impliedProbability: invalid odds");
+  }
+  return 1 / odds;
+}
+
+/**
+ * Distribue uniformément la probabilité d'occurrences sur 3 sélections
+ * (1X2). Renvoie un objet avec `home` / `draw` / `away` chacun ∈ [0, 1].
+ *
+ * Si l'échantillon est vide, retourne 1/3 partout (cote équitable
+ * neutre).
+ */
+export function computeOneXTwoProbabilities(samples: {
+  home: number;
+  draws: number;
+  away: number;
+}): { home: number; draw: number; away: number } {
+  const total = samples.home + samples.draws + samples.away;
+  if (total <= 0) {
+    return { home: 1 / 3, draw: 1 / 3, away: 1 / 3 };
+  }
+  return {
+    home: samples.home / total,
+    draw: samples.draws / total,
+    away: samples.away / total,
+  };
+}
+
+/**
+ * Calcule la proba que la valeur observée soit strictement >
+ * `line`. Pour un line entier (ex 2.5), c'est strictement supérieur :
+ * `over = #{x > line} / N`. `under` est le complément.
+ *
+ * On utilise un line "fractionnaire" (.5) pour éviter les égalités —
+ * convention bookmaker.
+ */
+export function computeOverUnderProbabilities(
+  values: readonly number[],
+  line: number,
+): { over: number; under: number } {
+  if (values.length === 0) return { over: 0.5, under: 0.5 };
+  let over = 0;
+  for (const v of values) {
+    if (v > line) over += 1;
+  }
+  const overP = over / values.length;
+  return { over: overP, under: 1 - overP };
+}
+
+/**
+ * Compte la fraction de matchs où au moins un event Nuffle a été
+ * émis. Renvoie {yes, no} probabilities.
+ */
+export function computeNuffleOccursProbabilities(
+  values: readonly number[],
+): { yes: number; no: number } {
+  if (values.length === 0) return { yes: 0.5, no: 0.5 };
+  let yes = 0;
+  for (const v of values) {
+    if (v >= 1) yes += 1;
+  }
+  const yesP = yes / values.length;
+  return { yes: yesP, no: 1 - yesP };
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.3** — Calcul cotes dynamiques.

Pré-simule N=200 matchs entre les 2 équipes d'un `ProLeagueMatch` via le sim-engine, agrège les outcomes par market, applique la marge maison (5%) et upsert les `ProBetMarket`.

### `pro-bet-odds-math.ts` — helpers purs

| API | Rôle |
|---|---|
| `probabilityToDecimalOdds(p, margin)` | `(1/p)/(1+margin)`, clamp `[1.05, 99.0]`, round 2dp |
| `impliedProbability(odds)` | Inverse pour audit |
| `computeOneXTwoProbabilities(samples)` | `home/draw/away` depuis compteurs |
| `computeOverUnderProbabilities(values, line)` | Strict > line (convention .5) |
| `computeNuffleOccursProbabilities(values)` | ≥1 event = yes |

Tous fallback à neutre (1/3, 50/50) sur échantillon vide.

### `pro-bet-odds-calculator.ts` — service

| API | Rôle |
|---|---|
| `computeMarketsForMatch(matchId, options)` | Calcule 4 markets sans persister |
| `createOrRefreshMarketsForMatch(matchId)` | Upsert avec `closesAt = match.scheduledAt`, skip settled |

**4 markets calculés :**
- `ONE_X_TWO` : `{homeOdds, drawOdds, awayOdds}`
- `OVER_UNDER_TD` : `{line: 2.5 default, overOdds, underOdds}`
- `CAS_COUNT` : `{line: 0.5 default, overOdds, underOdds}`
- `NUFFLE_OCCURS` : `{yesOdds, noOdds}`

**Seeds déterministes** : `hashSeed("odds:" + matchId) + i` → reproducibilité.

**404 typé** `ProMatchNotReadyForOddsError` (slug introuvable / status `completed`/`failed`).

**Audit-safe** : skip les markets déjà `settled` pour ne pas réécrire l'historique.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-bet-odds` → **30/30 ✓**

Couverture :
| Module | Tests |
|---|---|
| Math helpers | 21 (margin, clamp, fallback, inverse) |
| Service calculator | 9 (404, 4 markets, options, upsert, settled skip) |

## Suite (lot 1.D)

- **1.D.4** : endpoints paris (`GET /markets`, `POST /bets`, `GET /me/bets`)
- **1.D.5** : settlement automatique post-match
- **1.D.6** : daily login bonus
- **1.D.7** : UI paris
- **1.D.8** : leaderboards parieurs
- **1.D.9** : badges/titres


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_