### PR TITLE
feat(server,db): casualties post-process roster (sprint 1.E.4)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -939,31 +939,32 @@ model ProLeagueRound {
 }
 
 model ProLeagueMatch {
-  id             String          @id @default(cuid())
-  season         ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
-  seasonId       String
-  round          ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
-  roundId        String
-  homeTeam       ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
-  homeTeamId     String
-  awayTeam       ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
-  awayTeamId     String
-  status         String          @default("scheduled")
-  scheduledAt    DateTime
-  simulatedAt    DateTime?
-  completedAt    DateTime?
-  seed           BigInt?
-  engineVer      String?
-  replayId       String?         @unique
-  scoreHome      Int?
-  scoreAway      Int?
-  outcome        String?
-  touchdownCount Int?
-  casualtyCount  Int?
-  turnoverCount  Int?
-  nuffleCount    Int?
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  id                  String          @id @default(cuid())
+  season              ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId            String
+  round               ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  roundId             String
+  homeTeam            ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
+  homeTeamId          String
+  awayTeam            ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
+  awayTeamId          String
+  status              String          @default("scheduled")
+  scheduledAt         DateTime
+  simulatedAt         DateTime?
+  completedAt         DateTime?
+  casualtiesAppliedAt DateTime?
+  seed                BigInt?
+  engineVer           String?
+  replayId            String?         @unique
+  scoreHome           Int?
+  scoreAway           Int?
+  outcome             String?
+  touchdownCount      Int?
+  casualtyCount       Int?
+  turnoverCount       Int?
+  nuffleCount         Int?
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
 
   betMarkets ProBetMarket[]
 

--- a/apps/server/src/services/pro-roster-casualties.test.ts
+++ b/apps/server/src/services/pro-roster-casualties.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
+    replay: { findUnique: vi.fn() },
+    proTeamRoster: { findMany: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("@bb/sim-engine", () => ({
+  decompressEvents: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { decompressEvents } from "@bb/sim-engine";
+import {
+  CasualtyApplicationError,
+  applyMatchCasualties,
+  countCasualtiesPerSide,
+  rollCasualtyOutcome,
+  sweepMatchCasualties,
+} from "./pro-roster-casualties";
+
+interface MockedPrisma {
+  proLeagueMatch: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+  proTeamRoster: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+const mocked = prisma as unknown as MockedPrisma;
+const mockedDecompress = vi.mocked(decompressEvents);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proLeagueMatch.update.mockResolvedValue({});
+  mocked.proTeamRoster.update.mockResolvedValue({});
+});
+
+describe("rollCasualtyOutcome — sprint 1.E.4", () => {
+  it("table de probabilités respectée", () => {
+    expect(rollCasualtyOutcome(0)).toBe("niggling");
+    expect(rollCasualtyOutcome(0.49)).toBe("niggling");
+    expect(rollCasualtyOutcome(0.5)).toBe("ma_minus_1");
+    expect(rollCasualtyOutcome(0.74)).toBe("ma_minus_1");
+    expect(rollCasualtyOutcome(0.75)).toBe("st_minus_1");
+    expect(rollCasualtyOutcome(0.86)).toBe("st_minus_1");
+    expect(rollCasualtyOutcome(0.87)).toBe("av_minus_1");
+    expect(rollCasualtyOutcome(0.94)).toBe("av_minus_1");
+    expect(rollCasualtyOutcome(0.95)).toBe("dead");
+    expect(rollCasualtyOutcome(0.99)).toBe("dead");
+  });
+});
+
+describe("countCasualtiesPerSide — sprint 1.E.4", () => {
+  it("compte par préfixe playerId", () => {
+    const events = [
+      { type: "CASUALTY", meta: { playerId: "home-LOS" } },
+      { type: "CASUALTY", meta: { playerId: "away-LOS" } },
+      { type: "CASUALTY", meta: { playerId: "home-NUFFLE-1-3" } },
+      { type: "TD", meta: { team: "home" } },
+      { type: "CASUALTY", meta: { playerId: "weird" } },
+    ];
+    expect(countCasualtiesPerSide(events)).toEqual({ home: 2, away: 1 });
+  });
+
+  it("ignore events non-CASUALTY ou sans meta valide", () => {
+    expect(countCasualtiesPerSide([])).toEqual({ home: 0, away: 0 });
+    expect(
+      countCasualtiesPerSide([{ type: "CASUALTY" }, { type: "CASUALTY", meta: null }]),
+    ).toEqual({ home: 0, away: 0 });
+  });
+});
+
+describe("applyMatchCasualties — sprint 1.E.4", () => {
+  async function expectCode(p: Promise<unknown>, code: string) {
+    try {
+      await p;
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CasualtyApplicationError);
+      expect((err as CasualtyApplicationError).code).toBe(code);
+    }
+  }
+
+  it("MATCH_NOT_FOUND", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expectCode(applyMatchCasualties("m1"), "MATCH_NOT_FOUND");
+  });
+
+  it("MATCH_NOT_COMPLETED", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "scheduled",
+      casualtiesAppliedAt: null,
+      casualtyCount: 0,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: null,
+    });
+    await expectCode(applyMatchCasualties("m1"), "MATCH_NOT_COMPLETED");
+  });
+
+  it("idempotent : skip si casualtiesAppliedAt non null", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+      casualtiesAppliedAt: new Date(),
+      casualtyCount: 2,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: "m1",
+    });
+    const out = await applyMatchCasualties("m1");
+    expect(out.skipped).toBe(true);
+    expect(out.skipReason).toBe("already_applied");
+    expect(out.affected).toBe(0);
+    expect(mocked.replay.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("skip 'no_casualties' si casualtyCount=0 et marque applied", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+      casualtiesAppliedAt: null,
+      casualtyCount: 0,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: "m1",
+    });
+    const out = await applyMatchCasualties("m1");
+    expect(out.skipReason).toBe("no_casualties");
+    expect(mocked.proLeagueMatch.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ casualtiesAppliedAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it("REPLAY_NOT_FOUND si replay manquant", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+      casualtiesAppliedAt: null,
+      casualtyCount: 2,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: "m1",
+    });
+    mocked.replay.findUnique.mockResolvedValue(null);
+    await expectCode(applyMatchCasualties("m1"), "REPLAY_NOT_FOUND");
+  });
+
+  it("no-op silencieux si roster vide (cas MVP courant)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+      casualtiesAppliedAt: null,
+      casualtyCount: 2,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: "m1",
+    });
+    mocked.replay.findUnique.mockResolvedValue({
+      payload: Buffer.from([]),
+    });
+    mockedDecompress.mockResolvedValue([
+      { type: "CASUALTY", meta: { playerId: "home-LOS" } },
+      { type: "CASUALTY", meta: { playerId: "away-LOS" } },
+    ] as never);
+    mocked.proTeamRoster.findMany.mockResolvedValue([]);
+    const out = await applyMatchCasualties("m1");
+    expect(out.skipped).toBe(false);
+    expect(out.affected).toBe(0);
+    expect(out.homeCasualties).toBe(1);
+    expect(out.awayCasualties).toBe(1);
+    expect(mocked.proLeagueMatch.update).toHaveBeenCalled();
+  });
+
+  it("applique outcomes aléatoires sur roster non vide (déterministe)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m_match_1",
+      status: "completed",
+      casualtiesAppliedAt: null,
+      casualtyCount: 2,
+      homeTeamId: "th",
+      awayTeamId: "ta",
+      replayId: "m_match_1",
+    });
+    mocked.replay.findUnique.mockResolvedValue({ payload: Buffer.from([]) });
+    mockedDecompress.mockResolvedValue([
+      { type: "CASUALTY", meta: { playerId: "home-LOS" } },
+      { type: "CASUALTY", meta: { playerId: "away-LOS" } },
+    ] as never);
+    // 11 joueurs côté home et away
+    const homeRoster = Array.from({ length: 11 }, (_, i) => ({
+      id: `h${i}`,
+      name: `H${i}`,
+      niggling: 0,
+      maReduction: 0,
+      stReduction: 0,
+      avReduction: 0,
+    }));
+    const awayRoster = Array.from({ length: 11 }, (_, i) => ({
+      id: `a${i}`,
+      name: `A${i}`,
+      niggling: 0,
+      maReduction: 0,
+      stReduction: 0,
+      avReduction: 0,
+    }));
+    mocked.proTeamRoster.findMany
+      .mockResolvedValueOnce(homeRoster)
+      .mockResolvedValueOnce(awayRoster);
+
+    const out = await applyMatchCasualties("m_match_1");
+    expect(out.skipped).toBe(false);
+    expect(out.affected).toBe(2);
+    expect(out.outcomes).toHaveLength(2);
+    expect(out.outcomes[0].side).toBe("home");
+    expect(out.outcomes[1].side).toBe("away");
+    expect(mocked.proTeamRoster.update).toHaveBeenCalledTimes(2);
+    expect(mocked.proLeagueMatch.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          casualtiesAppliedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+});
+
+describe("sweepMatchCasualties — sprint 1.E.4", () => {
+  it("0/0/0 si rien", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    expect(await sweepMatchCasualties()).toEqual({
+      inspected: 0,
+      processed: 0,
+      failed: 0,
+    });
+  });
+
+  it("agrège processed + failed", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([{ id: "m1" }, { id: "m2" }]);
+    mocked.proLeagueMatch.findUnique
+      .mockResolvedValueOnce(null) // m1 → MATCH_NOT_FOUND → failed
+      .mockResolvedValueOnce({
+        id: "m2",
+        status: "completed",
+        casualtiesAppliedAt: null,
+        casualtyCount: 0,
+        homeTeamId: "th",
+        awayTeamId: "ta",
+        replayId: "m2",
+      });
+    const out = await sweepMatchCasualties();
+    expect(out.inspected).toBe(2);
+    expect(out.processed).toBe(1);
+    expect(out.failed).toBe(1);
+  });
+});

