### PR TITLE
feat(metrics): Pro League sim engine metrics (Lot 2.A.1 + 2.A.2)

### DIFF
--- a/apps/server/src/utils/metrics.test.ts
+++ b/apps/server/src/utils/metrics.test.ts
@@ -94,4 +94,95 @@ describe("metrics registry", () => {
       expect(text).toContain("# TYPE");
     });
   });
+
+  describe("Pro League sim metrics (Lot 2.A.2)", () => {
+    it("declare toutes les metriques nuffle_* attendues", async () => {
+      // Touch chaque métrique au moins une fois pour qu'elle apparaisse
+      // dans la sortie Prometheus (les histogrammes/counters non touchés
+      // peuvent être omis du rendu).
+      metrics.observeSimMatchDuration(
+        { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+        0.05,
+      );
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.observeReplaySize({ engineVer: "0.16.0" }, 4096);
+      metrics.setBroadcasterActiveSessions(3);
+      metrics.setBroadcasterTotalSubscribers(12);
+      metrics.observeBroadcasterDispatchLag(45);
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.04,
+      );
+      const text = await metricsExposition(metrics.registry);
+      for (const name of [
+        "nuffle_sim_match_duration_seconds",
+        "nuffle_sim_match_total",
+        "nuffle_replay_size_bytes",
+        "nuffle_broadcaster_active_sessions",
+        "nuffle_broadcaster_total_subscribers",
+        "nuffle_broadcaster_event_dispatch_lag_ms",
+        "nuffle_engine_drift",
+      ]) {
+        expect(text).toContain(name);
+      }
+    });
+
+    it("recordSimMatch incremente le compteur par labels {status, driver}", async () => {
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "failed", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "full" });
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="hybrid"[^}]*\} 2/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="failed"[^}]*driver="hybrid"[^}]*\} 1/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="full"[^}]*\} 1/);
+    });
+
+    it("setBroadcasterActiveSessions / setBroadcasterTotalSubscribers clampent a 0", async () => {
+      metrics.setBroadcasterActiveSessions(-5);
+      metrics.setBroadcasterTotalSubscribers(-1);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(0);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
+      metrics.setBroadcasterActiveSessions(7);
+      metrics.setBroadcasterTotalSubscribers(42);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(7);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(42);
+    });
+
+    it("observeBroadcasterDispatchLag clamp les valeurs <=0 a 0", async () => {
+      // Si le wallclock recule, on observe 0 plutôt que de polluer.
+      metrics.observeBroadcasterDispatchLag(-50);
+      metrics.observeBroadcasterDispatchLag(120);
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toContain("nuffle_broadcaster_event_dispatch_lag_ms");
+      // Bucket le=200 doit avoir capturé l'observation 120ms.
+      expect(text).toMatch(/nuffle_broadcaster_event_dispatch_lag_ms_bucket\{le="200"\} [12]/);
+    });
+
+    it("setEngineDrift accepte des valeurs positives et negatives", async () => {
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Halfling", seasonId: "S2026" },
+        -0.08,
+      );
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.05,
+      );
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Halfling"[^}]*\} -0\.08/);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Wood Elf"[^}]*\} 0\.05/);
+    });
+
+    it("observeSimMatchDuration peuple l'histogramme avec les buckets attendus", async () => {
+      for (const seconds of [0.04, 0.08, 0.5, 1.5, 4.0]) {
+        metrics.observeSimMatchDuration(
+          { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+          seconds,
+        );
+      }
+      const text = await metricsExposition(metrics.registry);
+      // Bucket le=5 capture toutes les observations <= 5s.
+      expect(text).toMatch(/nuffle_sim_match_duration_seconds_bucket\{[^}]*le="5"[^}]*\} 5/);
+    });
+  });
 });

