### PR TITLE
feat(server): Pro League LLM Gazette daily generation (sprint 1.E.1)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -754,3 +754,62 @@ if (!inTestHofEnv && hofTickMs > 0) {
     },
   );
 }
+
+
+// =============================================================================
+// Pro League Nuffle Gazette LLM cron (sprint 1.E.1).
+// =============================================================================
+// Genere quotidiennement (8h UTC par defaut) une edition Gazette pour
+// J-1 via Claude Haiku. Idempotent (skip si edition existante).
+//
+// Strategie : tick 5 min, declenche generateEditionForDate si l'heure
+// UTC == PRO_LEAGUE_GAZETTE_HOUR_UTC (default 8) et qu'on n'a pas
+// deja tick aujourd'hui. Simple et tolerant aux redemarrages : si le
+// serveur restart entre 8h00 et 8h05, ca tick au prochain tick.
+//
+// Mettre PRO_LEAGUE_GAZETTE_TICK_MS = 0 pour desactiver.
+// Necessite ANTHROPIC_API_KEY dans l'env.
+const inTestGazetteEnv =
+  process.env.NODE_ENV === "test" || process.env.TEST_SQLITE === "1";
+const gazetteTickMsEnv = Number(process.env.PRO_LEAGUE_GAZETTE_TICK_MS);
+const gazetteTickMs = Number.isFinite(gazetteTickMsEnv)
+  ? gazetteTickMsEnv
+  : 5 * 60 * 1000;
+const gazetteHourEnv = Number(process.env.PRO_LEAGUE_GAZETTE_HOUR_UTC);
+const gazetteHourUtc = Number.isFinite(gazetteHourEnv) ? gazetteHourEnv : 8;
+if (
+  !inTestGazetteEnv &&
+  gazetteTickMs > 0 &&
+  process.env.ANTHROPIC_API_KEY
+) {
+  void import("./services/pro-gazette-llm").then(
+    ({ generateEditionForDate }) => {
+      let lastRunDate: string | null = null;
+      const tick = async () => {
+        const now = new Date();
+        if (now.getUTCHours() !== gazetteHourUtc) return;
+        const today = now.toISOString().slice(0, 10);
+        if (lastRunDate === today) return;
+        lastRunDate = today;
+        try {
+          const out = await generateEditionForDate();
+          if (!out.skipped) {
+            serverLog.info(
+              `[pro-gazette-llm] cron: generated date=${out.date} articles=${out.created}`,
+            );
+          } else {
+            serverLog.info(
+              `[pro-gazette-llm] cron: skipped (${out.skipReason}) date=${out.date}`,
+            );
+          }
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : "unknown";
+          serverLog.error(`[pro-gazette-llm] cron failed: ${msg}`);
+        }
+      };
+      setInterval(() => {
+        void tick();
+      }, gazetteTickMs).unref();
+    },
+  );
+}

