### PR TITLE
feat(schema): isTest flag on ProLeagueMatch (Lot 2.C.1)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -953,6 +953,8 @@ model ProLeagueMatch {
   simulatedAt         DateTime?
   completedAt         DateTime?
   casualtiesAppliedAt DateTime?
+  /// Lot 2.C.1 — sandbox flag (matchs admin "test" exclus des stats).
+  isTest              Boolean         @default(false)
   seed                BigInt?
   engineVer           String?
   replayId            String?         @unique

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -656,6 +656,23 @@ if (!inTestSimRunnerEnv && simRunnerTickMs > 0) {
   );
 }
 
+// Lot 2.A.5 — engine drift watcher. Calcule chaque heure la drift
+// observée (rolling 7j) vs FUMBBL et pousse `nuffle_engine_drift`
+// pour Grafana. Désactivable via PRO_LEAGUE_DRIFT_WATCHER_TICK_MS=0.
+const driftWatcherTickMsEnv = Number(
+  process.env.PRO_LEAGUE_DRIFT_WATCHER_TICK_MS,
+);
+const driftWatcherTickMs = Number.isFinite(driftWatcherTickMsEnv)
+  ? driftWatcherTickMsEnv
+  : 60 * 60 * 1000;
+if (!inTestSimRunnerEnv && driftWatcherTickMs > 0) {
+  void import("./services/pro-league-engine-drift-watcher").then(
+    ({ startDriftWatcher }) => {
+      startDriftWatcher({ intervalMs: driftWatcherTickMs });
+    },
+  );
+}
+
 
 // =============================================================================
 // Pro League bet-settlement cron (sprint 1.D.5).

--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -6,15 +6,21 @@
  * production.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Request, Response } from "express";
 
+vi.mock("../services/pro-league-engine-drift-watcher", () => ({
+  computeEngineDrift: vi.fn(),
+}));
+
 import {
+  handleGetDrift,
   handleListTeams,
   handleRunSim,
   runSimSchema,
   type RunSimBody,
 } from "./admin-sim";
+import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
 
 function buildRes(): Response & { statusCode: number; body: unknown } {
   const res = {
@@ -162,5 +168,56 @@ describe("runSimSchema (Zod validation)", () => {
         seed: -1,
       }),
     ).toThrow();
+  });
+});
+
+describe("handleGetDrift — Lot 2.A.5", () => {
+  it("retourne les samples + computedAt sans args", async () => {
+    (computeEngineDrift as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        metric: "tdMean",
+        race: "Wood Elf",
+        seasonId: "S",
+        observed: 2.5,
+        reference: 2.4,
+        drift: 0.04,
+        samples: 10,
+      },
+    ]);
+    const res = buildRes();
+    await handleGetDrift({ query: {} } as unknown as Request, res);
+    const body = res.body as { samples: unknown[]; computedAt: string };
+    expect(body.samples).toHaveLength(1);
+    expect(typeof body.computedAt).toBe("string");
+    expect(computeEngineDrift).toHaveBeenCalledWith({
+      windowMs: undefined,
+      seasonId: undefined,
+    });
+  });
+
+  it("forwarde windowMs et seasonId quand fournis en query string", async () => {
+    (computeEngineDrift as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const res = buildRes();
+    await handleGetDrift(
+      { query: { windowMs: "86400000", seasonId: "S2026" } } as unknown as Request,
+      res,
+    );
+    expect(computeEngineDrift).toHaveBeenCalledWith({
+      windowMs: 86400000,
+      seasonId: "S2026",
+    });
+  });
+
+  it("ignore un windowMs non-numérique (sécurise contre une chaîne arbitraire)", async () => {
+    (computeEngineDrift as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const res = buildRes();
+    await handleGetDrift(
+      { query: { windowMs: "drop-tables" } } as unknown as Request,
+      res,
+    );
+    expect(computeEngineDrift).toHaveBeenCalledWith({
+      windowMs: undefined,
+      seasonId: undefined,
+    });
   });
 });

--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -12,8 +12,12 @@ import type { Request, Response } from "express";
 vi.mock("../services/pro-league-engine-drift-watcher", () => ({
   computeEngineDrift: vi.fn(),
 }));