--- a/apps/server/src/services/pro-roster-casualties.ts
+++ b/apps/server/src/services/pro-roster-casualties.ts
@@ -1,0 +1,343 @@
+/**
+ * Pro League roster casualties post-process — sprint 1.E.4.
+ *
+ * Hook post-match : pour chaque ProLeagueMatch `completed`, lit le
+ * Replay et compte les `CASUALTY` events par côté (home / away) en
+ * inspectant le préfixe du `playerId` synthétique (ex: "home-LOS",
+ * "away-NUFFLE-1-3"). Pour chaque côté, sélectionne aléatoirement
+ * `casualtyCount` joueurs `active` du roster et applique un outcome
+ * tiré au sort selon la table de blessures BB :
+ *
+ *   50% niggling (n+1)
+ *   25% MA-1
+ *   12% ST-1
+ *    8% AV-1
+ *    5% dead   → status='dead', retire de l'active roster
+ *
+ * Tirage RNG seedé par `match.id` pour déterminisme replay.
+ * Idempotent via `ProLeagueMatch.casualtiesAppliedAt` (seul appel
+ * effectif si null).
+ *
+ * Si le roster est vide (cas MVP courant — 1.E.6 rookie pipeline pas
+ * encore livré), no-op silencieux (renvoie `affected: 0`).
+ *
+ * Ce service ne consomme PAS le sim-engine — uniquement la DB +
+ * `decompressEvents` du sim-engine pour parser le Replay.
+ */
+
+import { decompressEvents } from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+export type CasualtyOutcome =
+  | "niggling"
+  | "ma_minus_1"
+  | "st_minus_1"
+  | "av_minus_1"
+  | "dead";
+
+export class CasualtyApplicationError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "CasualtyApplicationError";
+  }
+}
+
+export interface AppliedCasualty {
+  readonly side: "home" | "away";
+  readonly rosterId: string;
+  readonly playerName: string;
+  readonly outcome: CasualtyOutcome;
+}
+
+export interface ApplyCasualtiesResult {
+  readonly matchId: string;
+  readonly skipped: boolean;
+  /** "no_roster" / "no_casualties" / null si appliqué */
+  readonly skipReason: string | null;
+  readonly homeCasualties: number;
+  readonly awayCasualties: number;
+  readonly affected: number;
+  readonly outcomes: readonly AppliedCasualty[];
+}
+
+/** Hash FNV1a 32-bit pour seed RNG (cohérent avec sim-runner). */
+function hashSeed(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * RNG mulberry32 — petit, déterministe, suffisant pour des tirages
+ * stochastiques de casualty outcomes (pas crypto).
+ */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+/**
+ * Tire un outcome casualty selon la table décrite dans le module.
+ * Pure : prend un random ∈ [0, 1).
+ */
+export function rollCasualtyOutcome(rand: number): CasualtyOutcome {
+  if (rand < 0.5) return "niggling";
+  if (rand < 0.75) return "ma_minus_1";
+  if (rand < 0.87) return "st_minus_1";
+  if (rand < 0.95) return "av_minus_1";
+  return "dead";
+}
+
+/**
+ * Compte les casualties par côté en inspectant le préfixe du
+ * `playerId` synthétique dans les events. Pure (consomme un array
+ * d'events). Le sim émet la victime (= côté qui subit).
+ */
+export function countCasualtiesPerSide(
+  events: readonly unknown[],
+): { home: number; away: number } {
+  let home = 0;
+  let away = 0;
+  for (const ev of events) {
+    if (!ev || typeof ev !== "object") continue;
+    const e = ev as { type?: unknown; meta?: unknown };
+    if (e.type !== "CASUALTY") continue;
+    const meta = (e.meta ?? {}) as { playerId?: unknown };
+    if (typeof meta.playerId !== "string") continue;
+    if (meta.playerId.startsWith("home-")) home += 1;
+    else if (meta.playerId.startsWith("away-")) away += 1;
+  }
+  return { home, away };
+}
+
+interface RosterPick {
+  readonly id: string;
+  readonly name: string;
+  readonly maReduction: number;
+  readonly stReduction: number;
+  readonly avReduction: number;
+  readonly niggling: number;
+}
+
+/**
+ * Sélectionne `count` rosters distincts dans `pool` via Fisher-Yates
+ * partiel seedé par `rng`.
+ */
+function pickRandomRosters<T extends { id: string }>(
+  pool: readonly T[],
+  count: number,
+  rng: () => number,
+): T[] {
+  if (count <= 0 || pool.length === 0) return [];
+  const arr = [...pool];
+  const n = Math.min(count, arr.length);
+  for (let i = 0; i < n; i += 1) {
+    const j = i + Math.floor(rng() * (arr.length - i));
+    if (j !== i) {
+      const tmp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = tmp;
+    }
+  }
+  return arr.slice(0, n);
+}
+
+function applyOutcomeToData(
+  outcome: CasualtyOutcome,
+  current: RosterPick,
+): {
+  data: Partial<{
+    niggling: number;
+    maReduction: number;
+    stReduction: number;
+    avReduction: number;
+    status: string;
+  }>;
+} {
+  switch (outcome) {
+    case "niggling":
+      return { data: { niggling: current.niggling + 1 } };
+    case "ma_minus_1":
+      return { data: { maReduction: current.maReduction + 1 } };
+    case "st_minus_1":
+      return { data: { stReduction: current.stReduction + 1 } };
+    case "av_minus_1":
+      return { data: { avReduction: current.avReduction + 1 } };
+    case "dead":
+      return { data: { status: "dead" } };
+  }
+}
+
+/**
+ * Applique les casualties d'un match `completed` sur les rosters
+ * concernés. Idempotent via `casualtiesAppliedAt`.
+ */
+export async function applyMatchCasualties(
+  matchId: string,
+): Promise<ApplyCasualtiesResult> {
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: {
+      id: true,
+      status: true,
+      casualtiesAppliedAt: true,
+      casualtyCount: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      replayId: true,
+    },
+  });
+  if (!match) {
+    throw new CasualtyApplicationError(
+      "MATCH_NOT_FOUND",
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  if (match.status !== "completed") {
+    throw new CasualtyApplicationError(
+      "MATCH_NOT_COMPLETED",
+      `Match status='${match.status}' — casualties post-process réservé aux matchs completed`,
+    );
+  }
+  if (match.casualtiesAppliedAt) {
+    return {
+      matchId,
+      skipped: true,
+      skipReason: "already_applied",
+      homeCasualties: 0,
+      awayCasualties: 0,
+      affected: 0,
+      outcomes: [],
+    };
+  }
+  if (!match.casualtyCount || match.casualtyCount === 0) {
+    // Marque applied pour ne pas re-checker.
+    await prisma.proLeagueMatch.update({
+      where: { id: matchId },
+      data: { casualtiesAppliedAt: new Date() },
+    });
+    return {
+      matchId,
+      skipped: true,
+      skipReason: "no_casualties",
+      homeCasualties: 0,
+      awayCasualties: 0,
+      affected: 0,
+      outcomes: [],
+    };
+  }
+
+  // Charge le replay pour compter par côté.
+  const replay = await prisma.replay.findUnique({
+    where: { matchId: matchId },
+    select: { payload: true },
+  });
+  if (!replay) {
+    throw new CasualtyApplicationError(
+      "REPLAY_NOT_FOUND",
+      `Replay manquant pour match '${matchId}' — impossible de répartir`,
+    );
+  }
+  const events = await decompressEvents(replay.payload as Buffer);
+  const { home, away } = countCasualtiesPerSide(events);
+
+  const homeTeamId = match.homeTeamId as string;
+  const awayTeamId = match.awayTeamId as string;
+
+  const rng = mulberry32(hashSeed(`cas:${matchId}`));
+  const outcomes: AppliedCasualty[] = [];
+
+  const sides: ReadonlyArray<["home" | "away", string, number]> = [
+    ["home", homeTeamId, home],
+    ["away", awayTeamId, away],
+  ];
+  for (const [side, teamId, count] of sides) {
+    if (count <= 0) continue;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const roster = (await prisma.proTeamRoster.findMany({
+      where: { teamId, status: "active" },
+      select: {
+        id: true,
+        name: true,
+        niggling: true,
+        maReduction: true,
+        stReduction: true,
+        avReduction: true,
+      },
+    })) as RosterPick[];
+    if (roster.length === 0) continue;
+
+    const picks = pickRandomRosters(roster, count, rng);
+    for (const pick of picks) {
+      const outcome = rollCasualtyOutcome(rng());
+      const { data } = applyOutcomeToData(outcome, pick);
+      await prisma.proTeamRoster.update({
+        where: { id: pick.id },
+        data,
+      });
+      outcomes.push({
+        side,
+        rosterId: pick.id,
+        playerName: pick.name,
+        outcome,
+      });
+    }
+  }
+
+  await prisma.proLeagueMatch.update({
+    where: { id: matchId },
+    data: { casualtiesAppliedAt: new Date() },
+  });
+
+  return {
+    matchId,
+    skipped: false,
+    skipReason: null,
+    homeCasualties: home,
+    awayCasualties: away,
+    affected: outcomes.length,
+    outcomes,
+  };
+}
+
+/**
+ * Cron sweep : trouve les matchs `completed` avec `casualtiesAppliedAt`
+ * null et applique. Erreur par match isolée. Limit 50.
+ */
+export async function sweepMatchCasualties(): Promise<{
+  inspected: number;
+  processed: number;
+  failed: number;
+}> {
+  const candidates = await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "completed",
+      casualtiesAppliedAt: null,
+    },
+    select: { id: true },
+    orderBy: { completedAt: "asc" },
+    take: 50,
+  });
+  let processed = 0;
+  let failed = 0;
+  for (const { id } of candidates) {
+    try {
+      await applyMatchCasualties(id as string);
+      processed += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return { inspected: candidates.length, processed, failed };
+}

--- a/prisma/migrations/20260507200000_add_pro_match_casualties_applied_at/migration.sql
+++ b/prisma/migrations/20260507200000_add_pro_match_casualties_applied_at/migration.sql
@@ -1,0 +1,6 @@
+-- Sprint Pro League lot 1.E.4 — flag idempotence pour le post-process
+-- casualties (sera set au moment où les casualties d'un match
+-- completed ont été reportées sur les rosters).
+
+ALTER TABLE "public"."ProLeagueMatch"
+  ADD COLUMN "casualtiesAppliedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1229,40 +1229,43 @@ model ProLeagueRound {
 /// counters) et on pointe vers `Replay` (lot 1.A.2) pour le payload
 /// binaire compresse.
 model ProLeagueMatch {
-  id             String          @id @default(cuid())
-  season         ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
-  seasonId       String
-  round          ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
-  roundId        String
-  homeTeam       ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
-  homeTeamId     String
-  awayTeam       ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
-  awayTeamId     String
+  id                  String          @id @default(cuid())
+  season              ProLeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId            String
+  round               ProLeagueRound  @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  roundId             String
+  homeTeam            ProTeam         @relation("ProMatchHome", fields: [homeTeamId], references: [id], onDelete: Cascade)
+  homeTeamId          String
+  awayTeam            ProTeam         @relation("ProMatchAway", fields: [awayTeamId], references: [id], onDelete: Cascade)
+  awayTeamId          String
   /// Status : "scheduled" | "ready" | "in_progress" | "completed" | "failed".
   /// "ready" = pre-simule, en attente du broadcaster (lot 1.B.1).
-  status         String          @default("scheduled")
-  scheduledAt    DateTime
-  simulatedAt    DateTime?
-  completedAt    DateTime?
+  status              String          @default("scheduled")
+  scheduledAt         DateTime
+  simulatedAt         DateTime?
+  completedAt         DateTime?
+  /// Sprint 1.E.4 — flag idempotence pour le post-process casualties.
+  /// Non-null = casualties déjà appliquées au roster.
+  casualtiesAppliedAt DateTime?
   /// Seed sim-engine + engineVer pinne au moment de la simulation.
   /// Permet de rejouer le match a l'identique tant que engineVer matche.
-  seed           BigInt?
-  engineVer      String?
+  seed                BigInt?
+  engineVer           String?
   /// Pointeur vers `Replay.matchId` (lot 1.A.2). Pas de FK ici tant que
   /// le modele Replay n'existe pas — sera converti en relation 1.A.2.
-  replayId       String?         @unique
+  replayId            String?         @unique
   /// Score cache pour listings rapides sans charger le replay.
-  scoreHome      Int?
-  scoreAway      Int?
+  scoreHome           Int?
+  scoreAway           Int?
   /// Outcome : "home" | "away" | "draw".
-  outcome        String?
+  outcome             String?
   /// Compteurs caches issus de MatchSummary.
-  touchdownCount Int?
-  casualtyCount  Int?
-  turnoverCount  Int?
-  nuffleCount    Int?
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  touchdownCount      Int?
+  casualtyCount       Int?
+  turnoverCount       Int?
+  nuffleCount         Int?
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
 
   betMarkets ProBetMarket[]
 


### PR DESCRIPTION
## Summary

Sprint Pro League **lot 1.E.4** — Casualties persistantes (post-process roster).

Hook post-match qui reporte les casualties émises par le sim sur les rosters réels (champs `niggling`, `maReduction`, `stReduction`, `avReduction`, `status` déjà présents depuis 1.A.1).

### Migration

`ProLeagueMatch.casualtiesAppliedAt: DateTime?` — flag idempotence.

### Service `pro-roster-casualties.ts`

| API | Rôle |
|---|---|
| `applyMatchCasualties(matchId)` | Pipeline complet idempotent |
| `rollCasualtyOutcome(rand)` | Table de blessures BB-like |
| `countCasualtiesPerSide(events)` | Pure helper |
| `sweepMatchCasualties()` | Cron sweep (limit 50, erreur isolée) |

**Pipeline `applyMatchCasualties` :**
1. Charge match `completed`, idempotent via `casualtiesAppliedAt`
2. No-op + flag si `casualtyCount=0`
3. Lit Replay via `decompressEvents`, compte CASUALTY events par side via préfixe `playerId` ("home-..." / "away-...")
4. Pour chaque side avec count > 0 : sélectionne `count` rosters `active` aléatoirement (Fisher-Yates partiel seedé par `hashSeed("cas:" + matchId)` → mulberry32) et applique un outcome

**Table de blessures** :
| Outcome | Proba | Effet |
|---|---|---|
| niggling | 50% | `niggling += 1` |
| ma_minus_1 | 25% | `maReduction += 1` |
| st_minus_1 | 12% | `stReduction += 1` |
| av_minus_1 | 8% | `avReduction += 1` |
| dead | 5% | `status='dead'` |

### MVP behavior

Si le roster est vide (cas courant — 1.E.6 rookie pipeline pas livré), le service marque quand même `casualtiesAppliedAt` pour ne pas re-checker, avec `affected: 0` et `homeCasualties`/`awayCasualties` reflétant les events sim.

### Erreurs typées

`CasualtyApplicationError` avec codes `MATCH_NOT_FOUND` / `MATCH_NOT_COMPLETED` / `REPLAY_NOT_FOUND`.

## Test plan

- [x] `pnpm --filter @bb/server typecheck` → clean
- [x] `npx vitest run pro-roster-casualties.test.ts` → **12/12 ✓**

Couverture :
| Cas | Résultat |
|---|---|
| `rollCasualtyOutcome` table | OK toutes bornes |
| `countCasualtiesPerSide` préfixe + filtre | OK |
| MATCH_NOT_FOUND / NOT_COMPLETED / REPLAY_NOT_FOUND | OK |
| Idempotent (already_applied) | skip |
| no_casualties + flag set | OK |
| Roster vide → no-op silencieux | `affected: 0` |
| Roster non-vide → outcomes déterministes appliqués | OK |
| Sweep agrège processed/failed | OK |

## Suite (lot 1.E)

- **1.E.1** : LLM Claude Haiku (Gazette cron + prompts)
- **1.E.5** : Hall of Fame light (entrée auto sur status='dead')
- **1.E.6** : rookie pipeline (génère nouveau joueur quand un meurt)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_