### PR TITLE
feat(server): Pro League wallet rewards + endpoints (sprint 1.D.6)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -35,7 +35,16 @@ import {
   listMyBets,
   placeBet,
 } from "../services/pro-bet";
-import { InsufficientFundsError } from "../services/pro-wallet";
+import {
+  InsufficientFundsError,
+  getBalance,
+  getRecentTransactions,
+} from "../services/pro-wallet";
+import {
+  claimDailyBonus,
+  getDailyBonusStatus,
+  grantFirstTimeBonus,
+} from "../services/pro-wallet-rewards";
 import {
   ProTeamFollowError,
   followProTeam,
@@ -502,6 +511,83 @@ export async function handleListMyBets(
   }
 }
 
+/**
+ * Sprint 1.D.6 — Snapshot wallet : solde + 20 dernières transactions.
+ */
+export async function handleGetMyWallet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const balance = await getBalance(userId);
+  const transactions = await getRecentTransactions(userId, 20);
+  res.json({ balance, transactions });
+}
+
+/**
+ * Sprint 1.D.6 — First-time bonus (1000 Crowns) — idempotent.
+ */
+export async function handleGrantFirstTimeBonus(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  try {
+    const out = await grantFirstTimeBonus(userId);
+    res.json(out);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/wallet/first-time] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint 1.D.6 — Daily bonus (50 Crowns / 24h glissantes).
+ */
+export async function handleClaimDailyBonus(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  try {
+    const out = await claimDailyBonus(userId);
+    res.json(out);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/wallet/daily-bonus] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint 1.D.6 — Statut daily bonus (sans rien crédit).
+ */
+export async function handleGetDailyBonusStatus(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const out = await getDailyBonusStatus(userId);
+  res.json(out);
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
@@ -522,5 +608,15 @@ router.get("/me/feed", authUser, handleGetMyFeed);
 // Sprint 1.D.4 — endpoints paris.
 router.post("/bets", authUser, handlePlaceBet);
 router.get("/me/bets", authUser, handleListMyBets);
+
+// Sprint 1.D.6 — wallet & bonuses.
+router.get("/me/wallet", authUser, handleGetMyWallet);
+router.post(
+  "/me/wallet/first-time-bonus",
+  authUser,
+  handleGrantFirstTimeBonus,
+);
+router.post("/me/wallet/daily-bonus", authUser, handleClaimDailyBonus);
+router.get("/me/wallet/daily-bonus", authUser, handleGetDailyBonusStatus);
 
 export default router;

--- a/apps/server/src/services/pro-wallet-rewards.test.ts
+++ b/apps/server/src/services/pro-wallet-rewards.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTransaction: { findFirst: vi.fn() },
+    proWallet: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("./pro-wallet", () => ({
+  credit: vi.fn(),
+  getOrCreateWallet: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { credit, getOrCreateWallet } from "./pro-wallet";
+import {
+  DAILY_BONUS_AMOUNT,
+  FIRST_TIME_BONUS_AMOUNT,
+  claimDailyBonus,
+  getDailyBonusStatus,
+  grantFirstTimeBonus,
+} from "./pro-wallet-rewards";
+
+interface MockedPrisma {
+  proTransaction: { findFirst: ReturnType<typeof vi.fn> };
+  proWallet: { findUnique: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+const mockedCredit = vi.mocked(credit);
+const mockedEnsure = vi.mocked(getOrCreateWallet);
+
+const USER = "user_1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedEnsure.mockResolvedValue({ userId: USER, crowns: 0 });
+  mocked.proWallet.findUnique.mockResolvedValue({ crowns: 0 });
+});
+
+describe("grantFirstTimeBonus — sprint 1.D.6", () => {
+  it("crédite 1000 si jamais réclamé", async () => {
+    mocked.proTransaction.findFirst.mockResolvedValue(null);
+    mockedCredit.mockResolvedValue(1000);
+
+    const out = await grantFirstTimeBonus(USER);
+    expect(out.granted).toBe(true);
+    expect(out.amount).toBe(FIRST_TIME_BONUS_AMOUNT);
+    expect(out.balance).toBe(1000);
+    expect(out.nextEligibleAt).toBeNull();
+    expect(mockedCredit).toHaveBeenCalledWith(
+      USER,
+      1000,
+      "REWARD",
+      "first_signup",
+    );
+  });
+
+  it("idempotent : ne crédit pas si déjà réclamé", async () => {
+    mocked.proTransaction.findFirst.mockResolvedValue({ id: "tx_old" });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 1500 });
+
+    const out = await grantFirstTimeBonus(USER);
+    expect(out.granted).toBe(false);
+    expect(out.amount).toBe(0);
+    expect(out.balance).toBe(1500);
+    expect(mockedCredit).not.toHaveBeenCalled();
+  });
+});
+
+describe("claimDailyBonus — sprint 1.D.6", () => {
+  it("crédite 50 si pas de DAILY antérieur", async () => {
+    mocked.proTransaction.findFirst.mockResolvedValue(null);
+    mockedCredit.mockResolvedValue(50);
+
+    const out = await claimDailyBonus(USER);
+    expect(out.granted).toBe(true);
+    expect(out.amount).toBe(DAILY_BONUS_AMOUNT);
+    expect(out.balance).toBe(50);
+    expect(out.nextEligibleAt).not.toBeNull();
+    expect(mockedCredit).toHaveBeenCalledWith(USER, 50, "DAILY");
+  });
+
+  it("rejette si dernier DAILY < 24h", async () => {
+    const now = new Date("2026-09-15T12:00:00Z");
+    const recentDaily = new Date("2026-09-15T08:00:00Z"); // 4h ago
+    mocked.proTransaction.findFirst.mockResolvedValue({
+      createdAt: recentDaily,
+    });
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 250 });
+
+    const out = await claimDailyBonus(USER, now);
+    expect(out.granted).toBe(false);
+    expect(out.amount).toBe(0);
+    expect(out.balance).toBe(250);
+    // nextEligibleAt = recentDaily + 24h
+    expect(out.nextEligibleAt).toBe("2026-09-16T08:00:00.000Z");
+    expect(mockedCredit).not.toHaveBeenCalled();
+  });
+
+  it("crédite si dernier DAILY >= 24h", async () => {
+    const now = new Date("2026-09-16T12:00:00Z");
+    const oldDaily = new Date("2026-09-15T08:00:00Z"); // 28h ago
+    mocked.proTransaction.findFirst.mockResolvedValue({
+      createdAt: oldDaily,
+    });
+    mockedCredit.mockResolvedValue(300);
+
+    const out = await claimDailyBonus(USER, now);
+    expect(out.granted).toBe(true);
+    expect(out.amount).toBe(DAILY_BONUS_AMOUNT);
+  });
+});
+
+describe("getDailyBonusStatus — sprint 1.D.6", () => {
+  it("available=true si pas de DAILY antérieur", async () => {
+    mocked.proTransaction.findFirst.mockResolvedValue(null);
+    const out = await getDailyBonusStatus(USER);
+    expect(out.available).toBe(true);
+    expect(out.nextEligibleAt).toBeNull();
+  });
+
+  it("available=true si DAILY > 24h", async () => {
+    const now = new Date("2026-09-16T12:00:00Z");
+    mocked.proTransaction.findFirst.mockResolvedValue({
+      createdAt: new Date("2026-09-15T11:00:00Z"),
+    });
+    const out = await getDailyBonusStatus(USER, now);
+    expect(out.available).toBe(true);
+  });
+
+  it("available=false + nextEligibleAt si DAILY < 24h", async () => {
+    const now = new Date("2026-09-15T12:00:00Z");
+    const recent = new Date("2026-09-15T08:00:00Z");
+    mocked.proTransaction.findFirst.mockResolvedValue({
+      createdAt: recent,
+    });
+    const out = await getDailyBonusStatus(USER, now);
+    expect(out.available).toBe(false);
+    expect(out.nextEligibleAt).toBe("2026-09-16T08:00:00.000Z");
+  });
+});

--- a/apps/server/src/services/pro-wallet-rewards.ts
+++ b/apps/server/src/services/pro-wallet-rewards.ts
@@ -1,0 +1,160 @@
+/**
+ * Pro Wallet rewards — sprint Pro League lot 1.D.6.
+ *
+ * Sources de Crowns "automatiques" :
+ *  - First-time bonus (REWARD, ref="first_signup") : 1000 Crowns
+ *    crédités une seule fois par user. Idempotence par check d'une
+ *    ProTransaction antérieure du même type+ref.
+ *  - Daily login bonus (DAILY) : 50 Crowns / 24h max. Le dernier
+ *    DAILY tx est lu pour gating ; pas de reset à minuit (window
+ *    glissante).
+ */
+
+import { prisma } from "../prisma";
+
+import { credit, getOrCreateWallet } from "./pro-wallet";
+
+export const FIRST_TIME_BONUS_AMOUNT = 1000;
+export const FIRST_TIME_BONUS_REF = "first_signup";
+
+export const DAILY_BONUS_AMOUNT = 50;
+export const DAILY_BONUS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export class RewardError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "RewardError";
+  }
+}
+
+export interface RewardOutcome {
+  /** True si le crédit a été appliqué dans cet appel. False si déjà
+   *  réclamé (idempotent). */
+  readonly granted: boolean;
+  /** Solde courant en Crowns (après éventuel crédit). */
+  readonly balance: number;
+  /** Montant du crédit appliqué (0 si déjà réclamé). */
+  readonly amount: number;
+  /** Date à partir de laquelle l'user pourra re-réclamer (DAILY only).
+   *  null pour first-time. */
+  readonly nextEligibleAt: string | null;
+}
+
+/**
+ * Crédite le first-time bonus (1000 Crowns) si l'user ne l'a jamais
+ * réclamé. Idempotent : appel répété renvoie `granted=false`.
+ */
+export async function grantFirstTimeBonus(
+  userId: string,
+): Promise<RewardOutcome> {
+  // Garantit l'existence du wallet (création silencieuse).
+  await getOrCreateWallet(userId);
+
+  // Idempotence : check ProTransaction REWARD + ref="first_signup".
+  const existing = await prisma.proTransaction.findFirst({
+    where: {
+      walletId: userId,
+      type: "REWARD",
+      ref: FIRST_TIME_BONUS_REF,
+    },
+    select: { id: true },
+  });
+  if (existing) {
+    const balance = await getCurrentBalance(userId);
+    return {
+      granted: false,
+      balance,
+      amount: 0,
+      nextEligibleAt: null,
+    };
+  }
+
+  const balance = await credit(
+    userId,
+    FIRST_TIME_BONUS_AMOUNT,
+    "REWARD",
+    FIRST_TIME_BONUS_REF,
+  );
+  return {
+    granted: true,
+    balance,
+    amount: FIRST_TIME_BONUS_AMOUNT,
+    nextEligibleAt: null,
+  };
+}
+
+/**
+ * Crédite le daily bonus (50 Crowns) si la dernière transaction
+ * DAILY date d'il y a > 24h. Renvoie `granted=false` + `nextEligibleAt`
+ * sinon (UI peut afficher un compte à rebours).
+ */
+export async function claimDailyBonus(
+  userId: string,
+  now: Date = new Date(),
+): Promise<RewardOutcome> {
+  await getOrCreateWallet(userId);
+
+  const lastDaily = await prisma.proTransaction.findFirst({
+    where: { walletId: userId, type: "DAILY" },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  });
+  if (lastDaily) {
+    const lastAt = (lastDaily.createdAt as Date).getTime();
+    const windowEnd = lastAt + DAILY_BONUS_WINDOW_MS;
+    if (now.getTime() < windowEnd) {
+      const balance = await getCurrentBalance(userId);
+      return {
+        granted: false,
+        balance,
+        amount: 0,
+        nextEligibleAt: new Date(windowEnd).toISOString(),
+      };
+    }
+  }
+
+  const balance = await credit(userId, DAILY_BONUS_AMOUNT, "DAILY");
+  return {
+    granted: true,
+    balance,
+    amount: DAILY_BONUS_AMOUNT,
+    nextEligibleAt: new Date(now.getTime() + DAILY_BONUS_WINDOW_MS).toISOString(),
+  };
+}
+
+/**
+ * Indique si l'user peut réclamer le daily bonus à `now`. Si non,
+ * renvoie le timestamp où il pourra à nouveau.
+ */
+export async function getDailyBonusStatus(
+  userId: string,
+  now: Date = new Date(),
+): Promise<{ available: boolean; nextEligibleAt: string | null }> {
+  const lastDaily = await prisma.proTransaction.findFirst({
+    where: { walletId: userId, type: "DAILY" },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  });
+  if (!lastDaily) {
+    return { available: true, nextEligibleAt: null };
+  }
+  const lastAt = (lastDaily.createdAt as Date).getTime();
+  const windowEnd = lastAt + DAILY_BONUS_WINDOW_MS;
+  if (now.getTime() >= windowEnd) {
+    return { available: true, nextEligibleAt: null };
+  }
+  return {
+    available: false,
+    nextEligibleAt: new Date(windowEnd).toISOString(),
+  };
+}
+
+async function getCurrentBalance(userId: string): Promise<number> {
+  const w = await prisma.proWallet.findUnique({
+    where: { userId },
+    select: { crowns: true },
+  });
+  return ((w?.crowns as number | undefined) ?? 0) as number;
+}


