### PR TITLE
feat(web): Pro League sitemap + JSON-LD SportsLeague/FAQ (sprint 1.F.3)

### DIFF
--- a/apps/web/app/pro-league/_components/ProLeagueStructuredData.tsx
+++ b/apps/web/app/pro-league/_components/ProLeagueStructuredData.tsx
@@ -1,0 +1,21 @@
+import Script from "next/script";
+
+import { buildProLeagueSchema } from "./pro-league-schema";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://nufflearena.fr";
+
+/**
+ * JSON-LD structured data pour la Pro League (sprint 1.F.3).
+ * Wrapper React autour de `buildProLeagueSchema` (pure).
+ */
+export default function ProLeagueStructuredData(): JSX.Element {
+  const data = buildProLeagueSchema({ baseUrl: BASE_URL });
+  return (
+    <Script
+      id="pro-league-structured-data"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/apps/web/app/pro-league/_components/pro-league-schema.test.ts
+++ b/apps/web/app/pro-league/_components/pro-league-schema.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProLeagueSchema } from "./pro-league-schema";
+
+describe("buildProLeagueSchema — sprint 1.F.3", () => {
+  const schema = buildProLeagueSchema({
+    baseUrl: "https://nufflearena.fr",
+  });
+
+  it("declare @context schema.org au top level", () => {
+    expect(schema["@context"]).toBe("https://schema.org");
+  });
+
+  it("contient un graph avec SportsLeague + FAQPage", () => {
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    expect(graph).toHaveLength(2);
+    const types = graph.map((g) => g["@type"]);
+    expect(types).toContain("SportsLeague");
+    expect(types).toContain("FAQPage");
+  });
+
+  it("SportsLeague pointe vers /pro-league avec 16 teams", () => {
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const league = graph.find((g) => g["@type"] === "SportsLeague")!;
+    expect(league.url).toBe("https://nufflearena.fr/pro-league");
+    expect(league.numberOfTeams).toBe(16);
+    expect(league.name).toBe("Old World League");
+  });
+
+  it("SportsLeague hooke sur l'Organization Nuffle Arena", () => {
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const league = graph.find((g) => g["@type"] === "SportsLeague")!;
+    const parent = league.parentOrganization as Record<string, unknown>;
+    expect(parent["@id"]).toBe("https://nufflearena.fr#organization");
+  });
+
+  it("FAQPage contient au moins 4 questions", () => {
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const faq = graph.find((g) => g["@type"] === "FAQPage")!;
+    const questions = faq.mainEntity as Array<Record<string, unknown>>;
+    expect(questions.length).toBeGreaterThanOrEqual(4);
+    for (const q of questions) {
+      expect(q["@type"]).toBe("Question");
+      expect(typeof q.name).toBe("string");
+      const answer = q.acceptedAnswer as Record<string, unknown>;
+      expect(answer["@type"]).toBe("Answer");
+      expect(typeof answer.text).toBe("string");
+      expect((answer.text as string).length).toBeGreaterThan(40);
+    }
+  });
+
+  it("FAQ couvre les 4 sujets cles : league, betting, gazette, hall of fame", () => {
+    const graph = schema["@graph"] as Array<Record<string, unknown>>;
+    const faq = graph.find((g) => g["@type"] === "FAQPage")!;
+    const questions = faq.mainEntity as Array<Record<string, unknown>>;
+    const names = questions.map((q) => q.name as string).join(" ");
+    expect(names).toMatch(/Pro League/i);
+    expect(names).toMatch(/parier/i);
+    expect(names).toMatch(/Gazette/i);
+    expect(names).toMatch(/Hall of Fame/i);
+  });
+
+  it("propage baseUrl custom aux ids", () => {
+    const custom = buildProLeagueSchema({
+      baseUrl: "https://staging.example.com",
+    });
+    const graph = custom["@graph"] as Array<Record<string, unknown>>;
+    const league = graph.find((g) => g["@type"] === "SportsLeague")!;
+    expect(league["@id"]).toBe("https://staging.example.com/pro-league#league");
+    expect(league.url).toBe("https://staging.example.com/pro-league");
+  });
+});

--- a/apps/web/app/pro-league/_components/pro-league-schema.ts
+++ b/apps/web/app/pro-league/_components/pro-league-schema.ts
@@ -1,0 +1,74 @@
+/**
+ * Builder pour le JSON-LD Pro League (sprint 1.F.3).
+ *
+ * Pure function : extrait du component pour etre testable sans React.
+ */
+
+export interface ProLeagueSchemaOptions {
+  readonly baseUrl: string;
+}
+
+export function buildProLeagueSchema(
+  opts: ProLeagueSchemaOptions,
+): Record<string, unknown> {
+  const { baseUrl } = opts;
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SportsLeague",
+        "@id": `${baseUrl}/pro-league#league`,
+        name: "Old World League",
+        alternateName: "Pro League Nuffle Arena",
+        url: `${baseUrl}/pro-league`,
+        sport: "Blood Bowl (fantasy football)",
+        numberOfTeams: 16,
+        description:
+          "Ligue simulee a 16 equipes (homages NFL × races Blood Bowl). 15 journees round-robin, mardi 21h, simulation engine BB-like.",
+        parentOrganization: {
+          "@type": "Organization",
+          "@id": `${baseUrl}#organization`,
+          name: "Nuffle Arena",
+        },
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${baseUrl}/pro-league#faq`,
+        mainEntity: [
+          {
+            "@type": "Question",
+            name: "Qu'est-ce que la Pro League Nuffle Arena ?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "La Pro League est une ligue Blood Bowl-like simulee : 16 equipes hommage NFL × races BB s'affrontent sur 15 journees round-robin. Les matchs sont joues automatiquement par un engine deterministe ; les fans suivent, parient et lisent la Gazette quotidienne.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Comment parier sur les matchs ?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Chaque match Pro League ouvre des marches de paris (Moneyline, Total TDs, etc.) avec une monnaie virtuelle creditee a l'inscription. Les gains sont credites automatiquement apres la simulation. Aucun argent reel n'est implique.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Qu'est-ce que la Nuffle Gazette ?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "La Nuffle Gazette est un journal sportif fictif quotidien genere par IA (Claude Haiku). Elle publie un article principal, des breves et un edito signe par 1 des 3 personas (le cynique, l'enthousiaste orc, le statisticien) a partir des resultats de la veille.",
+            },
+          },
+          {
+            "@type": "Question",
+            name: "Qu'est-ce que le Hall of Fame Pro League ?",
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: "Le Hall of Fame fige le snapshot des joueurs immortalises (mort en match au MVP, palmares carriere ensuite) — nom, race, stats, equipe et raison de l'induction restent consultables meme si le roster d'origine disparait.",
+            },
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/web/app/pro-league/layout.tsx
+++ b/apps/web/app/pro-league/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import ProLeagueStructuredData from "./_components/ProLeagueStructuredData";
+
 export const metadata: Metadata = {
   title: "Pro League — Old World League | Nuffle Arena",
   description:
@@ -27,5 +29,10 @@ export default function ProLeagueLayout({
 }: {
   children: React.ReactNode;
 }): JSX.Element {
-  return <>{children}</>;
+  return (
+    <>
+      <ProLeagueStructuredData />
+      {children}
+    </>
+  );
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -86,6 +86,37 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'yearly',
       priority: 0.3,
     },
+    // Pro League — sprint 1.F.3
+    {
+      url: `${BASE_URL}/pro-league`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/pro-league/standings`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/pro-league/leaderboard`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/pro-league/gazette`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/pro-league/hall-of-fame`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
   ];
 
   // Pages dynamiques - Teams
@@ -159,5 +190,41 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Erreur lors de la récupération des profils coach pour le sitemap:', error);
   }
 
-  return [...staticPages, ...teamPages, ...starPlayerPages, ...coachPages];
+  // Pro League — equipes officielles (sprint 1.F.3). Slugs stables
+  // venant de PRO_LEAGUE_TEAMS dans @bb/sim-engine. Inline ici pour
+  // ne pas dependre du runtime sim-engine cote sitemap.
+  const PRO_LEAGUE_TEAM_SLUGS = [
+    'pit-smashers',
+    'dal-vipers',
+    'kc-soaring-hawks',
+    'ne-cold-tacticians',
+    'sf-gold-rush',
+    'car-jungle-queens',
+    'lv-outlaws',
+    'no-voodoo-saints',
+    'chi-iron-bears',
+    'phi-storm-eagles',
+    'phx-tomb-cardinals',
+    'min-frostraiders',
+    'gb-cheese-halflings',
+    'jax-swamp-lizards',
+    'den-mile-high-centaurs',
+    'buf-snow-ogres',
+  ] as const;
+  const proLeagueTeamPages: MetadataRoute.Sitemap = PRO_LEAGUE_TEAM_SLUGS.map(
+    (slug) => ({
+      url: `${BASE_URL}/pro-league/teams/${slug}`,
+      lastModified: now,
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }),
+  );
+
+  return [
+    ...staticPages,
+    ...teamPages,
+    ...starPlayerPages,
+    ...coachPages,
+    ...proLeagueTeamPages,
+  ];
 }


### PR DESCRIPTION
## Sprint Pro League — lot 1.F.3 (sitemap + structured data)

Troisieme et dernier lot phase 1.F (E2E + go-live). Rend la Pro League pleinement decouvrable par les crawlers et LLM via sitemap + JSON-LD.

### Sitemap (`apps/web/app/sitemap.ts`)

Ajout de 21 routes Pro League :
- 5 hub : `/pro-league`, `/pro-league/standings`, `/pro-league/leaderboard`, `/pro-league/gazette`, `/pro-league/hall-of-fame` (priorite 0.6-0.9, changeFrequency `daily`/`weekly`).
- 16 team detail : `/pro-league/teams/<slug>` (slugs stables venant de PRO_LEAGUE_TEAMS, inline pour ne pas dependre du runtime sim-engine).

### Structured Data JSON-LD

**`buildProLeagueSchema(opts)`** (pure) :
- `SportsLeague` schema.org : Old World League, 16 teams, sport `Blood Bowl`, parentOrganization Nuffle Arena.
- `FAQPage` schema.org : 4 questions/reponses sur Pro League / paris / Gazette / Hall of Fame (rich results Google + cite-ability LLM).

**`ProLeagueStructuredData`** (server component) injecte le JSON-LD via `next/script` au top du layout `/pro-league` → propage a toutes les sous-pages.

### Tests

`pro-league-schema.test.ts` (7) :
- @context schema.org top-level
- graph contient SportsLeague + FAQPage
- SportsLeague URL/numberOfTeams/name corrects
- parentOrganization hooke vers Nuffle Arena #organization
- FAQ >= 4 questions, chaque answer non-trivial
- FAQ couvre les 4 sujets (Pro League, parier, Gazette, Hall of Fame)
- baseUrl propage aux ids (staging/prod)

```
✓ pro-league-schema.test.ts (7 tests)
```

### Test plan

- [x] `pnpm typecheck` (web) → OK
- [x] `pnpm vitest run app/pro-league/_components/pro-league-schema.test.ts` → 7/7 OK
- [ ] Verifier `curl -s <staging>/sitemap.xml | grep pro-league` post-deploy
- [ ] Verifier Google Rich Results Test (https://search.google.com/test/rich-results) sur `/pro-league` post-deploy

### Sprint 1.F complet apres ce merge

- 1.F.1 : Playwright E2E fan flow (PR #630, merged)
- 1.F.2 : SEO metadata + Pro League healthcheck (PR #631, merged)
- 1.F.3 : sitemap + JSON-LD (ce PR)

Phase 1 (MVP Pro League + Paris) est feature-complete.

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_