### PR TITLE
feat(metrics): instrument sim-runner + broadcaster (Lot 2.A.3 + 2.A.4)

### DIFF
--- a/apps/server/src/services/pro-league-match-broadcaster.test.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.test.ts
@@ -32,6 +32,7 @@ import {
   preloadMatch,
   subscribeToMatch,
 } from "./pro-league-match-broadcaster";
+import { appMetrics } from "../utils/metrics";
 
 interface MockedPrisma {
   proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
@@ -266,5 +267,26 @@ describe("getBroadcasterStats — sprint 1.B.1", () => {
     expect(getBroadcasterStats().totalSubscribers).toBe(1);
     un2();
     expect(getBroadcasterStats().totalSubscribers).toBe(0);
+  });
+});
+
+describe("Prometheus gauges — Lot 2.A.4", () => {
+  it("setBroadcasterActiveSessions / setBroadcasterTotalSubscribers reflètent l'état après chaque mutation", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(0);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
+
+    const un1 = await subscribeToMatch(MATCH_ID, () => undefined);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(1);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(1);
+
+    const un2 = await subscribeToMatch(MATCH_ID, () => undefined);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(2);
+
+    un1();
+    un2();
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
   });
 });

--- a/apps/server/src/services/pro-league-match-broadcaster.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.ts
@@ -40,6 +40,7 @@ import { EventEmitter } from "node:events";
 import { decompressEvents, type MatchEvent } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { appMetrics } from "../utils/metrics";
 
 /** Fréquence du tick interne (ms). 100ms = précision visuelle suffisante. */
 const TICK_INTERVAL_MS = 100;
@@ -64,6 +65,22 @@ interface MatchSession {
 }
 
 const sessions = new Map<string, MatchSession>();
