### PR TITLE
feat(server,web): Pro League Gazette models + UI (sprint 1.E.2)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -1104,3 +1104,18 @@ model ProUserBadge {
   @@index([badgeCode])
   @@index([userId])
 }
+
+model ProGazetteArticle {
+  id               String   @id @default(cuid())
+  date             DateTime
+  type             String
+  persona          String?
+  title            String
+  body             String
+  relatedTeamIds   String?
+  relatedPlayerIds String?
+  createdAt        DateTime @default(now())
+
+  @@index([date])
+  @@index([type, date])
+}

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -46,6 +46,12 @@ import {
   listUserBadges,
 } from "../services/pro-badges";
 import {
+  GazetteValidationError,
+  listEditionDates,
+  listEditionForDate,
+  listLatestEdition,
+} from "../services/pro-gazette";
+import {
   InsufficientFundsError,
   getBalance,
   getRecentTransactions,
@@ -562,6 +568,69 @@ export async function handleEvaluateMyBadges(
 }
 
 /**
+ * Sprint 1.E.2 — Renvoie la dernière édition de la Gazette publiée.
+ * 200 avec edition=null si aucun article.
+ */
+export async function handleGetLatestEdition(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const edition = await listLatestEdition();
+  res.json({ edition });
+}
+
+/**
+ * Sprint 1.E.2 — Renvoie l'édition d'une date donnée (YYYY-MM-DD).
+ */
+export async function handleGetEditionByDate(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const date = req.params.date;
+  if (typeof date !== "string") {
+    res.status(400).json({ error: "missing-date" });
+    return;
+  }
+  try {
+    const edition = await listEditionForDate(date);
+    res.json({ edition });
+  } catch (err: unknown) {
+    if (err instanceof GazetteValidationError) {
+      res.status(400).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/gazette/${date}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint 1.E.2 — Liste les dates publiées (archive). `?limit=N`.
+ */
+export async function handleListEditionDates(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const limit =
+    typeof req.query.limit === "string"
+      ? Number.parseInt(req.query.limit, 10)
+      : 30;
+  try {
+    const dates = await listEditionDates(limit);
+    res.json({ dates });
+  } catch (err: unknown) {
+    if (err instanceof GazetteValidationError) {
+      res.status(400).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/gazette/dates] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
  * Sprint 1.D.6 — Snapshot wallet : solde + 20 dernières transactions.
  */
 export async function handleGetMyWallet(
@@ -678,6 +747,9 @@ router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/markets", handleListMarkets);
 router.get("/matches/:id/stream", handleStreamProMatch);
 router.get("/leaderboard", handleGetBetLeaderboard);
+router.get("/gazette/latest", handleGetLatestEdition);
+router.get("/gazette/dates", handleListEditionDates);
+router.get("/gazette/:date", handleGetEditionByDate);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 
 // Sprint 1.C.4 — endpoints auth-protected pour le mode "fan".

--- a/apps/server/src/services/pro-gazette.test.ts
+++ b/apps/server/src/services/pro-gazette.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proGazetteArticle: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      groupBy: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  GazetteValidationError,
+  createArticles,
+  listEditionDates,
+  listEditionForDate,
+  listLatestEdition,
+} from "./pro-gazette";
+
+interface MockedPrisma {
+  proGazetteArticle: {
+    findMany: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+    groupBy: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+    fn(prisma),
+  );
+});
+
+describe("listEditionForDate — sprint 1.E.2", () => {
+  it("rejette format date invalide", async () => {
+    await expect(listEditionForDate("not-a-date")).rejects.toThrow(
+      GazetteValidationError,
+    );
+    await expect(listEditionForDate("2026-13-01")).rejects.toThrow();
+  });
+
+  it("renvoie articles d'une journée triés MAIN > BREVE > EDITO", async () => {
+    const day = new Date("2026-09-15T00:00:00Z");
+    mocked.proGazetteArticle.findMany.mockResolvedValue([
+      {
+        id: "a_breve",
+        date: day,
+        type: "BREVE",
+        persona: null,
+        title: "Brève",
+        body: "...",
+        relatedTeamIds: null,
+        relatedPlayerIds: null,
+        createdAt: new Date("2026-09-15T08:00:00Z"),
+      },
+      {
+        id: "a_edito",
+        date: day,
+        type: "EDITO",
+        persona: "cynic",
+        title: "Édito",
+        body: "...",
+        relatedTeamIds: null,
+        relatedPlayerIds: null,
+        createdAt: new Date("2026-09-15T08:01:00Z"),
+      },
+      {
+        id: "a_main",
+        date: day,
+        type: "MAIN",
+        persona: "statistician",
+        title: "Article principal",
+        body: "...",
+        relatedTeamIds: ["buf", "kc"],
+        relatedPlayerIds: null,
+        createdAt: new Date("2026-09-15T08:02:00Z"),
+      },
+    ]);
+    const out = await listEditionForDate("2026-09-15");
+    expect(out.date).toBe("2026-09-15");
+    expect(out.articles[0].type).toBe("MAIN");
+    expect(out.articles[0].relatedTeamIds).toEqual(["buf", "kc"]);
+    expect(out.articles[1].type).toBe("BREVE");
+    expect(out.articles[2].type).toBe("EDITO");
+  });
+
+  it("parse relatedTeamIds depuis JSON string (sqlite mirror)", async () => {
+    const day = new Date("2026-09-15T00:00:00Z");
+    mocked.proGazetteArticle.findMany.mockResolvedValue([
+      {
+        id: "a1",
+        date: day,
+        type: "MAIN",
+        persona: null,
+        title: "T",
+        body: "B",
+        relatedTeamIds: '["buf","kc"]',
+        relatedPlayerIds: null,
+        createdAt: day,
+      },
+    ]);
+    const out = await listEditionForDate("2026-09-15");
+    expect(out.articles[0].relatedTeamIds).toEqual(["buf", "kc"]);
+  });
+});
+
+describe("listLatestEdition — sprint 1.E.2", () => {
+  it("null si aucun article publié", async () => {
+    mocked.proGazetteArticle.findFirst.mockResolvedValue(null);
+    expect(await listLatestEdition()).toBeNull();
+  });
+
+  it("renvoie l'édition de la dernière date", async () => {
+    const latestDate = new Date("2026-09-15T00:00:00Z");
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: latestDate,
+    });
+    mocked.proGazetteArticle.findMany.mockResolvedValue([
+      {
+        id: "a1",
+        date: latestDate,
+        type: "MAIN",
+        persona: null,
+        title: "T",
+        body: "B",
+        relatedTeamIds: null,
+        relatedPlayerIds: null,
+        createdAt: latestDate,
+      },
+    ]);
+    const out = await listLatestEdition();
+    expect(out?.date).toBe("2026-09-15");
+    expect(out?.articles).toHaveLength(1);
+  });
+});
+
+describe("listEditionDates — sprint 1.E.2", () => {
+  it("rejette limit invalide", async () => {
+    await expect(listEditionDates(0)).rejects.toThrow(GazetteValidationError);
+    await expect(listEditionDates(500)).rejects.toThrow();
+  });
+
+  it("renvoie les dates au format YYYY-MM-DD", async () => {
+    mocked.proGazetteArticle.groupBy.mockResolvedValue([
+      { date: new Date("2026-09-15T00:00:00Z") },
+      { date: new Date("2026-09-14T00:00:00Z") },
+    ]);
+    const out = await listEditionDates();
+    expect(out).toEqual(["2026-09-15", "2026-09-14"]);
+  });
+});
+
+describe("createArticles — sprint 1.E.2", () => {
+  async function expectCode(p: Promise<unknown>, code: string) {
+    try {
+      await p;
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GazetteValidationError);
+      expect((err as GazetteValidationError).code).toBe(code);
+    }
+  }
+
+  it("rejette payload vide", async () => {
+    await expectCode(
+      createArticles({ date: "2026-09-15", articles: [] }),
+      "INVALID_PAYLOAD",
+    );
+  });
+
+  it("rejette type invalide", async () => {
+    await expectCode(
+      createArticles({
+        date: "2026-09-15",
+        articles: [
+          {
+            // @ts-expect-error type invalide volontaire
+            type: "FOOBAR",
+            title: "T",
+            body: "B",
+          },
+        ],
+      }),
+      "INVALID_TYPE",
+    );
+  });
+
+  it("rejette EDITO sans persona", async () => {
+    await expectCode(
+      createArticles({
+        date: "2026-09-15",
+        articles: [{ type: "EDITO", title: "T", body: "B" }],
+      }),
+      "EDITO_REQUIRES_PERSONA",
+    );
+  });
+
+  it("rejette persona invalide", async () => {
+    await expectCode(
+      createArticles({
+        date: "2026-09-15",
+        articles: [
+          {
+            type: "EDITO",
+            // @ts-expect-error persona invalide volontaire
+            persona: "alien",
+            title: "T",
+            body: "B",
+          },
+        ],
+      }),
+      "INVALID_PERSONA",
+    );
+  });
+
+  it("rejette title/body vides", async () => {
+    await expectCode(
+      createArticles({
+        date: "2026-09-15",
+        articles: [{ type: "MAIN", title: "", body: "B" }],
+      }),
+      "INVALID_TITLE",
+    );
+  });
+
+  it("crée plusieurs articles atomiques", async () => {
+    let i = 0;
+    mocked.proGazetteArticle.create.mockImplementation(async () => ({
+      id: `a${i++}`,
+    }));
+    const out = await createArticles({
+      date: "2026-09-15",
+      articles: [
+        {
+          type: "MAIN",
+          persona: "statistician",
+          title: "Stats du jour",
+          body: "...",
+          relatedTeamIds: ["buf"],
+        },
+        {
+          type: "EDITO",
+          persona: "cynic",
+          title: "Tout va mal",
+          body: "...",
+        },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(mocked.proGazetteArticle.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/server/src/services/pro-gazette.ts
+++ b/apps/server/src/services/pro-gazette.ts
@@ -1,0 +1,311 @@
+/**
+ * Pro League Nuffle Gazette service — sprint 1.E.2.
+ *
+ * CRUD minimal sur `ProGazetteArticle` :
+ *  - `listLatestEdition()` : articles les plus récents (= la dernière
+ *    date avec ≥1 article).
+ *  - `listEditionForDate(date)` : tous les articles d'une date donnée
+ *    (YYYY-MM-DD).
+ *  - `listEditionDates(limit)` : liste des dates publiées (archive).
+ *  - `createArticles({date, articles[]})` : insère plusieurs articles
+ *    en une seule transaction. Consommé par le LLM (lot 1.E.1) et
+ *    par les routes admin.
+ *
+ * `date` est normalisée à 00:00:00 UTC pour permettre une recherche
+ * par jour stable.
+ */
+
+import { prisma } from "../prisma";
+
+export type GazetteArticleType = "MAIN" | "BREVE" | "EDITO";
+export type GazettePersona =
+  | "cynic"
+  | "orc_enthusiast"
+  | "statistician";
+
+const VALID_TYPES: ReadonlySet<GazetteArticleType> = new Set([
+  "MAIN",
+  "BREVE",
+  "EDITO",
+]);
+const VALID_PERSONAS: ReadonlySet<GazettePersona> = new Set([
+  "cynic",
+  "orc_enthusiast",
+  "statistician",
+]);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export class GazetteValidationError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "GazetteValidationError";
+  }
+}
+
+export interface GazetteArticleSummary {
+  readonly id: string;
+  readonly date: string;
+  readonly type: GazetteArticleType;
+  readonly persona: GazettePersona | null;
+  readonly title: string;
+  readonly body: string;
+  readonly relatedTeamIds: readonly string[];
+  readonly relatedPlayerIds: readonly string[];
+  readonly createdAt: string;
+}
+
+export interface GazetteEdition {
+  readonly date: string;
+  readonly articles: readonly GazetteArticleSummary[];
+}
+
+interface ArticleRow {
+  id: string;
+  date: Date;
+  type: string;
+  persona: string | null;
+  title: string;
+  body: string;
+  relatedTeamIds: unknown;
+  relatedPlayerIds: unknown;
+  createdAt: Date;
+}
+
+function parseStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((v): v is string => typeof v === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(
+          (v): v is string => typeof v === "string",
+        );
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function rowToSummary(r: ArticleRow): GazetteArticleSummary {
+  return {
+    id: r.id,
+    date: r.date.toISOString().slice(0, 10),
+    type: r.type as GazetteArticleType,
+    persona: (r.persona as GazettePersona | null) ?? null,
+    title: r.title,
+    body: r.body,
+    relatedTeamIds: parseStringArray(r.relatedTeamIds),
+    relatedPlayerIds: parseStringArray(r.relatedPlayerIds),
+    createdAt: r.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Convertit une "YYYY-MM-DD" string ou Date en Date UTC normalisée
+ * (00:00:00). Throw si invalide.
+ */
+function normalizeDate(input: string | Date): Date {
+  if (input instanceof Date) {
+    return new Date(
+      Date.UTC(
+        input.getUTCFullYear(),
+        input.getUTCMonth(),
+        input.getUTCDate(),
+      ),
+    );
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+    throw new GazetteValidationError(
+      "INVALID_DATE",
+      `Date doit être au format YYYY-MM-DD (reçu: '${input}')`,
+    );
+  }
+  const [yyyy, mm, dd] = input.split("-").map((s) => Number.parseInt(s, 10));
+  const d = new Date(Date.UTC(yyyy, mm - 1, dd));
+  if (Number.isNaN(d.getTime())) {
+    throw new GazetteValidationError(
+      "INVALID_DATE",
+      `Date invalide : '${input}'`,
+    );
+  }
+  return d;
+}
+
+/**
+ * Liste tous les articles d'une date donnée (UTC).
+ * Triés par type (MAIN > BREVE > EDITO), puis createdAt asc.
+ */
+export async function listEditionForDate(
+  date: string | Date,
+): Promise<GazetteEdition> {
+  const day = normalizeDate(date);
+  const next = new Date(day.getTime() + DAY_MS);
+  const rows = (await prisma.proGazetteArticle.findMany({
+    where: { date: { gte: day, lt: next } },
+    orderBy: [{ createdAt: "asc" }],
+    select: {
+      id: true,
+      date: true,
+      type: true,
+      persona: true,
+      title: true,
+      body: true,
+      relatedTeamIds: true,
+      relatedPlayerIds: true,
+      createdAt: true,
+    },
+  })) as ArticleRow[];
+
+  // Tri MAIN > BREVE > EDITO sans changer l'ordre createdAt à
+  // l'intérieur d'un type.
+  const TYPE_ORDER: Record<GazetteArticleType, number> = {
+    MAIN: 0,
+    BREVE: 1,
+    EDITO: 2,
+  };
+  const articles = rows.map(rowToSummary).sort((a, b) => {
+    const oa = TYPE_ORDER[a.type] ?? 99;
+    const ob = TYPE_ORDER[b.type] ?? 99;
+    if (oa !== ob) return oa - ob;
+    return a.createdAt.localeCompare(b.createdAt);
+  });
+
+  return {
+    date: day.toISOString().slice(0, 10),
+    articles,
+  };
+}
+
+/**
+ * Renvoie l'édition la plus récente avec ≥1 article. null si aucun
+ * article publié.
+ */
+export async function listLatestEdition(): Promise<GazetteEdition | null> {
+  const latest = (await prisma.proGazetteArticle.findFirst({
+    orderBy: [{ date: "desc" }, { createdAt: "desc" }],
+    select: { date: true },
+  })) as { date: Date } | null;
+  if (!latest) return null;
+  return listEditionForDate(latest.date);
+}
+
+/**
+ * Liste les `limit` dernières dates avec articles (archive). Triées
+ * desc.
+ */
+export async function listEditionDates(
+  limit: number = 30,
+): Promise<string[]> {
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 365) {
+    throw new GazetteValidationError(
+      "INVALID_LIMIT",
+      `limit doit être ∈ [1, 365] (reçu: ${limit})`,
+    );
+  }
+  // SELECT DISTINCT date n'est pas trivial via Prisma sans groupBy.
+  // On fait groupBy.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (await (prisma as any).proGazetteArticle.groupBy({
+    by: ["date"],
+    orderBy: { date: "desc" },
+    take: limit,
+  })) as { date: Date }[];
+  return rows.map((r) => r.date.toISOString().slice(0, 10));
+}
+
+export interface CreateArticleInput {
+  readonly type: GazetteArticleType;
+  readonly persona?: GazettePersona | null;
+  readonly title: string;
+  readonly body: string;
+  readonly relatedTeamIds?: readonly string[];
+  readonly relatedPlayerIds?: readonly string[];
+}
+
+export interface CreateArticlesInput {
+  readonly date: string | Date;
+  readonly articles: readonly CreateArticleInput[];
+}
+
+/**
+ * Insère plusieurs articles pour une date donnée. Atomique. Renvoie
+ * les ids créés.
+ */
+export async function createArticles(
+  input: CreateArticlesInput,
+): Promise<string[]> {
+  const day = normalizeDate(input.date);
+  if (input.articles.length === 0) {
+    throw new GazetteValidationError(
+      "INVALID_PAYLOAD",
+      "Au moins 1 article requis",
+    );
+  }
+
+  for (const a of input.articles) {
+    if (!VALID_TYPES.has(a.type)) {
+      throw new GazetteValidationError(
+        "INVALID_TYPE",
+        `type invalide: '${a.type}' (attendu: MAIN/BREVE/EDITO)`,
+      );
+    }
+    if (a.persona !== undefined && a.persona !== null) {
+      if (!VALID_PERSONAS.has(a.persona)) {
+        throw new GazetteValidationError(
+          "INVALID_PERSONA",
+          `persona invalide: '${a.persona}'`,
+        );
+      }
+    }
+    if (a.type === "EDITO" && !a.persona) {
+      throw new GazetteValidationError(
+        "EDITO_REQUIRES_PERSONA",
+        "Un EDITO doit être signé par une persona",
+      );
+    }
+    if (typeof a.title !== "string" || a.title.length === 0) {
+      throw new GazetteValidationError(
+        "INVALID_TITLE",
+        "title requis (string non vide)",
+      );
+    }
+    if (typeof a.body !== "string" || a.body.length === 0) {
+      throw new GazetteValidationError(
+        "INVALID_BODY",
+        "body requis (string non vide)",
+      );
+    }
+  }
+
+  const ids: string[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    for (const a of input.articles) {
+      const created = await tx.proGazetteArticle.create({
+        data: {
+          date: day,
+          type: a.type,
+          persona: a.persona ?? null,
+          title: a.title,
+          body: a.body,
+          relatedTeamIds: a.relatedTeamIds
+            ? (a.relatedTeamIds as unknown as object)
+            : null,
+          relatedPlayerIds: a.relatedPlayerIds
+            ? (a.relatedPlayerIds as unknown as object)
+            : null,
+        },
+        select: { id: true },
+      });
+      ids.push(created.id as string);
+    }
+  });
+  return ids;
+}

--- a/apps/web/app/pro-league/gazette/[date]/page.tsx
+++ b/apps/web/app/pro-league/gazette/[date]/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest, ApiClientError } from "../../../lib/api-client";
+
+import { type GazetteEdition, EditionDisplay } from "../_shared";
+
+/**
+ * Archive : édition d'une date donnée — sprint 1.E.2.
+ */
+
+interface PageProps {
+  readonly params: { date: string };
+}
+
+interface EditionResponse {
+  readonly edition: GazetteEdition;
+}
+
+export default function GazetteArchivePage({
+  params,
+}: PageProps): JSX.Element {
+  const [edition, setEdition] = useState<GazetteEdition | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<EditionResponse>(
+      `/pro-league/gazette/${encodeURIComponent(params.date)}`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setEdition(d.edition);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiClientError && e.status === 400) {
+          setError("Date invalide.");
+          return;
+        }
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.date]);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-black tracking-tight text-amber-200">
+            🗞️ Nuffle Gazette
+          </h1>
+          <p className="mt-1 text-sm text-slate-400">
+            Édition du{" "}
+            <span className="font-mono text-slate-300">{params.date}</span>
+          </p>
+        </div>
+        <Link
+          href="/pro-league/gazette"
+          className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+        >
+          ← Latest
+        </Link>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : edition ? (
+        <EditionDisplay edition={edition} />
+      ) : (
+        <p
+          data-testid="gazette-empty"
+          className="text-sm text-slate-500"
+        >
+          Aucun article pour cette date.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/pro-league/gazette/_shared.tsx
+++ b/apps/web/app/pro-league/gazette/_shared.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Shared types + components — sprint 1.E.2.
+ */
+
+export type GazetteArticleType = "MAIN" | "BREVE" | "EDITO";
+export type GazettePersona = "cynic" | "orc_enthusiast" | "statistician";
+
+export interface GazetteArticle {
+  readonly id: string;
+  readonly date: string;
+  readonly type: GazetteArticleType;
+  readonly persona: GazettePersona | null;
+  readonly title: string;
+  readonly body: string;
+  readonly relatedTeamIds: readonly string[];
+  readonly relatedPlayerIds: readonly string[];
+  readonly createdAt: string;
+}
+
+export interface GazetteEdition {
+  readonly date: string;
+  readonly articles: readonly GazetteArticle[];
+}
+
+export const PERSONA_LABEL: Record<GazettePersona, string> = {
+  cynic: "Le Cynique",
+  orc_enthusiast: "L'Enthousiaste Orc",
+  statistician: "Le Statisticien",
+};
+
+export const PERSONA_EMOJI: Record<GazettePersona, string> = {
+  cynic: "🦝",
+  orc_enthusiast: "🟢",
+  statistician: "📊",
+};
+
+export const TYPE_LABEL: Record<GazetteArticleType, string> = {
+  MAIN: "Article principal",
+  BREVE: "Brève",
+  EDITO: "Édito",
+};
+
+const TYPE_BG: Record<GazetteArticleType, string> = {
+  MAIN: "bg-amber-950 border-amber-800",
+  BREVE: "bg-slate-900 border-slate-800",
+  EDITO: "bg-purple-950 border-purple-800",
+};
+
+export function ArticleCard({
+  article,
+}: {
+  article: GazetteArticle;
+}): JSX.Element {
+  return (
+    <article
+      data-testid={`gazette-article-${article.type}`}
+      className={`rounded border-l-4 px-4 py-3 ${TYPE_BG[article.type]}`}
+    >
+      <div className="mb-2 flex items-center gap-2 text-xs uppercase">
+        <span className="font-bold tracking-wide text-slate-400">
+          {TYPE_LABEL[article.type]}
+        </span>
+        {article.persona ? (
+          <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-300">
+            {PERSONA_EMOJI[article.persona]} {PERSONA_LABEL[article.persona]}
+          </span>
+        ) : null}
+      </div>
+      <h2 className="mb-2 text-xl font-bold text-slate-50">{article.title}</h2>
+      <div className="prose prose-invert max-w-none whitespace-pre-line text-sm text-slate-200">
+        {article.body}
+      </div>
+      {article.relatedTeamIds.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {article.relatedTeamIds.map((slug) => (
+            <Link
+              key={slug}
+              href={`/pro-league/teams/${encodeURIComponent(slug)}`}
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-700"
+            >
+              {slug}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function EditionDisplay({
+  edition,
+}: {
+  edition: GazetteEdition;
+}): JSX.Element {
+  if (edition.articles.length === 0) {
+    return (
+      <p className="text-sm text-slate-500" data-testid="gazette-empty">
+        Aucun article publié pour le {edition.date}.
+      </p>
+    );
+  }
+  return (
+    <div data-testid="gazette-edition" className="flex flex-col gap-4">
+      {edition.articles.map((a) => (
+        <ArticleCard key={a.id} article={a} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/pro-league/gazette/page.test.tsx
+++ b/apps/web/app/pro-league/gazette/page.test.tsx
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {},
+}));
+
+import { apiRequest } from "../../lib/api-client";
+import GazetteHomePage from "./page";
+
+const mockedApi = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GazetteHomePage — sprint 1.E.2", () => {
+  it("affiche 'Chargement' pendant le fetch", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<GazetteHomePage />);
+    expect(screen.getByText(/Chargement/)).toBeTruthy();
+  });
+
+  it("affiche le placeholder si edition=null", async () => {
+    mockedApi
+      .mockResolvedValueOnce({ edition: null })
+      .mockResolvedValueOnce({ dates: [] });
+    render(<GazetteHomePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("gazette-no-edition")).toBeTruthy();
+    });
+  });
+
+  it("affiche l'édition avec les articles", async () => {
+    mockedApi
+      .mockResolvedValueOnce({
+        edition: {
+          date: "2026-09-15",
+          articles: [
+            {
+              id: "a1",
+              date: "2026-09-15",
+              type: "MAIN",
+              persona: "statistician",
+              title: "Stats du jour",
+              body: "Buffalo écrase tout le monde.",
+              relatedTeamIds: ["buf-snow-ogres"],
+              relatedPlayerIds: [],
+              createdAt: "2026-09-15T08:00:00Z",
+            },
+            {
+              id: "a2",
+              date: "2026-09-15",
+              type: "EDITO",
+              persona: "cynic",
+              title: "Pas de surprise",
+              body: "Encore une journée banale.",
+              relatedTeamIds: [],
+              relatedPlayerIds: [],
+              createdAt: "2026-09-15T08:01:00Z",
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ dates: ["2026-09-15", "2026-09-14"] });
+
+    render(<GazetteHomePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("gazette-edition")).toBeTruthy();
+    });
+    expect(screen.getByText("Stats du jour")).toBeTruthy();
+    expect(screen.getByText(/Buffalo/)).toBeTruthy();
+    expect(screen.getByText("Pas de surprise")).toBeTruthy();
+    expect(screen.getByText(/Le Statisticien/)).toBeTruthy();
+    expect(screen.getByText(/Le Cynique/)).toBeTruthy();
+  });
+
+  it("affiche l'archive quand >1 dates", async () => {
+    mockedApi
+      .mockResolvedValueOnce({
+        edition: {
+          date: "2026-09-15",
+          articles: [
+            {
+              id: "a1",
+              date: "2026-09-15",
+              type: "MAIN",
+              persona: null,
+              title: "T",
+              body: "B",
+              relatedTeamIds: [],
+              relatedPlayerIds: [],
+              createdAt: "2026-09-15T08:00:00Z",
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        dates: ["2026-09-15", "2026-09-14", "2026-09-13"],
+      });
+
+    render(<GazetteHomePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("gazette-archive")).toBeTruthy();
+    });
+    // Archive ne montre que les dates antérieures (pas la latest)
+    expect(screen.getByText("2026-09-14")).toBeTruthy();
+    expect(screen.getByText("2026-09-13")).toBeTruthy();
+  });
+
+  it("affiche message d'erreur sur API throw", async () => {
+    mockedApi.mockRejectedValue(new Error("boom"));
+    render(<GazetteHomePage />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/pro-league/gazette/page.tsx
+++ b/apps/web/app/pro-league/gazette/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+import { type GazetteEdition, EditionDisplay } from "./_shared";
+
+/**
+ * Page d'accueil de la Nuffle Gazette — sprint 1.E.2.
+ *
+ * Affiche la dernière édition publiée + lien vers l'archive.
+ */
+
+interface LatestResponse {
+  readonly edition: GazetteEdition | null;
+}
+
+interface DatesResponse {
+  readonly dates: readonly string[];
+}
+
+export default function GazetteHomePage(): JSX.Element {
+  const [edition, setEdition] = useState<GazetteEdition | null>(null);
+  const [archiveDates, setArchiveDates] = useState<readonly string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      apiRequest<LatestResponse>("/pro-league/gazette/latest"),
+      apiRequest<DatesResponse>("/pro-league/gazette/dates?limit=20"),
+    ])
+      .then(([latest, dates]) => {
+        if (cancelled) return;
+        setEdition(latest.edition);
+        setArchiveDates(dates.dates);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "fetch error";
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+      <header className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-black tracking-tight text-amber-200">
+            🗞️ Nuffle Gazette
+          </h1>
+          <p className="mt-1 text-sm text-slate-400">
+            Le quotidien officiel de la Pro League
+          </p>
+        </div>
+        <Link
+          href="/pro-league"
+          className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+        >
+          ← Hub
+        </Link>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Chargement…</p>
+      ) : error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      ) : !edition ? (
+        <p
+          data-testid="gazette-no-edition"
+          className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
+        >
+          La Gazette n'a encore rien publié. Reviens demain matin pour le
+          premier numéro !
+        </p>
+      ) : (
+        <>
+          <p className="mb-4 text-sm text-slate-500">
+            Édition du{" "}
+            <span className="font-mono text-slate-300">{edition.date}</span>
+          </p>
+          <EditionDisplay edition={edition} />
+        </>
+      )}
+
+      {archiveDates.length > 1 ? (
+        <section className="mt-8" data-testid="gazette-archive">
+          <h2 className="mb-2 text-lg font-semibold text-slate-100">
+            Archive
+          </h2>
+          <ul className="flex flex-wrap gap-2">
+            {archiveDates.slice(1).map((d) => (
+              <li key={d}>
+                <Link
+                  href={`/pro-league/gazette/${d}`}
+                  className="rounded border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-300 hover:bg-slate-800"
+                >
+                  {d}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/prisma/migrations/20260507100000_add_pro_gazette_article/migration.sql
+++ b/prisma/migrations/20260507100000_add_pro_gazette_article/migration.sql
@@ -1,0 +1,19 @@
+-- Pro League Gazette articles (sprint 1.E.2).
+
+CREATE TABLE "public"."ProGazetteArticle" (
+    "id"               TEXT NOT NULL,
+    "date"             TIMESTAMP(3) NOT NULL,
+    "type"             TEXT NOT NULL,
+    "persona"          TEXT,
+    "title"            TEXT NOT NULL,
+    "body"             TEXT NOT NULL,
+    "relatedTeamIds"   JSONB,
+    "relatedPlayerIds" JSONB,
+    "createdAt"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProGazetteArticle_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProGazetteArticle_date_idx" ON "public"."ProGazetteArticle"("date");
+CREATE INDEX "ProGazetteArticle_type_date_idx"
+  ON "public"."ProGazetteArticle"("type", "date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1507,3 +1507,46 @@ model ProUserBadge {
   @@index([badgeCode])
   @@index([userId])
 }
+
+/// Sprint Pro League lot 1.E.2 — Article de la Nuffle Gazette.
+///
+/// Genere quotidiennement par le service `pro-gazette-llm.ts` (lot
+/// 1.E.1, LLM Claude Haiku) a partir du recap aggregator (1.E.3).
+/// Stocke en DB pour permettre l'archive consultable a l'URL
+/// `/nuffle-gazette/:date` (1.E.2).
+///
+/// `type` :
+///  - MAIN  : article principal du jour (resume long, ~300 mots)
+///  - BREVE : breve courte (~50-80 mots) sur une storyline secondaire
+///  - EDITO : editorial signe par 1 des 3 personas
+///
+/// `persona` :
+///  - 'cynic'           : le cynique (rumeurs, sarcasmes)
+///  - 'orc_enthusiast'  : l'enthousiaste orc (hype, capslock)
+///  - 'statistician'    : le statisticien (chiffres, analyses)
+///
+/// `relatedTeamIds` / `relatedPlayerIds` : Json arrays de slugs
+/// referenced dans l'article — sert au cross-linking UI (lot 1.E.5
+/// HoF, 1.C.2 team page).
+model ProGazetteArticle {
+  id               String   @id @default(cuid())
+  /// Date d'edition (YYYY-MM-DD). Plusieurs articles par date.
+  /// Index pour archive rapide.
+  date             DateTime
+  /// 'MAIN' | 'BREVE' | 'EDITO'
+  type             String
+  /// 'cynic' | 'orc_enthusiast' | 'statistician'
+  /// MAIN/BREVE peuvent etre signes ou non ; EDITO l'est toujours.
+  persona          String?
+  title            String
+  /// Markdown-friendly. Pas de HTML brut (sanitize cote rendu UI).
+  body             String   @db.Text
+  /// Json array de slugs ProTeam : ['buf-snow-ogres', 'kc-...'].
+  relatedTeamIds   Json?
+  /// Json array de roster ids ou autres ids joueur.
+  relatedPlayerIds Json?
+  createdAt        DateTime @default(now())
+
+  @@index([date])
+  @@index([type, date])
+}


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.E.2** — Modèle Gazette + UI.

### Modèle Prisma `ProGazetteArticle`

| Champ | Rôle |
|---|---|
| `id`, `date`, `createdAt` | metadata standard |
| `type` | `MAIN` / `BREVE` / `EDITO` |
| `persona` | `cynic` / `orc_enthusiast` / `statistician` (obligatoire EDITO) |
| `title`, `body` | titre + markdown-friendly text |
| `relatedTeamIds`, `relatedPlayerIds` | Json arrays pour cross-linking UI |

Index `date` + `(type, date)`. Postgres + sqlite mirror + migration.

### Service `pro-gazette.ts`

| API | Rôle |
|---|---|
| `listLatestEdition()` | Dernière édition publiée (null si rien) |
| `listEditionForDate(date)` | Articles d'une date (tri MAIN > BREVE > EDITO) |
| `listEditionDates(limit)` | Archive (dates publiées desc) |
| `createArticles({date, articles[]})` | Insertion atomique multi-articles avec validation |

Erreurs typées via `GazetteValidationError` (codes propres pour UX).

### 3 endpoints (public)

- `GET /pro-league/gazette/latest`
- `GET /pro-league/gazette/dates?limit=N`
- `GET /pro-league/gazette/:date` (YYYY-MM-DD)

### Pages frontend

**`/pro-league/gazette`** — accueil 🗞️ Nuffle Gazette :
- Header branding amber
- Cards par article avec couleur selon type (MAIN amber, BREVE slate, EDITO purple) + badge persona avec emoji 🦝/🟢/📊
- Section archive avec chips cliquables vers éditions précédentes
- Placeholder si rien publié

**`/pro-league/gazette/[date]`** — archive d'une date.

`<ArticleCard/>` réutilisable : type label, persona badge, titre, body en `whitespace-pre-line`, links cliquables vers pages team via `relatedTeamIds`.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `pnpm --filter @bb/web typecheck` → clean
- [x] Backend `pro-gazette.test.ts` → **13/13 ✓**
- [x] Frontend `gazette/page.test.tsx` → **5/5 ✓**

Couverture totale : **18 tests**.

## Suite (lot 1.E)

- **1.E.1** : LLM Claude Haiku (cron 8h, prompt template, cache prompts) → branche `createArticles` sur la sortie LLM consommant le recap (1.E.3)
- **1.E.4** : casualties persistantes
- **1.E.5** : Hall of Fame light
- **1.E.6** : rookie pipeline


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_