### PR TITLE
feat(web): MatchReplayPlayer with scrub bar + speed controls (sprint 1.G.2)

### DIFF
--- a/apps/web/app/lib/use-replay-clock.test.ts
+++ b/apps/web/app/lib/use-replay-clock.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Sprint 1.G.2 — Tests `useReplayClock` (pure browser clock pour replay).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  PLAYBACK_SPEEDS,
+  formatReplayClock,
+  useReplayClock,
+} from "./use-replay-clock";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-07T10:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * Crée un schedule-tick contrôlable manuellement par les tests :
+ * `controller.tick()` invoque la callback enregistrée par le hook.
+ */
+function makeController() {
+  const fns = new Set<() => void>();
+  const scheduleTick = (fn: () => void): (() => void) => {
+    fns.add(fn);
+    return () => fns.delete(fn);
+  };
+  const tick = (): void => {
+    for (const fn of fns) fn();
+  };
+  return { scheduleTick, tick };
+}
+
+describe("useReplayClock — sprint 1.G.2", () => {
+  it("initialise sur currentMs=0, paused, vitesse 1×", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({ durationMs: 100_000, scheduleTick: ctrl.scheduleTick }),
+    );
+    expect(result.current.currentMs).toBe(0);
+    expect(result.current.playing).toBe(false);
+    expect(result.current.playbackSpeed).toBe(1);
+    expect(result.current.durationMs).toBe(100_000);
+  });
+
+  it("respecte initialMs et initialSpeed", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialMs: 30_000,
+        initialSpeed: 2,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    expect(result.current.currentMs).toBe(30_000);
+    expect(result.current.playbackSpeed).toBe(2);
+  });
+
+  it("clamp initialMs au range [0, durationMs]", () => {
+    const ctrl = makeController();
+    const { result: a } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialMs: -50,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    expect(a.current.currentMs).toBe(0);
+
+    const { result: b } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialMs: 999_999,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    expect(b.current.currentMs).toBe(100_000);
+  });
+
+  it("play() declenche playing=true et avance currentMs sur tick", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => {
+      result.current.play();
+    });
+    expect(result.current.playing).toBe(true);
+
+    // Avance la wall clock de 1s puis tick.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      ctrl.tick();
+    });
+    expect(result.current.currentMs).toBeGreaterThanOrEqual(900);
+    expect(result.current.currentMs).toBeLessThanOrEqual(1100);
+  });
+
+  it("playbackSpeed multiplie la progression", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialSpeed: 4,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => {
+      result.current.play();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      ctrl.tick();
+    });
+    // 1s wall × 4 = ~4s replay clock.
+    expect(result.current.currentMs).toBeGreaterThanOrEqual(3500);
+    expect(result.current.currentMs).toBeLessThanOrEqual(4500);
+  });
+
+  it("pause() arrete l'avancement", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.play());
+    act(() => {
+      vi.advanceTimersByTime(1000);
+      ctrl.tick();
+    });
+    const beforePause = result.current.currentMs;
+    act(() => result.current.pause());
+    expect(result.current.playing).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+      ctrl.tick();
+    });
+    expect(result.current.currentMs).toBe(beforePause);
+  });
+
+  it("auto-pause quand currentMs >= durationMs", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 1000,
+        initialSpeed: 8,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.play());
+    act(() => {
+      vi.advanceTimersByTime(500);
+      ctrl.tick();
+    });
+    expect(result.current.playing).toBe(false);
+    expect(result.current.currentMs).toBe(1000);
+  });
+
+  it("seek() clamp dans [0, durationMs]", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.seek(50_000));
+    expect(result.current.currentMs).toBe(50_000);
+    act(() => result.current.seek(-1));
+    expect(result.current.currentMs).toBe(0);
+    act(() => result.current.seek(999_999));
+    expect(result.current.currentMs).toBe(100_000);
+  });
+
+  it("setSpeed() change vitesse sans interrompre playing", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.play());
+    act(() => result.current.setSpeed(8));
+    expect(result.current.playbackSpeed).toBe(8);
+    expect(result.current.playing).toBe(true);
+  });
+
+  it("toggle() relance depuis 0 si on etait a la fin", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.toggle());
+    expect(result.current.playing).toBe(true);
+    expect(result.current.currentMs).toBe(0);
+  });
+
+  it("skipToEnd() sette currentMs=durationMs et pause", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.play());
+    act(() => result.current.skipToEnd());
+    expect(result.current.currentMs).toBe(100_000);
+    expect(result.current.playing).toBe(false);
+  });
+
+  it("restart() remet a 0 et redemarre", () => {
+    const ctrl = makeController();
+    const { result } = renderHook(() =>
+      useReplayClock({
+        durationMs: 100_000,
+        initialMs: 50_000,
+        scheduleTick: ctrl.scheduleTick,
+      }),
+    );
+    act(() => result.current.restart());
+    expect(result.current.currentMs).toBe(0);
+    expect(result.current.playing).toBe(true);
+  });
+});
+
+describe("formatReplayClock — sprint 1.G.2", () => {
+  it("0 -> 00:00", () => {
+    expect(formatReplayClock(0)).toBe("00:00");
+  });
+
+  it("65000 -> 01:05", () => {
+    expect(formatReplayClock(65_000)).toBe("01:05");
+  });
+
+  it("clamp negatives a 00:00", () => {
+    expect(formatReplayClock(-500)).toBe("00:00");
+  });
+
+  it("60s -> 01:00", () => {
+    expect(formatReplayClock(60_000)).toBe("01:00");
+  });
+
+  it("expose les vitesses standards", () => {
+    expect(PLAYBACK_SPEEDS).toEqual([0.5, 1, 2, 4, 8]);
+  });
+});

