### PR TITLE
feat(ai): tactical profile modulates AI weights (Lot 3.A.0.a)

### DIFF
--- a/packages/game-engine/src/ai/difficulty.ts
+++ b/packages/game-engine/src/ai/difficulty.ts
@@ -15,7 +15,7 @@
 import type { GameState, Move, RNG, TeamId } from '../core/types';
 import { getLegalMoves } from '../actions/actions';
 import { makeRNG } from '../utils/rng';
-import { pickBestMove, scoreMove } from './evaluator';
+import { pickBestMove, scoreMove, type EvalWeights } from './evaluator';
 
 export type AIDifficulty = 'easy' | 'medium' | 'hard';
 
@@ -90,9 +90,10 @@ export function scoreMoveForDifficulty(
   move: Move,
   team: TeamId,
   difficulty: AIDifficulty,
-  rng?: RNG
+  rng?: RNG,
+  weightsOverride?: Partial<EvalWeights>
 ): number {
-  const base = scoreMove(state, move, team);
+  const base = scoreMove(state, move, team, weightsOverride);
   const profile = getAIDifficultyProfile(difficulty);
   let score = base;
   if (move.type === 'END_TURN') {
@@ -107,6 +108,14 @@ export function scoreMoveForDifficulty(
 export interface PickAIMoveOptions {
   difficulty?: AIDifficulty;
   rng?: RNG;
+  /**
+   * Lot 3.A.0.a — override partiel des pondérations d'évaluation.
+   * Permet au sim-engine full driver de moduler les poids selon le
+   * `TacticalProfile` racial (Halflings ≠ Wood Elves ≠ Orcs) sans
+   * dupliquer la logique d'IA. game-engine ne dépend pas de
+   * sim-engine — la dérivation se fait côté caller.
+   */
+  weights?: Partial<EvalWeights>;
 }
 
 /**
@@ -122,9 +131,10 @@ export function pickAIMove(
   options: PickAIMoveOptions = {}
 ): Move | null {
   const difficulty = options.difficulty ?? DEFAULT_AI_DIFFICULTY;
+  const weights = options.weights;
 
   if (difficulty === 'hard') {
-    return pickBestMove(state, team);
+    return pickBestMove(state, team, weights);
   }
 
   const legal = getLegalMoves(state);
@@ -138,7 +148,7 @@ export function pickAIMove(
 
   const scored = pool.map(candidate => ({
     move: candidate,
-    score: scoreMoveForDifficulty(state, candidate, team, difficulty, rng),
+    score: scoreMoveForDifficulty(state, candidate, team, difficulty, rng, weights),
   }));
 
   const sorted = sortByScoreDescStable(scored);

--- a/packages/game-engine/src/ai/evaluator.ts
+++ b/packages/game-engine/src/ai/evaluator.ts
@@ -58,6 +58,39 @@ export const EVAL_WEIGHTS = {
   END_TURN_PENALTY: 1,
 } as const;
 
+/**
+ * Sprint Pro League — Lot 3.A.0.a : pondérations effectives passées
+ * aux fonctions de scoring. Permet aux callers (sim-engine full
+ * driver) d'override certaines poids selon le profil tactique de
+ * l'équipe (Halflings ne pénalisent pas les casualties autant qu'une
+ * équipe élite, Wood Elves valorisent plus la progression de balle,
+ * etc.) tout en gardant `EVAL_WEIGHTS` immuable comme baseline.
+ *
+ * Le découplage est volontaire : `game-engine` ne dépend pas de
+ * `@bb/sim-engine` (cyclic dep), donc la conversion
+ * `TacticalProfile → Partial<EvalWeights>` se fait côté sim-engine
+ * (`packages/sim-engine/src/tactics/ai-weights.ts`).
+ *
+ * Note typage : `EvalWeights` élargit chaque entrée de `EVAL_WEIGHTS`
+ * (literals via `as const`) en `number` pour permettre des overrides
+ * avec n'importe quelle valeur entière. La constante baseline reste
+ * littérale et donc immutable.
+ */
+export type EvalWeights = {
+  [K in keyof typeof EVAL_WEIGHTS]: number;
+};
+
+/**
+ * Merge un override partiel avec les pondérations baseline. Toute
+ * clé absente du `override` retombe sur la valeur d'`EVAL_WEIGHTS`.
+ */
+export function resolveWeights(
+  override?: Partial<EvalWeights>
+): EvalWeights {
+  if (!override) return EVAL_WEIGHTS;
+  return { ...EVAL_WEIGHTS, ...override } as EvalWeights;
+}
+
 const OPPOSITE: Record<TeamId, TeamId> = { A: 'B', B: 'A' };
 
 function otherTeam(team: TeamId): TeamId {
@@ -93,33 +126,45 @@ function findBallCarrier(state: GameState): Player | undefined {
   return state.players.find(p => p.hasBall);
 }
 
-function attritionScore(state: GameState, team: TeamId): number {
+function attritionScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   let score = 0;
   for (const p of state.players) {
     const sign = p.team === team ? -1 : 1;
     if (p.state === 'casualty') {
-      score += sign * EVAL_WEIGHTS.PLAYER_CASUALTY_PENALTY;
+      score += sign * weights.PLAYER_CASUALTY_PENALTY;
     } else if (p.state === 'sent_off') {
-      score += sign * EVAL_WEIGHTS.PLAYER_SENT_OFF_PENALTY;
+      score += sign * weights.PLAYER_SENT_OFF_PENALTY;
     } else if (p.state === 'knocked_out') {
-      score += sign * EVAL_WEIGHTS.PLAYER_KO_PENALTY;
+      score += sign * weights.PLAYER_KO_PENALTY;
     } else if (p.stunned) {
-      score += sign * EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY;
+      score += sign * weights.PLAYER_STUNNED_PENALTY;
     }
   }
   return score;
 }
 
-function playerCountScore(state: GameState, team: TeamId): number {
+function playerCountScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   let score = 0;
   for (const p of state.players) {
     if (!isActive(p)) continue;
-    score += (p.team === team ? 1 : -1) * EVAL_WEIGHTS.PLAYER_ACTIVE;
+    score += (p.team === team ? 1 : -1) * weights.PLAYER_ACTIVE;
   }
   return score;
 }
 
-function carrierSafetyScore(state: GameState, team: TeamId): number {
+function carrierSafetyScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   const carrier = findBallCarrier(state);
   if (!carrier) return 0;
   const sign = carrier.team === team ? 1 : -1;
@@ -135,8 +180,8 @@ function carrierSafetyScore(state: GameState, team: TeamId): number {
 
   return (
     sign *
-    (allies * EVAL_WEIGHTS.CARRIER_PROTECTION_ALLY -
-      opponentsInTz * EVAL_WEIGHTS.CARRIER_TACKLEZONE_PENALTY)
+    (allies * weights.CARRIER_PROTECTION_ALLY -
+      opponentsInTz * weights.CARRIER_TACKLEZONE_PENALTY)
   );
 }
 
@@ -157,7 +202,11 @@ function chebyshevDistance(a: Position, b: Position): number {
  *    (pression / marquage). Si la balle est libre, on recompense la
  *    proximite a la balle (course au pickup).
  */
-function positioningScore(state: GameState, team: TeamId): number {
+function positioningScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   const carrier = findBallCarrier(state);
   let total = 0;
   for (const p of state.players) {
@@ -166,50 +215,70 @@ function positioningScore(state: GameState, team: TeamId): number {
 
     if (carrier && p.team === carrier.team) {
       const distance = distanceToEndzone(state, p.pos, p.team);
-      total += sign * (state.width - 1 - distance) * EVAL_WEIGHTS.POSITIONING_PER_STEP;
+      total += sign * (state.width - 1 - distance) * weights.POSITIONING_PER_STEP;
       continue;
     }
 
     if (carrier) {
       const distance = chebyshevDistance(p.pos, carrier.pos);
-      total += sign * Math.max(0, state.width - distance) * EVAL_WEIGHTS.POSITIONING_PER_STEP;
+      total += sign * Math.max(0, state.width - distance) * weights.POSITIONING_PER_STEP;
       continue;
     }
 
     if (state.ball) {
       const distance = chebyshevDistance(p.pos, state.ball);
-      total += sign * Math.max(0, state.width - distance) * EVAL_WEIGHTS.POSITIONING_PER_STEP;
+      total += sign * Math.max(0, state.width - distance) * weights.POSITIONING_PER_STEP;
     }
   }
   return total;
 }
 
-function ballProgressScore(state: GameState, team: TeamId): number {
+function ballProgressScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   const carrier = findBallCarrier(state);
   if (!carrier) return 0;
   const sign = carrier.team === team ? 1 : -1;
   const distance = distanceToEndzone(state, carrier.pos, carrier.team);
-  const progress = (state.width - 1 - distance) * EVAL_WEIGHTS.BALL_PROGRESS_PER_STEP;
-  const endzoneBonus = distance === 0 ? EVAL_WEIGHTS.CARRIER_IN_ENDZONE_BONUS : 0;
+  const progress = (state.width - 1 - distance) * weights.BALL_PROGRESS_PER_STEP;
+  const endzoneBonus = distance === 0 ? weights.CARRIER_IN_ENDZONE_BONUS : 0;
   return sign * (progress + endzoneBonus);
 }
 
-function possessionScore(state: GameState, team: TeamId): number {
+function possessionScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   const carrier = findBallCarrier(state);
   if (!carrier) return 0;
-  return (carrier.team === team ? 1 : -1) * EVAL_WEIGHTS.POSSESSION;
+  return (carrier.team === team ? 1 : -1) * weights.POSSESSION;
 }
 
-function scoreDifferenceScore(state: GameState, team: TeamId): number {
+function scoreDifferenceScore(
+  state: GameState,
+  team: TeamId,
+  weights: EvalWeights
+): number {
   const diff = teamScore(state, team) - teamScore(state, otherTeam(team));
-  return diff * EVAL_WEIGHTS.TOUCHDOWN;
+  return diff * weights.TOUCHDOWN;
 }
 
 /**
  * Score global d'un GameState du point de vue de `team`.
  * Plus haut = meilleur pour `team`.
+ *
+ * Lot 3.A.0.a — accepte un override `weights` partiel pour modulation
+ * tactique (sim-engine full driver passe les poids dérivés du
+ * `TacticalProfile` de l'équipe).
  */
-export function evaluatePosition(state: GameState, team: TeamId): PositionEvaluation {
+export function evaluatePosition(
+  state: GameState,
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
+): PositionEvaluation {
   if (state.gamePhase === 'ended' && state.score.teamA === 0 && state.score.teamB === 0) {
     const zero: EvaluationBreakdown = {
       score: 0,
@@ -223,14 +292,15 @@ export function evaluatePosition(state: GameState, team: TeamId): PositionEvalua
     return { total: 0, breakdown: zero };
   }
 
+  const weights = resolveWeights(weightsOverride);
   const breakdown: EvaluationBreakdown = {
-    score: scoreDifferenceScore(state, team),
-    possession: possessionScore(state, team),
-    ballProgress: ballProgressScore(state, team),
-    playerCount: playerCountScore(state, team),
-    carrierSafety: carrierSafetyScore(state, team),
-    attrition: attritionScore(state, team),
-    positioning: positioningScore(state, team),
+    score: scoreDifferenceScore(state, team, weights),
+    possession: possessionScore(state, team, weights),
+    ballProgress: ballProgressScore(state, team, weights),
+    playerCount: playerCountScore(state, team, weights),
+    carrierSafety: carrierSafetyScore(state, team, weights),
+    attrition: attritionScore(state, team, weights),
+    positioning: positioningScore(state, team, weights),
   };
 
   const total =
@@ -275,12 +345,13 @@ function estimateBlockKnockdown(state: GameState, attacker: Player, target: Play
 function scoreMoveMove(
   state: GameState,
   move: Extract<Move, { type: 'MOVE' }>,
-  team: TeamId
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
 ): number {
   const player = findPlayer(state, move.playerId);
   if (!player) return -Infinity;
 
-  const before = evaluatePosition(state, team).total;
+  const before = evaluatePosition(state, team, weightsOverride).total;
   const simulated: GameState = {
     ...state,
     players: state.players.map(p =>
@@ -288,30 +359,28 @@ function scoreMoveMove(
     ),
     ball: player.hasBall ? { ...move.to } : state.ball,
   };
-  const after = evaluatePosition(simulated, team).total;
+  const after = evaluatePosition(simulated, team, weightsOverride).total;
   return after - before;
 }
 
 function scoreMoveBlock(
   state: GameState,
   move: Extract<Move, { type: 'BLOCK' }>,
-  team: TeamId
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
 ): number {
   const attacker = findPlayer(state, move.playerId);
   const target = findPlayer(state, move.targetId);
   if (!attacker || !target) return -Infinity;
 
+  const weights = resolveWeights(weightsOverride);
   const knockdown = estimateBlockKnockdown(state, attacker, target);
   const knockoutValue =
     target.team === team
-      ? -EVAL_WEIGHTS.PLAYER_ACTIVE - EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY
-      : EVAL_WEIGHTS.PLAYER_ACTIVE + EVAL_WEIGHTS.PLAYER_STUNNED_PENALTY;
+      ? -weights.PLAYER_ACTIVE - weights.PLAYER_STUNNED_PENALTY
+      : weights.PLAYER_ACTIVE + weights.PLAYER_STUNNED_PENALTY;
 
-  const possessionSwing = target.hasBall ? EVAL_WEIGHTS.POSSESSION * 0.5 : 0;
-  // Risque calibre pour qu un block 50/50 reste preferable a END_TURN :
-  // un attaquant tombe rarement (defAssists > atkAssists) sur un block
-  // equilibre, le malus reflete le risque reel de turnover sans le rendre
-  // prohibitif.
+  const possessionSwing = target.hasBall ? weights.POSSESSION * 0.5 : 0;
   const selfRisk = knockdown < 0.2 ? -30 : knockdown < 0.4 ? -10 : 0;
   return knockdown * (knockoutValue + possessionSwing) + selfRisk;
 }
@@ -319,7 +388,8 @@ function scoreMoveBlock(
 function scoreMoveBlitz(
   state: GameState,
   move: Extract<Move, { type: 'BLITZ' }>,
-  team: TeamId
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
 ): number {
   const attacker = findPlayer(state, move.playerId);
   const target = findPlayer(state, move.targetId);
@@ -328,7 +398,8 @@ function scoreMoveBlitz(
   const moveDelta = scoreMoveMove(
     state,
     { type: 'MOVE', playerId: move.playerId, to: move.to },
-    team
+    team,
+    weightsOverride
   );
   const simulated: GameState = {
     ...state,
@@ -337,7 +408,8 @@ function scoreMoveBlitz(
   const blockDelta = scoreMoveBlock(
     simulated,
     { type: 'BLOCK', playerId: move.playerId, targetId: move.targetId },
-    team
+    team,
+    weightsOverride
   );
   return moveDelta + blockDelta;
 }
@@ -345,7 +417,8 @@ function scoreMoveBlitz(
 function scoreMovePass(
   state: GameState,
   move: Extract<Move, { type: 'PASS' | 'HANDOFF' }>,
-  team: TeamId
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
 ): number {
   const passer = findPlayer(state, move.playerId);
   const receiver = findPlayer(state, move.targetId);
@@ -360,9 +433,9 @@ function scoreMovePass(
       return p;
     }),
   };
-  const delta = evaluatePosition(simulated, team).total - evaluatePosition(state, team).total;
-  // Risque de PASS reduit (echec/intercept) : avec l ancien -20, l IA refusait
-  // toute passe sauf gain positionnel exceptionnel.
+  const delta =
+    evaluatePosition(simulated, team, weightsOverride).total -
+    evaluatePosition(state, team, weightsOverride).total;
   const risk = move.type === 'PASS' ? -8 : 0;
   return delta + risk;
 }
@@ -382,27 +455,38 @@ function scoreMoveFoul(
 /**
  * Score heuristique d'un coup (perspective `team`).
  * Un score plus haut indique un coup juge preferable.
+ *
+ * Lot 3.A.0.a — accepte un override `weights` partiel (typiquement
+ * dérivé du `TacticalProfile` côté sim-engine full driver).
  */
-export function scoreMove(state: GameState, move: Move, team: TeamId): number {
+export function scoreMove(
+  state: GameState,
+  move: Move,
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
+): number {
+  const weights = resolveWeights(weightsOverride);
   switch (move.type) {
     case 'END_TURN':
-      // Petite penalite pour casser les egalites avec les MOVE neutres.
-      // Sans ca, END_TURN (premier dans getLegalMoves) gagne tout tie-break
-      // stable et l IA passe son tour des qu un coup ne change pas l evaluation.
-      return -EVAL_WEIGHTS.END_TURN_PENALTY;
+      return -weights.END_TURN_PENALTY;
     case 'MOVE':
-      return scoreMoveMove(state, move, team);
+      return scoreMoveMove(state, move, team, weightsOverride);
     case 'LEAP':
       return (
-        scoreMoveMove(state, { type: 'MOVE', playerId: move.playerId, to: move.to }, team) - 15
+        scoreMoveMove(
+          state,
+          { type: 'MOVE', playerId: move.playerId, to: move.to },
+          team,
+          weightsOverride
+        ) - 15
       );
     case 'BLOCK':
-      return scoreMoveBlock(state, move, team);
+      return scoreMoveBlock(state, move, team, weightsOverride);
     case 'BLITZ':
-      return scoreMoveBlitz(state, move, team);
+      return scoreMoveBlitz(state, move, team, weightsOverride);
     case 'PASS':
     case 'HANDOFF':
-      return scoreMovePass(state, move, team);
+      return scoreMovePass(state, move, team, weightsOverride);
     case 'FOUL':
       return scoreMoveFoul(state, move, team);
     case 'END_PLAYER_TURN':
@@ -415,16 +499,22 @@ export function scoreMove(state: GameState, move: Move, team: TeamId): number {
 /**
  * Retourne le coup legal au meilleur score pour `team` (null si aucun coup).
  * En cas d'egalite, conserve le premier coup rencontre (ordre stable).
+ *
+ * Lot 3.A.0.a — `weightsOverride` propagé jusqu'au scoring.
  */
-export function pickBestMove(state: GameState, team: TeamId): Move | null {
+export function pickBestMove(
+  state: GameState,
+  team: TeamId,
+  weightsOverride?: Partial<EvalWeights>
+): Move | null {
   const legal = getLegalMoves(state);
   if (legal.length === 0) return null;
 
   let bestMove: Move = legal[0];
-  let bestScore = scoreMove(state, bestMove, team);
+  let bestScore = scoreMove(state, bestMove, team, weightsOverride);
   for (let i = 1; i < legal.length; i++) {
     const candidate = legal[i];
-    const candidateScore = scoreMove(state, candidate, team);
+    const candidateScore = scoreMove(state, candidate, team, weightsOverride);
     if (candidateScore > bestScore) {
       bestScore = candidateScore;
       bestMove = candidate;

--- a/packages/game-engine/src/ai/index.ts
+++ b/packages/game-engine/src/ai/index.ts
@@ -9,8 +9,13 @@ export {
   scoreMove,
   pickBestMove,
   EVAL_WEIGHTS,
+  resolveWeights,
 } from './evaluator';
-export type { EvaluationBreakdown, PositionEvaluation } from './evaluator';
+export type {
+  EvalWeights,
+  EvaluationBreakdown,
+  PositionEvaluation,
+} from './evaluator';
 
 export {
   AI_DIFFICULTY_LEVELS,

--- a/packages/game-engine/src/index.ts
+++ b/packages/game-engine/src/index.ts
@@ -406,6 +406,7 @@ export {
   scoreMove,
   pickBestMove,
   EVAL_WEIGHTS,
+  resolveWeights,
   AI_DIFFICULTY_LEVELS,
   AI_DIFFICULTY_PROFILES,
   DEFAULT_AI_DIFFICULTY,
@@ -422,6 +423,7 @@ export {
   pickAIKickoffBallPosition,
 } from './ai';
 export type {
+  EvalWeights,
   EvaluationBreakdown,
   PositionEvaluation,
   AIDifficulty,

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -23,6 +23,7 @@ export {
   type ProTeamId,
   type ProTeamProfile,
 } from './tactics/race-profiles';
+export { weightsFromProfile } from './tactics/ai-weights';
 export {
   riskAppetiteToTemperature,
   softmaxSample,

--- a/packages/sim-engine/src/tactics/ai-weights.test.ts
+++ b/packages/sim-engine/src/tactics/ai-weights.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests pour `weightsFromProfile` (Lot 3.A.0.a).
+ *
+ * Vérifie que la conversion `TacticalProfile → Partial<EvalWeights>`
+ * produit des modulations cohérentes avec le profil tactique.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_TACTICAL_PROFILE } from './tactical-profile';
+import { weightsFromProfile } from './ai-weights';
+
+describe('weightsFromProfile — Lot 3.A.0.a', () => {
+  it('un profil neutre (tout à 50) retourne des poids ≈ baseline', () => {
+    const w = weightsFromProfile(DEFAULT_TACTICAL_PROFILE);
+    expect(w.PLAYER_CASUALTY_PENALTY).toBe(150);
+    expect(w.BALL_PROGRESS_PER_STEP).toBe(15);
+    expect(w.CARRIER_IN_ENDZONE_BONUS).toBe(250);
+    expect(w.POSSESSION).toBe(300);
+    expect(w.CARRIER_PROTECTION_ALLY).toBe(20);
+  });
+
+  it('un profil bash (Orcs) baisse PLAYER_CASUALTY_PENALTY et CARRIER_TACKLEZONE_PENALTY', () => {
+    const w = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      bashIndex: 95,
+    });
+    expect(w.PLAYER_CASUALTY_PENALTY).toBeLessThan(150);
+    expect(w.CARRIER_TACKLEZONE_PENALTY).toBeLessThan(35);
+  });
+
+  it('un profil pace (Wood Elves) augmente BALL_PROGRESS_PER_STEP et CARRIER_IN_ENDZONE_BONUS', () => {
+    const w = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      pace: 90,
+    });
+    expect(w.BALL_PROGRESS_PER_STEP).toBeGreaterThan(15);
+    expect(w.CARRIER_IN_ENDZONE_BONUS).toBeGreaterThan(250);
+  });
+
+  it('un profil stalling (Dwarves) baisse END_TURN_PENALTY et augmente POSITIONING_PER_STEP', () => {
+    const w = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      stallTendency: 90,
+    });
+    expect(w.END_TURN_PENALTY).toBeLessThan(1);
+    expect(w.POSITIONING_PER_STEP).toBeGreaterThan(2);
+  });
+
+  it('un profil patience élevé augmente CARRIER_PROTECTION_ALLY', () => {
+    const w = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      patience: 100,
+    });
+    expect(w.CARRIER_PROTECTION_ALLY).toBeGreaterThan(20);
+  });
+
+  it('un profil breakaway (Wood Elves / Skaven) augmente POSSESSION', () => {
+    const w = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      breakawayInstinct: 95,
+    });
+    expect(w.POSSESSION).toBeGreaterThan(300);
+  });
+
+  it('clampe les multiplicateurs entre 0.4× et 1.6× (pas de poids absurdes)', () => {
+    // Profil aux extrêmes : on vérifie qu'aucun poids ne saute en
+    // négatif ou n'explose ×3.
+    const extreme = weightsFromProfile({
+      ...DEFAULT_TACTICAL_PROFILE,
+      bashIndex: 100,
+      pace: 100,
+      stallTendency: 100,
+      patience: 100,
+      breakawayInstinct: 100,
+    });
+    for (const [, value] of Object.entries(extreme)) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      // Borne haute basée sur les baselines × MAX_FACTOR (1.6).
+      expect(value).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('même output sur des appels successifs (pure function)', () => {
+    const a = weightsFromProfile(DEFAULT_TACTICAL_PROFILE);
+    const b = weightsFromProfile(DEFAULT_TACTICAL_PROFILE);
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/sim-engine/src/tactics/ai-weights.ts
+++ b/packages/sim-engine/src/tactics/ai-weights.ts
@@ -1,0 +1,115 @@
+/**
+ * Pro League sim — Lot 3.A.0.a : conversion d'un `TacticalProfile`
+ * (ex: Halflings, Wood Elves) en `Partial<EvalWeights>` pour
+ * piloter l'IA `@bb/game-engine` sans dupliquer la logique
+ * d'évaluation.
+ *
+ * Pourquoi un module séparé
+ * -------------------------
+ * `@bb/game-engine` ne dépend PAS de `@bb/sim-engine` (cyclic dep).
+ * `TacticalProfile` vit côté sim-engine. Le full driver
+ * (Lot 3.A.2) appellera `weightsFromProfile(team.tactics)` puis
+ * passera le résultat à `pickAIMove(state, team, { weights })`.
+ *
+ * Mapping retenu
+ * --------------
+ * Chaque dimension du profil tactique module *un* poids cohérent :
+ *
+ * - bashIndex (haut = équipe bash, type Orcs / Norse / Khorne) :
+ *     ↓ PLAYER_CASUALTY_PENALTY (ils acceptent les pertes)
+ *     ↓ CARRIER_TACKLEZONE_PENALTY (le porteur peut prendre des coups)
+ * - pace (haut = tempo rapide, Wood Elves / Skaven) :
+ *     ↑ BALL_PROGRESS_PER_STEP (chaque case compte)
+ *     ↑ CARRIER_IN_ENDZONE_BONUS (rush vers le score)
+ * - stallTendency (haut = stalling, Dwarves / Lizardmen défensifs) :
+ *     ↓ END_TURN_PENALTY (pas pénalisé pour passer son tour)
+ *     ↑ POSITIONING_PER_STEP (chaque positionnement gagne du temps)
+ * - patience (haut = construit ses jeux, low = burns blitz) :
+ *     ↑ CARRIER_PROTECTION_ALLY (protection prioritaire)
+ * - breakawayInstinct (haut = sprint au porteur, Wood Elves) :
+ *     ↑ POSSESSION (récupérer/conserver la balle vaut plus)
+ * - foulFrequency (haut = Goblins / Underworld) :
+ *     traité dans le mapping de `scoreMoveFoul` côté evaluator
+ *     (constante interne) — pas de modulation ici au MVP.
+ *
+ * Tous les multiplicateurs sont bornés à `[0.4, 1.6]` pour éviter
+ * qu'un profil extrême ne casse l'IA (poids négatifs ou explosifs).
+ */
+
+import type { EvalWeights } from '@bb/game-engine';
+
+import type { TacticalProfile } from './tactical-profile';
+
+/** Borne supérieure et inférieure du multiplicateur appliqué. */
+const MIN_FACTOR = 0.4;
+const MAX_FACTOR = 1.6;
+
+function clamp(n: number): number {
+  if (!Number.isFinite(n)) return 1;
+  return Math.max(MIN_FACTOR, Math.min(MAX_FACTOR, n));
+}
+
+/**
+ * Maps un paramètre 0..100 à un facteur multiplicatif `1 ± span` :
+ * - paramètre 50 → facteur 1 (neutre)
+ * - paramètre 0  → facteur 1 - span
+ * - paramètre 100 → facteur 1 + span
+ */
+function paramFactor(value: number, span: number): number {
+  const normalized = Math.max(0, Math.min(100, value));
+  const offset = ((normalized - 50) / 50) * span;
+  return clamp(1 + offset);
+}
+
+/**
+ * Dérive un override `Partial<EvalWeights>` depuis un `TacticalProfile`.
+ * Les poids non listés (ex: `TOUCHDOWN`, `PLAYER_KO_PENALTY`) gardent
+ * leur valeur baseline `EVAL_WEIGHTS` côté game-engine.
+ *
+ * Le format `Partial` est important : le caller (full driver) peut
+ * ne fournir que les poids modifiés, le reste retombe sur la baseline.
+ *
+ * Span retenu
+ * -----------
+ * 0.4 sur les axes principaux (pace / bashIndex / stallTendency) :
+ * un profil extrême module ±40% du poids de base, suffisant pour
+ * différencier visiblement Halflings de Wood Elves sans rendre l'IA
+ * incohérente. Span 0.25 sur les axes secondaires.
+ */
+export function weightsFromProfile(
+  profile: TacticalProfile
+): Partial<EvalWeights> {
+  const bash = paramFactor(profile.bashIndex, 0.4);
+  const pace = paramFactor(profile.pace, 0.4);
+  const stall = paramFactor(profile.stallTendency, 0.4);
+  const patience = paramFactor(profile.patience, 0.25);
+  const breakaway = paramFactor(profile.breakawayInstinct, 0.25);
+
+  // Bash teams pénalisent moins les pertes (1 - (bash - 1))
+  const casualtyMul = 2 - bash;
+  // Pace teams progressent plus
+  const progressMul = pace;
+  // Stall teams pénalisent moins l'END_TURN
+  const endTurnMul = 2 - stall;
+  // Patience teams protègent plus le porteur
+  const protectionMul = patience;
+  // Breakaway teams valorisent plus la possession
+  const possessionMul = breakaway;
+
+  return {
+    PLAYER_CASUALTY_PENALTY: Math.round(150 * clamp(casualtyMul)),
+    CARRIER_TACKLEZONE_PENALTY: Math.round(35 * clamp(2 - bash)),
+    BALL_PROGRESS_PER_STEP: Math.round(15 * clamp(progressMul)),
+    CARRIER_IN_ENDZONE_BONUS: Math.round(250 * clamp(progressMul)),
+    END_TURN_PENALTY: Math.max(
+      0,
+      Math.round(1 * clamp(endTurnMul) * 10) / 10
+    ),
+    POSITIONING_PER_STEP: Math.max(
+      1,
+      Math.round(2 * clamp(stall))
+    ),
+    CARRIER_PROTECTION_ALLY: Math.round(20 * clamp(protectionMul)),
+    POSSESSION: Math.round(300 * clamp(possessionMul)),
+  };
+}


### PR DESCRIPTION
## Summary

Lot 3.A.0.a — résout le **gap #4 de l'audit Lot 3.A.1** (Choix 1 option A). L'AI `EVAL_WEIGHTS` étaient des constantes : toutes les races auraient produit des stats indiscernables en full driver. Maintenant chaque race peut moduler les poids selon son `TacticalProfile`.

> **Pré-requis Phase 3** : prépare le terrain pour les lots 3.A.0.b (2-ply), 3.A.0.c (opening book), puis 3.A.2.a/b/c (orchestrateur full driver découpé).

## Architecture

**`game-engine`** (zero new dep, retro-compatible) :
- `EvalWeights` type number-typed (élargi du `as const` baseline)
- `resolveWeights()` helper qui merge un override partiel
- Param optionnel `weightsOverride` propagé dans `evaluatePosition`, `scoreMove`, `pickBestMove`, `pickAIMove`
- Default = `EVAL_WEIGHTS` baseline → comportement legacy strict si pas d'override

**`sim-engine`** :
- `weightsFromProfile(profile)` produit un `Partial<EvalWeights>` selon les dimensions clés :
  - `bashIndex ↑` → moins pénalise les casualties + porteur dans TZ
  - `pace ↑` → boost progression balle + bonus endzone
  - `stallTendency ↑` → END_TURN moins pénalisant + positionnement plus rentable
  - `patience ↑` → protection porteur prioritaire
  - `breakawayInstinct ↑` → possession plus valorisée
- Multiplicateurs clampés `[0.4, 1.6]` (anti-absurdes)

Le découplage est strict : `game-engine` ne dépend pas de `sim-engine`. La conversion vit côté sim-engine.

## Test plan

- [x] 8 tests sur `weightsFromProfile` (baseline neutre, modulations par dimension, clamp, déterminisme)
- [x] 283 tests sim-engine passent
- [x] 4867 tests game-engine passent (21 failures unchanged from main — pre-existing S27)
- [x] Typecheck clean (game-engine + sim-engine)

## Suite

- **Lot 3.A.0.b** : 2-ply minimax (Choix 2 option B partie 1)
- **Lot 3.A.0.c** : opening book par race
- **Lot 3.A.2.a/b/c** : orchestrateur full driver découpé (Choix 3)

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_