### PR TITLE
feat(server,db): Pro League badges/titres (sprint 1.D.9)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -73,6 +73,7 @@ model User {
   proSpectatorFollows         ProSpectatorFollow[]
   proWallet                   ProWallet?
   proBets                     ProBet[]
+  proUserBadges               ProUserBadge[]
 }
 
 /// S26.3l — mirror SQLite de l'historique ELO Postgres (snapshot par mise a jour).
@@ -1089,4 +1090,17 @@ model ProBetSettlement {
   totalPayout      Int          @default(0)
   betCount         Int          @default(0)
   settledAt        DateTime     @default(now())
+}
+
+model ProUserBadge {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  badgeCode String
+  earnedAt  DateTime @default(now())
+  meta      String?
+
+  @@unique([userId, badgeCode])
+  @@index([badgeCode])
+  @@index([userId])
 }

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -41,6 +41,11 @@ import {
   getBetLeaderboard,
 } from "../services/pro-bet-leaderboard";
 import {
+  evaluateBadgesForUser,
+  getCatalogueWithStatus,
+  listUserBadges,
+} from "../services/pro-badges";
+import {
   InsufficientFundsError,
   getBalance,
   getRecentTransactions,
@@ -517,6 +522,46 @@ export async function handleListMyBets(
 }
 
 /**
+ * Sprint 1.D.9 — Liste les badges + statut (earned/not) du user.
+ */
+export async function handleListMyBadges(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const earned = await listUserBadges(userId);
+  const catalogue = await getCatalogueWithStatus(userId);
+  res.json({ earned, catalogue });
+}
+
+/**
+ * Sprint 1.D.9 — Évalue tous les criteria pour l'user et débloque
+ * les nouveaux badges. Renvoie les codes débloqués cette fois.
+ */
+export async function handleEvaluateMyBadges(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  try {
+    const newlyEarned = await evaluateBadgesForUser(userId);
+    res.json({ newlyEarned });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/me/badges/evaluate] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
  * Sprint 1.D.6 — Snapshot wallet : solde + 20 dernières transactions.
  */
 export async function handleGetMyWallet(
@@ -645,6 +690,10 @@ router.get("/me/feed", authUser, handleGetMyFeed);
 // Sprint 1.D.4 — endpoints paris.
 router.post("/bets", authUser, handlePlaceBet);
 router.get("/me/bets", authUser, handleListMyBets);
+
+// Sprint 1.D.9 — badges/titres.
+router.get("/me/badges", authUser, handleListMyBadges);
+router.post("/me/badges/evaluate", authUser, handleEvaluateMyBadges);
 
 // Sprint 1.D.6 — wallet & bonuses.
 router.get("/me/wallet", authUser, handleGetMyWallet);

--- a/apps/server/src/services/pro-badges.test.ts
+++ b/apps/server/src/services/pro-badges.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proUserBadge: {
+      findMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+    proBet: { findMany: vi.fn() },
+    proSpectatorFollow: { findFirst: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  BADGE_CATALOGUE,
+  evaluateBadgesForUser,
+  getCatalogueWithStatus,
+  listUserBadges,
+} from "./pro-badges";
+
+interface MockedPrisma {
+  proUserBadge: {
+    findMany: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
+  };
+  proBet: { findMany: ReturnType<typeof vi.fn> };
+  proSpectatorFollow: { findFirst: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+const USER = "user_1";
+
+function bet(
+  status: "won" | "lost" | "pending",
+  oddsAtPlace: number,
+  marketType: string,
+  i: number,
+) {
+  return {
+    id: `b${i}`,
+    stake: 100,
+    payoutAmount: status === "won" ? 200 : status === "lost" ? 0 : null,
+    oddsAtPlace,
+    status,
+    createdAt: new Date(2026, 0, i + 1),
+    market: { type: marketType },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proUserBadge.findMany.mockResolvedValue([]);
+  mocked.proUserBadge.createMany.mockResolvedValue({ count: 0 });
+  mocked.proBet.findMany.mockResolvedValue([]);
+  mocked.proSpectatorFollow.findFirst.mockResolvedValue(null);
+});
+
+describe("evaluateBadgesForUser — sprint 1.D.9", () => {
+  it("[] si rien n'est gagné", async () => {
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).toEqual([]);
+  });
+
+  it("first_kickoff sur 1er pari", async () => {
+    mocked.proBet.findMany.mockResolvedValue([
+      bet("pending", 2.0, "ONE_X_TWO", 0),
+    ]);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).toContain("first_kickoff");
+  });
+
+  it("oracle_of_nuffle après 10 wins consécutifs", async () => {
+    const bets = Array.from({ length: 10 }, (_, i) =>
+      bet("won", 2.0, "ONE_X_TWO", i),
+    );
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).toContain("oracle_of_nuffle");
+  });
+
+  it("ne donne pas oracle si streak cassé", async () => {
+    const bets = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        bet("won", 2.0, "ONE_X_TWO", i),
+      ),
+      bet("lost", 2.0, "ONE_X_TWO", 5),
+      ...Array.from({ length: 5 }, (_, i) =>
+        bet("won", 2.0, "ONE_X_TWO", i + 6),
+      ),
+    ];
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).not.toContain("oracle_of_nuffle");
+  });
+
+  it("blood_reader si ≥10 CAS_COUNT settled et accuracy ≥ 90%", async () => {
+    const bets = [
+      ...Array.from({ length: 9 }, (_, i) =>
+        bet("won", 1.7, "CAS_COUNT", i),
+      ),
+      bet("lost", 1.7, "CAS_COUNT", 9),
+      // 9/10 = 90% ✓
+    ];
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).toContain("blood_reader");
+  });
+
+  it("ne donne pas blood_reader si < 10 bets violents", async () => {
+    const bets = Array.from({ length: 9 }, (_, i) =>
+      bet("won", 1.7, "CAS_COUNT", i),
+    );
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).not.toContain("blood_reader");
+  });
+
+  it("underdog_whisperer si 5 wins à cote ≥ 5", async () => {
+    const bets = Array.from({ length: 5 }, (_, i) =>
+      bet("won", 6.0, "ONE_X_TWO", i),
+    );
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).toContain("underdog_whisperer");
+  });
+
+  it("ne donne pas underdog si cotes < 5", async () => {
+    const bets = Array.from({ length: 5 }, (_, i) =>
+      bet("won", 4.99, "ONE_X_TWO", i),
+    );
+    mocked.proBet.findMany.mockResolvedValue(bets);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).not.toContain("underdog_whisperer");
+  });
+
+  it("loyal_fan si follow depuis ≥ 30j", async () => {
+    const now = new Date("2026-09-30T00:00:00Z");
+    const oldFollow = new Date("2026-08-29T00:00:00Z"); // 32j
+    mocked.proSpectatorFollow.findFirst.mockResolvedValue({
+      since: oldFollow,
+    });
+    const out = await evaluateBadgesForUser(USER, now);
+    expect(out).toContain("loyal_fan");
+  });
+
+  it("ne donne pas loyal_fan si follow < 30j", async () => {
+    const now = new Date("2026-09-30T00:00:00Z");
+    mocked.proSpectatorFollow.findFirst.mockResolvedValue({
+      since: new Date("2026-09-15T00:00:00Z"), // 15j
+    });
+    const out = await evaluateBadgesForUser(USER, now);
+    expect(out).not.toContain("loyal_fan");
+  });
+
+  it("idempotent : ne re-grant pas les badges déjà earned", async () => {
+    mocked.proUserBadge.findMany.mockResolvedValue([
+      { badgeCode: "first_kickoff" },
+    ]);
+    mocked.proBet.findMany.mockResolvedValue([
+      bet("pending", 2.0, "ONE_X_TWO", 0),
+    ]);
+    const out = await evaluateBadgesForUser(USER);
+    expect(out).not.toContain("first_kickoff");
+  });
+
+  it("createMany appelé avec skipDuplicates=true", async () => {
+    mocked.proBet.findMany.mockResolvedValue([
+      bet("pending", 2.0, "ONE_X_TWO", 0),
+    ]);
+    await evaluateBadgesForUser(USER);
+    expect(mocked.proUserBadge.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ userId: USER, badgeCode: "first_kickoff" }],
+        skipDuplicates: true,
+      }),
+    );
+  });
+});
+
+describe("listUserBadges — sprint 1.D.9", () => {
+  it("formate les rows avec catalogue lookup", async () => {
+    mocked.proUserBadge.findMany.mockResolvedValue([
+      {
+        badgeCode: "first_kickoff",
+        earnedAt: new Date("2026-09-01T12:00:00Z"),
+      },
+      {
+        badgeCode: "unknown_badge",
+        earnedAt: new Date(),
+      },
+    ]);
+    const out = await listUserBadges(USER);
+    expect(out).toHaveLength(1); // unknown filtré
+    expect(out[0].code).toBe("first_kickoff");
+    expect(out[0].name).toBeTruthy();
+    expect(out[0].emoji).toBeTruthy();
+    expect(out[0].earnedAt).toBe("2026-09-01T12:00:00.000Z");
+  });
+});
+
+describe("getCatalogueWithStatus — sprint 1.D.9", () => {
+  it("renvoie tous les badges du catalogue avec earned status", async () => {
+    mocked.proUserBadge.findMany.mockResolvedValue([
+      { badgeCode: "first_kickoff", earnedAt: new Date() },
+    ]);
+    const out = await getCatalogueWithStatus(USER);
+    expect(out).toHaveLength(BADGE_CATALOGUE.length);
+    const fk = out.find((b) => b.code === "first_kickoff");
+    expect(fk?.earned).toBe(true);
+    const oracle = out.find((b) => b.code === "oracle_of_nuffle");
+    expect(oracle?.earned).toBe(false);
+  });
+});

