### PR TITLE
refactor(game-engine): extract failure helpers (S27.8.4)

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -111,6 +111,15 @@ import {
   handleEndTurn,
   handleFoul,
 } from './turn-foul-actions';
+// S27.8.4 — Helpers d'echec (applyRollFailure / applyPickupFailure)
+// extraits dans `actions/failure-helpers.ts`. Reutilises par
+// handleNormalMove / handleDodgeRoll / handleRerollChoose / handleLeap
+// / handleBallPickup. Permet aux extractions ulterieures de ces
+// handlers de ne pas dependre cycliquement de `actions.ts`.
+import {
+  applyRollFailure,
+  applyPickupFailure,
+} from './failure-helpers';
 import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import { checkDauntless } from '../mechanics/dauntless';
 import { checkBreakTackle } from '../mechanics/break-tackle';
@@ -623,65 +632,8 @@ function consumeTeamReroll(state: GameState, team: TeamId): GameState {
   return { ...state, teamRerolls: newRerolls, rerollUsedThisTurn: true };
 }
 
-/**
- * Applique les conséquences d'un échec de jet (chute, turnover, armure, perte de balle).
- * @param armorBonus Bonus optionnel applique au jet d'armure (ex: +1 d'Arm Bar
- *   quand un esquive a echoue dans la zone de tacle d'un adversaire avec ce skill).
- */
-function applyRollFailure(
-  state: GameState,
-  playerIndex: number,
-  rng: RNG,
-  armorBonus: number = 0,
-): GameState {
-  const player = state.players[playerIndex];
-  state.isTurnover = true;
-  state.players[playerIndex] = { ...player, stunned: true };
-
-  // Jet d'armure (avec bonus eventuel d'Arm Bar). `armorBonus` est exprime
-  // comme bonus a l'attaquant (i.e. +1 facilite la cassure d'armure). Il est
-  // negativise ici car `performArmorRollWithNotification` attend un modificateur
-  // a appliquer au TARGET (positif = armure plus difficile a percer).
-  const armorResult = performArmorRollWithNotification(state.players[playerIndex], rng, -armorBonus);
-  state.lastDiceResult = armorResult;
-  const armorLog = createLogEntry(
-    'dice',
-    `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '✓' : '✗'}${armorBonus > 0 ? ` [Arm Bar +${armorBonus}]` : ''}`,
-    player.id,
-    player.team,
-    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, success: armorResult.success, armBar: armorBonus > 0 }
-  );
-  state.gameLog = [...state.gameLog, armorLog];
-
-  // Si l'armure est percée (success = false), faire un jet de blessure
-  if (!armorResult.success) {
-    state = performInjuryRoll(state, state.players[playerIndex], rng);
-  }
-
-  // Perte de balle si le joueur la portait
-  if (player.hasBall) {
-    state.players[playerIndex] = { ...state.players[playerIndex], hasBall: false };
-    state.ball = { ...state.players[playerIndex].pos };
-    return bounceBall(state, rng);
-  }
-
-  return state;
-}
-
-/**
- * Applique les conséquences d'un échec de pickup (rebond + turnover)
- */
-function applyPickupFailure(state: GameState, playerIndex: number, rng: RNG): GameState {
-  state.isTurnover = true;
-  const failLog = createLogEntry(
-    'turnover',
-    `Échec du ramassage - Turnover`,
-    state.players[playerIndex].id,
-    state.players[playerIndex].team
-  );
-  state.gameLog = [...state.gameLog, failLog];
-  return bounceBall(state, rng);
-}
+// S27.8.4 — applyRollFailure / applyPickupFailure extraits dans
+// `actions/failure-helpers.ts` (re-importes en haut de ce fichier).
 
 /**
  * Applique un mouvement à l'état du jeu

--- a/packages/game-engine/src/actions/failure-helpers.ts
+++ b/packages/game-engine/src/actions/failure-helpers.ts
@@ -1,0 +1,108 @@
+/**
+ * S27.8.4 — Helpers d'echec extraits de `actions.ts`.
+ *
+ * Deux fonctions partagees par les handlers de mouvement / esquive /
+ * GFI / pickup / leap pour appliquer les consequences d'un jet rate :
+ *
+ *  - `applyRollFailure` : chute du joueur (turnover, jet d'armure +
+ *    blessure si percee, perte de balle). Optionnellement bonus
+ *    d'Arm Bar sur l'armure.
+ *  - `applyPickupFailure` : echec du ramassage (turnover + rebond
+ *    de la balle).
+ *
+ * Aucune dependance interne au dispatcher : ces helpers sont des
+ * "feuilles" qui n'appellent que des modules `mechanics/*`,
+ * `utils/dice-notifications` et `utils/logging`. Les extraire en
+ * premier permet aux handlers cycliques (handleLeap / handleNormalMove
+ * / handleRerollChoose etc.) d'etre extraits dans des slices suivants
+ * sans devoir re-importer ces helpers depuis `actions.ts`.
+ */
+
+import type { GameState, RNG } from '../core/types';
+import { performArmorRollWithNotification } from '../utils/dice-notifications';
+import { performInjuryRoll } from '../mechanics/injury';
+import { bounceBall } from '../mechanics/ball';
+import { createLogEntry } from '../utils/logging';
+
+/**
+ * Applique les consequences d'un echec de jet (chute, turnover,
+ * armure, perte de balle).
+ *
+ * @param armorBonus Bonus optionnel applique au jet d'armure (ex:
+ *   +1 d'Arm Bar quand une esquive a echoue dans la zone de tacle
+ *   d'un adversaire avec ce skill).
+ */
+export function applyRollFailure(
+  state: GameState,
+  playerIndex: number,
+  rng: RNG,
+  armorBonus = 0,
+): GameState {
+  const player = state.players[playerIndex];
+  state.isTurnover = true;
+  state.players[playerIndex] = { ...player, stunned: true };
+
+  // Jet d'armure (avec bonus eventuel d'Arm Bar). `armorBonus` est
+  // exprime comme bonus a l'attaquant (i.e. +1 facilite la cassure
+  // d'armure). Il est negativise ici car
+  // `performArmorRollWithNotification` attend un modificateur a
+  // appliquer au TARGET (positif = armure plus difficile a percer).
+  const armorResult = performArmorRollWithNotification(
+    state.players[playerIndex],
+    rng,
+    -armorBonus,
+  );
+  state.lastDiceResult = armorResult;
+  const armorLog = createLogEntry(
+    'dice',
+    `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${
+      armorResult.success ? '✓' : '✗'
+    }${armorBonus > 0 ? ` [Arm Bar +${armorBonus}]` : ''}`,
+    player.id,
+    player.team,
+    {
+      diceRoll: armorResult.diceRoll,
+      targetNumber: armorResult.targetNumber,
+      success: armorResult.success,
+      armBar: armorBonus > 0,
+    },
+  );
+  state.gameLog = [...state.gameLog, armorLog];
+
+  // Si l'armure est percee (success = false), faire un jet de
+  // blessure
+  if (!armorResult.success) {
+    state = performInjuryRoll(state, state.players[playerIndex], rng);
+  }
+
+  // Perte de balle si le joueur la portait
+  if (player.hasBall) {
+    state.players[playerIndex] = {
+      ...state.players[playerIndex],
+      hasBall: false,
+    };
+    state.ball = { ...state.players[playerIndex].pos };
+    return bounceBall(state, rng);
+  }
+
+  return state;
+}
+
+/**
+ * Applique les consequences d'un echec de pickup (rebond + turnover).
+ */
+export function applyPickupFailure(
+  state: GameState,
+  playerIndex: number,
+  rng: RNG,
+): GameState {
+  state.isTurnover = true;
+  const failLog = createLogEntry(
+    'turnover',
+    `Échec du ramassage - Turnover`,
+    state.players[playerIndex].id,
+    state.players[playerIndex].team,
+  );
+  state.gameLog = [...state.gameLog, failLog];
+  return bounceBall(state, rng);
+}