--- a/apps/server/src/utils/metrics.ts
+++ b/apps/server/src/utils/metrics.ts
@@ -1,26 +1,38 @@
 /**
- * Métriques Prometheus (tâche S25.3 — Sprint 25).
+ * Métriques Prometheus (tâche S25.3 — Sprint 25 ; étendu Lot 2.A.2).
  *
- * Expose 5 metriques custom requises par la roadmap + un histogramme de
- * latence HTTP. Chaque metrique est isolee dans son propre `Registry`
- * ou un registre injecte, afin de pouvoir instancier un mock dans les
- * tests sans polluer le state global.
+ * Expose les métriques applicatives custom + un histogramme de latence
+ * HTTP. Chaque metrique est isolee dans son propre `Registry` ou un
+ * registre injecte, afin de pouvoir instancier un mock dans les tests
+ * sans polluer le state global.
  *
- * Metriques :
- *   - match_active_count        gauge   (matches en cours, mis a jour
- *                                        par game-rooms.ts)
- *   - matchmaking_queue_size    gauge   (utilisateurs en queue, mis a
- *                                        jour par services/matchmaking.ts)
- *   - ws_connections_open       gauge   (sockets actives, mis a jour
- *                                        par socket.ts)
- *   - pass_attempts_total       counter (label `result` : success/fumble/
- *                                        intercepted/inaccurate)
- *   - armor_break_total         counter (armor rolls reussis cote
- *                                        attaquant)
+ * Catalogue
+ * ---------
+ * Live state (S25.3) :
+ *   - match_active_count        gauge   (game-rooms.ts)
+ *   - matchmaking_queue_size    gauge   (services/matchmaking.ts)
+ *   - ws_connections_open       gauge   (socket.ts)
+ *   - pass_attempts_total       counter (label `result`)
+ *   - armor_break_total         counter
  *   - http_request_duration_ms  histogram(method, route, statusCode)
  *
- * Le serveur expose `metricsHandler` sur `/metrics`, format
- * Prometheus standard text/plain.
+ * Pro League sim engine (Lot 2.A.2) :
+ *   - nuffle_sim_match_duration_seconds       histogram(engineVer, driver, outcome)
+ *   - nuffle_sim_match_total                  counter(status, driver)
+ *   - nuffle_replay_size_bytes                histogram(engineVer)
+ *   - nuffle_broadcaster_active_sessions      gauge
+ *   - nuffle_broadcaster_total_subscribers    gauge
+ *   - nuffle_broadcaster_event_dispatch_lag_ms histogram
+ *   - nuffle_engine_drift                     gauge(metric, race, seasonId)
+ *
+ * Le serveur expose `/metrics` sur le réseau Docker interne (Prometheus
+ * scrape, non exposé internet). Cardinality kept bounded :
+ *  - `driver` ∈ {'hybrid','full'}
+ *  - `outcome` ∈ {'home','away','draw','failed'}
+ *  - `status` ∈ {'success','failed'}
+ *  - `metric` ∈ {'tdMean','casualtyMean','turnoverMean','homeWinRate', …}
+ *  - `race` couvre les 16 archétypes Pro League
+ *  - `engineVer` change rarement (~1/saison via pinning)
  */
 
 import {
@@ -43,6 +55,39 @@ export interface HttpDurationLabels {
   statusCode: number;
 }
 
+/** Driver utilisé pour la simulation (lot 3.B.1 introduira 'full'). */
+export type SimDriver = "hybrid" | "full";
+
+/** Issue d'un match côté simulation (vs `proLeagueMatch.outcome`). */
+export type SimOutcome = "home" | "away" | "draw" | "failed";
+
+/** Statut top-level d'une simulation pour le compteur agrégé. */
+export type SimStatus = "success" | "failed";
+
+export interface SimMatchDurationLabels {
+  engineVer: string;
+  driver: SimDriver;
+  outcome: SimOutcome;
+}
+
+export interface SimMatchTotalLabels {
+  status: SimStatus;
+  driver: SimDriver;
+}
+
+export interface ReplaySizeLabels {
+  engineVer: string;
+}
+
+export interface EngineDriftLabels {
+  /** Métrique observée — `tdMean`, `casualtyMean`, `turnoverMean`, `homeWinRate`, etc. */
+  metric: string;
+  /** Race archétype concernée — `Orc`, `Wood Elf`, `Halfling`, … ou `*` pour aggregat. */
+  race: string;
+  /** Saison Pro League à laquelle se rattache la mesure. */
+  seasonId: string;
+}
+
 export interface MetricsRegistry {
   readonly registry: Registry;
 
@@ -59,6 +104,21 @@ export interface MetricsRegistry {
   /** Observe une duree HTTP (en ms). */
   observeHttpDuration(labels: HttpDurationLabels, ms: number): void;
 
+  /** Pro League sim — observe la durée d'une simulation (en secondes). */
+  observeSimMatchDuration(labels: SimMatchDurationLabels, seconds: number): void;
+  /** Pro League sim — incrémente le compteur de matchs simulés. */
+  recordSimMatch(labels: SimMatchTotalLabels): void;
+  /** Pro League sim — observe la taille (bytes) d'un replay compressé. */
+  observeReplaySize(labels: ReplaySizeLabels, bytes: number): void;
+  /** Broadcaster — set le nombre de sessions actives (clamp à 0). */
+  setBroadcasterActiveSessions(value: number): void;
+  /** Broadcaster — set le total de subscribers (clamp à 0). */
+  setBroadcasterTotalSubscribers(value: number): void;
+  /** Broadcaster — observe le délai de dispatch d'un event (en ms, peut être négatif si avance, dans ce cas clampé à 0). */
+  observeBroadcasterDispatchLag(ms: number): void;
+  /** Engine drift — set la dérive d'une métrique vs baseline (en delta relatif, ex: 0.04 pour +4%). */
+  setEngineDrift(labels: EngineDriftLabels, value: number): void;
+
   /** Helper test : retourne la valeur courante d'une gauge. */
   snapshotGauge(name: string): Promise<number>;
   /** Helper test : retourne les valeurs par label d'un counter. */
@@ -68,6 +128,23 @@ export interface MetricsRegistry {
 /** Buckets en millisecondes alignes sur des seuils SLO communs. */
 const HTTP_DURATION_BUCKETS_MS = [
   10, 25, 50, 100, 200, 350, 500, 750, 1000, 2500, 5000, 10000,
+];
+
+/** Buckets en secondes pour les sims (hybrid ~50ms, full attendu ~1-3s). */
+const SIM_DURATION_BUCKETS_SECONDS = [
+  0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 30,
+];
+
+/** Buckets en bytes pour la taille des replays (CBOR+gzip). Hybrid ~5-15KB,
+ *  full attendu ~30-100KB selon la verbosité d'events. */
+const REPLAY_SIZE_BUCKETS_BYTES = [
+  1024, 5_120, 10_240, 25_600, 51_200, 102_400, 256_000, 512_000, 1_048_576,
+];
+
+/** Buckets en millisecondes pour le lag de dispatch broadcaster.
+ *  Tick interne 100ms — un dispatch healthy reste sous 200ms. */
+const BROADCASTER_DISPATCH_LAG_BUCKETS_MS = [
+  10, 25, 50, 100, 200, 350, 500, 750, 1000, 2000, 5000,
 ];
 
 export function buildMetricsRegistry(): MetricsRegistry {
@@ -111,6 +188,50 @@ export function buildMetricsRegistry(): MetricsRegistry {
     registers: [registry],
   });
 
+  // Pro League sim engine metrics (Lot 2.A.2).
+  const simMatchDuration = new Histogram({
+    name: "nuffle_sim_match_duration_seconds",
+    help: "Durée d'une simulation de match Pro League (sim-engine), en secondes",
+    labelNames: ["engineVer", "driver", "outcome"],
+    buckets: SIM_DURATION_BUCKETS_SECONDS,
+    registers: [registry],
+  });
+  const simMatchTotal = new Counter({
+    name: "nuffle_sim_match_total",
+    help: "Total de simulations de matchs Pro League (label `status` : success|failed, `driver`)",
+    labelNames: ["status", "driver"],
+    registers: [registry],
+  });
+  const replaySize = new Histogram({
+    name: "nuffle_replay_size_bytes",
+    help: "Taille du replay compressé (CBOR+gzip) en bytes",
+    labelNames: ["engineVer"],
+    buckets: REPLAY_SIZE_BUCKETS_BYTES,
+    registers: [registry],
+  });
+  const broadcasterActiveSessions = new Gauge({
+    name: "nuffle_broadcaster_active_sessions",
+    help: "Nombre de MatchSession actives dans le broadcaster",
+    registers: [registry],
+  });
+  const broadcasterTotalSubscribers = new Gauge({
+    name: "nuffle_broadcaster_total_subscribers",
+    help: "Total des subscribers (SSE clients) connectés au broadcaster",
+    registers: [registry],
+  });
+  const broadcasterDispatchLag = new Histogram({
+    name: "nuffle_broadcaster_event_dispatch_lag_ms",
+    help: "Délai de dispatch d'un event (Date.now() - (startedAt + displayAtMs)) en ms",
+    buckets: BROADCASTER_DISPATCH_LAG_BUCKETS_MS,
+    registers: [registry],
+  });
+  const engineDrift = new Gauge({
+    name: "nuffle_engine_drift",
+    help: "Dérive relative d'une métrique sim vs baseline FUMBBL/snapshot (delta relatif, ex: 0.04 = +4%)",
+    labelNames: ["metric", "race", "seasonId"],
+    registers: [registry],
+  });
+
   const clamp = (n: number) => (Number.isFinite(n) && n > 0 ? n : 0);
 
   return {
@@ -138,6 +259,51 @@ export function buildMetricsRegistry(): MetricsRegistry {
           statusCode: String(labels.statusCode),
         },
         ms,
+      );
+    },
+    observeSimMatchDuration(labels, seconds) {
+      const safe = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+      simMatchDuration.observe(
+        {
+          engineVer: labels.engineVer,
+          driver: labels.driver,
+          outcome: labels.outcome,
+        },
+        safe,
+      );
+    },
+    recordSimMatch(labels) {
+      simMatchTotal.inc({
+        status: labels.status,
+        driver: labels.driver,
+      });
+    },
+    observeReplaySize(labels, bytes) {
+      const safe = Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
+      replaySize.observe({ engineVer: labels.engineVer }, safe);
+    },
+    setBroadcasterActiveSessions(value) {
+      broadcasterActiveSessions.set(clamp(value));
+    },
+    setBroadcasterTotalSubscribers(value) {
+      broadcasterTotalSubscribers.set(clamp(value));
+    },
+    observeBroadcasterDispatchLag(ms) {
+      // Lag négatif = event dispatché en avance (peu probable mais
+      // possible si le wallclock recule). On clamp pour ne pas polluer
+      // l'histogramme.
+      const safe = Number.isFinite(ms) && ms > 0 ? ms : 0;
+      broadcasterDispatchLag.observe(safe);
+    },
+    setEngineDrift(labels, value) {
+      const safe = Number.isFinite(value) ? value : 0;
+      engineDrift.set(
+        {
+          metric: labels.metric,
+          race: labels.race,
+          seasonId: labels.seasonId,
+        },
+        safe,
       );
     },
 


### PR DESCRIPTION
## Summary

Lot 2.A.1 (logger audit) + Lot 2.A.2 (Prometheus metric catalogue) du sprint sim-engine observability ([cf. roadmap PR #667](./docs/roadmap/sprints/SPRINT-sim-engine-observability.md)).

### Lot 2.A.1 — Logger audit (no code change)

Pino est déjà câblé (`apps/server/src/utils/pino-logger.ts`) avec `service: "@bb/server"`. Loki indexe le JSON structuré comme prévu. Sim runner + broadcaster passent par `serverLog` et héritent du format. **Closed as DONE.**

### Lot 2.A.2 — Extend `appMetrics`

L'endpoint `/metrics` existe déjà (S25.3). Ce PR étend le registre avec le catalogue sim engine :

```
nuffle_sim_match_duration_seconds   histogram(engineVer, driver, outcome)
nuffle_sim_match_total              counter(status, driver)
nuffle_replay_size_bytes            histogram(engineVer)
nuffle_broadcaster_active_sessions  gauge
nuffle_broadcaster_total_subscribers gauge
nuffle_broadcaster_event_dispatch_lag_ms  histogram
nuffle_engine_drift                 gauge(metric, race, seasonId)
```

Buckets calibrés pour les plages attendues :
- sim duration : 25ms..30s (hybrid ~50ms, full attendu ~1-3s)
- replay size : 1KB..1MB
- broadcaster lag : 10ms..5s (tick 100ms, healthy < 200ms)

Cardinalité bornée : driver ∈ {hybrid, full}, outcome ∈ {home, away, draw, failed}, status ∈ {success, failed}, engineVer pinné par saison.

## Test plan

- [x] 14 tests passent (`apps/server/src/utils/metrics.test.ts`) — 8 existants + 6 nouveaux
- [x] `pnpm typecheck` propre
- [x] Endpoint `/metrics` déjà exposé sur `:8201/metrics` (rien à wirer)
- [ ] Lots 2.A.3 / 2.A.4 / 2.A.5 (suivants) consommeront ces helpers

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_