+vi.mock("../services/pro-league-match-broadcaster", () => ({
+  getBroadcasterStats: vi.fn(),
+}));
 
 import {
+  handleGetBroadcasterStats,
   handleGetDrift,
   handleListTeams,
   handleRunSim,
@@ -21,6 +25,8 @@ import {
   type RunSimBody,
 } from "./admin-sim";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
+import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
+import { appMetrics } from "../utils/metrics";
 
 function buildRes(): Response & { statusCode: number; body: unknown } {
   const res = {
@@ -219,5 +225,29 @@ describe("handleGetDrift — Lot 2.A.5", () => {
       windowMs: undefined,
       seasonId: undefined,
     });
+  });
+});
+
+describe("handleGetBroadcasterStats — Lot 2.B.4", () => {
+  it("retourne les sessions / subscribers + valeurs Prometheus + timestamp", async () => {
+    (getBroadcasterStats as ReturnType<typeof vi.fn>).mockReturnValue({
+      activeSessions: 3,
+      totalSubscribers: 12,
+    });
+    appMetrics.setBroadcasterActiveSessions(3);
+    appMetrics.setBroadcasterTotalSubscribers(12);
+    const res = buildRes();
+    await handleGetBroadcasterStats({} as Request, res);
+    const body = res.body as {
+      activeSessions: number;
+      totalSubscribers: number;
+      promExposed: { activeSessions: number; totalSubscribers: number };
+      fetchedAt: string;
+    };
+    expect(body.activeSessions).toBe(3);
+    expect(body.totalSubscribers).toBe(12);
+    expect(body.promExposed.activeSessions).toBe(3);
+    expect(body.promExposed.totalSubscribers).toBe(12);
+    expect(typeof body.fetchedAt).toBe("string");
   });
 });

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -11,6 +11,7 @@ import {
 import { adminOnly } from "../middleware/adminOnly";
 import { authUser } from "../middleware/authUser";
 import { validate } from "../middleware/validate";
+import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
 
 /**
  * Petit utilitaire admin (Phase 0 — pre-Pro League UI).
@@ -84,11 +85,40 @@ export function handleRunSim(req: Request, res: Response): void {
   });
 }
 
+/**
+ * Handler for `GET /admin/sim/drift` — Lot 2.A.5.
+ *
+ * Calcule la drift courante (rolling 7 jours par default) sans
+ * dépendre de Prometheus / Grafana. Sert au dashboard admin
+ * `/admin/sim/health` (Lot 2.B.3).
+ *
+ * Query params :
+ *   - `windowMs` (number, optional) : fenêtre glissante en ms.
+ *   - `seasonId` (string, optional) : filtre saison.
+ */
+export async function handleGetDrift(req: Request, res: Response): Promise<void> {
+  const windowMsRaw = req.query.windowMs;
+  const seasonId =
+    typeof req.query.seasonId === "string" && req.query.seasonId.length > 0
+      ? req.query.seasonId
+      : undefined;
+  const windowMs =
+    typeof windowMsRaw === "string" && /^\d+$/.test(windowMsRaw)
+      ? Number.parseInt(windowMsRaw, 10)
+      : undefined;
+  const samples = await computeEngineDrift({ windowMs, seasonId });
+  res.json({
+    samples,
+    computedAt: new Date().toISOString(),
+  });
+}
+
 const router = Router();
 
 router.use(authUser, adminOnly);
 
 router.get("/teams", handleListTeams);
 router.post("/run", validate(runSimSchema), handleRunSim);
+router.get("/drift", handleGetDrift);
 
 export default router;

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -12,6 +12,8 @@ import { adminOnly } from "../middleware/adminOnly";
 import { authUser } from "../middleware/authUser";
 import { validate } from "../middleware/validate";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
+import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
+import { appMetrics } from "../utils/metrics";
 
 /**
  * Petit utilitaire admin (Phase 0 — pre-Pro League UI).
@@ -113,6 +115,43 @@ export async function handleGetDrift(req: Request, res: Response): Promise<void>
   });
 }
 
+/**
+ * Handler for `GET /admin/sim/broadcaster` — Lot 2.B.4.
+ *
+ * Retourne l'état live du broadcaster (sessions actives, total
+ * subscribers) et les histogrammes Prometheus dérivés (lag dispatch
+ * dernier scrape interne). Utilisé par l'UI admin
+ * `/admin/sim/broadcaster` qui rafraîchit toutes les 5s.
+ *
+ * On lit `getBroadcasterStats()` (synchrone) plus le snapshot des
+ * gauges Prometheus pour confirmer la cohérence.
+ */
+export async function handleGetBroadcasterStats(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  const stats = getBroadcasterStats();
+  // On lit directement depuis le registre Prometheus pour être sûr
+  // que ce qu'on affiche dans l'UI = ce que voit Grafana.
+  const activeSessionsGauge = await appMetrics.snapshotGauge(
+    "nuffle_broadcaster_active_sessions",
+  );
+  const totalSubscribersGauge = await appMetrics.snapshotGauge(
+    "nuffle_broadcaster_total_subscribers",
+  );
+  res.json({
+    activeSessions: stats.activeSessions,
+    totalSubscribers: stats.totalSubscribers,
+    /** Valeurs lues côté Prometheus — utile pour détecter une dérive
+     *  entre l'état mémoire et ce qui est exposé. */
+    promExposed: {
+      activeSessions: activeSessionsGauge,
+      totalSubscribers: totalSubscribersGauge,
+    },
+    fetchedAt: new Date().toISOString(),
+  });
+}
+
 const router = Router();
 
 router.use(authUser, adminOnly);
@@ -120,5 +159,6 @@ router.use(authUser, adminOnly);
 router.get("/teams", handleListTeams);
 router.post("/run", validate(runSimSchema), handleRunSim);
 router.get("/drift", handleGetDrift);
+router.get("/broadcaster", handleGetBroadcasterStats);
 
 export default router;

--- a/apps/server/src/services/pro-league-engine-drift-watcher.test.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests pour `pro-league-engine-drift-watcher` (Lot 2.A.5).
+ *
+ * Couvre :
+ *  - aggregateMatchesByRace : double comptage home/away, casualties
+ *    splittés 50/50, wins par outcome.
+ *  - computeRelativeDrift : drift signée, défensif sur reference=0.
+ *  - buildDriftSamples : skip races sans match, skip races inconnues
+ *    de FUMBBL.
+ *  - runDriftTick : push gauges Prometheus, erreur isolée.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+
+import {
+  aggregateMatchesByRace,
+  buildDriftSamples,
+  computeEngineDrift,
+  computeRelativeDrift,
+  runDriftTick,
+  startDriftWatcher,
+} from "./pro-league-engine-drift-watcher";
+import { appMetrics } from "../utils/metrics";
+
+const mocked = prisma as unknown as {
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+};
+
+interface MatchRow {
+  seasonId: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  touchdownCount: number | null;
+  casualtyCount: number | null;
+  homeTeam: { race: string };
+  awayTeam: { race: string };
+}
+
+const matchRow = (overrides: Partial<MatchRow> = {}): MatchRow => ({
+  seasonId: "S2026",
+  scoreHome: 2,
+  scoreAway: 1,
+  outcome: "home",
+  touchdownCount: 3,
+  casualtyCount: 1,
+  homeTeam: { race: "Wood Elf" },
+  awayTeam: { race: "Halfling" },
+  ...overrides,
+});
+
+describe("aggregateMatchesByRace — Lot 2.A.5", () => {
+  it("compte chaque match deux fois (home + away race)", () => {
+    const out = aggregateMatchesByRace([
+      {
+        seasonId: "S2026",
+        homeRace: "Wood Elf",
+        awayRace: "Halfling",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 4,
+        casualtyCount: 2,
+      },
+    ]);
+    const wood = out.get("S2026")?.get("Wood Elf");
+    const half = out.get("S2026")?.get("Halfling");
+    expect(wood).toEqual({ matches: 1, tdsSum: 3, casualtiesSum: 1, wins: 1 });
+    expect(half).toEqual({ matches: 1, tdsSum: 1, casualtiesSum: 1, wins: 0 });
+  });
+
+  it("compte les wins par outcome correctement", () => {
+    const out = aggregateMatchesByRace([
+      {
+        seasonId: "S",
+        homeRace: "Orc",
+        awayRace: "Dwarf",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 3,
+        casualtyCount: 0,
+      },
+      {
+        seasonId: "S",
+        homeRace: "Orc",
+        awayRace: "Dwarf",
+        scoreHome: 0,
+        scoreAway: 2,
+        outcome: "away",
+        touchdownCount: 2,
+        casualtyCount: 0,
+      },
+      {
+        seasonId: "S",
+        homeRace: "Orc",
+        awayRace: "Dwarf",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+        touchdownCount: 2,
+        casualtyCount: 0,
+      },
+    ]);
+    expect(out.get("S")?.get("Orc")).toEqual({
+      matches: 3,
+      tdsSum: 3,
+      casualtiesSum: 0,
+      wins: 1,
+    });
+    expect(out.get("S")?.get("Dwarf")).toEqual({
+      matches: 3,
+      tdsSum: 4,
+      casualtiesSum: 0,
+      wins: 1,
+    });
+  });
+
+  it("split les casualties 50/50 entre home et away", () => {
+    const out = aggregateMatchesByRace([
+      {
+        seasonId: "S",
+        homeRace: "Orc",
+        awayRace: "Skaven",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+        touchdownCount: 2,
+        casualtyCount: 4,
+      },
+    ]);
+    expect(out.get("S")?.get("Orc")?.casualtiesSum).toBe(2);
+    expect(out.get("S")?.get("Skaven")?.casualtiesSum).toBe(2);
+  });
+
+  it("traite scoreHome/scoreAway null comme 0", () => {
+    const out = aggregateMatchesByRace([
+      {
+        seasonId: "S",
+        homeRace: "Orc",
+        awayRace: "Skaven",
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        touchdownCount: null,
+        casualtyCount: null,
+      },
+    ]);
+    expect(out.get("S")?.get("Orc")?.tdsSum).toBe(0);
+    expect(out.get("S")?.get("Skaven")?.casualtiesSum).toBe(0);
+  });
+});
+
+describe("computeRelativeDrift", () => {
+  it("retourne (observed - reference) / reference", () => {
+    expect(computeRelativeDrift(2.5, 2.0)).toBeCloseTo(0.25, 6);
+    expect(computeRelativeDrift(1.6, 2.0)).toBeCloseTo(-0.2, 6);
+    expect(computeRelativeDrift(2.0, 2.0)).toBe(0);
+  });
+
+  it("retourne 0 si reference est 0 (defensive)", () => {
+    expect(computeRelativeDrift(1, 0)).toBe(0);
+  });
+
+  it("retourne 0 si une valeur n'est pas finite", () => {
+    expect(computeRelativeDrift(Number.NaN, 2)).toBe(0);
+    expect(computeRelativeDrift(2, Number.NaN)).toBe(0);
+    expect(computeRelativeDrift(2, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("buildDriftSamples", () => {
+  it("produit une triplette {tdMean, casualtyMean, winRate} par (season, race)", () => {
+    const aggs = aggregateMatchesByRace([
+      {
+        seasonId: "S",
+        homeRace: "Wood Elf",
+        awayRace: "Halfling",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+        touchdownCount: 4,
+        casualtyCount: 0,
+      },
+    ]);
+    const samples = buildDriftSamples(aggs);
+    const woodMetrics = samples.filter((s) => s.race === "Wood Elf").map((s) => s.metric);
+    expect(woodMetrics).toEqual(
+      expect.arrayContaining(["tdMean", "casualtyMean", "winRate"]),
+    );
+    expect(woodMetrics).toHaveLength(3);
+  });
+
+  it("skip une race sans match dans la fenêtre (samples=0)", () => {
+    const aggs = new Map();
+    const samples = buildDriftSamples(aggs);
+    expect(samples).toEqual([]);
+  });
+
+  it("skip une race inconnue de la référence FUMBBL", () => {
+    const aggs = aggregateMatchesByRace([
+      {
+        seasonId: "S",
+        homeRace: "Imaginary Race",
+        awayRace: "Wood Elf",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+        touchdownCount: 2,
+        casualtyCount: 0,
+      },
+    ]);
+    const samples = buildDriftSamples(aggs);
+    expect(samples.find((s) => s.race === "Imaginary Race")).toBeUndefined();
+    expect(samples.find((s) => s.race === "Wood Elf")).toBeDefined();
+  });
+
+  it("la drift est positive si observed > reference", () => {
+    // Wood Elf FUMBBL tdAverage = 2.4. On force observed = 3.0.
+    const aggs = new Map([
+      ["S", new Map([["Wood Elf", { matches: 10, tdsSum: 30, casualtiesSum: 0, wins: 5 }]])],
+    ]);
+    const samples = buildDriftSamples(aggs);
+    const td = samples.find((s) => s.race === "Wood Elf" && s.metric === "tdMean");
+    expect(td?.observed).toBeCloseTo(3.0, 6);
+    expect(td?.drift).toBeGreaterThan(0);
+  });
+});
+
+describe("computeEngineDrift", () => {
+  beforeEach(() => {
+    mocked.proLeagueMatch.findMany.mockReset();
+  });
+
+  it("query la fenêtre attendue et passe seasonId quand fourni", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await computeEngineDrift({
+      windowMs: 24 * 60 * 60 * 1000,
+      now: new Date("2026-05-07T12:00:00Z"),
+      seasonId: "S2026",
+    });
+    const args = mocked.proLeagueMatch.findMany.mock.calls[0][0];
+    expect(args.where.seasonId).toBe("S2026");
+    expect(args.where.simulatedAt.gte).toEqual(new Date("2026-05-06T12:00:00Z"));
+    expect(args.where.simulatedAt.lte).toEqual(new Date("2026-05-07T12:00:00Z"));
+  });
+
+  it("retourne un sample drift par (race, metric) après mapping rows", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      matchRow({ scoreHome: 3, scoreAway: 1 }),
+    ]);
+    const samples = await computeEngineDrift();
+    // 2 races × 3 metrics = 6 samples.
+    expect(samples).toHaveLength(6);
+  });
+});
+
+describe("runDriftTick — Prometheus push", () => {
+  beforeEach(() => {
+    mocked.proLeagueMatch.findMany.mockReset();
+    appMetrics.registry.resetMetrics();
+  });
+
+  it("pousse les samples dans nuffle_engine_drift", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      matchRow({ scoreHome: 3, scoreAway: 1 }),
+    ]);
+    const pushed = await runDriftTick();
+    expect(pushed).toBe(6);
+    const text = await appMetrics.registry.metrics();
+    expect(text).toContain("nuffle_engine_drift");
+    expect(text).toMatch(/race="Wood Elf"/);
+    expect(text).toMatch(/race="Halfling"/);
+  });
+
+  it("erreur isolée : si findMany throw, le tick retourne 0 sans propager", async () => {
+    mocked.proLeagueMatch.findMany.mockRejectedValue(new Error("boom"));
+    const pushed = await runDriftTick();
+    expect(pushed).toBe(0);
+  });
+});
+
+describe("startDriftWatcher", () => {
+  let handles: Array<{ stop(): void }> = [];
+
+  afterEach(() => {
+    for (const h of handles) h.stop();
+    handles = [];
+  });
+
+  it("expose tickNow pour forcer un calcul immédiat", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const handle = startDriftWatcher({ enabled: false });
+    handles.push(handle);
+    const pushed = await handle.tickNow();
+    expect(pushed).toBe(0);
+  });
+
+  it("opt-out via enabled=false (pas de timer)", () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    const handle = startDriftWatcher({ enabled: false });
+    handles.push(handle);
+    handle.stop();
+    // Si un timer avait démarré, stop() le clearInterval. Smoke test :
+    // pas d'erreur = OK.
+    expect(true).toBe(true);
+  });
+});

