### PR TITLE
feat(sandbox): exclude isTest matches from aggregators (Lot 2.C.3)

### DIFF
--- a/apps/server/src/services/pro-bet-settlement.ts
+++ b/apps/server/src/services/pro-bet-settlement.ts
@@ -300,6 +300,11 @@ export async function sweepUnsettledMarkets(): Promise<SweepResult> {
       betMarkets: {
         some: { status: { in: ["open", "closed"] } },
       },
+      // Lot 2.C.3 — sandbox matchs ne settle aucun pari (par
+      // construction ils n'ont pas de markets puisque la création
+      // de bet est refusée sur isTest=true ; mais on filtre quand
+      // même par défense en profondeur).
+      isTest: false,
     },
     select: { id: true },
     orderBy: { completedAt: "asc" },

--- a/apps/server/src/services/pro-bet.ts
+++ b/apps/server/src/services/pro-bet.ts
@@ -227,10 +227,21 @@ export async function placeBet(input: PlaceBetInput): Promise<ProBetSummary> {
       config: true,
       status: true,
       closesAt: true,
+      // Lot 2.C.3 — `match.isTest` permet de refuser tout pari sur
+      // un sandbox match. Aucun market ne devrait jamais être créé
+      // pour un sandbox match, mais on filtre par défense en
+      // profondeur au moment du placement.
+      match: { select: { isTest: true } },
     },
   });
   if (!market) {
     throw new MarketNotFoundError(input.marketId);
+  }
+  if (market.match?.isTest === true) {
+    throw new BetValidationError(
+      "TEST_MATCH",
+      "Les paris ne sont pas autorisés sur les matchs sandbox / test.",
+    );
   }
   const marketType = market.type as string;
   const marketStatus = market.status as string;

