### PR TITLE
feat(web): i18n Pro League gazette + hall-of-fame (sprint i18n.3)

### DIFF
--- a/apps/web/app/i18n/translations.ts
+++ b/apps/web/app/i18n/translations.ts
@@ -735,6 +735,35 @@ export const translations = {
         thStreak: "Streak",
         thBiggest: "Biggest",
       },
+      gazette: {
+        title: "🗞️ Nuffle Gazette",
+        subtitle: "Le quotidien officiel de la Pro League",
+        backToLatest: "← Latest",
+        editionDate: "Édition du",
+        noEditionYet:
+          "La Gazette n'a encore rien publié. Reviens demain matin pour le premier numéro !",
+        archiveTitle: "Archive",
+        emptyEdition: "Aucun article publié pour le {date}.",
+        emptyDateGeneric: "Aucun article pour cette date.",
+        invalidDate: "Date invalide.",
+        articleTypeMain: "Article principal",
+        articleTypeBreve: "Brève",
+        articleTypeEdito: "Édito",
+        personaCynic: "Le Cynique",
+        personaOrcEnthusiast: "L'Enthousiaste Orc",
+        personaStatistician: "Le Statisticien",
+      },
+      hof: {
+        title: "Hall of Fame",
+        intro:
+          "Les joueurs immortalisés de la Old World League. Tombés au champ d'honneur de Nuffle ou couronnés par leur palmarès.",
+        emptyState:
+          "Aucun joueur au Hall of Fame pour le moment. Soyez patient — Nuffle finira par réclamer son dû.",
+        reasonDeath: "Mort en match",
+        reasonCareerTds: "TDs carrière",
+        reasonMvpLegend: "Légende MVP",
+        reasonTitle: "Titre",
+      },
       about: {
         backToHub: "← Hub",
         eyebrow: "Old World League",
@@ -1560,6 +1589,35 @@ export const translations = {
         thAccuracy: "Accuracy",
         thStreak: "Streak",
         thBiggest: "Biggest",
+      },
+      gazette: {
+        title: "🗞️ Nuffle Gazette",
+        subtitle: "The official daily of the Pro League",
+        backToLatest: "← Latest",
+        editionDate: "Edition of",
+        noEditionYet:
+          "The Gazette has not published yet. Come back tomorrow morning for the first issue!",
+        archiveTitle: "Archive",
+        emptyEdition: "No articles published for {date}.",
+        emptyDateGeneric: "No articles for this date.",
+        invalidDate: "Invalid date.",
+        articleTypeMain: "Main article",
+        articleTypeBreve: "Brief",
+        articleTypeEdito: "Editorial",
+        personaCynic: "The Cynic",
+        personaOrcEnthusiast: "The Orc Enthusiast",
+        personaStatistician: "The Statistician",
+      },
+      hof: {
+        title: "Hall of Fame",
+        intro:
+          "The immortalised players of the Old World League. Fallen on Nuffle's field of honour or crowned by their career achievements.",
+        emptyState:
+          "No player in the Hall of Fame yet. Be patient — Nuffle will eventually claim his due.",
+        reasonDeath: "Killed in match",
+        reasonCareerTds: "Career TDs",
+        reasonMvpLegend: "MVP legend",
+        reasonTitle: "Title",
       },
       about: {
         backToHub: "← Hub",

--- a/apps/web/app/pro-league/gazette/[date]/page.tsx
+++ b/apps/web/app/pro-league/gazette/[date]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiRequest, ApiClientError } from "../../../lib/api-client";
+import { useLanguage } from "../../../contexts/LanguageContext";
 
 import { type GazetteEdition, EditionDisplay } from "../_shared";
 
@@ -22,6 +23,7 @@ interface EditionResponse {
 export default function GazetteArchivePage({
   params,
 }: PageProps): JSX.Element {
+  const { t } = useLanguage();
   const [edition, setEdition] = useState<GazetteEdition | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +42,7 @@ export default function GazetteArchivePage({
       .catch((e: unknown) => {
         if (cancelled) return;
         if (e instanceof ApiClientError && e.status === 400) {
-          setError("Date invalide.");
+          setError(t.proLeague.gazette.invalidDate);
           return;
         }
         const msg = e instanceof Error ? e.message : "fetch error";
@@ -52,17 +54,17 @@ export default function GazetteArchivePage({
     return () => {
       cancelled = true;
     };
-  }, [params.date]);
+  }, [params.date, t.proLeague.gazette.invalidDate]);
 
   return (
     <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
       <header className="mb-6 flex items-start justify-between">
         <div>
           <h1 className="text-3xl font-black tracking-tight text-amber-200">
-            🗞️ Nuffle Gazette
+            {t.proLeague.gazette.title}
           </h1>
           <p className="mt-1 text-sm text-slate-400">
-            Édition du{" "}
+            {t.proLeague.gazette.editionDate}{" "}
             <span className="font-mono text-slate-300">{params.date}</span>
           </p>
         </div>
@@ -70,12 +72,12 @@ export default function GazetteArchivePage({
           href="/pro-league/gazette"
           className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
         >
-          ← Latest
+          {t.proLeague.gazette.backToLatest}
         </Link>
       </header>
 
       {loading ? (
-        <p className="text-sm text-slate-400">Chargement…</p>
+        <p className="text-sm text-slate-400">{t.proLeague.common.loading}</p>
       ) : error ? (
         <p
           role="alert"
@@ -90,7 +92,7 @@ export default function GazetteArchivePage({
           data-testid="gazette-empty"
           className="text-sm text-slate-500"
         >
-          Aucun article pour cette date.
+          {t.proLeague.gazette.emptyDateGeneric}
         </p>
       )}
     </main>

--- a/apps/web/app/pro-league/gazette/_shared.tsx
+++ b/apps/web/app/pro-league/gazette/_shared.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 
+import { useLanguage } from "../../contexts/LanguageContext";
+
 /**
- * Shared types + components — sprint 1.E.2.
+ * Shared types + components — sprint 1.E.2 + i18n.3.
  */
 
 export type GazetteArticleType = "MAIN" | "BREVE" | "EDITO";
@@ -26,22 +28,10 @@ export interface GazetteEdition {
   readonly articles: readonly GazetteArticle[];
 }
 
-export const PERSONA_LABEL: Record<GazettePersona, string> = {
-  cynic: "Le Cynique",
-  orc_enthusiast: "L'Enthousiaste Orc",
-  statistician: "Le Statisticien",
-};
-
 export const PERSONA_EMOJI: Record<GazettePersona, string> = {
   cynic: "🦝",
   orc_enthusiast: "🟢",
   statistician: "📊",
-};
-
-export const TYPE_LABEL: Record<GazetteArticleType, string> = {
-  MAIN: "Article principal",
-  BREVE: "Brève",
-  EDITO: "Édito",
 };
 
 const TYPE_BG: Record<GazetteArticleType, string> = {
@@ -55,6 +45,17 @@ export function ArticleCard({
 }: {
   article: GazetteArticle;
 }): JSX.Element {
+  const { t } = useLanguage();
+  const typeLabel: Record<GazetteArticleType, string> = {
+    MAIN: t.proLeague.gazette.articleTypeMain,
+    BREVE: t.proLeague.gazette.articleTypeBreve,
+    EDITO: t.proLeague.gazette.articleTypeEdito,
+  };
+  const personaLabel: Record<GazettePersona, string> = {
+    cynic: t.proLeague.gazette.personaCynic,
+    orc_enthusiast: t.proLeague.gazette.personaOrcEnthusiast,
+    statistician: t.proLeague.gazette.personaStatistician,
+  };
   return (
     <article
       data-testid={`gazette-article-${article.type}`}
@@ -62,11 +63,11 @@ export function ArticleCard({
     >
       <div className="mb-2 flex items-center gap-2 text-xs uppercase">
         <span className="font-bold tracking-wide text-slate-400">
-          {TYPE_LABEL[article.type]}
+          {typeLabel[article.type]}
         </span>
         {article.persona ? (
           <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-300">
-            {PERSONA_EMOJI[article.persona]} {PERSONA_LABEL[article.persona]}
+            {PERSONA_EMOJI[article.persona]} {personaLabel[article.persona]}
           </span>
         ) : null}
       </div>
@@ -96,10 +97,11 @@ export function EditionDisplay({
 }: {
   edition: GazetteEdition;
 }): JSX.Element {
+  const { t } = useLanguage();
   if (edition.articles.length === 0) {
     return (
       <p className="text-sm text-slate-500" data-testid="gazette-empty">
-        Aucun article publié pour le {edition.date}.
+        {t.proLeague.gazette.emptyEdition.replace("{date}", edition.date)}
       </p>
     );
   }

--- a/apps/web/app/pro-league/gazette/page.test.tsx
+++ b/apps/web/app/pro-league/gazette/page.test.tsx
@@ -7,9 +7,18 @@ vi.mock("../../lib/api-client", () => ({
 }));
 
 import { apiRequest } from "../../lib/api-client";
+import { LanguageProvider } from "../../contexts/LanguageContext";
 import GazetteHomePage from "./page";
 
 const mockedApi = vi.mocked(apiRequest);
+
+function renderPage(): ReturnType<typeof render> {
+  return render(
+    <LanguageProvider>
+      <GazetteHomePage />
+    </LanguageProvider>,
+  );
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -18,7 +27,7 @@ beforeEach(() => {
 describe("GazetteHomePage — sprint 1.E.2", () => {
   it("affiche 'Chargement' pendant le fetch", () => {
     mockedApi.mockReturnValue(new Promise(() => undefined));
-    render(<GazetteHomePage />);
+    renderPage();
     expect(screen.getByText(/Chargement/)).toBeTruthy();
   });
 
@@ -26,7 +35,7 @@ describe("GazetteHomePage — sprint 1.E.2", () => {
     mockedApi
       .mockResolvedValueOnce({ edition: null })
       .mockResolvedValueOnce({ dates: [] });
-    render(<GazetteHomePage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByTestId("gazette-no-edition")).toBeTruthy();
     });
@@ -65,7 +74,7 @@ describe("GazetteHomePage — sprint 1.E.2", () => {
       })
       .mockResolvedValueOnce({ dates: ["2026-09-15", "2026-09-14"] });
 
-    render(<GazetteHomePage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByTestId("gazette-edition")).toBeTruthy();
     });
@@ -100,7 +109,7 @@ describe("GazetteHomePage — sprint 1.E.2", () => {
         dates: ["2026-09-15", "2026-09-14", "2026-09-13"],
       });
 
-    render(<GazetteHomePage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByTestId("gazette-archive")).toBeTruthy();
     });
@@ -111,7 +120,7 @@ describe("GazetteHomePage — sprint 1.E.2", () => {
 
   it("affiche message d'erreur sur API throw", async () => {
     mockedApi.mockRejectedValue(new Error("boom"));
-    render(<GazetteHomePage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeTruthy();
     });

--- a/apps/web/app/pro-league/gazette/page.tsx
+++ b/apps/web/app/pro-league/gazette/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiRequest } from "../../lib/api-client";
+import { useLanguage } from "../../contexts/LanguageContext";
 
 import { type GazetteEdition, EditionDisplay } from "./_shared";
 
@@ -22,6 +23,7 @@ interface DatesResponse {
 }
 
 export default function GazetteHomePage(): JSX.Element {
+  const { t } = useLanguage();
   const [edition, setEdition] = useState<GazetteEdition | null>(null);
   const [archiveDates, setArchiveDates] = useState<readonly string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -58,22 +60,22 @@ export default function GazetteHomePage(): JSX.Element {
       <header className="mb-6 flex items-start justify-between">
         <div>
           <h1 className="text-3xl font-black tracking-tight text-amber-200">
-            🗞️ Nuffle Gazette
+            {t.proLeague.gazette.title}
           </h1>
           <p className="mt-1 text-sm text-slate-400">
-            Le quotidien officiel de la Pro League
+            {t.proLeague.gazette.subtitle}
           </p>
         </div>
         <Link
           href="/pro-league"
           className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
         >
-          ← Hub
+          {t.proLeague.common.backToHub}
         </Link>
       </header>
 
       {loading ? (
-        <p className="text-sm text-slate-400">Chargement…</p>
+        <p className="text-sm text-slate-400">{t.proLeague.common.loading}</p>
       ) : error ? (
         <p
           role="alert"
@@ -86,13 +88,12 @@ export default function GazetteHomePage(): JSX.Element {
           data-testid="gazette-no-edition"
           className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
         >
-          La Gazette n'a encore rien publié. Reviens demain matin pour le
-          premier numéro !
+          {t.proLeague.gazette.noEditionYet}
         </p>
       ) : (
         <>
           <p className="mb-4 text-sm text-slate-500">
-            Édition du{" "}
+            {t.proLeague.gazette.editionDate}{" "}
             <span className="font-mono text-slate-300">{edition.date}</span>
           </p>
           <EditionDisplay edition={edition} />
@@ -102,7 +103,7 @@ export default function GazetteHomePage(): JSX.Element {
       {archiveDates.length > 1 ? (
         <section className="mt-8" data-testid="gazette-archive">
           <h2 className="mb-2 text-lg font-semibold text-slate-100">
-            Archive
+            {t.proLeague.gazette.archiveTitle}
           </h2>
           <ul className="flex flex-wrap gap-2">
             {archiveDates.slice(1).map((d) => (

--- a/apps/web/app/pro-league/hall-of-fame/page.tsx
+++ b/apps/web/app/pro-league/hall-of-fame/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiRequest } from "../../lib/api-client";
+import { useLanguage } from "../../contexts/LanguageContext";
 
 import { WalletBadge } from "../_components/WalletBadge";
 
@@ -30,20 +31,9 @@ interface HallOfFameData {
   readonly entries: readonly HallOfFameEntry[];
 }
 
-const REASON_LABELS: Record<string, string> = {
-  death_in_match: "Mort en match",
-  career_tds: "TDs carriere",
-  mvp_legend: "Legende MVP",
-  title: "Titre",
-};
-
-function reasonLabel(code: string): string {
-  return REASON_LABELS[code] ?? code;
-}
-
-function formatDate(iso: string): string {
+function formatDate(iso: string, locale: string): string {
   const d = new Date(iso);
-  return d.toLocaleDateString("fr-FR", {
+  return d.toLocaleDateString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",
@@ -51,9 +41,19 @@ function formatDate(iso: string): string {
 }
 
 export default function HallOfFamePage(): JSX.Element {
+  const { t, language } = useLanguage();
   const [data, setData] = useState<HallOfFameData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const reasonLabel = (code: string): string => {
+    if (code === "death_in_match") return t.proLeague.hof.reasonDeath;
+    if (code === "career_tds") return t.proLeague.hof.reasonCareerTds;
+    if (code === "mvp_legend") return t.proLeague.hof.reasonMvpLegend;
+    if (code === "title") return t.proLeague.hof.reasonTitle;
+    return code;
+  };
+  const localeTag = language === "fr" ? "fr-FR" : "en-US";
 
   useEffect(() => {
     let cancelled = false;
@@ -81,7 +81,7 @@ export default function HallOfFamePage(): JSX.Element {
     <main className="mx-auto flex min-h-screen max-w-4xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
       <header className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-wide text-amber-200">
-          Hall of Fame
+          {t.proLeague.hof.title}
         </h1>
         <div className="flex items-center gap-2">
           <WalletBadge />
@@ -89,18 +89,15 @@ export default function HallOfFamePage(): JSX.Element {
             href="/pro-league"
             className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
           >
-            ← Hub
+            {t.proLeague.common.backToHub}
           </Link>
         </div>
       </header>
 
-      <p className="mb-4 text-sm text-slate-400">
-        Les joueurs immortalises de la Old World League. Tombes au champ
-        d&apos;honneur de Nuffle ou couronnes par leur palmares.
-      </p>
+      <p className="mb-4 text-sm text-slate-400">{t.proLeague.hof.intro}</p>
 
       {loading ? (
-        <p className="text-sm text-slate-400">Chargement…</p>
+        <p className="text-sm text-slate-400">{t.proLeague.common.loading}</p>
       ) : error ? (
         <p
           role="alert"
@@ -113,8 +110,7 @@ export default function HallOfFamePage(): JSX.Element {
           data-testid="empty-hof"
           className="rounded border border-slate-800 bg-slate-900 px-3 py-3 text-sm text-slate-400"
         >
-          Aucun joueur au Hall of Fame pour le moment. Soyez patient — Nuffle
-          finira par reclamer son du.
+          {t.proLeague.hof.emptyState}
         </p>
       ) : (
         <ul
@@ -132,7 +128,7 @@ export default function HallOfFamePage(): JSX.Element {
                   {e.playerName}
                 </h2>
                 <span className="text-xs font-mono text-slate-500">
-                  {formatDate(e.inductedAt)}
+                  {formatDate(e.inductedAt, localeTag)}
                 </span>
               </div>
               <p className="mt-0.5 text-sm text-slate-400">


### PR DESCRIPTION
## Sprint i18n Pro League — lot 3 (gazette + hall-of-fame)

Suite de la série i18n. Refonte des pages Gazette (hub + archive [date]) et Hall of Fame.

### Translations

**`proLeague.gazette.*`** : title, subtitle, backToLatest, editionDate, noEditionYet, archiveTitle, emptyEdition (template `{date}`), emptyDateGeneric, invalidDate, articleType {Main/Breve/Edito}, persona {Cynic/OrcEnthusiast/Statistician}.

**`proLeague.hof.*`** : title, intro, emptyState, reasonDeath/CareerTds/MvpLegend/Title.

### Refactor

- **`/pro-league/gazette`** (hub) : `useLanguage()` + `t.proLeague.gazette.*`.
- **`/pro-league/gazette/[date]`** (archive) : `useLanguage()` + i18n. La string d'erreur `invalidDate` devient une dépendance de `useEffect` (capture stable via `t`).
- **`/pro-league/gazette/_shared`** (`<ArticleCard>`, `<EditionDisplay>`) : `useLanguage()` + maps locales pour `TYPE_LABEL` et `PERSONA_LABEL` (PERSONA_EMOJI reste const partagée).
- **`/pro-league/hall-of-fame`** : `useLanguage()` + `t.proLeague.hof.*`. `reasonLabel(code)` helper local. `formatDate(iso, locale)` reçoit maintenant une locale tag (`fr-FR` / `en-US`) selon `language` du context.
- `backToHub` + `loading` mutualisés via `t.proLeague.common.*`.

### Tests

- `gazette/page.test.tsx` : helper `renderPage()` wrap `LanguageProvider`.
- Pas de test existant sur hall-of-fame (création quand on aura besoin de couverture ciblée).

```
✓ gazette/page.test.tsx (5 tests)
Test Files 11 passed (11) — 84 tests pro-league suite complete
```

### Sequel

- i18n.4 : matches detail + live + replay (le plus gros chunk — controls + ticker + scrub + shortcuts hint)
- i18n.5 : components (WalletBadge, BetSlip, MarketsList) + feed + me

https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUgr8163N7cprQ5qJyqbgV)_