### PR TITLE
feat(web): auto LIVE vs REPLAY mode redirect (sprint 1.G.3)

### DIFF
--- a/apps/web/app/lib/use-match-mode-redirect.test.ts
+++ b/apps/web/app/lib/use-match-mode-redirect.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Sprint 1.G.3 — Tests `useMatchModeRedirect`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("./api-client", () => ({
+  apiRequest: vi.fn(),
+}));
+
+const mockReplace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+import { apiRequest } from "./api-client";
+import { useMatchModeRedirect } from "./use-match-mode-redirect";
+
+const mockedRequest = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useMatchModeRedirect — sprint 1.G.3", () => {
+  it("ne redirige pas si on est sur /live et que status='in_progress'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "in_progress" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "live"));
+    await waitFor(() => expect(result.current.status).toBe("in_progress"));
+    expect(result.current.redirecting).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("ne redirige pas si on est sur /replay et que status='completed'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "completed" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "replay"));
+    await waitFor(() => expect(result.current.status).toBe("completed"));
+    expect(result.current.redirecting).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("redirige /live -> /replay si status='completed'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "completed" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "live"));
+    await waitFor(() => expect(result.current.redirecting).toBe(true));
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/pro-league/matches/m1/replay",
+    );
+  });
+
+  it("redirige /replay -> /live si status='in_progress'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "in_progress" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "replay"));
+    await waitFor(() => expect(result.current.redirecting).toBe(true));
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/pro-league/matches/m1/live",
+    );
+  });
+
+  it("redirige vers la page parent si status='scheduled'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "scheduled" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "live"));
+    await waitFor(() => expect(result.current.redirecting).toBe(true));
+    expect(mockReplace).toHaveBeenCalledWith("/pro-league/matches/m1");
+  });
+
+  it("redirige vers la page parent si status='ready'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "ready" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "replay"));
+    await waitFor(() => expect(result.current.redirecting).toBe(true));
+    expect(mockReplace).toHaveBeenCalledWith("/pro-league/matches/m1");
+  });
+
+  it("redirige vers la page parent si status='failed'", async () => {
+    mockedRequest.mockResolvedValue({ id: "m1", status: "failed" });
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "replay"));
+    await waitFor(() => expect(result.current.redirecting).toBe(true));
+    expect(mockReplace).toHaveBeenCalledWith("/pro-league/matches/m1");
+  });
+
+  it("expose error sur fetch fail", async () => {
+    mockedRequest.mockRejectedValue(new Error("404 not found"));
+    const { result } = renderHook(() => useMatchModeRedirect("m1", "live"));
+    await waitFor(() =>
+      expect(result.current.error).toBe("404 not found"),
+    );
+    expect(result.current.redirecting).toBe(false);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/lib/use-match-mode-redirect.ts
+++ b/apps/web/app/lib/use-match-mode-redirect.ts
@@ -1,0 +1,80 @@
+/**
+ * Sprint 1.G.3 — Hook auto-redirect entre `/live` et `/replay`.
+ *
+ * Logique :
+ *  - Mode `live` est valide quand `match.status === 'in_progress'`.
+ *  - Mode `replay` est valide quand `match.status === 'completed'`.
+ *  - Si l'utilisateur arrive sur le mauvais mode, on `router.replace()`
+ *    vers le bon URL pour ne pas polluer l'historique.
+ *  - Sur un `scheduled` / `ready` / `failed` on redirige vers la page
+ *    parent `/pro-league/matches/:id` (info pre-match / erreur).
+ *
+ * Le hook fait sa propre fetch leger sur `/pro-league/matches/:id` (la
+ * route hub renvoie deja le status).
+ */
+
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "./api-client";
+
+export type MatchMode = "live" | "replay";
+
+interface MinimalMatch {
+  readonly id: string;
+  readonly status: string;
+}
+
+export interface MatchModeRedirectResult {
+  readonly redirecting: boolean;
+  readonly status: string | null;
+  readonly error: string | null;
+}
+
+function targetPathFor(matchId: string, status: string): string | null {
+  if (status === "in_progress") return `/pro-league/matches/${matchId}/live`;
+  if (status === "completed") return `/pro-league/matches/${matchId}/replay`;
+  // scheduled / ready / failed -> page parent (info pre-match / erreur).
+  return `/pro-league/matches/${matchId}`;
+}
+
+export function useMatchModeRedirect(
+  matchId: string,
+  expectedMode: MatchMode,
+): MatchModeRedirectResult {
+  const router = useRouter();
+  const [status, setStatus] = useState<string | null>(null);
+  const [redirecting, setRedirecting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiRequest<MinimalMatch>(
+      `/pro-league/matches/${encodeURIComponent(matchId)}`,
+    )
+      .then((m) => {
+        if (cancelled) return;
+        setStatus(m.status);
+        const expected =
+          expectedMode === "live" ? "in_progress" : "completed";
+        if (m.status !== expected) {
+          const target = targetPathFor(matchId, m.status);
+          if (target) {
+            setRedirecting(true);
+            router.replace(target);
+          }
+        }
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "fetch error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [matchId, expectedMode, router]);
+
+  return { redirecting, status, error };
+}

--- a/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.test.tsx
@@ -13,6 +13,14 @@ vi.mock("../../../../lib/use-pro-league-match-stream", () => ({
   useProLeagueMatchStream: vi.fn(),
 }));
 
+vi.mock("../../../../lib/use-match-mode-redirect", () => ({
+  useMatchModeRedirect: () => ({
+    redirecting: false,
+    status: "in_progress",
+    error: null,
+  }),
+}));
+
 import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
 import LiveProMatchPage from "./page";
 

--- a/apps/web/app/pro-league/matches/[id]/live/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import type { MatchEvent } from "@bb/shared-types";
 
 import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
+import { useMatchModeRedirect } from "../../../../lib/use-match-mode-redirect";
 import { useProLeagueMatchStream } from "../../../../lib/use-pro-league-match-stream";
 
 // Lazy-load Pixi (>500KB) — même pattern que /play et /spectate PvP.
@@ -153,12 +154,23 @@ function ConnectionBadge({
 export default function LiveProMatchPage({
   params,
 }: LivePageProps): JSX.Element {
+  const redirect = useMatchModeRedirect(params.id, "live");
   const { events, connectionState, error } = useProLeagueMatchStream(params.id);
   const score = useMemo(() => deriveScore(events), [events]);
   const fieldState = useMemo(
     () => deriveProLeagueFieldState(events),
     [events],
   );
+
+  if (redirect.redirecting) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+        <p data-testid="live-redirecting" className="text-sm text-slate-400">
+          Redirection vers le replay…
+        </p>
+      </main>
+    );
+  }
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">

--- a/apps/web/app/pro-league/matches/[id]/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/page.tsx
@@ -288,7 +288,7 @@ function PostMatchCard({ match }: { match: MatchDetail }): JSX.Element {
       ) : null}
 
       <Link
-        href={`/pro-league/matches/${match.id}/live`}
+        href={`/pro-league/matches/${match.id}/replay`}
         className="inline-block rounded bg-slate-800 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700"
       >
         Revoir le replay →

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
@@ -14,6 +14,10 @@ vi.mock("../../../../lib/api-client", () => ({
   apiRequest: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
 // Stub le ProLeagueField (chargee via next/dynamic) pour eviter Pixi.
 vi.mock("../live/ProLeagueField", () => ({
   default: () => <div data-testid="field-stub" />,

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
@@ -7,6 +7,7 @@ import type { MatchEvent } from "@bb/shared-types";
 
 import { apiRequest } from "../../../../lib/api-client";
 import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
+import { useMatchModeRedirect } from "../../../../lib/use-match-mode-redirect";
 import {
   PLAYBACK_SPEEDS,
   type PlaybackSpeed,
@@ -206,10 +207,13 @@ function PlayerControls({
 export default function MatchReplayPlayer({
   matchId,
 }: PlayerProps): JSX.Element {
+  const redirect = useMatchModeRedirect(matchId, "replay");
   const [dump, setDump] = useState<ReplayDump | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (redirect.redirecting) return;
+    if (redirect.status !== null && redirect.status !== "completed") return;
     let cancelled = false;
     apiRequest<ReplayDump>(
       `/pro-league/matches/${encodeURIComponent(matchId)}/replay`,
@@ -225,7 +229,17 @@ export default function MatchReplayPlayer({
     return () => {
       cancelled = true;
     };
-  }, [matchId]);
+  }, [matchId, redirect.redirecting, redirect.status]);
+
+  if (redirect.redirecting) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
+        <p data-testid="replay-redirecting" className="text-sm text-slate-400">
+          Redirection vers le mode adapte…
+        </p>
+      </main>
+    );
+  }
 
   const durationMs = dump?.durationMs ?? 0;
   const clock = useReplayClock({ durationMs });


### PR DESCRIPTION
## Sprint 1.G.3 — Auto LIVE vs REPLAY redirect

Troisième lot phase 1.G. Auto-route les utilisateurs vers le bon mode (`/live` ou `/replay`) selon `match.status`.

### Hook `useMatchModeRedirect(matchId, expectedMode)`

Fetch léger sur `/pro-league/matches/:id` puis `router.replace()` si mauvais mode :

| match.status | mode attendu live | mode attendu replay |
|---|---|---|
| `in_progress` | ✅ stay | → `/live` |
| `completed` | → `/replay` | ✅ stay |
| `scheduled` / `ready` / `failed` | → page parent | → page parent |

`router.replace()` (pas `push`) pour ne pas polluer l'historique.

### Intégration

- **`/pro-league/matches/[id]/live`** : si match a switché vers `completed`, redirect automatique vers `/replay`. Affiche "Redirection..." pendant la transition.
- **`/pro-league/matches/[id]/replay`** : si match est `in_progress` (ou autre), redirect. Skip la fetch du dump tant que status≠`completed`.
- **Post-match link** sur `/pro-league/matches/[id]` : `/live` → `/replay`.

### Tests

```
✓ use-match-mode-redirect.test.ts (8 tests)
✓ live/page.test.tsx (7 tests existants)
✓ replay/MatchReplayPlayer.test.tsx (10 tests existants)
✓ matches/[id]/page.test.tsx (8 tests existants)
Test Files 4 passed (4)
     Tests 33 passed (33)
```

Couvre : 6 cas de status (in_progress / completed / scheduled / ready / failed × live / replay), error path, mocks ajoutés aux tests live/replay existants.

### Sequel

- 1.G.4 : markers TD/CAS/NUFFLE sur la scrub bar
- 1.G.5 : keyboard shortcuts + Playwright spec

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_