### PR TITLE
feat(sim-engine): enriched narrator + regen 50 panel replays on 0.13.0

### DIFF
--- a/docs/roadmap/sprints/pro-league-panel/README.md
+++ b/docs/roadmap/sprints/pro-league-panel/README.md
@@ -33,7 +33,21 @@ Le seed `2026` est figé pour que tous les testeurs reçoivent le même
 
 ## Statut actuel
 
-- Engine version : `0.2.0` (lot 0.E.1 première itération)
-- Replays générés : 50 (seed 2026)
+- Engine version : `0.13.0` (lot 0.E.1 iter #16, gate stat C1-C5 ✅)
+- Replays générés : 50 (seed 2026, format narratif enrichi 2026-05-07)
 - Panel recruté : **TODO** — recrutement humain hors scope automatique
 - Synthèse remplie : **TODO** — après réception des 5 grilles
+
+## Format narratif (post 2026-05-07)
+
+Les `.txt` ont été enrichis pour rendre la lecture panel plus fidèle :
+
+- Préfixe `[T+MM:SS]` sur chaque event (timing match-clock issu de `displayAtMs`).
+- Annotation `(drive ±N yds)` sur les TURN_STARTs successifs même drive.
+- Skill annotations sur BLOCK (`wrestled`) et DODGE (`[tackle blocks reroll]`).
+- Détail `(armor=N, injury=M)` sur KO et CASUALTY quand disponible.
+- Footer FINAL inchangé (compatible aggregation panel).
+
+Restent agrégés à la turn (pas event-par-event) : déplacements simples, pickups
+réussis, setups. Pour la plénitude visuelle, donner aux testeurs l'URL spectate
+Pixi en complément du `.txt` (post-deploy).

--- a/docs/roadmap/sprints/pro-league-panel/notation-grille.md
+++ b/docs/roadmap/sprints/pro-league-panel/notation-grille.md
@@ -12,7 +12,7 @@
 | Profil | _FUMBBL veteran 312 matchs / NAF coach 2 tournois / autre_ |
 | Date d'envoi du brief | _YYYY-MM-DD_ |
 | Date de soumission | _YYYY-MM-DD_ |
-| Engine version review | `0.2.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
+| Engine version review | `0.13.0` (cf. `packages/sim-engine/CHANGELOG.md`) |
 | Replays reviewés | _x sur 50 lus integralement, y skim_ |
 
 ## Notes (0-10 par axe)

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-001-kc-soaring-hawks-vs-min-frostraiders-seed2026.txt
@@ -1,48 +1,48 @@
 === MATCH #1 — Soaring Hawks (Wood Elf) vs Frostraiders (Norse) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts min-frostraiders (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 14 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
-  ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 10 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 19 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 8 — home in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-1-8 is taken off by banana_skin.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → caught.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts min-frostraiders (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 14 (score 0-0) (drive +10 yds)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+00:30] TURNOVER — pass_fumble.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
+  [T+01:00] ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+01:00] TURNOVER — block_attacker_down.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  [T+01:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+01:30] TURNOVER — dodge_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
+  [T+02:00] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 10 (score 0-0)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 19 (score 0-0) (drive +9 yds)
+  [T+03:00] TURNOVER — pickup_failed.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 8 (score 0-0)
+  [T+03:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+03:30] CASUALTY — away-NUFFLE-1-8 is taken off by banana_skin.
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → caught.
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 2 • Turn 2 — home in possession at yardline 9 (score 0-0)
-  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
-Half 2 • Turn 3 — home in possession at yardline 13 (score 0-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 2 • Turn 4 — home in possession at yardline 14 (score 0-0)
-Half 2 • Turn 5 — home in possession at yardline 17 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 6 — home in possession at yardline 17 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 24 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0) (drive -4 yds)
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+04:45] DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 13 (score 0-0) (drive +4 yds)
+  [T+05:15] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 14 (score 0-0) (drive +1 yds)
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 17 (score 0-0) (drive +3 yds)
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 17 (score 0-0)
+  [T+06:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 24 (score 0-0) (drive +7 yds)
+  [T+07:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+07:15] TURNOVER — pass_fumble.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 0-0)
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
 
 --- END OF MATCH (score 0-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-002-kc-soaring-hawks-vs-no-voodoo-saints-seed2027.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-002-kc-soaring-hawks-vs-no-voodoo-saints-seed2027.txt
@@ -1,59 +1,59 @@
 === MATCH #2 — Soaring Hawks (Wood Elf) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
-Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 1 • Turn 3 — away in possession at yardline 9 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 6 — away in possession at yardline 7 (score 0-2)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 10 (score 0-2)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 0-3.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-3)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+00:30] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+  [T+00:30] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 9 (score 0-0)
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  [T+01:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  [T+01:30] TURNOVER — pickup_failed.
+  [T+01:30] Touchdown! away crosses the line. Score is now 0-2.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  [T+02:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+02:00] TURNOVER — pass_fumble.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 7 (score 0-2)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+02:30] TURNOVER — block_attacker_down.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 10 (score 0-2)
+  [T+03:00] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+03:00] TURNOVER — pickup_failed.
+  [T+03:00] Touchdown! away crosses the line. Score is now 0-3.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-3) (drive -6 yds)
+  [T+03:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+03:30] TURNOVER — pass_failed.
 
 --- HALFTIME (score 0-3) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-3)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  CASUALTY — away-NUFFLE-2-1 is taken off by bombardier_gone_wild.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → caught.
-Half 2 • Turn 2 — home in possession at yardline 6 (score 0-3)
-  Touchdown! home crosses the line. Score is now 1-3.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 1-3)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-3)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 2 • Turn 5 — home in possession at yardline 9 (score 1-3)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 6 — home in possession at yardline 12 (score 1-3)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 7 (score 1-3)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 1-3)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — home-NUFFLE-2-8 is taken off by nemesis_clash.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-3)
+  [T+04:15] ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  [T+04:15] CASUALTY — away-NUFFLE-2-1 is taken off by bombardier_gone_wild.
+  [T+04:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → caught.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 6 (score 0-3) (drive +2 yds)
+  [T+04:45] Touchdown! home crosses the line. Score is now 1-3.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 1-3)
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-3)
+  [T+05:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 9 (score 1-3) (drive +5 yds)
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 12 (score 1-3) (drive +3 yds)
+  [T+06:45] TURNOVER — pickup_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 7 (score 1-3)
+  [T+07:15] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 10 (score 1-3) (drive +3 yds)
+  [T+07:45] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+07:45] CASUALTY — home-NUFFLE-2-8 is taken off by nemesis_clash.
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- END OF MATCH (score 1-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-003-kc-soaring-hawks-vs-buf-snow-ogres-seed2028.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-003-kc-soaring-hawks-vs-buf-snow-ogres-seed2028.txt
@@ -1,54 +1,54 @@
 === MATCH #3 — Soaring Hawks (Wood Elf) vs Snow Ogres (Ogre) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts buf-snow-ogres (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 2 — away in possession at yardline 6 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — away-NUFFLE-1-3 is taken off by tantrum_star.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 4 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — home in possession at yardline 6 (score 0-0)
-Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts buf-snow-ogres (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+00:00] TURNOVER — pass_failed.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 6 (score 0-0)
+  [T+00:30] TURNOVER — pickup_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+01:00] CASUALTY — away-NUFFLE-1-3 is taken off by tantrum_star.
+  [T+01:00] TURNOVER — pickup_failed.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 10 (score 0-0)
+  [T+01:30] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+01:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 6 (score 0-0)
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0) (drive +3 yds)
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 10 (score 0-0)
+  [T+03:00] ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  [T+03:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PLAYER_DOWN], chose POW, defender_down.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 5 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 9 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 5 (score 0-1)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
+  [T+05:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 0-1)
+  [T+05:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW/PLAYER_DOWN], chose POW, defender_down.
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 5 (score 0-1)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 9 (score 0-1)
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 5 (score 0-1)
+  [T+07:15] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+07:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:15] Touchdown! home crosses the line. Score is now 1-1.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 1-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-004-jax-swamp-lizards-vs-car-jungle-queens-seed2029.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-004-jax-swamp-lizards-vs-car-jungle-queens-seed2029.txt
@@ -1,60 +1,60 @@
 === MATCH #4 — Swamp Lizards (Lizardmen) vs Jungle Queens (Amazon) ===
 engine 0.13.0
 
-KICKOFF — jax-swamp-lizards hosts car-jungle-queens (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 1 • Turn 4 — home in possession at yardline 17 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — away in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
+[T+00:00] KICKOFF — jax-swamp-lizards hosts car-jungle-queens (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
+  [T+01:00] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 17 (score 0-0) (drive +8 yds)
+  [T+01:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 9 (score 0-0)
+  [T+02:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
+  [T+02:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1) (drive -5 yds)
+  [T+03:00] Touchdown! home crosses the line. Score is now 1-1.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  [T+03:30] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+03:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+03:30] TURNOVER — pass_failed.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 2-1)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 4 — home in possession at yardline 9 (score 2-1)
-  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-Half 2 • Turn 5 — home in possession at yardline 19 (score 2-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 8 — home in possession at yardline 8 (score 2-1)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  [T+04:15] Touchdown! home crosses the line. Score is now 2-1.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 2-1)
+  [T+04:45] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
+  [T+04:45] TURNOVER — foul_sent_off.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 2-1)
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 9 (score 2-1) (drive +5 yds)
+  [T+05:45] ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 19 (score 2-1) (drive +10 yds)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
+  [T+06:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
+  [T+07:15] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+07:15] TURNOVER — pass_fumble.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 8 (score 2-1)
+  [T+07:45] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-005-dal-vipers-vs-chi-iron-bears-seed2030.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-005-dal-vipers-vs-chi-iron-bears-seed2030.txt
@@ -1,55 +1,55 @@
 === MATCH #5 — Vipers (Dark Elf) vs Iron Bears (Dwarf) ===
 engine 0.13.0
 
-KICKOFF — dal-vipers hosts chi-iron-bears (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
-Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 11 (score 0-0)
-Half 1 • Turn 4 — home in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-Half 1 • Turn 6 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — away-NUFFLE-1-8 is taken off by tantrum_star.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+00:00] KICKOFF — dal-vipers hosts chi-iron-bears (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0) (drive +3 yds)
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 11 (score 0-0) (drive +4 yds)
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 14 (score 0-0) (drive +3 yds)
+  [T+01:30] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+01:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 8 (score 0-0)
+  [T+02:00] ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 8 (score 0-0)
+  [T+02:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+  [T+02:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  [T+03:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+03:30] CASUALTY — away-NUFFLE-1-8 is taken off by tantrum_star.
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 2 — home in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-Half 2 • Turn 3 — home in possession at yardline 15 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 7 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-2-7 is taken off by banana_skin.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 0-2)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+  [T+04:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:15] TURNOVER — pickup_failed.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 9 (score 0-1)
+  [T+04:45] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 15 (score 0-1) (drive +6 yds)
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 7 (score 0-1)
+  [T+05:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+05:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+05:45] Touchdown! away crosses the line. Score is now 0-2.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
+  [T+06:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+06:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 0-2)
+  [T+07:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+07:15] CASUALTY — home-NUFFLE-2-7 is taken off by banana_skin.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 0-2)
+  [T+07:45] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
 
 --- END OF MATCH (score 0-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-006-kc-soaring-hawks-vs-no-voodoo-saints-seed2031.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-006-kc-soaring-hawks-vs-no-voodoo-saints-seed2031.txt
@@ -1,57 +1,57 @@
 === MATCH #6 — Soaring Hawks (Wood Elf) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 3 — away in possession at yardline 7 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 6 — away in possession at yardline 11 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — home in possession at yardline 5 (score 1-0)
-Half 1 • Turn 8 — home in possession at yardline 8 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts no-voodoo-saints (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+01:00] TURNOVER — block_attacker_down.
+  [T+01:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0) (drive -3 yds)
+  [T+01:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+01:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
+  [T+02:00] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+02:00] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose BOTH_DOWN, both_down.
+  [T+02:00] TURNOVER — block_attacker_down.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 11 (score 1-0)
+  [T+02:30] TURNOVER — pickup_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 5 (score 1-0)
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 8 (score 1-0) (drive +3 yds)
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
 
 --- HALFTIME (score 1-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 2 — away in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — away in possession at yardline 9 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — home in possession at yardline 5 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 8 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-Half 2 • Turn 7 — away in possession at yardline 15 (score 1-0)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  CASUALTY — home-NUFFLE-2-7 is taken off by bombardier_gone_wild.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 2-0)
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0) (drive -4 yds)
+  [T+04:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+04:15] TURNOVER — gfi_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 8 (score 1-0)
+  [T+04:45] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+04:45] TURNOVER — pass_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  [T+05:15] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:15] TURNOVER — block_attacker_down.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 9 (score 1-0)
+  [T+05:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 5 (score 1-0)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 8 (score 1-0)
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 15 (score 1-0) (drive +7 yds)
+  [T+07:15] ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  [T+07:15] CASUALTY — home-NUFFLE-2-7 is taken off by bombardier_gone_wild.
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+07:15] TURNOVER — pass_failed.
+  [T+07:15] Touchdown! home crosses the line. Score is now 2-0.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 2-0) (drive -11 yds)
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 2-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-007-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2032.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-007-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2032.txt
@@ -1,50 +1,50 @@
 === MATCH #7 — Soaring Hawks (Wood Elf) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 4 — home in possession at yardline 7 (score 0-0)
-Half 1 • Turn 5 — home in possession at yardline 13 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 6 — home in possession at yardline 17 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — away in possession at yardline 6 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — away in possession at yardline 10 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+00:00] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0) (drive +1 yds)
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 7 (score 0-0) (drive +2 yds)
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 13 (score 0-0) (drive +6 yds)
+  [T+02:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 17 (score 0-0) (drive +4 yds)
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+02:30] TURNOVER — block_attacker_down.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 6 (score 0-0)
+  [T+03:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+03:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 10 (score 0-0) (drive +4 yds)
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
+  [T+03:30] TURNOVER — foul_sent_off.
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — home in possession at yardline 6 (score 1-1)
-Half 2 • Turn 5 — home in possession at yardline 14 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
-Half 2 • Turn 7 — away in possession at yardline 10 (score 2-1)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 2 • Turn 8 — away in possession at yardline 14 (score 2-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, defender_down.
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0) (drive -6 yds)
+  [T+04:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+04:15] Touchdown! away crosses the line. Score is now 0-1.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+04:45] Touchdown! home crosses the line. Score is now 1-1.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 1-1)
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:15] TURNOVER — block_attacker_down.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 6 (score 1-1)
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 14 (score 1-1) (drive +8 yds)
+  [T+06:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+06:15] Touchdown! home crosses the line. Score is now 2-1.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 2-1)
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 10 (score 2-1) (drive +6 yds)
+  [T+07:15] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PUSH_BACK, push_only.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 14 (score 2-1) (drive +4 yds)
+  [T+07:45] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, defender_down.
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-008-dal-vipers-vs-phi-storm-eagles-seed2033.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-008-dal-vipers-vs-phi-storm-eagles-seed2033.txt
@@ -1,46 +1,46 @@
 === MATCH #8 — Vipers (Dark Elf) vs Storm Eagles (Pro Elf) ===
 engine 0.13.0
 
-KICKOFF — dal-vipers hosts phi-storm-eagles (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 4 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-Half 1 • Turn 8 — away in possession at yardline 6 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:00] KICKOFF — dal-vipers hosts phi-storm-eagles (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] TURNOVER — pickup_failed.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] TURNOVER — pickup_failed.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 10 (score 0-0)
+  [T+01:30] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+01:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0) (drive +3 yds)
+  [T+02:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+02:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  [T+02:30] Touchdown! home crosses the line. Score is now 1-1.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  [T+03:00] ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 6 (score 1-1) (drive +2 yds)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 3 — home in possession at yardline 17 (score 1-1)
-  DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 4 — home in possession at yardline 21 (score 1-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 2 • Turn 5 — home in possession at yardline 24 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 2 • Turn 6 — home in possession at yardline 24 (score 1-1)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 8 — home in possession at yardline 5 (score 2-1)
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  [T+04:15] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 12 (score 1-1) (drive +8 yds)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 17 (score 1-1) (drive +5 yds)
+  [T+05:15] DODGE — home-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 21 (score 1-1) (drive +4 yds)
+  [T+05:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 24 (score 1-1) (drive +3 yds)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 24 (score 1-1)
+  [T+06:45] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+06:45] Touchdown! home crosses the line. Score is now 2-1.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
+  [T+07:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+07:15] TURNOVER — pass_fumble.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 5 (score 2-1)
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-009-no-voodoo-saints-vs-phi-storm-eagles-seed2034.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-009-no-voodoo-saints-vs-phi-storm-eagles-seed2034.txt
@@ -1,50 +1,50 @@
 === MATCH #9 — Voodoo Saints (Undead) vs Storm Eagles (Pro Elf) ===
 engine 0.13.0
 
-KICKOFF — no-voodoo-saints hosts phi-storm-eagles (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 4 — home in possession at yardline 8 (score 0-0)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 7 — away in possession at yardline 5 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+00:00] KICKOFF — no-voodoo-saints hosts phi-storm-eagles (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+00:00] TURNOVER — pickup_failed.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0) (drive +2 yds)
+  [T+01:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 8 (score 0-0) (drive +2 yds)
+  [T+01:30] TURNOVER — gfi_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+03:00] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 10 (score 0-0) (drive +5 yds)
+  [T+03:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
-  CASUALTY — away-NUFFLE-2-3 is taken off by equipment_failure.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 6 — away in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 7 — home in possession at yardline 7 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 8 — home in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+04:45] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+04:45] TURNOVER — block_attacker_down.
+  [T+04:45] Touchdown! away crosses the line. Score is now 0-1.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 0-1) (drive -3 yds)
+  [T+05:15] ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
+  [T+05:15] CASUALTY — away-NUFFLE-2-3 is taken off by equipment_failure.
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  [T+05:45] Touchdown! home crosses the line. Score is now 1-1.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 9 (score 1-1) (drive +5 yds)
+  [T+06:45] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+06:45] TURNOVER — gfi_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 7 (score 1-1)
+  [T+07:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 9 (score 1-1) (drive +2 yds)
+  [T+07:45] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
 
 --- END OF MATCH (score 1-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-010-chi-iron-bears-vs-lv-outlaws-seed2035.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-010-chi-iron-bears-vs-lv-outlaws-seed2035.txt
@@ -1,64 +1,64 @@
 === MATCH #10 — Iron Bears (Dwarf) vs Outlaws (Norse) ===
 engine 0.13.0
 
-KICKOFF — chi-iron-bears hosts lv-outlaws (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
-  KO — away-LOS is knocked unconscious by home-LOS.
-Half 1 • Turn 4 — home in possession at yardline 5 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/POW], chose POW, defender_down.
-Half 1 • Turn 5 — home in possession at yardline 5 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 5 (score 2-0)
-Half 1 • Turn 8 — home in possession at yardline 5 (score 2-0)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! away crosses the line. Score is now 2-1.
+[T+00:00] KICKOFF — chi-iron-bears hosts lv-outlaws (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] TURNOVER — pickup_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  [T+01:00] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose BOTH_DOWN, defender_down.
+  [T+01:00] KO — away-LOS is knocked unconscious by home-LOS (armor=10, injury=9).
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 5 (score 1-0) (drive +1 yds)
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/POW], chose POW, defender_down.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 5 (score 1-0)
+  [T+02:00] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+02:00] Touchdown! home crosses the line. Score is now 2-0.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  [T+02:30] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+02:30] TURNOVER — block_attacker_down.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 5 (score 2-0)
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 5 (score 2-0)
+  [T+03:30] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+03:30] TURNOVER — pass_failed.
+  [T+03:30] Touchdown! away crosses the line. Score is now 2-1.
 
 --- HALFTIME (score 2-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-  Touchdown! home crosses the line. Score is now 3-1.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 3-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 4 — home in possession at yardline 5 (score 3-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 3-1)
-  Touchdown! away crosses the line. Score is now 3-2.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 7 (score 3-2)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 8 — home in possession at yardline 5 (score 3-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 2-1)
+  [T+04:15] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+04:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+04:15] TURNOVER — dodge_failed.
+  [T+04:15] Touchdown! home crosses the line. Score is now 3-1.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 3-1)
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
+  [T+05:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+05:15] TURNOVER — block_attacker_down.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 5 (score 3-1)
+  [T+05:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 3-1)
+  [T+06:15] Touchdown! away crosses the line. Score is now 3-2.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  [T+06:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 7 (score 3-2)
+  [T+07:15] ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+07:15] TURNOVER — pass_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 5 (score 3-2)
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- END OF MATCH (score 3-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-011-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2036.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-011-kc-soaring-hawks-vs-phx-tomb-cardinals-seed2036.txt
@@ -1,57 +1,57 @@
 === MATCH #11 — Soaring Hawks (Wood Elf) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-1-1 is taken off by banana_skin.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 4 — home in possession at yardline 8 (score 1-1)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — away in possession at yardline 7 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
-Half 1 • Turn 6 — away in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — home in possession at yardline 7 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 9 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
+[T+00:00] KICKOFF — kc-soaring-hawks hosts phx-tomb-cardinals (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+00:00] CASUALTY — away-NUFFLE-1-1 is taken off by banana_skin.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  [T+00:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  [T+01:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 8 (score 1-1) (drive +4 yds)
+  [T+01:30] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+01:30] TURNOVER — pickup_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 7 (score 1-1)
+  [T+02:00] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+02:00] CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 9 (score 1-1) (drive +2 yds)
+  [T+02:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+02:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 7 (score 1-1)
+  [T+03:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 9 (score 1-1) (drive +2 yds)
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+03:30] TURNOVER — pass_fumble.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 6 — away in possession at yardline 7 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/STUMBLE], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! home crosses the line. Score is now 2-2.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 2-2)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  [T+04:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+04:15] TURNOVER — pass_failed.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  [T+05:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+06:15] TURNOVER — block_attacker_down.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 7 (score 1-1)
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/STUMBLE], chose PUSH_BACK, push_only.
+  [T+06:45] Touchdown! away crosses the line. Score is now 1-2.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
+  [T+07:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+07:15] Touchdown! home crosses the line. Score is now 2-2.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 2-2)
+  [T+07:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
 
 --- END OF MATCH (score 2-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-012-no-voodoo-saints-vs-chi-iron-bears-seed2037.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-012-no-voodoo-saints-vs-chi-iron-bears-seed2037.txt
@@ -1,55 +1,55 @@
 === MATCH #12 — Voodoo Saints (Undead) vs Iron Bears (Dwarf) ===
 engine 0.13.0
 
-KICKOFF — no-voodoo-saints hosts chi-iron-bears (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — away-NUFFLE-1-1 is taken off by nemesis_clash.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 7 — away in possession at yardline 5 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — away in possession at yardline 5 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
+[T+00:00] KICKOFF — no-voodoo-saints hosts chi-iron-bears (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+00:00] CASUALTY — away-NUFFLE-1-1 is taken off by nemesis_clash.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  [T+01:00] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 1-0)
+  [T+01:30] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
+  [T+01:30] TURNOVER — foul_sent_off.
+  [T+01:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  [T+02:00] ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  [T+02:30] TURNOVER — foul_sent_off.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 5 (score 1-1)
+  [T+03:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 5 (score 1-1)
+  [T+03:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE], chose STUMBLE, defender_down.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 2 — away in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-2-2 is taken off by banana_skin.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
-Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
-  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 1-2)
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1) (drive -1 yds)
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 1-1)
+  [T+04:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+04:45] CASUALTY — home-NUFFLE-2-2 is taken off by banana_skin.
+  [T+04:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+04:45] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
+  [T+05:15] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+05:15] TURNOVER — pass_fumble.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 1-2)
+  [T+05:45] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
+  [T+06:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
+  [T+07:15] ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 10 (score 1-2) (drive +5 yds)
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-013-phx-tomb-cardinals-vs-lv-outlaws-seed2038.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-013-phx-tomb-cardinals-vs-lv-outlaws-seed2038.txt
@@ -1,58 +1,58 @@
 === MATCH #13 — Tomb Cardinals (Tomb Kings) vs Outlaws (Norse) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts lv-outlaws (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 8 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — home in possession at yardline 9 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — home in possession at yardline 9 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — away-NUFFLE-1-7 is taken off by cocky_drop.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 11 (score 1-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts lv-outlaws (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  [T+00:00] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 8 (score 0-0) (drive +4 yds)
+  [T+00:30] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 8 (score 0-0)
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 9 (score 0-0) (drive +1 yds)
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
+  [T+02:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+02:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
+  [T+02:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 9 (score 1-0)
+  [T+03:00] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+03:00] CASUALTY — away-NUFFLE-1-7 is taken off by cocky_drop.
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 11 (score 1-0) (drive +2 yds)
+  [T+03:30] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+03:30] TURNOVER — dodge_failed.
 
 --- HALFTIME (score 1-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — home in possession at yardline 5 (score 1-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 8 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 2-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+04:45] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+04:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+04:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+04:45] TURNOVER — dodge_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 5 (score 1-0)
+  [T+05:15] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 8 (score 1-0) (drive +3 yds)
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
+  [T+05:45] Touchdown! home crosses the line. Score is now 2-0.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 2-0)
+  [T+06:15] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  [T+06:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+06:45] TURNOVER — block_attacker_down.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 2-0)
+  [T+07:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 2-0)
+  [T+07:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
 
 --- END OF MATCH (score 2-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-014-min-frostraiders-vs-jax-swamp-lizards-seed2039.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-014-min-frostraiders-vs-jax-swamp-lizards-seed2039.txt
@@ -1,65 +1,65 @@
 === MATCH #14 — Frostraiders (Norse) vs Swamp Lizards (Lizardmen) ===
 engine 0.13.0
 
-KICKOFF — min-frostraiders hosts jax-swamp-lizards (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 5 — home in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 6 — home in possession at yardline 11 (score 0-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — home-NUFFLE-1-7 is taken off by cocky_drop.
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
-Half 1 • Turn 8 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
+[T+00:00] KICKOFF — min-frostraiders hosts jax-swamp-lizards (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
+  [T+01:00] ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  [T+01:00] CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+01:00] TURNOVER — pass_failed.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+02:00] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+02:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 11 (score 0-0) (drive +4 yds)
+  [T+02:30] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
+  [T+03:00] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+03:00] CASUALTY — home-NUFFLE-1-7 is taken off by cocky_drop.
+  [T+03:00] FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 8 (score 0-0) (drive +4 yds)
+  [T+03:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+03:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+03:30] TURNOVER — pass_failed.
+  [T+03:30] Touchdown! home crosses the line. Score is now 1-0.
 
 --- HALFTIME (score 1-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  CASUALTY — home-NUFFLE-2-2 is taken off by bombardier_gone_wild.
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 4 — home in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 14 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 6 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 8 — home in possession at yardline 6 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  Touchdown! home crosses the line. Score is now 2-0.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-0)
+  [T+04:15] TURNOVER — gfi_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+04:45] ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  [T+04:45] CASUALTY — home-NUFFLE-2-2 is taken off by bombardier_gone_wild.
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+04:45] TURNOVER — pass_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  [T+05:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+05:15] CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 8 (score 1-0) (drive +4 yds)
+  [T+05:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 8 (score 1-0)
+  [T+06:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+06:15] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 14 (score 1-0) (drive +6 yds)
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 6 (score 1-0)
+  [T+07:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 6 (score 1-0)
+  [T+07:45] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  [T+07:45] Touchdown! home crosses the line. Score is now 2-0.
 
 --- END OF MATCH (score 2-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-015-pit-smashers-vs-gb-cheese-halflings-seed2040.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-015-pit-smashers-vs-gb-cheese-halflings-seed2040.txt
@@ -1,57 +1,57 @@
 === MATCH #15 — Smashers (Orc) vs Cheese Halflings (Halfling) ===
 engine 0.13.0
 
-KICKOFF — pit-smashers hosts gb-cheese-halflings (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 4 — away in possession at yardline 6 (score 1-1)
-Half 1 • Turn 5 — away in possession at yardline 9 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 6 — away in possession at yardline 13 (score 1-1)
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 2-1)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 4 (score 2-1)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 3-1.
+[T+00:00] KICKOFF — pit-smashers hosts gb-cheese-halflings (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+00:00] TURNOVER — pass_failed.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+00:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  [T+01:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+01:00] TURNOVER — pass_fumble.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 6 (score 1-1)
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 9 (score 1-1) (drive +3 yds)
+  [T+02:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 13 (score 1-1) (drive +4 yds)
+  [T+02:30] TURNOVER — pickup_failed.
+  [T+02:30] Touchdown! home crosses the line. Score is now 2-1.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 2-1) (drive -9 yds)
+  [T+03:00] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 2-1)
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  [T+03:30] TURNOVER — pickup_failed.
+  [T+03:30] Touchdown! home crosses the line. Score is now 3-1.
 
 --- HALFTIME (score 3-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 14 (score 3-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 14 (score 3-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → ko, sent off!).
-  KO — away-PRONE is knocked unconscious by home-LOS.
-  TURNOVER — foul_sent_off.
-  Touchdown! away crosses the line. Score is now 3-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 3-2)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 2 • Turn 7 — home in possession at yardline 15 (score 3-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 4-2.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 4-2)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 14 (score 3-1) (drive +10 yds)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+04:45] TURNOVER — pickup_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 3-1)
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 14 (score 3-1)
+  [T+05:45] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → ko, sent off!).
+  [T+05:45] KO — away-PRONE is knocked unconscious by home-LOS.
+  [T+05:45] TURNOVER — foul_sent_off.
+  [T+05:45] Touchdown! away crosses the line. Score is now 3-2.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 3-2) (drive -10 yds)
+  [T+06:15] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 3-2)
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 15 (score 3-2) (drive +11 yds)
+  [T+07:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+07:15] Touchdown! home crosses the line. Score is now 4-2.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 4-2)
+  [T+07:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+07:45] TURNOVER — block_attacker_down.
 
 --- END OF MATCH (score 4-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-016-ne-cold-tacticians-vs-kc-soaring-hawks-seed2041.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-016-ne-cold-tacticians-vs-kc-soaring-hawks-seed2041.txt
@@ -1,49 +1,49 @@
 === MATCH #16 — Cold Tacticians (Lizardmen) vs Soaring Hawks (Wood Elf) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — away in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 4 — away in possession at yardline 12 (score 0-1)
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
-Half 1 • Turn 5 — away in possession at yardline 16 (score 0-1)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
-Half 1 • Turn 6 — away in possession at yardline 23 (score 0-1)
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 1 • Turn 8 — home in possession at yardline 6 (score 0-2)
+[T+00:00] KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+00:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  [T+00:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 10 (score 0-1)
+  [T+01:00] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 12 (score 0-1) (drive +2 yds)
+  [T+01:30] DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 16 (score 0-1) (drive +4 yds)
+  [T+02:00] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  [T+02:00] DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 23 (score 0-1) (drive +7 yds)
+  [T+02:30] DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 1 → success.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-2.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-2)
+  [T+03:00] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 6 (score 0-2) (drive +2 yds)
 
 --- HALFTIME (score 0-2) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 2 • Turn 2 — home in possession at yardline 10 (score 0-2)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  Touchdown! home crosses the line. Score is now 1-2.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 1-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → caught.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 4 — away in possession at yardline 6 (score 1-2)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 2 • Turn 5 — away in possession at yardline 13 (score 1-2)
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → casualty).
-  CASUALTY — home-PRONE is taken off by away-LOS.
-Half 2 • Turn 6 — away in possession at yardline 17 (score 1-2)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — home in possession at yardline 5 (score 1-2)
-Half 2 • Turn 8 — home in possession at yardline 5 (score 1-2)
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-2) (drive -2 yds)
+  [T+04:15] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 10 (score 0-2) (drive +6 yds)
+  [T+04:45] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  [T+04:45] Touchdown! home crosses the line. Score is now 1-2.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 1-2)
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → caught.
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 6 (score 1-2) (drive +2 yds)
+  [T+05:45] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 13 (score 1-2) (drive +7 yds)
+  [T+06:15] FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → casualty).
+  [T+06:15] CASUALTY — home-PRONE is taken off by away-LOS.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 17 (score 1-2) (drive +4 yds)
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+06:45] TURNOVER — block_attacker_down.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 5 (score 1-2)
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 5 (score 1-2)
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-017-phx-tomb-cardinals-vs-dal-vipers-seed2042.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-017-phx-tomb-cardinals-vs-dal-vipers-seed2042.txt
@@ -1,54 +1,54 @@
 === MATCH #17 — Tomb Cardinals (Tomb Kings) vs Vipers (Dark Elf) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts dal-vipers (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  TURNOVER — gfi_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 3 — home in possession at yardline 10 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 1 • Turn 4 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 7 — away in possession at yardline 7 (score 2-0)
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
-Half 1 • Turn 8 — away in possession at yardline 9 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts dal-vipers (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] TURNOVER — gfi_failed.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] TURNOVER — gfi_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 10 (score 1-0)
+  [T+01:00] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 10 (score 1-0)
+  [T+01:30] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+01:30] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+  [T+01:30] Touchdown! home crosses the line. Score is now 2-0.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
+  [T+02:00] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+02:00] CASUALTY — home-NUFFLE-1-5 is taken off by banana_skin.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  [T+02:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 7 (score 2-0) (drive +3 yds)
+  [T+03:00] DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 9 (score 2-0) (drive +2 yds)
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
 
 --- HALFTIME (score 2-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 8 (score 2-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 10 (score 2-0)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 4 — away in possession at yardline 7 (score 2-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 2-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 3-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 7 — home in possession at yardline 7 (score 3-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 4-0.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 4-0)
-  Touchdown! away crosses the line. Score is now 4-1.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 8 (score 2-0) (drive +4 yds)
+  [T+04:45] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+  [T+04:45] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 10 (score 2-0) (drive +2 yds)
+  [T+05:15] TURNOVER — gfi_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 7 (score 2-0)
+  [T+05:45] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:45] TURNOVER — block_attacker_down.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 2-0)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+06:15] Touchdown! home crosses the line. Score is now 3-0.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 3-0)
+  [T+06:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+06:45] TURNOVER — pass_fumble.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 7 (score 3-0)
+  [T+07:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+07:15] Touchdown! home crosses the line. Score is now 4-0.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 4-0)
+  [T+07:45] Touchdown! away crosses the line. Score is now 4-1.
 
 --- END OF MATCH (score 4-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-018-phx-tomb-cardinals-vs-no-voodoo-saints-seed2043.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-018-phx-tomb-cardinals-vs-no-voodoo-saints-seed2043.txt
@@ -1,50 +1,50 @@
 === MATCH #18 — Tomb Cardinals (Tomb Kings) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts no-voodoo-saints (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 3 — away in possession at yardline 6 (score 0-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — home-NUFFLE-1-4 is taken off by cocky_drop.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 6 — away in possession at yardline 6 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 7 — away in possession at yardline 6 (score 1-0)
-Half 1 • Turn 8 — away in possession at yardline 9 (score 1-0)
-  Touchdown! away crosses the line. Score is now 1-1.
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts no-voodoo-saints (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+00:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+00:30] TURNOVER — dodge_failed.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 6 (score 0-0)
+  [T+01:00] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+01:00] TURNOVER — pickup_failed.
+  [T+01:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0) (drive -2 yds)
+  [T+01:30] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+01:30] CASUALTY — home-NUFFLE-1-4 is taken off by cocky_drop.
+  [T+01:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 6 (score 1-0) (drive +2 yds)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 6 (score 1-0)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 9 (score 1-0) (drive +3 yds)
+  [T+03:30] Touchdown! away crosses the line. Score is now 1-1.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
-Half 2 • Turn 7 — away in possession at yardline 8 (score 1-1)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1) (drive -5 yds)
+  [T+04:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+04:15] TURNOVER — pass_failed.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  [T+05:15] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  [T+06:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+06:15] TURNOVER — pass_fumble.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 1-1)
+  [T+06:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 8 (score 1-1) (drive +4 yds)
+  [T+07:15] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+07:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
+  [T+07:45] ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-019-ne-cold-tacticians-vs-car-jungle-queens-seed2044.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-019-ne-cold-tacticians-vs-car-jungle-queens-seed2044.txt
@@ -1,56 +1,56 @@
 === MATCH #19 — Cold Tacticians (Lizardmen) vs Jungle Queens (Amazon) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts car-jungle-queens (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 2-1)
-Half 1 • Turn 6 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-  Touchdown! home crosses the line. Score is now 3-1.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 3-1)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  Touchdown! away crosses the line. Score is now 3-2.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 3-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:00] KICKOFF — ne-cold-tacticians hosts car-jungle-queens (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
+  [T+00:30] TURNOVER — foul_sent_off.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 9 (score 1-0)
+  [T+01:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+01:00] TURNOVER — pass_fumble.
+  [T+01:00] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1) (drive -5 yds)
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+01:30] Touchdown! home crosses the line. Score is now 2-1.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 2-1)
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 2-1)
+  [T+02:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+  [T+02:30] Touchdown! home crosses the line. Score is now 3-1.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 3-1)
+  [T+03:00] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  [T+03:00] Touchdown! away crosses the line. Score is now 3-2.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 3-2)
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- HALFTIME (score 3-2) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 3-2)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  Touchdown! away crosses the line. Score is now 3-3.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 3-3)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 3-3)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 3-3)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 5 — away in possession at yardline 6 (score 3-3)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-Half 2 • Turn 6 — away in possession at yardline 7 (score 3-3)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 7 — away in possession at yardline 8 (score 3-3)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 2 • Turn 8 — away in possession at yardline 9 (score 3-3)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 3-2)
+  [T+04:15] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+04:15] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+  [T+04:15] Touchdown! away crosses the line. Score is now 3-3.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 3-3)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+04:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 9 (score 3-3) (drive +5 yds)
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 3-3)
+  [T+05:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 6 (score 3-3) (drive +2 yds)
+  [T+06:15] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 7 (score 3-3) (drive +1 yds)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 8 (score 3-3) (drive +1 yds)
+  [T+07:15] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 9 (score 3-3) (drive +1 yds)
+  [T+07:45] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
 
 --- END OF MATCH (score 3-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-020-pit-smashers-vs-no-voodoo-saints-seed2045.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-020-pit-smashers-vs-no-voodoo-saints-seed2045.txt
@@ -1,52 +1,52 @@
 === MATCH #20 — Smashers (Orc) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — pit-smashers hosts no-voodoo-saints (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 8 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 1-1.
+[T+00:00] KICKOFF — pit-smashers hosts no-voodoo-saints (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+00:00] TURNOVER — pass_fumble.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+  [T+00:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+01:30] TURNOVER — block_attacker_down.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  [T+02:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  [T+02:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1) (drive +4 yds)
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 8 (score 0-1)
+  [T+03:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+03:30] Touchdown! home crosses the line. Score is now 1-1.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1)
-Half 2 • Turn 3 — home in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 6 — away in possession at yardline 7 (score 1-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — home-NUFFLE-2-6 is taken off by tantrum_star.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — home in possession at yardline 10 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 8 — home in possession at yardline 10 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 2-1.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1) (drive -4 yds)
+  [T+04:15] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1) (drive +3 yds)
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 9 (score 1-1) (drive +2 yds)
+  [T+05:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+05:15] CASUALTY — away-NUFFLE-2-3 is taken off by tantrum_star.
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
+  [T+05:45] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 7 (score 1-1) (drive +3 yds)
+  [T+06:45] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+06:45] CASUALTY — home-NUFFLE-2-6 is taken off by tantrum_star.
+  [T+06:45] TURNOVER — pickup_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 10 (score 1-1)
+  [T+07:15] BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 10 (score 1-1)
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+07:45] Touchdown! home crosses the line. Score is now 2-1.
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-021-sf-gold-rush-vs-phx-tomb-cardinals-seed2046.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-021-sf-gold-rush-vs-phx-tomb-cardinals-seed2046.txt
@@ -1,55 +1,55 @@
 === MATCH #21 — Gold Rush (Skaven) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — sf-gold-rush hosts phx-tomb-cardinals (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 4 → success.
-  PASS — home-LOS attempts a short pass: needs 4+, rolled 5 → caught.
-Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 4+, rolled 6 → caught.
-Half 1 • Turn 6 — home in possession at yardline 5 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 7 — away in possession at yardline 6 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  Touchdown! away crosses the line. Score is now 0-1.
+[T+00:00] KICKOFF — sf-gold-rush hosts phx-tomb-cardinals (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 10 (score 0-0) (drive +6 yds)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose POW, defender_down.
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
+  [T+01:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:00] TURNOVER — pickup_failed.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
+  [T+01:30] DODGE — home-LOS dodges to (13,7): needs 2+, rolled 4 → success.
+  [T+01:30] PASS — home-LOS attempts a short pass: needs 4+, rolled 5 → caught.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
+  [T+02:00] PASS — home-LOS attempts a short pass: needs 4+, rolled 6 → caught.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 5 (score 0-0)
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  [T+02:30] TURNOVER — foul_sent_off.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 6 (score 0-0)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 12 (score 0-0) (drive +6 yds)
+  [T+03:30] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  [T+03:30] Touchdown! away crosses the line. Score is now 0-1.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 6 → success.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 4+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 0-2)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! away crosses the line. Score is now 0-3.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-3)
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-3)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  Touchdown! home crosses the line. Score is now 1-3.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 1-3)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-  Touchdown! home crosses the line. Score is now 2-3.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 2-3)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 8 — home in possession at yardline 7 (score 2-3)
-  DODGE — home-LOS dodges to (13,7): needs 2+, rolled 3 → success.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  [T+04:15] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+04:15] DODGE — home-LOS dodges to (13,7): needs 2+, rolled 6 → success.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 7 (score 0-1) (drive +3 yds)
+  [T+04:45] PASS — home-LOS attempts a short pass: needs 4+, rolled 3 → failed.
+  [T+04:45] TURNOVER — pass_failed.
+  [T+04:45] Touchdown! away crosses the line. Score is now 0-2.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 0-2) (drive -3 yds)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:15] TURNOVER — block_attacker_down.
+  [T+05:15] Touchdown! away crosses the line. Score is now 0-3.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-3)
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 0-3)
+  [T+06:15] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+06:15] Touchdown! home crosses the line. Score is now 1-3.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 1-3)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+06:45] TURNOVER — dodge_failed.
+  [T+06:45] Touchdown! home crosses the line. Score is now 2-3.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 2-3)
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+07:15] TURNOVER — pass_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 7 (score 2-3)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 2+, rolled 3 → success.
 
 --- END OF MATCH (score 2-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-022-phi-storm-eagles-vs-car-jungle-queens-seed2047.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-022-phi-storm-eagles-vs-car-jungle-queens-seed2047.txt
@@ -1,52 +1,52 @@
 === MATCH #22 — Storm Eagles (Pro Elf) vs Jungle Queens (Amazon) ===
 engine 0.13.0
 
-KICKOFF — phi-storm-eagles hosts car-jungle-queens (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
-  ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
-  CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 4 — away in possession at yardline 17 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 8 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 10 (score 0-1)
-Half 1 • Turn 8 — away in possession at yardline 10 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+[T+00:00] KICKOFF — phi-storm-eagles hosts car-jungle-queens (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0) (drive +1 yds)
+  [T+01:00] ✨ NUFFLE [bombardier_gone_wild] — The Bombardier mistakes his own teammate for an enemy.
+  [T+01:00] CASUALTY — home-NUFFLE-1-3 is taken off by bombardier_gone_wild.
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 17 (score 0-0) (drive +7 yds)
+  [T+01:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+01:30] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+01:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 8 (score 0-1)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 10 (score 0-1) (drive +2 yds)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 10 (score 0-1)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+03:30] TURNOVER — block_attacker_down.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 4 — home in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 5 — home in possession at yardline 14 (score 0-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 6 — away in possession at yardline 5 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+04:45] TURNOVER — dodge_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 0-1)
+  [T+05:15] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
+  [T+05:15] TURNOVER — foul_sent_off.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 9 (score 0-1)
+  [T+05:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+05:45] CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 14 (score 0-1) (drive +5 yds)
+  [T+06:15] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+06:15] TURNOVER — dodge_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 5 (score 0-1)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+06:45] TURNOVER — dodge_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
+  [T+07:15] Touchdown! home crosses the line. Score is now 1-1.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 1-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-023-lv-outlaws-vs-sf-gold-rush-seed2048.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-023-lv-outlaws-vs-sf-gold-rush-seed2048.txt
@@ -1,59 +1,59 @@
 === MATCH #23 — Outlaws (Norse) vs Gold Rush (Skaven) ===
 engine 0.13.0
 
-KICKOFF — lv-outlaws hosts sf-gold-rush (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
-Half 1 • Turn 6 — away in possession at yardline 9 (score 2-0)
-  DODGE — away-LOS dodges to (13,7): needs 2+, rolled 6 → success.
-  DODGE — away-LOS dodges to (13,7): needs 2+, rolled 2 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 1 • Turn 7 — away in possession at yardline 17 (score 2-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 8 — home in possession at yardline 12 (score 2-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:00] KICKOFF — lv-outlaws hosts sf-gold-rush (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+00:00] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/STUMBLE], chose PUSH_BACK, push_only.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+00:30] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+00:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  [T+01:00] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0) (drive +3 yds)
+  [T+01:30] PASS — away-LOS attempts a short pass: needs 4+, rolled 3 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+  [T+01:30] Touchdown! home crosses the line. Score is now 2-0.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0) (drive -3 yds)
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 9 (score 2-0) (drive +5 yds)
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 2+, rolled 6 → success.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 2+, rolled 2 → success.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 17 (score 2-0) (drive +8 yds)
+  [T+03:00] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+03:00] PASS — away-LOS attempts a short pass: needs 4+, rolled 2 → failed.
+  [T+03:00] TURNOVER — pass_failed.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 12 (score 2-0)
+  [T+03:30] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- HALFTIME (score 2-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-Half 2 • Turn 2 — away in possession at yardline 6 (score 2-0)
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 4 → caught.
-Half 2 • Turn 3 — away in possession at yardline 15 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 4 — home in possession at yardline 8 (score 2-0)
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 2-1.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 2 • Turn 6 — home in possession at yardline 6 (score 2-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 9 (score 2-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-Half 2 • Turn 8 — away in possession at yardline 9 (score 2-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  TURNOVER — gfi_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 2-0)
+  [T+04:15] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 6 (score 2-0) (drive +2 yds)
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 4+, rolled 4 → caught.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 15 (score 2-0) (drive +9 yds)
+  [T+05:15] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
+  [T+05:15] TURNOVER — foul_sent_off.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 8 (score 2-0)
+  [T+05:45] TURNOVER — pickup_failed.
+  [T+05:45] Touchdown! away crosses the line. Score is now 2-1.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 2-1) (drive -4 yds)
+  [T+06:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+06:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 6 (score 2-1) (drive +2 yds)
+  [T+06:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 9 (score 2-1)
+  [T+07:15] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 9 (score 2-1)
+  [T+07:45] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+07:45] TURNOVER — gfi_failed.
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-024-min-frostraiders-vs-phx-tomb-cardinals-seed2049.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-024-min-frostraiders-vs-phx-tomb-cardinals-seed2049.txt
@@ -1,57 +1,57 @@
 === MATCH #24 — Frostraiders (Norse) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — min-frostraiders hosts phx-tomb-cardinals (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 1 • Turn 3 — away in possession at yardline 5 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 4 — away in possession at yardline 5 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — home in possession at yardline 7 (score 0-0)
-Half 1 • Turn 6 — home in possession at yardline 11 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
+[T+00:00] KICKOFF — min-frostraiders hosts phx-tomb-cardinals (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 5 (score 0-0)
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+01:30] TURNOVER — pickup_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 7 (score 0-0)
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 11 (score 0-0) (drive +4 yds)
+  [T+02:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1) (drive -7 yds)
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+03:00] Touchdown! home crosses the line. Score is now 1-1.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  [T+03:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+03:30] TURNOVER — pass_failed.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — away-NUFFLE-2-1 is taken off by tantrum_star.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 2-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 2-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  KO — home-LOS is knocked unconscious by away-LOS.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 2 • Turn 6 — away in possession at yardline 6 (score 2-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  Touchdown! away crosses the line. Score is now 2-2.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 2-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! home crosses the line. Score is now 3-2.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 3-2)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  [T+04:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+04:15] CASUALTY — away-NUFFLE-2-1 is taken off by tantrum_star.
+  [T+04:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+  [T+04:45] Touchdown! home crosses the line. Score is now 2-1.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 2-1)
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 2-1)
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:45] KO — home-LOS is knocked unconscious by away-LOS (armor=12, injury=9).
+  [T+05:45] TURNOVER — block_attacker_down.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 2-1)
+  [T+06:15] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 6 (score 2-1) (drive +2 yds)
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  [T+06:45] Touchdown! away crosses the line. Score is now 2-2.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 2-2)
+  [T+07:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+07:15] Touchdown! home crosses the line. Score is now 3-2.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 3-2)
+  [T+07:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+07:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
 --- END OF MATCH (score 3-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-025-gb-cheese-halflings-vs-phi-storm-eagles-seed2050.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-025-gb-cheese-halflings-vs-phi-storm-eagles-seed2050.txt
@@ -1,66 +1,66 @@
 === MATCH #25 — Cheese Halflings (Halfling) vs Storm Eagles (Pro Elf) ===
 engine 0.13.0
 
-KICKOFF — gb-cheese-halflings hosts phi-storm-eagles (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
-  KO — away-PRONE is knocked unconscious by home-LOS.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — away in possession at yardline 5 (score 0-0)
-  ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — away in possession at yardline 18 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-1-4 is taken off by banana_skin.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — home-NUFFLE-1-6 is taken off by nemesis_clash.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-Half 1 • Turn 8 — home in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+00:00] KICKOFF — gb-cheese-halflings hosts phi-storm-eagles (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+00:00] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
+  [T+00:00] KO — away-PRONE is knocked unconscious by home-LOS.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 5 (score 0-0)
+  [T+01:00] ✨ NUFFLE [ref_blunder] — The ref makes a baffling call — the crowd boos.
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 18 (score 0-0) (drive +13 yds)
+  [T+01:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+01:30] CASUALTY — home-NUFFLE-1-4 is taken off by banana_skin.
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  [T+01:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
+  [T+02:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+02:00] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false, sent off!).
+  [T+02:00] TURNOVER — foul_sent_off.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
+  [T+02:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+02:30] CASUALTY — home-NUFFLE-1-6 is taken off by nemesis_clash.
+  [T+02:30] TURNOVER — pickup_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 10 (score 0-1) (drive +6 yds)
+  [T+03:30] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 2 — home in possession at yardline 10 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 3 — home in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 4 — away in possession at yardline 12 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 6 — away in possession at yardline 11 (score 0-2)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 0-3.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 0-3)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-3.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 1-3)
-  Touchdown! away crosses the line. Score is now 1-4.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
+  [T+04:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+04:15] TURNOVER — dodge_failed.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 10 (score 0-1)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 10 (score 0-1)
+  [T+05:15] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+05:15] TURNOVER — dodge_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 12 (score 0-1)
+  [T+05:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+05:45] Touchdown! away crosses the line. Score is now 0-2.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+06:15] TURNOVER — block_attacker_down.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 11 (score 0-2)
+  [T+06:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+06:45] Touchdown! away crosses the line. Score is now 0-3.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 0-3)
+  [T+07:15] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+07:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:15] Touchdown! home crosses the line. Score is now 1-3.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 1-3)
+  [T+07:45] Touchdown! away crosses the line. Score is now 1-4.
 
 --- END OF MATCH (score 1-4) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-026-chi-iron-bears-vs-phx-tomb-cardinals-seed2051.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-026-chi-iron-bears-vs-phx-tomb-cardinals-seed2051.txt
@@ -1,61 +1,61 @@
 === MATCH #26 — Iron Bears (Dwarf) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — chi-iron-bears hosts phx-tomb-cardinals (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 0-1)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-Half 1 • Turn 4 — away in possession at yardline 4 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 6 — home in possession at yardline 5 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/POW], chose BOTH_DOWN, push_only.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:00] KICKOFF — chi-iron-bears hosts phx-tomb-cardinals (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  [T+00:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+00:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 0-1)
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 0-1)
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+01:30] TURNOVER — block_attacker_down.
+  [T+01:30] Touchdown! home crosses the line. Score is now 1-1.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 1-1)
+  [T+02:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+02:00] TURNOVER — pass_failed.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 5 (score 1-1)
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+02:30] TURNOVER — pass_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  [T+03:00] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/POW], chose BOTH_DOWN, push_only.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 1-1)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! home crosses the line. Score is now 2-2.
-Half 2 • Turn 6 — away in possession at yardline 4 (score 2-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, push_only.
-Half 2 • Turn 7 — away in possession at yardline 9 (score 2-2)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 2-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! away crosses the line. Score is now 2-3.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  [T+04:15] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [POW/POW], chose POW, defender_down.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+  [T+04:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+04:45] TURNOVER — pickup_failed.
+  [T+04:45] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  [T+06:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+06:15] Touchdown! home crosses the line. Score is now 2-2.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 4 (score 2-2)
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, push_only.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 9 (score 2-2) (drive +5 yds)
+  [T+07:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+07:15] TURNOVER — dodge_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 2-2)
+  [T+07:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+07:45] TURNOVER — pass_failed.
+  [T+07:45] Touchdown! away crosses the line. Score is now 2-3.
 
 --- END OF MATCH (score 2-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-027-jax-swamp-lizards-vs-gb-cheese-halflings-seed2052.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-027-jax-swamp-lizards-vs-gb-cheese-halflings-seed2052.txt
@@ -1,54 +1,54 @@
 === MATCH #27 — Swamp Lizards (Lizardmen) vs Cheese Halflings (Halfling) ===
 engine 0.13.0
 
-KICKOFF — jax-swamp-lizards hosts gb-cheese-halflings (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-  TURNOVER — gfi_failed.
-Half 1 • Turn 3 — home in possession at yardline 13 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — home in possession at yardline 13 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! home crosses the line. Score is now 2-1.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 2-1)
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 3-1.
+[T+00:00] KICKOFF — jax-swamp-lizards hosts gb-cheese-halflings (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+  [T+00:30] TURNOVER — gfi_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 13 (score 0-0)
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+01:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  [T+01:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+01:30] TURNOVER — pickup_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 13 (score 1-0)
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 1-0)
+  [T+02:30] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+02:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
+  [T+03:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+03:00] Touchdown! home crosses the line. Score is now 2-1.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 2-1)
+  [T+03:30] TURNOVER — pickup_failed.
+  [T+03:30] Touchdown! home crosses the line. Score is now 3-1.
 
 --- HALFTIME (score 3-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-Half 2 • Turn 2 — home in possession at yardline 12 (score 3-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 23 (score 3-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 3-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 16 (score 3-1)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
-Half 2 • Turn 6 — home in possession at yardline 25 (score 3-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 3-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 3-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 3-1)
+  [T+04:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 12 (score 3-1) (drive +8 yds)
+  [T+04:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+04:45] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 23 (score 3-1) (drive +11 yds)
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 3-1)
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 16 (score 3-1)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 25 (score 3-1) (drive +9 yds)
+  [T+06:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 3-1)
+  [T+07:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 3-1)
+  [T+07:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+07:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+07:45] TURNOVER — pass_failed.
 
 --- END OF MATCH (score 3-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-028-buf-snow-ogres-vs-dal-vipers-seed2053.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-028-buf-snow-ogres-vs-dal-vipers-seed2053.txt
@@ -1,53 +1,53 @@
 === MATCH #28 — Snow Ogres (Ogre) vs Vipers (Dark Elf) ===
 engine 0.13.0
 
-KICKOFF — buf-snow-ogres hosts dal-vipers (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/BOTH_DOWN], chose POW, defender_down.
-  TURNOVER — gfi_failed.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 1 • Turn 5 — away in possession at yardline 11 (score 0-0)
-  ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 8 — home in possession at yardline 7 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+[T+00:00] KICKOFF — buf-snow-ogres hosts dal-vipers (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+00:00] TURNOVER — pickup_failed.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/BOTH_DOWN], chose POW, defender_down.
+  [T+00:30] TURNOVER — gfi_failed.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 0-0)
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 11 (score 0-0) (drive +7 yds)
+  [T+01:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 11 (score 0-0)
+  [T+02:00] ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
+  [T+02:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  [T+02:30] Touchdown! home crosses the line. Score is now 1-1.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  [T+03:00] TURNOVER — gfi_failed.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 7 (score 1-1)
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+03:30] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 2 — away in possession at yardline 6 (score 1-1)
-Half 2 • Turn 3 — away in possession at yardline 6 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 2 • Turn 5 — home in possession at yardline 11 (score 1-2)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-Half 2 • Turn 6 — home in possession at yardline 14 (score 1-2)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 8 — away in possession at yardline 8 (score 1-2)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1) (drive -3 yds)
+  [T+04:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+04:15] TURNOVER — pass_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 6 (score 1-1)
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 6 (score 1-1)
+  [T+05:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+05:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  [T+05:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 11 (score 1-2) (drive +7 yds)
+  [T+06:15] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 14 (score 1-2) (drive +3 yds)
+  [T+06:45] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+06:45] TURNOVER — pickup_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
+  [T+07:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 8 (score 1-2) (drive +3 yds)
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  [T+07:45] TURNOVER — block_attacker_down.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-029-no-voodoo-saints-vs-kc-soaring-hawks-seed2054.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-029-no-voodoo-saints-vs-kc-soaring-hawks-seed2054.txt
@@ -1,60 +1,60 @@
 === MATCH #29 — Voodoo Saints (Undead) vs Soaring Hawks (Wood Elf) ===
 engine 0.13.0
 
-KICKOFF — no-voodoo-saints hosts kc-soaring-hawks (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-1-7 is taken off by banana_skin.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
+[T+00:00] KICKOFF — no-voodoo-saints hosts kc-soaring-hawks (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  [T+00:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 10 (score 0-0) (drive +6 yds)
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+01:00] TURNOVER — block_attacker_down.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 5 (score 0-0)
+  [T+01:30] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 5 (score 0-0)
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  [T+02:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+02:30] CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  [T+02:30] TURNOVER — block_attacker_down.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-0)
+  [T+03:00] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+03:00] CASUALTY — away-NUFFLE-1-7 is taken off by banana_skin.
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false, sent off!).
+  [T+03:00] TURNOVER — foul_sent_off.
+  [T+03:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+03:30] TURNOVER — pass_failed.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 2 — away in possession at yardline 9 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — home in possession at yardline 12 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 5 — away in possession at yardline 8 (score 1-1)
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — away in possession at yardline 7 (score 1-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 (fumble!) → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 8 — home in possession at yardline 10 (score 1-2)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! home crosses the line. Score is now 2-2.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  [T+04:15] ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  [T+04:15] TURNOVER — pickup_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 9 (score 0-1)
+  [T+04:45] TURNOVER — pickup_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 12 (score 0-1)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+05:15] Touchdown! home crosses the line. Score is now 1-1.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 1-1)
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 8 (score 1-1) (drive +4 yds)
+  [T+06:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 1-2)
+  [T+06:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+  [T+06:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+06:45] TURNOVER — dodge_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 7 (score 1-2)
+  [T+07:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 (fumble!) → failed.
+  [T+07:15] TURNOVER — pass_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 10 (score 1-2)
+  [T+07:45] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+07:45] Touchdown! home crosses the line. Score is now 2-2.
 
 --- END OF MATCH (score 2-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-030-dal-vipers-vs-kc-soaring-hawks-seed2055.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-030-dal-vipers-vs-kc-soaring-hawks-seed2055.txt
@@ -1,51 +1,51 @@
 === MATCH #30 — Vipers (Dark Elf) vs Soaring Hawks (Wood Elf) ===
 engine 0.13.0
 
-KICKOFF — dal-vipers hosts kc-soaring-hawks (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
-Half 1 • Turn 4 — home in possession at yardline 16 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 6 — home in possession at yardline 13 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 8 — away in possession at yardline 8 (score 2-0)
-  DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
+[T+00:00] KICKOFF — dal-vipers hosts kc-soaring-hawks (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 9 (score 0-0)
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 16 (score 0-0) (drive +7 yds)
+  [T+01:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+01:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 1-0)
+  [T+02:00] ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  [T+02:00] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+02:00] TURNOVER — block_attacker_down.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 13 (score 1-0)
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+02:30] Touchdown! home crosses the line. Score is now 2-0.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 2-0)
+  [T+03:00] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+03:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 8 (score 2-0) (drive +4 yds)
+  [T+03:30] DODGE — away-LOS dodges to (13,7) (rerolled): needs 3+, rolled 2 → success.
 
 --- HALFTIME (score 2-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 2 — away in possession at yardline 13 (score 2-0)
-Half 2 • Turn 3 — away in possession at yardline 20 (score 2-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — home in possession at yardline 6 (score 2-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — away in possession at yardline 7 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 14 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 7 — home in possession at yardline 9 (score 2-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 2 • Turn 8 — home in possession at yardline 12 (score 2-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+  [T+04:15] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+04:15] TURNOVER — pickup_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 13 (score 2-0)
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 20 (score 2-0) (drive +7 yds)
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 6 (score 2-0)
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 7 (score 2-0)
+  [T+06:15] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 14 (score 2-0) (drive +7 yds)
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 9 (score 2-0)
+  [T+07:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+07:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 12 (score 2-0) (drive +3 yds)
+  [T+07:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
 --- END OF MATCH (score 2-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-031-ne-cold-tacticians-vs-buf-snow-ogres-seed2056.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-031-ne-cold-tacticians-vs-buf-snow-ogres-seed2056.txt
@@ -1,64 +1,64 @@
 === MATCH #31 — Cold Tacticians (Lizardmen) vs Snow Ogres (Ogre) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — home in possession at yardline 5 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 5 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+[T+00:00] KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+00:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PUSH_BACK, push_only.
+  [T+00:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  [T+01:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-1)
+  [T+02:00] TURNOVER — pickup_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 0-1)
+  [T+02:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+02:30] CASUALTY — home-NUFFLE-1-6 is taken off by banana_skin.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 5 (score 0-1)
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=2, broken=false).
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 5 (score 0-1)
+  [T+03:30] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  [T+03:30] TURNOVER — block_attacker_down.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — away in possession at yardline 5 (score 0-1)
-Half 2 • Turn 3 — away in possession at yardline 9 (score 0-1)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 5 — away in possession at yardline 7 (score 0-2)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  Touchdown! home crosses the line. Score is now 1-2.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-  KO — home-LOS is knocked unconscious by away-LOS.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 2-2.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1) (drive -1 yds)
+  [T+04:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  [T+04:15] TURNOVER — block_attacker_down.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 5 (score 0-1)
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 9 (score 0-1) (drive +4 yds)
+  [T+05:15] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+05:15] Touchdown! away crosses the line. Score is now 0-2.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-2)
+  [T+05:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+05:45] CASUALTY — away-NUFFLE-2-4 is taken off by banana_skin.
+  [T+05:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+05:45] TURNOVER — dodge_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 7 (score 0-2)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
+  [T+06:45] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  [T+06:45] Touchdown! home crosses the line. Score is now 1-2.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
+  [T+07:15] BLOCK — away-LOS blocks home-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+  [T+07:15] KO — home-LOS is knocked unconscious by away-LOS (armor=11, injury=8).
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 1-2)
+  [T+07:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+07:45] TURNOVER — pickup_failed.
+  [T+07:45] Touchdown! home crosses the line. Score is now 2-2.
 
 --- END OF MATCH (score 2-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-032-phx-tomb-cardinals-vs-den-mile-high-centaurs-seed2057.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-032-phx-tomb-cardinals-vs-den-mile-high-centaurs-seed2057.txt
@@ -1,53 +1,53 @@
 === MATCH #32 — Tomb Cardinals (Tomb Kings) vs Mile High Centaurs (Beastmen) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts den-mile-high-centaurs (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
-Half 1 • Turn 4 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 8 — away in possession at yardline 4 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts den-mile-high-centaurs (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 9 (score 0-0) (drive +4 yds)
+  [T+01:30] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 9 (score 0-0)
+  [T+02:00] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
+  [T+02:30] ✨ NUFFLE [equipment_failure] — A boot strap snaps, leaving a player limping.
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 0-0)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 0-0)
+  [T+03:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — home-NUFFLE-2-1 is taken off by nemesis_clash.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 2 • Turn 3 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 7 (score 0-1)
-Half 2 • Turn 6 — away in possession at yardline 7 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 0-1)
-Half 2 • Turn 8 — home in possession at yardline 6 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+04:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+04:15] CASUALTY — home-NUFFLE-2-1 is taken off by nemesis_clash.
+  [T+04:15] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 8 (score 0-0) (drive +4 yds)
+  [T+05:15] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  [T+05:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+05:15] Touchdown! away crosses the line. Score is now 0-1.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 7 (score 0-1)
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 7 (score 0-1)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+06:45] TURNOVER — dodge_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 0-1)
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 6 (score 0-1) (drive +2 yds)
+  [T+07:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
 --- END OF MATCH (score 0-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-033-ne-cold-tacticians-vs-kc-soaring-hawks-seed2058.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-033-ne-cold-tacticians-vs-kc-soaring-hawks-seed2058.txt
@@ -1,62 +1,62 @@
 === MATCH #33 — Cold Tacticians (Lizardmen) vs Soaring Hawks (Wood Elf) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
-Half 1 • Turn 3 — home in possession at yardline 14 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0)
-  TURNOVER — gfi_failed.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
-  CASUALTY — away-PRONE is taken off by home-LOS.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 7 — away in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 8 — home in possession at yardline 9 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:00] KICKOFF — ne-cold-tacticians hosts kc-soaring-hawks (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/BOTH_DOWN], chose PUSH_BACK, push_only.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 14 (score 0-0) (drive +7 yds)
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose PUSH_BACK, push_only.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
+  [T+01:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  [T+01:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0) (drive +1 yds)
+  [T+02:00] TURNOVER — gfi_failed.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
+  [T+02:30] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
+  [T+02:30] CASUALTY — away-PRONE is taken off by home-LOS.
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/BOTH_DOWN], chose BOTH_DOWN, both_down.
+  [T+02:30] TURNOVER — block_attacker_down.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 8 (score 1-0)
+  [T+03:00] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  [T+03:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+03:00] TURNOVER — pass_failed.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 9 (score 1-0)
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- HALFTIME (score 1-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-Half 2 • Turn 2 — away in possession at yardline 9 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 3 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — away-NUFFLE-2-3 is taken off by cocky_drop.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 4 — away in possession at yardline 11 (score 1-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 2 • Turn 5 — away in possession at yardline 11 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 15 (score 1-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 2-1.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+  [T+04:15] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 9 (score 1-0) (drive +5 yds)
+  [T+04:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+04:45] TURNOVER — pass_fumble.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 10 (score 1-0)
+  [T+05:15] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+05:15] CASUALTY — away-NUFFLE-2-3 is taken off by cocky_drop.
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+05:15] TURNOVER — pass_fumble.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 11 (score 1-0)
+  [T+05:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 11 (score 1-0)
+  [T+06:15] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 15 (score 1-0) (drive +4 yds)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+  [T+06:45] Touchdown! home crosses the line. Score is now 2-0.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 2-0) (drive -11 yds)
+  [T+07:15] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+07:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+07:15] Touchdown! away crosses the line. Score is now 2-1.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 2-1)
+  [T+07:45] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+07:45] TURNOVER — dodge_failed.
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-034-chi-iron-bears-vs-pit-smashers-seed2059.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-034-chi-iron-bears-vs-pit-smashers-seed2059.txt
@@ -1,48 +1,48 @@
 === MATCH #34 — Iron Bears (Dwarf) vs Smashers (Orc) ===
 engine 0.13.0
 
-KICKOFF — chi-iron-bears hosts pit-smashers (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
-  KO — away-PRONE is knocked unconscious by home-LOS.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
-Half 1 • Turn 8 — home in possession at yardline 5 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — away-NUFFLE-1-8 is taken off by nemesis_clash.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+00:00] KICKOFF — chi-iron-bears hosts pit-smashers (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [streaker_invasion] — A streaker invades the pitch. Players don't know where to look.
+  [T+00:00] TURNOVER — pickup_failed.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+01:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
+  [T+01:30] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
+  [T+02:00] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → ko).
+  [T+02:00] KO — away-PRONE is knocked unconscious by home-LOS.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-0)
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-0)
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [POW/PUSH_BACK], chose POW, defender_down.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+03:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+03:30] CASUALTY — away-NUFFLE-1-8 is taken off by nemesis_clash.
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 2 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-  KO — away-LOS is knocked unconscious by home-LOS.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, push_only.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0) (drive -1 yds)
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+04:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+04:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  [T+05:15] KO — away-LOS is knocked unconscious by home-LOS (armor=10, injury=8).
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-0)
+  [T+05:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+05:45] Touchdown! home crosses the line. Score is now 1-0.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 1-0)
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose BOTH_DOWN, push_only.
+  [T+06:15] Touchdown! away crosses the line. Score is now 1-1.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  [T+06:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+06:45] TURNOVER — dodge_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 1-1)
 
 --- END OF MATCH (score 1-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-035-chi-iron-bears-vs-sf-gold-rush-seed2060.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-035-chi-iron-bears-vs-sf-gold-rush-seed2060.txt
@@ -1,53 +1,53 @@
 === MATCH #35 — Iron Bears (Dwarf) vs Gold Rush (Skaven) ===
 engine 0.13.0
 
-KICKOFF — chi-iron-bears hosts sf-gold-rush (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — home-NUFFLE-1-2 is taken off by tantrum_star.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  TURNOVER — pickup_failed.
-Half 1 • Turn 7 — away in possession at yardline 10 (score 1-1)
-Half 1 • Turn 8 — away in possession at yardline 14 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose PUSH_BACK, push_only.
-  PASS — away-LOS attempts a short pass: needs 4+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
+[T+00:00] KICKOFF — chi-iron-bears hosts sf-gold-rush (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 8 (score 0-0) (drive +4 yds)
+  [T+00:30] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+00:30] CASUALTY — home-NUFFLE-1-2 is taken off by tantrum_star.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0) (drive -4 yds)
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  [T+01:00] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
+  [T+01:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+01:30] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  [T+02:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 1-1)
+  [T+02:30] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+02:30] TURNOVER — pickup_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 10 (score 1-1)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 14 (score 1-1) (drive +4 yds)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/POW], chose PUSH_BACK, push_only.
+  [T+03:30] PASS — away-LOS attempts a short pass: needs 4+, rolled 1 (fumble!) → failed.
+  [T+03:30] TURNOVER — pass_fumble.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
-Half 2 • Turn 2 — home in possession at yardline 8 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 3 — home in possession at yardline 8 (score 1-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 6 (score 1-1)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 5 — home in possession at yardline 8 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 6 — home in possession at yardline 8 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 8 — home in possession at yardline 8 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/POW/PUSH_BACK], chose POW, defender_down.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 8 (score 1-1) (drive +4 yds)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 8 (score 1-1)
+  [T+05:15] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 6 (score 1-1)
+  [T+05:45] TURNOVER — gfi_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 8 (score 1-1)
+  [T+06:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK/POW], chose POW, defender_down.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 8 (score 1-1)
+  [T+06:45] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+  [T+06:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+06:45] TURNOVER — gfi_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 1-1)
+  [T+07:15] TURNOVER — pickup_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 8 (score 1-1)
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- END OF MATCH (score 1-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-036-gb-cheese-halflings-vs-chi-iron-bears-seed2061.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-036-gb-cheese-halflings-vs-chi-iron-bears-seed2061.txt
@@ -1,56 +1,56 @@
 === MATCH #36 — Cheese Halflings (Halfling) vs Iron Bears (Dwarf) ===
 engine 0.13.0
 
-KICKOFF — gb-cheese-halflings hosts chi-iron-bears (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — away-NUFFLE-1-5 is taken off by nemesis_clash.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE/PUSH_BACK], chose STUMBLE, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 7 — away in possession at yardline 15 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-Half 1 • Turn 8 — away in possession at yardline 20 (score 1-1)
+[T+00:00] KICKOFF — gb-cheese-halflings hosts chi-iron-bears (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+00:00] TURNOVER — pass_fumble.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+01:00] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 1-1)
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-1)
+  [T+02:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+02:00] CASUALTY — away-NUFFLE-1-5 is taken off by nemesis_clash.
+  [T+02:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:00] TURNOVER — dodge_failed.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 1-1)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/STUMBLE/PUSH_BACK], chose STUMBLE, defender_down.
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 15 (score 1-1) (drive +11 yds)
+  [T+03:00] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 20 (score 1-1) (drive +5 yds)
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-Half 2 • Turn 2 — away in possession at yardline 12 (score 1-1)
-  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  CASUALTY — home-NUFFLE-2-2 is taken off by crowd_riot.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK/POW], chose POW, defender_down.
-Half 2 • Turn 3 — away in possession at yardline 19 (score 1-1)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — away in possession at yardline 11 (score 1-2)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — home-NUFFLE-2-6 is taken off by cocky_drop.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
-  Touchdown! home crosses the line. Score is now 2-2.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 2-2)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1) (drive -16 yds)
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 12 (score 1-1) (drive +8 yds)
+  [T+04:45] ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
+  [T+04:45] CASUALTY — home-NUFFLE-2-2 is taken off by crowd_riot.
+  [T+04:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK/POW], chose POW, defender_down.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 19 (score 1-1) (drive +7 yds)
+  [T+05:15] ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+05:15] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+05:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 11 (score 1-2)
+  [T+06:45] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+06:45] CASUALTY — home-NUFFLE-2-6 is taken off by cocky_drop.
+  [T+06:45] TURNOVER — pickup_failed.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
+  [T+07:15] Touchdown! home crosses the line. Score is now 2-2.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 2-2)
+  [T+07:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+07:45] TURNOVER — pass_fumble.
 
 --- END OF MATCH (score 2-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-037-ne-cold-tacticians-vs-buf-snow-ogres-seed2062.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-037-ne-cold-tacticians-vs-buf-snow-ogres-seed2062.txt
@@ -1,59 +1,59 @@
 === MATCH #37 — Cold Tacticians (Lizardmen) vs Snow Ogres (Ogre) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — away in possession at yardline 9 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 4 — away in possession at yardline 9 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 14 (score 0-0)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-Half 1 • Turn 6 — away in possession at yardline 15 (score 0-0)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 7 — away in possession at yardline 18 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 8 — away in possession at yardline 19 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
+[T+00:00] KICKOFF — ne-cold-tacticians hosts buf-snow-ogres (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+00:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 9 (score 0-0)
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 9 (score 0-0)
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 14 (score 0-0) (drive +5 yds)
+  [T+02:00] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 15 (score 0-0) (drive +1 yds)
+  [T+02:30] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [POW/BOTH_DOWN], chose POW, defender_down.
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false).
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 18 (score 0-0) (drive +3 yds)
+  [T+03:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 19 (score 0-0) (drive +1 yds)
+  [T+03:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+03:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+03:30] Touchdown! away crosses the line. Score is now 0-1.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
-  FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → casualty, sent off!).
-  CASUALTY — away-PRONE is taken off by home-LOS.
-  TURNOVER — foul_sent_off.
-  Touchdown! away crosses the line. Score is now 0-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 0-2)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  Touchdown! away crosses the line. Score is now 0-3.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 0-3)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 0-1) (drive -15 yds)
+  [T+04:15] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+04:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+  [T+04:45] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+04:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+04:45] TURNOVER — dodge_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 0-1)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 0-1)
+  [T+05:45] ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
+  [T+05:45] FOUL — home-LOS fouls away-PRONE (armor=11, broken=true → casualty, sent off!).
+  [T+05:45] CASUALTY — away-PRONE is taken off by home-LOS.
+  [T+05:45] TURNOVER — foul_sent_off.
+  [T+05:45] Touchdown! away crosses the line. Score is now 0-2.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 0-2)
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 0-2)
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+06:45] TURNOVER — block_attacker_down.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 0-2)
+  [T+07:15] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+07:15] Touchdown! away crosses the line. Score is now 0-3.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 0-3)
+  [T+07:45] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+07:45] TURNOVER — dodge_failed.
 
 --- END OF MATCH (score 0-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-038-buf-snow-ogres-vs-pit-smashers-seed2063.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-038-buf-snow-ogres-vs-pit-smashers-seed2063.txt
@@ -1,54 +1,54 @@
 === MATCH #38 — Snow Ogres (Ogre) vs Smashers (Orc) ===
 engine 0.13.0
 
-KICKOFF — buf-snow-ogres hosts pit-smashers (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
-  CASUALTY — away-PRONE is taken off by home-LOS.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
-  BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
-Half 1 • Turn 7 — home in possession at yardline 11 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, push_only.
+[T+00:00] KICKOFF — buf-snow-ogres hosts pit-smashers (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+00:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  [T+01:00] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-0)
+  [T+01:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:30] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false, sent off!).
+  [T+01:30] TURNOVER — foul_sent_off.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-0)
+  [T+02:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
+  [T+02:30] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → casualty).
+  [T+02:30] CASUALTY — away-PRONE is taken off by home-LOS.
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose POW, defender_down.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 11 (score 1-0) (drive +7 yds)
+  [T+03:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+03:00] TURNOVER — dodge_failed.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 1-0)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/BOTH_DOWN], chose BOTH_DOWN, push_only.
 
 --- HALFTIME (score 1-0) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
-Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 3 — home in possession at yardline 8 (score 1-0)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 6 (score 1-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — home in possession at yardline 8 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 2 • Turn 6 — home in possession at yardline 8 (score 1-0)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
-Half 2 • Turn 7 — home in possession at yardline 9 (score 1-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 8 — home in possession at yardline 15 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-0)
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+04:45] BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose STUMBLE, defender_down.
+  [T+04:45] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/STUMBLE], chose PLAYER_DOWN, attacker_down.
+  [T+04:45] TURNOVER — block_attacker_down.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 8 (score 1-0)
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 6 (score 1-0)
+  [T+05:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 8 (score 1-0)
+  [T+06:15] FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 8 (score 1-0)
+  [T+06:45] ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/BOTH_DOWN], chose STUMBLE, defender_down.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 9 (score 1-0) (drive +1 yds)
+  [T+07:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 15 (score 1-0) (drive +6 yds)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
 
 --- END OF MATCH (score 1-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-039-chi-iron-bears-vs-buf-snow-ogres-seed2064.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-039-chi-iron-bears-vs-buf-snow-ogres-seed2064.txt
@@ -1,54 +1,54 @@
 === MATCH #39 — Iron Bears (Dwarf) vs Snow Ogres (Ogre) ===
 engine 0.13.0
 
-KICKOFF — chi-iron-bears hosts buf-snow-ogres (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
-Half 1 • Turn 7 — away in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-Half 1 • Turn 8 — away in possession at yardline 9 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
+[T+00:00] KICKOFF — chi-iron-bears hosts buf-snow-ogres (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+00:30] TURNOVER — pickup_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+01:00] TURNOVER — block_attacker_down.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 0-0)
+  [T+02:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 0-0)
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+03:00] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 9 (score 0-0) (drive +2 yds)
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, push_only.
 
 --- HALFTIME (score 0-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 3 — away in possession at yardline 6 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 4 — away in possession at yardline 6 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  KO — home-LOS is knocked unconscious by away-LOS.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-Half 2 • Turn 5 — away in possession at yardline 6 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 6 — away in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-  FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+04:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 0-0)
+  [T+04:45] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+04:45] TURNOVER — pass_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 6 (score 0-0)
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 6 (score 0-0)
+  [T+05:45] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  [T+05:45] KO — home-LOS is knocked unconscious by away-LOS (armor=12, injury=9).
+  [T+05:45] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 6 (score 0-0)
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 7 (score 0-0) (drive +1 yds)
+  [T+06:45] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=5, broken=false).
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+06:45] TURNOVER — pass_failed.
+  [T+06:45] Touchdown! home crosses the line. Score is now 1-0.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 1-0) (drive -3 yds)
+  [T+07:15] TURNOVER — pickup_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 1-0)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 1-0) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-040-dal-vipers-vs-pit-smashers-seed2065.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-040-dal-vipers-vs-pit-smashers-seed2065.txt
@@ -1,46 +1,46 @@
 === MATCH #40 — Vipers (Dark Elf) vs Smashers (Orc) ===
 engine 0.13.0
 
-KICKOFF — dal-vipers hosts pit-smashers (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
-Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
-Half 1 • Turn 3 — away in possession at yardline 16 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
-Half 1 • Turn 4 — away in possession at yardline 16 (score 0-0)
-Half 1 • Turn 5 — away in possession at yardline 22 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 1 • Turn 7 — home in possession at yardline 11 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 8 — away in possession at yardline 6 (score 0-1)
-  TURNOVER — pickup_failed.
+[T+00:00] KICKOFF — dal-vipers hosts pit-smashers (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [apprentice_wizard_spotted] — An apprentice wizard sneaks a Lightning Bolt into play.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+00:30] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 16 (score 0-0) (drive +9 yds)
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+01:00] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 16 (score 0-0)
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 22 (score 0-0) (drive +6 yds)
+  [T+02:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+02:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  [T+02:30] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 11 (score 0-1) (drive +7 yds)
+  [T+03:00] TURNOVER — pickup_failed.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 6 (score 0-1)
+  [T+03:30] TURNOVER — pickup_failed.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — away in possession at yardline 7 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — away in possession at yardline 8 (score 0-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 7 — home in possession at yardline 13 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
-Half 2 • Turn 8 — home in possession at yardline 13 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  [T+04:15] ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 8 (score 0-1) (drive +4 yds)
+  [T+04:45] TURNOVER — pickup_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 7 (score 0-1)
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose PUSH_BACK, push_only.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 8 (score 0-1) (drive +1 yds)
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 0-1)
+  [T+06:15] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1) (drive +2 yds)
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 13 (score 0-1) (drive +7 yds)
+  [T+07:15] FOUL — home-LOS fouls away-PRONE (armor=10, broken=true → stunned).
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 13 (score 0-1)
+  [T+07:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
 
 --- END OF MATCH (score 0-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-041-ne-cold-tacticians-vs-no-voodoo-saints-seed2066.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-041-ne-cold-tacticians-vs-no-voodoo-saints-seed2066.txt
@@ -1,53 +1,53 @@
 === MATCH #41 — Cold Tacticians (Lizardmen) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 4 — home in possession at yardline 5 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
-  CASUALTY — home-NUFFLE-1-5 is taken off by tantrum_star.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 8 — home in possession at yardline 13 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
+[T+00:00] KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+00:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 5 (score 0-1) (drive +1 yds)
+  [T+01:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 0-1)
+  [T+02:00] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+  [T+02:00] CASUALTY — home-NUFFLE-1-5 is taken off by tantrum_star.
+  [T+02:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+02:00] TURNOVER — pass_failed.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
+  [T+02:30] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+02:30] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 8 (score 0-1) (drive +4 yds)
+  [T+03:00] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 13 (score 0-1) (drive +5 yds)
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+03:30] TURNOVER — block_attacker_down.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-Half 2 • Turn 3 — home in possession at yardline 11 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 6 (score 0-1)
-Half 2 • Turn 5 — away in possession at yardline 10 (score 0-1)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 6 — away in possession at yardline 10 (score 0-1)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 0-1)
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1) (drive -9 yds)
+  [T+04:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 7 (score 0-1) (drive +3 yds)
+  [T+04:45] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 11 (score 0-1) (drive +4 yds)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 6 (score 0-1)
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 10 (score 0-1) (drive +4 yds)
+  [T+06:15] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 10 (score 0-1)
+  [T+06:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+06:45] TURNOVER — pass_fumble.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 6 (score 0-1)
+  [T+07:15] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+07:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+07:15] TURNOVER — block_attacker_down.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 0-1)
 
 --- END OF MATCH (score 0-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-042-car-jungle-queens-vs-gb-cheese-halflings-seed2067.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-042-car-jungle-queens-vs-gb-cheese-halflings-seed2067.txt
@@ -1,58 +1,58 @@
 === MATCH #42 — Jungle Queens (Amazon) vs Cheese Halflings (Halfling) ===
 engine 0.13.0
 
-KICKOFF — car-jungle-queens hosts gb-cheese-halflings (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 4 — away in possession at yardline 7 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 5 — home in possession at yardline 10 (score 0-0)
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-1-6 is taken off by banana_skin.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 7 — home in possession at yardline 15 (score 0-1)
-Half 1 • Turn 8 — home in possession at yardline 25 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
+[T+00:00] KICKOFF — car-jungle-queens hosts gb-cheese-halflings (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+00:30] TURNOVER — pass_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-0)
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+01:00] TURNOVER — dodge_failed.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 7 (score 0-0)
+  [T+01:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+01:30] TURNOVER — pass_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 10 (score 0-0)
+  [T+02:00] TURNOVER — pickup_failed.
+  [T+02:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 0-1) (drive -6 yds)
+  [T+02:30] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+02:30] CASUALTY — away-NUFFLE-1-6 is taken off by banana_skin.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 15 (score 0-1) (drive +11 yds)
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 25 (score 0-1) (drive +10 yds)
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+  [T+03:30] Touchdown! home crosses the line. Score is now 1-1.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1)
-Half 2 • Turn 2 — home in possession at yardline 13 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
-  CASUALTY — home-NUFFLE-2-4 is taken off by wardrobe_malfunction.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 2 • Turn 5 — home in possession at yardline 16 (score 1-2)
-  ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
-  CASUALTY — away-NUFFLE-2-5 is taken off by cocky_drop.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
-Half 2 • Turn 6 — home in possession at yardline 25 (score 1-2)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 1-1) (drive -21 yds)
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 13 (score 1-1) (drive +9 yds)
+  [T+04:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+04:45] TURNOVER — pass_fumble.
+  [T+04:45] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 1-2) (drive -9 yds)
+  [T+05:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 2 → failed.
+  [T+05:15] TURNOVER — pass_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 1-2)
+  [T+05:45] ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
+  [T+05:45] CASUALTY — home-NUFFLE-2-4 is taken off by wardrobe_malfunction.
+  [T+05:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+05:45] TURNOVER — pass_fumble.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 16 (score 1-2)
+  [T+06:15] ✨ NUFFLE [cocky_drop] — Showboating costs the carrier the ball.
+  [T+06:15] CASUALTY — away-NUFFLE-2-5 is taken off by cocky_drop.
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 5 → success.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 25 (score 1-2) (drive +9 yds)
+  [T+06:45] TURNOVER — pickup_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 1-2)
+  [T+07:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+07:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+07:15] TURNOVER — dodge_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
+  [T+07:45] ✨ NUFFLE [tantrum_star] — A star player throws a tantrum and refuses to obey instructions.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-043-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2068.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-043-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2068.txt
@@ -1,58 +1,58 @@
 === MATCH #43 — Tomb Cardinals (Tomb Kings) vs Cold Tacticians (Lizardmen) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — away-NUFFLE-1-3 is taken off by nemesis_clash.
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 4 — home in possession at yardline 7 (score 1-0)
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 8 — home in possession at yardline 6 (score 1-1)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-0)
+  [T+01:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:00] CASUALTY — away-NUFFLE-1-3 is taken off by nemesis_clash.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 7 (score 1-0) (drive +3 yds)
+  [T+01:30] TURNOVER — pickup_failed.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 5 (score 1-0)
+  [T+02:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:00] TURNOVER — dodge_failed.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 4 (score 1-0)
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+  [T+02:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 1-1)
+  [T+03:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 6 (score 1-1) (drive +2 yds)
+  [T+03:30] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+03:30] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+03:30] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 3 — away in possession at yardline 9 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
-  TURNOVER — pass_failed.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-2)
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-Half 2 • Turn 6 — away in possession at yardline 5 (score 1-2)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — home in possession at yardline 6 (score 1-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  [T+04:15] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, attacker_down.
+  [T+04:15] TURNOVER — block_attacker_down.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 7 (score 1-1)
+  [T+04:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+04:45] TURNOVER — pass_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 9 (score 1-1)
+  [T+05:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+05:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 1-2)
+  [T+05:45] PASS — home-LOS attempts a short pass: needs 5+, rolled 4 → failed.
+  [T+05:45] TURNOVER — pass_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 1-2)
+  [T+06:15] FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 5 (score 1-2) (drive +1 yds)
+  [T+06:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+06:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 5 (score 1-2)
+  [T+07:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+07:15] TURNOVER — block_attacker_down.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 6 (score 1-2)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:45] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-044-lv-outlaws-vs-pit-smashers-seed2069.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-044-lv-outlaws-vs-pit-smashers-seed2069.txt
@@ -1,61 +1,61 @@
 === MATCH #44 — Outlaws (Norse) vs Smashers (Orc) ===
 engine 0.13.0
 
-KICKOFF — lv-outlaws hosts pit-smashers (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — home in possession at yardline 9 (score 0-0)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 3 — away in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-Half 1 • Turn 4 — away in possession at yardline 15 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
-Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-Half 1 • Turn 7 — home in possession at yardline 9 (score 0-0)
-  FOUL — home-LOS fouls away-PRONE (armor=12, broken=true → casualty, sent off!).
-  CASUALTY — away-PRONE is taken off by home-LOS.
-  TURNOVER — foul_sent_off.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
+[T+00:00] KICKOFF — lv-outlaws hosts pit-smashers (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+00:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+00:30] TURNOVER — dodge_failed.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 8 (score 0-0)
+  [T+01:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 15 (score 0-0) (drive +7 yds)
+  [T+01:30] FOUL — away-LOS fouls home-PRONE (armor=7, broken=false, sent off!).
+  [T+01:30] TURNOVER — foul_sent_off.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
+  [T+02:00] FOUL — home-LOS fouls away-PRONE (armor=9, broken=false).
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 9 (score 0-0) (drive +5 yds)
+  [T+02:30] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 9 (score 0-0)
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=12, broken=true → casualty, sent off!).
+  [T+03:00] CASUALTY — away-PRONE is taken off by home-LOS.
+  [T+03:00] TURNOVER — foul_sent_off.
+  [T+03:00] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1) (drive -5 yds)
+  [T+03:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+03:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+03:30] Touchdown! home crosses the line. Score is now 1-1.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-Half 2 • Turn 3 — home in possession at yardline 10 (score 1-1)
-  BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 7 (score 1-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 6 — away in possession at yardline 9 (score 1-2)
-  ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
-  FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → stunned, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 1-3.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-3)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
-  Touchdown! home crosses the line. Score is now 2-3.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
+  [T+04:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+04:15] TURNOVER — block_attacker_down.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-1)
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 10 (score 1-1) (drive +6 yds)
+  [T+05:15] BLOCK — home-LOS blocks away-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 7 (score 1-1)
+  [T+05:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+05:45] PASS — away-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+  [T+05:45] Touchdown! away crosses the line. Score is now 1-2.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  [T+06:15] ✨ NUFFLE [cheering_section] — A new cheering section ignites — the home team feels invincible.
+  [T+06:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+06:15] TURNOVER — dodge_failed.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 9 (score 1-2)
+  [T+06:45] ✨ NUFFLE [veteran_redemption] — A grizzled veteran finds one more ounce of glory.
+  [T+06:45] FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → stunned, sent off!).
+  [T+06:45] TURNOVER — foul_sent_off.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 1-2)
+  [T+07:15] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+07:15] TURNOVER — pickup_failed.
+  [T+07:15] Touchdown! away crosses the line. Score is now 1-3.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 1-3)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:45] FOUL — home-LOS fouls away-PRONE (armor=7, broken=false).
+  [T+07:45] Touchdown! home crosses the line. Score is now 2-3.
 
 --- END OF MATCH (score 2-3) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-045-gb-cheese-halflings-vs-phx-tomb-cardinals-seed2070.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-045-gb-cheese-halflings-vs-phx-tomb-cardinals-seed2070.txt
@@ -1,53 +1,53 @@
 === MATCH #45 — Cheese Halflings (Halfling) vs Tomb Cardinals (Tomb Kings) ===
 engine 0.13.0
 
-KICKOFF — gb-cheese-halflings hosts phx-tomb-cardinals (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-Half 1 • Turn 2 — away in possession at yardline 12 (score 0-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 3 — away in possession at yardline 24 (score 0-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0)
-Half 1 • Turn 6 — away in possession at yardline 20 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  CASUALTY — away-NUFFLE-1-7 is taken off by nemesis_clash.
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+[T+00:00] KICKOFF — gb-cheese-halflings hosts phx-tomb-cardinals (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 12 (score 0-0) (drive +8 yds)
+  [T+00:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/POW], chose POW, defender_down.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 24 (score 0-0) (drive +12 yds)
+  [T+01:00] BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+  [T+01:00] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+01:00] TURNOVER — dodge_failed.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 4 (score 0-0)
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PLAYER_DOWN, attacker_down.
+  [T+01:30] TURNOVER — block_attacker_down.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 13 (score 0-0)
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 20 (score 0-0) (drive +7 yds)
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
+  [T+03:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+03:00] CASUALTY — away-NUFFLE-1-7 is taken off by nemesis_clash.
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 4 (score 0-1)
+  [T+03:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  TURNOVER — pickup_failed.
-Half 2 • Turn 3 — away in possession at yardline 8 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 4 — away in possession at yardline 19 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 6 — away in possession at yardline 13 (score 1-1)
-Half 2 • Turn 7 — away in possession at yardline 20 (score 1-1)
-  FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
+  [T+04:15] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 0-1)
+  [T+04:45] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+04:45] TURNOVER — pickup_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 8 (score 0-1)
+  [T+05:15] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 19 (score 0-1) (drive +11 yds)
+  [T+05:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+05:45] TURNOVER — pickup_failed.
+  [T+05:45] Touchdown! home crosses the line. Score is now 1-1.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 1-1) (drive -15 yds)
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [BOTH_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 13 (score 1-1) (drive +9 yds)
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 20 (score 1-1) (drive +7 yds)
+  [T+07:15] FOUL — away-LOS fouls home-PRONE (armor=8, broken=false).
+  [T+07:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 4 (score 1-2)
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+  [T+07:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
 
 --- END OF MATCH (score 1-2) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-046-phx-tomb-cardinals-vs-min-frostraiders-seed2071.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-046-phx-tomb-cardinals-vs-min-frostraiders-seed2071.txt
@@ -1,60 +1,60 @@
 === MATCH #46 — Tomb Cardinals (Tomb Kings) vs Frostraiders (Norse) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts min-frostraiders (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-Half 1 • Turn 4 — home in possession at yardline 10 (score 1-0)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 5 — home in possession at yardline 12 (score 1-0)
-  ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
-Half 1 • Turn 6 — home in possession at yardline 12 (score 1-0)
-  ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
-Half 1 • Turn 7 — home in possession at yardline 12 (score 1-0)
-  FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 8 — away in possession at yardline 4 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts min-frostraiders (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+00:00] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+00:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+00:30] TURNOVER — block_attacker_down.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+  [T+01:00] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+01:00] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+01:00] TURNOVER — pass_fumble.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 10 (score 1-0)
+  [T+01:30] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+01:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 12 (score 1-0) (drive +2 yds)
+  [T+02:00] ✨ NUFFLE [sudden_inspiration] — A player is struck by sudden inspiration and grows half a foot.
+  [T+02:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 6 → caught.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 12 (score 1-0)
+  [T+02:30] ✨ NUFFLE [blood_in_water] — Blood in the water — the crowd's bloodlust is rising.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 12 (score 1-0)
+  [T+03:00] FOUL — home-LOS fouls away-PRONE (armor=8, broken=false).
+  [T+03:00] Touchdown! home crosses the line. Score is now 2-0.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 4 (score 2-0)
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=6, broken=false).
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
 
 --- HALFTIME (score 2-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
-  FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → ko, sent off!).
-  KO — home-PRONE is knocked unconscious by away-LOS.
-  TURNOVER — foul_sent_off.
-  Touchdown! home crosses the line. Score is now 3-0.
-Half 2 • Turn 3 — away in possession at yardline 4 (score 3-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — home in possession at yardline 8 (score 3-0)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 5 — away in possession at yardline 4 (score 3-0)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 3-1.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 3-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 7 — away in possession at yardline 5 (score 3-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 2 • Turn 8 — away in possession at yardline 10 (score 3-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-  Touchdown! home crosses the line. Score is now 4-1.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+  [T+04:15] TURNOVER — gfi_failed.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 2-0)
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+  [T+04:45] FOUL — away-LOS fouls home-PRONE (armor=11, broken=true → ko, sent off!).
+  [T+04:45] KO — home-PRONE is knocked unconscious by away-LOS.
+  [T+04:45] TURNOVER — foul_sent_off.
+  [T+04:45] Touchdown! home crosses the line. Score is now 3-0.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 4 (score 3-0)
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 8 (score 3-0)
+  [T+05:45] TURNOVER — pickup_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 4 (score 3-0)
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+  [T+06:15] Touchdown! away crosses the line. Score is now 3-1.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 3-1)
+  [T+06:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+06:45] TURNOVER — gfi_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 5 (score 3-1)
+  [T+07:15] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 10 (score 3-1) (drive +5 yds)
+  [T+07:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+07:45] TURNOVER — dodge_failed.
+  [T+07:45] Touchdown! home crosses the line. Score is now 4-1.
 
 --- END OF MATCH (score 4-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-047-ne-cold-tacticians-vs-no-voodoo-saints-seed2072.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-047-ne-cold-tacticians-vs-no-voodoo-saints-seed2072.txt
@@ -1,55 +1,55 @@
 === MATCH #47 — Cold Tacticians (Lizardmen) vs Voodoo Saints (Undead) ===
 engine 0.13.0
 
-KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
-  PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
-Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-  Touchdown! home crosses the line. Score is now 2-0.
-Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 8 — away in possession at yardline 5 (score 2-0)
-  FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
+[T+00:00] KICKOFF — ne-cold-tacticians hosts no-voodoo-saints (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+  [T+00:00] FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 0-0)
+  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+00:30] TURNOVER — pass_fumble.
+  [T+00:30] Touchdown! home crosses the line. Score is now 1-0.
+[T+01:00] Half 1 • Turn 3 — away in possession at yardline 4 (score 1-0)
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 7 (score 1-0) (drive +3 yds)
+  [T+01:30] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+01:30] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false, sent off!).
+  [T+01:30] TURNOVER — foul_sent_off.
+  [T+01:30] Touchdown! home crosses the line. Score is now 2-0.
+[T+02:00] Half 1 • Turn 5 — away in possession at yardline 4 (score 2-0) (drive -3 yds)
+  [T+02:00] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+02:00] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE], chose STUMBLE, defender_down.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 2-0)
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=3, broken=false).
+  [T+02:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 2-0)
+  [T+03:00] ✨ NUFFLE [crowd_riot] — A riot breaks out in the stands. Some fans spill onto the pitch.
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+03:00] TURNOVER — block_attacker_down.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 5 (score 2-0)
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=10, broken=true → stunned).
 
 --- HALFTIME (score 2-0) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
-Half 2 • Turn 2 — home in possession at yardline 4 (score 2-0)
-Half 2 • Turn 3 — home in possession at yardline 4 (score 2-0)
-  ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
-  FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
-  TURNOVER — gfi_failed.
-  Touchdown! away crosses the line. Score is now 2-1.
-Half 2 • Turn 4 — home in possession at yardline 4 (score 2-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 5 — away in possession at yardline 11 (score 2-1)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 2-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 8 — home in possession at yardline 5 (score 2-1)
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 2-0)
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 2-0)
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 4 (score 2-0)
+  [T+05:15] ✨ NUFFLE [lucky_bounce] — The ball takes a friendly bounce — fortune favours the bold.
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=6, broken=false).
+  [T+05:15] TURNOVER — gfi_failed.
+  [T+05:15] Touchdown! away crosses the line. Score is now 2-1.
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 4 (score 2-1)
+  [T+05:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+05:45] TURNOVER — dodge_failed.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 11 (score 2-1)
+  [T+06:15] TURNOVER — pickup_failed.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 2-1)
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+06:45] TURNOVER — block_attacker_down.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 4 (score 2-1)
+  [T+07:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+07:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+07:15] TURNOVER — block_attacker_down.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 5 (score 2-1)
 
 --- END OF MATCH (score 2-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-048-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2073.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-048-phx-tomb-cardinals-vs-ne-cold-tacticians-seed2073.txt
@@ -1,63 +1,63 @@
 === MATCH #48 — Tomb Cardinals (Tomb Kings) vs Cold Tacticians (Lizardmen) ===
 engine 0.13.0
 
-KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, away receives).
-Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
-Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 3 — home in possession at yardline 7 (score 0-0)
-  ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-  TURNOVER — pickup_failed.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-Half 1 • Turn 6 — home in possession at yardline 8 (score 0-0)
-  ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
-  TURNOVER — pass_fumble.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 8 — home in possession at yardline 6 (score 0-1)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
+[T+00:00] KICKOFF — phx-tomb-cardinals hosts ne-cold-tacticians (weather: nice, away receives).
+[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 5 (score 0-0) (drive +1 yds)
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 1 → fail.
+  [T+00:30] TURNOVER — dodge_failed.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 7 (score 0-0)
+  [T+01:00] ✨ NUFFLE [sudden_downpour] — A sudden downpour soaks the pitch. Pickups get harder.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+01:00] TURNOVER — block_attacker_down.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 0-0)
+  [T+01:30] FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  [T+01:30] TURNOVER — pickup_failed.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 0-0)
+  [T+02:00] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 8 (score 0-0) (drive +4 yds)
+  [T+02:30] ✨ NUFFLE [fan_factor_surge] — Fan Factor surges — a roar that can be heard for miles.
+  [T+02:30] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+02:30] PASS — home-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
+  [T+02:30] TURNOVER — pass_fumble.
+  [T+02:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 0-1) (drive -4 yds)
+  [T+03:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK], chose PUSH_BACK, push_only.
+[T+03:30] Half 1 • Turn 8 — home in possession at yardline 6 (score 0-1) (drive +2 yds)
+  [T+03:30] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+03:30] TURNOVER — pickup_failed.
 
 --- HALFTIME (score 0-1) ---
 
-Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — home in possession at yardline 7 (score 0-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-Half 2 • Turn 4 — home in possession at yardline 7 (score 0-1)
-  BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 5 — away in possession at yardline 8 (score 0-1)
-  ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
-  TURNOVER — block_attacker_down.
-Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-2-6 is taken off by banana_skin.
-  BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
-  BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
-Half 2 • Turn 7 — home in possession at yardline 7 (score 0-1)
-  FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
-Half 2 • Turn 8 — away in possession at yardline 6 (score 0-1)
-  BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
+[T+04:15] Half 2 • Turn 1 — home in possession at yardline 4 (score 0-1) (drive -2 yds)
+  [T+04:15] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+04:15] TURNOVER — block_attacker_down.
+[T+04:45] Half 2 • Turn 2 — away in possession at yardline 4 (score 0-1)
+  [T+04:45] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+04:45] TURNOVER — dodge_failed.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 7 (score 0-1)
+  [T+05:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+05:15] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+05:15] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+[T+05:45] Half 2 • Turn 4 — home in possession at yardline 7 (score 0-1)
+  [T+05:45] BLOCK — home-LOS blocks away-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+05:45] TURNOVER — block_attacker_down.
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 8 (score 0-1)
+  [T+06:15] ✨ NUFFLE [spike_magazine_arrives] — A Spike Magazine reporter arrives. Players posture for the photo.
+  [T+06:15] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
+  [T+06:15] TURNOVER — block_attacker_down.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 6 (score 0-1)
+  [T+06:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+06:45] CASUALTY — away-NUFFLE-2-6 is taken off by banana_skin.
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [BOTH_DOWN], chose BOTH_DOWN, defender_down.
+  [T+06:45] BLOCK — home-LOS blocks away-LOS: dice [POW], chose POW, defender_down.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 7 (score 0-1) (drive +1 yds)
+  [T+07:15] FOUL — home-LOS fouls away-PRONE (armor=1, broken=false, sent off!).
+  [T+07:15] TURNOVER — foul_sent_off.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 6 (score 0-1)
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [POW], chose POW, defender_down.
 
 --- END OF MATCH (score 0-1) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-049-min-frostraiders-vs-chi-iron-bears-seed2074.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-049-min-frostraiders-vs-chi-iron-bears-seed2074.txt
@@ -1,58 +1,58 @@
 === MATCH #49 — Frostraiders (Norse) vs Iron Bears (Dwarf) ===
 engine 0.13.0
 
-KICKOFF — min-frostraiders hosts chi-iron-bears (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0)
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 0-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1)
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! home crosses the line. Score is now 1-1.
-Half 1 • Turn 4 — away in possession at yardline 4 (score 1-1)
-  BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 1 • Turn 5 — home in possession at yardline 4 (score 1-2)
-  FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
-  Touchdown! home crosses the line. Score is now 2-2.
-Half 1 • Turn 6 — away in possession at yardline 4 (score 2-2)
-  FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
-  Touchdown! away crosses the line. Score is now 2-3.
-Half 1 • Turn 7 — home in possession at yardline 4 (score 2-3)
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
-  TURNOVER — pass_failed.
-Half 1 • Turn 8 — away in possession at yardline 6 (score 2-3)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/POW], chose POW, defender_down.
+[T+00:00] KICKOFF — min-frostraiders hosts chi-iron-bears (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] ✨ NUFFLE [unhappy_fans] — Unhappy fans throw rotten produce at their own stars.
+  [T+00:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+[T+00:30] Half 1 • Turn 2 — home in possession at yardline 7 (score 0-0) (drive +3 yds)
+  [T+00:30] TURNOVER — pickup_failed.
+  [T+00:30] Touchdown! away crosses the line. Score is now 0-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 0-1) (drive -3 yds)
+  [T+01:00] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+01:00] Touchdown! home crosses the line. Score is now 1-1.
+[T+01:30] Half 1 • Turn 4 — away in possession at yardline 4 (score 1-1)
+  [T+01:30] BLOCK — away-LOS blocks home-LOS: dice [PLAYER_DOWN/PUSH_BACK], chose PUSH_BACK, push_only.
+  [T+01:30] Touchdown! away crosses the line. Score is now 1-2.
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 4 (score 1-2)
+  [T+02:00] FOUL — home-LOS fouls away-PRONE (armor=4, broken=false).
+  [T+02:00] Touchdown! home crosses the line. Score is now 2-2.
+[T+02:30] Half 1 • Turn 6 — away in possession at yardline 4 (score 2-2)
+  [T+02:30] FOUL — away-LOS fouls home-PRONE (armor=4, broken=false).
+  [T+02:30] BLOCK — away-LOS blocks home-LOS: dice [POW/STUMBLE], chose POW, defender_down.
+  [T+02:30] Touchdown! away crosses the line. Score is now 2-3.
+[T+03:00] Half 1 • Turn 7 — home in possession at yardline 4 (score 2-3)
+  [T+03:00] PASS — home-LOS attempts a short pass: needs 5+, rolled 3 → failed.
+  [T+03:00] TURNOVER — pass_failed.
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 6 (score 2-3)
+  [T+03:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+03:30] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/POW], chose POW, defender_down.
 
 --- HALFTIME (score 2-3) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 2-3)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  Touchdown! away crosses the line. Score is now 2-4.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 2-4)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
-Half 2 • Turn 3 — home in possession at yardline 9 (score 2-4)
-  TURNOVER — pickup_failed.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 2-4)
-  FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
-  BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
-  CASUALTY — home-LOS is taken off by away-LOS.
-Half 2 • Turn 5 — away in possession at yardline 10 (score 2-4)
-Half 2 • Turn 6 — away in possession at yardline 14 (score 2-4)
-  Touchdown! away crosses the line. Score is now 2-5.
-Half 2 • Turn 7 — home in possession at yardline 4 (score 2-5)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  CASUALTY — away-NUFFLE-2-7 is taken off by banana_skin.
-  PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
-  Touchdown! home crosses the line. Score is now 3-5.
-Half 2 • Turn 8 — away in possession at yardline 4 (score 3-5)
-  ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
-  BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 2-3) (drive -2 yds)
+  [T+04:15] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+04:15] Touchdown! away crosses the line. Score is now 2-4.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 2-4)
+  [T+04:45] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 4 → success.
+[T+05:15] Half 2 • Turn 3 — home in possession at yardline 9 (score 2-4) (drive +5 yds)
+  [T+05:15] TURNOVER — pickup_failed.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 2-4)
+  [T+05:45] FOUL — away-LOS fouls home-PRONE (armor=2, broken=false).
+  [T+05:45] BLOCK — away-LOS blocks home-LOS: dice [STUMBLE/PLAYER_DOWN], chose STUMBLE, defender_down.
+  [T+05:45] CASUALTY — home-LOS is taken off by away-LOS (armor=10, injury=11).
+[T+06:15] Half 2 • Turn 5 — away in possession at yardline 10 (score 2-4) (drive +6 yds)
+[T+06:45] Half 2 • Turn 6 — away in possession at yardline 14 (score 2-4) (drive +4 yds)
+  [T+06:45] Touchdown! away crosses the line. Score is now 2-5.
+[T+07:15] Half 2 • Turn 7 — home in possession at yardline 4 (score 2-5)
+  [T+07:15] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+07:15] CASUALTY — away-NUFFLE-2-7 is taken off by banana_skin.
+  [T+07:15] PASS — home-LOS attempts a short pass: needs 5+, rolled 5 → caught.
+  [T+07:15] Touchdown! home crosses the line. Score is now 3-5.
+[T+07:45] Half 2 • Turn 8 — away in possession at yardline 4 (score 3-5)
+  [T+07:45] ✨ NUFFLE [banana_skin] — A banana skin appears from nowhere. A player slips spectacularly.
+  [T+07:45] BLOCK — away-LOS blocks home-LOS: dice [PUSH_BACK/STUMBLE], chose STUMBLE, defender_down.
 
 --- END OF MATCH (score 3-5) ---
 

--- a/docs/roadmap/sprints/pro-league-panel/replays/replay-050-min-frostraiders-vs-car-jungle-queens-seed2075.txt
+++ b/docs/roadmap/sprints/pro-league-panel/replays/replay-050-min-frostraiders-vs-car-jungle-queens-seed2075.txt
@@ -1,57 +1,57 @@
 === MATCH #50 — Frostraiders (Norse) vs Jungle Queens (Amazon) ===
 engine 0.13.0
 
-KICKOFF — min-frostraiders hosts car-jungle-queens (weather: nice, home receives).
-Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
-  Touchdown! home crosses the line. Score is now 1-0.
-Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
-  Touchdown! away crosses the line. Score is now 1-1.
-Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
-  ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 4 — home in possession at yardline 13 (score 1-1)
-  FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
-Half 1 • Turn 5 — home in possession at yardline 14 (score 1-1)
-  ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
-  BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
-Half 1 • Turn 6 — home in possession at yardline 18 (score 1-1)
-  ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
-Half 1 • Turn 8 — away in possession at yardline 9 (score 1-1)
-  ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
-  FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
-  TURNOVER — foul_sent_off.
+[T+00:00] KICKOFF — min-frostraiders hosts car-jungle-queens (weather: nice, home receives).
+[T+00:00] Half 1 • Turn 1 — home in possession at yardline 4 (score 0-0)
+  [T+00:00] Touchdown! home crosses the line. Score is now 1-0.
+[T+00:30] Half 1 • Turn 2 — away in possession at yardline 4 (score 1-0)
+  [T+00:30] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 6 → success.
+  [T+00:30] Touchdown! away crosses the line. Score is now 1-1.
+[T+01:00] Half 1 • Turn 3 — home in possession at yardline 4 (score 1-1)
+  [T+01:00] ✨ NUFFLE [weather_shift] — The Nuffle Gods stir the clouds. Weather shifts.
+  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+01:30] Half 1 • Turn 4 — home in possession at yardline 13 (score 1-1) (drive +9 yds)
+  [T+01:30] FOUL — home-LOS fouls away-PRONE (armor=5, broken=false).
+[T+02:00] Half 1 • Turn 5 — home in possession at yardline 14 (score 1-1) (drive +1 yds)
+  [T+02:00] ✨ NUFFLE [star_player_rising] — The star player ascends — the cameras eat it up.
+  [T+02:00] BLOCK — home-LOS blocks away-LOS: dice [PUSH_BACK/PUSH_BACK], chose PUSH_BACK, push_only.
+[T+02:30] Half 1 • Turn 6 — home in possession at yardline 18 (score 1-1) (drive +4 yds)
+  [T+02:30] ✨ NUFFLE [nemesis_clash] — Two old rivals lock eyes — the next block will be personal.
+  [T+02:30] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+02:30] TURNOVER — dodge_failed.
+[T+03:00] Half 1 • Turn 7 — away in possession at yardline 4 (score 1-1)
+[T+03:30] Half 1 • Turn 8 — away in possession at yardline 9 (score 1-1) (drive +5 yds)
+  [T+03:30] ✨ NUFFLE [lightning_strike] — A lightning strike hits the pitch. Nobody is hurt — yet.
+  [T+03:30] FOUL — away-LOS fouls home-PRONE (armor=1, broken=false, sent off!).
+  [T+03:30] TURNOVER — foul_sent_off.
 
 --- HALFTIME (score 1-1) ---
 
-Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1)
-  DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
-  Touchdown! away crosses the line. Score is now 1-2.
-Half 2 • Turn 2 — home in possession at yardline 4 (score 1-2)
-  ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
-  DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
-  TURNOVER — dodge_failed.
-Half 2 • Turn 3 — away in possession at yardline 6 (score 1-2)
-  FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
-  TURNOVER — pickup_failed.
-  Touchdown! home crosses the line. Score is now 2-2.
-Half 2 • Turn 4 — away in possession at yardline 4 (score 2-2)
-  ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
-  TURNOVER — gfi_failed.
-Half 2 • Turn 5 — home in possession at yardline 7 (score 2-2)
-  ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
-  TURNOVER — pickup_failed.
-  Touchdown! away crosses the line. Score is now 2-3.
-Half 2 • Turn 6 — home in possession at yardline 4 (score 2-3)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 7 — away in possession at yardline 8 (score 2-3)
-  TURNOVER — gfi_failed.
-Half 2 • Turn 8 — home in possession at yardline 5 (score 2-3)
-  ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
-  TURNOVER — pickup_failed.
+[T+04:15] Half 2 • Turn 1 — away in possession at yardline 4 (score 1-1) (drive -5 yds)
+  [T+04:15] DODGE — away-LOS dodges to (13,7): needs 3+, rolled 3 → success.
+  [T+04:15] Touchdown! away crosses the line. Score is now 1-2.
+[T+04:45] Half 2 • Turn 2 — home in possession at yardline 4 (score 1-2)
+  [T+04:45] ✨ NUFFLE [wind_picks_up] — A gust catches the ball mid-pass.
+  [T+04:45] DODGE — home-LOS dodges to (13,7): needs 3+, rolled 2 → fail.
+  [T+04:45] TURNOVER — dodge_failed.
+[T+05:15] Half 2 • Turn 3 — away in possession at yardline 6 (score 1-2)
+  [T+05:15] FOUL — away-LOS fouls home-PRONE (armor=9, broken=false).
+  [T+05:15] TURNOVER — pickup_failed.
+  [T+05:15] Touchdown! home crosses the line. Score is now 2-2.
+[T+05:45] Half 2 • Turn 4 — away in possession at yardline 4 (score 2-2) (drive -2 yds)
+  [T+05:45] ✨ NUFFLE [coach_sideline_rant] — A sideline rant electrifies the squad — and the ref.
+  [T+05:45] TURNOVER — gfi_failed.
+[T+06:15] Half 2 • Turn 5 — home in possession at yardline 7 (score 2-2)
+  [T+06:15] ✨ NUFFLE [rookie_brilliance] — A rookie pulls off a play above their stats — Nuffle smiles.
+  [T+06:15] TURNOVER — pickup_failed.
+  [T+06:15] Touchdown! away crosses the line. Score is now 2-3.
+[T+06:45] Half 2 • Turn 6 — home in possession at yardline 4 (score 2-3) (drive -3 yds)
+  [T+06:45] TURNOVER — gfi_failed.
+[T+07:15] Half 2 • Turn 7 — away in possession at yardline 8 (score 2-3)
+  [T+07:15] TURNOVER — gfi_failed.
+[T+07:45] Half 2 • Turn 8 — home in possession at yardline 5 (score 2-3)
+  [T+07:45] ✨ NUFFLE [wardrobe_malfunction] — Wardrobe malfunction. The crowd is, uh, distracted.
+  [T+07:45] TURNOVER — pickup_failed.
 
 --- END OF MATCH (score 2-3) ---
 

--- a/packages/sim-engine/src/replay/narrator.test.ts
+++ b/packages/sim-engine/src/replay/narrator.test.ts
@@ -91,4 +91,44 @@ describe('narrateMatch — sprint Pro League 0.E.2', () => {
     const b = narrateMatch(simulateMatch(baseInput({ seed: 7 })));
     expect(b).toBe(a);
   });
+
+  it('prefixes event lines with [T+MM:SS] timestamps by default', () => {
+    const out = narrateMatch(simulateMatch(baseInput()));
+    // KICKOFF is the first event at displayAtMs=0.
+    expect(out).toMatch(/\[T\+00:00\] KICKOFF/);
+    // At least one TURN_START after kickoff carries a non-zero timestamp.
+    expect(out).toMatch(/\[T\+\d{2}:\d{2}\] Half \d+ • Turn \d+/);
+  });
+
+  it('honours hideTimestamps=true to drop the [T+MM:SS] prefix', () => {
+    const out = narrateMatch(simulateMatch(baseInput()), {
+      hideTimestamps: true,
+    });
+    expect(out).not.toMatch(/\[T\+\d{2}:\d{2}\]/);
+    // The events themselves are still rendered.
+    expect(out).toMatch(/KICKOFF/);
+  });
+
+  it('renders ball-yardline delta on consecutive TURN_STARTs same drive', () => {
+    // Run several seeds until at least one match shows a "(drive ±N yds)"
+    // annotation — guaranteed when 2+ TURN_STARTs share the same driving
+    // team and the ball moved.
+    let withDelta: string | null = null;
+    for (let seed = 0; seed < 30 && withDelta === null; seed += 1) {
+      const out = narrateMatch(simulateMatch(baseInput({ seed })));
+      if (/\(drive [+-]\d+ yds\)/.test(out)) withDelta = out;
+    }
+    expect(withDelta).not.toBeNull();
+  });
+
+  it('exposes armor + injury detail on KO and CASUALTY when available', () => {
+    let withDetail: string | null = null;
+    for (let seed = 0; seed < 50 && withDetail === null; seed += 1) {
+      const out = narrateMatch(simulateMatch(baseInput({ seed })));
+      if (/(KO|CASUALTY) — .* \(armor=\d+, injury=\d+\)/.test(out)) {
+        withDetail = out;
+      }
+    }
+    expect(withDetail).not.toBeNull();
+  });
 });

--- a/packages/sim-engine/src/replay/narrator.ts
+++ b/packages/sim-engine/src/replay/narrator.ts
@@ -1,11 +1,18 @@
 /**
- * Replay narrator — sprint Pro League 0.E.2.
+ * Replay narrator — sprint Pro League 0.E.2 (enrichi 1.F follow-up).
  *
  * Convertit la timeline d'un `SimResult` en texte narratif lisible
  * pour le panel humain BB experts (lot 0.E.3) : grille de notation
  * "lisibilite tactique, coherence drives, identite raciale, moments
  * memorables". Le narrateur n'invente rien — il reformate les events
  * 0.A.3 dans une langue accessible aux coachs FUMBBL/NAF.
+ *
+ * Enrichissement (post-merge Phase 1) :
+ *  - Prefixe `[T+MM:SS]` sur chaque event via `displayAtMs`.
+ *  - Delta de yardline entre TURN_STARTs successifs ("+7 yds").
+ *  - Annotations skills sur BLOCK (wrestle) et DODGE (tackle suppress).
+ *  - Detail armor/injury (rolls 2d6) sur KO et CASUALTY.
+ *  - Score live affiche apres chaque TD.
  *
  * Pure function : aucune I/O. Le CLI `pnpm sim:replay` (script
  * `scripts/replay.ts`) appelle ce narrateur avec les SimResults
@@ -21,6 +28,8 @@ export interface NarrateOptions {
   title?: string;
   /** Hide the FINAL score footer (useful when concatenating). */
   hideFooter?: boolean;
+  /** Hide the `[T+MM:SS]` timestamp prefix (default: shown). */
+  hideTimestamps?: boolean;
 }
 
 interface MetaShape {
@@ -37,6 +46,16 @@ function n(value: unknown, fallback = '?'): string {
   return fallback;
 }
 
+/** Format displayAtMs as `[T+MM:SS]`. */
+function formatTimestamp(displayAtMs: number): string {
+  const total = Math.max(0, Math.floor(displayAtMs / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(s).padStart(2, '0');
+  return `[T+${mm}:${ss}]`;
+}
+
 function renderKickoff(ev: MatchEvent): string {
   const meta = getMeta(ev);
   const home = n(meta.home);
@@ -46,13 +65,34 @@ function renderKickoff(ev: MatchEvent): string {
   return `KICKOFF — ${home} hosts ${away} (weather: ${weather}, ${receiver} receives).`;
 }
 
-function renderTurnStart(ev: MatchEvent): string {
+interface TurnStartContext {
+  prevYardline?: number;
+  prevDrivingTeam?: string;
+}
+
+function renderTurnStart(ev: MatchEvent, ctx: TurnStartContext): string {
   const meta = getMeta(ev);
   const score = (meta.score as { home: number; away: number } | undefined) ?? {
     home: 0,
     away: 0,
   };
-  return `Half ${n(meta.half)} • Turn ${n(meta.turn)} — ${n(meta.drivingTeam)} in possession at yardline ${n(meta.ballYardline)} (score ${score.home}-${score.away})`;
+  const yardline = typeof meta.ballYardline === 'number' ? meta.ballYardline : null;
+  const drivingTeam = n(meta.drivingTeam);
+
+  let delta = '';
+  if (
+    yardline !== null &&
+    ctx.prevYardline !== undefined &&
+    ctx.prevDrivingTeam === drivingTeam
+  ) {
+    const d = yardline - ctx.prevYardline;
+    if (d !== 0) {
+      const sign = d > 0 ? '+' : '';
+      delta = ` (drive ${sign}${d} yds)`;
+    }
+  }
+
+  return `Half ${n(meta.half)} • Turn ${n(meta.turn)} — ${drivingTeam} in possession at yardline ${n(meta.ballYardline)} (score ${score.home}-${score.away})${delta}`;
 }
 
 function renderBlock(ev: MatchEvent): string {
@@ -67,7 +107,8 @@ function renderBlock(ev: MatchEvent): string {
   const dice = (meta.rolls as string[] | undefined)?.join('/') ?? '?';
   const chosen = n(meta.chosen);
   const resolution = n(meta.resolution);
-  return `  BLOCK — ${n(meta.attackerId)} blocks ${n(meta.defenderId)}: dice [${dice}], chose ${chosen}, ${resolution}.`;
+  const wrestle = meta.useWrestle === true ? ', wrestled' : '';
+  return `  BLOCK — ${n(meta.attackerId)} blocks ${n(meta.defenderId)}: dice [${dice}], chose ${chosen}, ${resolution}${wrestle}.`;
 }
 
 function renderDodge(ev: MatchEvent): string {
@@ -76,7 +117,9 @@ function renderDodge(ev: MatchEvent): string {
   const target = n(meta.target);
   const roll = n(meta.roll);
   const reroll = meta.usedReroll === true ? ' (rerolled)' : '';
-  return `  DODGE — ${n(meta.playerId)} dodges to ${formatPos(meta.to)}${reroll}: needs ${target}+, rolled ${roll} → ${success ? 'success' : 'fail'}.`;
+  const tackleNote =
+    meta.rerollSuppressedByTackle === true ? ' [tackle blocks reroll]' : '';
+  return `  DODGE — ${n(meta.playerId)} dodges to ${formatPos(meta.to)}${reroll}${tackleNote}: needs ${target}+, rolled ${roll} → ${success ? 'success' : 'fail'}.`;
 }
 
 function renderPass(ev: MatchEvent): string {
@@ -107,12 +150,18 @@ function renderTurnover(ev: MatchEvent): string {
 
 function renderKO(ev: MatchEvent): string {
   const meta = getMeta(ev);
-  return `  KO — ${n(meta.playerId)} is knocked unconscious${meta.causedBy ? ` by ${n(meta.causedBy)}` : ''}.`;
+  const armor = typeof meta.armor === 'number' ? ` (armor=${meta.armor}` : '';
+  const injury =
+    typeof meta.injury === 'number' ? `, injury=${meta.injury})` : armor ? ')' : '';
+  return `  KO — ${n(meta.playerId)} is knocked unconscious${meta.causedBy ? ` by ${n(meta.causedBy)}` : ''}${armor}${injury}.`;
 }
 
 function renderCasualty(ev: MatchEvent): string {
   const meta = getMeta(ev);
-  return `  CASUALTY — ${n(meta.playerId)} is taken off${meta.causedBy ? ` by ${n(meta.causedBy)}` : ''}.`;
+  const armor = typeof meta.armor === 'number' ? ` (armor=${meta.armor}` : '';
+  const injury =
+    typeof meta.injury === 'number' ? `, injury=${meta.injury})` : armor ? ')' : '';
+  return `  CASUALTY — ${n(meta.playerId)} is taken off${meta.causedBy ? ` by ${n(meta.causedBy)}` : ''}${armor}${injury}.`;
 }
 
 function renderNuffle(ev: MatchEvent): string {
@@ -153,12 +202,12 @@ function formatPos(value: unknown): string {
   return '?';
 }
 
-function renderEvent(ev: MatchEvent): string {
+function renderEvent(ev: MatchEvent, ctx: TurnStartContext): string {
   switch (ev.type) {
     case 'KICKOFF':
       return renderKickoff(ev);
     case 'TURN_START':
-      return renderTurnStart(ev);
+      return renderTurnStart(ev, ctx);
     case 'BLOCK':
       return renderBlock(ev);
     case 'DODGE':
@@ -184,7 +233,26 @@ function renderEvent(ev: MatchEvent): string {
   }
 }
 
+/** Apply optional `[T+MM:SS]` prefix. Skips on pure separator lines
+ *  (HALFTIME / END which start with a blank line). */
+function withTimestamp(
+  line: string,
+  ev: MatchEvent,
+  showTimestamp: boolean,
+): string {
+  if (!showTimestamp) return line;
+  if (line.startsWith('\n')) return line;
+  const ts = formatTimestamp(ev.displayAtMs);
+  // Indented event lines : `  BLOCK — ...` becomes `  [T+00:30] BLOCK — ...`.
+  if (line.startsWith('  ')) {
+    return `  ${ts} ${line.slice(2)}`;
+  }
+  // Non-indented (KICKOFF, TURN_START) : `[T+00:30] KICKOFF — ...`.
+  return `${ts} ${line}`;
+}
+
 export function narrateMatch(result: SimResult, options: NarrateOptions = {}): string {
+  const showTimestamps = options.hideTimestamps !== true;
   const lines: string[] = [];
 
   // Header — extract team names from the KICKOFF event meta when possible.
@@ -201,8 +269,19 @@ export function narrateMatch(result: SimResult, options: NarrateOptions = {}): s
 
   // Body : one line per event, grouped by turn (the TURN_START line is a
   // mini header ; subsequent events are indented inside it).
+  const ctx: TurnStartContext = {};
   for (const ev of result.events) {
-    lines.push(renderEvent(ev));
+    const raw = renderEvent(ev, ctx);
+    lines.push(withTimestamp(raw, ev, showTimestamps));
+    if (ev.type === 'TURN_START') {
+      const m = getMeta(ev);
+      if (typeof m.ballYardline === 'number') {
+        ctx.prevYardline = m.ballYardline;
+      }
+      if (typeof m.drivingTeam === 'string') {
+        ctx.prevDrivingTeam = m.drivingTeam;
+      }
+    }
   }
 
   if (!options.hideFooter) {


### PR DESCRIPTION
## Contexte

Préparation du panel humain BB experts (C6-C9 du sprint Pro League). Les 50 `.txt` étaient sur `engineVer 0.12.0` alors que le gate stat est passé sur `0.13.0` (iter #16). Le narrator condensait trop l'info, ce qui rend la note "lisibilité tactique" partiellement injuste pour le testeur.

## Modifs

**Narrator enrichi (`packages/sim-engine/src/replay/narrator.ts`)**

- Préfixe `[T+MM:SS]` sur chaque event line via `displayAtMs`. Toggle via `NarrateOptions.hideTimestamps` pour les call-sites legacy.
- Annotation `(drive ±N yds)` sur TURN_STARTs successifs partageant le même `drivingTeam` — rend visible la progression de drive sans avoir à lire entre les lignes.
- Skill notes :
  - BLOCK : `wrestled` quand `useWrestle === true`
  - DODGE : `[tackle blocks reroll]` quand `rerollSuppressedByTackle === true`
- KO et CASUALTY exposent désormais `(armor=N, injury=M)` quand le meta le contient (déjà émis par `block.ts`).
- API rétro-compatible : les 9 tests narrator existants passent sans modif. 4 nouveaux tests couvrent l'enrichissement (timestamps présents, hideTimestamps drop, drive delta, armor/injury detail).

**50 panel replays regénérés (`docs/roadmap/sprints/pro-league-panel/replays/`)**

```bash
pnpm --filter @bb/sim-engine sim:replay --random=50 --seed=2026 \
  --out=docs/roadmap/sprints/pro-league-panel/replays
```

Engine `0.13.0` (vs `0.12.0` précédent). Seed `2026` conservé → reproductible.

**Docs panel**

- `pro-league-panel/README.md` : statut engineVer `0.13.0` + nouvelle section "Format narratif" expliquant les enrichissements.
- `pro-league-panel/notation-grille.md` : Engine version review `0.13.0`.

## Exemple de sortie enrichie

```
=== MATCH #1 — Soaring Hawks (Wood Elf) vs Frostraiders (Norse) ===
engine 0.13.0

[T+00:00] KICKOFF — kc-soaring-hawks hosts min-frostraiders (weather: nice, away receives).
[T+00:00] Half 1 • Turn 1 — away in possession at yardline 4 (score 0-0)
[T+00:30] Half 1 • Turn 2 — away in possession at yardline 14 (score 0-0) (drive +10 yds)
  [T+00:30] PASS — away-LOS attempts a short pass: needs 5+, rolled 1 (fumble!) → failed.
  [T+00:30] TURNOVER — pass_fumble.
[T+01:00] Half 1 • Turn 3 — home in possession at yardline 6 (score 0-0)
  [T+01:00] ✨ NUFFLE [fog_rolls_in] — Fog rolls onto the field. Long passes become a prayer.
  [T+01:00] BLOCK — home-LOS blocks away-LOS: dice [POW/PLAYER_DOWN], chose PLAYER_DOWN, attacker_down.
```

## Tests

```
✓ src/replay/narrator.test.ts (13 tests) — 9 existants + 4 nouveaux
Test Files  18 passed (18)
     Tests 267 passed (267)  // suite sim-engine complète
```

## Test plan

- [x] `pnpm test` (sim-engine) → 267/267
- [x] Visual diff sur 1-2 replays pour valider la lisibilité
- [ ] Re-distribuer aux testeurs panel via le brief existant (`panel-instructions.md`)
- [ ] Une fois 5 grilles reçues, transcrire dans `score-synthesis.md` + verdict C6-C9 dans `pro-league-gate.md`

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_