### PR TITLE
Add MOVE events to narrate bulk yardage advances (#4)

### DIFF
--- a/packages/shared-types/src/match-event.test.ts
+++ b/packages/shared-types/src/match-event.test.ts
@@ -16,6 +16,7 @@ describe('EventType — sprint Pro League 0.A.3 catalogue', () => {
       'BLOCK',
       'DODGE',
       'PASS',
+      'MOVE',
       'TD',
       'KO',
       'CASUALTY',

--- a/packages/shared-types/src/match-event.ts
+++ b/packages/shared-types/src/match-event.ts
@@ -25,6 +25,15 @@ export const EVENT_TYPES = Object.freeze([
   'BLOCK',
   'DODGE',
   'PASS',
+  /**
+   * Generic ball-carrier advance not tied to a key moment (#4). The
+   * sim-engine bulk yardage roll used to be invisible on the timeline
+   * — only TURN_START's "(drive +N yds)" annotation hinted at it.
+   * MOVE makes the play explicit : every yard the ball travels is
+   * backed by a narrated event with a `kind` (positioning / run /
+   * sweep / breakaway / halt / scoring_run).
+   */
+  'MOVE',
   'TD',
   'KO',
   'CASUALTY',

--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.15.0",
+  "engineVer": "0.16.0",
   "snapshotAt": "2026-05-07",
   "tolerance": 0.05,
   "pairings": [

--- a/packages/sim-engine/src/driver/hybrid-driver.test.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { SimInput } from '../types';
 
-import { runHybridDriver } from './hybrid-driver';
+import { classifyMove, runHybridDriver } from './hybrid-driver';
 
 const baseInput = (overrides: Partial<SimInput> = {}): SimInput => ({
   seed: 42,
@@ -384,6 +384,117 @@ describe('runHybridDriver — Underdog variance boost (sprint 0.C.3)', () => {
     const a = runHybridDriver(lopsidedMatch(7777));
     const b = runHybridDriver(lopsidedMatch(7777));
     expect(b).toEqual(a);
+  });
+});
+
+describe('runHybridDriver — yards as narrated MOVE events (#4)', () => {
+  it('classifyMove maps yardage to the documented narrative kind', () => {
+    expect(classifyMove(0, false)).toBe('halt');
+    expect(classifyMove(1, false)).toBe('positioning');
+    expect(classifyMove(3, false)).toBe('positioning');
+    expect(classifyMove(4, false)).toBe('run');
+    expect(classifyMove(7, false)).toBe('run');
+    expect(classifyMove(8, false)).toBe('sweep');
+    expect(classifyMove(12, false)).toBe('sweep');
+    expect(classifyMove(13, false)).toBe('breakaway');
+    expect(classifyMove(16, false)).toBe('breakaway');
+    // scoring overrides yardage classification
+    expect(classifyMove(0, true)).toBe('scoring_run');
+    expect(classifyMove(5, true)).toBe('scoring_run');
+    expect(classifyMove(16, true)).toBe('scoring_run');
+  });
+
+  /**
+   * Smoke regression : every non-turnover, non-end-of-half turn
+   * should emit at least one MOVE event so no yardage is invisible
+   * on the timeline. We require the bulk advance to produce a MOVE
+   * — even a "halt" 0-yard gain is narrated.
+   */
+  it('every non-turnover turn emits at least one MOVE event explaining the bulk advance', () => {
+    const out = runHybridDriver(baseInput({ seed: 7 }));
+    let currentTurnHasTurnover = false;
+    let currentTurnHasMove = false;
+    let inTurn = false;
+    let totalNonTurnoverTurns = 0;
+    let turnsWithMove = 0;
+    for (const ev of out.events) {
+      if (ev.type === 'TURN_START') {
+        if (inTurn && !currentTurnHasTurnover) {
+          totalNonTurnoverTurns += 1;
+          if (currentTurnHasMove) turnsWithMove += 1;
+        }
+        inTurn = true;
+        currentTurnHasTurnover = false;
+        currentTurnHasMove = false;
+      } else if (ev.type === 'TURNOVER') {
+        currentTurnHasTurnover = true;
+      } else if (ev.type === 'MOVE') {
+        currentTurnHasMove = true;
+      } else if (ev.type === 'HALFTIME' || ev.type === 'END') {
+        if (inTurn && !currentTurnHasTurnover) {
+          totalNonTurnoverTurns += 1;
+          if (currentTurnHasMove) turnsWithMove += 1;
+        }
+        inTurn = false;
+      }
+    }
+    expect(totalNonTurnoverTurns).toBeGreaterThan(0);
+    expect(turnsWithMove).toBe(totalNonTurnoverTurns);
+  });
+
+  /**
+   * Regression : MOVE meta integrity. Each event must declare
+   * coherent `from` / `to` / `yards` / `team` / `kind` so consumers
+   * (narrator, broadcaster, future analytics) can rely on the shape.
+   */
+  it('MOVE events carry coherent meta on every seed sampled', () => {
+    for (let seed = 0; seed < 30; seed += 1) {
+      const out = runHybridDriver(baseInput({ seed }));
+      for (const ev of out.events) {
+        if (ev.type !== 'MOVE') continue;
+        const meta = (ev.meta ?? {}) as Record<string, unknown>;
+        expect(typeof meta.team).toBe('string');
+        expect(['home', 'away']).toContain(String(meta.team));
+        expect(typeof meta.kind).toBe('string');
+        expect([
+          'halt',
+          'positioning',
+          'run',
+          'sweep',
+          'breakaway',
+          'scoring_run',
+        ]).toContain(String(meta.kind));
+        expect(typeof meta.yards).toBe('number');
+        expect(typeof meta.from).toBe('number');
+        expect(typeof meta.to).toBe('number');
+        expect(Number(meta.yards)).toBeGreaterThanOrEqual(0);
+        expect(Number(meta.yards)).toBeLessThanOrEqual(16);
+        expect(Number(meta.to) - Number(meta.from)).toBe(Number(meta.yards));
+      }
+    }
+  });
+
+  /**
+   * Regression : a MOVE with kind='scoring_run' must always be
+   * paired with a TD event at the same displayAtMs. Conversely,
+   * any bulk-advance TD must be preceded by a scoring_run MOVE
+   * (passes have their own PASS+TD pairing).
+   */
+  it('scoring_run MOVE events are always paired with a TD on the same displayAtMs', () => {
+    for (let seed = 0; seed < 30; seed += 1) {
+      const out = runHybridDriver(baseInput({ seed }));
+      for (let i = 0; i < out.events.length; i += 1) {
+        const ev = out.events[i];
+        if (ev.type === 'MOVE') {
+          const meta = (ev.meta ?? {}) as Record<string, unknown>;
+          if (meta.kind === 'scoring_run') {
+            const next = out.events[i + 1];
+            expect(next?.type).toBe('TD');
+            expect(next?.displayAtMs).toBe(ev.displayAtMs);
+          }
+        }
+      }
+    }
   });
 });
 

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -101,6 +101,37 @@ type Side = 'home' | 'away';
 type KeyMomentKind = 'block' | 'pass' | 'dodge' | 'pickup' | 'gfi' | 'foul';
 
 /**
+ * (#4) Narrative classifier for the bulk yardage advance. The hybrid
+ * driver previously returned an opaque integer ("the team gained 7
+ * yards") which read poorly on the timeline — the user couldn't
+ * tell what kind of play just happened. Each category maps to a
+ * narrator tagline :
+ *
+ *   halt          : 0 yards, defense holds the line
+ *   positioning   : 1-3 yards, line build-up / formation push
+ *   run           : 4-7 yards, ball carrier sprints forward
+ *   sweep         : 8-12 yards, wide play to the wing
+ *   breakaway     : 13+ yards, long play (was the breakthrough roll)
+ *   scoring_run   : reached the goal line, regardless of yardage
+ */
+export type MoveKind =
+  | 'halt'
+  | 'positioning'
+  | 'run'
+  | 'sweep'
+  | 'breakaway'
+  | 'scoring_run';
+
+export function classifyMove(yards: number, scored: boolean): MoveKind {
+  if (scored) return 'scoring_run';
+  if (yards <= 0) return 'halt';
+  if (yards <= 3) return 'positioning';
+  if (yards <= 7) return 'run';
+  if (yards <= 12) return 'sweep';
+  return 'breakaway';
+}
+
+/**
  * Drive state in the hybrid driver. The active team always carries
  * the ball — the model has no "loose ball" phase between turns
  * (kickoff scatter, fumble pickups, etc. are abstracted away). A
@@ -700,8 +731,32 @@ function processTurn(
     // single-turn-TD from yardline 6, breaking the cap #1 guarantee.
     const remaining = Math.max(0, MAX_TURN_YARDS - yardsThisTurn);
     const gained = Math.min(rolled, remaining);
-    const newYard = m.state.drive.ballYardline + gained;
-    if (newYard >= FIELD_YARDS) {
+    const fromYard = m.state.drive.ballYardline;
+    const newYard = fromYard + gained;
+    const scored = newYard >= FIELD_YARDS;
+    // Clamp the destination at the goal line. If the bulk roll
+    // overshoots (e.g. fromYard=14, gained=16 → newYard=30), the
+    // ball stops at FIELD_YARDS=26 and the played yardage is the
+    // distance actually travelled, not the raw roll. This keeps the
+    // MOVE event invariant `yards == to - from` true.
+    const to = scored ? FIELD_YARDS : newYard;
+    const actualYards = to - fromYard;
+    // (#4) Every yard the ball travels must be backed by a narrated
+    // event. Replace the previously-invisible bulk advance with a
+    // MOVE event whose `kind` reflects the play's character.
+    m.events.push({
+      type: 'MOVE',
+      displayAtMs: bulkAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        team: m.state.drive.drivingTeam,
+        kind: classifyMove(actualYards, scored),
+        yards: actualYards,
+        from: fromYard,
+        to,
+      },
+    });
+    if (scored) {
       const scoring = m.state.drive.drivingTeam;
       if (scoring === 'home') m.state = { ...m.state, scoreHome: m.state.scoreHome + 1 };
       else m.state = { ...m.state, scoreAway: m.state.scoreAway + 1 };

--- a/packages/sim-engine/src/replay/narrator.ts
+++ b/packages/sim-engine/src/replay/narrator.ts
@@ -142,6 +142,33 @@ function renderTd(ev: MatchEvent): string {
   return `  Touchdown! ${team} crosses the line. Score is now ${score.home}-${score.away}.`;
 }
 
+function renderMove(ev: MatchEvent): string {
+  const meta = getMeta(ev);
+  const team = n(meta.team);
+  const yards = typeof meta.yards === 'number' ? meta.yards : 0;
+  const kind = String(meta.kind ?? 'run');
+  const from = typeof meta.from === 'number' ? meta.from : null;
+  const to = typeof meta.to === 'number' ? meta.to : null;
+  const range = from !== null && to !== null ? ` (yardline ${from} → ${to})` : '';
+  // Sprint Pro League #4 — narrative taglines per move kind.
+  switch (kind) {
+    case 'halt':
+      return `  HALT — ${team} drive stalls : the defense holds the line${range}.`;
+    case 'positioning':
+      return `  POSITIONING — ${team} pushes the line forward, +${yards} yds${range}.`;
+    case 'run':
+      return `  RUN — ${team} ball carrier drives through the middle, +${yards} yds${range}.`;
+    case 'sweep':
+      return `  SWEEP — ${team} sweeps wide, +${yards} yds${range}.`;
+    case 'breakaway':
+      return `  BREAKAWAY — ${team} breaks open daylight, +${yards} yds${range}.`;
+    case 'scoring_run':
+      return `  SCORING RUN — ${team} sprints for the endzone, +${yards} yds${range}.`;
+    default:
+      return `  MOVE — ${team} +${yards} yds${range}.`;
+  }
+}
+
 function renderTurnover(ev: MatchEvent): string {
   const meta = getMeta(ev);
   const cause = n(meta.cause, 'unknown');
@@ -214,6 +241,8 @@ function renderEvent(ev: MatchEvent, ctx: TurnStartContext): string {
       return renderDodge(ev);
     case 'PASS':
       return renderPass(ev);
+    case 'MOVE':
+      return renderMove(ev);
     case 'TD':
       return renderTd(ev);
     case 'TURNOVER':

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.15.0';
+export const ENGINE_VER = '0.16.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Résumé

- [x] Introduce `MOVE` event type to make bulk yardage advances visible on the timeline
- [x] Classify yardage into narrative kinds (halt, positioning, run, sweep, breakaway, scoring_run)
- [x] Update narrator to render MOVE events with contextual taglines
- [x] Bump engine version to 0.16.0

## Description

Previously, the hybrid driver's bulk yardage roll was invisible on the timeline—only the `TURN_START` annotation hinted at yards gained. This PR makes every yard explicit by emitting a `MOVE` event for each turn's bulk advance.

### Key Changes

**sim-engine/src/driver/hybrid-driver.ts**
- Export `MoveKind` type and `classifyMove()` function to map yardage to narrative categories
- Emit `MOVE` event in `processTurn()` with coherent meta (team, kind, yards, from, to)
- Clamp destination at goal line to preserve invariant: `yards == to - from`

**shared-types/src/match-event.ts**
- Add `MOVE` to `EVENT_TYPES` catalogue with documentation

**sim-engine/src/replay/narrator.ts**
- Implement `renderMove()` with contextual taglines per kind
- Wire `MOVE` case in `renderEvent()`

**Tests**
- `classifyMove()` unit tests covering all yardage ranges and scoring override
- Regression: every non-turnover turn emits at least one MOVE event
- Regression: MOVE meta integrity across 30 seed samples
- Regression: scoring_run MOVE events paired with TD on same displayAtMs

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires (comprehensive coverage added)
- [x] Changeset ajouté

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J