### PR TITLE
feat(server): Pro League bet settlement + cron (sprint 1.D.5)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -636,3 +636,42 @@ if (!inTestSimRunnerEnv && simRunnerTickMs > 0) {
     },
   );
 }
+
+
+// =============================================================================
+// Pro League bet-settlement cron (sprint 1.D.5).
+// =============================================================================
+// Sweep les matchs completed dont les markets restent open/closed (jamais
+// settled) et evalue les bets : credit gagnants WIN, marque market settled.
+// Idempotent (skip si ProBetSettlement existe deja).
+//
+// Tick par defaut : 5 min. Configurable via PRO_LEAGUE_BET_SETTLE_TICK_MS.
+// Mettre = 0 pour desactiver (CI / dev local).
+const inTestBetSettleEnv =
+  process.env.NODE_ENV === "test" || process.env.TEST_SQLITE === "1";
+const betSettleTickMsEnv = Number(process.env.PRO_LEAGUE_BET_SETTLE_TICK_MS);
+const betSettleTickMs = Number.isFinite(betSettleTickMsEnv)
+  ? betSettleTickMsEnv
+  : 5 * 60 * 1000;
+if (!inTestBetSettleEnv && betSettleTickMs > 0) {
+  void import("./services/pro-bet-settlement").then(
+    ({ sweepUnsettledMarkets }) => {
+      const tick = async () => {
+        try {
+          const out = await sweepUnsettledMarkets();
+          if (out.settled > 0 || out.failed > 0) {
+            serverLog.info(
+              `[pro-bet-settle] sweep: settled=${out.settled} failed=${out.failed} (inspected=${out.matchesInspected})`,
+            );
+          }
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : "unknown";
+          serverLog.error(`[pro-bet-settle] sweep failed: ${msg}`);
+        }
+      };
+      setInterval(() => {
+        void tick();
+      }, betSettleTickMs).unref();
+    },
+  );
+}

