### PR TITLE
feat(server,web): SEO metadata + Pro League healthcheck (sprint 1.F.2)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -130,6 +130,25 @@ app.get("/health", liveness);
 app.get("/health/live", liveness);
 app.get("/health/ready", probeReadiness);
 
+// Pro League healthcheck (sprint 1.F.2). Sous-systeme observable :
+// season, simRunner, gazette, bettingMarkets. 503 si "down", 200
+// sinon (degraded compris : un orchestrateur qui veut un signal
+// strict peut filtrer status='up').
+app.get("/health/pro-league", async (_req, res) => {
+  try {
+    const { getProLeagueHealth } = await import(
+      "./services/pro-league-health"
+    );
+    const out = await getProLeagueHealth();
+    const code = out.status === "down" ? 503 : 200;
+    res.status(code).json(out);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "unknown";
+    serverLog.error(`[health/pro-league] failed: ${msg}`);
+    res.status(503).json({ status: "down", error: "internal-error" });
+  }
+});
+
 // Endpoint Prometheus (S25.3). Format texte standard, scrape par
 // Prometheus qui le pousse ensuite vers Grafana LGTM.
 app.get("/metrics", async (_req, res, next) => {

--- a/apps/server/src/services/pro-league-health.test.ts
+++ b/apps/server/src/services/pro-league-health.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueMatch: { findFirst: vi.fn() },
+    proGazetteArticle: { findFirst: vi.fn() },
+    proBetMarket: { count: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import { getProLeagueHealth } from "./pro-league-health";
+
+interface MockedPrisma {
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueMatch: { findFirst: ReturnType<typeof vi.fn> };
+  proGazetteArticle: { findFirst: ReturnType<typeof vi.fn> };
+  proBetMarket: { count: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+const NOW = new Date("2026-05-07T12:00:00Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function recentDate(hoursAgo: number): Date {
+  return new Date(NOW.getTime() - hoursAgo * 60 * 60 * 1000);
+}
+
+describe("getProLeagueHealth — sprint 1.F.2", () => {
+  it("status global up si tous les checks sont up", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(2),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(4),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(3);
+
+    const out = await getProLeagueHealth();
+    expect(out.status).toBe("up");
+    const byName = new Map(out.checks.map((c) => [c.name, c]));
+    expect(byName.get("season")?.status).toBe("up");
+    expect(byName.get("simRunner")?.status).toBe("up");
+    expect(byName.get("gazette")?.status).toBe("up");
+    expect(byName.get("bettingMarkets")?.status).toBe("up");
+    expect(out.checkedAt).toBe(NOW.toISOString());
+  });
+
+  it("season degraded si pas de saison in_progress", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(2),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(2),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(1);
+
+    const out = await getProLeagueHealth();
+    expect(out.status).toBe("degraded");
+    expect(
+      out.checks.find((c) => c.name === "season")?.status,
+    ).toBe("degraded");
+  });
+
+  it("simRunner degraded si dernier match > 24h", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(48),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(2),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(1);
+
+    const out = await getProLeagueHealth();
+    expect(out.status).toBe("degraded");
+    const sim = out.checks.find((c) => c.name === "simRunner");
+    expect(sim?.status).toBe("degraded");
+    expect(sim?.detail).toContain("48h ago");
+  });
+
+  it("simRunner degraded si pas encore de match", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue(null);
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(2),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(1);
+
+    const out = await getProLeagueHealth();
+    expect(out.checks.find((c) => c.name === "simRunner")?.status).toBe(
+      "degraded",
+    );
+  });
+
+  it("gazette degraded si > 48h", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(2),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(72),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(1);
+
+    const out = await getProLeagueHealth();
+    expect(out.checks.find((c) => c.name === "gazette")?.status).toBe(
+      "degraded",
+    );
+  });
+
+  it("bettingMarkets degraded si 0 open", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(2),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(2),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(0);
+
+    const out = await getProLeagueHealth();
+    expect(out.checks.find((c) => c.name === "bettingMarkets")?.status).toBe(
+      "degraded",
+    );
+  });
+
+  it("season down si la query throw -> status global down", async () => {
+    mocked.proLeagueSeason.findFirst.mockRejectedValue(new Error("DB closed"));
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(2),
+    });
+    mocked.proGazetteArticle.findFirst.mockResolvedValue({
+      date: recentDate(2),
+    });
+    mocked.proBetMarket.count.mockResolvedValue(1);
+
+    const out = await getProLeagueHealth();
+    expect(out.status).toBe("down");
+    const season = out.checks.find((c) => c.name === "season");
+    expect(season?.status).toBe("down");
+    expect(season?.detail).toContain("DB closed");
+  });
+
+  it("worstStatus: down domine degraded", async () => {
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({ id: "s1", year: 2026 });
+    mocked.proLeagueMatch.findFirst.mockResolvedValue({
+      completedAt: recentDate(48), // degraded
+    });
+    mocked.proGazetteArticle.findFirst.mockRejectedValue(new Error("nope")); // down
+    mocked.proBetMarket.count.mockResolvedValue(0); // degraded
+
+    const out = await getProLeagueHealth();
+    expect(out.status).toBe("down");
+  });
+
+  it("checks executes en parallele (Promise.all)", async () => {
+    const order: string[] = [];
+    mocked.proLeagueSeason.findFirst.mockImplementation(async () => {
+      order.push("season");
+      return { id: "s1", year: 2026 };
+    });
+    mocked.proLeagueMatch.findFirst.mockImplementation(async () => {
+      order.push("match");
+      return { completedAt: recentDate(1) };
+    });
+    mocked.proGazetteArticle.findFirst.mockImplementation(async () => {
+      order.push("gazette");
+      return { date: recentDate(1) };
+    });
+    mocked.proBetMarket.count.mockImplementation(async () => {
+      order.push("market");
+      return 1;
+    });
+
+    await getProLeagueHealth();
+    expect(order).toHaveLength(4);
+  });
+});

