### PR TITLE
feat(server): replay dump endpoint for completed matches (sprint 1.G.1)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -87,6 +87,10 @@ import {
   getProMatchDetail,
 } from "../services/pro-league-match";
 import {
+  ReplayDumpError,
+  getMatchReplayDump,
+} from "../services/pro-league-replay";
+import {
   ProTeamNotFoundError,
   getProTeamDetail,
 } from "../services/pro-league-team";
@@ -192,6 +196,40 @@ export async function handleStreamProMatch(
  */
 export function handleBroadcasterStats(_req: Request, res: Response): void {
   res.json(getBroadcasterStats());
+}
+
+/**
+ * Sprint 1.G.1 — Dump complet du replay d'un match `completed`. Pour
+ * matchs `in_progress` utiliser `/stream` (SSE). Pour `scheduled` /
+ * `failed` la route renvoie 409.
+ */
+export async function handleGetMatchReplay(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const matchId = req.params.id;
+  if (!matchId || typeof matchId !== "string") {
+    res.status(400).json({ error: "missing-match-id" });
+    return;
+  }
+  try {
+    const dump = await getMatchReplayDump(matchId);
+    res.json(dump);
+  } catch (err: unknown) {
+    if (err instanceof ReplayDumpError) {
+      const status =
+        err.code === "MATCH_NOT_REPLAYABLE"
+          ? 409
+          : err.code === "MATCH_NOT_FOUND" || err.code === "REPLAY_NOT_FOUND"
+            ? 404
+            : 500;
+      res.status(status).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/matches/${matchId}/replay] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
 }
 
 /**
@@ -771,6 +809,7 @@ router.get("/teams/:slug", handleGetTeamDetail);
 router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/markets", handleListMarkets);
 router.get("/matches/:id/stream", handleStreamProMatch);
+router.get("/matches/:id/replay", handleGetMatchReplay);
 router.get("/leaderboard", handleGetBetLeaderboard);
 router.get("/gazette/latest", handleGetLatestEdition);
 router.get("/gazette/dates", handleListEditionDates);

--- a/apps/server/src/services/pro-league-replay.test.ts
+++ b/apps/server/src/services/pro-league-replay.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn() },
+    replay: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@bb/sim-engine", () => ({
+  decompressEvents: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { decompressEvents } from "@bb/sim-engine";
+import {
+  ReplayDumpError,
+  getMatchReplayDump,
+} from "./pro-league-replay";
+
+interface MockedPrisma {
+  proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+const mockedDecompress = vi.mocked(decompressEvents);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+async function expectCode(p: Promise<unknown>, code: string): Promise<void> {
+  try {
+    await p;
+    throw new Error("expected throw");
+  } catch (err) {
+    expect(err).toBeInstanceOf(ReplayDumpError);
+    expect((err as ReplayDumpError).code).toBe(code);
+  }
+}
+
+describe("getMatchReplayDump — sprint 1.G.1", () => {
+  it("throw MATCH_NOT_FOUND si le match est inconnu", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue(null);
+    await expectCode(getMatchReplayDump("missing"), "MATCH_NOT_FOUND");
+  });
+
+  it("throw MATCH_NOT_REPLAYABLE si status='scheduled'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "scheduled",
+    });
+    await expectCode(getMatchReplayDump("m1"), "MATCH_NOT_REPLAYABLE");
+  });
+
+  it("throw MATCH_NOT_REPLAYABLE si status='in_progress'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "in_progress",
+    });
+    await expectCode(getMatchReplayDump("m1"), "MATCH_NOT_REPLAYABLE");
+  });
+
+  it("throw MATCH_NOT_REPLAYABLE si status='failed'", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "failed",
+    });
+    await expectCode(getMatchReplayDump("m1"), "MATCH_NOT_REPLAYABLE");
+  });
+
+  it("throw REPLAY_NOT_FOUND si le replay manque pour un match completed", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+    });
+    mocked.replay.findUnique.mockResolvedValue(null);
+    await expectCode(getMatchReplayDump("m1"), "REPLAY_NOT_FOUND");
+  });
+
+  it("renvoie le dump trie pour un match completed", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+    });
+    mocked.replay.findUnique.mockResolvedValue({
+      payload: Buffer.from([1, 2, 3]),
+      durationMs: 600_000,
+    });
+    // Events deliberement desordonnes pour valider le sort.
+    mockedDecompress.mockResolvedValue([
+      { type: "TURN_START", displayAtMs: 30_000, engineVer: "0.13.0" },
+      { type: "KICKOFF", displayAtMs: 0, engineVer: "0.13.0" },
+      { type: "TD", displayAtMs: 120_000, engineVer: "0.13.0" },
+    ] as never);
+
+    const out = await getMatchReplayDump("m1");
+    expect(out.matchId).toBe("m1");
+    expect(out.status).toBe("completed");
+    expect(out.durationMs).toBe(600_000);
+    expect(out.eventCount).toBe(3);
+    expect(out.events.map((e) => e.type)).toEqual([
+      "KICKOFF",
+      "TURN_START",
+      "TD",
+    ]);
+  });
+
+  it("eventCount = 0 pour un replay vide (cas degenere)", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({
+      id: "m1",
+      status: "completed",
+    });
+    mocked.replay.findUnique.mockResolvedValue({
+      payload: Buffer.from([]),
+      durationMs: 0,
+    });
+    mockedDecompress.mockResolvedValue([] as never);
+
+    const out = await getMatchReplayDump("m1");
+    expect(out.eventCount).toBe(0);
+    expect(out.events).toEqual([]);
+  });
+});

--- a/apps/server/src/services/pro-league-replay.ts
+++ b/apps/server/src/services/pro-league-replay.ts
@@ -1,0 +1,86 @@
+/**
+ * Pro League replay dump service — sprint 1.G.1.
+ *
+ * Pour les matchs `completed`, expose la totalite des events d'un seul
+ * coup (vs le SSE 1.B.2 qui dispatche au rythme `displayAtMs` real-time).
+ * Le client `<MatchReplayPlayer>` (1.G.2) consomme cet endpoint pour
+ * gerer play/pause/scrub/speed entierement cote browser, sans charger
+ * le serveur pour chaque speed bump.
+ *
+ * Reponses possibles :
+ *  - `404 MATCH_NOT_FOUND`  : id inconnu.
+ *  - `409 MATCH_NOT_REPLAYABLE` : status != 'completed' (live -> SSE,
+ *    scheduled -> rien a rejouer, failed -> replay invalide).
+ *  - `404 REPLAY_NOT_FOUND` : match completed mais replay manquant
+ *    (cas degenere, ne devrait pas arriver en prod).
+ *  - `200` : `{ matchId, status, durationMs, eventCount, events }`.
+ *
+ * `events` est trie par `displayAtMs` ascending. Le payload reste petit
+ * (typiquement 50-300 events par match, ~10-30 KB JSON).
+ */
+
+import { decompressEvents } from "@bb/sim-engine";
+import type { MatchEvent } from "@bb/shared-types";
+
+import { prisma } from "../prisma";
+
+export class ReplayDumpError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "ReplayDumpError";
+  }
+}
+
+export interface MatchReplayDump {
+  readonly matchId: string;
+  readonly status: string;
+  readonly durationMs: number;
+  readonly eventCount: number;
+  readonly events: readonly MatchEvent[];
+}
+
+/**
+ * Dump complet d'un replay Pro League. Idempotent et sans effet de bord.
+ */
+export async function getMatchReplayDump(
+  matchId: string,
+): Promise<MatchReplayDump> {
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: { id: true, status: true },
+  });
+  if (!match) {
+    throw new ReplayDumpError(
+      "MATCH_NOT_FOUND",
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  if (match.status !== "completed") {
+    throw new ReplayDumpError(
+      "MATCH_NOT_REPLAYABLE",
+      `ProLeagueMatch '${matchId}' status='${match.status}' n'est pas rejouable (attendu 'completed')`,
+    );
+  }
+  const replay = await prisma.replay.findUnique({
+    where: { matchId },
+    select: { payload: true, durationMs: true },
+  });
+  if (!replay) {
+    throw new ReplayDumpError(
+      "REPLAY_NOT_FOUND",
+      `Replay pour match '${matchId}' introuvable`,
+    );
+  }
+  const events = await decompressEvents(replay.payload as Buffer);
+  // Tri stable (defensive ; le sim-engine emet deja en ordre).
+  const sorted = [...events].sort((a, b) => a.displayAtMs - b.displayAtMs);
+  return {
+    matchId,
+    status: match.status as string,
+    durationMs: replay.durationMs,
+    eventCount: sorted.length,
+    events: sorted,
+  };
+}


### PR DESCRIPTION
## Sprint 1.G.1 — Endpoint replay dump

Premier lot de la phase 1.G (Replay Player). Ajoute l'endpoint qui dump tous les events d'un match `completed` en une seule reponse JSON, pour permettre au futur `<MatchReplayPlayer>` (1.G.2) de controler play/pause/scrub/speed entierement cote browser sans charger le serveur a chaque speed bump.

### API

`GET /pro-league/matches/:id/replay`

| Status | Cas |
|---|---|
| 200 | match `completed` + replay present |
| 404 | match introuvable OU replay manquant |
| 409 | match `scheduled` / `in_progress` / `failed` (non-replayable) |
| 400 | id manquant |

Reponse 200 :
```json
{
  "matchId": "...",
  "status": "completed",
  "durationMs": 600000,
  "eventCount": 213,
  "events": [{ "type": "KICKOFF", "displayAtMs": 0, "engineVer": "0.13.0", ... }, ...]
}
```

### Tests

```
✓ pro-league-replay.test.ts (7 tests)
```

Couvre : MATCH_NOT_FOUND, 3 statuses non-replayable, REPLAY_NOT_FOUND, sorted dump, empty replay.

### Sequel

- 1.G.2 : `<MatchReplayPlayer>` (controls + scrub bar) — consomme cet endpoint
- 1.G.3 : auto LIVE vs REPLAY mode + redirect
- 1.G.4 : markers TD/CAS/NUFFLE sur la scrub bar
- 1.G.5 : keyboard shortcuts + Playwright spec

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_