### PR TITLE
feat(web): TD/CASUALTY/NUFFLE markers on replay scrub bar (sprint 1.G.4)

### DIFF
--- a/apps/web/app/lib/replay-scrub-markers.test.ts
+++ b/apps/web/app/lib/replay-scrub-markers.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Sprint 1.G.4 — Tests `buildScrubMarkers`.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MatchEvent } from "@bb/shared-types";
+
+import { buildScrubMarkers } from "./replay-scrub-markers";
+
+function ev(
+  type: string,
+  displayAtMs: number,
+  meta: Record<string, unknown> = {},
+): MatchEvent {
+  return { type: type as MatchEvent["type"], displayAtMs, engineVer: "0.13.0", meta };
+}
+
+describe("buildScrubMarkers — sprint 1.G.4", () => {
+  it("renvoie [] si durationMs <= 0", () => {
+    expect(
+      buildScrubMarkers({
+        events: [ev("TD", 0)],
+        durationMs: 0,
+      }),
+    ).toEqual([]);
+    expect(
+      buildScrubMarkers({
+        events: [ev("TD", 0)],
+        durationMs: -1,
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignore les types non-marker (KICKOFF, BLOCK, etc.)", () => {
+    const out = buildScrubMarkers({
+      events: [
+        ev("KICKOFF", 0),
+        ev("TURN_START", 30_000),
+        ev("BLOCK", 35_000),
+        ev("TD", 90_000, { team: "home" }),
+        ev("PASS", 100_000),
+      ],
+      durationMs: 600_000,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("TD");
+  });
+
+  it("calcule percent comme displayAtMs / durationMs * 100", () => {
+    const out = buildScrubMarkers({
+      events: [ev("TD", 60_000, { team: "home" })],
+      durationMs: 600_000,
+    });
+    expect(out[0].percent).toBeCloseTo(10);
+  });
+
+  it("clamp percent a [0, 100]", () => {
+    const out = buildScrubMarkers({
+      events: [
+        ev("TD", -500, { team: "home" }),
+        ev("CASUALTY", 1_000_000),
+      ],
+      durationMs: 600_000,
+    });
+    expect(out[0].percent).toBe(0);
+    expect(out[1].percent).toBe(100);
+  });
+
+  it("trie par displayAtMs ascending", () => {
+    const out = buildScrubMarkers({
+      events: [
+        ev("TD", 480_000, { team: "home" }),
+        ev("NUFFLE", 90_000, { id: "fog_rolls_in" }),
+        ev("CASUALTY", 200_000),
+      ],
+      durationMs: 600_000,
+    });
+    expect(out.map((m) => m.type)).toEqual(["NUFFLE", "CASUALTY", "TD"]);
+  });
+
+  it("preserve eventIndex de l'array d'origine (pour scroll-to)", () => {
+    const events = [
+      ev("KICKOFF", 0),
+      ev("TURN_START", 30_000),
+      ev("TD", 90_000, { team: "home" }),
+      ev("BLOCK", 100_000),
+      ev("CASUALTY", 200_000),
+    ];
+    const out = buildScrubMarkers({ events, durationMs: 600_000 });
+    expect(out.find((m) => m.type === "TD")?.eventIndex).toBe(2);
+    expect(out.find((m) => m.type === "CASUALTY")?.eventIndex).toBe(4);
+  });
+
+  it("label TD inclut le team en MAJ", () => {
+    const out = buildScrubMarkers({
+      events: [ev("TD", 90_000, { team: "home" })],
+      durationMs: 600_000,
+    });
+    expect(out[0].label).toBe("TOUCHDOWN HOME");
+  });
+
+  it("label TD sans team -> 'TOUCHDOWN'", () => {
+    const out = buildScrubMarkers({
+      events: [ev("TD", 90_000)],
+      durationMs: 600_000,
+    });
+    expect(out[0].label).toBe("TOUCHDOWN");
+  });
+
+  it("label CASUALTY inclut causedBy si fourni", () => {
+    const out = buildScrubMarkers({
+      events: [ev("CASUALTY", 200_000, { causedBy: "banana_skin" })],
+      durationMs: 600_000,
+    });
+    expect(out[0].label).toBe("Casualty (banana_skin)");
+  });
+
+  it("label NUFFLE inclut id", () => {
+    const out = buildScrubMarkers({
+      events: [ev("NUFFLE", 100_000, { id: "fog_rolls_in" })],
+      durationMs: 600_000,
+    });
+    expect(out[0].label).toBe("Nuffle: fog_rolls_in");
+  });
+
+  it("renvoie [] sur events vide", () => {
+    expect(buildScrubMarkers({ events: [], durationMs: 600_000 })).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/web/app/lib/replay-scrub-markers.ts
+++ b/apps/web/app/lib/replay-scrub-markers.ts
@@ -1,0 +1,82 @@
+/**
+ * Sprint 1.G.4 — Builder pure des markers de scrub bar pour replays.
+ *
+ * Extrait les events "key moments" (TD / CASUALTY / NUFFLE) d'un dump
+ * de replay et les positionne en pourcentage de la duration totale,
+ * pour rendu dans la UI scrub bar.
+ *
+ * Pure — pas de React, pas de DOM. Testable sans render.
+ */
+
+import type { MatchEvent } from "@bb/shared-types";
+
+export type ScrubMarkerType = "TD" | "CASUALTY" | "NUFFLE";
+
+export interface ScrubMarker {
+  readonly type: ScrubMarkerType;
+  readonly displayAtMs: number;
+  /** Position 0..100 sur la scrub bar. */
+  readonly percent: number;
+  /** Texte tooltip court (ex: "TOUCHDOWN home", "Casualty", "Nuffle: fog_rolls_in"). */
+  readonly label: string;
+  /** Index dans le tableau d'events (utile pour ticker scroll-to). */
+  readonly eventIndex: number;
+}
+
+const MARKER_TYPES: ReadonlySet<string> = new Set([
+  "TD",
+  "CASUALTY",
+  "NUFFLE",
+]);
+
+function buildLabel(ev: MatchEvent): string {
+  const meta = (ev.meta ?? {}) as Record<string, unknown>;
+  switch (ev.type) {
+    case "TD": {
+      const team =
+        typeof meta.team === "string" ? meta.team.toUpperCase() : "";
+      return team ? `TOUCHDOWN ${team}` : "TOUCHDOWN";
+    }
+    case "CASUALTY": {
+      const cause =
+        typeof meta.causedBy === "string" ? ` (${meta.causedBy})` : "";
+      return `Casualty${cause}`;
+    }
+    case "NUFFLE": {
+      const id = typeof meta.id === "string" ? meta.id : "?";
+      return `Nuffle: ${id}`;
+    }
+    default:
+      return ev.type;
+  }
+}
+
+export interface BuildScrubMarkersInput {
+  readonly events: readonly MatchEvent[];
+  readonly durationMs: number;
+}
+
+/**
+ * Renvoie les markers tries par `displayAtMs` ascending. Clamp `percent`
+ * a [0, 100]. durationMs <= 0 renvoie [].
+ */
+export function buildScrubMarkers(
+  input: BuildScrubMarkersInput,
+): ScrubMarker[] {
+  const { events, durationMs } = input;
+  if (durationMs <= 0) return [];
+  const out: ScrubMarker[] = [];
+  for (let i = 0; i < events.length; i += 1) {
+    const ev = events[i];
+    if (!MARKER_TYPES.has(ev.type)) continue;
+    const ratio = Math.max(0, Math.min(1, ev.displayAtMs / durationMs));
+    out.push({
+      type: ev.type as ScrubMarkerType,
+      displayAtMs: ev.displayAtMs,
+      percent: ratio * 100,
+      label: buildLabel(ev),
+      eventIndex: i,
+    });
+  }
+  return out.sort((a, b) => a.displayAtMs - b.displayAtMs);
+}

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
@@ -223,4 +223,73 @@ describe("<MatchReplayPlayer> — sprint 1.G.2", () => {
     expect(items[0].textContent).toContain("END");
     expect(items[items.length - 1].textContent).toContain("KICKOFF");
   });
+
+  it("affiche les markers TD pour chaque touchdown du replay", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const tdMarkers = screen.queryAllByTestId("scrub-marker-td");
+    // FIXTURE_EVENTS contient 2 TDs.
+    expect(tdMarkers).toHaveLength(2);
+  });
+
+  it("click sur un marker TD seek vers son displayAtMs", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const tdMarkers = screen.getAllByTestId("scrub-marker-td");
+    // Premier TD = displayAtMs 90_000 (1:30). Avant click, currentMs=0 -> score 0-0.
+    expect(screen.getByTestId("replay-score").textContent).toContain("0 – 0");
+    await act(async () => {
+      fireEvent.click(tdMarkers[0]);
+    });
+    // Apres seek a 90s, le 1er TD est inclus -> score 0-1.
+    expect(screen.getByTestId("replay-score").textContent).toContain("0 – 1");
+  });
+
+  it("expose un title (tooltip) sur chaque marker", async () => {
+    mockedRequest.mockResolvedValue(FIXTURE_DUMP);
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const tdMarkers = screen.getAllByTestId("scrub-marker-td");
+    // Chaque title contient "TOUCHDOWN" + team.
+    expect(tdMarkers[0].getAttribute("title")).toMatch(/TOUCHDOWN/);
+  });
+
+  it("ne rend pas de markers si le replay n'a aucun key moment", async () => {
+    mockedRequest.mockResolvedValue({
+      ...FIXTURE_DUMP,
+      events: [
+        {
+          type: "KICKOFF",
+          displayAtMs: 0,
+          engineVer: "0.13.0",
+          meta: {},
+        } as never,
+        {
+          type: "TURN_START",
+          displayAtMs: 30_000,
+          engineVer: "0.13.0",
+          meta: { half: 1, turn: 1, drivingTeam: "home", ballYardline: 4 },
+        } as never,
+        {
+          type: "END",
+          displayAtMs: 600_000,
+          engineVer: "0.13.0",
+          meta: { score: { home: 0, away: 0 } },
+        } as never,
+      ],
+    });
+    render(<MatchReplayPlayer matchId="m1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId("scrub-markers")).toBeNull();
+  });
 });

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
@@ -7,6 +7,10 @@ import type { MatchEvent } from "@bb/shared-types";
 
 import { apiRequest } from "../../../../lib/api-client";
 import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
+import {
+  type ScrubMarker,
+  buildScrubMarkers,
+} from "../../../../lib/replay-scrub-markers";
 import { useMatchModeRedirect } from "../../../../lib/use-match-mode-redirect";
 import {
   PLAYBACK_SPEEDS,
@@ -125,6 +129,47 @@ function deriveScore(events: readonly MatchEvent[]): {
     }
   }
   return { home, away, half };
+}
+
+const MARKER_COLOR_CLASSES: Record<ScrubMarker["type"], string> = {
+  TD: "bg-emerald-500 hover:bg-emerald-300",
+  CASUALTY: "bg-rose-500 hover:bg-rose-300",
+  NUFFLE: "bg-purple-500 hover:bg-purple-300",
+};
+
+interface ScrubMarkersProps {
+  readonly markers: readonly ScrubMarker[];
+  readonly onSeek: (ms: number) => void;
+}
+
+function ScrubMarkers({
+  markers,
+  onSeek,
+}: ScrubMarkersProps): JSX.Element | null {
+  if (markers.length === 0) return null;
+  return (
+    <div
+      data-testid="scrub-markers"
+      role="list"
+      aria-label="Key moments"
+      className="relative h-2"
+    >
+      {markers.map((m) => (
+        <button
+          key={`${m.eventIndex}-${m.type}`}
+          type="button"
+          role="listitem"
+          onClick={() => onSeek(m.displayAtMs)}
+          aria-label={`${m.label} (seek)`}
+          title={m.label}
+          data-testid={`scrub-marker-${m.type.toLowerCase()}`}
+          data-event-index={m.eventIndex}
+          style={{ left: `${m.percent}%` }}
+          className={`absolute top-0 h-2 w-2 -translate-x-1/2 rounded-full ${MARKER_COLOR_CLASSES[m.type]} transition-colors`}
+        />
+      ))}
+    </div>
+  );
 }
 
 interface ControlsProps {
@@ -254,6 +299,13 @@ export default function MatchReplayPlayer({
     [visibleEvents],
   );
   const score = useMemo(() => deriveScore(visibleEvents), [visibleEvents]);
+  const markers = useMemo(() => {
+    if (!dump) return [];
+    return buildScrubMarkers({
+      events: dump.events,
+      durationMs: dump.durationMs,
+    });
+  }, [dump]);
 
   if (error) {
     return (
@@ -319,6 +371,7 @@ export default function MatchReplayPlayer({
             {formatReplayClock(durationMs)}
           </span>
         </div>
+        <ScrubMarkers markers={markers} onSeek={clock.seek} />
         <input
           type="range"
           min={0}


### PR DESCRIPTION
## Sprint 1.G.4 — Markers TD/CAS/NUFFLE sur la scrub bar

Quatrième lot phase 1.G. Affiche des markers cliquables au-dessus de la scrub bar pour permettre un saut direct sur les key moments du match.

### Builder pure (`buildScrubMarkers`)

Extrait les events `TD` / `CASUALTY` / `NUFFLE` d'un dump et calcule leur position en `%` de la duration.

```typescript
buildScrubMarkers({ events, durationMs }) -> ScrubMarker[]
// { type, displayAtMs, percent, label, eventIndex }
```

- Tri ascending par `displayAtMs`
- Clamp `percent` à `[0, 100]` (events hors-bornes possibles)
- Labels prêts pour tooltip : `TOUCHDOWN HOME` / `Casualty (banana_skin)` / `Nuffle: fog_rolls_in`
- `eventIndex` préservé pour brancher un scroll-to ticker plus tard

### UI

Composant `<ScrubMarkers>` ajouté au-dessus du range input dans le scrubber :
- Boutons `absolute` avec `left: ${percent}%` + `translate-x-1/2` pour centrage
- Code couleur : 🟢 emerald TD / 🔴 rose CAS / 🟣 purple NUFFLE
- Click → `clock.seek(displayAtMs)` (instantané, même quand la lecture est en pause)
- `title` attr → tooltip natif
- `role="list"` + `aria-label="Key moments"` + `aria-label` par marker
- No-op render si `markers.length === 0`

### Tests

```
✓ replay-scrub-markers.test.ts (11 tests)
✓ MatchReplayPlayer.test.tsx (14 tests)
Test Files 2 passed (2)
     Tests 25 passed (25)
```

Couvre : durationMs<=0, types non-marker ignorés, percent calc + clamp, sort, eventIndex, labels (avec/sans team/causedBy/id), empty array. Component : 2 markers TD rendus, click seek met à jour le score, title tooltip présent, no markers si replay sans key moment.

### Sequel

- 1.G.5 : keyboard shortcuts (space, ←→, shift+←→) + Playwright spec

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_