--- a/apps/server/src/services/anthropic-client.test.ts
+++ b/apps/server/src/services/anthropic-client.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AnthropicError, callClaude } from "./anthropic-client";
+
+const ORIGINAL_KEY = process.env.ANTHROPIC_API_KEY;
+
+beforeEach(() => {
+  process.env.ANTHROPIC_API_KEY = "sk-test";
+});
+
+afterEach(() => {
+  if (ORIGINAL_KEY === undefined) {
+    delete process.env.ANTHROPIC_API_KEY;
+  } else {
+    process.env.ANTHROPIC_API_KEY = ORIGINAL_KEY;
+  }
+});
+
+function makeFetch(impl: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (url: string, init?: RequestInit) => impl(url, init));
+}
+
+describe("callClaude — sprint 1.E.1", () => {
+  it("MISSING_API_KEY si pas de clé", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await expect(
+      callClaude({
+        model: "claude-haiku-4-5-20251001",
+        maxTokens: 100,
+        system: "sys",
+        userPrompt: "user",
+      }),
+    ).rejects.toMatchObject({ code: "MISSING_API_KEY" });
+  });
+
+  it("appelle l'endpoint correct avec headers + body", async () => {
+    const fetchImpl = makeFetch(async (url, init) => {
+      expect(url).toBe("https://api.anthropic.com/v1/messages");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["x-api-key"]).toBe("sk-test");
+      expect(headers["anthropic-version"]).toBe("2023-06-01");
+      expect(headers["content-type"]).toBe("application/json");
+      const body = JSON.parse(init?.body as string);
+      expect(body.model).toBe("claude-haiku-4-5-20251001");
+      expect(body.max_tokens).toBe(100);
+      expect(body.system).toBe("sys");
+      expect(body.messages[0].content).toBe("user");
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "hello" }],
+          usage: { input_tokens: 5, output_tokens: 1 },
+        }),
+        { status: 200 },
+      );
+    });
+    const out = await callClaude({
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 100,
+      system: "sys",
+      userPrompt: "user",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(out.text).toBe("hello");
+    expect(out.usage?.inputTokens).toBe(5);
+    expect(out.usage?.outputTokens).toBe(1);
+  });
+
+  it("concatene plusieurs blocks text", async () => {
+    const fetchImpl = makeFetch(async () =>
+      new Response(
+        JSON.stringify({
+          content: [
+            { type: "text", text: "foo" },
+            { type: "tool_use", id: "x" },
+            { type: "text", text: "bar" },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const out = await callClaude({
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 100,
+      system: "sys",
+      userPrompt: "user",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(out.text).toBe("foobar");
+  });
+
+  it("HTTP_ERROR si status != 2xx", async () => {
+    const fetchImpl = makeFetch(async () =>
+      new Response("rate limit hit", { status: 429 }),
+    );
+    await expect(
+      callClaude({
+        model: "claude-haiku-4-5-20251001",
+        maxTokens: 100,
+        system: "sys",
+        userPrompt: "user",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "HTTP_ERROR", status: 429 });
+  });
+
+  it("EMPTY_RESPONSE si pas de text content", async () => {
+    const fetchImpl = makeFetch(async () =>
+      new Response(JSON.stringify({ content: [] }), { status: 200 }),
+    );
+    await expect(
+      callClaude({
+        model: "claude-haiku-4-5-20251001",
+        maxTokens: 100,
+        system: "sys",
+        userPrompt: "user",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toBeInstanceOf(AnthropicError);
+  });
+
+  it("INVALID_JSON si reponse invalide", async () => {
+    const fetchImpl = makeFetch(async () =>
+      new Response("not json", { status: 200 }),
+    );
+    await expect(
+      callClaude({
+        model: "m",
+        maxTokens: 100,
+        system: "s",
+        userPrompt: "u",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_JSON" });
+  });
+
+  it("NETWORK_ERROR si fetch throw", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("conn refused");
+    });
+    await expect(
+      callClaude({
+        model: "m",
+        maxTokens: 100,
+        system: "s",
+        userPrompt: "u",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "NETWORK_ERROR" });
+  });
+});

--- a/apps/server/src/services/anthropic-client.ts
+++ b/apps/server/src/services/anthropic-client.ts
@@ -1,0 +1,113 @@
+/**
+ * Anthropic Claude API client — minimal raw fetch.
+ *
+ * Used by `pro-gazette-llm.ts` (sprint 1.E.1). Direct call to
+ * `/v1/messages` to keep the dep surface small.
+ *
+ * Auth via `ANTHROPIC_API_KEY` env. Calls fail explicitly if absent.
+ */
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_API_VERSION = "2023-06-01";
+
+export class AnthropicError extends Error {
+  readonly code: string;
+  readonly status?: number;
+  constructor(code: string, message: string, status?: number) {
+    super(message);
+    this.code = code;
+    this.name = "AnthropicError";
+    this.status = status;
+  }
+}
+
+export interface CallClaudeOptions {
+  readonly model: string;
+  readonly maxTokens: number;
+  readonly system: string;
+  readonly userPrompt: string;
+  /** Optional — defaults to the value from `ANTHROPIC_API_KEY` env. */
+  readonly apiKey?: string;
+  /** Override fetch (tests). */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface CallClaudeResult {
+  readonly text: string;
+  readonly usage?: {
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+  };
+}
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+/**
+ * Calls `/v1/messages` and returns the text concatenation of all `text`
+ * content blocks. Throws AnthropicError on any failure (no fallback).
+ */
+export async function callClaude(
+  opts: CallClaudeOptions,
+): Promise<CallClaudeResult> {
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new AnthropicError(
+      "MISSING_API_KEY",
+      "ANTHROPIC_API_KEY env var is not set",
+    );
+  }
+  const fetchFn = opts.fetchImpl ?? fetch;
+  let response: Response;
+  try {
+    response = await fetchFn(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": ANTHROPIC_API_VERSION,
+      },
+      body: JSON.stringify({
+        model: opts.model,
+        max_tokens: opts.maxTokens,
+        system: opts.system,
+        messages: [{ role: "user", content: opts.userPrompt }],
+      }),
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    throw new AnthropicError("NETWORK_ERROR", `fetch failed: ${msg}`);
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new AnthropicError(
+      "HTTP_ERROR",
+      `Anthropic returned ${response.status}: ${text.slice(0, 256)}`,
+      response.status,
+    );
+  }
+  let body: AnthropicResponse;
+  try {
+    body = (await response.json()) as AnthropicResponse;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    throw new AnthropicError("INVALID_JSON", `cannot parse JSON: ${msg}`);
+  }
+  const blocks = Array.isArray(body.content) ? body.content : [];
+  const text = blocks
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("");
+  if (text.length === 0) {
+    throw new AnthropicError("EMPTY_RESPONSE", "no text content returned");
+  }
+  return {
+    text,
+    usage: {
+      inputTokens: body.usage?.input_tokens,
+      outputTokens: body.usage?.output_tokens,
+    },
+  };
+}

--- a/apps/server/src/services/pro-gazette-llm.test.ts
+++ b/apps/server/src/services/pro-gazette-llm.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./pro-gazette-recap", () => ({
+  getDailyRecap: vi.fn(),
+}));
+
+vi.mock("./pro-gazette", () => ({
+  createArticles: vi.fn(),
+  listEditionForDate: vi.fn(),
+}));
+
+vi.mock("./anthropic-client", () => ({
+  callClaude: vi.fn(),
+  AnthropicError: class extends Error {
+    code: string;
+    constructor(code: string, msg: string) {
+      super(msg);
+      this.code = code;
+    }
+  },
+}));
+
+import { getDailyRecap, type DailyRecap } from "./pro-gazette-recap";
+import { createArticles, listEditionForDate } from "./pro-gazette";
+import { callClaude } from "./anthropic-client";
+import {
+  GazetteLLMError,
+  buildUserPrompt,
+  generateEditionForDate,
+  parseLLMResponse,
+} from "./pro-gazette-llm";
+
+const mockedRecap = vi.mocked(getDailyRecap);
+const mockedListEdition = vi.mocked(listEditionForDate);
+const mockedCreate = vi.mocked(createArticles);
+const mockedCall = vi.mocked(callClaude);
+
+const RECAP_FIXTURE: DailyRecap = {
+  fromAt: "2026-05-06T00:00:00.000Z",
+  toAt: "2026-05-07T00:00:00.000Z",
+  matchesPlayed: 1,
+  matches: [
+    {
+      id: "m1",
+      homeTeamSlug: "buf-snow-ogres",
+      homeTeamName: "Buffalo Snow Ogres",
+      awayTeamSlug: "gb-cheese-halflings",
+      awayTeamName: "Green Bay Cheese Halflings",
+      scoreHome: 4,
+      scoreAway: 0,
+      outcome: "home",
+      touchdownCount: 4,
+      casualtyCount: 5,
+      nuffleCount: 1,
+      playedAt: "2026-05-06T20:00:00.000Z",
+    },
+  ],
+  standings: [
+    {
+      teamSlug: "buf-snow-ogres",
+      teamName: "Buffalo Snow Ogres",
+      played: 5,
+      wins: 5,
+      draws: 0,
+      losses: 0,
+      points: 15,
+      rank: 1,
+    },
+  ],
+  storylines: [
+    {
+      type: "blowout",
+      weight: 8,
+      refs: { matchId: "m1", winner: "buf-snow-ogres" },
+      summary: "Buffalo ecrase Green Bay 4-0",
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildUserPrompt — sprint 1.E.1", () => {
+  it("inclut date + matchs + standings + storylines", () => {
+    const prompt = buildUserPrompt({
+      recap: RECAP_FIXTURE,
+      date: "2026-05-06",
+    });
+    expect(prompt).toContain("2026-05-06");
+    expect(prompt).toContain("Buffalo Snow Ogres");
+    expect(prompt).toContain("buf-snow-ogres");
+    expect(prompt).toContain("blowout");
+    expect(prompt).toContain('"score": "4-0"');
+    expect(prompt).toContain("MAIN");
+  });
+});
+
+function expectCode(fn: () => unknown, code: string): void {
+  try {
+    fn();
+    throw new Error("expected throw");
+  } catch (err) {
+    expect(err).toBeInstanceOf(GazetteLLMError);
+    expect((err as GazetteLLMError).code).toBe(code);
+  }
+}
+
+describe("parseLLMResponse — sprint 1.E.1", () => {
+  it("parse une reponse valide", () => {
+    const json = JSON.stringify({
+      articles: [
+        {
+          type: "MAIN",
+          persona: null,
+          title: "Buffalo broie Green Bay",
+          body: "Une victoire totale ce soir...",
+          relatedTeamSlugs: ["buf-snow-ogres"],
+        },
+        {
+          type: "EDITO",
+          persona: "cynic",
+          title: "Cynic edito",
+          body: "Tout cela etait previsible...",
+          relatedTeamSlugs: [],
+        },
+      ],
+    });
+    const out = parseLLMResponse(json);
+    expect(out).toHaveLength(2);
+    expect(out[0].type).toBe("MAIN");
+    expect(out[0].persona).toBeNull();
+    expect(out[0].relatedTeamIds).toEqual(["buf-snow-ogres"]);
+    expect(out[1].type).toBe("EDITO");
+    expect(out[1].persona).toBe("cynic");
+  });
+
+  it("tolere les fences ```json", () => {
+    const fenced = '```json\n{"articles":[{"type":"BREVE","persona":null,"title":"t","body":"b"}]}\n```';
+    const out = parseLLMResponse(fenced);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("BREVE");
+  });
+
+  it("INVALID_JSON sur garbage", () => {
+    expectCode(() => parseLLMResponse("not json"), "INVALID_JSON");
+  });
+
+  it("INVALID_SHAPE si pas d'articles", () => {
+    expectCode(() => parseLLMResponse('{"foo": 1}'), "INVALID_SHAPE");
+  });
+
+  it("NO_ARTICLES si articles vide", () => {
+    expectCode(() => parseLLMResponse('{"articles": []}'), "NO_ARTICLES");
+  });
+
+  it("INVALID_TYPE rejette des types inconnus", () => {
+    expectCode(
+      () =>
+        parseLLMResponse(
+          JSON.stringify({
+            articles: [{ type: "NEWSFLASH", title: "t", body: "b" }],
+          }),
+        ),
+      "INVALID_TYPE",
+    );
+  });
+
+  it("EDITO_REQUIRES_PERSONA si edito sans persona", () => {
+    expectCode(
+      () =>
+        parseLLMResponse(
+          JSON.stringify({
+            articles: [{ type: "EDITO", persona: null, title: "t", body: "b" }],
+          }),
+        ),
+      "EDITO_REQUIRES_PERSONA",
+    );
+  });
+
+  it("INVALID_PERSONA si persona inconnue", () => {
+    expectCode(
+      () =>
+        parseLLMResponse(
+          JSON.stringify({
+            articles: [
+              { type: "MAIN", persona: "alien", title: "t", body: "b" },
+            ],
+          }),
+        ),
+      "INVALID_PERSONA",
+    );
+  });
+
+  it("INVALID_TITLE rejette title vide", () => {
+    expectCode(
+      () =>
+        parseLLMResponse(
+          JSON.stringify({
+            articles: [{ type: "MAIN", persona: null, title: "", body: "b" }],
+          }),
+        ),
+      "INVALID_TITLE",
+    );
+  });
+
+  it("filtre relatedTeamSlugs non-string + default []", () => {
+    const out = parseLLMResponse(
+      JSON.stringify({
+        articles: [
+          {
+            type: "BREVE",
+            persona: null,
+            title: "t",
+            body: "b",
+            relatedTeamSlugs: ["ok", 42, null, "ok2"],
+          },
+        ],
+      }),
+    );
+    expect(out[0].relatedTeamIds).toEqual(["ok", "ok2"]);
+  });
+});
+
+describe("generateEditionForDate — sprint 1.E.1", () => {
+  it("skip si edition existe deja", async () => {
+    mockedListEdition.mockResolvedValue({
+      date: "2026-05-06",
+      articles: [
+        {
+          id: "a1",
+          date: "2026-05-06",
+          type: "MAIN",
+          persona: null,
+          title: "t",
+          body: "b",
+          relatedTeamIds: [],
+          relatedPlayerIds: [],
+          createdAt: "2026-05-07T00:00:00.000Z",
+        },
+      ],
+    });
+    const out = await generateEditionForDate({
+      date: new Date("2026-05-06T00:00:00Z"),
+    });
+    expect(out.skipped).toBe(true);
+    expect(out.skipReason).toBe("edition_already_exists");
+    expect(mockedRecap).not.toHaveBeenCalled();
+    expect(mockedCall).not.toHaveBeenCalled();
+  });
+
+  it("skip si recap.matchesPlayed=0", async () => {
+    mockedListEdition.mockResolvedValue(null);
+    mockedRecap.mockResolvedValue({
+      ...RECAP_FIXTURE,
+      matchesPlayed: 0,
+      matches: [],
+    });
+    const out = await generateEditionForDate({
+      date: new Date("2026-05-06T00:00:00Z"),
+    });
+    expect(out.skipped).toBe(true);
+    expect(out.skipReason).toBe("no_matches");
+    expect(mockedCall).not.toHaveBeenCalled();
+  });
+
+  it("genere + persiste + retourne ids", async () => {
+    mockedListEdition.mockResolvedValue(null);
+    mockedRecap.mockResolvedValue(RECAP_FIXTURE);
+    mockedCall.mockResolvedValue({
+      text: JSON.stringify({
+        articles: [
+          {
+            type: "MAIN",
+            persona: null,
+            title: "T1",
+            body: "B1",
+            relatedTeamSlugs: [],
+          },
+          {
+            type: "EDITO",
+            persona: "cynic",
+            title: "T2",
+            body: "B2",
+            relatedTeamSlugs: [],
+          },
+        ],
+      }),
+      usage: { inputTokens: 10, outputTokens: 20 },
+    });
+    mockedCreate.mockResolvedValue(["id1", "id2"]);
+    const out = await generateEditionForDate({
+      date: new Date("2026-05-06T00:00:00Z"),
+    });
+    expect(out.skipped).toBe(false);
+    expect(out.created).toBe(2);
+    expect(out.articleIds).toEqual(["id1", "id2"]);
+    expect(mockedCreate).toHaveBeenCalledWith({
+      date: "2026-05-06",
+      articles: expect.any(Array),
+    });
+    const passedArticles = mockedCreate.mock.calls[0][0].articles;
+    expect(passedArticles).toHaveLength(2);
+  });
+
+  it("propage erreur LLM (pas swallow)", async () => {
+    mockedListEdition.mockResolvedValue(null);
+    mockedRecap.mockResolvedValue(RECAP_FIXTURE);
+    mockedCall.mockRejectedValue(new Error("network"));
+    await expect(
+      generateEditionForDate({
+        date: new Date("2026-05-06T00:00:00Z"),
+      }),
+    ).rejects.toThrow(/network/);
+  });
+
+  it("propage GazetteLLMError si parse fail", async () => {
+    mockedListEdition.mockResolvedValue(null);
+    mockedRecap.mockResolvedValue(RECAP_FIXTURE);
+    mockedCall.mockResolvedValue({ text: "not json" });
+    await expect(
+      generateEditionForDate({
+        date: new Date("2026-05-06T00:00:00Z"),
+      }),
+    ).rejects.toBeInstanceOf(GazetteLLMError);
+  });
+});

--- a/apps/server/src/services/pro-gazette-llm.ts
+++ b/apps/server/src/services/pro-gazette-llm.ts
@@ -1,0 +1,309 @@
+/**
+ * Pro League Nuffle Gazette LLM generator — sprint Pro League lot
+ * 1.E.1.
+ *
+ * Pipeline complet :
+ *   1. `getDailyRecap(at)` (1.E.3) -> recap deterministe (matches +
+ *      standings + storylines).
+ *   2. `buildPrompt(recap)` -> prompt template (system + user) avec
+ *      contraintes de sortie JSON et personas Gazette.
+ *   3. `callClaude(...)` -> Claude Haiku.
+ *   4. `parseLLMResponse(text)` -> articles structures.
+ *   5. `createArticles(...)` -> persistance ProGazetteArticle.
+ *
+ * Idempotent : skip si une edition existe deja pour la date cible
+ * (verifie via `listEditionForDate`). Toute erreur est isolee — le
+ * cron 8h ne plante jamais le serveur.
+ *
+ * Personas (cf. schema ProGazetteArticle) :
+ *   - cynic           : sarcasme, rumeurs
+ *   - orc_enthusiast  : hype, capslock
+ *   - statistician    : chiffres, analyses
+ *
+ * Article shape par jour (default) : 1 MAIN + 2 BREVE + 1 EDITO.
+ */
+
+import { callClaude, type CallClaudeOptions } from "./anthropic-client";
+import { getDailyRecap, type DailyRecap } from "./pro-gazette-recap";
+import {
+  type CreateArticleInput,
+  type GazetteArticleType,
+  type GazettePersona,
+  createArticles,
+  listEditionForDate,
+} from "./pro-gazette";
+import { serverLog } from "../utils/server-log";
+
+export class GazetteLLMError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "GazetteLLMError";
+  }
+}
+
+const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_MAX_TOKENS = 2048;
+
+const VALID_TYPES: ReadonlySet<GazetteArticleType> = new Set([
+  "MAIN",
+  "BREVE",
+  "EDITO",
+]);
+const VALID_PERSONAS: ReadonlySet<GazettePersona> = new Set([
+  "cynic",
+  "orc_enthusiast",
+  "statistician",
+]);
+
+const SYSTEM_PROMPT = `Tu es le redacteur en chef de la "Nuffle Gazette", journal sportif fictif de la Old World League (Blood Bowl-like).
+
+Style : enthousiaste, pulp fiction, references cyclopiques aux dieux (Nuffle), exagerations comiques, mais factuellement ancre dans les donnees fournies.
+
+Personas signataires possibles :
+- cynic           : sarcasme aigre, rumeurs douteuses, ironie. Persona cynique francaise.
+- orc_enthusiast  : majuscules ENORMES, hyperboles, adore les casualties.
+- statistician    : analyses chiffrees, ratios, comparatif standings.
+
+Tu produis des articles courts. Pas de markdown lourd, pas d'HTML.
+
+Tu DOIS repondre avec UNIQUEMENT un objet JSON strict (pas de texte avant ou apres, pas de \`\`\`json fences). Schema :
+
+{
+  "articles": [
+    {
+      "type": "MAIN" | "BREVE" | "EDITO",
+      "persona": null | "cynic" | "orc_enthusiast" | "statistician",
+      "title": string,
+      "body": string,
+      "relatedTeamSlugs": string[]
+    }
+  ]
+}
+
+Contraintes de chaque article :
+- MAIN : 200-350 mots, persona optionnelle (sinon null)
+- BREVE : 50-100 mots, persona optionnelle
+- EDITO : 100-200 mots, persona OBLIGATOIRE (signe)
+
+relatedTeamSlugs : liste des slugs ProTeam mentionnes (peut etre []).
+Le titre est court, accrocheur (max 80 caracteres).`;
+
+export interface BuildPromptOptions {
+  readonly recap: DailyRecap;
+  readonly date: string;
+}
+
+/**
+ * Construit le user-prompt a injecter (le system est constant).
+ * Pure (testable sans fetch).
+ */
+export function buildUserPrompt(opts: BuildPromptOptions): string {
+  const { recap, date } = opts;
+  const matchesSummary = recap.matches.map((m) => ({
+    home: `${m.homeTeamName} (${m.homeTeamSlug})`,
+    away: `${m.awayTeamName} (${m.awayTeamSlug})`,
+    score: `${m.scoreHome}-${m.scoreAway}`,
+    outcome: m.outcome,
+    tds: m.touchdownCount,
+    cas: m.casualtyCount,
+    nuffle: m.nuffleCount,
+  }));
+  const standingsTop = recap.standings
+    .slice(0, 5)
+    .map((s) => `#${s.rank} ${s.teamName} (${s.wins}-${s.draws}-${s.losses}, ${s.points} pts)`);
+  const storylines = recap.storylines.map((s) => ({
+    type: s.type,
+    weight: s.weight,
+    summary: s.summary,
+  }));
+  const payload = {
+    date,
+    matchesPlayed: recap.matchesPlayed,
+    matches: matchesSummary,
+    standingsTop5: standingsTop,
+    storylines,
+  };
+  return [
+    `Genere l'edition Nuffle Gazette pour le ${date}.`,
+    "Donnees factuelles (recap aggregator) :",
+    "```json",
+    JSON.stringify(payload, null, 2),
+    "```",
+    "",
+    "Cible : 1 MAIN (story principale, base sur la storyline la plus ponderee), 2 BREVE (storylines secondaires), 1 EDITO (signe par 1 persona).",
+    "Reponds UNIQUEMENT en JSON strict.",
+  ].join("\n");
+}
+
+interface ParsedArticle {
+  readonly type: string;
+  readonly persona: string | null;
+  readonly title: string;
+  readonly body: string;
+  readonly relatedTeamSlugs?: readonly string[];
+}
+
+interface ParsedResponse {
+  readonly articles: readonly ParsedArticle[];
+}
+
+/**
+ * Parse + valide la reponse LLM. Throw GazetteLLMError sur invalide.
+ * Pure.
+ */
+export function parseLLMResponse(text: string): CreateArticleInput[] {
+  // Tolere "```json ... ```" dans le cas ou Claude n'obeit pas tout
+  // a fait au prompt strict.
+  const cleaned = text
+    .trim()
+    .replace(/^```json\s*/i, "")
+    .replace(/^```\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    throw new GazetteLLMError(
+      "INVALID_JSON",
+      `LLM response is not valid JSON: ${msg}`,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !Array.isArray((parsed as ParsedResponse).articles)
+  ) {
+    throw new GazetteLLMError(
+      "INVALID_SHAPE",
+      "expected { articles: [...] } object",
+    );
+  }
+  const articles = (parsed as ParsedResponse).articles;
+  if (articles.length === 0) {
+    throw new GazetteLLMError("NO_ARTICLES", "LLM returned 0 articles");
+  }
+  const out: CreateArticleInput[] = [];
+  for (const a of articles) {
+    if (typeof a.type !== "string" || !VALID_TYPES.has(a.type as GazetteArticleType)) {
+      throw new GazetteLLMError("INVALID_TYPE", `bad type: ${a.type}`);
+    }
+    if (typeof a.title !== "string" || a.title.length === 0) {
+      throw new GazetteLLMError("INVALID_TITLE", "title required");
+    }
+    if (typeof a.body !== "string" || a.body.length === 0) {
+      throw new GazetteLLMError("INVALID_BODY", "body required");
+    }
+    let persona: GazettePersona | null = null;
+    if (
+      typeof a.persona === "string" &&
+      VALID_PERSONAS.has(a.persona as GazettePersona)
+    ) {
+      persona = a.persona as GazettePersona;
+    } else if (a.persona !== null && a.persona !== undefined) {
+      throw new GazetteLLMError(
+        "INVALID_PERSONA",
+        `bad persona: ${a.persona}`,
+      );
+    }
+    if (a.type === "EDITO" && persona === null) {
+      throw new GazetteLLMError(
+        "EDITO_REQUIRES_PERSONA",
+        "EDITO must be signed",
+      );
+    }
+    out.push({
+      type: a.type as GazetteArticleType,
+      persona,
+      title: a.title.slice(0, 200),
+      body: a.body,
+      relatedTeamIds: Array.isArray(a.relatedTeamSlugs)
+        ? a.relatedTeamSlugs.filter((s): s is string => typeof s === "string")
+        : [],
+    });
+  }
+  return out;
+}
+
+export interface GenerateEditionOptions {
+  /** Date cible. Default = J-1 a 00h UTC. */
+  readonly date?: Date;
+  /** Override (tests). */
+  readonly model?: string;
+  readonly maxTokens?: number;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface GenerateEditionResult {
+  readonly date: string;
+  readonly skipped: boolean;
+  readonly skipReason?: string;
+  readonly created: number;
+  readonly articleIds: readonly string[];
+}
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function previousDayUtc(): Date {
+  const now = new Date();
+  const d = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1),
+  );
+  return d;
+}
+
+/**
+ * Genere l'edition LLM pour une date (default J-1). Idempotent : skip
+ * si une edition existe deja a cette date.
+ */
+export async function generateEditionForDate(
+  opts: GenerateEditionOptions = {},
+): Promise<GenerateEditionResult> {
+  const at = opts.date ?? previousDayUtc();
+  const dateStr = isoDate(at);
+  const existing = await listEditionForDate(dateStr);
+  if (existing && existing.articles.length > 0) {
+    return {
+      date: dateStr,
+      skipped: true,
+      skipReason: "edition_already_exists",
+      created: 0,
+      articleIds: [],
+    };
+  }
+  const recap = await getDailyRecap(at);
+  if (recap.matchesPlayed === 0) {
+    return {
+      date: dateStr,
+      skipped: true,
+      skipReason: "no_matches",
+      created: 0,
+      articleIds: [],
+    };
+  }
+  const userPrompt = buildUserPrompt({ recap, date: dateStr });
+  const callOpts: CallClaudeOptions = {
+    model: opts.model ?? DEFAULT_MODEL,
+    maxTokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+    system: SYSTEM_PROMPT,
+    userPrompt,
+    fetchImpl: opts.fetchImpl,
+  };
+  const result = await callClaude(callOpts);
+  const articles = parseLLMResponse(result.text);
+  const ids = await createArticles({ date: dateStr, articles });
+  serverLog.info(
+    `[pro-gazette-llm] generated date=${dateStr} articles=${ids.length} input=${result.usage?.inputTokens ?? "?"} output=${result.usage?.outputTokens ?? "?"}`,
+  );
+  return {
+    date: dateStr,
+    skipped: false,
+    created: ids.length,
+    articleIds: ids,
+  };
+}


### PR DESCRIPTION
## Sprint Pro League — lot 1.E.1 (LLM Gazette quotidienne)

Generation quotidienne des articles `ProGazetteArticle` via Claude Haiku, a partir du recap aggregator (1.E.3). Le cycle 1.E est complet (1.E.2/3/4/5/6 deja merged).

### Pipeline

1. `getDailyRecap(at)` (1.E.3) → matches + standings + storylines (deterministe).
2. `buildUserPrompt(recap)` → JSON-only contract avec personas Gazette.
3. `callClaude({ model: 'claude-haiku-4-5-20251001' })` → reponse.
4. `parseLLMResponse(text)` → articles structures (tolere fences ```json).
5. `createArticles(...)` (1.E.2) → persistance.

### Modifs

**`apps/server/src/services/anthropic-client.ts`** (nouveau)
- Raw fetch sur `/v1/messages`, header `anthropic-version: 2023-06-01`.
- `AnthropicError` avec codes : `MISSING_API_KEY` / `HTTP_ERROR` / `NETWORK_ERROR` / `INVALID_JSON` / `EMPTY_RESPONSE`.
- `fetchImpl` injectable pour tests.

**`apps/server/src/services/pro-gazette-llm.ts`** (nouveau)
- `buildUserPrompt` pure : injecte recap + targets (1 MAIN + 2 BREVE + 1 EDITO).
- `parseLLMResponse` pure : valide schema, types, persona (EDITO requires persona), title/body non vides, `relatedTeamSlugs` filtre.
- `generateEditionForDate({ date? })` :
  - Skip `edition_already_exists` si `listEditionForDate(date)` non vide.
  - Skip `no_matches` si `recap.matchesPlayed === 0`.
  - Sinon call Claude → parse → `createArticles` → log usage tokens.

**`apps/server/src/index.ts`**
- Cron 5min checks heure UTC == `PRO_LEAGUE_GAZETTE_HOUR_UTC` (default 8) → fire 1×/jour pour J-1.
- Skip si `ANTHROPIC_API_KEY` absent.
- Configurable : `PRO_LEAGUE_GAZETTE_TICK_MS` (=0 desactive), `PRO_LEAGUE_GAZETTE_HOUR_UTC`.

**Tests (23 nouveaux)**
- `anthropic-client.test.ts` (7) : MISSING_API_KEY, headers/body POST, multi-block concat, HTTP_ERROR + status, EMPTY_RESPONSE, INVALID_JSON, NETWORK_ERROR.
- `pro-gazette-llm.test.ts` (16) : prompt content, parse valide, fences tolerance, INVALID_JSON / SHAPE / NO_ARTICLES / TYPE / EDITO_REQUIRES_PERSONA / PERSONA / TITLE, filter relatedTeamSlugs, skip edition_already_exists, skip no_matches, generate happy path, propage erreurs LLM/parse.

### Tests

```
✓ anthropic-client.test.ts (7 tests)
✓ pro-gazette-llm.test.ts  (16 tests)
Test Files 25 passed (25)
     Tests 282 passed (282)
```

### Test plan

- [x] `pnpm typecheck` (server) → OK
- [x] `pnpm vitest run src/services/pro src/services/anthropic` → 282/282 OK
- [ ] Set `ANTHROPIC_API_KEY` en staging puis observer cron `[pro-gazette-llm]` a 8h UTC
- [ ] Verifier que les articles produits respectent les contraintes (longueur, persona EDITO, etc.) et apparaissent sur `/pro-league/gazette/latest`

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_