--- a/apps/web/app/lib/use-replay-clock.ts
+++ b/apps/web/app/lib/use-replay-clock.ts
@@ -1,0 +1,165 @@
+/**
+ * Pro League replay clock hook — sprint 1.G.2.
+ *
+ * State machine cote browser pour piloter un replay deja entierement
+ * charge en memoire (via `GET /pro-league/matches/:id/replay`, lot
+ * 1.G.1). Le hook tient `currentMs` et l'avance en temps reel selon
+ * `playbackSpeed`. Auto-stop a `durationMs`.
+ *
+ * Pure-ish : `tickFn` (default `requestAnimationFrame`) injectable pour
+ * tests deterministes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type PlaybackSpeed = 0.5 | 1 | 2 | 4 | 8;
+export const PLAYBACK_SPEEDS: readonly PlaybackSpeed[] = [0.5, 1, 2, 4, 8];
+
+export interface ReplayClockState {
+  readonly currentMs: number;
+  readonly playing: boolean;
+  readonly playbackSpeed: PlaybackSpeed;
+  readonly durationMs: number;
+}
+
+export interface ReplayClockControls {
+  readonly play: () => void;
+  readonly pause: () => void;
+  readonly toggle: () => void;
+  readonly seek: (ms: number) => void;
+  readonly setSpeed: (s: PlaybackSpeed) => void;
+  readonly skipToEnd: () => void;
+  readonly restart: () => void;
+}
+
+export interface UseReplayClockOptions {
+  readonly durationMs: number;
+  /** Initial currentMs (default 0). */
+  readonly initialMs?: number;
+  /** Initial playback speed (default 1×). */
+  readonly initialSpeed?: PlaybackSpeed;
+  /**
+   * Override frame scheduler. Production : `requestAnimationFrame`.
+   * Tests injectent un `setTimeout`-based driver pour avancer
+   * deterministiquement.
+   */
+  readonly scheduleTick?: (fn: () => void) => () => void;
+}
+
+const DEFAULT_TICK_INTERVAL_MS = 100;
+
+function defaultScheduleTick(fn: () => void): () => void {
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    let raf = window.requestAnimationFrame(function loop() {
+      fn();
+      raf = window.requestAnimationFrame(loop);
+    });
+    return () => window.cancelAnimationFrame(raf);
+  }
+  const id = setInterval(fn, DEFAULT_TICK_INTERVAL_MS);
+  return () => clearInterval(id);
+}
+
+export function useReplayClock(
+  opts: UseReplayClockOptions,
+): ReplayClockState & ReplayClockControls {
+  const durationMs = Math.max(0, opts.durationMs);
+  const [currentMs, setCurrentMs] = useState<number>(
+    Math.min(durationMs, Math.max(0, opts.initialMs ?? 0)),
+  );
+  const [playing, setPlaying] = useState<boolean>(false);
+  const [playbackSpeed, setPlaybackSpeed] = useState<PlaybackSpeed>(
+    opts.initialSpeed ?? 1,
+  );
+
+  const lastWallMsRef = useRef<number | null>(null);
+  const scheduleTick = opts.scheduleTick ?? defaultScheduleTick;
+
+  // Tick loop : avance currentMs tant que playing=true.
+  useEffect(() => {
+    if (!playing) {
+      lastWallMsRef.current = null;
+      return undefined;
+    }
+    lastWallMsRef.current = Date.now();
+    const cancel = scheduleTick(() => {
+      const now = Date.now();
+      const last = lastWallMsRef.current ?? now;
+      const wallDelta = Math.max(0, now - last);
+      lastWallMsRef.current = now;
+      setCurrentMs((prev) => {
+        const next = prev + wallDelta * playbackSpeed;
+        if (next >= durationMs) {
+          // Atteint la fin : pause auto + clamp.
+          setPlaying(false);
+          return durationMs;
+        }
+        return next;
+      });
+    });
+    return cancel;
+  }, [playing, playbackSpeed, durationMs, scheduleTick]);
+
+  const play = useCallback(() => {
+    setPlaying((p) => {
+      // Si on relance depuis la fin, on revient au debut.
+      if (!p) {
+        setCurrentMs((c) => (c >= durationMs ? 0 : c));
+      }
+      return true;
+    });
+  }, [durationMs]);
+
+  const pause = useCallback(() => setPlaying(false), []);
+
+  const toggle = useCallback(() => {
+    setPlaying((p) => {
+      if (!p) {
+        setCurrentMs((c) => (c >= durationMs ? 0 : c));
+      }
+      return !p;
+    });
+  }, [durationMs]);
+
+  const seek = useCallback(
+    (ms: number) => {
+      const clamped = Math.max(0, Math.min(durationMs, ms));
+      setCurrentMs(clamped);
+    },
+    [durationMs],
+  );
+
+  const setSpeed = useCallback((s: PlaybackSpeed) => setPlaybackSpeed(s), []);
+
+  const skipToEnd = useCallback(() => {
+    setPlaying(false);
+    setCurrentMs(durationMs);
+  }, [durationMs]);
+
+  const restart = useCallback(() => {
+    setCurrentMs(0);
+    setPlaying(true);
+  }, []);
+
+  return {
+    currentMs,
+    playing,
+    playbackSpeed,
+    durationMs,
+    play,
+    pause,
+    toggle,
+    seek,
+    setSpeed,
+    skipToEnd,
+    restart,
+  };
+}
+
+/** Format `currentMs` en `MM:SS`. */
+export function formatReplayClock(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Sprint 1.G.2 — Tests `<MatchReplayPlayer>`.
+ *
+ * Mocke `apiRequest` pour fournir un dump synthetique et `ProLeagueField`
+ * pour eviter de charger Pixi en jsdom.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+vi.mock("../../../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+}));
+
+// Stub le ProLeagueField (chargee via next/dynamic) pour eviter Pixi.
+vi.mock("../live/ProLeagueField", () => ({
+  default: () => <div data-testid="field-stub" />,
+}));
+
+// Stub next/dynamic pour reexporter direct le module (evite le wrapping
+// async qui ne resout pas en jsdom).
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    return function DynamicStub() {
+      return <div data-testid="field-stub" />;
+    };
+  },
+}));
+
+import { apiRequest } from "../../../../lib/api-client";
+import MatchReplayPlayer from "./MatchReplayPlayer";
+
+const mockedRequest = vi.mocked(apiRequest);
+
+const FIXTURE_EVENTS: MatchEvent[] = [
+  {
+    type: "KICKOFF",
+    displayAtMs: 0,
+    engineVer: "0.13.0",
+    meta: { home: "home", away: "away", weather: "nice" },
+  },
+  {
+    type: "TURN_START",
+    displayAtMs: 30_000,
+    engineVer: "0.13.0",
+    meta: { half: 1, turn: 1, drivingTeam: "away", ballYardline: 4 },
+  },
+  {
+    type: "TD",
+    displayAtMs: 90_000,
+    engineVer: "0.13.0",
+    meta: { team: "away", scoreAfter: { home: 0, away: 1 } },
+  },
+  {
+    type: "HALFTIME",
+    displayAtMs: 240_000,
+    engineVer: "0.13.0",
+    meta: { score: { home: 0, away: 1 } },
+  },
+  {
+    type: "TD",
+    displayAtMs: 480_000,
+    engineVer: "0.13.0",
+    meta: { team: "home", scoreAfter: { home: 1, away: 1 } },
+  },
+  {
+    type: "END",
+    displayAtMs: 600_000,
+    engineVer: "0.13.0",
+    meta: { score: { home: 1, away: 1 } },
+  },
+];
+
+const FIXTURE_DUMP = {
+  matchId: "m1",
+  status: "completed",
+  durationMs: 600_000,
+  eventCount: FIXTURE_EVENTS.length,
+  events: FIXTURE_EVENTS,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("<MatchReplayPlayer> — sprint 1.G.2", () => {
+  it("affiche un loading initial", () => {
+    mockedRequest.mockReturnValue(new Promise(() => {})); // never resolve
+    render(<MatchReplayPlayer matchId="m1" />);
+    expect(screen.getByTestId("replay-loading")).toBeTruthy();
+  });
+
+  it("affiche une erreur si la fetch echoue", async () => {
+    mockedRequest.mockRejectedValue(new Error("server down"));
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("replay-error").textContent).toContain(
+      "server down",
+    );
+  });
+
+  it("rend score 0-0 au mount (currentMs=0, avant les TDs)", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("replay-score").textContent).toContain("0 – 0");
+    expect(screen.getByTestId("replay-half").textContent).toContain("1st half");
+  });
+
+  it("affiche durationMs format MM:SS dans le scrubber", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("replay-duration").textContent).toBe("10:00");
+    expect(screen.getByTestId("replay-current-time").textContent).toBe("00:00");
+  });
+
+  it("seek via scrub bar update score si TD passe", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const scrub = screen.getByTestId("replay-scrub") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(scrub, { target: { value: "120000" } });
+    });
+    // 120s > TD #1 (90s) -> 0-1
+    expect(screen.getByTestId("replay-score").textContent).toContain("0 – 1");
+  });
+
+  it("skip-to-end affiche le score final + half=FT", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("replay-skip-end"));
+    });
+    expect(screen.getByTestId("replay-score").textContent).toContain("1 – 1");
+    expect(screen.getByTestId("replay-half").textContent).toContain("FT");
+    expect(screen.getByTestId("replay-current-time").textContent).toBe("10:00");
+  });
+
+  it("toggle play/pause met aria-pressed sur le bouton", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const toggle = screen.getByTestId("replay-toggle");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("speed selector marque la vitesse active", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      screen.getByTestId("replay-speed-1").getAttribute("aria-pressed"),
+    ).toBe("true");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("replay-speed-4"));
+    });
+    expect(
+      screen.getByTestId("replay-speed-4").getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByTestId("replay-speed-1").getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("event feed contient kickoff visible meme a currentMs=0", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const feed = screen.getByTestId("replay-event-feed");
+    expect(feed.textContent).toContain("KICKOFF");
+  });
+
+  it("event feed reverse-chronologique apres skip-to-end", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("replay-skip-end"));
+    });
+    const feed = screen.getByTestId("replay-event-feed");
+    const items = feed.querySelectorAll("li");
+    // Le 1er item de la liste = dernier event (END), le dernier item = KICKOFF.
+    expect(items[0].textContent).toContain("END");
+    expect(items[items.length - 1].textContent).toContain("KICKOFF");
+  });
+});

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState } from "react";
+
+import type { MatchEvent } from "@bb/shared-types";
+
+import { apiRequest } from "../../../../lib/api-client";
+import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
+import {
+  PLAYBACK_SPEEDS,
+  type PlaybackSpeed,
+  formatReplayClock,
+  useReplayClock,
+} from "../../../../lib/use-replay-clock";
+
+/**
+ * Sprint 1.G.2 — Player de replay Pro League.
+ *
+ * Charge le dump complet via `/pro-league/matches/:id/replay` (lot 1.G.1)
+ * puis pilote l'avancement cote browser : play/pause, scrub bar, controls
+ * de vitesse 0.5/1/2/4/8×, skip-to-end, restart.
+ *
+ * Re-utilise `<ProLeagueField>` (Pixi) + `deriveProLeagueFieldState`
+ * (pure) en filtrant les events `displayAtMs <= currentMs`.
+ *
+ * Markers (TD/CAS/NUFFLE) et keyboard shortcuts arrivent en 1.G.4 / 1.G.5.
+ */
+
+// Lazy-load Pixi (>500KB) — meme pattern que /live.
+const ProLeagueField = dynamic(
+  () =>
+    import("../live/ProLeagueField").then((m) => m.default),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="aspect-[3/1] w-full animate-pulse rounded bg-slate-800/60"
+        aria-label="Chargement du terrain"
+      />
+    ),
+  },
+);
+
+interface ReplayDump {
+  readonly matchId: string;
+  readonly status: string;
+  readonly durationMs: number;
+  readonly eventCount: number;
+  readonly events: readonly MatchEvent[];
+}
+
+interface PlayerProps {
+  readonly matchId: string;
+}
+
+const EVENT_BADGE_STYLES: Record<string, string> = {
+  KICKOFF: "bg-slate-700 text-slate-100",
+  TURN_START: "bg-slate-800 text-slate-300",
+  BLOCK: "bg-amber-900 text-amber-100",
+  DODGE: "bg-sky-900 text-sky-100",
+  PASS: "bg-blue-900 text-blue-100",
+  TD: "bg-emerald-700 text-emerald-50 font-semibold",
+  KO: "bg-orange-900 text-orange-100",
+  CASUALTY: "bg-red-700 text-red-50 font-semibold",
+  TURNOVER: "bg-rose-900 text-rose-100",
+  NUFFLE: "bg-purple-700 text-purple-50 font-semibold",
+  HALFTIME: "bg-indigo-900 text-indigo-100",
+  END: "bg-slate-900 text-slate-100 font-semibold",
+};
+
+function summarizeMeta(ev: MatchEvent): string {
+  const meta = (ev.meta ?? {}) as Record<string, unknown>;
+  switch (ev.type) {
+    case "KICKOFF": {
+      const home = String(meta.homeName ?? meta.home ?? "home");
+      const away = String(meta.awayName ?? meta.away ?? "away");
+      return `${home} vs ${away}`;
+    }
+    case "TURN_START": {
+      const half = meta.half;
+      const turn = meta.turn;
+      const drivingTeam = String(meta.drivingTeam ?? "");
+      return `Half ${half ?? ""} · Turn ${turn ?? ""}${drivingTeam ? ` · ${drivingTeam}` : ""}`;
+    }
+    case "TD": {
+      const team = String(meta.team ?? "");
+      return `TOUCHDOWN ${team.toUpperCase()}`;
+    }
+    case "CASUALTY": {
+      const cause = meta.causedBy ? ` (${String(meta.causedBy)})` : "";
+      return `Casualty${cause}`;
+    }
+    case "NUFFLE": {
+      const id = meta.id ?? meta.eventId ?? "?";
+      return `Nuffle: ${String(id)}`;
+    }
+    case "HALFTIME":
+      return "Halftime";
+    case "END":
+      return "Match end";
+    default:
+      return ev.type;
+  }
+}
+
+function deriveScore(events: readonly MatchEvent[]): {
+  home: number;
+  away: number;
+  half: 1 | 2 | "final";
+} {
+  let home = 0;
+  let away = 0;
+  let half: 1 | 2 | "final" = 1;
+  for (const ev of events) {
+    if (ev.type === "TD") {
+      const team = (ev.meta as { team?: string } | undefined)?.team;
+      if (team === "home") home += 1;
+      else if (team === "away") away += 1;
+    } else if (ev.type === "HALFTIME") {
+      half = 2;
+    } else if (ev.type === "END") {
+      half = "final";
+    }
+  }
+  return { home, away, half };
+}
+
+interface ControlsProps {
+  readonly playing: boolean;
+  readonly playbackSpeed: PlaybackSpeed;
+  readonly onToggle: () => void;
+  readonly onSpeedChange: (s: PlaybackSpeed) => void;
+  readonly onSkipToEnd: () => void;
+  readonly onRestart: () => void;
+}
+
+function PlayerControls({
+  playing,
+  playbackSpeed,
+  onToggle,
+  onSpeedChange,
+  onSkipToEnd,
+  onRestart,
+}: ControlsProps): JSX.Element {
+  return (
+    <div
+      data-testid="replay-controls"
+      className="flex items-center gap-2"
+    >
+      <button
+        type="button"
+        onClick={onRestart}
+        aria-label="Restart"
+        data-testid="replay-restart"
+        className="rounded border border-slate-700 px-2 py-1 text-sm text-slate-300 hover:bg-slate-800"
+      >
+        ⏮
+      </button>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label={playing ? "Pause" : "Play"}
+        aria-pressed={playing}
+        data-testid="replay-toggle"
+        className="rounded bg-emerald-700 px-3 py-1 text-sm font-semibold text-emerald-50 hover:bg-emerald-600"
+      >
+        {playing ? "⏸" : "▶"}
+      </button>
+      <button
+        type="button"
+        onClick={onSkipToEnd}
+        aria-label="Skip to end"
+        data-testid="replay-skip-end"
+        className="rounded border border-slate-700 px-2 py-1 text-sm text-slate-300 hover:bg-slate-800"
+      >
+        ⏭
+      </button>
+      <div
+        role="group"
+        aria-label="Playback speed"
+        data-testid="replay-speed-group"
+        className="ml-2 flex items-center gap-1 rounded border border-slate-800 bg-slate-900 p-0.5"
+      >
+        {PLAYBACK_SPEEDS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onSpeedChange(s)}
+            aria-pressed={playbackSpeed === s}
+            data-testid={`replay-speed-${s}`}
+            className={`rounded px-2 py-0.5 text-xs font-mono ${
+              playbackSpeed === s
+                ? "bg-emerald-700 text-emerald-50"
+                : "text-slate-400 hover:bg-slate-800"
+            }`}
+          >
+            {s}×
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function MatchReplayPlayer({
+  matchId,
+}: PlayerProps): JSX.Element {
+  const [dump, setDump] = useState<ReplayDump | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiRequest<ReplayDump>(
+      `/pro-league/matches/${encodeURIComponent(matchId)}/replay`,
+    )
+      .then((d) => {
+        if (cancelled) return;
+        setDump(d);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "fetch error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [matchId]);
+
+  const durationMs = dump?.durationMs ?? 0;
+  const clock = useReplayClock({ durationMs });
+
+  const visibleEvents = useMemo(() => {
+    if (!dump) return [];
+    return dump.events.filter((ev) => ev.displayAtMs <= clock.currentMs);
+  }, [dump, clock.currentMs]);
+
+  const fieldState = useMemo(
+    () => deriveProLeagueFieldState(visibleEvents),
+    [visibleEvents],
+  );
+  const score = useMemo(() => deriveScore(visibleEvents), [visibleEvents]);
+
+  if (error) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+        <p
+          role="alert"
+          data-testid="replay-error"
+          className="rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+        >
+          {error}
+        </p>
+      </main>
+    );
+  }
+
+  if (!dump) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+        <p data-testid="replay-loading" className="text-sm text-slate-400">
+          Chargement du replay…
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
+      <header
+        data-testid="replay-header"
+        className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-4 py-3 shadow"
+      >
+        <span
+          data-testid="replay-half"
+          className="font-mono text-sm text-slate-400"
+        >
+          {score.half === "final"
+            ? "FT"
+            : score.half === 1
+              ? "1st half"
+              : "2nd half"}
+        </span>
+        <span
+          data-testid="replay-score"
+          className="font-mono text-2xl font-bold tracking-wide"
+        >
+          {score.home} – {score.away}
+        </span>
+      </header>
+
+      <div className="px-4 pt-4" data-testid="replay-field-wrapper">
+        <ProLeagueField fieldState={fieldState} />
+      </div>
+
+      <section
+        data-testid="replay-scrubber"
+        className="px-4 py-3 flex flex-col gap-2"
+      >
+        <div className="flex items-center justify-between font-mono text-xs text-slate-400">
+          <span data-testid="replay-current-time">
+            {formatReplayClock(clock.currentMs)}
+          </span>
+          <span data-testid="replay-duration">
+            {formatReplayClock(durationMs)}
+          </span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={durationMs}
+          step={500}
+          value={clock.currentMs}
+          onChange={(e) => clock.seek(Number(e.target.value))}
+          aria-label="Scrub replay"
+          data-testid="replay-scrub"
+          className="w-full accent-emerald-500"
+        />
+        <PlayerControls
+          playing={clock.playing}
+          playbackSpeed={clock.playbackSpeed}
+          onToggle={clock.toggle}
+          onSpeedChange={clock.setSpeed}
+          onSkipToEnd={clock.skipToEnd}
+          onRestart={clock.restart}
+        />
+      </section>
+
+      <ol
+        data-testid="replay-event-feed"
+        className="flex flex-1 flex-col gap-1 px-4 py-3"
+      >
+        {visibleEvents.length === 0 ? (
+          <li className="text-sm text-slate-500">En attente du kickoff…</li>
+        ) : (
+          visibleEvents
+            .slice()
+            .reverse()
+            .map((ev, idx) => (
+              <li
+                key={`${visibleEvents.length - 1 - idx}-${ev.type}-${ev.displayAtMs}`}
+                className="flex items-start gap-3 rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm"
+              >
+                <span className="font-mono text-xs text-slate-500">
+                  {formatReplayClock(ev.displayAtMs)}
+                </span>
+                <span
+                  className={`rounded px-2 py-0.5 text-xs font-mono ${EVENT_BADGE_STYLES[ev.type] ?? "bg-slate-700 text-slate-100"}`}
+                >
+                  {ev.type}
+                </span>
+                <span className="flex-1 text-slate-200">
+                  {summarizeMeta(ev)}
+                </span>
+              </li>
+            ))
+        )}
+      </ol>
+    </main>
+  );
+}

--- a/apps/web/app/pro-league/matches/[id]/replay/layout.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Replay du match | Pro League | Nuffle Arena",
+  description:
+    "Rejoue un match Pro League avec controles play/pause, scrub bar et vitesse 0.5/1/2/4/8×. Analyse les drives, retrouve un moment cle, partage un timecode.",
+};
+
+export default function ReplayLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/matches/[id]/replay/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import MatchReplayPlayer from "./MatchReplayPlayer";
+
+interface ReplayPageProps {
+  readonly params: { id: string };
+}
+
+/**
+ * Sprint 1.G.2 — Page replay d'un match Pro League completed.
+ *
+ * Consomme `/pro-league/matches/:id/replay` et permet la lecture
+ * controlee via play/pause/scrub/speed. Pour les matchs en cours,
+ * le hub redirige vers `/live` (logique 1.G.3).
+ */
+export default function MatchReplayPage({
+  params,
+}: ReplayPageProps): JSX.Element {
+  return <MatchReplayPlayer matchId={params.id} />;
+}


