### PR TITLE
feat(sandbox): create test matches from admin (Lot 2.C.2 + 2.C.4 + 2.C.5)

### DIFF
--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -15,17 +15,28 @@ vi.mock("../services/pro-league-engine-drift-watcher", () => ({
 vi.mock("../services/pro-league-match-broadcaster", () => ({
   getBroadcasterStats: vi.fn(),
 }));
+vi.mock("../services/pro-league-sandbox", () => ({
+  createTestMatch: vi.fn(),
+  listTestMatches: vi.fn(),
+}));
 
 import {
+  handleCreateTestMatch,
   handleGetBroadcasterStats,
   handleGetDrift,
   handleListTeams,
+  handleListTestMatches,
   handleRunSim,
   runSimSchema,
+  testMatchSchema,
   type RunSimBody,
 } from "./admin-sim";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
 import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
+import {
+  createTestMatch,
+  listTestMatches,
+} from "../services/pro-league-sandbox";
 import { appMetrics } from "../utils/metrics";
 
 function buildRes(): Response & { statusCode: number; body: unknown } {
@@ -249,5 +260,110 @@ describe("handleGetBroadcasterStats — Lot 2.B.4", () => {
     expect(body.promExposed.activeSessions).toBe(3);
     expect(body.promExposed.totalSubscribers).toBe(12);
     expect(typeof body.fetchedAt).toBe("string");
+  });
+});
+
+describe("testMatchSchema — Lot 2.C.2 input validation", () => {
+  it("accepte un payload valide", () => {
+    const out = testMatchSchema.parse({
+      homeTeamId: "t1",
+      awayTeamId: "t2",
+    });
+    expect(out).toEqual({ homeTeamId: "t1", awayTeamId: "t2" });
+  });
+
+  it("rejette les ids vides", () => {
+    expect(() =>
+      testMatchSchema.parse({ homeTeamId: "", awayTeamId: "t2" }),
+    ).toThrow();
+  });
+});
+
+describe("handleCreateTestMatch — Lot 2.C.2", () => {
+  it("retourne 201 + matchId quand la création réussit", async () => {
+    (createTestMatch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      matchId: "m-abc",
+      seasonId: "s-2026",
+      engineVer: "0.16.0",
+    });
+    const res = buildRes();
+    await handleCreateTestMatch(
+      { body: { homeTeamId: "t1", awayTeamId: "t2" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({
+      matchId: "m-abc",
+      seasonId: "s-2026",
+      engineVer: "0.16.0",
+    });
+  });
+
+  it("retourne 400 quand les teams sont identiques (user input error)", async () => {
+    (createTestMatch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("homeTeamId et awayTeamId doivent être distincts"),
+    );
+    const res = buildRes();
+    await handleCreateTestMatch(
+      { body: { homeTeamId: "t1", awayTeamId: "t1" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("retourne 400 quand une team est introuvable", async () => {
+    (createTestMatch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Teams introuvables : t-unknown"),
+    );
+    const res = buildRes();
+    await handleCreateTestMatch(
+      {
+        body: { homeTeamId: "t1", awayTeamId: "t-unknown" },
+      } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("retourne 500 quand le sim crash (erreur interne)", async () => {
+    (createTestMatch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("simulateMatch boom"),
+    );
+    const res = buildRes();
+    await handleCreateTestMatch(
+      { body: { homeTeamId: "t1", awayTeamId: "t2" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("handleListTestMatches — Lot 2.C.2", () => {
+  it("retourne la liste sans limit", async () => {
+    (listTestMatches as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const res = buildRes();
+    await handleListTestMatches({ query: {} } as unknown as Request, res);
+    expect(listTestMatches).toHaveBeenCalledWith(undefined);
+    expect(res.body).toEqual({ matches: [] });
+  });
+
+  it("forwarde une limit numérique en query string", async () => {
+    (listTestMatches as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const res = buildRes();
+    await handleListTestMatches(
+      { query: { limit: "50" } } as unknown as Request,
+      res,
+    );
+    expect(listTestMatches).toHaveBeenCalledWith(50);
+  });
+
+  it("ignore une limit non-numérique", async () => {
+    (listTestMatches as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const res = buildRes();
+    await handleListTestMatches(
+      { query: { limit: "abc" } } as unknown as Request,
+      res,
+    );
+    expect(listTestMatches).toHaveBeenCalledWith(undefined);
   });
 });

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -13,6 +13,10 @@ import { authUser } from "../middleware/authUser";
 import { validate } from "../middleware/validate";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
 import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
+import {
+  createTestMatch,
+  listTestMatches,
+} from "../services/pro-league-sandbox";
 import { appMetrics } from "../utils/metrics";
 
 /**
@@ -152,6 +156,59 @@ export async function handleGetBroadcasterStats(
   });
 }
 
+/**
+ * Schema for `POST /admin/sim/test-match` — Lot 2.C.2.
+ *
+ * Pas de `seed` exposé dans cette V1 — le sim-runner dérive le seed
+ * depuis le matchId (cuid) ce qui est suffisant pour relancer
+ * exactement le même match en re-cliquant. Lot futur : exposer un
+ * seed override pour reproduire un bug donné.
+ */
+export const testMatchSchema = z.object({
+  homeTeamId: z.string().min(1),
+  awayTeamId: z.string().min(1),
+});
+
+export type TestMatchBody = z.infer<typeof testMatchSchema>;
+
+/** Handler `POST /admin/sim/test-match` — Lot 2.C.2. */
+export async function handleCreateTestMatch(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { homeTeamId, awayTeamId } = req.body as TestMatchBody;
+  try {
+    const result = await createTestMatch({ homeTeamId, awayTeamId });
+    res.status(201).json(result);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    // Erreur user-input → 400 ; sim qui throw → 500 propagé.
+    if (
+      msg.includes("introuvables") ||
+      msg.includes("distincts") ||
+      msg.includes("saison")
+    ) {
+      res.status(400).json({ error: msg });
+    } else {
+      res.status(500).json({ error: msg });
+    }
+  }
+}
+
+/** Handler `GET /admin/sim/test-matches` — Lot 2.C.4. */
+export async function handleListTestMatches(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const limitRaw = req.query.limit;
+  const limit =
+    typeof limitRaw === "string" && /^\d+$/.test(limitRaw)
+      ? Number.parseInt(limitRaw, 10)
+      : undefined;
+  const matches = await listTestMatches(limit);
+  res.json({ matches });
+}
+
 const router = Router();
 
 router.use(authUser, adminOnly);
@@ -160,5 +217,11 @@ router.get("/teams", handleListTeams);
 router.post("/run", validate(runSimSchema), handleRunSim);
 router.get("/drift", handleGetDrift);
 router.get("/broadcaster", handleGetBroadcasterStats);
+router.post(
+  "/test-match",
+  validate(testMatchSchema),
+  handleCreateTestMatch,
+);
+router.get("/test-matches", handleListTestMatches);
 
 export default router;

--- a/apps/server/src/services/pro-league-match.test.ts
+++ b/apps/server/src/services/pro-league-match.test.ts
@@ -31,6 +31,7 @@ function makeMatch(overrides: Record<string, unknown> = {}) {
     simulatedAt: new Date("2026-09-14T21:00:00Z"),
     completedAt: new Date("2026-09-15T21:08:00Z"),
     engineVer: "0.13.0",
+    isTest: false,
     scoreHome: 3,
     scoreAway: 1,
     outcome: "home",

--- a/apps/server/src/services/pro-league-match.ts
+++ b/apps/server/src/services/pro-league-match.ts
@@ -46,6 +46,9 @@ export interface ProMatchDetail {
   readonly simulatedAt: string | null;
   readonly completedAt: string | null;
   readonly engineVer: string | null;
+  /** Lot 2.C.1 — sandbox flag exposed to the frontend so the live
+   *  viewer can render a "TEST MATCH — does not count" banner. */
+  readonly isTest: boolean;
   readonly homeTeam: ProMatchDetailTeam;
   readonly awayTeam: ProMatchDetailTeam;
   readonly scoreHome: number | null;
@@ -136,6 +139,7 @@ export async function getProMatchDetail(id: string): Promise<ProMatchDetail> {
       simulatedAt: true,
       completedAt: true,
       engineVer: true,
+      isTest: true,
       scoreHome: true,
       scoreAway: true,
       outcome: true,
@@ -200,6 +204,7 @@ export async function getProMatchDetail(id: string): Promise<ProMatchDetail> {
     completedAt:
       (m.completedAt as Date | null)?.toISOString() ?? null,
     engineVer: (m.engineVer as string | null) ?? null,
+    isTest: Boolean(m.isTest),
     homeTeam: teamMeta(m.homeTeam),
     awayTeam: teamMeta(m.awayTeam),
     scoreHome: (m.scoreHome as number | null) ?? null,

--- a/apps/server/src/services/pro-league-sandbox.test.ts
+++ b/apps/server/src/services/pro-league-sandbox.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests pour le service sandbox / test match (Lot 2.C.2).
+ *
+ * Couvre :
+ *  - createTestMatch : validation des teams (distinctes, existantes),
+ *    saison active requise, upsert round sandbox, persist isTest=true,
+ *    appel simulateProMatch.
+ *  - listTestMatches : filtre isTest, ordre décroissant, limite clampée.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: { findFirst: vi.fn() },
+    proLeagueRound: { findUnique: vi.fn(), create: vi.fn() },
+    proLeagueMatch: { create: vi.fn(), findMany: vi.fn() },
+    proTeam: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("./pro-league-sim-runner", () => ({
+  simulateProMatch: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { simulateProMatch } from "./pro-league-sim-runner";
+import { createTestMatch, listTestMatches } from "./pro-league-sandbox";
+
+interface MockedPrisma {
+  proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
+  proLeagueRound: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  proTeam: { findMany: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+const mockedSim = simulateProMatch as ReturnType<typeof vi.fn>;
+
+describe("createTestMatch — Lot 2.C.2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejette homeTeamId === awayTeamId", async () => {
+    await expect(
+      createTestMatch({ homeTeamId: "t1", awayTeamId: "t1" }),
+    ).rejects.toThrow(/distincts/);
+  });
+
+  it("rejette si une team n'existe pas", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([{ id: "t1", slug: "a" }]);
+    await expect(
+      createTestMatch({ homeTeamId: "t1", awayTeamId: "t2" }),
+    ).rejects.toThrow(/introuvables.*t2/);
+  });
+
+  it("rejette si aucune saison active", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([
+      { id: "t1", slug: "a" },
+      { id: "t2", slug: "b" },
+    ]);
+    mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
+    await expect(
+      createTestMatch({ homeTeamId: "t1", awayTeamId: "t2" }),
+    ).rejects.toThrow(/saison.*active/);
+  });
+
+  it("crée le match avec isTest=true et appelle simulateProMatch", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([
+      { id: "t1", slug: "a" },
+      { id: "t2", slug: "b" },
+    ]);
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "season-2026",
+      engineVer: "0.16.0",
+    });
+    mocked.proLeagueRound.findUnique.mockResolvedValue({ id: "round-sandbox" });
+    mocked.proLeagueMatch.create.mockResolvedValue({ id: "match-abc" });
+
+    const result = await createTestMatch({
+      homeTeamId: "t1",
+      awayTeamId: "t2",
+    });
+
+    expect(mocked.proLeagueMatch.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          seasonId: "season-2026",
+          roundId: "round-sandbox",
+          homeTeamId: "t1",
+          awayTeamId: "t2",
+          isTest: true,
+          status: "scheduled",
+        }),
+      }),
+    );
+    expect(mockedSim).toHaveBeenCalledWith("match-abc");
+    expect(result).toEqual({
+      matchId: "match-abc",
+      seasonId: "season-2026",
+      engineVer: "0.16.0",
+    });
+  });
+
+  it("upsert le round sandbox (roundNumber=0) si absent", async () => {
+    mocked.proTeam.findMany.mockResolvedValue([
+      { id: "t1", slug: "a" },
+      { id: "t2", slug: "b" },
+    ]);
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "season-2026",
+      engineVer: "0.16.0",
+    });
+    mocked.proLeagueRound.findUnique.mockResolvedValue(null);
+    mocked.proLeagueRound.create.mockResolvedValue({ id: "round-fresh" });
+    mocked.proLeagueMatch.create.mockResolvedValue({ id: "m1" });
+
+    await createTestMatch({ homeTeamId: "t1", awayTeamId: "t2" });
+
+    expect(mocked.proLeagueRound.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          seasonId: "season-2026",
+          roundNumber: 0,
+          status: "completed",
+        }),
+      }),
+    );
+  });
+});
+
+describe("listTestMatches — Lot 2.C.2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("filtre isTest=true, ordre décroissant sur createdAt, limite 20 par défaut", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await listTestMatches();
+    expect(mocked.proLeagueMatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { isTest: true },
+        orderBy: { createdAt: "desc" },
+        take: 20,
+      }),
+    );
+  });
+
+  it("clamp la limite à [1, 100]", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await listTestMatches(0);
+    expect(mocked.proLeagueMatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 1 }),
+    );
+    await listTestMatches(99999);
+    expect(mocked.proLeagueMatch.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ take: 100 }),
+    );
+  });
+
+  it("formatte les rows en TestMatchSummary", async () => {
+    const now = new Date("2026-05-07T12:00:00Z");
+    mocked.proLeagueMatch.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        homeTeamId: "t1",
+        awayTeamId: "t2",
+        status: "ready",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        engineVer: "0.16.0",
+        createdAt: now,
+        simulatedAt: now,
+        homeTeam: { name: "Smashers" },
+        awayTeam: { name: "Hawks" },
+      },
+    ]);
+    const out = await listTestMatches();
+    expect(out).toEqual([
+      {
+        id: "m1",
+        homeTeamId: "t1",
+        awayTeamId: "t2",
+        homeTeamName: "Smashers",
+        awayTeamName: "Hawks",
+        status: "ready",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        engineVer: "0.16.0",
+        createdAt: now.toISOString(),
+        simulatedAt: now.toISOString(),
+      },
+    ]);
+  });
+});

--- a/apps/server/src/services/pro-league-sandbox.ts
+++ b/apps/server/src/services/pro-league-sandbox.ts
@@ -1,0 +1,235 @@
+/**
+ * Pro League sandbox / test match service — Lot 2.C.2.
+ *
+ * Permet à un admin de lancer un match Pro League depuis l'admin
+ * sans impact ELO / standings / paris / wallet / Hall of Fame /
+ * drift baseline. Les matchs créés ici portent `isTest=true` (Lot
+ * 2.C.1) et sont filtrés par les services agrégateurs (Lot 2.C.3).
+ *
+ * Pourquoi un service séparé du sim-runner
+ * ----------------------------------------
+ * Le sim-runner (`pro-league-sim-runner.ts`) gère les matchs déjà
+ * scheduled par le scheduler (round-robin). Il choisit l'engineVer,
+ * dérive le seed du `matchId`, etc. Pour le sandbox on veut :
+ *   - choisir librement homeTeamId / awayTeamId (pas forcément un
+ *     pairing du round-robin)
+ *   - optionnellement override le seed (pour reproduire un bug)
+ *   - optionnellement choisir le driver (`hybrid` / `full` quand
+ *     Lot 3.B.1 introduira le toggle)
+ *   - simuler immédiatement (pas attendre le tick du runner)
+ *   - retourner directement l'id pour que l'UI redirige vers le
+ *     replay
+ *
+ * Persistance
+ * -----------
+ * Tous les sandbox matchs vivent dans la **dernière saison active**
+ * (`status='in_progress'`), dans un round dédié `roundNumber=0`
+ * réservé au sandbox. Cette convention garde les FK intactes (un
+ * match doit toujours appartenir à un round + une saison) sans
+ * créer un modèle séparé. Le filtre `isTest=true` (Lot 2.C.1) suffit
+ * à exclure ces matchs des stats.
+ *
+ * Idempotence du round sandbox
+ * ----------------------------
+ * Le round `roundNumber=0` est créé à la demande (`upsert` sur
+ * la contrainte composite `[seasonId, roundNumber]` du schema).
+ * Les sandbox matchs accumulent dans ce même round.
+ */
+
+import { ENGINE_VER as CURRENT_ENGINE_VER } from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+import { simulateProMatch } from "./pro-league-sim-runner";
+
+const SANDBOX_ROUND_NUMBER = 0;
+
+export interface CreateTestMatchInput {
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  /** Override seed for reproducibility (optional, default = derived from cuid). */
+  readonly seed?: number;
+}
+
+export interface CreateTestMatchResult {
+  readonly matchId: string;
+  readonly seasonId: string;
+  readonly engineVer: string;
+}
+
+/**
+ * Trouve la saison active la plus récente. Les matchs sandbox vivent
+ * dans la même saison que les matchs prod (mais sont marqués
+ * `isTest=true` pour exclusion des stats).
+ *
+ * Throw si aucune saison active n'existe — évite de créer des sandbox
+ * matchs orphelins.
+ */
+async function findLatestActiveSeason(): Promise<{
+  id: string;
+  engineVer: string;
+}> {
+  const season = await prisma.proLeagueSeason.findFirst({
+    where: { status: "in_progress" },
+    orderBy: { year: "desc" },
+    select: { id: true, engineVer: true },
+  });
+  if (!season) {
+    throw new Error(
+      "Aucune saison Pro League active — créez d'abord une saison via le scheduler avant de lancer un sandbox match.",
+    );
+  }
+  return { id: season.id as string, engineVer: season.engineVer as string };
+}
+
+/**
+ * Récupère ou crée le round sandbox (`roundNumber=0`) de la saison
+ * fournie. Idempotent grâce à la contrainte unique `[seasonId,
+ * roundNumber]` côté schema.
+ */
+async function ensureSandboxRound(seasonId: string): Promise<string> {
+  const existing = await prisma.proLeagueRound.findUnique({
+    where: {
+      seasonId_roundNumber: {
+        seasonId,
+        roundNumber: SANDBOX_ROUND_NUMBER,
+      },
+    },
+    select: { id: true },
+  });
+  if (existing) return existing.id as string;
+
+  const created = await prisma.proLeagueRound.create({
+    data: {
+      seasonId,
+      roundNumber: SANDBOX_ROUND_NUMBER,
+      status: "completed",
+    },
+    select: { id: true },
+  });
+  return created.id as string;
+}
+
+/**
+ * Crée un sandbox match (`isTest=true`) entre deux équipes Pro
+ * League, le simule immédiatement, et retourne le matchId pour que
+ * l'UI puisse rediriger vers le replay.
+ *
+ * Erreur explicite si :
+ *   - homeTeamId === awayTeamId
+ *   - une team n'existe pas
+ *   - aucune saison active
+ *
+ * Side-effects :
+ *   - upsert d'un round sandbox (`roundNumber=0`)
+ *   - INSERT d'un ProLeagueMatch avec status='scheduled', isTest=true
+ *   - simulateProMatch synchrone (durée ~50ms en hybrid)
+ */
+export async function createTestMatch(
+  input: CreateTestMatchInput,
+): Promise<CreateTestMatchResult> {
+  if (input.homeTeamId === input.awayTeamId) {
+    throw new Error("homeTeamId et awayTeamId doivent être distincts");
+  }
+
+  // Vérifie l'existence des deux teams en une seule query.
+  const teams = (await prisma.proTeam.findMany({
+    where: { id: { in: [input.homeTeamId, input.awayTeamId] } },
+    select: { id: true, slug: true },
+  })) as Array<{ id: string; slug: string }>;
+  if (teams.length !== 2) {
+    const found = new Set(teams.map((t) => t.id));
+    const missing = [input.homeTeamId, input.awayTeamId].filter(
+      (id) => !found.has(id),
+    );
+    throw new Error(`Teams introuvables : ${missing.join(", ")}`);
+  }
+
+  const season = await findLatestActiveSeason();
+  const roundId = await ensureSandboxRound(season.id);
+
+  const created = await prisma.proLeagueMatch.create({
+    data: {
+      seasonId: season.id,
+      roundId,
+      homeTeamId: input.homeTeamId,
+      awayTeamId: input.awayTeamId,
+      status: "scheduled",
+      scheduledAt: new Date(),
+      isTest: true,
+    },
+    select: { id: true },
+  });
+  const matchId = created.id as string;
+
+  // Simulate immediately. Le sim-runner observe les métriques
+  // Prometheus comme un match prod (Lot 2.A.3). Les guards (Lot
+  // 2.C.3) excluent ces matchs des agrégateurs.
+  await simulateProMatch(matchId);
+
+  return {
+    matchId,
+    seasonId: season.id,
+    engineVer: season.engineVer || CURRENT_ENGINE_VER,
+  };
+}
+
+export interface TestMatchSummary {
+  readonly id: string;
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  readonly homeTeamName: string;
+  readonly awayTeamName: string;
+  readonly status: string;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+  readonly engineVer: string | null;
+  readonly createdAt: string;
+  readonly simulatedAt: string | null;
+}
+
+/**
+ * Liste les N derniers sandbox matchs lancés (UI admin Lot 2.C.4).
+ * Ordre décroissant sur `createdAt`. Limite par défaut 20, max 100.
+ */
+export async function listTestMatches(
+  limit = 20,
+): Promise<TestMatchSummary[]> {
+  const safeLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+  const rows = await prisma.proLeagueMatch.findMany({
+    where: { isTest: true },
+    orderBy: { createdAt: "desc" },
+    take: safeLimit,
+    select: {
+      id: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      status: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      engineVer: true,
+      createdAt: true,
+      simulatedAt: true,
+      homeTeam: { select: { name: true } },
+      awayTeam: { select: { name: true } },
+    },
+  });
+  type Row = (typeof rows)[number];
+  return (rows as Row[]).map((row) => ({
+    id: row.id as string,
+    homeTeamId: row.homeTeamId as string,
+    awayTeamId: row.awayTeamId as string,
+    homeTeamName: (row.homeTeam.name as string) ?? "",
+    awayTeamName: (row.awayTeam.name as string) ?? "",
+    status: row.status as string,
+    scoreHome: row.scoreHome as number | null,
+    scoreAway: row.scoreAway as number | null,
+    outcome: row.outcome as string | null,
+    engineVer: row.engineVer as string | null,
+    createdAt: (row.createdAt as Date).toISOString(),
+    simulatedAt: row.simulatedAt
+      ? (row.simulatedAt as Date).toISOString()
+      : null,
+  }));
+}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -80,6 +80,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/sim/replays", "Replays Panel", "📜")}
               {navItem("/admin/sim/health", "Sim Health", "❤️")}
               {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
+              {navItem("/admin/sim/test-match", "Test Match", "🧪")}
               {navItem("/admin/feedback", "Feedback", "💬")}
               {navItem("/admin/audit-log", "Journal d'audit", "📜")}
               {navItem("/admin/routes", "Routes", "📋")}

--- a/apps/web/app/admin/sim/test-match/page.tsx
+++ b/apps/web/app/admin/sim/test-match/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+/**
+ * Console admin — sandbox / test match (Lot 2.C.4).
+ *
+ * Permet à un admin de lancer un match Pro League depuis le navigateur
+ * sans impact ELO / standings / paris / wallet. Une fois lancé, le
+ * replay est accessible via le viewer normal (avec banner "TEST MATCH"
+ * — Lot 2.C.5).
+ *
+ * Affiche également les 20 derniers test matchs lancés pour relancer /
+ * comparer rapidement.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+interface Team {
+  id: string;
+  city: string;
+  name: string;
+  race: string;
+  nflFlavor: string;
+}
+
+interface CreateResult {
+  matchId: string;
+  seasonId: string;
+  engineVer: string;
+}
+
+interface TestMatchSummary {
+  id: string;
+  homeTeamId: string;
+  awayTeamId: string;
+  homeTeamName: string;
+  awayTeamName: string;
+  status: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  engineVer: string | null;
+  createdAt: string;
+  simulatedAt: string | null;
+}
+
+async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export default function AdminTestMatchPage() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [homeTeamId, setHomeTeamId] = useState<string>("");
+  const [awayTeamId, setAwayTeamId] = useState<string>("");
+  const [list, setList] = useState<TestMatchSummary[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [running, setRunning] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastResult, setLastResult] = useState<CreateResult | null>(null);
+
+  const loadTeams = async () => {
+    const data = await fetchJSON<{ teams: Team[] }>("/admin/sim/teams");
+    setTeams(data.teams);
+    if (data.teams.length >= 2) {
+      setHomeTeamId(data.teams[0].id);
+      setAwayTeamId(data.teams[1].id);
+    }
+  };
+
+  const loadList = async () => {
+    const data = await fetchJSON<{ matches: TestMatchSummary[] }>(
+      "/admin/sim/test-matches?limit=20",
+    );
+    setList(data.matches);
+  };
+
+  useEffect(() => {
+    void (async () => {
+      setLoading(true);
+      try {
+        await Promise.all([loadTeams(), loadList()]);
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const launch = async () => {
+    if (homeTeamId === awayTeamId) {
+      setError("Choisis deux équipes différentes.");
+      return;
+    }
+    setRunning(true);
+    setError(null);
+    setLastResult(null);
+    try {
+      const result = await fetchJSON<CreateResult>(
+        "/admin/sim/test-match",
+        {
+          method: "POST",
+          body: JSON.stringify({ homeTeamId, awayTeamId }),
+        },
+      );
+      setLastResult(result);
+      await loadList();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">Sandbox — test match</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Lance un match Pro League sans impact ELO / standings / paris /
+        wallet. Le replay est accessible immédiatement après simulation
+        (~50ms). Les matchs créés ici sont marqués <code>isTest=true</code>
+        et exclus des statistiques agrégées.
+      </p>
+
+      <div className="grid grid-cols-3 gap-3 items-end mb-4 p-4 border rounded bg-white">
+        <label className="text-sm">
+          <div className="mb-1">Équipe à domicile</div>
+          <select
+            value={homeTeamId}
+            onChange={(e) => setHomeTeamId(e.target.value)}
+            className="w-full border rounded p-2"
+          >
+            {teams.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.city} {t.name} ({t.race})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Équipe à l&apos;extérieur</div>
+          <select
+            value={awayTeamId}
+            onChange={(e) => setAwayTeamId(e.target.value)}
+            className="w-full border rounded p-2"
+          >
+            {teams.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.city} {t.name} ({t.race})
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          onClick={() => void launch()}
+          disabled={running || loading || homeTeamId === awayTeamId}
+          className="px-4 py-2 rounded bg-nuffle-gold text-white font-medium disabled:opacity-50"
+        >
+          {running ? "Simulation…" : "Lancer le match test"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {lastResult && (
+        <div className="mb-4 p-3 border border-green-300 bg-green-50 rounded text-sm">
+          Match simulé : <code>{lastResult.matchId}</code> (engineVer{" "}
+          {lastResult.engineVer}) ·{" "}
+          <Link
+            href={`/pro-league/match/${lastResult.matchId}` as never}
+            className="underline text-green-700"
+          >
+            Voir le replay
+          </Link>
+        </div>
+      )}
+
+      <h2 className="text-lg font-semibold mb-2 mt-6">
+        Derniers matchs test ({list.length})
+      </h2>
+      {list.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          Aucun match test pour le moment.
+        </p>
+      ) : (
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b bg-gray-50">
+              <th className="text-left p-2">Date</th>
+              <th className="text-left p-2">Match</th>
+              <th className="text-right p-2">Score</th>
+              <th className="text-right p-2">Status</th>
+              <th className="text-right p-2">engineVer</th>
+              <th className="text-right p-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((m) => (
+              <tr key={m.id} className="border-b">
+                <td className="p-2 text-gray-500 text-xs">
+                  {new Date(m.createdAt).toLocaleString()}
+                </td>
+                <td className="p-2">
+                  {m.homeTeamName}{" "}
+                  <span className="text-gray-400">vs</span> {m.awayTeamName}
+                </td>
+                <td className="p-2 text-right font-mono">
+                  {m.scoreHome ?? "-"} - {m.scoreAway ?? "-"}
+                </td>
+                <td className="p-2 text-right">{m.status}</td>
+                <td className="p-2 text-right text-gray-500 text-xs">
+                  {m.engineVer ?? "-"}
+                </td>
+                <td className="p-2 text-right">
+                  <Link
+                    href={`/pro-league/match/${m.id}` as never}
+                    className="text-blue-600 underline"
+                  >
+                    Replay
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/lib/use-match-mode-redirect.ts
+++ b/apps/web/app/lib/use-match-mode-redirect.ts
@@ -25,12 +25,19 @@ export type MatchMode = "live" | "replay";
 interface MinimalMatch {
   readonly id: string;
   readonly status: string;
+  readonly isTest?: boolean;
 }
 
 export interface MatchModeRedirectResult {
   readonly redirecting: boolean;
   readonly status: string | null;
   readonly error: string | null;
+  /**
+   * Lot 2.C.5 — `true` quand le match est un sandbox lancé depuis
+   * l'admin. Permet aux pages live/replay d'afficher un bandeau
+   * "TEST MATCH — does not count" sans une fetch séparée.
+   */
+  readonly isTest: boolean;
 }
 
 function targetPathFor(matchId: string, status: string): string | null {
@@ -48,6 +55,7 @@ export function useMatchModeRedirect(
   const [status, setStatus] = useState<string | null>(null);
   const [redirecting, setRedirecting] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [isTest, setIsTest] = useState<boolean>(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -57,6 +65,7 @@ export function useMatchModeRedirect(
       .then((m) => {
         if (cancelled) return;
         setStatus(m.status);
+        setIsTest(Boolean(m.isTest));
         const expected =
           expectedMode === "live" ? "in_progress" : "completed";
         if (m.status !== expected) {
@@ -76,5 +85,5 @@ export function useMatchModeRedirect(
     };
   }, [matchId, expectedMode, router]);
 
-  return { redirecting, status, error };
+  return { redirecting, status, error, isTest };
 }

--- a/apps/web/app/pro-league/matches/[id]/live/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/live/page.tsx
@@ -200,6 +200,15 @@ export default function LiveProMatchPage({
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
+      {redirect.isTest && (
+        <div
+          data-testid="test-match-banner"
+          className="sticky top-0 z-20 bg-amber-500 px-4 py-2 text-center text-sm font-semibold text-amber-950 shadow"
+        >
+          🧪 TEST MATCH — sandbox, ne compte ni dans les standings ni
+          dans l&apos;ELO ni dans les paris.
+        </div>
+      )}
       <header
         data-testid="score-header"
         className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-4 py-3 shadow"

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
@@ -370,6 +370,15 @@ export default function MatchReplayPlayer({
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-slate-950 text-slate-100">
+      {redirect.isTest && (
+        <div
+          data-testid="test-match-banner"
+          className="sticky top-0 z-20 bg-amber-500 px-4 py-2 text-center text-sm font-semibold text-amber-950 shadow"
+        >
+          🧪 TEST MATCH — sandbox, ne compte ni dans les standings ni
+          dans l&apos;ELO ni dans les paris.
+        </div>
+      )}
       <header
         data-testid="replay-header"
         className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-slate-800 bg-slate-900 px-4 py-3 shadow"


### PR DESCRIPTION
## Summary

Lot 2.C.2 + 2.C.4 + 2.C.5 — flow complet de création / visualisation des sandbox matchs depuis l'admin.

> **Dépend de #675** (schema `isTest`). À merger après #675.

## Lot 2.C.2 — service + routes admin

**`pro-league-sandbox.ts`**
- `createTestMatch({ homeTeamId, awayTeamId })` :
  - valide teams distinctes, existantes
  - trouve la saison active la plus récente
  - upsert un round sandbox (`roundNumber=0`) dans cette saison
  - INSERT `ProLeagueMatch` avec `isTest=true`, `status='scheduled'`
  - appelle `simulateProMatch` synchrone (~50ms hybrid)
  - retourne `{ matchId, seasonId, engineVer }`
- `listTestMatches(limit)` : 20 derniers par défaut, max 100.

**Routes admin** :
- `POST /admin/sim/test-match` — création
- `GET /admin/sim/test-matches` — listing

Erreurs mappées : 400 user input, 500 sim crash.

`ProMatchDetail` étendu avec `isTest` pour que le public metadata endpoint expose le flag.

## Lot 2.C.4 — UI admin

`/admin/sim/test-match` :
- formulaire 2 selects + bouton "Lancer"
- tableau des 20 derniers matchs test avec lien direct vers le replay
- entrée sidebar "🧪 Test Match"

## Lot 2.C.5 — Banner replay

`useMatchModeRedirect` expose `isTest` (sans fetch supplémentaire — même payload). Live page + replay page affichent une bannière sticky ambre "🧪 TEST MATCH — sandbox, ne compte ni dans les standings ni dans l'ELO ni dans les paris."

## Test plan

- [x] 8 tests unitaires sur le service sandbox
- [x] 9 tests sur les routes admin
- [x] 1820 tests serveur passent
- [x] `pnpm typecheck` clean (server + web)
- [ ] À tester en prod : flow complet création → replay → vérifier exclusion stats

## Suite

**Lot 2.C.3** : audit + guards sur tous les agrégateurs (standings, paris, wallet, drift watcher, Hall of Fame, gazette) pour exclure `isTest=true`.

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_