### PR TITLE
refactor(game-engine): extract handleBallPickup + canUseTeamReroll (S27.8.5)

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -63,6 +63,8 @@ import {
   // S27.8.3 — `advanceHalfIfNeeded` et `handlePostTouchdown` consommes
   // uniquement dans `actions/turn-foul-actions.ts` (handleEndTurn).
   canTeamBlitz,
+  // S27.8.5 — `canUseTeamReroll` deplace dans `core/game-state.ts`.
+  canUseTeamReroll,
 } from '../core/game-state';
 // S27.8.2 — `executePass` / `executeHandoff` consommes dans
 // `actions/pass-actions.ts`. `getPassRange` + `canAttemptPassForRange`
@@ -120,6 +122,10 @@ import {
   applyRollFailure,
   applyPickupFailure,
 } from './failure-helpers';
+// S27.8.5 — `handleBallPickup` extrait dans `actions/ball-pickup.ts`
+// pour servir de feuille reutilisable par handleNormalMove /
+// handleDodgeRoll / handleLeap / handleRerollChoose.
+import { handleBallPickup } from './ball-pickup';
 import { canDumpOff, getDumpOffReceivers, executeDumpOff } from '../mechanics/dump-off';
 import { checkDauntless } from '../mechanics/dauntless';
 import { checkBreakTackle } from '../mechanics/break-tackle';
@@ -430,14 +436,9 @@ function getAdjacentOpponents(state: GameState, position: Position, team: TeamId
   return opponents;
 }
 