### PR DESCRIPTION
## Sprint 1.G.2 — `<MatchReplayPlayer>` controls + scrub bar

Deuxième lot phase 1.G (Replay Player). Consomme l'endpoint dump (1.G.1) et délivre le contrôle complet de lecture côté browser.

### Hook `useReplayClock`

Pure state machine pour piloter un replay préchargé :

| Action | Effet |
|---|---|
| `play()` / `pause()` / `toggle()` | start/stop la wall-clock advance |
| `seek(ms)` | clamp `[0, durationMs]` |
| `setSpeed(s)` | 0.5× / 1× / 2× / 4× / 8× sans interrompre playing |
| `skipToEnd()` | currentMs = durationMs + pause |
| `restart()` | currentMs = 0 + play |

Auto-pause à `durationMs`. `scheduleTick` injectable (rAF en prod, controllé en tests).

Helper `formatReplayClock(ms)` → `MM:SS`.

### Component `<MatchReplayPlayer>`

- Fetch `/pro-league/matches/:id/replay` au mount.
- Scrub bar (`<input type="range">` step 500ms) → seek live.
- Controls bar :
  - ⏮ restart, ⏯ toggle (aria-pressed), ⏭ skip-to-end
  - Speed selector groupe 5 boutons (aria-pressed)
- Réutilise `<ProLeagueField>` (Pixi lazy-load) + `deriveProLeagueFieldState` avec events filtrés `displayAtMs <= currentMs`.
- Header sticky avec score live + half (`1st half / 2nd half / FT`).
- Ticker reverse-chronologique des events visibles.
- Loading + error states.

Route : `/pro-league/matches/:id/replay` + layout SEO metadata.

### Tests

```
✓ use-replay-clock.test.ts (17 tests)
✓ MatchReplayPlayer.test.tsx (10 tests)
Test Files  2 passed
     Tests 27 passed (27)
```

Couvre : init/clamp/play/pause/seek/skipToEnd/restart sur le hook ; loading/error/score/scrub seek/skip-to-end/toggle aria/speed pressed/ticker order sur le composant.

### Ce qui reste pour 1.G

- 1.G.3 : détection auto LIVE vs REPLAY mode dans `/live` (redirect intelligent selon `match.status`)
- 1.G.4 : markers TD/CAS/NUFFLE visibles sur la scrub bar
- 1.G.5 : keyboard shortcuts (space, ←→, shift+←→) + Playwright spec

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_