--- a/apps/server/src/services/pro-bet-settlement.test.ts
+++ b/apps/server/src/services/pro-bet-settlement.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn() },
+    proBetMarket: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    proBet: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    proBetSettlement: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("./pro-wallet", () => ({
+  credit: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { credit } from "./pro-wallet";
+import {
+  SettlementError,
+  settleMarketsForMatch,
+  sweepUnsettledMarkets,
+} from "./pro-bet-settlement";
+
+interface MockedPrisma {
+  proLeagueMatch: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  proBetMarket: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  proBet: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  proBetSettlement: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+const mockedCredit = vi.mocked(credit);
+
+const MATCH_ID = "m_1";
+
+function buildCompletedMatch(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MATCH_ID,
+    status: "completed",
+    outcome: "home",
+    touchdownCount: 4,
+    casualtyCount: 2,
+    nuffleCount: 3,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proBetMarket.update.mockResolvedValue({});
+  mocked.proBet.update.mockResolvedValue({});
+  mocked.proBetSettlement.findUnique.mockResolvedValue(null);
+  mocked.proBetSettlement.create.mockResolvedValue({});
+});
+
+describe("settleMarketsForMatch — sprint 1.D.5", () => {
+  it("MATCH_NOT_FOUND si match inconnu", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    try {
+      await settleMarketsForMatch(MATCH_ID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SettlementError);
+      expect((err as SettlementError).code).toBe("MATCH_NOT_FOUND");
+    }
+  });
+
+  it("MATCH_NOT_COMPLETED si match status != completed", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ status: "scheduled" }),
+    );
+    try {
+      await settleMarketsForMatch(MATCH_ID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as SettlementError).code).toBe("MATCH_NOT_COMPLETED");
+    }
+  });
+
+  it("ne touche à rien si aucun market non-settled", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(buildCompletedMatch());
+    mocked.proBetMarket.findMany.mockResolvedValue([]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.settled).toBe(0);
+    expect(out.skipped).toBe(0);
+    expect(out.summaries).toEqual([]);
+    expect(mockedCredit).not.toHaveBeenCalled();
+  });
+
+  it("settle 1X2 : home win → bets home gagnent, draw/away perdent", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(buildCompletedMatch());
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt1",
+        type: "ONE_X_TWO",
+        config: { homeOdds: 2.0, drawOdds: 3.5, awayOdds: 4.0 },
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([
+      {
+        id: "b_home",
+        userId: "u1",
+        selection: "home",
+        stake: 100,
+        oddsAtPlace: 2.0,
+      },
+      {
+        id: "b_draw",
+        userId: "u2",
+        selection: "draw",
+        stake: 50,
+        oddsAtPlace: 3.5,
+      },
+      {
+        id: "b_away",
+        userId: "u3",
+        selection: "away",
+        stake: 200,
+        oddsAtPlace: 4.0,
+      },
+    ]);
+
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.settled).toBe(1);
+    expect(out.summaries).toHaveLength(1);
+    const s = out.summaries[0];
+    expect(s.winningSelection).toBe("home");
+    expect(s.wonCount).toBe(1);
+    expect(s.lostCount).toBe(2);
+    expect(s.totalStake).toBe(350);
+    // payout = round(100 * 2) = 200
+    expect(s.totalPayout).toBe(200);
+
+    // u1 (home) credité 200, u2/u3 non.
+    expect(mockedCredit).toHaveBeenCalledTimes(1);
+    expect(mockedCredit).toHaveBeenCalledWith("u1", 200, "WIN", "b_home");
+
+    // proBet.update : 3 fois (1 won + 2 lost)
+    expect(mocked.proBet.update).toHaveBeenCalledTimes(3);
+    // proBetSettlement créée
+    expect(mocked.proBetSettlement.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          marketId: "mkt1",
+          winningSelection: "home",
+          totalStake: 350,
+          totalPayout: 200,
+          betCount: 3,
+        }),
+      }),
+    );
+    // market passe à settled
+    expect(mocked.proBetMarket.update).toHaveBeenCalledWith({
+      where: { id: "mkt1" },
+      data: { status: "settled" },
+    });
+  });
+
+  it("OVER_UNDER_TD : line=2.5, td=4 → over gagne", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ touchdownCount: 4 }),
+    );
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt_ou",
+        type: "OVER_UNDER_TD",
+        config: { line: 2.5, overOdds: 1.7, underOdds: 2.1 },
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([
+      {
+        id: "b_o",
+        userId: "u1",
+        selection: "over",
+        stake: 100,
+        oddsAtPlace: 1.7,
+      },
+    ]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.summaries[0].winningSelection).toBe("over");
+    expect(mockedCredit).toHaveBeenCalledWith(
+      "u1",
+      170, // round(100 * 1.7)
+      "WIN",
+      "b_o",
+    );
+  });
+
+  it("CAS_COUNT : line=0.5, cas=0 → under gagne", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ casualtyCount: 0 }),
+    );
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt_cas",
+        type: "CAS_COUNT",
+        config: { line: 0.5, overOdds: 1.6, underOdds: 2.3 },
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.summaries[0].winningSelection).toBe("under");
+  });
+
+  it("NUFFLE_OCCURS : nuffle=0 → no gagne", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ nuffleCount: 0 }),
+    );
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt_nuf",
+        type: "NUFFLE_OCCURS",
+        config: { yesOdds: 1.5, noOdds: 2.4 },
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.summaries[0].winningSelection).toBe("no");
+  });
+
+  it("idempotent : skip si ProBetSettlement existe déjà", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(buildCompletedMatch());
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt1",
+        type: "ONE_X_TWO",
+        config: { homeOdds: 2, drawOdds: 3, awayOdds: 4 },
+      },
+    ]);
+    mocked.proBetSettlement.findUnique.mockResolvedValue({ id: "exist" });
+
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.settled).toBe(0);
+    expect(out.skipped).toBe(1);
+    expect(mocked.proBet.findMany).not.toHaveBeenCalled();
+    expect(mockedCredit).not.toHaveBeenCalled();
+  });
+
+  it("skip si winningSelection introuvable (counter null)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ touchdownCount: null }),
+    );
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt_ou",
+        type: "OVER_UNDER_TD",
+        config: { line: 2.5, overOdds: 1.7, underOdds: 2.1 },
+      },
+    ]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.settled).toBe(0);
+    expect(out.skipped).toBe(1);
+  });
+
+  it("parse config string sqlite mirror", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(
+      buildCompletedMatch({ touchdownCount: 1 }),
+    );
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt_ou",
+        type: "OVER_UNDER_TD",
+        config: '{"line":0.5,"overOdds":1.5,"underOdds":2.5}',
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([]);
+    const out = await settleMarketsForMatch(MATCH_ID);
+    expect(out.summaries[0].winningSelection).toBe("over"); // td=1 > 0.5
+  });
+});
+
+describe("sweepUnsettledMarkets — sprint 1.D.5", () => {
+  it("renvoie 0/0/0 si aucun candidat", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const out = await sweepUnsettledMarkets();
+    expect(out).toEqual({ matchesInspected: 0, settled: 0, failed: 0 });
+  });
+
+  it("agrège settled / failed par match", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      { id: "m1" },
+      { id: "m2" },
+    ]);
+    // m1 OK, m2 throw
+    mocked.proLeagueMatch.findUnique
+      .mockResolvedValueOnce(buildCompletedMatch({ id: "m1" }))
+      .mockResolvedValueOnce(null); // m2 introuvable → throw
+    mocked.proBetMarket.findMany.mockResolvedValue([
+      {
+        id: "mkt1",
+        type: "ONE_X_TWO",
+        config: { homeOdds: 2, drawOdds: 3, awayOdds: 4 },
+      },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([]);
+
+    const out = await sweepUnsettledMarkets();
+    expect(out.matchesInspected).toBe(2);
+    expect(out.settled).toBe(1);
+    expect(out.failed).toBe(1);
+  });
+});

