### PR TITLE
feat(web): i18n Pro League hub + about pages (sprint i18n.1)

### DIFF
--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -679,6 +679,113 @@ export const translations = {
       configMissing: "Le formulaire n'est pas configuré (clé Turnstile manquante). Contactez l'administrateur du site.",
       messageMinHint: "Au moins 10 caractères.",
     },
+    proLeague: {
+      hub: {
+        defaultName: "Pro League",
+        loading: "Chargement…",
+        seasonInfo: "Saison {year} · {status} · engine",
+        aboutLink: "À propos",
+        currentRound: "Journée actuelle",
+        nextMatches: "Prochains matchs",
+        standingsTitle: "Classement",
+        noSeason:
+          "Aucune saison active pour le moment. La prochaine kickoff sera annoncée bientôt.",
+        countdownPrefix: "Kickoff dans",
+        liveBadge: "● LIVE",
+        finalBadge: "FT",
+        standingsEmpty:
+          "Le classement apparaîtra après la première journée.",
+      },
+      about: {
+        backToHub: "← Hub",
+        eyebrow: "Old World League",
+        title: "La Pro League Nuffle Arena",
+        intro:
+          "Une ligue Blood Bowl-like permanente : 16 équipes simulées, 15 journées, paris virtuels, Gazette quotidienne et Hall of Fame. Chaque mardi 21h, Nuffle décide du destin des plus grandes légendes du Vieux Monde.",
+        ctaHub: "Voir le hub",
+        ctaStandings: "Classement live",
+        howItWorksTitle: "Comment ça marche",
+        howItWorksStep1Title: "Simulation déterministe.",
+        howItWorksStep1Body:
+          "Le sim engine joue chaque match selon un seed et une version gelée (`engineVer`). Pas d'aléa caché — tout est rejouable à l'identique.",
+        howItWorksStep2Title: "Diffusion live SSE.",
+        howItWorksStep2Body:
+          "À l'heure du kickoff, le broadcaster dispatch les events pré-simulés en temps réel. Latence faible, reconnect-friendly via Last-Event-ID.",
+        howItWorksStep3Title: "Paris en Crowns.",
+        howItWorksStep3Body:
+          "Les cotes sont calculées par pré-simulation (N=200 runs). La cote au moment du pari (`oddsAtPlace`) est gelée pour fairness. Settlement automatique post-match.",
+        howItWorksStep4Title: "Gazette LLM.",
+        howItWorksStep4Body:
+          "Chaque matin 8h, Claude Haiku écrit l'édition du jour à partir du recap factuel : 1 article principal + brèves + édito signé.",
+        featuresTitle: "Ce que tu peux faire",
+        featureLiveTitle: "Diffusion live mardi 21h",
+        featureLiveBody:
+          "8 matchs simulés en parallèle chaque mardi soir, diffusés en direct via SSE avec rendu Pixi + ticker textuel mobile-friendly.",
+        featureLiveCta: "Voir la prochaine journée",
+        featureBetsTitle: "Paris virtuels en Crowns",
+        featureBetsBody:
+          "6+ marchés par match (Moneyline, Total TDs, MVP, Casualties, Nuffle, Double chance). Cotes dynamiques. Gains crédités automatiquement post-match.",
+        featureBetsCta: "Leaderboard parieurs",
+        featureGazetteTitle: "Nuffle Gazette quotidienne",
+        featureGazetteBody:
+          "Articles écrits par IA chaque matin à 8h : 1 article principal + brèves + édito signé par 1 des 3 personas (le cynique, l'enthousiaste orc, le statisticien).",
+        featureGazetteCta: "Lire l'édition du jour",
+        featureHofTitle: "Hall of Fame légendes",
+        featureHofBody:
+          "Snapshot figé des joueurs immortalisés (mort en match, palmarès carrière) — nom, race, stats, raison de l'induction restent consultables pour toujours.",
+        featureHofCta: "Hall of Fame",
+        scheduleTitle: "Calendrier",
+        scheduleHeaderWhen: "Quand",
+        scheduleHeaderTime: "Heure",
+        scheduleHeaderWhat: "Quoi",
+        scheduleTuesdayLabel: "Mardi",
+        scheduleTuesdayTime: "21h00",
+        scheduleTuesdayBody:
+          "Kickoff de la journée — 8 matchs simulés en parallèle, broadcast SSE en direct.",
+        scheduleDailyLabel: "Mercredi → Lundi",
+        scheduleDailyTime: "8h00",
+        scheduleDailyBody:
+          "Édition Nuffle Gazette du jour : article principal + brèves + édito.",
+        scheduleResetLabel: "Quotidien",
+        scheduleResetTime: "Reset 00h00 UTC",
+        scheduleResetBody:
+          "Bonus de connexion Crowns + 1ʳᵉ visite saison = bonus de bienvenue.",
+        scheduleSeasonLabel: "Saison",
+        scheduleSeasonTime: "15 journées",
+        scheduleSeasonBody:
+          "Round-robin classique. Saison alignée sur le calendrier NFL 2026-27.",
+        faqTitle: "FAQ",
+        faqQ1: "Qu'est-ce que la Pro League ?",
+        faqA1:
+          "Une ligue Blood Bowl-like de 16 équipes simulées (hommages NFL × races BB). Les matchs sont joués automatiquement par un engine déterministe, les fans suivent, parient et lisent la Gazette quotidienne.",
+        faqQ2: "Comment je participe ?",
+        faqA2:
+          "Aucune action obligatoire. Tu peux suivre passivement, ouvrir un compte gratuit pour parier en Crowns virtuels, ou suivre une équipe pour recevoir un newsfeed personnalisé.",
+        faqQ3: "Les paris sont-ils en argent réel ?",
+        faqA3:
+          "Non. Les Crowns sont une monnaie 100% virtuelle, créditée à l'inscription et regagnée par bonus quotidiens. Aucun cashout possible, aucun lien avec la monnaie réelle, aucun achat in-app.",
+        faqQ4: "Pourquoi 16 équipes ?",
+        faqA4:
+          "Round-robin classique : 16 équipes × 15 journées = 120 matchs par saison, 8 matchs par journée. Calibré pour aligner sur la saison NFL (septembre → janvier).",
+        faqQ5: "Comment l'engine garantit-il du fair-play ?",
+        faqA5:
+          "Tous les matchs utilisent le même engine déterministe versionné (engineVer figé sur chaque match). Les replays sont stockés en CBOR + gzip et rejouables à l'identique. Les cotes sont gelées au moment du pari (`oddsAtPlace`) — pas de re-pricing rétroactif.",
+        faqQ6: "Que se passe-t-il quand un joueur meurt en match ?",
+        faqA6:
+          "Casualty 'dead' → joueur retiré du roster, entrée automatique au Hall of Fame, rookie procédural généré pour combler le manque. Cycle réaliste qui imite l'attrition Blood Bowl.",
+        faqQ7: "La Gazette est-elle écrite par un humain ?",
+        faqA7:
+          "Non — c'est Claude Haiku qui rédige chaque édition à partir du recap factuel de la veille. Le ton est pulp Blood Bowl-like, signé par 1 des 3 personas. Tout est ancré sur les données réelles du match.",
+        faqQ8: "Puis-je rejouer un match passé ?",
+        faqA8:
+          "Oui. Chaque match completed dispose d'un replay player avec play/pause, scrub bar, vitesse 0.5×–8×, markers sur les key moments (TD/casualty/Nuffle), et raccourcis clavier.",
+        disclaimerTitle: "🛡 Pas d'argent réel impliqué",
+        disclaimerBody:
+          "Les Crowns sont une monnaie de jeu virtuelle. Pas de cashout, pas d'achat in-app, pas de lien avec la monnaie réelle. Nuffle Arena n'est pas une plateforme de paris sportifs au sens légal — c'est un jeu fantasy où la stratégie, les pronostics et l'humour pulp remplacent l'argent. La participation est gratuite et sans obligation.",
+        footerCtaHub: "Rejoindre le hub →",
+        footerCtaGazette: "Lire la Gazette",
+      },
+    },
   },
   en: {
     // Navigation
@@ -1359,6 +1466,112 @@ export const translations = {
       captchaMissing: "Loading the anti-spam protection...",
       configMissing: "This form is not configured (missing Turnstile key). Please contact the site admin.",
       messageMinHint: "At least 10 characters.",
+    },
+    proLeague: {
+      hub: {
+        defaultName: "Pro League",
+        loading: "Loading…",
+        seasonInfo: "Season {year} · {status} · engine",
+        aboutLink: "About",
+        currentRound: "Current round",
+        nextMatches: "Upcoming matches",
+        standingsTitle: "Standings",
+        noSeason:
+          "No active season at the moment. The next kickoff will be announced soon.",
+        countdownPrefix: "Kickoff in",
+        liveBadge: "● LIVE",
+        finalBadge: "FT",
+        standingsEmpty: "Standings will appear after matchday 1.",
+      },
+      about: {
+        backToHub: "← Hub",
+        eyebrow: "Old World League",
+        title: "The Nuffle Arena Pro League",
+        intro:
+          "A permanent Blood Bowl-like league: 16 simulated teams, 15 matchdays, virtual betting, daily Gazette and a Hall of Fame. Every Tuesday at 9 PM CET, Nuffle decides the fate of the Old World's greatest legends.",
+        ctaHub: "Open the hub",
+        ctaStandings: "Live standings",
+        howItWorksTitle: "How it works",
+        howItWorksStep1Title: "Deterministic simulation.",
+        howItWorksStep1Body:
+          "The sim engine plays each match using a seed and a frozen version (`engineVer`). No hidden randomness — everything is replayable bit-for-bit.",
+        howItWorksStep2Title: "Live SSE broadcast.",
+        howItWorksStep2Body:
+          "At kickoff, the broadcaster dispatches pre-simulated events in real time. Low latency, reconnect-friendly via Last-Event-ID.",
+        howItWorksStep3Title: "Crowns betting.",
+        howItWorksStep3Body:
+          "Odds come from pre-simulation (N=200 runs). The odd at bet placement (`oddsAtPlace`) is locked for fairness. Automatic post-match settlement.",
+        howItWorksStep4Title: "LLM Gazette.",
+        howItWorksStep4Body:
+          "Every morning at 8 AM, Claude Haiku writes the day's edition from the factual recap: 1 main article + briefs + signed editorial.",
+        featuresTitle: "What you can do",
+        featureLiveTitle: "Tuesday 9 PM live broadcast",
+        featureLiveBody:
+          "8 matches simulated in parallel each Tuesday night, streamed live via SSE with Pixi rendering and a mobile-friendly text ticker.",
+        featureLiveCta: "Next matchday",
+        featureBetsTitle: "Virtual Crowns betting",
+        featureBetsBody:
+          "6+ markets per match (Moneyline, Total TDs, MVP, Casualties, Nuffle, Double chance). Dynamic odds. Winnings credited automatically post-match.",
+        featureBetsCta: "Bettors leaderboard",
+        featureGazetteTitle: "Daily Nuffle Gazette",
+        featureGazetteBody:
+          "Articles written by AI every morning at 8 AM: 1 main article + briefs + editorial signed by 1 of 3 personas (the cynic, the orc enthusiast, the statistician).",
+        featureGazetteCta: "Read today's edition",
+        featureHofTitle: "Hall of Fame legends",
+        featureHofBody:
+          "Frozen snapshot of immortalised players (death in match, career achievements) — name, race, stats, induction reason remain accessible forever.",
+        featureHofCta: "Hall of Fame",
+        scheduleTitle: "Schedule",
+        scheduleHeaderWhen: "When",
+        scheduleHeaderTime: "Time",
+        scheduleHeaderWhat: "What",
+        scheduleTuesdayLabel: "Tuesday",
+        scheduleTuesdayTime: "9:00 PM CET",
+        scheduleTuesdayBody:
+          "Matchday kickoff — 8 matches simulated in parallel, live SSE broadcast.",
+        scheduleDailyLabel: "Wed → Mon",
+        scheduleDailyTime: "8:00 AM",
+        scheduleDailyBody:
+          "Day's Nuffle Gazette: main article + briefs + editorial.",
+        scheduleResetLabel: "Daily",
+        scheduleResetTime: "Reset 00:00 UTC",
+        scheduleResetBody:
+          "Daily Crowns login bonus + first season visit = welcome bonus.",
+        scheduleSeasonLabel: "Season",
+        scheduleSeasonTime: "15 matchdays",
+        scheduleSeasonBody:
+          "Classic round-robin. Season aligned with the NFL 2026-27 calendar.",
+        faqTitle: "FAQ",
+        faqQ1: "What is the Pro League?",
+        faqA1:
+          "A Blood Bowl-like league of 16 simulated teams (NFL × BB race tributes). Matches are played automatically by a deterministic engine; fans follow, bet and read the daily Gazette.",
+        faqQ2: "How do I take part?",
+        faqA2:
+          "No mandatory action. You can follow passively, open a free account to bet in virtual Crowns, or follow a team to receive a personalised newsfeed.",
+        faqQ3: "Do bets involve real money?",
+        faqA3:
+          "No. Crowns are a 100% virtual currency, credited at signup and earned through daily bonuses. No cashout, no link to real currency, no in-app purchases.",
+        faqQ4: "Why 16 teams?",
+        faqA4:
+          "Classic round-robin: 16 teams × 15 matchdays = 120 matches per season, 8 matches per matchday. Calibrated to align with the NFL season (September → January).",
+        faqQ5: "How does the engine guarantee fair play?",
+        faqA5:
+          "All matches use the same versioned deterministic engine (engineVer frozen on each match). Replays are stored in CBOR + gzip and replayable bit-for-bit. Odds are locked at the time of the bet (`oddsAtPlace`) — no retroactive re-pricing.",
+        faqQ6: "What happens when a player dies in a match?",
+        faqA6:
+          "Casualty 'dead' → player removed from the roster, automatic entry to the Hall of Fame, procedurally generated rookie to fill the gap. A realistic cycle that mimics Blood Bowl attrition.",
+        faqQ7: "Is the Gazette written by a human?",
+        faqA7:
+          "No — Claude Haiku writes each edition from the previous day's factual recap. The tone is pulp Blood Bowl-like, signed by 1 of 3 personas. Everything is anchored on real match data.",
+        faqQ8: "Can I rewatch a past match?",
+        faqA8:
+          "Yes. Every completed match has a replay player with play/pause, scrub bar, 0.5×–8× speed, markers on key moments (TD/casualty/Nuffle), and keyboard shortcuts.",
+        disclaimerTitle: "🛡 No real money involved",
+        disclaimerBody:
+          "Crowns are a virtual in-game currency. No cashout, no in-app purchase, no link to real currency. Nuffle Arena is not a sports betting platform in any legal sense — it's a fantasy game where strategy, predictions and pulp humour replace money. Participation is free and without obligation.",
+        footerCtaHub: "Join the hub →",
+        footerCtaGazette: "Read the Gazette",
+      },
     },
   },
 } as const;

