### PR TITLE
feat(server,web): Pro League bet leaderboard (sprint 1.D.8)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -36,6 +36,11 @@ import {
   placeBet,
 } from "../services/pro-bet";
 import {
+  LeaderboardError,
+  type LeaderboardPeriod,
+  getBetLeaderboard,
+} from "../services/pro-bet-leaderboard";
+import {
   InsufficientFundsError,
   getBalance,
   getRecentTransactions,
@@ -588,6 +593,37 @@ export async function handleGetDailyBonusStatus(
   res.json(out);
 }
 
+/**
+ * Sprint 1.D.8 — Leaderboard parieurs (public).
+ * Query : `?period=weekly|season|all-time&limit=N&offset=N`.
+ */
+export async function handleGetBetLeaderboard(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const period = (req.query.period ?? "season") as LeaderboardPeriod;
+  const limit =
+    typeof req.query.limit === "string"
+      ? Number.parseInt(req.query.limit, 10)
+      : 20;
+  const offset =
+    typeof req.query.offset === "string"
+      ? Number.parseInt(req.query.offset, 10)
+      : 0;
+  try {
+    const data = await getBetLeaderboard({ period, limit, offset });
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof LeaderboardError) {
+      res.status(400).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/leaderboard] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
 const router = Router();
 
 router.get("/seasons/current", handleGetCurrentSeasonHub);
@@ -596,6 +632,7 @@ router.get("/teams/:slug", handleGetTeamDetail);
 router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/markets", handleListMarkets);
 router.get("/matches/:id/stream", handleStreamProMatch);
+router.get("/leaderboard", handleGetBetLeaderboard);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 
 // Sprint 1.C.4 — endpoints auth-protected pour le mode "fan".

--- a/apps/server/src/services/pro-bet-leaderboard.test.ts
+++ b/apps/server/src/services/pro-bet-leaderboard.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: { findFirst: vi.fn() },
+    proBet: { findMany: vi.fn() },
+    user: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  LeaderboardError,
+  getBetLeaderboard,
+} from "./pro-bet-leaderboard";
+
+interface MockedPrisma {
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proBet: { findMany: ReturnType<typeof vi.fn> };
+  user: { findMany: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+});
+
+function bet(
+  userId: string,
+  status: "won" | "lost" | "pending",
+  stake: number,
+  payout: number | null,
+  createdAt: Date,
+) {
+  return {
+    id: `b_${userId}_${createdAt.getTime()}`,
+    userId,
+    stake,
+    payoutAmount: payout,
+    status,
+    createdAt,
+  };
+}
+
+describe("getBetLeaderboard — sprint 1.D.8", () => {
+  it("rejette period invalide", async () => {
+    await expect(
+      // @ts-expect-error volontaire
+      getBetLeaderboard({ period: "monthly" }),
+    ).rejects.toThrow(LeaderboardError);
+  });
+
+  it("rejette limit/offset invalides", async () => {
+    async function expectCode(p: Promise<unknown>, code: string) {
+      try {
+        await p;
+        throw new Error("expected throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(LeaderboardError);
+        expect((err as LeaderboardError).code).toBe(code);
+      }
+    }
+    await expectCode(
+      getBetLeaderboard({ period: "all-time", limit: 0 }),
+      "INVALID_LIMIT",
+    );
+    await expectCode(
+      getBetLeaderboard({ period: "all-time", limit: 1000 }),
+      "INVALID_LIMIT",
+    );
+    await expectCode(
+      getBetLeaderboard({ period: "all-time", offset: -1 }),
+      "INVALID_OFFSET",
+    );
+  });
+
+  it("renvoie [] si aucun bet", async () => {
+    mocked.proBet.findMany.mockResolvedValue([]);
+    const out = await getBetLeaderboard({ period: "all-time" });
+    expect(out.entries).toEqual([]);
+    expect(out.fromAt).toBeNull();
+  });
+
+  it("agrège profit + accuracy + streak + biggestWin", async () => {
+    const t0 = new Date("2026-09-01T10:00:00Z");
+    const t1 = new Date("2026-09-01T11:00:00Z");
+    const t2 = new Date("2026-09-01T12:00:00Z");
+    const t3 = new Date("2026-09-01T13:00:00Z");
+    mocked.proBet.findMany.mockResolvedValue([
+      // userA : won (100→250) → won (50→150) → lost 100 → won (200→500)
+      // streak max = 2 (avant le lost), biggestWin = 300 (500-200)
+      // profit = (250-100) + (150-50) - 100 + (500-200) = 150+100-100+300 = 450
+      bet("userA", "won", 100, 250, t0),
+      bet("userA", "won", 50, 150, t1),
+      bet("userA", "lost", 100, 0, t2),
+      bet("userA", "won", 200, 500, t3),
+      // userB : lost 50 + won 100→150 → profit = -50 + 50 = 0, streak 1
+      bet("userB", "lost", 50, 0, t0),
+      bet("userB", "won", 100, 150, t1),
+    ]);
+    mocked.user.findMany.mockResolvedValue([
+      { id: "userA", coachName: "Alice" },
+      { id: "userB", coachName: "Bob" },
+    ]);
+
+    const out = await getBetLeaderboard({ period: "all-time" });
+    expect(out.entries).toHaveLength(2);
+    const a = out.entries.find((e) => e.userId === "userA");
+    const b = out.entries.find((e) => e.userId === "userB");
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a!.profit).toBe(450);
+    expect(a!.wonCount).toBe(3);
+    expect(a!.settledCount).toBe(4);
+    expect(a!.accuracy).toBe(75); // 3/4 = 75%
+    expect(a!.longestStreak).toBe(2);
+    expect(a!.biggestWin).toBe(300);
+    expect(a!.coachName).toBe("Alice");
+    expect(a!.rank).toBe(1);
+
+    expect(b!.profit).toBe(0);
+    expect(b!.accuracy).toBe(50);
+    expect(b!.rank).toBe(2);
+  });
+
+  it("trie par profit desc, accuracy desc, betsCount desc", async () => {
+    mocked.proBet.findMany.mockResolvedValue([
+      bet("u1", "won", 100, 200, new Date()),  // profit +100
+      bet("u2", "won", 50, 200, new Date()),   // profit +150 ← top
+      bet("u3", "lost", 50, 0, new Date()),    // profit -50
+    ]);
+    mocked.user.findMany.mockResolvedValue([
+      { id: "u1", coachName: "U1" },
+      { id: "u2", coachName: "U2" },
+      { id: "u3", coachName: "U3" },
+    ]);
+    const out = await getBetLeaderboard({ period: "all-time" });
+    expect(out.entries[0].userId).toBe("u2");
+    expect(out.entries[1].userId).toBe("u1");
+    expect(out.entries[2].userId).toBe("u3");
+  });
+
+  it("weekly filtre les bets > 7j", async () => {
+    const now = new Date("2026-09-15T12:00:00Z");
+    mocked.proBet.findMany.mockResolvedValue([]);
+    await getBetLeaderboard({ period: "weekly", now });
+
+    const where = mocked.proBet.findMany.mock.calls[0][0].where;
+    const expectedFrom = new Date("2026-09-08T12:00:00Z");
+    expect(where.createdAt.gte).toEqual(expectedFrom);
+  });
+
+  it("season utilise startsAt de la saison in_progress", async () => {
+    const seasonStart = new Date("2026-09-01T00:00:00Z");
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      startsAt: seasonStart,
+      createdAt: new Date(),
+    });
+    mocked.proBet.findMany.mockResolvedValue([]);
+
+    const out = await getBetLeaderboard({ period: "season" });
+    expect(out.fromAt).toBe(seasonStart.toISOString());
+    const where = mocked.proBet.findMany.mock.calls[0][0].where;
+    expect(where.createdAt.gte).toEqual(seasonStart);
+  });
+
+  it("all-time : pas de filtre createdAt", async () => {
+    mocked.proBet.findMany.mockResolvedValue([]);
+    await getBetLeaderboard({ period: "all-time" });
+    const where = mocked.proBet.findMany.mock.calls[0][0].where;
+    expect(where).toEqual({});
+  });
+
+  it("paginate avec offset+limit, rang absolu", async () => {
+    const samples = [];
+    for (let i = 0; i < 5; i += 1) {
+      samples.push(
+        bet(`u${i}`, "won", 100, 100 + 50 * (5 - i), new Date()),
+      );
+    }
+    mocked.proBet.findMany.mockResolvedValue(samples);
+    mocked.user.findMany.mockResolvedValue(
+      samples.map((s) => ({ id: s.userId, coachName: s.userId.toUpperCase() })),
+    );
+
+    const out = await getBetLeaderboard({
+      period: "all-time",
+      offset: 2,
+      limit: 2,
+    });
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0].rank).toBe(3);
+    expect(out.entries[1].rank).toBe(4);
+  });
+});