--- a/apps/server/src/services/pro-bet-settlement.ts
+++ b/apps/server/src/services/pro-bet-settlement.ts
@@ -1,0 +1,324 @@
+/**
+ * Pro League bet settlement — sprint Pro League lot 1.D.5.
+ *
+ * Hook post-match qui évalue les `ProBetMarket` d'un match terminé,
+ * met à jour `ProBet.status` (won/lost/void), crédite les wallets
+ * gagnants (WIN tx) et crée la row d'audit `ProBetSettlement`.
+ *
+ * Idempotent : un market `settled` est skip ; un market avec une row
+ * `ProBetSettlement` existante est aussi skip (sécurité 2 niveaux).
+ *
+ * Pour chaque market :
+ *  1. Détermine la `winningSelection` à partir de `ProLeagueMatch`
+ *     (outcome / counters TD / casualtyCount / nuffleCount selon
+ *     le type).
+ *  2. Pour chaque `ProBet pending` :
+ *     - Si `selection === winningSelection` : status `won`,
+ *       payoutAmount = `round(stake * oddsAtPlace)`, crédit wallet.
+ *     - Sinon : status `lost`, payoutAmount = 0, pas de crédit.
+ *  3. Crée `ProBetSettlement` avec totalStake/totalPayout/betCount.
+ *  4. Marque market `status = 'settled'`.
+ *
+ * Wire-up : exposé pour appel manuel (admin) et via cron sweep
+ * `sweepUnsettledMarkets()` (lot 1.D.5 boot integration).
+ */
+
+import { prisma } from "../prisma";
+
+import { credit } from "./pro-wallet";
+
+const TYPES_WITH_OVER_UNDER = new Set(["OVER_UNDER_TD", "CAS_COUNT"]);
+
+export class SettlementError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "SettlementError";
+  }
+}
+
+export interface MarketSettlementSummary {
+  readonly marketId: string;
+  readonly winningSelection: string;
+  readonly totalStake: number;
+  readonly totalPayout: number;
+  readonly betCount: number;
+  readonly wonCount: number;
+  readonly lostCount: number;
+  readonly voidCount: number;
+}
+
+export interface SettlementResult {
+  readonly matchId: string;
+  readonly settled: number;
+  readonly skipped: number;
+  readonly summaries: readonly MarketSettlementSummary[];
+}
+
+interface MatchSnapshot {
+  readonly id: string;
+  readonly status: string;
+  readonly outcome: string | null;
+  readonly touchdownCount: number | null;
+  readonly casualtyCount: number | null;
+  readonly nuffleCount: number | null;
+}
+
+function parseConfig(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+/**
+ * Détermine la sélection gagnante d'un market à partir du snapshot
+ * du match. Renvoie `null` si la donnée n'est pas disponible (le
+ * settlement est alors skip et le market reste `closed`).
+ */
+function determineWinningSelection(
+  marketType: string,
+  match: MatchSnapshot,
+  config: Record<string, unknown>,
+): string | null {
+  switch (marketType) {
+    case "ONE_X_TWO": {
+      if (match.outcome === "home") return "home";
+      if (match.outcome === "away") return "away";
+      if (match.outcome === "draw") return "draw";
+      return null;
+    }
+    case "OVER_UNDER_TD": {
+      const td = match.touchdownCount;
+      if (td === null) return null;
+      const line = typeof config.line === "number" ? config.line : 2.5;
+      return td > line ? "over" : "under";
+    }
+    case "CAS_COUNT": {
+      const cas = match.casualtyCount;
+      if (cas === null) return null;
+      const line = typeof config.line === "number" ? config.line : 0.5;
+      return cas > line ? "over" : "under";
+    }
+    case "NUFFLE_OCCURS": {
+      const nuffle = match.nuffleCount;
+      if (nuffle === null) return null;
+      return nuffle >= 1 ? "yes" : "no";
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Évalue + settle tous les markets non-`settled` d'un match `completed`.
+ * Idempotent : skip silencieux des markets déjà settled.
+ *
+ * Lève `SettlementError` si :
+ *  - match introuvable
+ *  - match.status ≠ 'completed' (settlement pré-completion = bug)
+ */
+export async function settleMarketsForMatch(
+  matchId: string,
+): Promise<SettlementResult> {
+  const match = (await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: {
+      id: true,
+      status: true,
+      outcome: true,
+      touchdownCount: true,
+      casualtyCount: true,
+      nuffleCount: true,
+    },
+  })) as MatchSnapshot | null;
+
+  if (!match) {
+    throw new SettlementError(
+      "MATCH_NOT_FOUND",
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  if (match.status !== "completed") {
+    throw new SettlementError(
+      "MATCH_NOT_COMPLETED",
+      `Match status='${match.status}' — settlement réservé aux matchs completed`,
+    );
+  }
+
+  const markets = await prisma.proBetMarket.findMany({
+    where: {
+      matchId,
+      status: { in: ["open", "closed"] }, // skip 'settled'
+    },
+    select: {
+      id: true,
+      type: true,
+      config: true,
+    },
+  });
+
+  let settled = 0;
+  let skipped = 0;
+  const summaries: MarketSettlementSummary[] = [];
+
+  for (const market of markets) {
+    const marketId = market.id as string;
+    const marketType = market.type as string;
+    const config = parseConfig(market.config);
+
+    // Sécurité supplémentaire : si une row settlement existe déjà,
+    // skip (race condition possible si 2 cron tournent en parallèle).
+    const existingSettlement = await prisma.proBetSettlement.findUnique({
+      where: { marketId },
+      select: { id: true },
+    });
+    if (existingSettlement) {
+      skipped += 1;
+      continue;
+    }
+
+    const winningSelection = determineWinningSelection(
+      marketType,
+      match,
+      config,
+    );
+    if (winningSelection === null) {
+      skipped += 1;
+      continue;
+    }
+
+    // Charge tous les bets pending pour ce market.
+    const bets = await prisma.proBet.findMany({
+      where: { marketId, status: "pending" },
+      select: {
+        id: true,
+        userId: true,
+        selection: true,
+        stake: true,
+        oddsAtPlace: true,
+      },
+    });
+
+    let totalStake = 0;
+    let totalPayout = 0;
+    let wonCount = 0;
+    let lostCount = 0;
+    const voidCount = 0;
+
+    for (const bet of bets) {
+      const stake = bet.stake as number;
+      const oddsAtPlace = bet.oddsAtPlace as number;
+      const userId = bet.userId as string;
+      const won = (bet.selection as string) === winningSelection;
+      totalStake += stake;
+      if (won) {
+        const payoutAmount = Math.round(stake * oddsAtPlace);
+        totalPayout += payoutAmount;
+        wonCount += 1;
+        await prisma.proBet.update({
+          where: { id: bet.id as string },
+          data: {
+            status: "won",
+            payoutAmount,
+          },
+        });
+        await credit(userId, payoutAmount, "WIN", bet.id as string);
+      } else {
+        lostCount += 1;
+        await prisma.proBet.update({
+          where: { id: bet.id as string },
+          data: {
+            status: "lost",
+            payoutAmount: 0,
+          },
+        });
+      }
+    }
+
+    // Audit row + market settled.
+    await prisma.proBetSettlement.create({
+      data: {
+        marketId,
+        winningSelection,
+        totalStake,
+        totalPayout,
+        betCount: bets.length,
+      },
+    });
+    await prisma.proBetMarket.update({
+      where: { id: marketId },
+      data: { status: "settled" },
+    });
+
+    settled += 1;
+    summaries.push({
+      marketId,
+      winningSelection,
+      totalStake,
+      totalPayout,
+      betCount: bets.length,
+      wonCount,
+      lostCount,
+      voidCount,
+    });
+  }
+
+  return { matchId, settled, skipped, summaries };
+}
+
+export interface SweepResult {
+  readonly matchesInspected: number;
+  readonly settled: number;
+  readonly failed: number;
+}
+
+const SWEEP_BATCH_LIMIT = 50;
+
+/**
+ * Cron sweep : trouve les matchs `completed` qui ont des markets
+ * `open`/`closed` (= jamais settled), et les settle un par un.
+ * Erreur par match isolée.
+ */
+export async function sweepUnsettledMarkets(): Promise<SweepResult> {
+  // Un match a des markets non-settled <=> il existe au moins une
+  // row ProBetMarket avec status open/closed pour ce match.
+  const candidates = await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "completed",
+      betMarkets: {
+        some: { status: { in: ["open", "closed"] } },
+      },
+    },
+    select: { id: true },
+    orderBy: { completedAt: "asc" },
+    take: SWEEP_BATCH_LIMIT,
+  });
+
+  let settled = 0;
+  let failed = 0;
+  for (const { id } of candidates) {
+    try {
+      const out = await settleMarketsForMatch(id as string);
+      if (out.settled > 0) settled += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return {
+    matchesInspected: candidates.length,
+    settled,
+    failed,
+  };
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.5** — Settlement automatique post-match.

### Service `pro-bet-settlement.ts`

**`settleMarketsForMatch(matchId)`** — pour chaque ProBetMarket non-settled d'un match `completed` :

1. **Détermine la `winningSelection`** depuis le snapshot match :
   - `ONE_X_TWO` : match.outcome (home/away/draw)
   - `OVER_UNDER_TD` : `touchdownCount > line` ? "over" : "under"
   - `CAS_COUNT` : idem avec casualtyCount
   - `NUFFLE_OCCURS` : `nuffleCount ≥ 1` ? "yes" : "no"

2. **Pour chaque ProBet pending :**
   - Match → `status='won'`, `payoutAmount = round(stake * oddsAtPlace)`, `wallet.credit(WIN, ref=betId)`
   - Sinon → `status='lost'`, `payoutAmount=0`

3. **Crée `ProBetSettlement`** audit (winningSelection + totalStake + totalPayout + betCount).

4. **Marque market `status='settled'`**.

**`sweepUnsettledMarkets()`** : cron sweep — trouve les matchs completed avec markets non-settled, settle un par un. Erreur par match isolée. Limit 50.

**Idempotent à 2 niveaux** : skip si market.status='settled' OU si ProBetSettlement existe (race condition entre 2 cron).

### Activation cron

Branché dans `index.ts` similaire à sim-runner :
- Tick par défaut : **5 min**, configurable via `PRO_LEAGUE_BET_SETTLE_TICK_MS`
- Désactivé en mode test (`NODE_ENV=test` / `TEST_SQLITE=1`)
- Import dynamique + `.unref()`
- Logs si `settled > 0` OU `failed > 0`

### Erreurs typées

| Erreur | Code |
|---|---|
| `SettlementError` | `MATCH_NOT_FOUND` / `MATCH_NOT_COMPLETED` |

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-bet-settlement.test.ts` → **12/12 ✓**

Couverture :
| Cas | Résultat |
|---|---|
| Match introuvable | MATCH_NOT_FOUND |
| Match status≠completed | MATCH_NOT_COMPLETED |
| Empty markets | no-op |
| 1X2 home win (3 bets) | 1 won credit + 2 lost, audit OK |
| OVER_UNDER_TD line=2.5 td=4 | over gagne + payout 170 |
| CAS_COUNT line=0.5 cas=0 | under gagne |
| NUFFLE_OCCURS nuffle=0 | no gagne |
| Idempotent (settlement existe) | skip |
| Counter null | skip |
| Config sqlite string mirror | parsé |
| Sweep | agrège settled/failed |

## Suite (lot 1.D)

- **1.D.6** : daily login bonus + first-time bonus 1000 Crowns
- **1.D.7** : UI paris (BetSlip + MarketsList + MyBets)
- **1.D.8** : leaderboards parieurs
- **1.D.9** : badges/titres


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_