### PR DESCRIPTION
### Service `pro-wallet-rewards.ts`

- `grantFirstTimeBonus(userId)` : crédite **1000 Crowns** une seule
  fois par user. Idempotence par check d'une `ProTransaction`
  antérieure de type=REWARD + ref="first_signup".
- `claimDailyBonus(userId, now?)` : crédite **50 Crowns** si le
  dernier DAILY tx date d'il y a > 24h (window glissante, pas reset
  minuit). Renvoie `nextEligibleAt` si gating actif.
- `getDailyBonusStatus(userId, now?)` : check sans rien crédit (UI
  peut afficher un compte à rebours).

`RewardOutcome` typé : `{granted, balance, amount, nextEligibleAt}`.

### Endpoints (auth-required)

| URL | Méthode | Rôle |
|---|---|---|
| `GET /pro-league/me/wallet` | GET | Snapshot wallet : balance + 20 dernières transactions |
| `POST /pro-league/me/wallet/first-time-bonus` | POST | Réclame le bonus 1000 Crowns (idempotent) |
| `POST /pro-league/me/wallet/daily-bonus` | POST | Réclame le bonus quotidien 50 Crowns |
| `GET /pro-league/me/wallet/daily-bonus` | GET | Statut du bonus quotidien (sans crédit) |

### Tests (8/8 ✓)

- `grantFirstTimeBonus` : crédit OK 1000 + ref="first_signup",
  idempotent (granted=false si déjà réclamé).
- `claimDailyBonus` : crédit si pas de DAILY antérieur, rejet si
  < 24h + nextEligibleAt = lastDaily + 24h, OK si >= 24h.
- `getDailyBonusStatus` : available=true sans antérieur ou > 24h,
  available=false + nextEligibleAt si < 24h.

### Suite (lot 1.D)

- 1.D.7 : UI paris (BetSlip + MarketsList + MyBets + WalletWidget)
- 1.D.8 : leaderboards parieurs
- 1.D.9 : badges/titres