--- a/apps/server/src/services/pro-league-health.ts
+++ b/apps/server/src/services/pro-league-health.ts
@@ -1,0 +1,183 @@
+/**
+ * Pro League healthcheck — sprint 1.F.2.
+ *
+ * Expose un sous-systeme observable specifique a la Pro League, en
+ * complement du `/health/ready` generique. Pour chaque check, on
+ * renvoie `up | degraded | down` avec un indice metier :
+ *   - `season`         : up si une saison `in_progress` existe.
+ *   - `simRunner`      : up si la derniere `ProLeagueMatch` completed
+ *                        date de moins de 24h. degraded sinon (en
+ *                        intersaison, c'est attendu).
+ *   - `gazette`        : up si une edition Gazette publiee dans les
+ *                        48h. degraded sinon.
+ *   - `bettingMarkets` : up si au moins 1 ProBetMarket open existe sur
+ *                        un match a venir.
+ *
+ * Le statut global = pire des sous-statuts (down > degraded > up).
+ *
+ * Toutes les queries sont read-only et bornees pour ne pas charger la
+ * DB. Erreur isolee par check.
+ */
+
+import { prisma } from "../prisma";
+
+export type CheckStatus = "up" | "degraded" | "down";
+
+export interface CheckResult {
+  readonly name: string;
+  readonly status: CheckStatus;
+  readonly detail?: string;
+}
+
+export interface ProLeagueHealth {
+  readonly status: CheckStatus;
+  readonly checks: readonly CheckResult[];
+  readonly checkedAt: string;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const SIM_FRESHNESS_MS = 24 * HOUR_MS;
+const GAZETTE_FRESHNESS_MS = 48 * HOUR_MS;
+
+function worstStatus(checks: readonly CheckResult[]): CheckStatus {
+  if (checks.some((c) => c.status === "down")) return "down";
+  if (checks.some((c) => c.status === "degraded")) return "degraded";
+  return "up";
+}
+
+async function checkSeason(): Promise<CheckResult> {
+  try {
+    const season = await prisma.proLeagueSeason.findFirst({
+      where: { status: "in_progress" },
+      select: { id: true, year: true },
+    });
+    if (!season) {
+      return {
+        name: "season",
+        status: "degraded",
+        detail: "no in_progress season (intersaison ?)",
+      };
+    }
+    return { name: "season", status: "up", detail: `season ${season.year}` };
+  } catch (e: unknown) {
+    return {
+      name: "season",
+      status: "down",
+      detail: e instanceof Error ? e.message : "unknown",
+    };
+  }
+}
+
+async function checkSimRunner(): Promise<CheckResult> {
+  try {
+    const last = await prisma.proLeagueMatch.findFirst({
+      where: { status: "completed" },
+      orderBy: { completedAt: "desc" },
+      select: { completedAt: true },
+    });
+    if (!last || !last.completedAt) {
+      return {
+        name: "simRunner",
+        status: "degraded",
+        detail: "no completed match yet",
+      };
+    }
+    const ageMs = Date.now() - last.completedAt.getTime();
+    if (ageMs > SIM_FRESHNESS_MS) {
+      return {
+        name: "simRunner",
+        status: "degraded",
+        detail: `last match completed ${Math.floor(ageMs / HOUR_MS)}h ago`,
+      };
+    }
+    return {
+      name: "simRunner",
+      status: "up",
+      detail: `last match ${Math.floor(ageMs / HOUR_MS)}h ago`,
+    };
+  } catch (e: unknown) {
+    return {
+      name: "simRunner",
+      status: "down",
+      detail: e instanceof Error ? e.message : "unknown",
+    };
+  }
+}
+
+async function checkGazette(): Promise<CheckResult> {
+  try {
+    const last = await prisma.proGazetteArticle.findFirst({
+      orderBy: { date: "desc" },
+      select: { date: true },
+    });
+    if (!last) {
+      return {
+        name: "gazette",
+        status: "degraded",
+        detail: "no gazette article yet",
+      };
+    }
+    const ageMs = Date.now() - last.date.getTime();
+    if (ageMs > GAZETTE_FRESHNESS_MS) {
+      return {
+        name: "gazette",
+        status: "degraded",
+        detail: `last edition ${Math.floor(ageMs / HOUR_MS)}h ago`,
+      };
+    }
+    return {
+      name: "gazette",
+      status: "up",
+      detail: `last edition ${Math.floor(ageMs / HOUR_MS)}h ago`,
+    };
+  } catch (e: unknown) {
+    return {
+      name: "gazette",
+      status: "down",
+      detail: e instanceof Error ? e.message : "unknown",
+    };
+  }
+}
+
+async function checkBettingMarkets(): Promise<CheckResult> {
+  try {
+    const count = await prisma.proBetMarket.count({
+      where: { status: "open" },
+    });
+    if (count === 0) {
+      return {
+        name: "bettingMarkets",
+        status: "degraded",
+        detail: "no open markets",
+      };
+    }
+    return {
+      name: "bettingMarkets",
+      status: "up",
+      detail: `${count} open markets`,
+    };
+  } catch (e: unknown) {
+    return {
+      name: "bettingMarkets",
+      status: "down",
+      detail: e instanceof Error ? e.message : "unknown",
+    };
+  }
+}
+
+/**
+ * Aggrege tous les checks Pro League. Run en parallele pour latency.
+ */
+export async function getProLeagueHealth(): Promise<ProLeagueHealth> {
+  const checks = await Promise.all([
+    checkSeason(),
+    checkSimRunner(),
+    checkGazette(),
+    checkBettingMarkets(),
+  ]);
+  return {
+    status: worstStatus(checks),
+    checks,
+    checkedAt: new Date().toISOString(),
+  };
+}

--- a/apps/web/app/pro-league/gazette/layout.tsx
+++ b/apps/web/app/pro-league/gazette/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Nuffle Gazette — Edition quotidienne | Nuffle Arena",
+  description:
+    "La Nuffle Gazette : journal sportif fictif de la Pro League. Articles quotidiens generes par IA, signes par 3 personas (le cynique, l'enthousiaste orc, le statisticien).",
+  openGraph: {
+    title: "Nuffle Gazette — La Pro League par ses redacteurs",
+    description:
+      "Editions quotidiennes : articles, breves, editos. 3 personas, ton pulp Blood Bowl-like.",
+    type: "website",
+  },
+};
+
+export default function GazetteLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/hall-of-fame/layout.tsx
+++ b/apps/web/app/pro-league/hall-of-fame/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Hall of Fame Pro League | Nuffle Arena",
+  description:
+    "Les joueurs immortalises de la Pro League Nuffle Arena. Tombes au champ d'honneur de Nuffle ou couronnes par leur palmares.",
+  openGraph: {
+    title: "Hall of Fame — Les legendes de la Pro League",
+    description:
+      "Snapshot fige des joueurs immortalises (mort en match, palmares carriere).",
+    type: "website",
+  },
+};
+
+export default function HallOfFameLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/layout.tsx
+++ b/apps/web/app/pro-league/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Pro League — Old World League | Nuffle Arena",
+  description:
+    "Suivez la Pro League Nuffle Arena : 16 equipes simulees, 15 journees, paris, Gazette quotidienne et Hall of Fame. Une ligue Blood Bowl-like jouee par l'IA, supportee par les fans.",
+  keywords: [
+    "Blood Bowl",
+    "Pro League",
+    "Old World League",
+    "Nuffle Arena",
+    "fantasy football",
+    "betting",
+    "Gazette",
+    "Hall of Fame",
+  ],
+  openGraph: {
+    title: "Pro League Nuffle Arena — Ligue simulee 16 equipes",
+    description:
+      "16 equipes hommage NFL × races Blood Bowl. Paris, Gazette quotidienne, Hall of Fame. Suivez votre equipe favorite.",
+    type: "website",
+  },
+};
+
+export default function ProLeagueLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/leaderboard/layout.tsx
+++ b/apps/web/app/pro-league/leaderboard/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Leaderboard parieurs Pro League | Nuffle Arena",
+  description:
+    "Classement des parieurs Pro League : profit, accuracy, plus longue serie. Triable par semaine, saison, tout temps.",
+};
+
+export default function LeaderboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/standings/layout.tsx
+++ b/apps/web/app/pro-league/standings/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Classement Pro League — Old World League | Nuffle Arena",
+  description:
+    "Le classement live des 16 equipes de la Pro League Nuffle Arena : victoires, defaites, points et tie-break selon les regles BB.",
+};
+
+export default function StandingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Sprint Pro League — lot 1.F.2 (SEO + monitoring)

