### PR TITLE
feat(server): Pro League storyline detector + Gazette daily recap (sprint 1.E.3)

### DIFF
--- a/apps/server/src/services/pro-gazette-recap.test.ts
+++ b/apps/server/src/services/pro-gazette-recap.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findMany: vi.fn() },
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueStandings: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import { getDailyRecap } from "./pro-gazette-recap";
+
+interface MockedPrisma {
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+  mocked.proLeagueStandings.findMany.mockResolvedValue([]);
+});
+
+describe("getDailyRecap — sprint 1.E.3", () => {
+  it("retourne un recap vide si pas de matchs", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const out = await getDailyRecap(new Date("2026-09-15T00:00:00Z"));
+    expect(out.matchesPlayed).toBe(0);
+    expect(out.matches).toEqual([]);
+    expect(out.storylines).toEqual([]);
+    expect(out.fromAt).toBe("2026-09-15T00:00:00.000Z");
+    expect(out.toAt).toBe("2026-09-16T00:00:00.000Z");
+  });
+
+  it("filtre les matchs failed (scoreHome null)", async () => {
+    // 1er findMany = matchs principaux
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m1",
+        homeTeamId: "h1",
+        awayTeamId: "a1",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 3,
+        casualtyCount: 1,
+        nuffleCount: 0,
+        completedAt: new Date("2026-09-15T22:00:00Z"),
+        homeTeam: { slug: "buf", name: "Buffalo" },
+        awayTeam: { slug: "kc", name: "KC" },
+      },
+      {
+        id: "m_failed",
+        homeTeamId: "h2",
+        awayTeamId: "a2",
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        touchdownCount: null,
+        casualtyCount: null,
+        nuffleCount: null,
+        completedAt: new Date("2026-09-15T22:00:00Z"),
+        homeTeam: { slug: "x", name: "X" },
+        awayTeam: { slug: "y", name: "Y" },
+      },
+    ]);
+    // priorMatchups query — empty
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+
+    const out = await getDailyRecap(new Date("2026-09-15T00:00:00Z"));
+    expect(out.matchesPlayed).toBe(1);
+    expect(out.matches[0].id).toBe("m1");
+  });
+
+  it("agrège standings + storylines", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m1",
+        homeTeamId: "h1",
+        awayTeamId: "a1",
+        scoreHome: 5,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 6,
+        casualtyCount: 4,
+        nuffleCount: 0,
+        completedAt: new Date("2026-09-15T22:00:00Z"),
+        homeTeam: { slug: "buf", name: "Buffalo" },
+        awayTeam: { slug: "kc", name: "KC" },
+      },
+    ]);
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce({
+      id: "season_1",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        teamId: "h1",
+        played: 5,
+        wins: 4,
+        draws: 0,
+        losses: 1,
+        points: 12,
+        tdFor: 12,
+        team: { slug: "buf", name: "Buffalo" },
+      },
+      {
+        teamId: "a1",
+        played: 5,
+        wins: 1,
+        draws: 0,
+        losses: 4,
+        points: 3,
+        tdFor: 5,
+        team: { slug: "kc", name: "KC" },
+      },
+    ]);
+    // priorMatchups query — empty (pas de rivalry)
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+
+    const out = await getDailyRecap(new Date("2026-09-15T00:00:00Z"));
+    expect(out.matchesPlayed).toBe(1);
+    expect(out.standings).toHaveLength(2);
+    expect(out.standings[0].rank).toBe(1);
+    expect(out.standings[0].teamName).toBe("Buffalo");
+
+    // Storylines : season_top (Buffalo rank=1) + blowout (5-1) + record_td (6) + bloodbath (4)
+    const types = out.storylines.map((s) => s.type);
+    expect(types).toContain("season_top");
+    expect(types).toContain("blowout");
+    expect(types).toContain("record_td");
+    expect(types).toContain("bloodbath");
+  });
+
+  it("détecte rivalry_buildup quand priorMatchups ≥ 3", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m_today",
+        homeTeamId: "h1",
+        awayTeamId: "a1",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 3,
+        casualtyCount: 1,
+        nuffleCount: 0,
+        completedAt: new Date("2026-09-15T22:00:00Z"),
+        homeTeam: { slug: "buf", name: "Buffalo" },
+        awayTeam: { slug: "kc", name: "KC" },
+      },
+    ]);
+    mocked.proLeagueSeason.findFirst.mockResolvedValueOnce(null);
+    // Rivalry query : 3 matchs passés entre Buffalo & KC
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      { completedAt: new Date("2026-08-25T22:00:00Z") },
+      { completedAt: new Date("2026-09-05T22:00:00Z") },
+      { completedAt: new Date("2026-09-15T22:00:00Z") },
+    ]);
+    const out = await getDailyRecap(new Date("2026-09-15T00:00:00Z"));
+    expect(out.storylines.some((s) => s.type === "rivalry_buildup")).toBe(true);
+  });
+});