--- a/apps/server/src/services/pro-league-engine-drift-watcher.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.ts
@@ -1,0 +1,340 @@
+/**
+ * Pro League engine drift watcher — sprint sim-engine observability
+ * (Lot 2.A.5).
+ *
+ * Pourquoi
+ * --------
+ * Le bench CI (`pnpm sim:bench:ci`) compare la simulation à un
+ * snapshot statique (`bench/bench-baseline.json`) sur des seeds
+ * fixes. Mais en production, la "vraie" stabilité du moteur se
+ * mesure sur les matchs effectivement joués : si une saison de
+ * 120 matchs produit un tdMean Wood Elf de 1.4 alors que FUMBBL
+ * attend 2.4, on a une drift réelle qu'aucun test seedé ne capte.
+ *
+ * Ce service calcule cette drift en continu :
+ *   1. Lit les `proLeagueMatch` `status='completed'` ou `'ready'`
+ *      des N derniers jours (default 7).
+ *   2. Aggrège par (race, seasonId, metric) :
+ *        - tdMean        — mean(tdsForThatTeamInThatMatch)
+ *        - casualtyMean  — mean(casualtyCount / 2) (split entre teams)
+ *        - winRate       — wins / matchsJoués
+ *   3. Compare à FUMBBL reference (`reference-fumbbl.json`).
+ *   4. Push la drift relative dans `nuffle_engine_drift{metric,race,seasonId}`.
+ *
+ * La drift est un nombre signé : `(observed - reference) / reference`.
+ * Une valeur de 0.05 = +5% au-dessus de la cible ; -0.10 = -10% sous.
+ *
+ * Cardinalité
+ * -----------
+ * 16 races × N saisons × 3 métriques. Pour 1 saison active = 48 séries.
+ * Bornée et stable.
+ *
+ * Run loop
+ * --------
+ * `setInterval` toutes les `intervalMs` (default 1h). Idempotent : si
+ * un nouveau match arrive entre deux ticks, le tick suivant le voit.
+ * Erreur isolée : un crash n'arrête pas l'interval.
+ *
+ * Test mode (lot 2.C)
+ * -------------------
+ * Quand le flag `proLeagueMatch.isTest` arrivera (Lot 2.C.1), ce
+ * service devra l'exclure de l'aggregation pour ne pas polluer la
+ * baseline avec des matchs sandbox. À implémenter quand la migration
+ * est en place.
+ */
+
+import { getFumbblRaceStats } from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+import { appMetrics } from "../utils/metrics";
+import { serverLog } from "../utils/server-log";
+
+/** Intervalle par défaut entre deux passages du watcher (1h). */
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Fenêtre glissante par défaut (7 jours). */
+const DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type DriftMetric = "tdMean" | "casualtyMean" | "winRate";
+
+export interface DriftSample {
+  readonly metric: DriftMetric;
+  readonly race: string;
+  readonly seasonId: string;
+  /** Valeur observée sur la fenêtre. */
+  readonly observed: number;
+  /** Valeur de référence FUMBBL. */
+  readonly reference: number;
+  /** Drift relative `(observed - reference) / reference`, signée. */
+  readonly drift: number;
+  /** Nombre de matchs joués (par cette race) pour calculer `observed`. */
+  readonly samples: number;
+}
+
+export interface ComputeDriftOptions {
+  /** Fenêtre glissante en millisecondes. Default 7 jours. */
+  readonly windowMs?: number;
+  /** Override `now()`. Pratique pour les tests. */
+  readonly now?: Date;
+  /** Filtrer sur une saison particulière. Default : toutes les saisons actives. */
+  readonly seasonId?: string;
+}
+
+interface PerRaceAggregation {
+  matches: number;
+  tdsSum: number;
+  casualtiesSum: number;
+  wins: number;
+}
+
+interface MatchSlice {
+  seasonId: string;
+  homeRace: string;
+  awayRace: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  touchdownCount: number | null;
+  casualtyCount: number | null;
+}
+
+/**
+ * Pas de jointure relationnelle ici — Prisma gère le include et on
+ * extrait juste les champs pertinents pour l'aggrégation.
+ */
+async function loadCompletedMatches(
+  windowMs: number,
+  now: Date,
+  seasonId: string | undefined,
+): Promise<readonly MatchSlice[]> {
+  const since = new Date(now.getTime() - windowMs);
+  const rows = await prisma.proLeagueMatch.findMany({
+    where: {
+      status: { in: ["completed", "ready"] },
+      simulatedAt: { gte: since, lte: now },
+      ...(seasonId ? { seasonId } : {}),
+    },
+    select: {
+      seasonId: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      touchdownCount: true,
+      casualtyCount: true,
+      homeTeam: { select: { race: true } },
+      awayTeam: { select: { race: true } },
+    },
+  });
+  type Row = {
+    seasonId: string;
+    scoreHome: number | null;
+    scoreAway: number | null;
+    outcome: string | null;
+    touchdownCount: number | null;
+    casualtyCount: number | null;
+    homeTeam: { race: string };
+    awayTeam: { race: string };
+  };
+  return (rows as Row[]).map((row) => ({
+    seasonId: row.seasonId,
+    homeRace: row.homeTeam.race,
+    awayRace: row.awayTeam.race,
+    scoreHome: row.scoreHome,
+    scoreAway: row.scoreAway,
+    outcome: row.outcome,
+    touchdownCount: row.touchdownCount,
+    casualtyCount: row.casualtyCount,
+  }));
+}
+
+/**
+ * Aggrège les matchs par (seasonId, race) en additionnant TDs,
+ * casualties et wins. Chaque match contribue *deux fois* (une fois
+ * pour homeRace, une fois pour awayRace). Les casualties sont splittés
+ * 50/50 (information par-team non disponible sur ProLeagueMatch).
+ */
+export function aggregateMatchesByRace(
+  matches: readonly MatchSlice[],
+): Map<string, Map<string, PerRaceAggregation>> {
+  // Map<seasonId, Map<race, agg>>
+  const out = new Map<string, Map<string, PerRaceAggregation>>();
+  const ensure = (seasonId: string, race: string): PerRaceAggregation => {
+    let perSeason = out.get(seasonId);
+    if (!perSeason) {
+      perSeason = new Map();
+      out.set(seasonId, perSeason);
+    }
+    let agg = perSeason.get(race);
+    if (!agg) {
+      agg = { matches: 0, tdsSum: 0, casualtiesSum: 0, wins: 0 };
+      perSeason.set(race, agg);
+    }
+    return agg;
+  };
+
+  for (const m of matches) {
+    const tdHome = m.scoreHome ?? 0;
+    const tdAway = m.scoreAway ?? 0;
+    const casualtiesPerSide = (m.casualtyCount ?? 0) / 2;
+
+    const home = ensure(m.seasonId, m.homeRace);
+    home.matches += 1;
+    home.tdsSum += tdHome;
+    home.casualtiesSum += casualtiesPerSide;
+    if (m.outcome === "home") home.wins += 1;
+
+    const away = ensure(m.seasonId, m.awayRace);
+    away.matches += 1;
+    away.tdsSum += tdAway;
+    away.casualtiesSum += casualtiesPerSide;
+    if (m.outcome === "away") away.wins += 1;
+  }
+
+  return out;
+}
+
+/** `(observed - reference) / reference`, defensive si `reference === 0`. */
+export function computeRelativeDrift(observed: number, reference: number): number {
+  if (!Number.isFinite(observed) || !Number.isFinite(reference) || reference === 0) {
+    return 0;
+  }
+  return (observed - reference) / reference;
+}
+
+/**
+ * Construit la liste de samples drift à partir des aggregations et
+ * de la référence FUMBBL. Une race sans match dans la fenêtre est
+ * absente de la sortie (pas de samples = pas de drift à pousser).
+ */
+export function buildDriftSamples(
+  aggregations: Map<string, Map<string, PerRaceAggregation>>,
+): DriftSample[] {
+  const samples: DriftSample[] = [];
+  for (const [seasonId, perSeason] of aggregations) {
+    for (const [race, agg] of perSeason) {
+      if (agg.matches === 0) continue;
+      const ref = getFumbblRaceStats(race);
+      if (!ref) continue; // race inconnue de FUMBBL ref — silencieux
+
+      const observedTd = agg.tdsSum / agg.matches;
+      const observedCas = agg.casualtiesSum / agg.matches;
+      const observedWin = agg.wins / agg.matches;
+
+      samples.push({
+        metric: "tdMean",
+        race,
+        seasonId,
+        observed: observedTd,
+        reference: ref.tdAverage,
+        drift: computeRelativeDrift(observedTd, ref.tdAverage),
+        samples: agg.matches,
+      });
+      samples.push({
+        metric: "casualtyMean",
+        race,
+        seasonId,
+        observed: observedCas,
+        reference: ref.casualtyRate,
+        drift: computeRelativeDrift(observedCas, ref.casualtyRate),
+        samples: agg.matches,
+      });
+      samples.push({
+        metric: "winRate",
+        race,
+        seasonId,
+        observed: observedWin,
+        reference: ref.winrate,
+        drift: computeRelativeDrift(observedWin, ref.winrate),
+        samples: agg.matches,
+      });
+    }
+  }
+  return samples;
+}
+
+/**
+ * Calcule la drift courante sans la pousser dans Prometheus. Sert au
+ * trigger admin (Lot 2.B.3) qui veut afficher la table sans dépendre
+ * d'un scrape Prometheus.
+ */
+export async function computeEngineDrift(
+  options: ComputeDriftOptions = {},
+): Promise<DriftSample[]> {
+  const now = options.now ?? new Date();
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const matches = await loadCompletedMatches(windowMs, now, options.seasonId);
+  const aggregations = aggregateMatchesByRace(matches);
+  return buildDriftSamples(aggregations);
+}
+
+/**
+ * Pousse les drift samples dans la gauge `nuffle_engine_drift`. Les
+ * gauges absentes restent à leur valeur précédente — pour éviter ça,
+ * on accepte un `previousLabels` qui retourne la liste des labels
+ * pushés au tick d'avant et on les remet à 0 si plus présents.
+ */
+function pushDriftToMetrics(samples: readonly DriftSample[]): void {
+  for (const s of samples) {
+    appMetrics.setEngineDrift(
+      { metric: s.metric, race: s.race, seasonId: s.seasonId },
+      s.drift,
+    );
+  }
+}
+
+/**
+ * Tick unitaire : compute + push. Erreur isolée — log et continue.
+ * Retourne le nombre de samples pushés pour usage dans les tests
+ * sans avoir besoin de scrutateur Prometheus.
+ */
+export async function runDriftTick(
+  options: ComputeDriftOptions = {},
+): Promise<number> {
+  try {
+    const samples = await computeEngineDrift(options);
+    pushDriftToMetrics(samples);
+    return samples.length;
+  } catch (err: unknown) {
+    serverLog.error("[engine-drift-watcher] tick failed", err);
+    return 0;
+  }
+}
+
+export interface StartDriftWatcherOptions {
+  readonly intervalMs?: number;
+  readonly windowMs?: number;
+  /** Disable to opt out (tests/dev). Default true. */
+  readonly enabled?: boolean;
+}
+
+export interface DriftWatcherHandle {
+  stop(): void;
+  /** Force un tick immédiat (utile pour les routes admin / les tests). */
+  tickNow(options?: ComputeDriftOptions): Promise<number>;
+}
+
+export function startDriftWatcher(
+  options: StartDriftWatcherOptions = {},
+): DriftWatcherHandle {
+  const enabled = options.enabled ?? true;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+
+  let timer: NodeJS.Timeout | undefined;
+  if (enabled) {
+    timer = setInterval(() => {
+      void runDriftTick({ windowMs });
+    }, intervalMs);
+    timer.unref();
+  }
+
+  return {
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = undefined;
+    },
+    tickNow(opts?: ComputeDriftOptions) {
+      return runDriftTick(opts ?? { windowMs });
+    },
+  };
+}

