### PR TITLE
feat(server): Pro League rookie generator + seed + replenish (sprint 1.E.6)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -675,3 +675,43 @@ if (!inTestBetSettleEnv && betSettleTickMs > 0) {
     },
   );
 }
+
+
+// =============================================================================
+// Pro League rookie replenish cron (sprint 1.E.6).
+// =============================================================================
+// Sweep les equipes Pro dont le roster `active` est sous la cible
+// (TARGET_ROSTER_SIZE = 12) et genere des rookies pour combler. Couvre
+// les morts (status='dead' apres casualties 1.E.4) et toute attrition
+// future. Idempotent (no-op si deja plein).
+//
+// Tick par defaut : 30 min. Configurable via PRO_LEAGUE_ROOKIE_TICK_MS.
+// Mettre = 0 pour desactiver (CI / dev local).
+const inTestRookieEnv =
+  process.env.NODE_ENV === "test" || process.env.TEST_SQLITE === "1";
+const rookieTickMsEnv = Number(process.env.PRO_LEAGUE_ROOKIE_TICK_MS);
+const rookieTickMs = Number.isFinite(rookieTickMsEnv)
+  ? rookieTickMsEnv
+  : 30 * 60 * 1000;
+if (!inTestRookieEnv && rookieTickMs > 0) {
+  void import("./services/pro-roster-generator").then(
+    ({ sweepRookieReplenish }) => {
+      const tick = async () => {
+        try {
+          const out = await sweepRookieReplenish();
+          if (out.replenished > 0 || out.failed > 0) {
+            serverLog.info(
+              `[pro-rookie] sweep: replenished=${out.replenished} failed=${out.failed} (inspected=${out.inspected})`,
+            );
+          }
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : "unknown";
+          serverLog.error(`[pro-rookie] sweep failed: ${msg}`);
+        }
+      };
+      setInterval(() => {
+        void tick();
+      }, rookieTickMs).unref();
+    },
+  );
+}

--- a/apps/server/src/seeders/pro-league.ts
+++ b/apps/server/src/seeders/pro-league.ts
@@ -22,6 +22,7 @@
 import { PRO_LEAGUE_TEAMS } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { seedTeamRoster } from "../services/pro-roster-generator";
 
 export const OLD_WORLD_LEAGUE_SLUG = "old-world-league";
 export const OLD_WORLD_LEAGUE_NAME = "Old World League";