--- a/apps/server/src/services/pro-gazette-recap.ts
+++ b/apps/server/src/services/pro-gazette-recap.ts
@@ -1,0 +1,220 @@
+/**
+ * Pro League Gazette daily recap aggregator — sprint Pro League lot
+ * 1.E.3 (intermédiaire qui sera consommé par 1.E.1 LLM Gazette).
+ *
+ * Pour une date `at` donnée, agrège :
+ *  - les matchs `completed` de la journée (= `completedAt` ∈ [at, at+24h])
+ *  - les standings courants de la saison
+ *  - les storylines détectés via `detectStorylines`
+ *  - les `priorMatchups` (compte historique entre 2 équipes sur les
+ *    30 derniers jours) pour détecter `rivalry_buildup`
+ *
+ * Le résultat est consommable par le LLM Claude Haiku (lot 1.E.1) pour
+ * générer 1 article principal + 3 brèves + 1 édito.
+ */
+
+import { prisma } from "../prisma";
+
+import {
+  type MatchSnapshot,
+  type StandingEntry,
+  type Storyline,
+  detectStorylines,
+  matchupKey,
+} from "./pro-storyline-detector";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RIVALRY_WINDOW_DAYS = 30;
+
+export interface DailyRecap {
+  /** Borne basse incluse (ISO). */
+  readonly fromAt: string;
+  /** Borne haute exclue (ISO). */
+  readonly toAt: string;
+  readonly matchesPlayed: number;
+  readonly matches: readonly MatchSnapshot[];
+  readonly standings: readonly StandingEntry[];
+  readonly storylines: readonly Storyline[];
+}
+
+interface MatchRow {
+  id: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  touchdownCount: number | null;
+  casualtyCount: number | null;
+  nuffleCount: number | null;
+  completedAt: Date | null;
+  homeTeam: { slug: string; name: string };
+  awayTeam: { slug: string; name: string };
+}
+
+interface StandingRow {
+  teamId: string;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  points: number;
+  tdFor: number;
+  team: { slug: string; name: string };
+}
+
+/**
+ * Récupère le snapshot d'une journée Pro League prêt pour la Gazette.
+ *
+ * @param at Borne basse de la fenêtre (24h glissantes). Default = il y
+ *   a 24h (i.e. on génère la Gazette du jour pour les matchs de J-1).
+ */
+export async function getDailyRecap(
+  at: Date = new Date(Date.now() - DAY_MS),
+): Promise<DailyRecap> {
+  const fromAt = new Date(at.getTime());
+  const toAt = new Date(at.getTime() + DAY_MS);
+
+  const matchRows = (await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "completed",
+      completedAt: { gte: fromAt, lt: toAt },
+    },
+    orderBy: { completedAt: "asc" },
+    select: {
+      id: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      touchdownCount: true,
+      casualtyCount: true,
+      nuffleCount: true,
+      completedAt: true,
+      homeTeam: { select: { slug: true, name: true } },
+      awayTeam: { select: { slug: true, name: true } },
+    },
+  })) as MatchRow[];
+
+  // Matchs filtrés : on jette ceux qui n'ont pas tous les champs
+  // requis (ex: failed). Le storyline detector exige des nombres.
+  const matches: MatchSnapshot[] = matchRows
+    .filter(
+      (m) =>
+        m.scoreHome !== null &&
+        m.scoreAway !== null &&
+        m.outcome !== null &&
+        m.completedAt !== null,
+    )
+    .map((m) => ({
+      id: m.id,
+      homeTeamSlug: m.homeTeam.slug,
+      homeTeamName: m.homeTeam.name,
+      awayTeamSlug: m.awayTeam.slug,
+      awayTeamName: m.awayTeam.name,
+      scoreHome: m.scoreHome ?? 0,
+      scoreAway: m.scoreAway ?? 0,
+      outcome: m.outcome as "home" | "away" | "draw",
+      touchdownCount: m.touchdownCount ?? 0,
+      casualtyCount: m.casualtyCount ?? 0,
+      nuffleCount: m.nuffleCount ?? 0,
+      playedAt: (m.completedAt as Date).toISOString(),
+    }));
+
+  // Standings courants : on prend la saison `in_progress` (fallback
+  // la plus récente).
+  const inProgress = await prisma.proLeagueSeason.findFirst({
+    where: { status: "in_progress" },
+    orderBy: { year: "asc" },
+    select: { id: true },
+  });
+  const season =
+    inProgress ??
+    (await prisma.proLeagueSeason.findFirst({
+      orderBy: { year: "desc" },
+      select: { id: true },
+    }));
+
+  let standings: StandingEntry[] = [];
+  if (season) {
+    const standingRows = (await prisma.proLeagueStandings.findMany({
+      where: { seasonId: season.id as string },
+      orderBy: [
+        { points: "desc" },
+        { tdFor: "desc" },
+      ],
+      select: {
+        teamId: true,
+        played: true,
+        wins: true,
+        draws: true,
+        losses: true,
+        points: true,
+        tdFor: true,
+        team: { select: { slug: true, name: true } },
+      },
+    })) as StandingRow[];
+    standings = standingRows.map((s, i) => ({
+      teamSlug: s.team.slug,
+      teamName: s.team.name,
+      played: s.played,
+      wins: s.wins,
+      draws: s.draws,
+      losses: s.losses,
+      points: s.points,
+      rank: i + 1,
+    }));
+  }
+
+  // Compte les matchups passés sur les 30 derniers jours pour les
+  // pairings de la journée.
+  const rivalryFromAt = new Date(at.getTime() - RIVALRY_WINDOW_DAYS * DAY_MS);
+  const priorMatchups = new Map<
+    string,
+    { count: number; firstAt: string }
+  >();
+  for (const m of matches) {
+    const key = matchupKey(m.homeTeamSlug, m.awayTeamSlug);
+    if (priorMatchups.has(key)) continue; // déjà calculé
+    const past = (await prisma.proLeagueMatch.findMany({
+      where: {
+        status: "completed",
+        completedAt: { gte: rivalryFromAt, lte: toAt },
+        OR: [
+          {
+            homeTeam: { slug: m.homeTeamSlug },
+            awayTeam: { slug: m.awayTeamSlug },
+          },
+          {
+            homeTeam: { slug: m.awayTeamSlug },
+            awayTeam: { slug: m.homeTeamSlug },
+          },
+        ],
+      },
+      orderBy: { completedAt: "asc" },
+      select: { completedAt: true },
+    })) as { completedAt: Date | null }[];
+    if (past.length > 0) {
+      priorMatchups.set(key, {
+        count: past.length,
+        firstAt: (past[0].completedAt as Date).toISOString(),
+      });
+    }
+  }
+
+  const storylines = detectStorylines({
+    matches,
+    standings,
+    priorMatchups,
+  });
+
+  return {
+    fromAt: fromAt.toISOString(),
+    toAt: toAt.toISOString(),
+    matchesPlayed: matches.length,
+    matches,
+    standings,
+    storylines,
+  };
+}