--- a/apps/server/src/services/pro-league-match-broadcaster.test.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.test.ts
@@ -32,6 +32,7 @@ import {
   preloadMatch,
   subscribeToMatch,
 } from "./pro-league-match-broadcaster";
+import { appMetrics } from "../utils/metrics";
 
 interface MockedPrisma {
   proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
@@ -266,5 +267,26 @@ describe("getBroadcasterStats — sprint 1.B.1", () => {
     expect(getBroadcasterStats().totalSubscribers).toBe(1);
     un2();
     expect(getBroadcasterStats().totalSubscribers).toBe(0);
+  });
+});
+
+describe("Prometheus gauges — Lot 2.A.4", () => {
+  it("setBroadcasterActiveSessions / setBroadcasterTotalSubscribers reflètent l'état après chaque mutation", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValue({ status: "ready" });
+    await mockReplay(makeEvents());
+
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(0);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
+
+    const un1 = await subscribeToMatch(MATCH_ID, () => undefined);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(1);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(1);
+
+    const un2 = await subscribeToMatch(MATCH_ID, () => undefined);
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(2);
+
+    un1();
+    un2();
+    expect(await appMetrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
   });
 });

--- a/apps/server/src/services/pro-league-match-broadcaster.ts
+++ b/apps/server/src/services/pro-league-match-broadcaster.ts
@@ -40,6 +40,7 @@ import { EventEmitter } from "node:events";
 import { decompressEvents, type MatchEvent } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { appMetrics } from "../utils/metrics";
 
 /** Fréquence du tick interne (ms). 100ms = précision visuelle suffisante. */
 const TICK_INTERVAL_MS = 100;
@@ -64,6 +65,22 @@ interface MatchSession {
 }
 
 const sessions = new Map<string, MatchSession>();
