### PR TITLE
feat(web): Pro League betting UI (sprint 1.D.7)

### DIFF
--- a/apps/web/app/lib/use-wallet.test.ts
+++ b/apps/web/app/lib/use-wallet.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("./api-client", () => {
+  class FakeApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return { apiRequest: vi.fn(), ApiClientError: FakeApiError };
+});
+
+import { ApiClientError, apiRequest } from "./api-client";
+import { useWallet } from "./use-wallet";
+
+const mockedApi = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useWallet — sprint 1.D.7", () => {
+  it("charge balance + transactions + dailyStatus au mount", async () => {
+    mockedApi
+      .mockResolvedValueOnce({ balance: 1500, transactions: [] })
+      .mockResolvedValueOnce({ available: true, nextEligibleAt: null });
+
+    const { result } = renderHook(() => useWallet());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.balance).toBe(1500);
+    expect(result.current.dailyAvailable).toBe(true);
+    expect(result.current.authed).toBe(true);
+  });
+
+  it("authed=false sur 401", async () => {
+    const FakeError = ApiClientError as unknown as new (
+      msg: string,
+      status: number,
+    ) => Error;
+    mockedApi.mockRejectedValue(new FakeError("auth", 401));
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.authed).toBe(false);
+  });
+
+  it("claimDaily met à jour le balance + dailyAvailable", async () => {
+    mockedApi
+      .mockResolvedValueOnce({ balance: 1000, transactions: [] })
+      .mockResolvedValueOnce({ available: true, nextEligibleAt: null });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    mockedApi
+      .mockResolvedValueOnce({
+        granted: true,
+        amount: 50,
+        balance: 1050,
+        nextEligibleAt: "2026-09-16T00:00:00.000Z",
+      })
+      // Then refresh()
+      .mockResolvedValueOnce({ balance: 1050, transactions: [] })
+      .mockResolvedValueOnce({
+        available: false,
+        nextEligibleAt: "2026-09-16T00:00:00.000Z",
+      });
+
+    let outcome: { granted: boolean; amount: number } | undefined;
+    await act(async () => {
+      outcome = await result.current.claimDaily();
+    });
+
+    expect(outcome?.granted).toBe(true);
+    expect(outcome?.amount).toBe(50);
+    expect(result.current.balance).toBe(1050);
+    expect(result.current.dailyAvailable).toBe(false);
+  });
+
+  it("grantFirstTime renvoie outcome", async () => {
+    mockedApi
+      .mockResolvedValueOnce({ balance: 0, transactions: [] })
+      .mockResolvedValueOnce({ available: true, nextEligibleAt: null });
+
+    const { result } = renderHook(() => useWallet());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    mockedApi
+      .mockResolvedValueOnce({
+        granted: true,
+        amount: 1000,
+        balance: 1000,
+        nextEligibleAt: null,
+      })
+      .mockResolvedValueOnce({ balance: 1000, transactions: [] })
+      .mockResolvedValueOnce({ available: true, nextEligibleAt: null });
+
+    let outcome: { granted: boolean; amount: number } | undefined;
+    await act(async () => {
+      outcome = await result.current.grantFirstTime();
+    });
+
+    expect(outcome?.granted).toBe(true);
+    expect(outcome?.amount).toBe(1000);
+  });
+});