--- a/apps/server/src/services/pro-storyline-detector.test.ts
+++ b/apps/server/src/services/pro-storyline-detector.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type DetectStorylinesInput,
+  type MatchSnapshot,
+  type StandingEntry,
+  detectStorylines,
+  matchupKey,
+} from "./pro-storyline-detector";
+
+function match(over: Partial<MatchSnapshot> = {}): MatchSnapshot {
+  return {
+    id: "m1",
+    homeTeamSlug: "home",
+    homeTeamName: "Home",
+    awayTeamSlug: "away",
+    awayTeamName: "Away",
+    scoreHome: 2,
+    scoreAway: 1,
+    outcome: "home",
+    touchdownCount: 3,
+    casualtyCount: 1,
+    nuffleCount: 1,
+    playedAt: "2026-09-01T21:00:00Z",
+    ...over,
+  };
+}
+
+function standing(over: Partial<StandingEntry> = {}): StandingEntry {
+  return {
+    teamSlug: "team_x",
+    teamName: "Team X",
+    played: 5,
+    wins: 3,
+    draws: 0,
+    losses: 2,
+    points: 9,
+    rank: 5,
+    ...over,
+  };
+}
+
+function emptyInput(over: Partial<DetectStorylinesInput> = {}): DetectStorylinesInput {
+  return { matches: [], standings: [], ...over };
+}
+
+describe("matchupKey — sprint 1.E.3", () => {
+  it("ordre alphabétique stable", () => {
+    expect(matchupKey("buf", "kc")).toBe("buf|kc");
+    expect(matchupKey("kc", "buf")).toBe("buf|kc");
+  });
+});
+
+describe("detectStorylines — sprint 1.E.3", () => {
+  it("[] sur input vide", () => {
+    expect(detectStorylines(emptyInput())).toEqual([]);
+  });
+
+  it("season_top sur leader (rank=1)", () => {
+    const out = detectStorylines(
+      emptyInput({
+        standings: [
+          standing({ teamSlug: "buf", teamName: "Buffalo", rank: 1, points: 12 }),
+          standing({ teamSlug: "kc", rank: 2, points: 9 }),
+        ],
+      }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("season_top");
+    expect(out[0].refs.teamName).toBe("Buffalo");
+  });
+
+  it("blowout sur écart ≥ 4 TDs", () => {
+    const out = detectStorylines(
+      emptyInput({
+        matches: [
+          match({ scoreHome: 5, scoreAway: 1, outcome: "home" }),
+        ],
+      }),
+    );
+    expect(out.some((s) => s.type === "blowout")).toBe(true);
+    const blowout = out.find((s) => s.type === "blowout");
+    expect(blowout?.refs.scoreHome).toBe(5);
+  });
+
+  it("narrow sur 1 TD d'écart ou nul", () => {
+    const out1 = detectStorylines(
+      emptyInput({
+        matches: [match({ scoreHome: 3, scoreAway: 2, outcome: "home" })],
+      }),
+    );
+    expect(out1.some((s) => s.type === "narrow")).toBe(true);
+
+    const out2 = detectStorylines(
+      emptyInput({
+        matches: [match({ scoreHome: 2, scoreAway: 2, outcome: "draw" })],
+      }),
+    );
+    expect(out2.some((s) => s.type === "narrow")).toBe(true);
+  });
+
+  it("upset : favori (>70% V) perd contre underdog (<50% V)", () => {
+    const out = detectStorylines({
+      matches: [
+        match({
+          homeTeamSlug: "buf",
+          homeTeamName: "Buffalo",
+          awayTeamSlug: "kc",
+          awayTeamName: "KC",
+          scoreHome: 2,
+          scoreAway: 1,
+          outcome: "home",
+        }),
+      ],
+      standings: [
+        standing({
+          teamSlug: "buf",
+          teamName: "Buffalo",
+          played: 5,
+          wins: 1,
+          losses: 4, // 20% V
+        }),
+        standing({
+          teamSlug: "kc",
+          teamName: "KC",
+          played: 5,
+          wins: 4,
+          losses: 1, // 80% V
+        }),
+      ],
+    });
+    expect(out.some((s) => s.type === "upset")).toBe(true);
+  });
+
+  it("ne détecte pas upset si écart de standings insuffisant", () => {
+    const out = detectStorylines({
+      matches: [match({ outcome: "home" })],
+      standings: [
+        standing({ teamSlug: "home", played: 5, wins: 3, losses: 2 }),
+        standing({ teamSlug: "away", played: 5, wins: 3, losses: 2 }),
+      ],
+    });
+    expect(out.some((s) => s.type === "upset")).toBe(false);
+  });
+
+  it("record_td sur ≥6 TDs", () => {
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ scoreHome: 4, scoreAway: 3 })],
+      }),
+    );
+    expect(out.some((s) => s.type === "record_td")).toBe(true);
+  });
+
+  it("bloodbath sur ≥4 casualties", () => {
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ casualtyCount: 5 })],
+      }),
+    );
+    expect(out.some((s) => s.type === "bloodbath")).toBe(true);
+  });
+
+  it("nuffle_chaos sur ≥3 events Nuffle", () => {
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ nuffleCount: 4 })],
+      }),
+    );
+    expect(out.some((s) => s.type === "nuffle_chaos")).toBe(true);
+  });
+
+  it("rivalry_buildup sur ≥3 matchups", () => {
+    const priorMatchups = new Map();
+    priorMatchups.set(matchupKey("home", "away"), {
+      count: 3,
+      firstAt: "2026-08-01T00:00:00Z",
+    });
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match()],
+        priorMatchups,
+      }),
+    );
+    expect(out.some((s) => s.type === "rivalry_buildup")).toBe(true);
+  });
+
+  it("ne détecte pas rivalry si <3 matchups", () => {
+    const priorMatchups = new Map();
+    priorMatchups.set(matchupKey("home", "away"), {
+      count: 2,
+      firstAt: "2026-08-01T00:00:00Z",
+    });
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match()],
+        priorMatchups,
+      }),
+    );
+    expect(out.some((s) => s.type === "rivalry_buildup")).toBe(false);
+  });
+
+  it("trie par weight desc (upset > blowout > narrow)", () => {
+    const out = detectStorylines({
+      matches: [
+        match({
+          id: "m_blowout",
+          scoreHome: 5,
+          scoreAway: 1,
+          outcome: "home",
+        }),
+      ],
+      standings: [
+        standing({ teamSlug: "home", played: 5, wins: 1, losses: 4 }),
+        standing({ teamSlug: "away", played: 5, wins: 4, losses: 1 }),
+      ],
+    });
+    // upset weight=90, blowout weight=80+
+    expect(out[0].type).toBe("upset");
+    expect(out[1].type).toBe("blowout");
+  });
+
+  it("un même match peut générer plusieurs storylines (blowout + bloodbath)", () => {
+    const out = detectStorylines(
+      emptyInput({
+        matches: [
+          match({
+            scoreHome: 5,
+            scoreAway: 1,
+            outcome: "home",
+            casualtyCount: 5,
+          }),
+        ],
+      }),
+    );
+    expect(out.some((s) => s.type === "blowout")).toBe(true);
+    expect(out.some((s) => s.type === "bloodbath")).toBe(true);
+  });
+});