--- a/apps/server/src/services/pro-bet-leaderboard.ts
+++ b/apps/server/src/services/pro-bet-leaderboard.ts
@@ -1,0 +1,294 @@
+/**
+ * Pro League bet leaderboard — sprint Pro League lot 1.D.8.
+ *
+ * Calcule un classement de parieurs sur 3 périodes :
+ *  - `weekly`   : 7 derniers jours (rolling)
+ *  - `season`   : depuis le début de la saison courante (in_progress
+ *                 ou la plus récente completed)
+ *  - `all-time` : tous les paris jamais placés
+ *
+ * Métriques par user :
+ *  - profit (Crowns) : Σ(payoutAmount - stake) sur les bets settled
+ *  - accuracy (%) : won / settled (où settled = won OR lost, void exclus)
+ *  - longestStreak : plus longue série de wins consécutifs
+ *  - biggestWin : max(payoutAmount - stake) parmi les bets won
+ *  - betsCount : nombre total de bets sur la période
+ *
+ * Implémentation : on agrège côté JS (pas Prisma raw SQL) car
+ * `longestStreak` exige un parcours ordonné. Pour des volumes de
+ * dizaines de milliers de bets ça reste sub-seconde ; au-delà il
+ * faudra matérialiser une table de stats (lot 1.F.x optimisation).
+ *
+ * Le coachName est exposé comme display name (déjà public via
+ * `/coach/:slug`).
+ */
+
+import { prisma } from "../prisma";
+
+export type LeaderboardPeriod = "weekly" | "season" | "all-time";
+
+const ALLOWED_PERIODS: ReadonlySet<LeaderboardPeriod> = new Set([
+  "weekly",
+  "season",
+  "all-time",
+]);
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+export class LeaderboardError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "LeaderboardError";
+  }
+}
+
+export interface LeaderboardEntry {
+  /** Rang 1-based dans le classement renvoyé. */
+  readonly rank: number;
+  readonly userId: string;
+  readonly coachName: string;
+  readonly betsCount: number;
+  readonly settledCount: number;
+  readonly wonCount: number;
+  /** Pourcentage 0-100, arrondi à l'entier. */
+  readonly accuracy: number;
+  readonly profit: number;
+  readonly longestStreak: number;
+  /** Plus gros gain net = max(payoutAmount - stake) sur les won. */
+  readonly biggestWin: number;
+}
+
+export interface LeaderboardResult {
+  readonly period: LeaderboardPeriod;
+  /** Date début de la fenêtre (ISO). null pour all-time. */
+  readonly fromAt: string | null;
+  readonly entries: readonly LeaderboardEntry[];
+  readonly limit: number;
+  readonly offset: number;
+}
+
+interface BetRow {
+  id: string;
+  userId: string;
+  stake: number;
+  payoutAmount: number | null;
+  status: string;
+  createdAt: Date;
+}
+
+interface UserAggregate {
+  userId: string;
+  bets: BetRow[]; // ordered by createdAt asc
+}
+
+/**
+ * Renvoie le timestamp de début de fenêtre pour la période choisie.
+ * Pour `season` : startsAt de la saison courante (in_progress > la
+ * plus récente completed). Pour `all-time` : null.
+ */
+async function resolveFromDate(
+  period: LeaderboardPeriod,
+  now: Date,
+): Promise<Date | null> {
+  if (period === "weekly") {
+    return new Date(now.getTime() - WEEK_MS);
+  }
+  if (period === "season") {
+    const inProgress = await prisma.proLeagueSeason.findFirst({
+      where: { status: "in_progress" },
+      orderBy: { year: "asc" },
+      select: { startsAt: true, createdAt: true },
+    });
+    const season =
+      inProgress ??
+      (await prisma.proLeagueSeason.findFirst({
+        orderBy: { year: "desc" },
+        select: { startsAt: true, createdAt: true },
+      }));
+    if (!season) return null;
+    return ((season.startsAt as Date | null) ??
+      (season.createdAt as Date)) as Date;
+  }
+  return null; // all-time
+}
+
+function computeStreakAndBiggestWin(bets: BetRow[]): {
+  longestStreak: number;
+  biggestWin: number;
+} {
+  let longest = 0;
+  let current = 0;
+  let biggest = 0;
+  for (const b of bets) {
+    if (b.status === "won") {
+      current += 1;
+      if (current > longest) longest = current;
+      const stake = b.stake;
+      const payout = b.payoutAmount ?? 0;
+      const net = payout - stake;
+      if (net > biggest) biggest = net;
+    } else if (b.status === "lost") {
+      current = 0;
+    }
+    // pending / void : ne reset pas le streak (le pari n'a pas
+    // d'issue tranchée encore).
+  }
+  return { longestStreak: longest, biggestWin: biggest };
+}
+
+function aggregateUser(
+  agg: UserAggregate,
+  coachName: string,
+): Omit<LeaderboardEntry, "rank"> {
+  let betsCount = 0;
+  let wonCount = 0;
+  let lostCount = 0;
+  let profit = 0;
+
+  for (const b of agg.bets) {
+    betsCount += 1;
+    if (b.status === "won") {
+      wonCount += 1;
+      const payout = b.payoutAmount ?? 0;
+      profit += payout - b.stake;
+    } else if (b.status === "lost") {
+      lostCount += 1;
+      profit -= b.stake;
+    }
+  }
+  const settledCount = wonCount + lostCount;
+  const accuracy =
+    settledCount > 0 ? Math.round((wonCount / settledCount) * 100) : 0;
+
+  const { longestStreak, biggestWin } = computeStreakAndBiggestWin(agg.bets);
+
+  return {
+    userId: agg.userId,
+    coachName,
+    betsCount,
+    settledCount,
+    wonCount,
+    accuracy,
+    profit,
+    longestStreak,
+    biggestWin,
+  };
+}
+
+export interface GetLeaderboardOptions {
+  readonly period: LeaderboardPeriod;
+  readonly limit?: number;
+  readonly offset?: number;
+  readonly now?: Date;
+}
+
+/**
+ * Calcule + renvoie le leaderboard pour la période demandée.
+ * Trié par profit desc, accuracy desc.
+ */
+export async function getBetLeaderboard(
+  options: GetLeaderboardOptions,
+): Promise<LeaderboardResult> {
+  const { period } = options;
+  if (!ALLOWED_PERIODS.has(period)) {
+    throw new LeaderboardError(
+      "INVALID_PERIOD",
+      `period invalide : '${period}' (attendu : weekly / season / all-time)`,
+    );
+  }
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  if (!Number.isInteger(limit) || limit <= 0 || limit > MAX_LIMIT) {
+    throw new LeaderboardError(
+      "INVALID_LIMIT",
+      `limit doit être ∈ [1, ${MAX_LIMIT}] (reçu: ${limit})`,
+    );
+  }
+  const offset = options.offset ?? 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new LeaderboardError(
+      "INVALID_OFFSET",
+      `offset doit être entier ≥ 0 (reçu: ${offset})`,
+    );
+  }
+  const now = options.now ?? new Date();
+  const fromAt = await resolveFromDate(period, now);
+
+  // Charge les bets de la période. On filtre `status` exclus de
+  // 'void' (placeholder futur) — pour le MVP, void n'est pas émis.
+  const bets = (await prisma.proBet.findMany({
+    where: fromAt
+      ? { createdAt: { gte: fromAt } }
+      : {},
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      stake: true,
+      payoutAmount: true,
+      status: true,
+      createdAt: true,
+    },
+  })) as BetRow[];
+
+  if (bets.length === 0) {
+    return {
+      period,
+      fromAt: fromAt ? fromAt.toISOString() : null,
+      entries: [],
+      limit,
+      offset,
+    };
+  }
+
+  // Group par user.
+  const byUser = new Map<string, BetRow[]>();
+  for (const b of bets) {
+    const arr = byUser.get(b.userId) ?? [];
+    arr.push(b);
+    byUser.set(b.userId, arr);
+  }
+
+  // Lookup coachName (1 query batch).
+  const userIds = Array.from(byUser.keys());
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const users = (await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, coachName: true },
+  })) as { id: string; coachName: string }[];
+  const coachByUser = new Map<string, string>(
+    users.map((u) => [u.id, u.coachName]),
+  );
+
+  // Aggrège.
+  const aggregates: Omit<LeaderboardEntry, "rank">[] = [];
+  for (const [userId, userBets] of byUser.entries()) {
+    const coachName = coachByUser.get(userId) ?? "Coach inconnu";
+    aggregates.push(aggregateUser({ userId, bets: userBets }, coachName));
+  }
+
+  // Trie : profit desc, accuracy desc, betsCount desc (tiebreaker).
+  aggregates.sort((a, b) => {
+    if (b.profit !== a.profit) return b.profit - a.profit;
+    if (b.accuracy !== a.accuracy) return b.accuracy - a.accuracy;
+    return b.betsCount - a.betsCount;
+  });
+
+  // Paginate avec rang absolu (1-based depuis le début du tri global).
+  const sliced = aggregates.slice(offset, offset + limit);
+  const entries: LeaderboardEntry[] = sliced.map((a, i) => ({
+    ...a,
+    rank: offset + i + 1,
+  }));
+
+  return {
+    period,
+    fromAt: fromAt ? fromAt.toISOString() : null,
+    entries,
+    limit,
+    offset,
+  };
+}