--- a/apps/web/app/lib/use-wallet.ts
+++ b/apps/web/app/lib/use-wallet.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { ApiClientError, apiRequest } from "./api-client";
+
+/**
+ * Hook React qui gère l'état du wallet Pro League : balance + statut
+ * du daily bonus + transactions récentes — sprint Pro League lot 1.D.7.
+ *
+ * `authed` est `false` si l'API renvoie 401 (visiteur anonyme) — l'UI
+ * peut alors masquer les composants paris ou inviter à login.
+ */
+
+export interface ProTransactionEntry {
+  readonly id: string;
+  readonly type: "BET" | "WIN" | "REWARD" | "DAILY" | "BADGE";
+  readonly amount: number;
+  readonly ref: string | null;
+  readonly createdAt: string;
+}
+
+export interface UseWalletResult {
+  readonly authed: boolean;
+  readonly loading: boolean;
+  readonly balance: number;
+  readonly transactions: readonly ProTransactionEntry[];
+  readonly dailyAvailable: boolean;
+  readonly dailyNextEligibleAt: string | null;
+  readonly error: string | null;
+  readonly refresh: () => Promise<void>;
+  readonly claimDaily: () => Promise<{ granted: boolean; amount: number }>;
+  readonly grantFirstTime: () => Promise<{ granted: boolean; amount: number }>;
+}
+
+interface WalletSnapshot {
+  readonly balance: number;
+  readonly transactions: readonly ProTransactionEntry[];
+}
+
+interface DailyStatus {
+  readonly available: boolean;
+  readonly nextEligibleAt: string | null;
+}
+
+interface BonusOutcome {
+  readonly granted: boolean;
+  readonly amount: number;
+  readonly balance: number;
+  readonly nextEligibleAt: string | null;
+}
+
+export function useWallet(): UseWalletResult {
+  const [authed, setAuthed] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [balance, setBalance] = useState(0);
+  const [transactions, setTransactions] = useState<readonly ProTransactionEntry[]>(
+    [],
+  );
+  const [dailyAvailable, setDailyAvailable] = useState(false);
+  const [dailyNextEligibleAt, setDailyNextEligibleAt] = useState<string | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [snap, daily] = await Promise.all([
+        apiRequest<WalletSnapshot>("/pro-league/me/wallet"),
+        apiRequest<DailyStatus>("/pro-league/me/wallet/daily-bonus"),
+      ]);
+      setAuthed(true);
+      setBalance(snap.balance);
+      setTransactions(snap.transactions);
+      setDailyAvailable(daily.available);
+      setDailyNextEligibleAt(daily.nextEligibleAt);
+    } catch (e: unknown) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        setAuthed(false);
+        return;
+      }
+      const msg = e instanceof Error ? e.message : "fetch error";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const claimDaily = useCallback(async (): Promise<{
+    granted: boolean;
+    amount: number;
+  }> => {
+    setError(null);
+    try {
+      const out = await apiRequest<BonusOutcome>(
+        "/pro-league/me/wallet/daily-bonus",
+        { method: "POST" },
+      );
+      setBalance(out.balance);
+      setDailyAvailable(false);
+      setDailyNextEligibleAt(out.nextEligibleAt);
+      // Refresh transactions list (cheap).
+      void refresh();
+      return { granted: out.granted, amount: out.amount };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "claim error";
+      setError(msg);
+      return { granted: false, amount: 0 };
+    }
+  }, [refresh]);
+
+  const grantFirstTime = useCallback(async (): Promise<{
+    granted: boolean;
+    amount: number;
+  }> => {
+    setError(null);
+    try {
+      const out = await apiRequest<BonusOutcome>(
+        "/pro-league/me/wallet/first-time-bonus",
+        { method: "POST" },
+      );
+      setBalance(out.balance);
+      void refresh();
+      return { granted: out.granted, amount: out.amount };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "claim error";
+      setError(msg);
+      return { granted: false, amount: 0 };
+    }
+  }, [refresh]);
+
+  return {
+    authed,
+    loading,
+    balance,
+    transactions,
+    dailyAvailable,
+    dailyNextEligibleAt,
+    error,
+    refresh,
+    claimDaily,
+    grantFirstTime,
+  };
+}