--- a/apps/server/src/services/pro-storyline-detector.ts
+++ b/apps/server/src/services/pro-storyline-detector.ts
@@ -1,0 +1,279 @@
+/**
+ * Pro League storyline detector — sprint Pro League lot 1.E.3.
+ *
+ * Détecte automatiquement des "storylines" (= angles narratifs)
+ * dans un set de matchs joués + standings, qui seront consommés par
+ * la Nuffle Gazette (lot 1.E.1) comme contexte pour ses articles
+ * LLM.
+ *
+ * Types détectés :
+ *  - `blowout`         : écart de score ≥ 4 TDs.
+ *  - `narrow`          : score serré (1 TD d'écart, ou nul).
+ *  - `upset`           : équipe avec record < 50% gagne contre une
+ *                        équipe avec record > 70% (par standings J-1).
+ *  - `record_td`       : match avec ≥ 6 TDs au total (rare).
+ *  - `bloodbath`       : match avec ≥ 4 casualties.
+ *  - `nuffle_chaos`    : match avec ≥ 3 events Nuffle.
+ *  - `rivalry_buildup` : 3e match consécutif entre les 2 mêmes
+ *                        équipes en < 30 jours (rare au MVP, mais
+ *                        détectable via history).
+ *  - `season_top`      : équipe atteint la 1ère place du classement.
+ *
+ * Chaque storyline a un `weight` ∈ [0, 100] qui sert au LLM pour
+ * trier les angles à mentionner en priorité dans la Gazette.
+ *
+ * Le service est PUR — pas d'I/O ; il consomme un snapshot de la
+ * journée + standings + history. La couche DB est gérée séparément
+ * (lot 1.E.1 quand on branche le cron Gazette).
+ */
+
+export type StorylineType =
+  | "blowout"
+  | "narrow"
+  | "upset"
+  | "record_td"
+  | "bloodbath"
+  | "nuffle_chaos"
+  | "rivalry_buildup"
+  | "season_top";
+
+export interface MatchSnapshot {
+  readonly id: string;
+  readonly homeTeamSlug: string;
+  readonly homeTeamName: string;
+  readonly awayTeamSlug: string;
+  readonly awayTeamName: string;
+  readonly scoreHome: number;
+  readonly scoreAway: number;
+  readonly outcome: "home" | "away" | "draw";
+  readonly touchdownCount: number;
+  readonly casualtyCount: number;
+  readonly nuffleCount: number;
+  readonly playedAt: string;
+}
+
+export interface StandingEntry {
+  readonly teamSlug: string;
+  readonly teamName: string;
+  readonly played: number;
+  readonly wins: number;
+  readonly draws: number;
+  readonly losses: number;
+  readonly points: number;
+  readonly rank: number;
+}
+
+export interface PriorMatchupCounts {
+  /** Pour un couple ordonné (slug A, slug B), nombre de matchs joués
+   *  entre eux dans les `historyDays` derniers jours (cf. helpers).
+   *  La fonction de détection est agnostique de la fenêtre — elle
+   *  compte juste le nombre fourni. */
+  readonly count: number;
+  /** Date du plus ancien match du compte, pour aider le LLM. */
+  readonly firstAt: string;
+}
+
+export interface DetectStorylinesInput {
+  readonly matches: readonly MatchSnapshot[];
+  readonly standings: readonly StandingEntry[];
+  /** Pour chaque match, le compte historique du matchup (incluant
+   *  le match courant). Optionnel ; si absent, `rivalry_buildup`
+   *  n'est pas détecté. */
+  readonly priorMatchups?: ReadonlyMap<string, PriorMatchupCounts>;
+}
+
+export interface Storyline {
+  readonly type: StorylineType;
+  readonly weight: number;
+  /** Référence(s) match / team / player. Forme libre, consommée
+   *  par le LLM côté lot 1.E.1. */
+  readonly refs: Record<string, string | number>;
+  /** Synthèse 1-line lisible (logging / preview). */
+  readonly summary: string;
+}
+
+const TD_BLOWOUT_DIFF = 4;
+const TD_RECORD_TOTAL = 6;
+const CASUALTY_BLOODBATH = 4;
+const NUFFLE_CHAOS = 3;
+const UPSET_LOSER_WIN_RATIO = 0.7;
+const UPSET_WINNER_WIN_RATIO = 0.5;
+
+function diff(a: number, b: number): number {
+  return Math.abs(a - b);
+}
+
+/**
+ * Construit la clé d'un matchup ordonnée alphabétiquement (peu importe
+ * home/away) — pour lookup `priorMatchups`.
+ */
+export function matchupKey(slugA: string, slugB: string): string {
+  return [slugA, slugB].sort().join("|");
+}
+
+function winRatio(s: StandingEntry): number {
+  if (s.played === 0) return 0;
+  return s.wins / s.played;
+}
+
+/**
+ * Renvoie les storylines détectés pour la journée. Les doublons
+ * (même type sur le même match) sont possibles uniquement si types
+ * différents (ex: même match peut être à la fois `blowout` et
+ * `bloodbath`). La fonction n'élimine pas les redondances cross-type.
+ */
+export function detectStorylines(
+  input: DetectStorylinesInput,
+): Storyline[] {
+  const standingsBySlug = new Map<string, StandingEntry>(
+    input.standings.map((s) => [s.teamSlug, s]),
+  );
+  const out: Storyline[] = [];
+
+  // season_top : si un seul leader (rank=1), une storyline par leader.
+  for (const s of input.standings) {
+    if (s.rank === 1) {
+      out.push({
+        type: "season_top",
+        weight: 70,
+        refs: {
+          teamSlug: s.teamSlug,
+          teamName: s.teamName,
+          points: s.points,
+          played: s.played,
+        },
+        summary: `${s.teamName} prend la tête du classement (${s.points} pts en ${s.played} match${s.played > 1 ? "s" : ""}).`,
+      });
+    }
+  }
+
+  for (const m of input.matches) {
+    const td = m.scoreHome + m.scoreAway;
+    const scoreDiff = diff(m.scoreHome, m.scoreAway);
+
+    // blowout
+    if (scoreDiff >= TD_BLOWOUT_DIFF) {
+      const winnerName =
+        m.outcome === "home"
+          ? m.homeTeamName
+          : m.outcome === "away"
+            ? m.awayTeamName
+            : null;
+      out.push({
+        type: "blowout",
+        weight: 80 + Math.min(20, (scoreDiff - TD_BLOWOUT_DIFF) * 5),
+        refs: {
+          matchId: m.id,
+          scoreHome: m.scoreHome,
+          scoreAway: m.scoreAway,
+          winner: winnerName ?? "draw",
+        },
+        summary: winnerName
+          ? `${winnerName} écrase ${m.homeTeamName === winnerName ? m.awayTeamName : m.homeTeamName} ${m.scoreHome}-${m.scoreAway}.`
+          : `Score d'écart inhabituel ${m.scoreHome}-${m.scoreAway}.`,
+      });
+    }
+
+    // narrow (1 d'écart ou draw)
+    if (scoreDiff <= 1 && (td > 0 || m.outcome === "draw")) {
+      out.push({
+        type: "narrow",
+        weight: 55,
+        refs: {
+          matchId: m.id,
+          scoreHome: m.scoreHome,
+          scoreAway: m.scoreAway,
+        },
+        summary:
+          m.outcome === "draw"
+            ? `Match nul ${m.scoreHome}-${m.scoreAway} entre ${m.homeTeamName} et ${m.awayTeamName}.`
+            : `${m.homeTeamName} vs ${m.awayTeamName} : décision à 1 TD près (${m.scoreHome}-${m.scoreAway}).`,
+      });
+    }
+
+    // upset (loser was favori sur les standings J-1)
+    if (m.outcome !== "draw") {
+      const winnerSlug =
+        m.outcome === "home" ? m.homeTeamSlug : m.awayTeamSlug;
+      const loserSlug =
+        m.outcome === "home" ? m.awayTeamSlug : m.homeTeamSlug;
+      const winnerStanding = standingsBySlug.get(winnerSlug);
+      const loserStanding = standingsBySlug.get(loserSlug);
+      if (
+        winnerStanding &&
+        loserStanding &&
+        winnerStanding.played >= 2 &&
+        loserStanding.played >= 2 &&
+        winRatio(winnerStanding) < UPSET_WINNER_WIN_RATIO &&
+        winRatio(loserStanding) > UPSET_LOSER_WIN_RATIO
+      ) {
+        out.push({
+          type: "upset",
+          weight: 90,
+          refs: {
+            matchId: m.id,
+            winnerSlug,
+            winnerName: winnerStanding.teamName,
+            loserSlug,
+            loserName: loserStanding.teamName,
+          },
+          summary: `Surprise : ${winnerStanding.teamName} (${(winRatio(winnerStanding) * 100).toFixed(0)}% V) renverse ${loserStanding.teamName} (${(winRatio(loserStanding) * 100).toFixed(0)}% V).`,
+        });
+      }
+    }
+
+    // record_td
+    if (td >= TD_RECORD_TOTAL) {
+      out.push({
+        type: "record_td",
+        weight: 75,
+        refs: { matchId: m.id, totalTd: td },
+        summary: `Festival de touchdowns : ${td} TDs entre ${m.homeTeamName} et ${m.awayTeamName}.`,
+      });
+    }
+
+    // bloodbath
+    if (m.casualtyCount >= CASUALTY_BLOODBATH) {
+      out.push({
+        type: "bloodbath",
+        weight: 80,
+        refs: { matchId: m.id, casualties: m.casualtyCount },
+        summary: `Bain de sang : ${m.casualtyCount} blessures dans ${m.homeTeamName} - ${m.awayTeamName}.`,
+      });
+    }
+
+    // nuffle_chaos
+    if (m.nuffleCount >= NUFFLE_CHAOS) {
+      out.push({
+        type: "nuffle_chaos",
+        weight: 65,
+        refs: { matchId: m.id, nuffleCount: m.nuffleCount },
+        summary: `Nuffle s'est déchaîné : ${m.nuffleCount} events scriptés sur ${m.homeTeamName} - ${m.awayTeamName}.`,
+      });
+    }
+
+    // rivalry_buildup
+    if (input.priorMatchups) {
+      const key = matchupKey(m.homeTeamSlug, m.awayTeamSlug);
+      const matchup = input.priorMatchups.get(key);
+      if (matchup && matchup.count >= 3) {
+        out.push({
+          type: "rivalry_buildup",
+          weight: 85,
+          refs: {
+            matchId: m.id,
+            home: m.homeTeamSlug,
+            away: m.awayTeamSlug,
+            priorCount: matchup.count,
+            since: matchup.firstAt,
+          },
+          summary: `${m.homeTeamName} et ${m.awayTeamName} : ${matchup.count}e affrontement, la rivalité s'enracine.`,
+        });
+      }
+    }
+  }
+
+  // Trie par weight desc — le LLM consommera dans cet ordre.
+  out.sort((a, b) => b.weight - a.weight);
+  return out;
+}