--- a/apps/web/app/pro-league/about/page.test.tsx
+++ b/apps/web/app/pro-league/about/page.test.tsx
@@ -1,19 +1,28 @@
 /**
  * Sprint 1.F.4 — Tests page marketing `/pro-league/about`.
  *
- * Server component pure (pas de fetch, pas d'interactivite).
- * On verifie : presence des sections cles + contenu critique
- * (CTAs, disclaimer, FAQ items, calendrier).
+ * Client component (apres i18n refonte). On verifie : presence des
+ * sections cles + contenu critique (CTAs, disclaimer, FAQ items,
+ * calendrier). Les rendus passent par LanguageProvider pour `t`.
  */
 
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 
+import { LanguageProvider } from "../../contexts/LanguageContext";
 import ProLeagueAboutPage from "./page";
+
+function renderPage(): ReturnType<typeof render> {
+  return render(
+    <LanguageProvider>
+      <ProLeagueAboutPage />
+    </LanguageProvider>,
+  );
+}
 
 describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   it("rend le hero avec titre + CTAs principaux", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     expect(screen.getByTestId("about-hero")).toBeTruthy();
     expect(
       screen.getByRole("heading", { level: 1 }).textContent,
@@ -28,7 +37,7 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("rend la section 'Comment ca marche' avec 4 etapes ordonnees", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const section = screen.getByTestId("about-howitworks");
     const items = section.querySelectorAll("li");
     expect(items.length).toBe(4);
@@ -39,18 +48,18 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("rend 4 feature cards avec liens vers les sub-pages cles", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const cards = screen.getAllByTestId("about-feature-card");
     expect(cards.length).toBe(4);
     // Chaque card a son CTA
     expect(
-      screen.getByRole("link", { name: /Voir la prochaine journee/i }),
+      screen.getByRole("link", { name: /Voir la prochaine journ.e/i }),
     ).toHaveProperty("href");
     expect(
       screen.getByRole("link", { name: /Leaderboard parieurs/i }),
     ).toHaveProperty("href");
     expect(
-      screen.getByRole("link", { name: /Lire l'edition du jour/i }),
+      screen.getByRole("link", { name: /Lire l'.dition du jour/i }),
     ).toHaveProperty("href");
     expect(
       screen.getByRole("link", { name: /Hall of Fame/i }),
@@ -58,7 +67,7 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("rend la table calendrier avec >= 4 slots", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const rows = screen.getAllByTestId("about-schedule-row");
     expect(rows.length).toBeGreaterThanOrEqual(4);
     // Mardi 21h doit apparaitre (kickoff)
@@ -68,7 +77,7 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("rend la FAQ avec >= 6 items", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const items = screen.getAllByTestId("about-faq-item");
     expect(items.length).toBeGreaterThanOrEqual(6);
     // Verifie le contenu critique
@@ -79,7 +88,7 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("FAQ items sont en details collapsibles (summary present)", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const items = screen.getAllByTestId("about-faq-item");
     for (const item of items) {
       expect(item.querySelector("summary")).not.toBeNull();
@@ -87,7 +96,7 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("affiche le disclaimer 'no real money' en evidence", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const disclaimer = screen.getByTestId("about-disclaimer");
     expect(disclaimer.getAttribute("role")).toBe("note");
     expect(disclaimer.getAttribute("aria-label")).toMatch(/disclaimer/i);
@@ -96,15 +105,13 @@ describe("ProLeagueAboutPage — sprint 1.F.4", () => {
   });
 
   it("expose un lien retour vers /pro-league", () => {
-    render(<ProLeagueAboutPage />);
+    renderPage();
     const backLinks = screen.getAllByRole("link", { name: /Hub/i });
     expect(backLinks.length).toBeGreaterThanOrEqual(1);
     expect(backLinks[0].getAttribute("href")).toBe("/pro-league");
   });
 
-  it("est un server component sans state runtime (smoke)", () => {
-    // Si la page essaye de muter du state cote serveur, le render
-    // jsdom planterait. Verifie que ca ne lance aucune exception.
-    expect(() => render(<ProLeagueAboutPage />)).not.toThrow();
+  it("rend sans throw (smoke)", () => {
+    expect(() => renderPage()).not.toThrow();
   });
 });

--- a/apps/web/app/pro-league/about/page.tsx
+++ b/apps/web/app/pro-league/about/page.tsx
@@ -1,127 +1,114 @@
+"use client";
+
 import Link from "next/link";
 
+import { useLanguage } from "../../contexts/LanguageContext";
+
 /**
- * Page marketing Pro League — sprint 1.F.4.
+ * Page marketing Pro League — sprint 1.F.4 + i18n.
  *
- * Server component (pas d'interactivite). Pitch produit + comment ca
- * marche + features + calendrier + FAQ + disclaimer "no real money".
+ * Client component pour acceder a useLanguage(). Le contenu (pitch,
+ * features, calendrier, FAQ, disclaimer) est entierement traduit via
+ * `t.proLeague.about.*`.
  *
  * SEO meta dans `./layout.tsx`. JSON-LD parent (SportsLeague + FAQPage)
  * deja injecte par le layout `/pro-league` (sprint 1.F.3).
  */
 
-interface Feature {
+interface FeatureCard {
+  readonly key: string;
   readonly title: string;
   readonly description: string;
   readonly href: string;
   readonly cta: string;
 }
 
-const FEATURES: readonly Feature[] = [
-  {
-    title: "Diffusion live mardi 21h",
-    description:
-      "8 matchs simulés en parallèle chaque mardi soir, diffusés en direct via SSE avec rendu Pixi + ticker textuel mobile-friendly.",
-    href: "/pro-league",
-    cta: "Voir la prochaine journee",
-  },
-  {
-    title: "Paris virtuels en Crowns",
-    description:
-      "6+ marchés par match (Moneyline, Total TDs, MVP, Casualties, Nuffle, Double chance). Cotes dynamiques. Gains crédités automatiquement post-match.",
-    href: "/pro-league/leaderboard",
-    cta: "Leaderboard parieurs",
-  },
-  {
-    title: "Nuffle Gazette quotidienne",
-    description:
-      "Articles écrits par IA chaque matin à 8h : 1 article principal + brèves + édito signé par 1 des 3 personas (le cynique, l'enthousiaste orc, le statisticien).",
-    href: "/pro-league/gazette",
-    cta: "Lire l'edition du jour",
-  },
-  {
-    title: "Hall of Fame légendes",
-    description:
-      "Snapshot fige des joueurs immortalisés (mort en match, palmares carrière) — nom, race, stats, raison de l'induction restent consultables pour toujours.",
-    href: "/pro-league/hall-of-fame",
-    cta: "Hall of Fame",
-  },
-];
-
-interface FAQItem {
+interface FaqEntry {
+  readonly key: string;
   readonly q: string;
   readonly a: string;
 }
 
-const FAQ: readonly FAQItem[] = [
-  {
-    q: "Qu'est-ce que la Pro League ?",
-    a: "Une ligue Blood Bowl-like de 16 équipes simulées (hommages NFL × races BB). Les matchs sont joués automatiquement par un engine déterministe, les fans suivent, parient et lisent la Gazette quotidienne.",
-  },
-  {
-    q: "Comment je participe ?",
-    a: "Aucune action obligatoire. Tu peux suivre passivement, ouvrir un compte gratuit pour parier en Crowns virtuels, ou suivre une équipe pour recevoir un newsfeed personnalisé.",
-  },
-  {
-    q: "Les paris sont-ils en argent réel ?",
-    a: "Non. Les Crowns sont une monnaie 100% virtuelle, créditée à l'inscription et regagnée par bonus quotidiens. Aucun cashout possible, aucun lien avec la monnaie réelle, aucun achat in-app.",
-  },
-  {
-    q: "Pourquoi 16 équipes ?",
-    a: "Round-robin classique : 16 équipes × 15 journées = 120 matchs par saison, 8 matchs par journée. Calibré pour aligner sur la saison NFL (septembre → janvier).",
-  },
-  {
-    q: "Comment l'engine garantit-il du fair-play ?",
-    a: "Tous les matchs utilisent le même engine déterministe versionné (engineVer figé sur chaque match). Les replays sont stockés en CBOR + gzip et rejouables à l'identique. Les cotes sont gelées au moment du pari (`oddsAtPlace`) — pas de re-pricing rétroactif.",
-  },
-  {
-    q: "Que se passe-t-il quand un joueur meurt en match ?",
-    a: "Casualty 'dead' → joueur retiré du roster, entrée automatique au Hall of Fame, rookie procédural généré pour combler le manque. Cycle réaliste qui imite l'attrition Blood Bowl.",
-  },
-  {
-    q: "La Gazette est-elle écrite par un humain ?",
-    a: "Non — c'est Claude Haiku qui rédige chaque édition à partir du recap factuel de la veille. Le ton est pulp Blood Bowl-like, signé par 1 des 3 personas. Tout est ancré sur les données réelles du match.",
-  },
-  {
-    q: "Puis-je rejouer un match passé ?",
-    a: "Oui. Chaque match completed dispose d'un replay player avec play/pause, scrub bar, vitesse 0.5×–8×, markers sur les key moments (TD/casualty/Nuffle), et raccourcis clavier.",
-  },
-];
-
 interface ScheduleSlot {
+  readonly key: string;
   readonly label: string;
   readonly time: string;
   readonly description: string;
 }
 
-const SCHEDULE: readonly ScheduleSlot[] = [
-  {
-    label: "Mardi",
-    time: "21h00",
-    description:
-      "Kickoff de la journée — 8 matchs simulés en parallèle, broadcast SSE en direct.",
-  },
-  {
-    label: "Mercredi → Lundi",
-    time: "8h00",
-    description:
-      "Édition Nuffle Gazette du jour : article principal + brèves + édito.",
-  },
-  {
-    label: "Quotidien",
-    time: "Reset 00h00 UTC",
-    description:
-      "Bonus de connexion Crowns + 1ʳᵉ visite saison = bonus de bienvenue.",
-  },
-  {
-    label: "Saison",
-    time: "15 journées",
-    description:
-      "Round-robin classique. Saison alignée sur le calendrier NFL 2026-27.",
-  },
-];
-
 export default function ProLeagueAboutPage(): JSX.Element {
+  const { t } = useLanguage();
+  const a = t.proLeague.about;
+
+  const features: readonly FeatureCard[] = [
+    {
+      key: "live",
+      title: a.featureLiveTitle,
+      description: a.featureLiveBody,
+      href: "/pro-league",
+      cta: a.featureLiveCta,
+    },
+    {
+      key: "bets",
+      title: a.featureBetsTitle,
+      description: a.featureBetsBody,
+      href: "/pro-league/leaderboard",
+      cta: a.featureBetsCta,
+    },
+    {
+      key: "gazette",
+      title: a.featureGazetteTitle,
+      description: a.featureGazetteBody,
+      href: "/pro-league/gazette",
+      cta: a.featureGazetteCta,
+    },
+    {
+      key: "hof",
+      title: a.featureHofTitle,
+      description: a.featureHofBody,
+      href: "/pro-league/hall-of-fame",
+      cta: a.featureHofCta,
+    },
+  ];
+
+  const faq: readonly FaqEntry[] = [
+    { key: "q1", q: a.faqQ1, a: a.faqA1 },
+    { key: "q2", q: a.faqQ2, a: a.faqA2 },
+    { key: "q3", q: a.faqQ3, a: a.faqA3 },
+    { key: "q4", q: a.faqQ4, a: a.faqA4 },
+    { key: "q5", q: a.faqQ5, a: a.faqA5 },
+    { key: "q6", q: a.faqQ6, a: a.faqA6 },
+    { key: "q7", q: a.faqQ7, a: a.faqA7 },
+    { key: "q8", q: a.faqQ8, a: a.faqA8 },
+  ];
+
+  const schedule: readonly ScheduleSlot[] = [
+    {
+      key: "tuesday",
+      label: a.scheduleTuesdayLabel,
+      time: a.scheduleTuesdayTime,
+      description: a.scheduleTuesdayBody,
+    },
+    {
+      key: "daily",
+      label: a.scheduleDailyLabel,
+      time: a.scheduleDailyTime,
+      description: a.scheduleDailyBody,
+    },
+    {
+      key: "reset",
+      label: a.scheduleResetLabel,
+      time: a.scheduleResetTime,
+      description: a.scheduleResetBody,
+    },
+    {
+      key: "season",
+      label: a.scheduleSeasonLabel,
+      time: a.scheduleSeasonTime,
+      description: a.scheduleSeasonBody,
+    },
+  ];
+
   return (
     <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
       <header className="mb-8 flex items-center justify-between gap-3">
@@ -129,7 +116,7 @@ export default function ProLeagueAboutPage(): JSX.Element {
           href="/pro-league"
           className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
         >
-          ← Hub
+          {a.backToHub}
         </Link>
       </header>
 
@@ -138,104 +125,64 @@ export default function ProLeagueAboutPage(): JSX.Element {
         className="mb-10 rounded-lg border border-slate-800 bg-gradient-to-br from-slate-900 to-slate-950 px-6 py-8"
       >
         <p className="text-xs font-semibold uppercase tracking-widest text-amber-300">
-          Old World League
+          {a.eyebrow}
         </p>
         <h1 className="mt-2 text-3xl font-black tracking-tight text-amber-100 sm:text-4xl">
-          La Pro League Nuffle Arena
+          {a.title}
         </h1>
-        <p className="mt-3 text-base text-slate-300">
-          Une ligue Blood Bowl-like permanente : 16 équipes simulées, 15
-          journées, paris virtuels, Gazette quotidienne et Hall of Fame.
-          Chaque mardi 21h, Nuffle décide du destin des plus grandes légendes
-          du Vieux Monde.
-        </p>
+        <p className="mt-3 text-base text-slate-300">{a.intro}</p>
         <div className="mt-5 flex flex-wrap gap-2">
           <Link
             href="/pro-league"
             className="rounded bg-amber-600 px-4 py-2 text-sm font-semibold text-amber-50 hover:bg-amber-500"
           >
-            Voir le hub
+            {a.ctaHub}
           </Link>
           <Link
             href="/pro-league/standings"
             className="rounded border border-slate-700 px-4 py-2 text-sm text-slate-200 hover:bg-slate-800"
           >
-            Classement live
+            {a.ctaStandings}
           </Link>
         </div>
       </section>
 
       <section data-testid="about-howitworks" className="mb-10">
         <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-100">
-          Comment ça marche
+          {a.howItWorksTitle}
         </h2>
         <ol className="flex flex-col gap-3 text-sm text-slate-300">
-          <li className="flex gap-3">
-            <span
-              aria-hidden
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-700 text-xs font-bold text-amber-50"
-            >
-              1
-            </span>
-            <span>
-              <strong className="text-slate-100">Simulation déterministe.</strong>{" "}
-              Le sim engine joue chaque match selon un seed et une version
-              gelée (`engineVer`). Pas d'aléa caché — tout est rejouable à
-              l'identique.
-            </span>
-          </li>
-          <li className="flex gap-3">
-            <span
-              aria-hidden
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-700 text-xs font-bold text-amber-50"
-            >
-              2
-            </span>
-            <span>
-              <strong className="text-slate-100">Diffusion live SSE.</strong>{" "}
-              À l'heure du kickoff, le broadcaster dispatch les events
-              pré-simulés en temps réel. Latence faible, reconnect-friendly
-              via Last-Event-ID.
-            </span>
-          </li>
-          <li className="flex gap-3">
-            <span
-              aria-hidden
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-700 text-xs font-bold text-amber-50"
-            >
-              3
-            </span>
-            <span>
-              <strong className="text-slate-100">Paris en Crowns.</strong> Les
-              cotes sont calculées par pré-simulation (N=200 runs). La cote au
-              moment du pari (`oddsAtPlace`) est gelée pour fairness. Settlement
-              automatique post-match.
-            </span>
-          </li>
-          <li className="flex gap-3">
-            <span
-              aria-hidden
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-700 text-xs font-bold text-amber-50"
-            >
-              4
-            </span>
-            <span>
-              <strong className="text-slate-100">Gazette LLM.</strong> Chaque
-              matin 8h, Claude Haiku écrit l'édition du jour à partir du
-              recap factuel : 1 article principal + brèves + édito signé.
-            </span>
-          </li>
+          {(
+            [
+              [a.howItWorksStep1Title, a.howItWorksStep1Body],
+              [a.howItWorksStep2Title, a.howItWorksStep2Body],
+              [a.howItWorksStep3Title, a.howItWorksStep3Body],
+              [a.howItWorksStep4Title, a.howItWorksStep4Body],
+            ] as ReadonlyArray<readonly [string, string]>
+          ).map(([title, body], idx) => (
+            <li key={idx} className="flex gap-3">
+              <span
+                aria-hidden
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-700 text-xs font-bold text-amber-50"
+              >
+                {idx + 1}
+              </span>
+              <span>
+                <strong className="text-slate-100">{title}</strong> {body}
+              </span>
+            </li>
+          ))}
         </ol>
       </section>
 
       <section data-testid="about-features" className="mb-10">
         <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-100">
-          Ce que tu peux faire
+          {a.featuresTitle}
         </h2>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {FEATURES.map((f) => (
+          {features.map((f) => (
             <article
-              key={f.title}
+              key={f.key}
               data-testid="about-feature-card"
               className="flex flex-col rounded border border-slate-800 bg-slate-900 px-4 py-3"
             >
@@ -246,7 +193,7 @@ export default function ProLeagueAboutPage(): JSX.Element {
                 {f.description}
               </p>
               <Link
-                href={f.href}
+                href={f.href as never}
                 className="mt-3 inline-block text-sm font-semibold text-amber-300 hover:text-amber-200"
               >
                 {f.cta} →
@@ -258,21 +205,27 @@ export default function ProLeagueAboutPage(): JSX.Element {
 
       <section data-testid="about-schedule" className="mb-10">
         <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-100">
-          Calendrier
+          {a.scheduleTitle}
         </h2>
         <div className="overflow-x-auto rounded border border-slate-800">
           <table className="w-full text-sm">
             <thead className="bg-slate-900 text-xs uppercase text-slate-400">
               <tr>
-                <th className="w-32 px-3 py-2 text-left">Quand</th>
-                <th className="w-24 px-3 py-2 text-left">Heure</th>
-                <th className="px-3 py-2 text-left">Quoi</th>
+                <th className="w-32 px-3 py-2 text-left">
+                  {a.scheduleHeaderWhen}
+                </th>
+                <th className="w-24 px-3 py-2 text-left">
+                  {a.scheduleHeaderTime}
+                </th>
+                <th className="px-3 py-2 text-left">
+                  {a.scheduleHeaderWhat}
+                </th>
               </tr>
             </thead>
             <tbody>
-              {SCHEDULE.map((s) => (
+              {schedule.map((s) => (
                 <tr
-                  key={s.label}
+                  key={s.key}
                   data-testid="about-schedule-row"
                   className="border-t border-slate-800"
                 >
@@ -301,12 +254,12 @@ export default function ProLeagueAboutPage(): JSX.Element {
           id="about-faq-heading"
           className="mb-3 text-2xl font-bold tracking-tight text-slate-100"
         >
-          FAQ
+          {a.faqTitle}
         </h2>
         <ul className="flex flex-col gap-3">
-          {FAQ.map((item) => (
+          {faq.map((item) => (
             <li
-              key={item.q}
+              key={item.key}
               data-testid="about-faq-item"
               className="rounded border border-slate-800 bg-slate-900 px-4 py-3"
             >
@@ -328,16 +281,9 @@ export default function ProLeagueAboutPage(): JSX.Element {
         className="mb-10 rounded-lg border border-amber-700 bg-amber-950/40 px-5 py-4"
       >
         <h2 className="mb-1 text-base font-semibold text-amber-200">
-          🛡 Pas d'argent réel impliqué
+          {a.disclaimerTitle}
         </h2>
-        <p className="text-sm text-amber-100/90">
-          Les Crowns sont une monnaie de jeu virtuelle. Pas de cashout, pas
-          d'achat in-app, pas de lien avec la monnaie réelle. Nuffle Arena
-          n'est pas une plateforme de paris sportifs au sens légal — c'est un
-          jeu fantasy où la stratégie, les pronostics et l'humour pulp
-          remplacent l'argent. La participation est gratuite et sans
-          obligation.
-        </p>
+        <p className="text-sm text-amber-100/90">{a.disclaimerBody}</p>
       </aside>
 
       <footer className="mt-2 mb-8 flex flex-wrap gap-2">
@@ -345,13 +291,13 @@ export default function ProLeagueAboutPage(): JSX.Element {
           href="/pro-league"
           className="rounded bg-amber-600 px-4 py-2 text-sm font-semibold text-amber-50 hover:bg-amber-500"
         >
-          Rejoindre le hub →
+          {a.footerCtaHub}
         </Link>
         <Link
           href="/pro-league/gazette"
           className="rounded border border-slate-700 px-4 py-2 text-sm text-slate-200 hover:bg-slate-800"
         >
-          Lire la Gazette
+          {a.footerCtaGazette}
         </Link>
       </footer>
     </main>

--- a/apps/web/app/pro-league/page.test.tsx
+++ b/apps/web/app/pro-league/page.test.tsx
@@ -14,7 +14,16 @@ vi.mock("../lib/api-client", () => ({
 }));
 
 import { apiRequest } from "../lib/api-client";
+import { LanguageProvider } from "../contexts/LanguageContext";
 import ProLeagueHubPage from "./page";
+
+function renderWithLang(): ReturnType<typeof render> {
+  return render(
+    <LanguageProvider>
+      <ProLeagueHubPage />
+    </LanguageProvider>,
+  );
+}
 
 const mockedApi = vi.mocked(apiRequest);
 
@@ -90,13 +99,13 @@ beforeEach(() => {
 describe("ProLeagueHubPage — sprint 1.C.1", () => {
   it("affiche 'Chargement…' pendant le fetch", () => {
     mockedApi.mockReturnValue(new Promise(() => undefined));
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     expect(screen.getByText(/Chargement/)).toBeTruthy();
   });
 
   it("affiche le titre + motto une fois la donnée chargée", async () => {
     mockedApi.mockResolvedValue(makeHubData());
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByText("Old World League")).toBeTruthy();
     });
@@ -108,7 +117,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
 
   it("affiche le current round", async () => {
     mockedApi.mockResolvedValue(makeHubData());
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByTestId("current-round")).toBeTruthy();
     });
@@ -119,7 +128,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
 
   it("affiche les match cards avec noms équipes", async () => {
     mockedApi.mockResolvedValue(makeHubData());
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByTestId("match-card")).toBeTruthy();
     });
@@ -129,7 +138,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
 
   it("affiche le classement avec points", async () => {
     mockedApi.mockResolvedValue(makeHubData());
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByTestId("standings-table")).toBeTruthy();
     });
@@ -141,7 +150,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
     mockedApi.mockResolvedValue(
       makeHubData({ season: null, currentRound: null, nextMatches: [], standings: [] }),
     );
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByText(/Aucune saison active/i)).toBeTruthy();
     });
@@ -149,7 +158,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
 
   it("affiche un message d'erreur si l'API throw", async () => {
     mockedApi.mockRejectedValue(new Error("boom"));
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeTruthy();
     });
@@ -158,7 +167,7 @@ describe("ProLeagueHubPage — sprint 1.C.1", () => {
 
   it("affiche un placeholder dans la table de classement si vide", async () => {
     mockedApi.mockResolvedValue(makeHubData({ standings: [] }));
-    render(<ProLeagueHubPage />);
+    renderWithLang();
     await waitFor(() => {
       expect(
         screen.getByText(/classement apparaîtra/i),

--- a/apps/web/app/pro-league/page.tsx
+++ b/apps/web/app/pro-league/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import { apiRequest } from "../lib/api-client";
+import { useLanguage } from "../contexts/LanguageContext";
 
 import { WalletBadge } from "./_components/WalletBadge";
 
@@ -156,10 +157,11 @@ function StandingsTable({
 }: {
   rows: readonly HubStandingsEntry[];
 }): JSX.Element {
+  const { t } = useLanguage();
   if (rows.length === 0) {
     return (
       <p className="text-sm text-slate-500">
-        Le classement apparaîtra après la première journée.
+        {t.proLeague.hub.standingsEmpty}
       </p>
     );
   }
@@ -205,6 +207,7 @@ function StandingsTable({
 }
 
 export default function ProLeagueHubPage(): JSX.Element {
+  const { t } = useLanguage();
   const [data, setData] = useState<HubData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -251,7 +254,7 @@ export default function ProLeagueHubPage(): JSX.Element {
       <header data-testid="hub-header" className="mb-6">
         <div className="flex items-start justify-between gap-3">
           <h1 className="text-2xl font-bold tracking-wide text-slate-50">
-            {data?.league.name ?? "Pro League"}
+            {data?.league.name ?? t.proLeague.hub.defaultName}
           </h1>
           <div className="flex items-center gap-2">
             <Link
@@ -259,7 +262,7 @@ export default function ProLeagueHubPage(): JSX.Element {
               data-testid="hub-about-link"
               className="rounded border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800"
             >
-              À propos
+              {t.proLeague.hub.aboutLink}
             </Link>
             <WalletBadge />
           </div>
@@ -269,14 +272,16 @@ export default function ProLeagueHubPage(): JSX.Element {
         ) : null}
         {data?.season ? (
           <p className="mt-2 text-sm text-slate-300">
-            Saison {data.season.year} · {data.season.status} · engine{" "}
+            {t.proLeague.hub.seasonInfo
+              .replace("{year}", String(data.season.year))
+              .replace("{status}", data.season.status)}{" "}
             <span className="font-mono">{data.season.engineVer}</span>
           </p>
         ) : null}
       </header>
 
       {loading ? (
-        <p className="text-sm text-slate-400">Chargement…</p>
+        <p className="text-sm text-slate-400">{t.proLeague.hub.loading}</p>
       ) : error ? (
         <p
           role="alert"
@@ -286,8 +291,7 @@ export default function ProLeagueHubPage(): JSX.Element {
         </p>
       ) : !data?.season ? (
         <p className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400">
-          Aucune saison active pour le moment. La prochaine kickoff sera
-          annoncée bientôt.
+          {t.proLeague.hub.noSeason}
         </p>
       ) : (
         <>
@@ -299,7 +303,7 @@ export default function ProLeagueHubPage(): JSX.Element {
               <div className="flex items-center justify-between">
                 <div>
                   <h2 className="text-lg font-semibold text-slate-100">
-                    Round {data.currentRound.roundNumber}
+                    {t.proLeague.hub.currentRound} {data.currentRound.roundNumber}
                   </h2>
                   <p className="text-xs uppercase text-slate-500">
                     {data.currentRound.status}
@@ -319,12 +323,10 @@ export default function ProLeagueHubPage(): JSX.Element {
 
           <section data-testid="next-matches" className="mb-6">
             <h2 className="mb-2 text-lg font-semibold text-slate-100">
-              Prochains matchs
+              {t.proLeague.hub.nextMatches}
             </h2>
             {data.nextMatches.length === 0 ? (
-              <p className="text-sm text-slate-500">
-                Aucun match programmé.
-              </p>
+              <p className="text-sm text-slate-500">—</p>
             ) : (
               <div className="grid gap-2 sm:grid-cols-2">
                 {data.nextMatches.map((m) => (
@@ -336,7 +338,7 @@ export default function ProLeagueHubPage(): JSX.Element {
 
           <section data-testid="standings">
             <h2 className="mb-2 text-lg font-semibold text-slate-100">
-              Classement
+              {t.proLeague.hub.standingsTitle}
             </h2>
             <StandingsTable rows={data.standings} />
           </section>


### PR DESCRIPTION
## Sprint i18n Pro League — lot 1 (hub + about)

Premier lot d'une série visant à passer toutes les pages Pro League sur `useLanguage()` (cohérence avec le reste du site qui est entièrement i18n FR/EN).

### Translations (`apps/web/app/i18n/translations.ts`)

Ajout de la section `proLeague.*` (FR + EN) :

**`proLeague.hub.*`** : defaultName, loading, seasonInfo (template `{year}`/`{status}`), aboutLink, currentRound, nextMatches, standingsTitle, noSeason, countdownPrefix, liveBadge, finalBadge, standingsEmpty.

**`proLeague.about.*`** : 
- Hero : eyebrow, title, intro, ctaHub, ctaStandings
- 4 étapes how-it-works (title + body)
- 4 feature cards (title, body, cta)
- 4 schedule slots (label, time, body)
- 8 FAQ pairs (q + a)
- Disclaimer (title + body)
- Footer CTAs

### Refactor

- **`/pro-league`** (hub) : utilise `useLanguage()` + `t.proLeague.hub.*`. Le sub-component `<StandingsTable>` reçoit aussi i18n (`standingsEmpty`).
- **`/pro-league/about`** : converti en **client component** (`"use client"`) pour accéder au context. Contenu entièrement piloté par `t.proLeague.about.*` via builders locaux (`features`, `faq`, `schedule`).

Aucun changement aux APIs, layouts SEO inchangés (la metadata reste dans les `layout.tsx` server-side).

### Tests

- Hub test : helper `renderWithLang()` wrap `LanguageProvider` autour des 8 `render()`.
- About test : helper `renderPage()` similaire, ajustement du smoke test (plus server component) et regex tolérantes aux accents.

```
✓ pro-league/page.test.tsx (8 tests)
✓ pro-league/about/page.test.tsx (9 tests)
Test Files 11 passed (11) — 84 tests passent (suite Pro League complete)
```

### Sequel

Suivront en chaîne (un PR par chunk pour faciliter la review) :
- i18n.2 : standings + leaderboard
- i18n.3 : gazette + hall-of-fame
- i18n.4 : matches detail + live + replay
- i18n.5 : components (WalletBadge, BetSlip, MarketsList) + feed + me

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_