--- a/apps/web/app/pro-league/_components/BetSlip.tsx
+++ b/apps/web/app/pro-league/_components/BetSlip.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+
+import { ApiClientError, apiRequest } from "../../lib/api-client";
+import { useWallet } from "../../lib/use-wallet";
+
+/**
+ * Modale de pose de pari — sprint 1.D.7.
+ *
+ * UX :
+ * - Affiche le market + selection picked + cote courante
+ * - Input mise (stake) avec quick chips 50/100/250/500
+ * - Calcule le payout potentiel = round(stake * odds)
+ * - Bouton "Confirmer" → POST /pro-league/bets avec clientToken cuid
+ * - Errors : INVALID_STAKE / WALLET_INSUFFICIENT_FUNDS / STALE_ODDS …
+ *   affichés inline avec un message friendly
+ * - Animation success : pas de toast lib, juste un état local "won"
+ *   avec couleur emerald
+ */
+
+interface MarketSummary {
+  readonly id: string;
+  readonly matchId: string;
+  readonly type: string;
+}
+
+interface SelectionTarget {
+  readonly market: MarketSummary;
+  readonly selection: string;
+  readonly label: string;
+  readonly odds: number;
+}
+
+interface BetSlipProps {
+  readonly target: SelectionTarget;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+const QUICK_STAKES = [50, 100, 250, 500];
+
+interface PlaceBetResponse {
+  readonly id: string;
+  readonly status: string;
+  readonly stake: number;
+  readonly oddsAtPlace: number;
+}
+
+/** Génère un cuid-like minimal (timestamp + random). Suffit pour
+ *  l'idempotence (clientToken est unique au scope user/session). */
+function makeClientToken(): string {
+  const ts = Date.now().toString(36);
+  const rnd = Math.random().toString(36).slice(2, 10);
+  return `cw${ts}${rnd}`;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  WALLET_INSUFFICIENT_FUNDS: "Solde insuffisant.",
+  INVALID_STAKE: "Mise invalide.",
+  INVALID_ODDS: "Cote invalide.",
+  STALE_ODDS: "La cote a changé. Rafraîchis et réessaie.",
+  MARKET_CLOSED: "Le market est fermé.",
+  INVALID_SELECTION: "Sélection invalide.",
+  MARKET_NOT_FOUND: "Market introuvable.",
+};
+
+export function BetSlip({
+  target,
+  onClose,
+  onSuccess,
+}: BetSlipProps): JSX.Element {
+  const wallet = useWallet();
+  const dialogId = useId();
+  const [stake, setStake] = useState(50);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmation, setConfirmation] = useState<{
+    id: string;
+    payout: number;
+  } | null>(null);
+
+  // Re-générer un clientToken à chaque ouverture (target change).
+  const [clientToken, setClientToken] = useState(() => makeClientToken());
+  useEffect(() => {
+    setClientToken(makeClientToken());
+    setStake(50);
+    setError(null);
+    setConfirmation(null);
+  }, [target.market.id, target.selection]);
+
+  const potentialPayout = useMemo(() => {
+    return Math.round(stake * target.odds);
+  }, [stake, target.odds]);
+
+  const submit = async (): Promise<void> => {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const out = await apiRequest<PlaceBetResponse>("/pro-league/bets", {
+        method: "POST",
+        body: JSON.stringify({
+          marketId: target.market.id,
+          selection: target.selection,
+          stake,
+          oddsAtPlace: target.odds,
+          clientToken,
+        }),
+      });
+      setConfirmation({
+        id: out.id,
+        payout: Math.round(out.stake * out.oddsAtPlace),
+      });
+      // Actualise wallet en arrière-plan.
+      void wallet.refresh();
+    } catch (e: unknown) {
+      const code =
+        e instanceof ApiClientError && typeof e.message === "string"
+          ? extractCode(e.message)
+          : null;
+      const friendly =
+        (code && ERROR_MESSAGES[code]) ||
+        (e instanceof Error ? e.message : "Erreur inconnue");
+      setError(friendly);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby={`${dialogId}-title`}
+      aria-modal="true"
+      data-testid="bet-slip"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 p-3 sm:items-center"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border border-slate-700 bg-slate-900 p-4 text-slate-100 shadow-xl">
+        <header className="mb-3 flex items-center justify-between">
+          <h3 id={`${dialogId}-title`} className="text-lg font-bold">
+            Placer un pari
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Fermer"
+            className="rounded p-1 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          >
+            ✕
+          </button>
+        </header>
+
+        {confirmation ? (
+          <div
+            data-testid="bet-confirmation"
+            className="rounded border border-emerald-700 bg-emerald-950 px-3 py-3"
+          >
+            <p className="text-sm text-emerald-100">
+              ✓ Pari placé avec succès
+            </p>
+            <p className="mt-2 font-mono text-emerald-200">
+              Mise {stake} → gain potentiel{" "}
+              <span className="font-bold">{confirmation.payout}</span> Crowns
+            </p>
+            <div className="mt-3 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onSuccess}
+                className="rounded bg-emerald-700 px-3 py-1.5 text-sm font-semibold hover:bg-emerald-600"
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="mb-3 rounded border border-slate-800 bg-slate-950 px-3 py-2">
+              <p className="text-xs uppercase text-slate-500">
+                Sélection
+              </p>
+              <p className="text-sm font-medium text-slate-100">
+                {target.label}
+              </p>
+              <p className="mt-1 text-xs uppercase text-slate-500">Cote</p>
+              <p className="font-mono text-lg font-bold text-emerald-300">
+                {target.odds.toFixed(2)}
+              </p>
+            </div>
+
+            <label
+              htmlFor={`${dialogId}-stake`}
+              className="text-xs uppercase text-slate-400"
+            >
+              Mise (Crowns)
+            </label>
+            <div className="mb-2 flex items-center gap-2">
+              <input
+                id={`${dialogId}-stake`}
+                data-testid="stake-input"
+                type="number"
+                min={1}
+                max={100_000}
+                value={stake}
+                onChange={(e) => {
+                  const n = Number.parseInt(e.target.value, 10);
+                  setStake(Number.isNaN(n) ? 0 : n);
+                }}
+                className="flex-1 rounded border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-base text-slate-100 focus:border-emerald-500 focus:outline-none"
+              />
+            </div>
+            <div className="mb-3 flex flex-wrap gap-2">
+              {QUICK_STAKES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setStake(s)}
+                  className="rounded border border-slate-700 bg-slate-800 px-3 py-1 text-xs hover:bg-slate-700"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+
+            <div className="mb-3 flex items-center justify-between rounded bg-slate-950 px-3 py-2">
+              <span className="text-xs uppercase text-slate-500">
+                Gain potentiel
+              </span>
+              <span className="font-mono text-lg font-bold text-emerald-300">
+                {potentialPayout}
+              </span>
+            </div>
+
+            {wallet.authed ? (
+              <p className="mb-3 text-xs text-slate-500">
+                Solde dispo :{" "}
+                <span className="font-mono">{wallet.balance}</span> Crowns
+              </p>
+            ) : null}
+
+            {error ? (
+              <p
+                role="alert"
+                className="mb-3 rounded border border-rose-700 bg-rose-950 px-2 py-1 text-sm text-rose-200"
+              >
+                {error}
+              </p>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded border border-slate-700 px-3 py-1.5 text-sm hover:bg-slate-800"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                data-testid="confirm-bet"
+                onClick={() => {
+                  void submit();
+                }}
+                disabled={pending || stake < 1}
+                className="rounded bg-emerald-700 px-3 py-1.5 text-sm font-semibold hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {pending ? "..." : "Confirmer"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Extrait le code d'erreur backend depuis un message ApiClientError.
+ *  Le serveur renvoie `{error, code}` ; la classe ApiClientError ne
+ *  conserve que `message` = error. On re-fetch le code via une heuristique
+ *  basée sur des keywords du message. */
+function extractCode(message: string): string | null {
+  if (message.includes("Solde insuffisant")) return "WALLET_INSUFFICIENT_FUNDS";
+  if (message.includes("stake") && message.includes("entier"))
+    return "INVALID_STAKE";
+  if (message.includes("Cote a changé")) return "STALE_ODDS";
+  if (message.toLowerCase().includes("market") && message.includes("statut"))
+    return "MARKET_CLOSED";
+  if (message.includes("Market clos")) return "MARKET_CLOSED";
+  if (message.includes("introuvable")) return "MARKET_NOT_FOUND";
+  return null;
+}

--- a/apps/web/app/pro-league/_components/MarketsList.tsx
+++ b/apps/web/app/pro-league/_components/MarketsList.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { ApiClientError, apiRequest } from "../../lib/api-client";
+
+import { BetSlip } from "./BetSlip";
+
+/**
+ * Liste les markets `open` d'un match Pro League — sprint 1.D.7.
+ *
+ * Affiche un bloc par market type avec les selections cliquables.
+ * Au clic sur une selection : ouvre le `<BetSlip/>` modale pour
+ * saisir la mise, puis confirme via `POST /pro-league/bets`.
+ *
+ * Si l'user n'est pas authentifié, masque la section et invite à
+ * login (les markets sont chargés publiquement, juste les CTAs sont
+ * gated).
+ */
+
+interface MarketSummary {
+  readonly id: string;
+  readonly matchId: string;
+  readonly type: string;
+  readonly config: Record<string, unknown>;
+  readonly status: string;
+  readonly closesAt: string;
+}
+
+interface MarketsListProps {
+  readonly matchId: string;
+  /** Si false, masque les CTAs (visiteur anonyme). */
+  readonly authed: boolean;
+}
+
+interface SelectionTarget {
+  readonly market: MarketSummary;
+  readonly selection: string;
+  readonly label: string;
+  readonly odds: number;
+}
+
+const MARKET_LABELS: Record<string, string> = {
+  ONE_X_TWO: "Vainqueur",
+  OVER_UNDER_TD: "Total touchdowns",
+  CAS_COUNT: "Nombre de blessés",
+  NUFFLE_OCCURS: "Event Nuffle",
+};
+
+function readNumber(o: Record<string, unknown>, key: string): number | null {
+  const v = o[key];
+  return typeof v === "number" ? v : null;
+}
+
+function selectionsForMarket(market: MarketSummary): SelectionTarget[] {
+  const cfg = market.config;
+  switch (market.type) {
+    case "ONE_X_TWO": {
+      const home = readNumber(cfg, "homeOdds");
+      const draw = readNumber(cfg, "drawOdds");
+      const away = readNumber(cfg, "awayOdds");
+      const out: SelectionTarget[] = [];
+      if (home !== null)
+        out.push({
+          market,
+          selection: "home",
+          label: "Domicile",
+          odds: home,
+        });
+      if (draw !== null)
+        out.push({ market, selection: "draw", label: "Nul", odds: draw });
+      if (away !== null)
+        out.push({
+          market,
+          selection: "away",
+          label: "Extérieur",
+          odds: away,
+        });
+      return out;
+    }
+    case "OVER_UNDER_TD":
+    case "CAS_COUNT": {
+      const line = typeof cfg.line === "number" ? cfg.line : 0;
+      const over = readNumber(cfg, "overOdds");
+      const under = readNumber(cfg, "underOdds");
+      const out: SelectionTarget[] = [];
+      if (over !== null)
+        out.push({
+          market,
+          selection: "over",
+          label: `Plus de ${line}`,
+          odds: over,
+        });
+      if (under !== null)
+        out.push({
+          market,
+          selection: "under",
+          label: `Moins de ${line}`,
+          odds: under,
+        });
+      return out;
+    }
+    case "NUFFLE_OCCURS": {
+      const yes = readNumber(cfg, "yesOdds");
+      const no = readNumber(cfg, "noOdds");
+      const out: SelectionTarget[] = [];
+      if (yes !== null)
+        out.push({ market, selection: "yes", label: "Oui", odds: yes });
+      if (no !== null)
+        out.push({ market, selection: "no", label: "Non", odds: no });
+      return out;
+    }
+    default:
+      return [];
+  }
+}
+
+export function MarketsList({
+  matchId,
+  authed,
+}: MarketsListProps): JSX.Element {
+  const [markets, setMarkets] = useState<readonly MarketSummary[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pickedTarget, setPickedTarget] = useState<SelectionTarget | null>(
+    null,
+  );
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<{ markets: readonly MarketSummary[] }>(
+      `/pro-league/matches/${encodeURIComponent(matchId)}/markets`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setMarkets(d.markets);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiClientError && e.status === 401) {
+          // markets endpoint est public, mais on tolère le cas
+          setMarkets([]);
+          return;
+        }
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [matchId, refreshTick]);
+
+  const grouped = useMemo(() => {
+    if (!markets) return [];
+    return markets.map((m) => ({
+      market: m,
+      selections: selectionsForMarket(m),
+    }));
+  }, [markets]);
+
+  if (loading) {
+    return (
+      <p className="text-sm text-slate-400" data-testid="markets-loading">
+        Chargement des paris…
+      </p>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+      >
+        {error}
+      </p>
+    );
+  }
+  if (!markets || markets.length === 0) {
+    return (
+      <p className="text-sm text-slate-500" data-testid="markets-empty">
+        Aucun pari disponible pour ce match.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div data-testid="markets-list" className="flex flex-col gap-3">
+        {grouped.map(({ market, selections }) => (
+          <section
+            key={market.id}
+            className="rounded border border-slate-800 bg-slate-900 px-3 py-2"
+          >
+            <h3 className="mb-2 text-sm font-semibold text-slate-100">
+              {MARKET_LABELS[market.type] ?? market.type}
+            </h3>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {selections.map((s) => (
+                <button
+                  key={`${market.id}-${s.selection}`}
+                  type="button"
+                  onClick={() => setPickedTarget(s)}
+                  disabled={!authed}
+                  data-testid={`bet-button-${market.type}-${s.selection}`}
+                  className="flex flex-col items-center justify-center gap-1 rounded border border-slate-700 bg-slate-800 px-2 py-2 text-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <span className="text-slate-200">{s.label}</span>
+                  <span className="font-mono text-base font-bold text-emerald-300">
+                    {s.odds.toFixed(2)}
+                  </span>
+                </button>
+              ))}
+            </div>
+            {!authed ? (
+              <p className="mt-2 text-xs text-slate-500">
+                Connecte-toi pour parier.
+              </p>
+            ) : null}
+          </section>
+        ))}
+      </div>
+
+      {pickedTarget ? (
+        <BetSlip
+          target={pickedTarget}
+          onClose={() => setPickedTarget(null)}
+          onSuccess={() => {
+            setPickedTarget(null);
+            setRefreshTick((n) => n + 1);
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/app/pro-league/_components/WalletBadge.tsx
+++ b/apps/web/app/pro-league/_components/WalletBadge.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { useWallet } from "../../lib/use-wallet";
+
+/**
+ * Pastille wallet affichée sur la page hub / autres pages Pro League
+ * — sprint 1.D.7. Affiche :
+ *  - le solde courant en Crowns
+ *  - un bouton "Bonus quotidien" si dispo
+ *  - un toast inline après claim ("+50 ✓")
+ *
+ * Masquée si `wallet.authed === false`.
+ */
+
+export function WalletBadge(): JSX.Element | null {
+  const wallet = useWallet();
+  const [toast, setToast] = useState<string | null>(null);
+
+  if (!wallet.authed && !wallet.loading) return null;
+
+  const handleClaim = async (): Promise<void> => {
+    const out = await wallet.claimDaily();
+    if (out.granted) {
+      setToast(`+${out.amount} Crowns`);
+      window.setTimeout(() => setToast(null), 2_500);
+    }
+  };
+
+  return (
+    <div
+      data-testid="wallet-badge"
+      className="flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs"
+    >
+      <Link
+        href="/pro-league/me/bets"
+        className="flex items-center gap-1 text-slate-300 hover:text-slate-100"
+      >
+        <span aria-hidden>👑</span>
+        <span className="font-mono font-bold text-emerald-300">
+          {wallet.loading ? "…" : wallet.balance}
+        </span>
+        <span className="text-slate-500">Crowns</span>
+      </Link>
+      {wallet.dailyAvailable ? (
+        <button
+          type="button"
+          data-testid="claim-daily"
+          onClick={() => {
+            void handleClaim();
+          }}
+          className="rounded bg-emerald-700 px-2 py-0.5 text-xs font-semibold text-emerald-50 hover:bg-emerald-600"
+        >
+          +50 Daily
+        </button>
+      ) : null}
+      {toast ? (
+        <span
+          role="status"
+          data-testid="claim-toast"
+          className="rounded bg-emerald-800 px-2 py-0.5 text-emerald-100"
+        >
+          {toast}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/pro-league/matches/[id]/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/page.tsx
@@ -4,6 +4,10 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiRequest } from "../../../lib/api-client";
+import { useWallet } from "../../../lib/use-wallet";
+
+import { MarketsList } from "../../_components/MarketsList";
+import { WalletBadge } from "../../_components/WalletBadge";
 
 /**
  * Page détail d'un match Pro League — sprint Pro League lot 1.C.3.
@@ -297,6 +301,11 @@ interface MatchDetailPageProps {
   readonly params: { id: string };
 }
 
+function MatchMarkets({ matchId }: { matchId: string }): JSX.Element {
+  const wallet = useWallet();
+  return <MarketsList matchId={matchId} authed={wallet.authed} />;
+}
+
 export default function ProLeagueMatchDetailPage({
   params,
 }: MatchDetailPageProps): JSX.Element {
@@ -352,7 +361,15 @@ export default function ProLeagueMatchDetailPage({
           <ScoreboardBanner match={data} />
           <div className="px-4 py-6">
             {data.status === "scheduled" || data.status === "ready" ? (
-              <PreMatchCard match={data} now={now} />
+              <>
+                <PreMatchCard match={data} now={now} />
+                <section data-testid="markets-section" className="mt-4">
+                  <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                    Paris
+                  </h2>
+                  <MatchMarkets matchId={data.id} />
+                </section>
+              </>
             ) : data.status === "in_progress" ? (
               <section
                 data-testid="live-card"

--- a/apps/web/app/pro-league/me/bets/page.tsx
+++ b/apps/web/app/pro-league/me/bets/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { ApiClientError, apiRequest } from "../../../lib/api-client";
+import { useWallet } from "../../../lib/use-wallet";
+
+import { WalletBadge } from "../../_components/WalletBadge";
+
+/**
+ * Historique des paris utilisateur — sprint 1.D.7.
+ *
+ * Affiche les paris passés (status pending/won/lost) avec :
+ *  - Match + selection + cote figée
+ *  - Mise + payout (si gagné)
+ *  - Badge couleur selon status
+ *  - Lien vers la page match
+ */
+
+interface BetRow {
+  readonly id: string;
+  readonly userId: string;
+  readonly marketId: string;
+  readonly marketType: string;
+  readonly matchId: string;
+  readonly selection: string;
+  readonly stake: number;
+  readonly oddsAtPlace: number;
+  readonly status: string;
+  readonly payoutAmount: number | null;
+  readonly clientToken: string;
+  readonly createdAt: string;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: "bg-slate-700 text-slate-100",
+  won: "bg-emerald-700 text-emerald-50",
+  lost: "bg-rose-700 text-rose-50",
+  void: "bg-amber-700 text-amber-50",
+};
+
+const SELECTION_LABEL: Record<string, Record<string, string>> = {
+  ONE_X_TWO: { home: "Domicile", draw: "Nul", away: "Extérieur" },
+  OVER_UNDER_TD: { over: "Plus", under: "Moins" },
+  CAS_COUNT: { over: "Plus", under: "Moins" },
+  NUFFLE_OCCURS: { yes: "Oui", no: "Non" },
+};
+
+function selectionLabel(marketType: string, selection: string): string {
+  return SELECTION_LABEL[marketType]?.[selection] ?? selection;
+}
+
+const MARKET_LABEL: Record<string, string> = {
+  ONE_X_TWO: "Vainqueur",
+  OVER_UNDER_TD: "Total TD",
+  CAS_COUNT: "Blessés",
+  NUFFLE_OCCURS: "Nuffle",
+};
+
+export default function MyBetsPage(): JSX.Element {
+  const wallet = useWallet();
+  const [bets, setBets] = useState<readonly BetRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [needsAuth, setNeedsAuth] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setNeedsAuth(false);
+    apiRequest<{ bets: readonly BetRow[] }>("/pro-league/me/bets?limit=50")
+      .then((d) => {
+        if (cancelled) return;
+        setBets(d.bets);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiClientError && e.status === 401) {
+          setNeedsAuth(true);
+          return;
+        }
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+          Mes paris
+        </h1>
+        <div className="flex items-center gap-2">
+          <WalletBadge />
+          <Link
+            href="/pro-league"
+            className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            ← Hub
+          </Link>
+        </div>
+      </header>
+
+      {wallet.authed ? (
+        <section className="mb-6 rounded border border-slate-800 bg-slate-900 px-4 py-3">
+          <p className="text-xs uppercase text-slate-500">Solde</p>
+          <p className="font-mono text-2xl font-bold text-emerald-300">
+            {wallet.balance} <span className="text-sm text-slate-400">Crowns</span>
+          </p>
+        </section>
+      ) : null}
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : needsAuth ? (
+        <p
+          data-testid="auth-required"
+          className="rounded border border-amber-700 bg-amber-950 px-3 py-2 text-sm text-amber-200"
+        >
+          Connecte-toi pour voir ton historique de paris.
+        </p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : bets.length === 0 ? (
+        <p
+          data-testid="empty-bets"
+          className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
+        >
+          Aucun pari placé. Choisis un match et tente ta chance !
+        </p>
+      ) : (
+        <ol data-testid="bets-list" className="flex flex-col gap-2">
+          {bets.map((b) => (
+            <li
+              key={b.id}
+              className="flex items-center justify-between gap-3 rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm"
+            >
+              <div className="flex flex-col">
+                <Link
+                  href={`/pro-league/matches/${b.matchId}`}
+                  className="text-slate-100 hover:text-emerald-300"
+                >
+                  {MARKET_LABEL[b.marketType] ?? b.marketType} ·{" "}
+                  {selectionLabel(b.marketType, b.selection)}
+                </Link>
+                <span className="text-xs text-slate-500">
+                  Cote {b.oddsAtPlace.toFixed(2)} · Mise {b.stake} ·{" "}
+                  {new Date(b.createdAt).toLocaleString("fr-FR", {
+                    day: "2-digit",
+                    month: "short",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </span>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-mono uppercase ${STATUS_BADGE[b.status] ?? STATUS_BADGE.pending}`}
+                >
+                  {b.status}
+                </span>
+                {b.status === "won" && b.payoutAmount !== null ? (
+                  <span className="font-mono text-sm font-bold text-emerald-300">
+                    +{b.payoutAmount}
+                  </span>
+                ) : null}
+                {b.status === "lost" ? (
+                  <span className="font-mono text-sm text-rose-300">
+                    -{b.stake}
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/pro-league/page.tsx
+++ b/apps/web/app/pro-league/page.tsx
@@ -5,6 +5,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import { apiRequest } from "../lib/api-client";
 
+import { WalletBadge } from "./_components/WalletBadge";
+
 /**
  * Page d'accueil Pro League — sprint Pro League lot 1.C.1.
  *
@@ -247,9 +249,12 @@ export default function ProLeagueHubPage(): JSX.Element {
   return (
     <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
       <header data-testid="hub-header" className="mb-6">
-        <h1 className="text-2xl font-bold tracking-wide text-slate-50">
-          {data?.league.name ?? "Pro League"}
-        </h1>
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+            {data?.league.name ?? "Pro League"}
+          </h1>
+          <WalletBadge />
+        </div>
         {motto ? (
           <p className="mt-1 text-sm italic text-slate-400">"{motto}"</p>
         ) : null}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.7** — UI complète pour le système de paris.

### Hook `useWallet` (`lib/use-wallet.ts`)

- Charge balance + transactions + dailyStatus au mount
- `authed=false` si 401 (masque les CTAs paris pour visiteurs anonymes)
- `claimDaily()` / `grantFirstTime()` : POST + refresh local
- `refresh()` exposé pour synchros post-pari

### Composants `apps/web/app/pro-league/_components/`

| Composant | Rôle |
|---|---|
| `<WalletBadge/>` | Pastille solde + bouton "+50 Daily" + toast post-claim |
| `<MarketsList matchId authed/>` | Liste markets `open` (1X2, OU TD, Cas, Nuffle), boutons cliquables avec cotes |
| `<BetSlip target onClose onSuccess/>` | Modale mobile/desktop avec input mise, chips quick 50/100/250/500, gain potentiel calculé, confirmation success |

### Intégrations

- `/pro-league` (hub) : `<WalletBadge/>` dans le header
- `/pro-league/matches/[id]` : section **Paris** avec `<MarketsList/>` en pre-match
- Nouvelle page **`/pro-league/me/bets`** : historique paris (status badge, payout coloré +vert / -rose, liens matchs)

### UX details

- **Idempotence** : clientToken cuid-like régénéré à l'ouverture du BetSlip — un retry réseau ne place pas 2 paris
- **Erreurs friendly** : mapping codes backend → messages FR (`WALLET_INSUFFICIENT_FUNDS` → "Solde insuffisant.", `STALE_ODDS` → "La cote a changé. Rafraîchis et réessaie.", etc.)
- **Mobile-first** : modale BetSlip s'ancre en bas sur mobile, centered desktop ; toast claim avec auto-dismiss 2.5s

## Test plan

- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run app/lib/use-wallet.test.ts` → **4/4 ✓**
- [x] `npx vitest run app/pro-league` → **41/41 ✓** (pas de régression)

Hook tests :
| Cas | Résultat |
|---|---|
| Charge balance + tx + dailyStatus au mount | OK |
| 401 → `authed=false` | OK |
| `claimDaily` met à jour balance + dailyAvailable | OK |
| `grantFirstTime` renvoie outcome | OK |

## Suite (lot 1.D)

- **1.D.8** : leaderboards parieurs
- **1.D.9** : badges/titres


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_