### PR DESCRIPTION
## Summary

Démarrage du **lot 1.E** — sprint 1.E.3 (storyline detector + Gazette daily recap aggregator).

Ces 2 services sont des fondations pure backend qui alimenteront la Nuffle Gazette LLM (lot 1.E.1) à venir.

### `services/pro-storyline-detector.ts` — pure logic

`detectStorylines({matches, standings, priorMatchups?})` détecte 8 types d'angles narratifs :

| Type | Critère | Weight |
|---|---|---|
| `upset` | Favori (>70% V) perd contre underdog (<50% V) | 90 |
| `rivalry_buildup` | 3e matchup en ≤30j | 85 |
| `blowout` | Écart ≥ 4 TDs | 80-100 |
| `bloodbath` | ≥ 4 casualties | 80 |
| `record_td` | ≥ 6 TDs total | 75 |
| `season_top` | Équipe atteint rank 1 | 70 |
| `nuffle_chaos` | ≥ 3 events Nuffle | 65 |
| `narrow` | Nul ou 1 TD d'écart | 55 |

Chaque storyline : `{type, weight, refs, summary}`. Tri par weight desc — le LLM consommera les angles les plus forts en priorité.

**Pure function, sans I/O** — testable seule.

### `services/pro-gazette-recap.ts` — DB aggregator

`getDailyRecap(at?)` agrège pour la fenêtre `[at, at+24h]` :

- Matchs `completed` (filtre les `failed` qui ont scoreHome=null)
- Standings courants (saison `in_progress` > fallback `completed` la plus récente, rank 1-based via tri Prisma)
- Prior matchups (30j) pour détection rivalry
- Storylines via `detectStorylines`

Default `at` = il y a 24h (Gazette du jour pour J-1).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-storyline-detector pro-gazette-recap` → **18/18 ✓**

Couverture :
| Cas | Résultat |
|---|---|
| Empty input | OK |
| 8 types de storylines détectés ou non selon criteria | OK |
| Tri par weight desc (upset > blowout) | OK |
| 1 match → multiples storylines (blowout + bloodbath) | OK |
| Recap : empty / filtre failed / standings + storylines / rivalry detection | OK |

## Suite (lot 1.E)

- **1.E.2** : modèle Prisma `ProGazetteArticle` + page `/nuffle-gazette` UI
- **1.E.1** : LLM Claude Haiku (cron 8h, prompt template, cache)
- **1.E.4** : casualties persistantes (post-process roster)
- **1.E.5** : Hall of Fame light
- **1.E.6** : rookie pipeline


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_