--- a/apps/server/src/services/pro-gazette-recap.ts
+++ b/apps/server/src/services/pro-gazette-recap.ts
@@ -79,6 +79,8 @@ export async function getDailyRecap(
     where: {
       status: "completed",
       completedAt: { gte: fromAt, lt: toAt },
+      // Lot 2.C.3 — la Nuffle Gazette ne couvre pas les matchs sandbox.
+      isTest: false,
     },
     orderBy: { completedAt: "asc" },
     select: {
@@ -181,6 +183,7 @@ export async function getDailyRecap(
       where: {
         status: "completed",
         completedAt: { gte: rivalryFromAt, lte: toAt },
+        isTest: false,
         OR: [
           {
             homeTeam: { slug: m.homeTeamSlug },

--- a/apps/server/src/services/pro-league-engine-drift-watcher.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.ts
@@ -112,6 +112,10 @@ async function loadCompletedMatches(
     where: {
       status: { in: ["completed", "ready"] },
       simulatedAt: { gte: since, lte: now },
+      // Lot 2.C.3 — exclude sandbox / test matchs from the drift
+      // baseline so admin sandbox runs don't pollute the moving
+      // average of real production matches.
+      isTest: false,
       ...(seasonId ? { seasonId } : {}),
     },
     select: {

--- a/apps/server/src/services/pro-league-follow.ts
+++ b/apps/server/src/services/pro-league-follow.ts
@@ -297,6 +297,8 @@ export async function getMyFeed(userId: string): Promise<FeedEntry[]> {
       where: {
         OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
         status: { in: ["scheduled", "ready"] },
+        // Lot 2.C.3 — fan feed n'inclut pas les sandbox matchs.
+        isTest: false,
       },
       orderBy: { scheduledAt: "asc" },
       take: FEED_UPCOMING_PER_TEAM,
@@ -310,6 +312,7 @@ export async function getMyFeed(userId: string): Promise<FeedEntry[]> {
       where: {
         OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
         status: "completed",
+        isTest: false,
       },
       orderBy: { scheduledAt: "desc" },
       take: FEED_RECENT_PER_TEAM,

--- a/apps/server/src/services/pro-league-hub.ts
+++ b/apps/server/src/services/pro-league-hub.ts
@@ -194,6 +194,8 @@ export async function getProLeagueHubSnapshot(
     where: {
       seasonId,
       status: { in: ["scheduled", "ready"] },
+      // Lot 2.C.3 — exclure les sandbox matchs du hub public.
+      isTest: false,
     },
     orderBy: [{ scheduledAt: "asc" }],
     take: NEXT_MATCHES_LIMIT,

--- a/apps/server/src/services/pro-league-isTest-guards.test.ts
+++ b/apps/server/src/services/pro-league-isTest-guards.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for Lot 2.C.3 — guards excluding isTest=true matches from
+ * production aggregators / writers.
+ *
+ * Each suite asserts that the where clauses include `isTest: false`
+ * (or equivalent) so sandbox matchs don't leak into stats, feeds,
+ * casualties applied, bets, drift baseline, gazette, etc.
+ *
+ * We mock prisma at module level and inspect the args passed to
+ * findMany / findUnique so the tests are fast and don't require a
+ * database.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    proLeagueSeason: { findFirst: vi.fn() },
+    proTeam: { findUnique: vi.fn() },
+    proTeamRoster: { findMany: vi.fn() },
+    proLeagueStandings: { findMany: vi.fn() },
+    proBetMarket: { findUnique: vi.fn() },
+    proBet: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import { computeEngineDrift } from "./pro-league-engine-drift-watcher";
+import { sweepMatchCasualties } from "./pro-roster-casualties";
+import { sweepUnsettledMarkets } from "./pro-bet-settlement";
+
+const mocked = prisma as unknown as {
+  proLeagueMatch: {
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+  proBetMarket: { findUnique: ReturnType<typeof vi.fn> };
+  proBet: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+describe("Lot 2.C.3 — guards on aggregators", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("computeEngineDrift filtre isTest=false", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await computeEngineDrift();
+    const args = mocked.proLeagueMatch.findMany.mock.calls[0][0];
+    expect(args.where.isTest).toBe(false);
+  });
+
+  it("sweepMatchCasualties filtre isTest=false", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await sweepMatchCasualties();
+    const args = mocked.proLeagueMatch.findMany.mock.calls[0][0];
+    expect(args.where.isTest).toBe(false);
+  });
+
+  it("sweepUnsettledMarkets filtre isTest=false", async () => {
+    mocked.proLeagueMatch.findMany.mockResolvedValue([]);
+    await sweepUnsettledMarkets();
+    const args = mocked.proLeagueMatch.findMany.mock.calls[0][0];
+    expect(args.where.isTest).toBe(false);
+  });
+});
+
+describe("Lot 2.C.3 — placeBet rejects isTest matches", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("placeBet renvoie BetValidationError quand le match est sandbox", async () => {
+    const { placeBet, BetValidationError } = await import("./pro-bet");
+    mocked.proBet.findUnique.mockResolvedValue(null);
+    mocked.proBetMarket.findUnique.mockResolvedValue({
+      id: "market-1",
+      matchId: "m-test",
+      type: "winner",
+      config: '{"home":2.0,"away":2.0,"draw":3.0}',
+      status: "open",
+      closesAt: new Date(Date.now() + 60_000),
+      match: { isTest: true },
+    });
+
+    await expect(
+      placeBet({
+        clientToken: "abcdefghijklm",
+        marketId: "market-1",
+        userId: "u-1",
+        selection: "home",
+        stake: 100,
+        oddsAtPlace: 2.0,
+      }),
+    ).rejects.toBeInstanceOf(BetValidationError);
+  });
+});

--- a/apps/server/src/services/pro-league-team.ts
+++ b/apps/server/src/services/pro-league-team.ts
@@ -206,6 +206,9 @@ export async function getProTeamDetail(
         seasonId,
         OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
         status: { in: ["scheduled", "ready"] },
+        // Lot 2.C.3 — sandbox matchs ne doivent pas apparaître dans
+        // le calendrier public d'une équipe.
+        isTest: false,
       },
       orderBy: { scheduledAt: "asc" },
       take: UPCOMING_LIMIT,
@@ -216,6 +219,7 @@ export async function getProTeamDetail(
         seasonId,
         OR: [{ homeTeamId: teamId }, { awayTeamId: teamId }],
         status: "completed",
+        isTest: false,
       },
       orderBy: { scheduledAt: "desc" },
       take: RECENT_LIMIT,

--- a/apps/server/src/services/pro-roster-casualties.ts
+++ b/apps/server/src/services/pro-roster-casualties.ts
@@ -324,6 +324,10 @@ export async function sweepMatchCasualties(): Promise<{
     where: {
       status: "completed",
       casualtiesAppliedAt: null,
+      // Lot 2.C.3 — sandbox matchs n'appliquent pas leurs casualties
+      // au roster (sinon les coachs subiraient des absences sur des
+      // matchs qui ne devraient avoir aucun impact).
+      isTest: false,
     },
     select: { id: true },
     orderBy: { completedAt: "asc" },


### PR DESCRIPTION
## Summary

Lot 2.C.3 — ferme la boucle d'isolation sandbox. Les matchs `isTest=true` (introduits par #675 + #678) sont maintenant **activement exclus** de chaque agrégateur de production et des side-effects.

> **Dépend de #678** (qui dépend de #675). À merger après #678.

## Audited services

### Read-only aggregators — `isTest: false` ajouté
- `pro-league-engine-drift-watcher` (TODO marqué en Lot 2.A.5, résolu)
- `pro-league-team` : recent + upcoming public
- `pro-league-hub` : next matches public
- `pro-gazette-recap` : daily Gazette + rivalry lookback
- `pro-league-follow` : fan feed

### Side-effect sweeps — filtre par défense en profondeur
- `pro-roster-casualties.sweepMatchCasualties` (les casualties sandbox ne tuent pas de vrais joueurs)
- `pro-bet-settlement.sweepUnsettledMarkets`

### Bet placement — guard explicite
`placeBet` jette `BetValidationError("TEST_MATCH")` si le market sous-jacent pointe vers un match `isTest=true`.

## Intentionnellement préservé

- `pro-league-sim-runner` — doit simuler les sandbox matchs (c'est le but)
- `pro-league-match.getProMatchDetail` — le frontend en a besoin pour afficher la bannière "TEST MATCH"
- `pro-league-replay` / `broadcaster` — les sandbox matchs doivent rester visualisables
- `pro-bet-odds-calculator` — lit par id ; placeBet bloque déjà en amont
- `pro-league-standings` / `pro-hall-of-fame` — n'écrivent pas depuis `proLeagueMatch` aujourd'hui (tables pré-agrégées)

## Test plan

- [x] Nouveau `pro-league-isTest-guards.test.ts` : 4 tests vérifiant les filtres + le rejet de bet sur sandbox
- [x] 1808 tests serveur passent
- [x] `pnpm typecheck` clean
- [ ] Vérifier en prod : lancer un sandbox match, observer que (a) il n'apparaît pas dans hub/feed/team/gazette, (b) ses casualties ne sont pas appliquées, (c) impossible de placer un pari, (d) la drift baseline ne shift pas

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_