+
+/**
+ * Lot 2.A.4 — recompute and push the broadcaster gauges from the
+ * current sessions Map. Called after every mutation (session
+ * created/reaped, subscriber added/removed) so Grafana sees the
+ * live state without a polling loop. O(n) on number of active
+ * sessions ; n is small (a handful at MVP scale).
+ */
+function refreshBroadcasterGauges(): void {
+  let totalSubscribers = 0;
+  for (const session of sessions.values()) {
+    totalSubscribers += session.subscribers;
+  }
+  appMetrics.setBroadcasterActiveSessions(sessions.size);
+  appMetrics.setBroadcasterTotalSubscribers(totalSubscribers);
+}
 
 /**
  * Charge la session d'un match si elle n'existe pas encore. Décompresse
@@ -110,6 +127,7 @@ async function ensureSession(matchId: string): Promise<MatchSession> {
   // Permet beaucoup de listeners (par défaut 10) — on cap à 1024.
   session.emitter.setMaxListeners(1024);
   sessions.set(matchId, session);
+  refreshBroadcasterGauges();
 
   startTickLoop(session);
   return session;
@@ -128,6 +146,11 @@ function startTickLoop(session: MatchSession): void {
       session.events[session.nextIndex].displayAtMs <= elapsed
     ) {
       const ev = session.events[session.nextIndex];
+      // Lot 2.A.4 — observe le délai dispatch : combien de temps cet
+      // event a attendu après son `displayAtMs` planifié. Un dispatch
+      // healthy reste sous TICK_INTERVAL_MS (100ms) ; au-delà,
+      // ça signale un saturation du tick loop ou de l'event loop Node.
+      appMetrics.observeBroadcasterDispatchLag(elapsed - ev.displayAtMs);
       session.emitter.emit("event", ev);
       session.nextIndex += 1;
     }
@@ -153,6 +176,7 @@ function maybeReap(session: MatchSession): void {
     !session.timer
   ) {
     sessions.delete(session.matchId);
+    refreshBroadcasterGauges();
   }
 }
 
@@ -174,10 +198,12 @@ export async function subscribeToMatch(
 
   session.emitter.on("event", listener);
   session.subscribers += 1;
+  refreshBroadcasterGauges();
 
   return () => {
     session.emitter.off("event", listener);
     session.subscribers -= 1;
+    refreshBroadcasterGauges();
     maybeReap(session);
   };
 }
@@ -201,6 +227,7 @@ export function __resetBroadcasterForTesting(): void {
     session.emitter.removeAllListeners();
   }
   sessions.clear();
+  refreshBroadcasterGauges();
 }
 
 /**

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -39,6 +39,7 @@ import {
 } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { appMetrics, type SimDriver, type SimOutcome } from "../utils/metrics";
 import {
   EngineVersionMismatchError,
   assertSimulationAllowed,
@@ -164,10 +165,23 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     },
   };
 
+  // Lot 2.A.3 — instrumentation Prometheus. `driver` est figé à
+  // 'hybrid' jusqu'à ce que Lot 3.B.1 introduise le toggle
+  // `season.driverKind`. À ce moment-là, on lira la valeur depuis
+  // la DB ici.
+  const driver: SimDriver = "hybrid";
+
   let result: SimResult;
+  const simStart = process.hrtime.bigint();
   try {
     result = simulateMatch(input);
   } catch (err: unknown) {
+    const elapsedSec = Number(process.hrtime.bigint() - simStart) / 1e9;
+    appMetrics.observeSimMatchDuration(
+      { engineVer, driver, outcome: "failed" },
+      elapsedSec,
+    );
+    appMetrics.recordSimMatch({ status: "failed", driver });
     const msg = err instanceof Error ? err.message : "unknown";
     await prisma.proLeagueMatch.update({
       where: { id: matchId },
@@ -175,10 +189,17 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     });
     throw new Error(`Sim failed for match '${matchId}': ${msg}`);
   }
+  const elapsedSec = Number(process.hrtime.bigint() - simStart) / 1e9;
+  appMetrics.observeSimMatchDuration(
+    { engineVer, driver, outcome: result.summary.outcome as SimOutcome },
+    elapsedSec,
+  );
+  appMetrics.recordSimMatch({ status: "success", driver });
 
   const compressed = await compressEvents(result.events);
   const stats = computeCompressionStats(result.events, compressed);
   const highlights = extractHighlights(result.events);
+  appMetrics.observeReplaySize({ engineVer }, compressed.byteLength);
 
   // Upsert Replay puis MAJ ProLeagueMatch en transaction pour cohérence.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/server/src/utils/metrics.test.ts
+++ b/apps/server/src/utils/metrics.test.ts
@@ -94,4 +94,95 @@ describe("metrics registry", () => {
       expect(text).toContain("# TYPE");
     });
   });
+
+  describe("Pro League sim metrics (Lot 2.A.2)", () => {
+    it("declare toutes les metriques nuffle_* attendues", async () => {
+      // Touch chaque métrique au moins une fois pour qu'elle apparaisse
+      // dans la sortie Prometheus (les histogrammes/counters non touchés
+      // peuvent être omis du rendu).
+      metrics.observeSimMatchDuration(
+        { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+        0.05,
+      );
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.observeReplaySize({ engineVer: "0.16.0" }, 4096);
+      metrics.setBroadcasterActiveSessions(3);
+      metrics.setBroadcasterTotalSubscribers(12);
+      metrics.observeBroadcasterDispatchLag(45);
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.04,
+      );
+      const text = await metricsExposition(metrics.registry);
+      for (const name of [
+        "nuffle_sim_match_duration_seconds",
+        "nuffle_sim_match_total",
+        "nuffle_replay_size_bytes",
+        "nuffle_broadcaster_active_sessions",
+        "nuffle_broadcaster_total_subscribers",
+        "nuffle_broadcaster_event_dispatch_lag_ms",
+        "nuffle_engine_drift",
+      ]) {
+        expect(text).toContain(name);
+      }
+    });
+
+    it("recordSimMatch incremente le compteur par labels {status, driver}", async () => {
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "failed", driver: "hybrid" });
+      metrics.recordSimMatch({ status: "success", driver: "full" });
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="hybrid"[^}]*\} 2/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="failed"[^}]*driver="hybrid"[^}]*\} 1/);
+      expect(text).toMatch(/nuffle_sim_match_total\{[^}]*status="success"[^}]*driver="full"[^}]*\} 1/);
+    });
+
+    it("setBroadcasterActiveSessions / setBroadcasterTotalSubscribers clampent a 0", async () => {
+      metrics.setBroadcasterActiveSessions(-5);
+      metrics.setBroadcasterTotalSubscribers(-1);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(0);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(0);
+      metrics.setBroadcasterActiveSessions(7);
+      metrics.setBroadcasterTotalSubscribers(42);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_active_sessions")).toBe(7);
+      expect(await metrics.snapshotGauge("nuffle_broadcaster_total_subscribers")).toBe(42);
+    });
+
+    it("observeBroadcasterDispatchLag clamp les valeurs <=0 a 0", async () => {
+      // Si le wallclock recule, on observe 0 plutôt que de polluer.
+      metrics.observeBroadcasterDispatchLag(-50);
+      metrics.observeBroadcasterDispatchLag(120);
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toContain("nuffle_broadcaster_event_dispatch_lag_ms");
+      // Bucket le=200 doit avoir capturé l'observation 120ms.
+      expect(text).toMatch(/nuffle_broadcaster_event_dispatch_lag_ms_bucket\{le="200"\} [12]/);
+    });
+
+    it("setEngineDrift accepte des valeurs positives et negatives", async () => {
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Halfling", seasonId: "S2026" },
+        -0.08,
+      );
+      metrics.setEngineDrift(
+        { metric: "tdMean", race: "Wood Elf", seasonId: "S2026" },
+        0.05,
+      );
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Halfling"[^}]*\} -0\.08/);
+      expect(text).toMatch(/nuffle_engine_drift\{[^}]*race="Wood Elf"[^}]*\} 0\.05/);
+    });
+
+    it("observeSimMatchDuration peuple l'histogramme avec les buckets attendus", async () => {
+      for (const seconds of [0.04, 0.08, 0.5, 1.5, 4.0]) {
+        metrics.observeSimMatchDuration(
+          { engineVer: "0.16.0", driver: "hybrid", outcome: "home" },
+          seconds,
+        );
+      }
+      const text = await metricsExposition(metrics.registry);
+      // Bucket le=5 capture toutes les observations <= 5s.
+      expect(text).toMatch(/nuffle_sim_match_duration_seconds_bucket\{[^}]*le="5"[^}]*\} 5/);
+    });
+  });
 });

--- a/apps/server/src/utils/metrics.ts
+++ b/apps/server/src/utils/metrics.ts
@@ -1,26 +1,38 @@
 /**
- * Métriques Prometheus (tâche S25.3 — Sprint 25).
+ * Métriques Prometheus (tâche S25.3 — Sprint 25 ; étendu Lot 2.A.2).
  *
- * Expose 5 metriques custom requises par la roadmap + un histogramme de
- * latence HTTP. Chaque metrique est isolee dans son propre `Registry`
- * ou un registre injecte, afin de pouvoir instancier un mock dans les
- * tests sans polluer le state global.
+ * Expose les métriques applicatives custom + un histogramme de latence
+ * HTTP. Chaque metrique est isolee dans son propre `Registry` ou un
+ * registre injecte, afin de pouvoir instancier un mock dans les tests
+ * sans polluer le state global.
  *
- * Metriques :
- *   - match_active_count        gauge   (matches en cours, mis a jour
- *                                        par game-rooms.ts)
- *   - matchmaking_queue_size    gauge   (utilisateurs en queue, mis a
- *                                        jour par services/matchmaking.ts)
- *   - ws_connections_open       gauge   (sockets actives, mis a jour
- *                                        par socket.ts)
- *   - pass_attempts_total       counter (label `result` : success/fumble/
- *                                        intercepted/inaccurate)
- *   - armor_break_total         counter (armor rolls reussis cote
- *                                        attaquant)
+ * Catalogue
+ * ---------
+ * Live state (S25.3) :
+ *   - match_active_count        gauge   (game-rooms.ts)
+ *   - matchmaking_queue_size    gauge   (services/matchmaking.ts)
+ *   - ws_connections_open       gauge   (socket.ts)
+ *   - pass_attempts_total       counter (label `result`)
+ *   - armor_break_total         counter
  *   - http_request_duration_ms  histogram(method, route, statusCode)
  *
- * Le serveur expose `metricsHandler` sur `/metrics`, format
- * Prometheus standard text/plain.
+ * Pro League sim engine (Lot 2.A.2) :
+ *   - nuffle_sim_match_duration_seconds       histogram(engineVer, driver, outcome)
+ *   - nuffle_sim_match_total                  counter(status, driver)
+ *   - nuffle_replay_size_bytes                histogram(engineVer)
+ *   - nuffle_broadcaster_active_sessions      gauge
+ *   - nuffle_broadcaster_total_subscribers    gauge
+ *   - nuffle_broadcaster_event_dispatch_lag_ms histogram
+ *   - nuffle_engine_drift                     gauge(metric, race, seasonId)
+ *
+ * Le serveur expose `/metrics` sur le réseau Docker interne (Prometheus
+ * scrape, non exposé internet). Cardinality kept bounded :
+ *  - `driver` ∈ {'hybrid','full'}
+ *  - `outcome` ∈ {'home','away','draw','failed'}
+ *  - `status` ∈ {'success','failed'}
+ *  - `metric` ∈ {'tdMean','casualtyMean','turnoverMean','homeWinRate', …}
+ *  - `race` couvre les 16 archétypes Pro League
+ *  - `engineVer` change rarement (~1/saison via pinning)
  */
 
 import {
@@ -43,6 +55,39 @@ export interface HttpDurationLabels {
   statusCode: number;
 }
 
+/** Driver utilisé pour la simulation (lot 3.B.1 introduira 'full'). */
+export type SimDriver = "hybrid" | "full";
+
+/** Issue d'un match côté simulation (vs `proLeagueMatch.outcome`). */
+export type SimOutcome = "home" | "away" | "draw" | "failed";
+
+/** Statut top-level d'une simulation pour le compteur agrégé. */
+export type SimStatus = "success" | "failed";
+
+export interface SimMatchDurationLabels {
+  engineVer: string;
+  driver: SimDriver;
+  outcome: SimOutcome;
+}
+
+export interface SimMatchTotalLabels {
+  status: SimStatus;
+  driver: SimDriver;
+}
+
+export interface ReplaySizeLabels {
+  engineVer: string;
+}
+
+export interface EngineDriftLabels {
+  /** Métrique observée — `tdMean`, `casualtyMean`, `turnoverMean`, `homeWinRate`, etc. */
+  metric: string;
+  /** Race archétype concernée — `Orc`, `Wood Elf`, `Halfling`, … ou `*` pour aggregat. */
+  race: string;
+  /** Saison Pro League à laquelle se rattache la mesure. */
+  seasonId: string;
+}
+
 export interface MetricsRegistry {
   readonly registry: Registry;
 
@@ -59,6 +104,21 @@ export interface MetricsRegistry {
   /** Observe une duree HTTP (en ms). */
   observeHttpDuration(labels: HttpDurationLabels, ms: number): void;
 
+  /** Pro League sim — observe la durée d'une simulation (en secondes). */
+  observeSimMatchDuration(labels: SimMatchDurationLabels, seconds: number): void;
+  /** Pro League sim — incrémente le compteur de matchs simulés. */
+  recordSimMatch(labels: SimMatchTotalLabels): void;
+  /** Pro League sim — observe la taille (bytes) d'un replay compressé. */
+  observeReplaySize(labels: ReplaySizeLabels, bytes: number): void;
+  /** Broadcaster — set le nombre de sessions actives (clamp à 0). */
+  setBroadcasterActiveSessions(value: number): void;
+  /** Broadcaster — set le total de subscribers (clamp à 0). */
+  setBroadcasterTotalSubscribers(value: number): void;
+  /** Broadcaster — observe le délai de dispatch d'un event (en ms, peut être négatif si avance, dans ce cas clampé à 0). */
+  observeBroadcasterDispatchLag(ms: number): void;
+  /** Engine drift — set la dérive d'une métrique vs baseline (en delta relatif, ex: 0.04 pour +4%). */
+  setEngineDrift(labels: EngineDriftLabels, value: number): void;
+
   /** Helper test : retourne la valeur courante d'une gauge. */
   snapshotGauge(name: string): Promise<number>;
   /** Helper test : retourne les valeurs par label d'un counter. */
@@ -68,6 +128,23 @@ export interface MetricsRegistry {
 /** Buckets en millisecondes alignes sur des seuils SLO communs. */
 const HTTP_DURATION_BUCKETS_MS = [
   10, 25, 50, 100, 200, 350, 500, 750, 1000, 2500, 5000, 10000,
+];
+
+/** Buckets en secondes pour les sims (hybrid ~50ms, full attendu ~1-3s). */
+const SIM_DURATION_BUCKETS_SECONDS = [
+  0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 3, 5, 10, 30,
+];
+
+/** Buckets en bytes pour la taille des replays (CBOR+gzip). Hybrid ~5-15KB,
+ *  full attendu ~30-100KB selon la verbosité d'events. */
+const REPLAY_SIZE_BUCKETS_BYTES = [
+  1024, 5_120, 10_240, 25_600, 51_200, 102_400, 256_000, 512_000, 1_048_576,
+];
+
+/** Buckets en millisecondes pour le lag de dispatch broadcaster.
+ *  Tick interne 100ms — un dispatch healthy reste sous 200ms. */
+const BROADCASTER_DISPATCH_LAG_BUCKETS_MS = [
+  10, 25, 50, 100, 200, 350, 500, 750, 1000, 2000, 5000,
 ];
 
 export function buildMetricsRegistry(): MetricsRegistry {
@@ -111,6 +188,50 @@ export function buildMetricsRegistry(): MetricsRegistry {
     registers: [registry],
   });
 
+  // Pro League sim engine metrics (Lot 2.A.2).
+  const simMatchDuration = new Histogram({
+    name: "nuffle_sim_match_duration_seconds",
+    help: "Durée d'une simulation de match Pro League (sim-engine), en secondes",
+    labelNames: ["engineVer", "driver", "outcome"],
+    buckets: SIM_DURATION_BUCKETS_SECONDS,
+    registers: [registry],
+  });
+  const simMatchTotal = new Counter({
+    name: "nuffle_sim_match_total",
+    help: "Total de simulations de matchs Pro League (label `status` : success|failed, `driver`)",
+    labelNames: ["status", "driver"],
+    registers: [registry],
+  });
+  const replaySize = new Histogram({
+    name: "nuffle_replay_size_bytes",
+    help: "Taille du replay compressé (CBOR+gzip) en bytes",
+    labelNames: ["engineVer"],
+    buckets: REPLAY_SIZE_BUCKETS_BYTES,
+    registers: [registry],
+  });
+  const broadcasterActiveSessions = new Gauge({
+    name: "nuffle_broadcaster_active_sessions",
+    help: "Nombre de MatchSession actives dans le broadcaster",
+    registers: [registry],
+  });
+  const broadcasterTotalSubscribers = new Gauge({
+    name: "nuffle_broadcaster_total_subscribers",
+    help: "Total des subscribers (SSE clients) connectés au broadcaster",
+    registers: [registry],
+  });
+  const broadcasterDispatchLag = new Histogram({
+    name: "nuffle_broadcaster_event_dispatch_lag_ms",
+    help: "Délai de dispatch d'un event (Date.now() - (startedAt + displayAtMs)) en ms",
+    buckets: BROADCASTER_DISPATCH_LAG_BUCKETS_MS,
+    registers: [registry],
+  });
+  const engineDrift = new Gauge({
+    name: "nuffle_engine_drift",
+    help: "Dérive relative d'une métrique sim vs baseline FUMBBL/snapshot (delta relatif, ex: 0.04 = +4%)",
+    labelNames: ["metric", "race", "seasonId"],
+    registers: [registry],
+  });
+
   const clamp = (n: number) => (Number.isFinite(n) && n > 0 ? n : 0);
 
   return {
@@ -138,6 +259,51 @@ export function buildMetricsRegistry(): MetricsRegistry {
           statusCode: String(labels.statusCode),
         },
         ms,
+      );
+    },
+    observeSimMatchDuration(labels, seconds) {
+      const safe = Number.isFinite(seconds) && seconds >= 0 ? seconds : 0;
+      simMatchDuration.observe(
+        {
+          engineVer: labels.engineVer,
+          driver: labels.driver,
+          outcome: labels.outcome,
+        },
+        safe,
+      );
+    },
+    recordSimMatch(labels) {
+      simMatchTotal.inc({
+        status: labels.status,
+        driver: labels.driver,
+      });
+    },
+    observeReplaySize(labels, bytes) {
+      const safe = Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
+      replaySize.observe({ engineVer: labels.engineVer }, safe);
+    },
+    setBroadcasterActiveSessions(value) {
+      broadcasterActiveSessions.set(clamp(value));
+    },
+    setBroadcasterTotalSubscribers(value) {
+      broadcasterTotalSubscribers.set(clamp(value));
+    },
+    observeBroadcasterDispatchLag(ms) {
+      // Lag négatif = event dispatché en avance (peu probable mais
+      // possible si le wallclock recule). On clamp pour ne pas polluer
+      // l'histogramme.
+      const safe = Number.isFinite(ms) && ms > 0 ? ms : 0;
+      broadcasterDispatchLag.observe(safe);
+    },
+    setEngineDrift(labels, value) {
+      const safe = Number.isFinite(value) ? value : 0;
+      engineDrift.set(
+        {
+          metric: labels.metric,
+          race: labels.race,
+          seasonId: labels.seasonId,
+        },
+        safe,
       );
     },
 

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -78,6 +78,8 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/feature-flags", "Feature Flags", "🚩")}
               {navItem("/admin/sim", "Sim Pro League", "🎲")}
               {navItem("/admin/sim/replays", "Replays Panel", "📜")}
+              {navItem("/admin/sim/health", "Sim Health", "❤️")}
+              {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
               {navItem("/admin/feedback", "Feedback", "💬")}
               {navItem("/admin/audit-log", "Journal d'audit", "📜")}
               {navItem("/admin/routes", "Routes", "📋")}

--- a/apps/web/app/admin/sim/broadcaster/page.tsx
+++ b/apps/web/app/admin/sim/broadcaster/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * Console admin — broadcaster live state (Lot 2.B.4).
+ *
+ * Affiche en temps réel les sessions broadcaster actives + total
+ * subscribers. Auto-refresh toutes les 5s. Lecture seule.
+ *
+ * Source : `GET /admin/sim/broadcaster`. Compare la valeur en mémoire
+ * (`getBroadcasterStats()`) avec la gauge Prometheus : un écart
+ * signale un bug d'instrumentation à investiguer.
+ */
+
+import { useEffect, useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+interface BroadcasterPayload {
+  activeSessions: number;
+  totalSubscribers: number;
+  promExposed: {
+    activeSessions: number;
+    totalSubscribers: number;
+  };
+  fetchedAt: string;
+}
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+const REFRESH_MS = 5_000;
+
+export default function AdminBroadcasterPage() {
+  const [data, setData] = useState<BroadcasterPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState<boolean>(true);
+
+  const load = async () => {
+    try {
+      const payload = await fetchJSON<BroadcasterPayload>(
+        "/admin/sim/broadcaster",
+      );
+      setData(payload);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+    if (!autoRefresh) return;
+    const id = setInterval(() => void load(), REFRESH_MS);
+    return () => clearInterval(id);
+  }, [autoRefresh]);
+
+  const driftActive =
+    data && data.activeSessions !== data.promExposed.activeSessions;
+  const driftSubs =
+    data && data.totalSubscribers !== data.promExposed.totalSubscribers;
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">Broadcaster — live state</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Sessions broadcaster actives + subscribers SSE connectés.
+        Auto-refresh {(REFRESH_MS / 1000).toFixed(0)}s. Une dérive entre
+        la valeur en mémoire et la gauge Prometheus signale un bug
+        d&apos;instrumentation.
+      </p>
+
+      <div className="flex gap-3 items-center mb-6">
+        <label className="text-sm flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={autoRefresh}
+            onChange={(e) => setAutoRefresh(e.target.checked)}
+          />
+          Auto-refresh
+        </label>
+        <button
+          onClick={() => void load()}
+          className="px-3 py-1 border rounded"
+        >
+          Rafraîchir maintenant
+        </button>
+        {data && (
+          <span className="text-xs text-gray-500">
+            Dernière lecture : {new Date(data.fetchedAt).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {data && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="p-4 border rounded bg-white">
+            <div className="text-xs text-gray-500 mb-1">Sessions actives</div>
+            <div className="text-3xl font-bold">{data.activeSessions}</div>
+            <div className="text-xs text-gray-400 mt-2">
+              Prometheus : {data.promExposed.activeSessions}
+              {driftActive && <span className="ml-2 text-red-600">⚠ drift</span>}
+            </div>
+          </div>
+          <div className="p-4 border rounded bg-white">
+            <div className="text-xs text-gray-500 mb-1">Total subscribers</div>
+            <div className="text-3xl font-bold">{data.totalSubscribers}</div>
+            <div className="text-xs text-gray-400 mt-2">
+              Prometheus : {data.promExposed.totalSubscribers}
+              {driftSubs && <span className="ml-2 text-red-600">⚠ drift</span>}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <details className="mt-6 text-xs text-gray-600">
+        <summary className="cursor-pointer">Notes</summary>
+        <ul className="mt-2 list-disc list-inside space-y-1">
+          <li>
+            Une session est créée à la première subscription d&apos;un
+            match et libérée quand tous les events sont dispatchés ET
+            qu&apos;il n&apos;y a plus de subscribers.
+          </li>
+          <li>
+            Le tick interne de dispatch tourne à 100ms. Pour le lag p95
+            et la distribution, voir Grafana dashboard
+            <code className="mx-1">nuffle_broadcaster_event_dispatch_lag_ms</code>.
+          </li>
+          <li>
+            La capacité maximale d&apos;événements broadcastés en
+            simultané est aujourd&apos;hui limitée par
+            <code className="mx-1">setMaxListeners(1024)</code> par session.
+          </li>
+        </ul>
+      </details>
+    </div>
+  );
+}

--- a/apps/web/app/admin/sim/health/page.tsx
+++ b/apps/web/app/admin/sim/health/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+/**
+ * Console admin — sim engine health (Lot 2.B.3).
+ *
+ * Affiche la drift courante du moteur (rolling 7j) par race vs
+ * référence FUMBBL. Sert de fallback quand Grafana est down ou pour
+ * un rapide sanity check sans quitter l'app.
+ *
+ * Code couleur :
+ *   🟢  drift ∈ ]−5%, +5%[
+ *   🟡  drift ∈ ]−10%, +10%[
+ *   🔴  drift au-delà de ±10%
+ *
+ * Lecture seule. Source : `GET /admin/sim/drift`.
+ */
+
+import { useEffect, useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+type DriftMetric = "tdMean" | "casualtyMean" | "winRate";
+
+interface DriftSample {
+  metric: DriftMetric;
+  race: string;
+  seasonId: string;
+  observed: number;
+  reference: number;
+  drift: number;
+  samples: number;
+}
+
+interface DriftPayload {
+  samples: DriftSample[];
+  computedAt: string;
+}
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function classifyDrift(absDrift: number): "ok" | "warn" | "crit" {
+  if (absDrift < 0.05) return "ok";
+  if (absDrift < 0.1) return "warn";
+  return "crit";
+}
+
+function trafficLight(drift: number): string {
+  switch (classifyDrift(Math.abs(drift))) {
+    case "ok":
+      return "🟢";
+    case "warn":
+      return "🟡";
+    case "crit":
+      return "🔴";
+  }
+}
+
+function formatPct(drift: number): string {
+  const sign = drift > 0 ? "+" : drift < 0 ? "" : "±";
+  return `${sign}${(drift * 100).toFixed(1)}%`;
+}
+
+interface RaceSummary {
+  race: string;
+  seasonId: string;
+  samples: number;
+  metrics: Partial<Record<DriftMetric, DriftSample>>;
+}
+
+function groupByRace(samples: readonly DriftSample[]): RaceSummary[] {
+  const map = new Map<string, RaceSummary>();
+  for (const s of samples) {
+    const key = `${s.seasonId}::${s.race}`;
+    let entry = map.get(key);
+    if (!entry) {
+      entry = {
+        race: s.race,
+        seasonId: s.seasonId,
+        samples: s.samples,
+        metrics: {},
+      };
+      map.set(key, entry);
+    }
+    entry.metrics[s.metric] = s;
+  }
+  return Array.from(map.values()).sort((a, b) => a.race.localeCompare(b.race));
+}
+
+export default function AdminSimHealthPage() {
+  const [data, setData] = useState<DriftPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [windowDays, setWindowDays] = useState<number>(7);
+
+  const refresh = async (days: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const windowMs = days * 24 * 60 * 60 * 1000;
+      const payload = await fetchJSON<DriftPayload>(
+        `/admin/sim/drift?windowMs=${windowMs}`,
+      );
+      setData(payload);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh(windowDays);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const races = data ? groupByRace(data.samples) : [];
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">Sim engine — health</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Drift relative observée (matchs réels Pro League) vs référence
+        FUMBBL. 🟢 ∈ ±5% · 🟡 ∈ ±10% · 🔴 au-delà.
+      </p>
+
+      <div className="flex gap-3 items-center mb-6">
+        <label className="text-sm">
+          Fenêtre :
+          <select
+            value={windowDays}
+            onChange={(e) => {
+              const days = Number(e.target.value);
+              setWindowDays(days);
+              void refresh(days);
+            }}
+            className="ml-2 border rounded p-1"
+          >
+            <option value={1}>24h</option>
+            <option value={7}>7 jours</option>
+            <option value={30}>30 jours</option>
+            <option value={90}>90 jours</option>
+          </select>
+        </label>
+        <button
+          onClick={() => void refresh(windowDays)}
+          disabled={loading}
+          className="px-3 py-1 border rounded disabled:opacity-50"
+        >
+          {loading ? "…" : "Rafraîchir"}
+        </button>
+        {data && (
+          <span className="text-xs text-gray-500">
+            Calculé : {new Date(data.computedAt).toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {data && races.length === 0 && (
+        <div className="p-4 bg-gray-50 border rounded text-sm text-gray-600">
+          Aucun match dans la fenêtre — pas de drift à mesurer.
+        </div>
+      )}
+
+      {races.length > 0 && (
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b bg-gray-50">
+              <th className="text-left p-2">Race</th>
+              <th className="text-right p-2">Saison</th>
+              <th className="text-right p-2">Matchs</th>
+              <th className="text-right p-2">tdMean</th>
+              <th className="text-right p-2">vs ref</th>
+              <th className="text-right p-2">casualtyMean</th>
+              <th className="text-right p-2">vs ref</th>
+              <th className="text-right p-2">winRate</th>
+              <th className="text-right p-2">vs ref</th>
+            </tr>
+          </thead>
+          <tbody>
+            {races.map((r) => (
+              <tr key={`${r.seasonId}-${r.race}`} className="border-b">
+                <td className="p-2 font-medium">{r.race}</td>
+                <td className="p-2 text-right text-gray-500">{r.seasonId}</td>
+                <td className="p-2 text-right">{r.samples}</td>
+                <td className="p-2 text-right">
+                  {r.metrics.tdMean?.observed.toFixed(2) ?? "—"}
+                </td>
+                <td className="p-2 text-right">
+                  {r.metrics.tdMean
+                    ? `${trafficLight(r.metrics.tdMean.drift)} ${formatPct(r.metrics.tdMean.drift)}`
+                    : "—"}
+                </td>
+                <td className="p-2 text-right">
+                  {r.metrics.casualtyMean?.observed.toFixed(2) ?? "—"}
+                </td>
+                <td className="p-2 text-right">
+                  {r.metrics.casualtyMean
+                    ? `${trafficLight(r.metrics.casualtyMean.drift)} ${formatPct(r.metrics.casualtyMean.drift)}`
+                    : "—"}
+                </td>
+                <td className="p-2 text-right">
+                  {r.metrics.winRate
+                    ? `${(r.metrics.winRate.observed * 100).toFixed(1)}%`
+                    : "—"}
+                </td>
+                <td className="p-2 text-right">
+                  {r.metrics.winRate
+                    ? `${trafficLight(r.metrics.winRate.drift)} ${formatPct(r.metrics.winRate.drift)}`
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <details className="mt-6 text-xs text-gray-600">
+        <summary className="cursor-pointer">Méthodologie</summary>
+        <p className="mt-2">
+          Chaque match contribue deux fois à l&apos;aggrégation (homeRace +
+          awayRace). Les casualties sont split 50/50 entre les deux équipes
+          (donnée per-team non disponible sur ProLeagueMatch). La drift est
+          relative : <code>(observed − reference) / reference</code>. Une
+          race sans match dans la fenêtre n&apos;apparaît pas.
+        </p>
+      </details>
+    </div>
+  );
+}

--- a/prisma/migrations/20260507500000_add_pro_match_is_test/migration.sql
+++ b/prisma/migrations/20260507500000_add_pro_match_is_test/migration.sql
@@ -1,0 +1,21 @@
+-- Lot 2.C.1 — sandbox test matches.
+--
+-- Flag `isTest` sur ProLeagueMatch pour distinguer les matchs lancés
+-- depuis l'admin (`POST /admin/sim/test-match`) qui ne doivent ni
+-- compter dans les standings/ELO, ni générer de paiement de paris,
+-- ni alimenter les leaderboards/Hall of Fame.
+--
+-- Default false : tous les matchs Pro League existants restent
+-- "production" (impact ELO normal). Les matchs "test" sont créés
+-- explicitement avec isTest=true par les routes admin.
+
+ALTER TABLE "public"."ProLeagueMatch"
+    ADD COLUMN "isTest" BOOLEAN NOT NULL DEFAULT false;
+
+-- Index partiel : on ne charge l'index que sur les `isTest=true`
+-- (rare). Permet aux routes admin/sim/test-match/list de scanner
+-- rapidement les matchs sandbox sans pénaliser les requêtes
+-- production qui filtrent isTest=false (la majorité écrasante).
+CREATE INDEX "ProLeagueMatch_isTest_idx"
+    ON "public"."ProLeagueMatch" ("isTest")
+    WHERE "isTest" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1247,6 +1247,11 @@ model ProLeagueMatch {
   /// Sprint 1.E.4 — flag idempotence pour le post-process casualties.
   /// Non-null = casualties déjà appliquées au roster.
   casualtiesAppliedAt DateTime?
+  /// Lot 2.C.1 — sandbox flag. `true` = match lancé depuis l'admin
+  /// (`POST /admin/sim/test-match`), exclu des standings/ELO/paris/
+  /// wallet/leaderboards. Permet de tester un nouveau driver ou une
+  /// nouvelle race-profile en prod sans polluer les compétitions.
+  isTest              Boolean         @default(false)
   /// Seed sim-engine + engineVer pinne au moment de la simulation.
   /// Permet de rejouer le match a l'identique tant que engineVer matche.
   seed                BigInt?


### PR DESCRIPTION
## Summary

Lot 2.C.1 — fondation du sandbox / test mode. Ajoute `isTest Boolean` sur `ProLeagueMatch` pour permettre à un admin de lancer des matchs **sans impact** ELO / standings / paris / wallet / Hall of Fame / drift baseline.

## Changes

### Schema
- `prisma/schema.prisma` : `isTest Boolean @default(false)` sur `ProLeagueMatch`
- `apps/server/prisma/sqlite/schema.prisma` : même colonne pour la DB de test SQLite (kept in sync)

### Migration
`prisma/migrations/20260507500000_add_pro_match_is_test/migration.sql` :
- `ADD COLUMN isTest BOOLEAN NOT NULL DEFAULT false`
- Index partiel sur `isTest = true` uniquement (les sandbox sont rares, l'index ne pénalise pas les requêtes prod qui filtrent `isTest=false`)

### Default safety
`default false` — tous les matchs Pro League existants restent "production". Aucun impact sur les données live. Les sandbox sont créés explicitement par les routes admin du Lot 2.C.2.

## Test plan

- [x] 1787 tests serveur passent
- [x] Prisma client régénéré → `pnpm typecheck` clean
- [ ] Migration testée en local sur Postgres + SQLite

## Suite

Sous-PRs prévues sur cette branche :
- **Lot 2.C.2 / 2.C.4 / 2.C.5** : route `POST /admin/sim/test-match`, UI de création, banner "TEST MATCH" sur le replay
- **Lot 2.C.3** : audit + guards sur tous les agrégateurs (standings, paris, wallet, drift watcher, Hall of Fame, gazette)

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_