@@ -73,7 +74,7 @@ export async function seedProLeague(): Promise<void> {
 
   for (const team of PRO_LEAGUE_TEAMS) {
     const branding = TEAM_BRANDING[team.id];
-    await prisma.proTeam.upsert({
+    const upserted = await prisma.proTeam.upsert({
       where: { slug: team.id },
       create: {
         leagueId: league.id,
@@ -96,5 +97,8 @@ export async function seedProLeague(): Promise<void> {
         baseTv: team.tv,
       },
     });
+    // Sprint 1.E.6 — peuple le ProTeamRoster initial via le rookie
+    // generator. Idempotent : skip si l'equipe a deja un roster.
+    await seedTeamRoster(upserted.id);
   }
 }

--- a/apps/server/src/services/pro-roster-generator.test.ts
+++ b/apps/server/src/services/pro-roster-generator.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn(), findMany: vi.fn() },
+    proTeamRoster: { count: vi.fn(), create: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  generateRookieData,
+  replenishTeamRoster,
+  seedTeamRoster,
+  sweepRookieReplenish,
+} from "./pro-roster-generator";
+
+interface MockedPrisma {
+  proTeam: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  proTeamRoster: {
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocked.proTeamRoster.create.mockResolvedValue({});
+});
+
+describe("generateRookieData — sprint 1.E.6", () => {
+  it("retourne stats baseline pour Orc", () => {
+    const rng = () => 0.1;
+    const { name, stats } = generateRookieData("Orc", rng);
+    expect(stats.ma).toBe(5);
+    expect(stats.st).toBe(3);
+    expect(stats.ag).toBe(3);
+    expect(stats.av).toBe(10);
+    expect(stats.position).toBe("Lineman");
+    expect(stats.skills).toContain("block");
+    expect(name.length).toBeGreaterThan(0);
+    expect(name).toContain(" ");
+  });
+
+  it("retourne stats baseline pour Ogre (pa=null)", () => {
+    const rng = () => 0.2;
+    const { stats } = generateRookieData("Ogre", rng);
+    expect(stats.st).toBe(5);
+    expect(stats.pa).toBeNull();
+    expect(stats.position).toBe("Big Guy");
+    expect(stats.skills).toContain("mighty_blow");
+  });
+
+  it("fallback sur stats par défaut si race inconnue", () => {
+    const rng = () => 0.5;
+    const { name, stats } = generateRookieData("Unknown Race", rng);
+    expect(stats.ma).toBe(6);
+    expect(stats.st).toBe(3);
+    expect(stats.position).toBe("Lineman");
+    expect(name).toBe("Player Rookie");
+  });
+
+  it("est déterministe pour un RNG fixe", () => {
+    let i = 0;
+    const seq = [0.1, 0.4, 0.7, 0.2];
+    const rng = () => seq[i++ % seq.length];
+    const a = generateRookieData("Wood Elf", rng);
+    i = 0;
+    const b = generateRookieData("Wood Elf", rng);
+    expect(a.name).toBe(b.name);
+  });
+});
+
+describe("seedTeamRoster — sprint 1.E.6", () => {
+  it("throw si team introuvable", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    await expect(seedTeamRoster("missing")).rejects.toThrow(/introuvable/);
+  });
+
+  it("idempotent : skip si roster déjà présent", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Orc",
+      slug: "orks",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(12);
+    const out = await seedTeamRoster("t1");
+    expect(out.created).toBe(0);
+    expect(out.skipped).toBe(12);
+    expect(out.skipReason).toBe("roster_already_seeded");
+    expect(mocked.proTeamRoster.create).not.toHaveBeenCalled();
+  });
+
+  it("crée `count` rookies si roster vide", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Orc",
+      slug: "orks",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(0);
+    const out = await seedTeamRoster("t1", 5);
+    expect(out.created).toBe(5);
+    expect(out.skipped).toBe(0);
+    expect(mocked.proTeamRoster.create).toHaveBeenCalledTimes(5);
+    const firstCall = mocked.proTeamRoster.create.mock.calls[0][0];
+    expect(firstCall.data.teamId).toBe("t1");
+    expect(firstCall.data.status).toBe("active");
+    expect(firstCall.data.position).toBe("Lineman");
+    expect(firstCall.data.ma).toBe(5);
+  });
+
+  it("default count = 12 si non spécifié", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Halfling",
+      slug: "halfs",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(0);
+    const out = await seedTeamRoster("t1");
+    expect(out.created).toBe(12);
+  });
+});
+
+describe("replenishTeamRoster — sprint 1.E.6", () => {
+  it("throw si team introuvable", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(null);
+    await expect(replenishTeamRoster("missing")).rejects.toThrow(/introuvable/);
+  });
+
+  it("no-op si actifs >= target", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Orc",
+      slug: "orks",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(12);
+    const out = await replenishTeamRoster("t1", 12);
+    expect(out.created).toBe(0);
+    expect(out.activeBefore).toBe(12);
+    expect(mocked.proTeamRoster.create).not.toHaveBeenCalled();
+  });
+
+  it("crée le manquant pour atteindre target", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Dwarf",
+      slug: "dorfs",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(8);
+    const out = await replenishTeamRoster("t1", 12);
+    expect(out.created).toBe(4);
+    expect(out.activeBefore).toBe(8);
+    expect(out.targetSize).toBe(12);
+    expect(mocked.proTeamRoster.create).toHaveBeenCalledTimes(4);
+  });
+
+  it("default target=12", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue({
+      id: "t1",
+      race: "Skaven",
+      slug: "rats",
+    });
+    mocked.proTeamRoster.count.mockResolvedValue(10);
+    const out = await replenishTeamRoster("t1");
+    expect(out.targetSize).toBe(12);
+    expect(out.created).toBe(2);
+  });
+});
+
+describe("sweepRookieReplenish — sprint 1.E.6", () => {
+  it("0/0/0 si aucune équipe", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([]);
+    expect(await sweepRookieReplenish()).toEqual({
+      inspected: 0,
+      replenished: 0,
+      failed: 0,
+    });
+  });
+
+  it("agrège replenished + failed", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([
+      { id: "t1" },
+      { id: "t2" },
+      { id: "t3" },
+    ]);
+    mocked.proTeam.findUnique
+      .mockResolvedValueOnce({ id: "t1", race: "Orc", slug: "o1" })
+      .mockResolvedValueOnce(null) // t2 → throw → failed
+      .mockResolvedValueOnce({ id: "t3", race: "Orc", slug: "o3" });
+    mocked.proTeamRoster.count
+      .mockResolvedValueOnce(8) // t1 manque 4 → replenished
+      .mockResolvedValueOnce(12); // t3 plein → no-op
+
+    const out = await sweepRookieReplenish(12);
+    expect(out.inspected).toBe(3);
+    expect(out.replenished).toBe(1);
+    expect(out.failed).toBe(1);
+  });
+});