+
+/**
+ * Lot 2.A.4 — recompute and push the broadcaster gauges from the
+ * current sessions Map. Called after every mutation (session
+ * created/reaped, subscriber added/removed) so Grafana sees the
+ * live state without a polling loop. O(n) on number of active
+ * sessions ; n is small (a handful at MVP scale).
+ */
+function refreshBroadcasterGauges(): void {
+  let totalSubscribers = 0;
+  for (const session of sessions.values()) {
+    totalSubscribers += session.subscribers;
+  }
+  appMetrics.setBroadcasterActiveSessions(sessions.size);
+  appMetrics.setBroadcasterTotalSubscribers(totalSubscribers);
+}
 
 /**
  * Charge la session d'un match si elle n'existe pas encore. Décompresse
@@ -110,6 +127,7 @@ async function ensureSession(matchId: string): Promise<MatchSession> {
   // Permet beaucoup de listeners (par défaut 10) — on cap à 1024.
   session.emitter.setMaxListeners(1024);
   sessions.set(matchId, session);
+  refreshBroadcasterGauges();
 
   startTickLoop(session);
   return session;
@@ -128,6 +146,11 @@ function startTickLoop(session: MatchSession): void {
       session.events[session.nextIndex].displayAtMs <= elapsed
     ) {
       const ev = session.events[session.nextIndex];
+      // Lot 2.A.4 — observe le délai dispatch : combien de temps cet
+      // event a attendu après son `displayAtMs` planifié. Un dispatch
+      // healthy reste sous TICK_INTERVAL_MS (100ms) ; au-delà,
+      // ça signale un saturation du tick loop ou de l'event loop Node.
+      appMetrics.observeBroadcasterDispatchLag(elapsed - ev.displayAtMs);
       session.emitter.emit("event", ev);
       session.nextIndex += 1;
     }
@@ -153,6 +176,7 @@ function maybeReap(session: MatchSession): void {
     !session.timer
   ) {
     sessions.delete(session.matchId);
+    refreshBroadcasterGauges();
   }
 }
 
@@ -174,10 +198,12 @@ export async function subscribeToMatch(
 
   session.emitter.on("event", listener);
   session.subscribers += 1;
+  refreshBroadcasterGauges();
 
   return () => {
     session.emitter.off("event", listener);
     session.subscribers -= 1;
+    refreshBroadcasterGauges();
     maybeReap(session);
   };
 }
@@ -201,6 +227,7 @@ export function __resetBroadcasterForTesting(): void {
     session.emitter.removeAllListeners();
   }
   sessions.clear();
+  refreshBroadcasterGauges();
 }
 
 /**

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -39,6 +39,7 @@ import {
 } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { appMetrics, type SimDriver, type SimOutcome } from "../utils/metrics";
 import {
   EngineVersionMismatchError,
   assertSimulationAllowed,
@@ -164,10 +165,23 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     },
   };
 
+  // Lot 2.A.3 — instrumentation Prometheus. `driver` est figé à
+  // 'hybrid' jusqu'à ce que Lot 3.B.1 introduise le toggle
+  // `season.driverKind`. À ce moment-là, on lira la valeur depuis
+  // la DB ici.
+  const driver: SimDriver = "hybrid";
+
   let result: SimResult;
+  const simStart = process.hrtime.bigint();
   try {
     result = simulateMatch(input);
   } catch (err: unknown) {
+    const elapsedSec = Number(process.hrtime.bigint() - simStart) / 1e9;
+    appMetrics.observeSimMatchDuration(
+      { engineVer, driver, outcome: "failed" },
+      elapsedSec,
+    );
+    appMetrics.recordSimMatch({ status: "failed", driver });
     const msg = err instanceof Error ? err.message : "unknown";
     await prisma.proLeagueMatch.update({
       where: { id: matchId },
@@ -175,10 +189,17 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     });
     throw new Error(`Sim failed for match '${matchId}': ${msg}`);
   }
+  const elapsedSec = Number(process.hrtime.bigint() - simStart) / 1e9;
+  appMetrics.observeSimMatchDuration(
+    { engineVer, driver, outcome: result.summary.outcome as SimOutcome },
+    elapsedSec,
+  );
+  appMetrics.recordSimMatch({ status: "success", driver });
 
   const compressed = await compressEvents(result.events);
   const stats = computeCompressionStats(result.events, compressed);
   const highlights = extractHighlights(result.events);
+  appMetrics.observeReplaySize({ engineVer }, compressed.byteLength);
 
   // Upsert Replay puis MAJ ProLeagueMatch en transaction pour cohérence.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/server/src/utils/metrics.test.ts
+++ b/apps/server/src/utils/metrics.test.ts
@@ -94,4 +94,95 @@ describe("metrics registry", () => {
       expect(text).toContain("# TYPE");
     });
   });
+
+  describe("Pro League sim metrics (Lot 2.A.2)", () => {
+    it("declare toutes les metriques nuffle_* attendues", async () => {
+      // Touch chaque métrique au moins une fois pour qu'elle apparaisse
+      // dans la sortie Prometheus (les histogrammes/counters non touchés
+      // peuvent être omis du rendu).
+      metrics.observeSimMatchDuration(
+        { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+        0.05,
+      );
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.observeReplaySize({ engineVer: "0.16.0" }, 4096);
+      metrics.setBroadcasterActiveSessions(3);
+      metrics.setBroadcasterTotalSubscribers(12);
+      metrics.observeBroadcasterDispatchLag(45);
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.04,
+      );
+      const text = await metricsExposition(metrics.registry);
+      for (const name of [
+        "nuffle_sim_match_duration_seconds",
+        "nuffle_sim_match_total",
+        "nuffle_replay_size_bytes",
+        "nuffle_broadcaster_active_sessions",
+        "nuffle_broadcaster_total_subscribers",
+        "nuffle_broadcaster_event_dispatch_lag_ms",
+        "nuffle_engine_drift",
+      ]) {
+        expect(text).toContain(name);
+      }
+    });
+
+    it("recordSimMatch incremente le compteur par labels {status, driver}", async () => {
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "failed", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "full" });
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="hybrid"[^}]*\} 2/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="failed"[^}]*driver="hybrid"[^}]*\} 1/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="full"[^}]*\} 1/);
+    });
+
+    it("setBroadcasterActiveSessions / setBroadcasterTotalSubscribers clampent a 0", async () => {
+      metrics.setBroadcasterActiveSessions(-5);
+      metrics.setBroadcasterTotalSubscribers(-1);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(0);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
+      metrics.setBroadcasterActiveSessions(7);
+      metrics.setBroadcasterTotalSubscribers(42);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(7);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(42);
+    });
+
+    it("observeBroadcasterDispatchLag clamp les valeurs <=0 a 0", async () => {
+      // Si le wallclock recule, on observe 0 plutôt que de polluer.
+      metrics.observeBroadcasterDispatchLag(-50);
+      metrics.observeBroadcasterDispatchLag(120);
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toContain("nuffle_broadcaster_event_dispatch_lag_ms");
+      // Bucket le=200 doit avoir capturé l'observation 120ms.
+      expect(text).toMatch(/nuffle_broadcaster_event_dispatch_lag_ms_bucket\{le="200"\} [12]/);
+    });
+
+    it("setEngineDrift accepte des valeurs positives et negatives", async () => {
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Halfling", seasonId: "S2026" },
+        -0.08,
+      );
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.05,
+      );
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Halfling"[^}]*\} -0\.08/);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Wood Elf"[^}]*\} 0\.05/);
+    });
+
+    it("observeSimMatchDuration peuple l'histogramme avec les buckets attendus", async () => {
+      for (const seconds of [0.04, 0.08, 0.5, 1.5, 4.0]) {
+        metrics.observeSimMatchDuration(
+          { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+          seconds,
+        );
+      }
+      const text = await metricsExposition(metrics.registry);
+      // Bucket le=5 capture toutes les observations <= 5s.
+      expect(text).toMatch(/nuffle_sim_match_duration_seconds_bucket\{[^}]*le="5"[^}]*\} 5/);
+    });
+  });
 });

--- a/apps/server/src/utils/metrics.ts
+++ b/apps/server/src/utils/metrics.ts
@@ -1,26 +1,38 @@
 /**
- * Métriques Prometheus (tâche S25.3 — Sprint 25).
+ * Métriques Prometheus (tâche S25.3 — Sprint 25 ; étendu Lot 2.A.2).
  *
- * Expose 5 metriques custom requises par la roadmap + un histogramme de
- * latence HTTP. Chaque metrique est isolee dans son propre `Registry`
- * ou un registre injecte, afin de pouvoir instancier un mock dans les
- * tests sans polluer le state global.
+ * Expose les métriques applicatives custom + un histogramme de latence
+ * HTTP. Chaque metrique est isolee dans son propre `Registry` ou un
+ * registre injecte, afin de pouvoir instancier un mock dans les tests
+ * sans polluer le state global.
  *
- * Metriques :
- *   - match_active_count        gauge   (matches en cours, mis a jour
- *                                        par game-rooms.ts)
- *   - matchmaking_queue_size    gauge   (utilisateurs en queue, mis a
- *                                        jour par services/matchmaking.ts)
- *   - ws_connections_open       gauge   (sockets actives, mis a jour
- *                                        par socket.ts)
- *   - pass_attempts_total       counter (label `result` : success/fumble/
- *                                        intercepted/inaccurate)
- *   - armor_break_total         counter (armor rolls reussis cote
- *                                        attaquant)
+ * Catalogue
+ * ---------
+ * Live state (S25.3) :
+ *   - match_active_count        gauge   (game-rooms.ts)
+ *   - matchmaking_queue_size    gauge   (services/matchmaking.ts)
+ *   - ws_connections_open       gauge   (socket.ts)
+ *   - pass_attempts_total       counter (label `result`)
+ *   - armor_break_total         counter
  *   - http_request_duration_ms  histogram(method, route, statusCode)
  *
- * Le serveur expose `metricsHandler` sur `/metrics`, format
- * Prometheus standard text/plain.
+ * Pro League sim engine (Lot 2.A.2) :
+ *   - nuffle_sim_match_duration_seconds       histogram(engineVer, driver, outcome)
+ *   - nuffle_sim_match_total                  counter(status, driver)
+ *   - nuffle_replay_size_bytes                histogram(engineVer)
+ *   - nuffle_broadcaster_active_sessions      gauge
+ *   - nuffle_broadcaster_total_subscribers    gauge
+ *   - nuffle_broadcaster_event_dispatch_lag_ms histogram
+ *   - nuffle_engine_drift                     gauge(metric, race, seasonId)
+ *
+ * Le serveur expose `/metrics` sur le réseau Docker interne (Prometheus
+ * scrape, non exposé internet). Cardinality kept bounded :
+ *  - `driver` ∈ {'hybrid','full'}
+ *  - `outcome` ∈ {'home','away','draw','failed'}
+ *  - `status` ∈ {'success','failed'}
+ *  - `metric` ∈ {'tdMean','casualtyMean','turnoverMean','homeWinRate', …}
+ *  - `race` couvre les 16 archétypes Pro League
+ *  - `engineVer` change rarement (~1/saison via pinning)
  */
 
 import {
@@ -43,6 +55,39 @@ export interface HttpDurationLabels {
   statusCode: number;
 }
 
+/** Driver utilisé pour la simulation (lot 3.B.1 introduira 'full'). */
+export type SimDriver = "hybrid" | "full";
+
+/** Issue d'un match côté simulation (vs `proLeagueMatch.outcome`). */
+export type SimOutcome = "home" | "away" | "draw" | "failed";
+
+/** Statut top-level d'une simulation pour le compteur agrégé. */
+export type SimStatus = "success" | "failed";
+
+export interface SimMatchDurationLabels {
+  engineVer: string;
+  driver: SimDriver;
+  outcome: SimOutcome;
+}
+
+export interface SimMatchTotalLabels {
+  status: SimStatus;
+  driver: SimDriver;
+}
+
+export interface ReplaySizeLabels {
+  engineVer: string;
+}
+
+export interface EngineDriftLabels {
+  /** Métrique observée — `tdMean`, `casualtyMean`, `turnoverMean`, `homeWinRate`, etc. */
+  metric: string;
+  /** Race archétype concernée — `Orc`, `Wood Elf`, `Halfling`, … ou `*` pour aggregat. */
+  race: string;
+  /** Saison Pro League à laquelle se rattache la mesure. */
+  seasonId: string;
+}
+
 export interface MetricsRegistry {
   readonly registry: Registry;
 
@@ -59,6 +104,21 @@ export interface MetricsRegistry {
   /** Observe une duree HTTP (en ms). */
   observeHttpDuration(labels: HttpDurationLabels, ms: number): void;
 
+  /** Pro League sim — observe la durée d'une simulation (en secondes). */
+  observeSimMatchDuration(labels: SimMatchDurationLabels, seconds: number): void;
+  /** Pro League sim — incrémente le compteur de matchs simulés. */
+  recordSimMatch(labels: SimMatchTotalLabels): void;
+  /** Pro League sim — observe la taille (bytes) d'un replay compressé. */
+  observeReplaySize(labels: ReplaySizeLabels, bytes: number): void;
+  /** Broadcaster — set le nombre de sessions actives (clamp à 0). */
+  setBroadcasterActiveSessions(value: number): void;
+  /** Broadcaster — set le total de subscribers (clamp à 0). */
+  setBroadcasterTotalSubscribers(value: number): void;
+  /** Broadcaster — observe le délai de dispatch d'un event (en ms, peut être négatif si avance, dans ce cas clampé à 0). */
+  observeBroadcasterDispatchLag(ms: number): void;
+  /** Engine drift — set la dérive d'une métrique vs baseline (en delta relatif, ex: 0.04 pour +4%). */
+  setEngineDrift(labels: EngineDriftLabels, value: number): void;
+
   /** Helper test : retourne la valeur courante d'une gauge. */
   snapshotGauge(name: string): Promise<number>;
   /** Helper test : retourne les valeurs par label d'un counter. */
@@ -68,6 +128,23 @@ export interface MetricsRegistry {
 /** Buckets en millisecondes alignes sur des seuils SLO communs. */
 const HTTP_DURATION_BUCKETS_MS = [
   10, 25, 50, 100, 200, 350, 500, 750, 1000, 2500, 5000, 10000,
+];
+
+/** Buckets en secondes pour les sims (hybrid ~50ms, full attendu ~1-3s). */
+const SIM_DURATION_BUCKETS_SECONDS = [
+  0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 30,
+];
+
+/** Buckets en bytes pour la taille des replays (CBOR+gzip). Hybrid ~5-15KB,
+ *  full attendu ~30-100KB selon la verbosité d'events. */
+const REPLAY_SIZE_BUCKETS_BYTES = [
+  1024, 5_120, 10_240, 25_600, 51_200, 102_400, 256_000, 512_000, 1_048_576,
+];
+
+/** Buckets en millisecondes pour le lag de dispatch broadcaster.
+ *  Tick interne 100ms — un dispatch healthy reste sous 200ms. */
+const BROADCASTER_DISPATCH_LAG_BUCKETS_MS = [
+  10, 25, 50, 100, 200, 350, 500, 750, 1000, 2000, 5000,
 ];
 
 export function buildMetricsRegistry(): MetricsRegistry {
@@ -111,6 +188,50 @@ export function buildMetricsRegistry(): MetricsRegistry {
     registers: [registry],
   });
 
+  // Pro League sim engine metrics (Lot 2.A.2).
+  const simMatchDuration = new Histogram({
+    name: "nuffle_sim_match_duration_seconds",
+    help: "Durée d'une simulation de match Pro League (sim-engine), en secondes",
+    labelNames: ["engineVer", "driver", "outcome"],
+    buckets: SIM_DURATION_BUCKETS_SECONDS,
+    registers: [registry],
+  });
+  const simMatchTotal = new Counter({
+    name: "nuffle_sim_match_total",
+    help: "Total de simulations de matchs Pro League (label `status` : success|failed, `driver`)",
+    labelNames: ["status", "driver"],
+    registers: [registry],
+  });
+  const replaySize = new Histogram({
+    name: "nuffle_replay_size_bytes",
+    help: "Taille du replay compressé (CBOR+gzip) en bytes",
+    labelNames: ["engineVer"],
+    buckets: REPLAY_SIZE_BUCKETS_BYTES,
+    registers: [registry],
+  });
+  const broadcasterActiveSessions = new Gauge({
+    name: "nuffle_broadcaster_active_sessions",
+    help: "Nombre de MatchSession actives dans le broadcaster",
+    registers: [registry],
+  });
+  const broadcasterTotalSubscribers = new Gauge({
+    name: "nuffle_broadcaster_total_subscribers",
+    help: "Total des subscribers (SSE clients) connectés au broadcaster",
+    registers: [registry],
+  });
+  const broadcasterDispatchLag = new Histogram({
+    name: "nuffle_broadcaster_event_dispatch_lag_ms",
+    help: "Délai de dispatch d'un event (Date.now() - (startedAt + displayAtMs)) en ms",
+    buckets: BROADCASTER_DISPATCH_LAG_BUCKETS_MS,
+    registers: [registry],
+  });
+  const engineDrift = new Gauge({
+    name: "nuffle_engine_drift",
+    help: "Dérive relative d'une métrique sim vs baseline FUMBBL/snapshot (delta relatif, ex: 0.04 = +4%)",
+    labelNames: ["metric", "race", "seasonId"],
+    registers: [registry],
+  });
+
   const clamp = (n: number) => (Number.isFinite(n) && n > 0 ? n : 0);
 
   return {
@@ -138,6 +259,51 @@ export function buildMetricsRegistry(): MetricsRegistry {
           statusCode: String(labels.statusCode),
         },
         ms,
+      );
+    },
+    observeSimMatchDuration(labels, seconds) {
+      const safe = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+      simMatchDuration.observe(
+        {
+          engineVer: labels.engineVer,
+          driver: labels.driver,
+          outcome: labels.outcome,
+        },
+        safe,
+      );
+    },
+    recordSimMatch(labels) {
+      simMatchTotal.inc({
+        status: labels.status,
+        driver: labels.driver,
+      });
+    },
+    observeReplaySize(labels, bytes) {
+      const safe = Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
+      replaySize.observe({ engineVer: labels.engineVer }, safe);
+    },
+    setBroadcasterActiveSessions(value) {
+      broadcasterActiveSessions.set(clamp(value));
+    },
+    setBroadcasterTotalSubscribers(value) {
+      broadcasterTotalSubscribers.set(clamp(value));
+    },
+    observeBroadcasterDispatchLag(ms) {
+      // Lag négatif = event dispatché en avance (peu probable mais
+      // possible si le wallclock recule). On clamp pour ne pas polluer
+      // l'histogramme.
+      const safe = Number.isFinite(ms) && ms > 0 ? ms : 0;
+      broadcasterDispatchLag.observe(safe);
+    },
+    setEngineDrift(labels, value) {
+      const safe = Number.isFinite(value) ? value : 0;
+      engineDrift.set(
+        {
+          metric: labels.metric,
+          race: labels.race,
+          seasonId: labels.seasonId,
+        },
+        safe,
       );
     },
 


### PR DESCRIPTION
## Summary

Lots 2.A.3 + 2.A.4 du sprint sim-engine observability. Wire les métriques Prometheus introduites par PR #668 dans leurs points d'émission réels.

> **Dépend de #668** (catalogue de métriques). Cette PR branchera dès que #668 est mergée. À mergé après #668.

### Lot 2.A.3 — `pro-league-sim-runner.ts`

- `simulateMatch` enveloppé avec `process.hrtime.bigint()` → `nuffle_sim_match_duration_seconds`
- Émission sur succès **et** échec (avec `outcome='failed'`) pour voir la latence des erreurs
- `nuffle_sim_match_total{status,driver}` incrémenté à chaque tentative
- `nuffle_replay_size_bytes{engineVer}` après `compressEvents` avec `compressed.byteLength`
- `driver` hardcodé à `'hybrid'` jusqu'à Lot 3.B.1 (TODO en commentaire)

### Lot 2.A.4 — `pro-league-match-broadcaster.ts`

- Nouveau helper `refreshBroadcasterGauges()` recalcule les gauges depuis la `sessions` Map
- Appelé après chaque mutation : `ensureSession`, subscribe (+1), unsubscribe (-1), `maybeReap`, `__resetBroadcasterForTesting`
- Tick loop observe `nuffle_broadcaster_event_dispatch_lag_ms` = `elapsed - displayAtMs` pour chaque event dispatché. Healthy < `TICK_INTERVAL_MS` (100ms)

## Test plan

- [x] 25 tests passent (`pro-league-sim-runner.test.ts` + `pro-league-match-broadcaster.test.ts`)
- [x] Nouveau test "Prometheus gauges — Lot 2.A.4" valide la mise à jour des gauges après chaque mutation
- [x] `pnpm typecheck` propre
- [x] Aucun changement de comportement (strict additions)

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_