-/**
- * Vérifie si une équipe peut utiliser une relance d'équipe
- */
-function canUseTeamReroll(state: GameState, team: TeamId): boolean {
-  if (state.rerollUsedThisTurn) return false;
-  const rerolls = team === 'A' ? state.teamRerolls?.teamA : state.teamRerolls?.teamB;
-  return (rerolls ?? 0) > 0;
-}
+// S27.8.5 — `canUseTeamReroll` deplace dans `core/game-state.ts` pour
+// pouvoir etre consomme par les handlers extraits (ball-leap-actions
+// notamment) sans creer de cycle d'import vers `actions.ts`.
 
 /**
  * Résout le second bloc Frenzy si `pendingFrenzyBlock` est défini et qu'il
@@ -1179,114 +1180,8 @@ function handleNormalMove(
   return next;
 }
 
-/**
- * Gère le ramassage de balle
- */
-function handleBallPickup(state: GameState, player: Player, rng: RNG, idx: number): GameState {
-  // No Hands: player cannot pick up the ball at all (no roll)
-  if (hasSkill(player, 'no-hands')) {
-    const noHandsLog = createLogEntry(
-      'info',
-      `Sans Ballon: ${player.name} ne peut pas ramasser le ballon !`,
-      player.id,
-      player.team,
-      { skill: 'no-hands' }
-    );
-    const turnoverLog = createLogEntry(
-      'turnover',
-      `Échec du ramassage (Sans Ballon) - Turnover`,
-      player.id,
-      player.team
-    );
-    const newState: GameState = {
-      ...state,
-      isTurnover: true,
-      gameLog: [...state.gameLog, noHandsLog, turnoverLog],
-    };
-    return bounceBall(newState, rng);
-  }
-
-  // Calculer les modificateurs de pickup (malus pour adversaires + bonus skills)
-  const basePickupModifiers = calculatePickupModifiers(state, state.ball!, player.team);
-  const skillPickupModifiers = getPickupSkillModifiers(state, player);
-  const pickupModifiers = basePickupModifiers + skillPickupModifiers;
-
-  // Effectuer le jet de pickup
-  let pickupResult = performPickupRollWithNotification(player, rng, pickupModifiers);
-
-  // Sure Hands : relance automatique du pickup raté (via skill registry)
-  if (!pickupResult.success && canSkillReroll(player, 'on-pickup', state)) {
-    const rerollLog = createLogEntry(
-      'dice',
-      `Sure Hands : relance du ramassage (${pickupResult.diceRoll} raté)`,
-      player.id,
-      player.team
-    );
-    state.gameLog = [...state.gameLog, rerollLog];
-    pickupResult = performPickupRollWithNotification(player, rng, pickupModifiers);
-  }
-
-  // Stocker le résultat pour l'affichage
-  state.lastDiceResult = pickupResult;
-
-  // Log du jet de pickup
-  const pickupLogEntry = createLogEntry(
-    'dice',
-    `Jet de pickup: ${pickupResult.diceRoll}/${pickupResult.targetNumber} ${pickupResult.success ? '✓' : '✗'}`,
-    player.id,
-    player.team,
-    {
-      diceRoll: pickupResult.diceRoll,
-      targetNumber: pickupResult.targetNumber,
-      success: pickupResult.success,
-      modifiers: pickupModifiers,
-    }
-  );
-  state.gameLog = [...state.gameLog, pickupLogEntry];
-
-  if (pickupResult.success) {
-    // Ramassage réussi : attacher la balle au joueur
-    state.ball = undefined;
-    state.players[idx].hasBall = true;
-
-    // Log du ramassage réussi
-    const successLogEntry = createLogEntry(
-      'action',
-      `Ballon ramassé avec succès`,
-      player.id,
-      player.team
-    );
-    state.gameLog = [...state.gameLog, successLogEntry];
-
-    // Si pickup dans l'en-but adverse, touchdown immédiat
-    const picker = state.players[idx];
-    if (isInOpponentEndzone(state, picker)) {
-      return awardTouchdown(state, picker.team, picker);
-    }
-  } else {
-    // Échec de pickup : offrir relance d'équipe si disponible
-    if (canUseTeamReroll(state, player.team)) {
-      state.pendingReroll = { rollType: 'pickup', playerId: player.id, team: player.team, targetNumber: pickupResult.targetNumber, modifiers: pickupModifiers, playerIndex: idx };
-      return state;
-    }
-    // Pas de relance : la balle rebondit et turnover
-    state.isTurnover = true;
-
-    // Log du ramassage échoué
-    const failLogEntry = createLogEntry(
-      'turnover',
-      `Échec du ramassage - Turnover`,
-      player.id,
-      player.team
-    );
-    state.gameLog = [...state.gameLog, failLogEntry];
-
-    // Faire rebondir la balle
-    return bounceBall(state, rng);
-  }
-
-  return state;
-}
+// S27.8.5 — `handleBallPickup` extrait dans `actions/ball-pickup.ts`
+// (re-importe en haut de ce fichier).
 
 /**
  * Gère une action d'esquive explicite

--- a/packages/game-engine/src/actions/ball-pickup.ts
+++ b/packages/game-engine/src/actions/ball-pickup.ts
@@ -1,0 +1,170 @@
+/**
+ * S27.8.5 — Handler de ramassage de balle extrait de `actions.ts`.
+ *
+ * `handleBallPickup` est appele par plusieurs handlers du dispatcher
+ * (handleNormalMove, handleDodgeRoll, handleLeap, handleRerollChoose
+ * via la branche pickup). En l'extrayant ici comme feuille (sans
+ * dependance interne a `actions.ts`), on permet aux handlers
+ * cycliques de l'importer librement dans des slices ulterieurs.
+ *
+ * Aucune logique modifiee : la fonction est copiee a l'identique.
+ */
+
+import type { GameState, Player, RNG } from '../core/types';
+import { hasSkill } from '../skills/skill-effects';
+import {
+  isInOpponentEndzone,
+  awardTouchdown,
+  bounceBall,
+} from '../mechanics/ball';
+import { calculatePickupModifiers } from '../mechanics/movement';
+import {
+  getPickupSkillModifiers,
+  canSkillReroll,
+} from '../skills/skill-bridge';
+import { performPickupRollWithNotification } from '../utils/dice-notifications';
+import { createLogEntry } from '../utils/logging';
+import { canUseTeamReroll } from '../core/game-state';
+
+/**
+ * Gere le ramassage de balle d'un joueur. Couvre :
+ *  - skill `no-hands` (interdit le pickup, turnover immediat).
+ *  - jet de pickup avec modifiers (zones de tacle adverses + skills
+ *    de pickup type Big Hand / Extra Arms).
+ *  - relance auto via `Sure Hands` (registry).
+ *  - succes -> attache la balle, touchdown si en-but adverse.
+ *  - echec -> propose relance d'equipe si dispo, sinon turnover +
+ *    rebond.
+ */
+export function handleBallPickup(
+  state: GameState,
+  player: Player,
+  rng: RNG,
+  idx: number,
+): GameState {
+  // No Hands: player cannot pick up the ball at all (no roll)
+  if (hasSkill(player, 'no-hands')) {
+    const noHandsLog = createLogEntry(
+      'info',
+      `Sans Ballon: ${player.name} ne peut pas ramasser le ballon !`,
+      player.id,
+      player.team,
+      { skill: 'no-hands' },
+    );
+    const turnoverLog = createLogEntry(
+      'turnover',
+      `Échec du ramassage (Sans Ballon) - Turnover`,
+      player.id,
+      player.team,
+    );
+    const newState: GameState = {
+      ...state,
+      isTurnover: true,
+      gameLog: [...state.gameLog, noHandsLog, turnoverLog],
+    };
+    return bounceBall(newState, rng);
+  }
+
+  // Calculer les modificateurs de pickup (malus pour adversaires +
+  // bonus skills)
+  const basePickupModifiers = calculatePickupModifiers(
+    state,
+    state.ball!,
+    player.team,
+  );
+  const skillPickupModifiers = getPickupSkillModifiers(state, player);
+  const pickupModifiers = basePickupModifiers + skillPickupModifiers;
+
+  // Effectuer le jet de pickup
+  let pickupResult = performPickupRollWithNotification(
+    player,
+    rng,
+    pickupModifiers,
+  );
+
+  // Sure Hands : relance automatique du pickup rate (via skill registry)
+  if (!pickupResult.success && canSkillReroll(player, 'on-pickup', state)) {
+    const rerollLog = createLogEntry(
+      'dice',
+      `Sure Hands : relance du ramassage (${pickupResult.diceRoll} raté)`,
+      player.id,
+      player.team,
+    );
+    state.gameLog = [...state.gameLog, rerollLog];
+    pickupResult = performPickupRollWithNotification(
+      player,
+      rng,
+      pickupModifiers,
+    );
+  }
+
+  // Stocker le resultat pour l'affichage
+  state.lastDiceResult = pickupResult;
+
+  // Log du jet de pickup
+  const pickupLogEntry = createLogEntry(
+    'dice',
+    `Jet de pickup: ${pickupResult.diceRoll}/${pickupResult.targetNumber} ${
+      pickupResult.success ? '✓' : '✗'
+    }`,
+    player.id,
+    player.team,
+    {
+      diceRoll: pickupResult.diceRoll,
+      targetNumber: pickupResult.targetNumber,
+      success: pickupResult.success,
+      modifiers: pickupModifiers,
+    },
+  );
+  state.gameLog = [...state.gameLog, pickupLogEntry];
+
+  if (pickupResult.success) {
+    // Ramassage reussi : attacher la balle au joueur
+    state.ball = undefined;
+    state.players[idx].hasBall = true;
+
+    // Log du ramassage reussi
+    const successLogEntry = createLogEntry(
+      'action',
+      `Ballon ramassé avec succès`,
+      player.id,
+      player.team,
+    );
+    state.gameLog = [...state.gameLog, successLogEntry];
+
+    // Si pickup dans l'en-but adverse, touchdown immediat
+    const picker = state.players[idx];
+    if (isInOpponentEndzone(state, picker)) {
+      return awardTouchdown(state, picker.team, picker);
+    }
+  } else {
+    // Echec de pickup : offrir relance d'equipe si disponible
+    if (canUseTeamReroll(state, player.team)) {
+      state.pendingReroll = {
+        rollType: 'pickup',
+        playerId: player.id,
+        team: player.team,
+        targetNumber: pickupResult.targetNumber,
+        modifiers: pickupModifiers,
+        playerIndex: idx,
+      };
+      return state;
+    }
+    // Pas de relance : la balle rebondit et turnover
+    state.isTurnover = true;
+
+    // Log du ramassage echoue
+    const failLogEntry = createLogEntry(
+      'turnover',
+      `Échec du ramassage - Turnover`,
+      player.id,
+      player.team,
+    );
+    state.gameLog = [...state.gameLog, failLogEntry];
+
+    // Faire rebondir la balle
+    return bounceBall(state, rng);
+  }
+
+  return state;
+}

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -936,6 +936,18 @@ export function getGfiCap(state: GameState, player: Player): number {
 }
 
 /**
+ * S27.8.5 — Verifie si une equipe peut utiliser une relance d'equipe
+ * (extrait de `actions/actions.ts` pour casser le cycle d'import vers
+ * les handlers extraits).
+ */
+export function canUseTeamReroll(state: GameState, team: TeamId): boolean {
+  if (state.rerollUsedThisTurn) return false;
+  const rerolls =
+    team === 'A' ? state.teamRerolls?.teamA : state.teamRerolls?.teamB;
+  return (rerolls ?? 0) > 0;
+}
+
+/**
  * Vérifie si un joueur peut bouger
  * @param state - État du jeu
  * @param playerId - ID du joueur

--- a/packages/game-engine/vitest.config.ts
+++ b/packages/game-engine/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         'src/actions/pass-actions.ts',
         'src/actions/turn-foul-actions.ts',
         'src/actions/failure-helpers.ts',
+        'src/actions/ball-pickup.ts',
       ],
       // S25.4 — Seuils initiaux conservateurs. v8 reporte 0% lines sur
       // certains fichiers TS du moteur a cause d'un quirk source-map ;


### PR DESCRIPTION
## Resume

Slice 5 de S27.8 (refactor monolith `actions.ts`).

**Extraction** (`packages/game-engine/src/actions/ball-pickup.ts`, nouveau)
- `handleBallPickup` : ramassage de balle complet (skill `no-hands`, modifiers basics + skills, relance Sure Hands, succes/touchdown, echec / team reroll / turnover + rebond).
- Aucune dependance interne au dispatcher : tout passe par les modules `mechanics/*`, `skills/*`, `utils/*` et `core/game-state`.

**Helper deplace** (`packages/game-engine/src/core/game-state.ts`)
- `canUseTeamReroll(state, team)` migre depuis `actions.ts`. Le fichier est la place naturelle pour ce check pur sur `state` (a cote de `canPlayerMove` / `canPlayerContinueMoving` / `getGfiCap`). Permet a `ball-pickup.ts` (et aux extractions ulterieures) de l'importer sans creer de cycle vers `actions.ts`.

**Resultat**
- `actions.ts` **2240 -> 2135 lignes** (-105 nettes ; cumul **-571 vs origine 2706 = ~21.1%**).
- `ball-pickup.ts` ajoute a la liste d'exclusion coverage.
- 4888 tests game-engine passent. Coverage 25.33% maintenue (>= 25% seuil).

## Tache roadmap

Sprint S27, tache S27.8 (slice 5 — ball pickup feuille)
Source : `docs/roadmap/sprints/S27-evolutions-confort.md`

Reste pour atteindre la cible <= 600 lignes :
- handleLeap (depend de getLegalMoves, cycle a casser)
- handleNormalMove / handleDodgeRoll / handleDodge / handleMove
- handleBlock / choice handlers
- handleBlitz

## Plan de test

- [x] `pnpm --filter @bb/game-engine test` : 4888 tests passent
- [x] `pnpm --filter @bb/game-engine run test:coverage` : 25.33% (>= 25%)
- [x] `pnpm typecheck` : 5/6 packages succes (3 erreurs pre-existantes web)
- [x] `pnpm lint` : 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jim8bQ2p2KiweXCBHAALrf)_