--- a/apps/server/src/services/pro-roster-generator.ts
+++ b/apps/server/src/services/pro-roster-generator.ts
@@ -1,0 +1,490 @@
+/**
+ * Pro League rookie generator — sprint Pro League lot 1.E.6.
+ *
+ * Génère procéduralement des `ProTeamRoster` pour :
+ *  - Le **seed initial** d'une équipe (au démarrage d'une saison ou
+ *    au seed de la ligue) — `seedTeamRoster(teamId, count)`.
+ *  - Le **remplacement** des joueurs morts (status='dead') ou
+ *    indisponibles longue durée — `replenishTeamRoster(teamId,
+ *    targetSize)`.
+ *  - Le **draft d'urgence** d'un rookie unique — `generateRookie(teamId)`.
+ *
+ * Stats par race basées sur les profils BB2020 (lineman position
+ * uniquement au MVP — les positions exotiques type Blitzer / Thrower
+ * arriveront avec le système de progression XP).
+ *
+ * Noms procéduraux : tirage simple dans des pools racial-flavored.
+ * Pas d'IA — restera lisible et performant.
+ *
+ * Tirage RNG seedé par `teamId` + `Date.now()` pour permettre 2 appels
+ * successifs de produire des joueurs différents (vs casualty service
+ * qui est seedé par matchId pour reproductibilité).
+ */
+
+import { prisma } from "../prisma";
+
+const TARGET_ROSTER_SIZE = 12;
+
+export type Race = string;
+
+export interface RookieStats {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number | null;
+  readonly av: number;
+  readonly position: string;
+  readonly skills: readonly string[];
+}
+
+/** Stats baseline par race (BB2020 Lineman position). */
+const RACE_BASELINE: Record<string, RookieStats> = {
+  Orc: {
+    ma: 5,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 10,
+    position: "Lineman",
+    skills: ["block"],
+  },
+  "Wood Elf": {
+    ma: 7,
+    st: 3,
+    ag: 2,
+    pa: 4,
+    av: 8,
+    position: "Lineman",
+    skills: [],
+  },
+  Dwarf: {
+    ma: 4,
+    st: 3,
+    ag: 4,
+    pa: 4,
+    av: 10,
+    position: "Lineman",
+    skills: ["block", "tackle"],
+  },
+  Halfling: {
+    ma: 5,
+    st: 2,
+    ag: 4,
+    pa: 5,
+    av: 7,
+    position: "Lineman",
+    skills: ["dodge", "right_stuff"],
+  },
+  Ogre: {
+    ma: 5,
+    st: 5,
+    ag: 4,
+    pa: null,
+    av: 10,
+    position: "Big Guy",
+    skills: ["mighty_blow", "thick_skull", "throw_team_mate"],
+  },
+  Skaven: {
+    ma: 7,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    position: "Lineman",
+    skills: [],
+  },
+  Lizardmen: {
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 9,
+    position: "Skink",
+    skills: ["dodge", "stunty"],
+  },
+  Amazon: {
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    position: "Linewoman",
+    skills: ["dodge"],
+  },
+  Norse: {
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    position: "Lineman",
+    skills: ["block"],
+  },
+  Undead: {
+    ma: 6,
+    st: 3,
+    ag: 4,
+    pa: 4,
+    av: 8,
+    position: "Zombie",
+    skills: ["regeneration"],
+  },
+  "Tomb Kings": {
+    ma: 4,
+    st: 3,
+    ag: 4,
+    pa: 4,
+    av: 9,
+    position: "Skeleton",
+    skills: ["regeneration", "thick_skull"],
+  },
+  "Pro Elf": {
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 3,
+    av: 8,
+    position: "Lineman",
+    skills: [],
+  },
+  "Dark Elf": {
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 3,
+    av: 8,
+    position: "Lineman",
+    skills: [],
+  },
+  Beastmen: {
+    ma: 6,
+    st: 3,
+    ag: 4,
+    pa: 4,
+    av: 9,
+    position: "Lineman",
+    skills: ["horns"],
+  },
+};
+
+const DEFAULT_STATS: RookieStats = {
+  ma: 6,
+  st: 3,
+  ag: 3,
+  pa: 4,
+  av: 9,
+  position: "Lineman",
+  skills: [],
+};
+
+/** Pools de noms par race (mini-MVP). */
+const NAME_POOLS: Record<string, { first: string[]; last: string[] }> = {
+  Orc: {
+    first: [
+      "Grimgut",
+      "Mox",
+      "Skraz",
+      "Gorbag",
+      "Brakk",
+      "Uzgar",
+      "Krogan",
+      "Bork",
+      "Drogga",
+      "Ugluk",
+    ],
+    last: [
+      "Ironjaw",
+      "Bonecruncher",
+      "Skullsplitter",
+      "Ratripper",
+      "Bloodtusk",
+      "Goretooth",
+    ],
+  },
+  "Wood Elf": {
+    first: [
+      "Aelar",
+      "Faelar",
+      "Sylvian",
+      "Thranduil",
+      "Lirien",
+      "Caelen",
+      "Aerith",
+      "Faelin",
+    ],
+    last: [
+      "Leafshade",
+      "Moonweaver",
+      "Stardust",
+      "Greenwhisper",
+      "Silverbough",
+    ],
+  },
+  Dwarf: {
+    first: [
+      "Thorgrim",
+      "Borin",
+      "Durok",
+      "Grimnir",
+      "Brokk",
+      "Dwalin",
+      "Balin",
+      "Nori",
+    ],
+    last: [
+      "Stoneshield",
+      "Ironbeard",
+      "Hammerhand",
+      "Goldforge",
+      "Anvilbreaker",
+    ],
+  },
+  Halfling: {
+    first: [
+      "Pippin",
+      "Frodo",
+      "Sam",
+      "Merry",
+      "Bilbo",
+      "Otho",
+      "Bungo",
+      "Drogo",
+    ],
+    last: [
+      "Cheesetoes",
+      "Pieface",
+      "Buttercup",
+      "Honeyfoot",
+      "Tubblesworth",
+    ],
+  },
+  Ogre: {
+    first: ["Bork", "Gronk", "Mash", "Ugg", "Zog", "Brog"],
+    last: ["Bonecruncher", "Smashface", "Ribcrusher"],
+  },
+  Skaven: {
+    first: ["Skritch", "Rikkit", "Snik", "Verminkin", "Gnaw"],
+    last: ["Quicktail", "Blackwhisker", "Sneakypaw", "Plagueclaw"],
+  },
+  Lizardmen: {
+    first: ["Sotek", "Tehenhauin", "Kroq", "Tlaqua", "Itzl"],
+    last: ["Sunblade", "Coldscale", "Stonecharger", "Quickfeather"],
+  },
+  Amazon: {
+    first: ["Itzpapalotl", "Citlali", "Xiuhcoatl", "Yoltzin", "Mahuizoh"],
+    last: ["Spearfeather", "Jadeheart", "Goldenfang", "Wildwind"],
+  },
+  Norse: {
+    first: [
+      "Ragnar",
+      "Bjorn",
+      "Eirik",
+      "Sigurd",
+      "Olaf",
+      "Ulfgar",
+      "Arngrim",
+    ],
+    last: ["Frostfist", "Stormbreaker", "Wolfclaw", "Trollbane"],
+  },
+  Undead: {
+    first: ["Mortimer", "Cadaver", "Lich", "Ghul"],
+    last: ["Boneless", "Pallidface", "Rotbreath", "Dustcrown"],
+  },
+  "Tomb Kings": {
+    first: ["Khepri", "Setep", "Anhur", "Mereb", "Khentkaues"],
+    last: ["Sandwalker", "Goldcurse", "Dustlord", "Painstone"],
+  },
+  "Pro Elf": {
+    first: ["Aelfric", "Lothric", "Tyrian", "Maelis", "Helior"],
+    last: ["Stormcrest", "Skywind", "Lightstride"],
+  },
+  "Dark Elf": {
+    first: ["Malus", "Vaelyn", "Drachau", "Khaine", "Hellebron"],
+    last: ["Bloodspike", "Shadowblade", "Soulrender", "Doomwhisper"],
+  },
+  Beastmen: {
+    first: ["Khazrak", "Gor", "Ungor", "Khorne", "Slaaneshi"],
+    last: ["Cloventooth", "Gorehoof", "Blackmane"],
+  },
+};
+
+const DEFAULT_NAMES = {
+  first: ["Player"],
+  last: ["Rookie"],
+};
+
+/** RNG mulberry32 — petit, déterministe, suffisant ici. */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function hashSeed(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+function pickRandom<T>(arr: readonly T[], rng: () => number): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+/**
+ * Génère un nom + stats baseline pour un rookie de la race donnée.
+ * Pure (RNG injecté) — testable sans I/O.
+ */
+export function generateRookieData(
+  race: string,
+  rng: () => number,
+): { name: string; stats: RookieStats } {
+  const pool = NAME_POOLS[race] ?? DEFAULT_NAMES;
+  const first = pickRandom(pool.first, rng);
+  const last = pickRandom(pool.last, rng);
+  const stats = RACE_BASELINE[race] ?? DEFAULT_STATS;
+  return {
+    name: `${first} ${last}`,
+    stats,
+  };
+}
+
+export interface SeedTeamRosterResult {
+  readonly teamId: string;
+  readonly created: number;
+  readonly skipped: number;
+  readonly skipReason?: string;
+}
+
+/**
+ * Crée `count` rookies pour une équipe au seed initial. No-op si
+ * l'équipe a déjà des joueurs (idempotent).
+ */
+export async function seedTeamRoster(
+  teamId: string,
+  count: number = TARGET_ROSTER_SIZE,
+): Promise<SeedTeamRosterResult> {
+  const team = await prisma.proTeam.findUnique({
+    where: { id: teamId },
+    select: { id: true, race: true, slug: true },
+  });
+  if (!team) {
+    throw new Error(`ProTeam '${teamId}' introuvable`);
+  }
+  const existing = await prisma.proTeamRoster.count({ where: { teamId } });
+  if (existing > 0) {
+    return {
+      teamId,
+      created: 0,
+      skipped: existing,
+      skipReason: "roster_already_seeded",
+    };
+  }
+  const rng = mulberry32(hashSeed(`seed:${teamId}:${team.slug}`));
+  let created = 0;
+  for (let i = 0; i < count; i += 1) {
+    const { name, stats } = generateRookieData(team.race as string, rng);
+    await prisma.proTeamRoster.create({
+      data: {
+        teamId,
+        name,
+        position: stats.position,
+        ma: stats.ma,
+        st: stats.st,
+        ag: stats.ag,
+        pa: stats.pa,
+        av: stats.av,
+        skills: stats.skills as unknown as object,
+        status: "active",
+      },
+    });
+    created += 1;
+  }
+  return { teamId, created, skipped: 0 };
+}
+
+export interface ReplenishResult {
+  readonly teamId: string;
+  readonly activeBefore: number;
+  readonly created: number;
+  readonly targetSize: number;
+}
+
+/**
+ * Si une équipe a moins de `targetSize` joueurs `active`, génère des
+ * rookies pour atteindre la cible. Idempotent (rien à faire si déjà
+ * complet).
+ */
+export async function replenishTeamRoster(
+  teamId: string,
+  targetSize: number = TARGET_ROSTER_SIZE,
+): Promise<ReplenishResult> {
+  const team = await prisma.proTeam.findUnique({
+    where: { id: teamId },
+    select: { id: true, race: true, slug: true },
+  });
+  if (!team) {
+    throw new Error(`ProTeam '${teamId}' introuvable`);
+  }
+  const activeBefore = await prisma.proTeamRoster.count({
+    where: { teamId, status: "active" },
+  });
+  const missing = Math.max(0, targetSize - activeBefore);
+  if (missing === 0) {
+    return { teamId, activeBefore, created: 0, targetSize };
+  }
+  // Seed avec teamId + timestamp pour ne pas re-générer les mêmes
+  // noms d'un appel à l'autre (cas casualties multiples sur saison).
+  const rng = mulberry32(
+    hashSeed(`replenish:${teamId}:${team.slug}:${Date.now()}`),
+  );
+  let created = 0;
+  for (let i = 0; i < missing; i += 1) {
+    const { name, stats } = generateRookieData(team.race as string, rng);
+    await prisma.proTeamRoster.create({
+      data: {
+        teamId,
+        name,
+        position: stats.position,
+        ma: stats.ma,
+        st: stats.st,
+        ag: stats.ag,
+        pa: stats.pa,
+        av: stats.av,
+        skills: stats.skills as unknown as object,
+        status: "active",
+      },
+    });
+    created += 1;
+  }
+  return { teamId, activeBefore, created, targetSize };
+}
+
+/**
+ * Cron sweep : pour chaque équipe avec roster `active` < target,
+ * génère les rookies manquants. Erreur par équipe isolée.
+ */
+export async function sweepRookieReplenish(
+  targetSize: number = TARGET_ROSTER_SIZE,
+): Promise<{ inspected: number; replenished: number; failed: number }> {
+  const teams = await prisma.proTeam.findMany({
+    select: { id: true },
+  });
+  let replenished = 0;
+  let failed = 0;
+  for (const t of teams) {
+    try {
+      const out = await replenishTeamRoster(t.id as string, targetSize);
+      if (out.created > 0) replenished += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  return { inspected: teams.length, replenished, failed };
+}


### PR DESCRIPTION
## Sprint Pro League — lot 1.E.6 (Rookie pipeline)

Generation procedurale des `ProTeamRoster` au seed initial et au remplacement des morts (apres casualties 1.E.4).

### Modifs

**`apps/server/src/services/pro-roster-generator.ts`** (nouveau)
- `RACE_BASELINE` : stats baseline pour 14 races BB2020 (Orc, Wood Elf, Dwarf, Halfling, Ogre, Skaven, Lizardmen, Amazon, Norse, Undead, Tomb Kings, Pro Elf, Dark Elf, Beastmen) — Lineman position au MVP.
- `NAME_POOLS` : pools de prenoms/noms par race (mini-MVP, lisible et performant).
- `generateRookieData(race, rng)` : pure, RNG injectable → testable.
- `seedTeamRoster(teamId, count=12)` : idempotent (no-op si roster deja seede), seed RNG = `seed:teamId:slug`.
- `replenishTeamRoster(teamId, target=12)` : top-up des actifs jusqu'a la cible, seed RNG = `replenish:teamId:slug:Date.now()` pour eviter doublons sur appels successifs.
- `sweepRookieReplenish(target=12)` : cron sweep, erreur isolee par equipe.

**`apps/server/src/seeders/pro-league.ts`**
- Appel `seedTeamRoster(team.id)` apres chaque upsert de ProTeam → seed de la ligue cree automatiquement les rosters initiaux.

**`apps/server/src/index.ts`**
- Cron tick `PRO_LEAGUE_ROOKIE_TICK_MS` (default 30 min, 0 pour desactiver).

**`apps/server/src/services/pro-roster-generator.test.ts`** (nouveau)
- 14 tests : stats par race, fallback default pour race inconnue, determinisme RNG, idempotence seed, replenish no-op + delta, sweep aggregation processed/failed.

### Tests

```
✓ src/services/pro-roster-generator.test.ts (14 tests) 12ms
Test Files  1 passed (1)
     Tests 14 passed (14)
```

Suite Pro complete : 22 fichiers, 246 tests passes.

### Test plan

- [x] `pnpm typecheck` (apps/server) → OK
- [x] `pnpm vitest run src/services/pro` → 246/246 OK
- [ ] Verifier `pnpm db:seed` cree les rosters initiaux apres merge
- [ ] Observer `[pro-rookie] sweep` logs en staging apres morts

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_