--- a/apps/web/app/pro-league/leaderboard/page.test.tsx
+++ b/apps/web/app/pro-league/leaderboard/page.test.tsx
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class extends Error {},
+}));
+vi.mock("../../lib/use-wallet", () => ({
+  useWallet: () => ({
+    authed: false,
+    loading: false,
+    balance: 0,
+    transactions: [],
+    dailyAvailable: false,
+    dailyNextEligibleAt: null,
+    error: null,
+    refresh: vi.fn(),
+    claimDaily: vi.fn(),
+    grantFirstTime: vi.fn(),
+  }),
+}));
+
+import { apiRequest } from "../../lib/api-client";
+import LeaderboardPage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+function makeData(entries: Array<Partial<{
+  rank: number; userId: string; coachName: string; betsCount: number;
+  settledCount: number; wonCount: number; accuracy: number; profit: number;
+  longestStreak: number; biggestWin: number;
+}>> = []): unknown {
+  return {
+    period: "season",
+    fromAt: null,
+    entries: entries.map((e, i) => ({
+      rank: e.rank ?? i + 1,
+      userId: e.userId ?? `u${i}`,
+      coachName: e.coachName ?? `Coach${i}`,
+      betsCount: e.betsCount ?? 5,
+      settledCount: e.settledCount ?? 5,
+      wonCount: e.wonCount ?? 3,
+      accuracy: e.accuracy ?? 60,
+      profit: e.profit ?? 100,
+      longestStreak: e.longestStreak ?? 2,
+      biggestWin: e.biggestWin ?? 200,
+    })),
+    limit: 20,
+    offset: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("LeaderboardPage — sprint 1.D.8", () => {
+  it("affiche 'Chargement' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<LeaderboardPage />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche les 3 onglets de période", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<LeaderboardPage />);
+    expect(screen.getByTestId("period-weekly")).toBeTruthy();
+    expect(screen.getByTestId("period-season")).toBeTruthy();
+    expect(screen.getByTestId("period-all-time")).toBeTruthy();
+  });
+
+  it("rendu table avec entries (rang + profit coloré)", async () => {
+    mockedApi.mockResolvedValue(
+      makeData([
+        { coachName: "Alice", profit: 450 },
+        { coachName: "Bob", profit: -100 },
+      ]),
+    );
+    render(<LeaderboardPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("leaderboard-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("+450")).toBeTruthy();
+    expect(screen.getByText("-100")).toBeTruthy();
+  });
+
+  it("change de période en cliquant sur un onglet", async () => {
+    mockedApi.mockResolvedValue(makeData());
+    render(<LeaderboardPage />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledWith(
+        expect.stringContaining("period=season"),
+      );
+    });
+    fireEvent.click(screen.getByTestId("period-weekly"));
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledWith(
+        expect.stringContaining("period=weekly"),
+      );
+    });
+  });
+
+  it("affiche placeholder si entries vide", async () => {
+    mockedApi.mockResolvedValue(makeData([]));
+    render(<LeaderboardPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-leaderboard")).toBeTruthy();
+    });
+  });
+
+  it("affiche message d'erreur si API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("boom"));
+    render(<LeaderboardPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+    expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+});