--- a/apps/server/src/services/pro-badges.ts
+++ b/apps/server/src/services/pro-badges.ts
@@ -1,0 +1,263 @@
+/**
+ * Pro League badges — sprint Pro League lot 1.D.9.
+ *
+ * Catalogue static (en code) + évaluation des criteria + persistance
+ * des badges débloqués dans `ProUserBadge`.
+ *
+ * Criteria MVP (cf. sprint table 1.D.9) :
+ *  - `oracle_of_nuffle` : 10 paris settled gagnants consécutifs
+ *  - `blood_reader` : ≥10 bets `CAS_COUNT` settled, accuracy ≥ 90%
+ *  - `underdog_whisperer` : 5 bets won avec oddsAtPlace ≥ 5.0
+ *  - `first_kickoff` : 1er pari placé (toutes périodes)
+ *  - `loyal_fan` : suivre une équipe depuis ≥ 30 jours
+ *
+ * `profit_king` (top 1% saison) est différé — nécessite une logique
+ * cross-user qui peut être ajoutée en sweep séparé.
+ */
+
+import { prisma } from "../prisma";
+
+export interface BadgeDefinition {
+  readonly code: string;
+  readonly name: string;
+  readonly description: string;
+  readonly emoji: string;
+}
+
+export const BADGE_CATALOGUE: readonly BadgeDefinition[] = Object.freeze([
+  {
+    code: "first_kickoff",
+    name: "First Kickoff",
+    description: "Premier pari placé — bienvenue dans l'arène.",
+    emoji: "🥇",
+  },
+  {
+    code: "oracle_of_nuffle",
+    name: "Oracle of Nuffle",
+    description: "10 paris gagnants consécutifs.",
+    emoji: "🔮",
+  },
+  {
+    code: "blood_reader",
+    name: "Blood Reader",
+    description: "90%+ d'accuracy sur les paris violents (≥10 paris).",
+    emoji: "🩸",
+  },
+  {
+    code: "underdog_whisperer",
+    name: "Underdog Whisperer",
+    description: "5 paris gagnés à cote ≥ 5.0.",
+    emoji: "🐺",
+  },
+  {
+    code: "loyal_fan",
+    name: "Loyal Fan",
+    description: "Suivre une équipe depuis 30 jours ou plus.",
+    emoji: "🎽",
+  },
+] as const);
+
+const BADGE_BY_CODE: Map<string, BadgeDefinition> = new Map(
+  BADGE_CATALOGUE.map((b) => [b.code, b]),
+);
+
+const STREAK_THRESHOLD = 10;
+const BLOOD_READER_MIN_BETS = 10;
+const BLOOD_READER_MIN_ACCURACY = 0.9;
+const UNDERDOG_MIN_WINS = 5;
+const UNDERDOG_MIN_ODDS = 5.0;
+const LOYAL_FAN_MIN_DAYS = 30;
+const LOYAL_FAN_MIN_MS = LOYAL_FAN_MIN_DAYS * 24 * 60 * 60 * 1000;
+
+export interface UserBadgeEntry {
+  readonly code: string;
+  readonly name: string;
+  readonly description: string;
+  readonly emoji: string;
+  readonly earnedAt: string;
+}
+
+/**
+ * Charge les badges déjà débloqués par un user.
+ */
+export async function listUserBadges(
+  userId: string,
+): Promise<UserBadgeEntry[]> {
+  const rows = await prisma.proUserBadge.findMany({
+    where: { userId },
+    orderBy: { earnedAt: "desc" },
+    select: { badgeCode: true, earnedAt: true },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows
+    .map((r: any) => {
+      const def = BADGE_BY_CODE.get(r.badgeCode as string);
+      if (!def) return null; // catalogue désynchro — ignore
+      return {
+        code: def.code,
+        name: def.name,
+        description: def.description,
+        emoji: def.emoji,
+        earnedAt: (r.earnedAt as Date).toISOString(),
+      } satisfies UserBadgeEntry;
+    })
+    .filter((x: UserBadgeEntry | null): x is UserBadgeEntry => x !== null);
+}
+
+/**
+ * Évalue tous les criteria pour un user et débloque les nouveaux
+ * badges (idempotent via `@@unique([userId, badgeCode])`).
+ *
+ * Renvoie la liste des codes débloqués dans cet appel (vide si rien).
+ */
+export async function evaluateBadgesForUser(
+  userId: string,
+  now: Date = new Date(),
+): Promise<string[]> {
+  const existing = await prisma.proUserBadge.findMany({
+    where: { userId },
+    select: { badgeCode: true },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const earned = new Set<string>(
+    existing.map((e: any) => e.badgeCode as string),
+  );
+
+  const newlyEarned: string[] = [];
+
+  // Charge les bets une fois pour tous les criteria qui en ont besoin.
+  const bets = await prisma.proBet.findMany({
+    where: { userId },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      stake: true,
+      payoutAmount: true,
+      oddsAtPlace: true,
+      status: true,
+      createdAt: true,
+      market: { select: { type: true } },
+    },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeBets = bets as Array<{
+    id: string;
+    stake: number;
+    payoutAmount: number | null;
+    oddsAtPlace: number;
+    status: string;
+    createdAt: Date;
+    market: { type: string };
+  }>;
+
+  // first_kickoff : ≥1 pari.
+  if (!earned.has("first_kickoff") && safeBets.length >= 1) {
+    newlyEarned.push("first_kickoff");
+  }
+
+  // oracle_of_nuffle : streak ≥ 10 wins consécutifs sur settled.
+  if (!earned.has("oracle_of_nuffle")) {
+    let current = 0;
+    let max = 0;
+    for (const b of safeBets) {
+      if (b.status === "won") {
+        current += 1;
+        if (current > max) max = current;
+      } else if (b.status === "lost") {
+        current = 0;
+      }
+    }
+    if (max >= STREAK_THRESHOLD) newlyEarned.push("oracle_of_nuffle");
+  }
+
+  // blood_reader : ≥10 bets CAS_COUNT settled, accuracy ≥ 90%.
+  if (!earned.has("blood_reader")) {
+    let won = 0;
+    let lost = 0;
+    for (const b of safeBets) {
+      if (b.market.type !== "CAS_COUNT") continue;
+      if (b.status === "won") won += 1;
+      else if (b.status === "lost") lost += 1;
+    }
+    const settled = won + lost;
+    if (
+      settled >= BLOOD_READER_MIN_BETS &&
+      won / settled >= BLOOD_READER_MIN_ACCURACY
+    ) {
+      newlyEarned.push("blood_reader");
+    }
+  }
+
+  // underdog_whisperer : 5 bets won avec oddsAtPlace ≥ 5.0.
+  if (!earned.has("underdog_whisperer")) {
+    let count = 0;
+    for (const b of safeBets) {
+      if (b.status === "won" && b.oddsAtPlace >= UNDERDOG_MIN_ODDS) {
+        count += 1;
+      }
+    }
+    if (count >= UNDERDOG_MIN_WINS) newlyEarned.push("underdog_whisperer");
+  }
+
+  // loyal_fan : suivre une équipe depuis ≥ 30 jours.
+  if (!earned.has("loyal_fan")) {
+    const oldestFollow = await prisma.proSpectatorFollow.findFirst({
+      where: { userId },
+      orderBy: { since: "asc" },
+      select: { since: true },
+    });
+    if (oldestFollow) {
+      const since = oldestFollow.since as Date;
+      if (now.getTime() - since.getTime() >= LOYAL_FAN_MIN_MS) {
+        newlyEarned.push("loyal_fan");
+      }
+    }
+  }
+
+  if (newlyEarned.length === 0) return [];
+
+  // Persiste atomique. Si une row existe déjà (race condition entre 2
+  // évaluations concurrentes), on `createMany skipDuplicates: true`.
+  await prisma.proUserBadge.createMany({
+    data: newlyEarned.map((code) => ({ userId, badgeCode: code })),
+    skipDuplicates: true,
+  });
+
+  return newlyEarned;
+}
+
+/**
+ * Renvoie tous les badges du catalogue + statut earned/not.
+ */
+export interface BadgeStatus {
+  readonly code: string;
+  readonly name: string;
+  readonly description: string;
+  readonly emoji: string;
+  readonly earned: boolean;
+  readonly earnedAt: string | null;
+}
+
+export async function getCatalogueWithStatus(
+  userId: string,
+): Promise<BadgeStatus[]> {
+  const rows = await prisma.proUserBadge.findMany({
+    where: { userId },
+    select: { badgeCode: true, earnedAt: true },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const earnedMap = new Map<string, Date>(
+    rows.map((r: any) => [r.badgeCode as string, r.earnedAt as Date]),
+  );
+  return BADGE_CATALOGUE.map((def) => {
+    const at = earnedMap.get(def.code);
+    return {
+      code: def.code,
+      name: def.name,
+      description: def.description,
+      emoji: def.emoji,
+      earned: at !== undefined,
+      earnedAt: at ? at.toISOString() : null,
+    } satisfies BadgeStatus;
+  });
+}

--- a/prisma/migrations/20260507000000_add_pro_user_badge/migration.sql
+++ b/prisma/migrations/20260507000000_add_pro_user_badge/migration.sql
@@ -1,0 +1,26 @@
+-- Pro League badges (sprint 1.D.9). Catalogue est en code, table
+-- stocke uniquement les badges effectivement débloqués par les users.
+
+CREATE TABLE "public"."ProUserBadge" (
+    "id"        TEXT NOT NULL,
+    "userId"    TEXT NOT NULL,
+    "badgeCode" TEXT NOT NULL,
+    "earnedAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "meta"      JSONB,
+
+    CONSTRAINT "ProUserBadge_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProUserBadge_userId_badgeCode_key"
+  ON "public"."ProUserBadge"("userId", "badgeCode");
+
+CREATE INDEX "ProUserBadge_badgeCode_idx"
+  ON "public"."ProUserBadge"("badgeCode");
+
+CREATE INDEX "ProUserBadge_userId_idx"
+  ON "public"."ProUserBadge"("userId");
+
+ALTER TABLE "public"."ProUserBadge"
+  ADD CONSTRAINT "ProUserBadge_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "public"."User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model User {
   proSpectatorFollows         ProSpectatorFollow[]
   proWallet                   ProWallet?
   proBets                     ProBet[]
+  proUserBadges               ProUserBadge[]
 }
 
 /// S26.3l — Historique ELO du coach. Une ligne par mise a jour ELO (donc 2
@@ -1484,4 +1485,25 @@ model ProBetSettlement {
   totalPayout      Int          @default(0)
   betCount         Int          @default(0)
   settledAt        DateTime     @default(now())
+}
+
+/// Sprint Pro League lot 1.D.9 — Badge debloque par un user.
+///
+/// Le catalogue des badges (codes + criteria) vit dans le code
+/// (apps/server/src/services/pro-badges-catalogue.ts) — pas en DB.
+/// La table ProUserBadge stocke uniquement les badges effectivement
+/// debloques.
+model ProUserBadge {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  /// Code stable du badge (ex: "oracle_of_nuffle", "first_kickoff").
+  badgeCode String
+  earnedAt  DateTime @default(now())
+  /// Meta optionnelles pour l'audit (ex: betId qui a debloque le badge).
+  meta      Json?
+
+  @@unique([userId, badgeCode])
+  @@index([badgeCode])
+  @@index([userId])
 }


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.D.9** — Badges & titres parieurs.

🎯 **Lot 1.D complet** avec ce PR (1.D.1 → 1.D.9 livrés).

### Modèle Prisma `ProUserBadge`

`{userId, badgeCode, earnedAt, meta}` avec `@@unique([userId, badgeCode])` (idempotence). **Catalogue static** dans le code (`pro-badges.ts`) — pas en DB pour rester versionnable avec le sim.

### Catalogue MVP

| Code | Nom | Critère |
|---|---|---|
| `first_kickoff` 🥇 | First Kickoff | 1er pari placé |
| `oracle_of_nuffle` 🔮 | Oracle of Nuffle | 10 paris settled gagnants consécutifs |
| `blood_reader` 🩸 | Blood Reader | ≥10 bets `CAS_COUNT` settled, accuracy ≥ 90% |
| `underdog_whisperer` 🐺 | Underdog Whisperer | 5 paris won à oddsAtPlace ≥ 5.0 |
| `loyal_fan` 🎽 | Loyal Fan | Suivre une équipe depuis ≥ 30 jours |

`profit_king` (top 1% saison) différé — nécessite logique cross-user (sweep séparé).

### Service

- `evaluateBadgesForUser(userId, now?)` → débloque nouveaux badges via `createMany skipDuplicates`
- `listUserBadges(userId)` → badges débloqués formatés avec catalogue
- `getCatalogueWithStatus(userId)` → tous les badges + flag `earned`

### Endpoints (auth-required)

| URL | Rôle |
|---|---|
| `GET /pro-league/me/badges` | earned + catalogue avec statut |
| `POST /pro-league/me/badges/evaluate` | force re-évaluation |

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-badges.test.ts` → **14/14 ✓**

Couverture : criteria positifs/négatifs pour chaque badge + idempotence + filtrage codes inconnus + catalogue avec statut.

## Lot 1.D — récap final

| Lot | PR | État |
|---|---|---|
| 1.D.1 — Wallet | #614 | ✅ |
| 1.D.2 — Bet models | #615 | ✅ |
| 1.D.3 — Odds calculator | #616 | ✅ |
| 1.D.4 — Bet endpoints | #617 | ✅ |
| 1.D.5 — Settlement | #618 | ✅ |
| 1.D.6 — Daily bonus | #619 | ✅ |
| 1.D.7 — Bet UI | #621 | ✅ |
| 1.D.8 — Leaderboards | #622 | ✅ |
| 1.D.9 — Badges | _this PR_ | ⏳ |

## Suite

- **Lot 1.E** : Nuffle Gazette (LLM) + casualties persistantes + HoF light
- **Lot 1.F** : E2E + go-live (Playwright + monitoring + page marketing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_