Deuxieme lot phase 1.F (E2E + go-live). Ajoute la metadata SEO sur les 5 ecrans Pro League et un healthcheck observable pour la stack Pro League.

### SEO Metadata (5 layouts Next.js)

Pages Pro League etaient client components sans metadata → invisibles aux crawlers. Ajout d'un layout.tsx par page :

| Path | Title |
|------|-------|
| `/pro-league` | Pro League — Old World League \| Nuffle Arena |
| `/pro-league/standings` | Classement Pro League — Old World League \| Nuffle Arena |
| `/pro-league/leaderboard` | Leaderboard parieurs Pro League \| Nuffle Arena |
| `/pro-league/gazette` | Nuffle Gazette — Edition quotidienne \| Nuffle Arena |
| `/pro-league/hall-of-fame` | Hall of Fame Pro League \| Nuffle Arena |

Chaque layout porte `description`, `keywords` (sur le hub), et `openGraph` (sur les pages "produit" — hub, gazette, hall-of-fame).

### Healthcheck Pro League

**`apps/server/src/services/pro-league-health.ts`** (nouveau)

4 sub-checks executes en parallele :
- `season` : up si `ProLeagueSeason.status='in_progress'` existe.
- `simRunner` : up si dernier `ProLeagueMatch.completed` < 24h.
- `gazette` : up si derniere edition `ProGazetteArticle` < 48h.
- `bettingMarkets` : up si >= 1 `ProBetMarket.status='open'`.

Statut global = pire des sub-statuts (`down > degraded > up`). Erreur DB par check isolee.

**`apps/server/src/index.ts`**
- `GET /health/pro-league` : 200 si up/degraded, 503 si down.

### Tests

- `pro-league-health.test.ts` (9) : up happy path, degraded individuels (no season, sim stale, no match yet, gazette stale, no markets), down propage en global, worstStatus arbitre down vs degraded, parallel exec.

```
✓ pro-league-health.test.ts (9 tests)
Test Files 26 passed (26)
     Tests 291 passed (291)
```

### Test plan

- [x] `pnpm typecheck` (server + web) → OK
- [x] `pnpm vitest run src/services/pro src/services/anthropic` → 291/291 OK
- [ ] Verifier SEO meta tags via `curl -s <url> | grep '<meta'` apres deploy
- [ ] Verifier `GET /health/pro-league` retourne 200/503 selon stack staging

### Sequel

- 1.F.3 final : page marketing dedie (selon priorite — la SEO sur les 5 ecrans courants est deja un go-live valide).

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_