--- a/packages/game-engine/vitest.config.ts
+++ b/packages/game-engine/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         'src/actions/special-actions.ts',
         'src/actions/pass-actions.ts',
         'src/actions/turn-foul-actions.ts',
+        'src/actions/failure-helpers.ts',
       ],
       // S25.4 — Seuils initiaux conservateurs. v8 reporte 0% lines sur
       // certains fichiers TS du moteur a cause d'un quirk source-map ;


### PR DESCRIPTION
## Resume

Slice 4 de S27.8 (refactor monolith `actions.ts`). Extraction de deux helpers "feuille" partages par les handlers de mouvement / esquive / GFI / pickup / leap.

**Extraction** (`packages/game-engine/src/actions/failure-helpers.ts`, nouveau)
- `applyRollFailure(state, playerIndex, rng, armorBonus?)` : chute du joueur (turnover, jet d'armure + blessure si percee, perte de balle). Bonus optionnel d'Arm Bar sur l'armure.
- `applyPickupFailure(state, playerIndex, rng)` : echec ramassage (turnover + rebond de la balle).

Aucune dependance interne au dispatcher : ces helpers n'appellent que des modules `mechanics/*`, `utils/dice-notifications` et `utils/logging`. Les extraire en premier permet aux handlers cycliques (`handleLeap` / `handleNormalMove` / `handleRerollChoose` / `handleDodgeRoll` / `handleBallPickup`) d'etre extraits dans des slices ulterieurs sans devoir re-importer ces helpers depuis `actions.ts`.

**Resultat**
- `actions.ts` **2288 -> 2240 lignes** (-48 nettes ; cumul **-466 vs origine 2706 = ~17.2%**).
- `failure-helpers.ts` ajoute a la liste d'exclusion coverage.
- 4888 tests game-engine passent. Coverage 25.33% maintenue (>= 25% seuil).

## Tache roadmap

Sprint S27, tache S27.8 (slice 4 — failure helpers, slice "enabling")
Source : `docs/roadmap/sprints/S27-evolutions-confort.md`

Ce slice est principalement preparatoire : il debloque l'extraction des handlers cycliques dans les slices suivants en isolant ces helpers en tant que feuilles importables.

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` : 4888 tests passent
- [x] `pnpm --filter @bb/game-engine run test:coverage` : 25.33% (>= 25%)
- [x] `pnpm typecheck` : 5/6 packages succes (3 erreurs pre-existantes web)
- [x] `pnpm lint` : 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jim8bQ2p2KiweXCBHAALrf)_