--- a/apps/web/app/pro-league/leaderboard/page.tsx
+++ b/apps/web/app/pro-league/leaderboard/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+import { WalletBadge } from "../_components/WalletBadge";
+
+/**
+ * Leaderboard parieurs Pro League — sprint 1.D.8.
+ *
+ * 3 périodes (weekly / season / all-time) sélectionnées via tabs.
+ * Affichage table : rang, coach, profit, accuracy, streak, biggest win.
+ */
+
+type Period = "weekly" | "season" | "all-time";
+
+interface LeaderboardEntry {
+  readonly rank: number;
+  readonly userId: string;
+  readonly coachName: string;
+  readonly betsCount: number;
+  readonly settledCount: number;
+  readonly wonCount: number;
+  readonly accuracy: number;
+  readonly profit: number;
+  readonly longestStreak: number;
+  readonly biggestWin: number;
+}
+
+interface LeaderboardData {
+  readonly period: Period;
+  readonly fromAt: string | null;
+  readonly entries: readonly LeaderboardEntry[];
+  readonly limit: number;
+  readonly offset: number;
+}
+
+const PERIOD_LABELS: Record<Period, string> = {
+  weekly: "Semaine",
+  season: "Saison",
+  "all-time": "Tout temps",
+};
+
+function profitColorClass(p: number): string {
+  if (p > 0) return "text-emerald-300";
+  if (p < 0) return "text-rose-300";
+  return "text-slate-400";
+}
+
+function formatProfit(p: number): string {
+  if (p > 0) return `+${p}`;
+  return `${p}`;
+}
+
+export default function LeaderboardPage(): JSX.Element {
+  const [period, setPeriod] = useState<Period>("season");
+  const [data, setData] = useState<LeaderboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<LeaderboardData>(
+      `/pro-league/leaderboard?period=${period}&limit=20`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [period]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-wide text-slate-50">
+          Leaderboard parieurs
+        </h1>
+        <div className="flex items-center gap-2">
+          <WalletBadge />
+          <Link
+            href="/pro-league"
+            className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+          >
+            ← Hub
+          </Link>
+        </div>
+      </header>
+
+      <div
+        data-testid="period-tabs"
+        className="mb-4 flex gap-1 rounded border border-slate-800 bg-slate-900 p-1"
+      >
+        {(Object.keys(PERIOD_LABELS) as Period[]).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPeriod(p)}
+            data-testid={`period-${p}`}
+            className={`flex-1 rounded px-3 py-1.5 text-sm ${
+              period === p
+                ? "bg-emerald-700 text-emerald-50 font-semibold"
+                : "text-slate-400 hover:bg-slate-800"
+            }`}
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !data || data.entries.length === 0 ? (
+        <p
+          data-testid="empty-leaderboard"
+          className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
+        >
+          Aucun parieur classé pour cette période. Soyez le premier !
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded border border-slate-800">
+          <table data-testid="leaderboard-table" className="w-full text-sm">
+            <thead className="bg-slate-900 text-xs uppercase text-slate-400">
+              <tr>
+                <th className="w-12 px-2 py-2 text-left">#</th>
+                <th className="px-2 py-2 text-left">Coach</th>
+                <th className="w-16 px-2 py-2 text-center">Paris</th>
+                <th className="w-20 px-2 py-2 text-center">Profit</th>
+                <th className="w-16 px-2 py-2 text-center">Accuracy</th>
+                <th className="w-16 px-2 py-2 text-center">Streak</th>
+                <th className="w-20 px-2 py-2 text-center">Biggest</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.entries.map((e) => (
+                <tr
+                  key={e.userId}
+                  className="border-t border-slate-800 hover:bg-slate-900"
+                >
+                  <td className="px-2 py-2 font-mono text-slate-400">
+                    {e.rank}
+                  </td>
+                  <td className="px-2 py-2 font-medium text-slate-100">
+                    {e.coachName}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-400">
+                    {e.betsCount}
+                  </td>
+                  <td
+                    className={`px-2 py-2 text-center font-mono font-bold ${profitColorClass(e.profit)}`}
+                  >
+                    {formatProfit(e.profit)}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-slate-300">
+                    {e.accuracy}%
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-emerald-300">
+                    {e.longestStreak}
+                  </td>
+                  <td className="px-2 py-2 text-center font-mono text-emerald-300">
+                    {e.biggestWin > 0 ? `+${e.biggestWin}` : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.8** — Leaderboard parieurs (backend + frontend).

### Backend `services/pro-bet-leaderboard.ts`

`getBetLeaderboard({period, limit, offset, now?})` :

**3 périodes :**
- `weekly` : 7 derniers jours (rolling)
- `season` : depuis `startsAt` de la saison courante (in_progress > completed)
- `all-time` : tous les paris

**Métriques par user :**
| Metric | Calcul |
|---|---|
| `profit` | Σ(payoutAmount - stake) sur won, -stake sur lost |
| `accuracy` (%) | won / settled (settled = won+lost) |
| `longestStreak` | Plus longue série de wins consécutifs (lost reset) |
| `biggestWin` | max(payoutAmount - stake) parmi les won |
| `betsCount` / `settledCount` / `wonCount` | Compteurs bruts |

**Tri** : profit desc, accuracy desc, betsCount desc. **Pagination** : offset/limit avec rang absolu.

### Endpoint

`GET /pro-league/leaderboard?period=...&limit=N&offset=N` (public).

400 typé `LeaderboardError` (`INVALID_PERIOD` / `INVALID_LIMIT` / `INVALID_OFFSET`).

### Frontend `/pro-league/leaderboard`

- **Tabs** Semaine / Saison / Tout temps
- **Tableau** scroll-x mobile : rang, coach, paris, profit (vert/rose), accuracy %, streak, biggest
- États loading / empty / erreur
- WalletBadge + lien Hub

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] `npx vitest run pro-bet-leaderboard.test.ts` → **9/9 ✓**
- [x] `npx vitest run app/pro-league/leaderboard` → **6/6 ✓**

Couverture totale : 15 tests.

## Suite (lot 1.D)

- **1.D.9** : badges/titres (Oracle of Nuffle, Profit King, Blood Reader, Underdog Whisperer, First Kickoff, Loyal Fan)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_