### PR TITLE
feat(ai): per-race opening book bonus (Lot 3.A.0.c)

### DIFF
--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -25,6 +25,15 @@ export {
 } from './tactics/race-profiles';
 export { weightsFromProfile } from './tactics/ai-weights';
 export {
+  RACE_OPENING_BOOKS,
+  getOpeningBookForRace,
+  openingBookBonus,
+  openingBookBonusForRace,
+  type OpeningBookMoveType,
+  type OpeningBookRule,
+  type RaceOpeningBook,
+} from './tactics/opening-book';
+export {
   riskAppetiteToTemperature,
   softmaxSample,
   type WeightedCandidate,

--- a/packages/sim-engine/src/tactics/opening-book.test.ts
+++ b/packages/sim-engine/src/tactics/opening-book.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests pour `opening-book.ts` (Lot 3.A.0.c).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  RACE_OPENING_BOOKS,
+  getOpeningBookForRace,
+  openingBookBonus,
+  openingBookBonusForRace,
+} from './opening-book';
+
+describe('opening book — Lot 3.A.0.c', () => {
+  it('expose un book pour chaque race Pro League majeure', () => {
+    const races = RACE_OPENING_BOOKS.map((b) => b.race);
+    // 14 races déclarées au minimum (toutes les Pro League teams).
+    expect(races.length).toBeGreaterThanOrEqual(14);
+    expect(races).toContain('Wood Elf');
+    expect(races).toContain('Orc');
+    expect(races).toContain('Halfling');
+    expect(races).toContain('Skaven');
+    expect(races).toContain('Dwarf');
+  });
+
+  it('getOpeningBookForRace retourne un book existant ou undefined', () => {
+    const wood = getOpeningBookForRace('Wood Elf');
+    expect(wood).toBeDefined();
+    expect(wood?.race).toBe('Wood Elf');
+
+    const unknown = getOpeningBookForRace('Imaginary Race');
+    expect(unknown).toBeUndefined();
+  });
+
+  it('openingBookBonus retourne 0 quand book est undefined', () => {
+    expect(openingBookBonus(undefined, 1, 'PASS')).toBe(0);
+    expect(openingBookBonus(undefined, 5, 'BLOCK')).toBe(0);
+  });
+
+  it('Wood Elves ont un bonus PASS positif au tour 1-3', () => {
+    const wood = getOpeningBookForRace('Wood Elf');
+    expect(openingBookBonus(wood, 1, 'PASS')).toBeGreaterThan(0);
+    expect(openingBookBonus(wood, 2, 'PASS')).toBeGreaterThan(0);
+    expect(openingBookBonus(wood, 3, 'PASS')).toBeGreaterThan(0);
+  });
+
+  it('Wood Elves perdent leur bonus PASS au tour 5', () => {
+    const wood = getOpeningBookForRace('Wood Elf');
+    expect(openingBookBonus(wood, 5, 'PASS')).toBe(0);
+  });
+
+  it('Orcs ont un malus PASS au début (les Orcs ne lancent pas)', () => {
+    expect(openingBookBonusForRace('Orc', 1, 'PASS')).toBeLessThan(0);
+    expect(openingBookBonusForRace('Orc', 2, 'PASS')).toBeLessThan(0);
+  });
+
+  it('Orcs ont un bonus BLOCK au tour 1-5', () => {
+    expect(openingBookBonusForRace('Orc', 1, 'BLOCK')).toBeGreaterThan(0);
+    expect(openingBookBonusForRace('Orc', 5, 'BLOCK')).toBeGreaterThan(0);
+    expect(openingBookBonusForRace('Orc', 7, 'BLOCK')).toBe(0);
+  });
+
+  it('Halflings ont un bonus négatif sur END_TURN (incite à jouer)', () => {
+    expect(openingBookBonusForRace('Halfling', 1, 'END_TURN')).toBeLessThan(0);
+    expect(openingBookBonusForRace('Halfling', 8, 'END_TURN')).toBeLessThan(0);
+  });
+
+  it('cumul de plusieurs règles applicables au même type de move', () => {
+    // Skaven : turn 1, MOVE → règle [1,2] applicable → bonus > 0.
+    expect(openingBookBonusForRace('Skaven', 1, 'MOVE')).toBeGreaterThan(0);
+  });
+
+  it('aucune règle ne match → 0 (pas de biais)', () => {
+    expect(openingBookBonusForRace('Wood Elf', 1, 'FOUL')).toBe(0);
+    expect(openingBookBonusForRace('Wood Elf', 8, 'PASS')).toBe(0);
+  });
+
+  it('toutes les règles ont un turnRange valide (start <= end, start >= 1)', () => {
+    for (const book of RACE_OPENING_BOOKS) {
+      for (const rule of book.rules) {
+        expect(rule.turnRange[0]).toBeLessThanOrEqual(rule.turnRange[1]);
+        expect(rule.turnRange[0]).toBeGreaterThanOrEqual(1);
+        expect(rule.turnRange[1]).toBeLessThanOrEqual(8);
+      }
+    }
+  });
+
+  it('aucun bonus de plus de ±25 (anti-overwrite scoring)', () => {
+    for (const book of RACE_OPENING_BOOKS) {
+      for (const rule of book.rules) {
+        expect(Math.abs(rule.bonus)).toBeLessThanOrEqual(25);
+      }
+    }
+  });
+});

--- a/packages/sim-engine/src/tactics/opening-book.ts
+++ b/packages/sim-engine/src/tactics/opening-book.ts
@@ -1,0 +1,218 @@
+/**
+ * Sprint Pro League — Lot 3.A.0.c : opening book par race.
+ *
+ * Le scoring AI (`scoreMove`, `scoreMove2Ply`) est neutre — il évalue
+ * chaque coup sur la position courante. Mais en BB, l'**opening de
+ * match** dépend largement de la race :
+ *
+ *  - Wood Elves / Skaven   → ouvrir vite, pass / breakaway
+ *  - Orcs / Khorne / Norse → form a cage, blitz le porteur
+ *  - Halflings             → turtle, attendre le Treeman
+ *  - Dwarves               → ralentir le tempo, build position
+ *
+ * L'opening book est un **bonus additif** appliqué par-dessus
+ * `scoreMove` :
+ *
+ *     score(move) = scoreMove(...) + openingBookBonus(rules, turn, move.type)
+ *
+ * Avantages de ce design :
+ *  - Aucun couplage avec game-engine (AI module reste vierge)
+ *  - Bonus = simple addition → garde le scoring déterministe
+ *  - Per-turn → l'IA "sort" naturellement de l'opening après les
+ *    premiers tours et retombe sur la stratégie générale
+ *  - Per-race → signature racée préservée même si la stratégie de
+ *    base est identique
+ *
+ * Le full driver (Lot 3.A.2) applique ces bonus côté orchestrateur,
+ * pas dans le sim de game-engine.
+ */
+
+import type { Move } from '@bb/game-engine';
+
+/** Type discriminant des Move BB. Sous-ensemble couvert par l'opening
+ *  book — les autres moves ne sont pas biaisés en opening. */
+export type OpeningBookMoveType =
+  | 'MOVE'
+  | 'BLOCK'
+  | 'BLITZ'
+  | 'PASS'
+  | 'HANDOFF'
+  | 'FOUL'
+  | 'END_TURN';
+
+export interface OpeningBookRule {
+  /** Plage [start, end] inclusive de turns BB où la règle s'applique. */
+  readonly turnRange: readonly [number, number];
+  /** Type de coup biaisé. Le scoring d'un autre type reste inchangé. */
+  readonly moveType: OpeningBookMoveType;
+  /** Bonus additif au scoreMove. Peut être négatif pour décourager. */
+  readonly bonus: number;
+  /** Free-form note pour l'audit / debug ("Wood Elves love passes"). */
+  readonly note?: string;
+}
+
+export interface RaceOpeningBook {
+  /** Race exacte (match strict avec `ProTeamProfile.race`). */
+  readonly race: string;
+  /** Règles à composer additivement par tour. */
+  readonly rules: readonly OpeningBookRule[];
+}
+
+/**
+ * Catalogue des opening books par race. Volontairement léger et
+ * conservateur — biais ±5 à ±25 par règle pour ne pas écraser le
+ * scoring 1-ply / 2-ply existant.
+ *
+ * Tuning à faire en Lot 3.A.3 sur la base du benchmark FUMBBL.
+ */
+export const RACE_OPENING_BOOKS: readonly RaceOpeningBook[] = Object.freeze([
+  {
+    race: 'Wood Elf',
+    rules: [
+      { turnRange: [1, 3], moveType: 'PASS', bonus: 20, note: 'Open with deep passes' },
+      { turnRange: [1, 2], moveType: 'MOVE', bonus: 5, note: 'Spread receivers' },
+    ],
+  },
+  {
+    race: 'Pro Elf',
+    rules: [
+      { turnRange: [1, 4], moveType: 'PASS', bonus: 15 },
+      { turnRange: [1, 2], moveType: 'MOVE', bonus: 4 },
+    ],
+  },
+  {
+    race: 'Dark Elf',
+    rules: [
+      { turnRange: [1, 4], moveType: 'BLITZ', bonus: 8, note: 'Punish exposed carriers' },
+      { turnRange: [1, 3], moveType: 'PASS', bonus: 10 },
+    ],
+  },
+  {
+    race: 'Skaven',
+    rules: [
+      { turnRange: [1, 3], moveType: 'PASS', bonus: 18, note: 'Gutter Runner deep' },
+      { turnRange: [1, 2], moveType: 'MOVE', bonus: 6, note: 'Wide formation' },
+    ],
+  },
+  {
+    race: 'Amazon',
+    rules: [
+      { turnRange: [1, 4], moveType: 'BLOCK', bonus: 8, note: 'Dodge skill, abuse blocks' },
+      { turnRange: [1, 3], moveType: 'BLITZ', bonus: 6 },
+    ],
+  },
+  {
+    race: 'Orc',
+    rules: [
+      { turnRange: [1, 5], moveType: 'BLOCK', bonus: 14, note: 'Bash everything down' },
+      { turnRange: [1, 3], moveType: 'BLITZ', bonus: 10 },
+      { turnRange: [1, 2], moveType: 'PASS', bonus: -15, note: 'Orcs hate passing' },
+    ],
+  },
+  {
+    race: 'Norse',
+    rules: [
+      { turnRange: [1, 5], moveType: 'BLOCK', bonus: 12 },
+      { turnRange: [1, 3], moveType: 'BLITZ', bonus: 8 },
+    ],
+  },
+  {
+    race: 'Beastmen',
+    rules: [
+      { turnRange: [1, 5], moveType: 'BLOCK', bonus: 10 },
+      { turnRange: [1, 3], moveType: 'FOUL', bonus: 5 },
+    ],
+  },
+  {
+    race: 'Undead',
+    rules: [
+      { turnRange: [1, 8], moveType: 'BLOCK', bonus: 8, note: 'Mummies grind' },
+      { turnRange: [1, 5], moveType: 'BLITZ', bonus: 6 },
+    ],
+  },
+  {
+    race: 'Tomb Kings',
+    rules: [
+      { turnRange: [1, 8], moveType: 'BLOCK', bonus: 10 },
+      { turnRange: [1, 4], moveType: 'BLITZ', bonus: 6 },
+    ],
+  },
+  {
+    race: 'Lizardmen',
+    rules: [
+      { turnRange: [1, 4], moveType: 'BLITZ', bonus: 12, note: 'Saurus blitz' },
+      { turnRange: [1, 6], moveType: 'BLOCK', bonus: 6 },
+    ],
+  },
+  {
+    race: 'Dwarf',
+    rules: [
+      { turnRange: [1, 8], moveType: 'BLOCK', bonus: 10, note: 'Stand firm grind' },
+      { turnRange: [3, 8], moveType: 'END_TURN', bonus: -3, note: 'Burn clock late' },
+    ],
+  },
+  {
+    race: 'Halfling',
+    rules: [
+      { turnRange: [1, 8], moveType: 'END_TURN', bonus: -2, note: 'Turtle until trees act' },
+      { turnRange: [1, 5], moveType: 'BLOCK', bonus: -10, note: 'Avoid fights' },
+    ],
+  },
+  {
+    race: 'Ogre',
+    rules: [
+      { turnRange: [1, 8], moveType: 'BLOCK', bonus: 16, note: 'Smash with snotlings cover' },
+      { turnRange: [1, 4], moveType: 'BLITZ', bonus: 12 },
+    ],
+  },
+]);
+
+const BOOK_BY_RACE: ReadonlyMap<string, RaceOpeningBook> = new Map(
+  RACE_OPENING_BOOKS.map((b) => [b.race, b])
+);
+
+/** Lookup case-sensitive sur le nom de race. Retourne `undefined` si
+ *  la race n'a pas d'entry (utile pour les tests / mock teams). */
+export function getOpeningBookForRace(race: string): RaceOpeningBook | undefined {
+  return BOOK_BY_RACE.get(race);
+}
+
+/**
+ * Calcule le bonus additif à appliquer sur `scoreMove` pour un coup
+ * donné, en fonction du tour BB courant et de la race.
+ *
+ * Convention : si `book` est `undefined` ou si aucune règle ne
+ * matche, retourne 0 (pas de biais → comportement legacy strict).
+ *
+ * @param book Opening book de la race ou undefined
+ * @param turnNumber Tour BB en cours (1-based, comme `state.turnNumber`)
+ * @param moveType Type du Move scoré
+ */
+export function openingBookBonus(
+  book: RaceOpeningBook | undefined,
+  turnNumber: number,
+  moveType: Move['type']
+): number {
+  if (!book) return 0;
+  let bonus = 0;
+  for (const rule of book.rules) {
+    if (turnNumber < rule.turnRange[0] || turnNumber > rule.turnRange[1]) {
+      continue;
+    }
+    if (rule.moveType !== moveType) continue;
+    bonus += rule.bonus;
+  }
+  return bonus;
+}
+
+/**
+ * Convenience overload : lookup par race + appel direct, courant
+ * dans le full driver.
+ */
+export function openingBookBonusForRace(
+  race: string,
+  turnNumber: number,
+  moveType: Move['type']
+): number {
+  return openingBookBonus(getOpeningBookForRace(race), turnNumber, moveType);
+}


### PR DESCRIPTION
## Summary

Lot 3.A.0.c — Choix 2 option B partie 2 (final pré-Phase 3.A.2). Ajoute un **opening book par race** sous forme de bonus additif appliqué au-dessus du scoring AI.

> **Pré-requis Phase 3** : préserve la signature racée en auto-play (Wood Elves passent, Orcs cognent, Halflings tortuent) sans coupler game-engine à sim-engine.

## Pourquoi un bonus additif

- Local au début de match (turns 1-3 typiquement) — l'IA "sort" de l'opening après quelques tours et retombe sur la stratégie générale
- Aucun couplage avec game-engine : le full driver applique le bonus côté orchestrateur
- Composable avec les Lots 3.A.0.a (weights) et 3.A.0.b (2-ply) sans conflit

## Catalogue

14 races couvertes :
- **Wood Elf / Pro Elf / Skaven** : bonus PASS + MOVE early
- **Dark Elf / Lizardmen / Tomb Kings** : BLITZ massif
- **Orc / Norse / Beastmen / Ogre / Undead** : BLOCK constant
- **Dwarf / Halfling** : stalling / clock-burn
- **Amazon** : exploite Dodge skill avec BLOCK + BLITZ

Tous les bonus bornés à **±25** pour ne pas écraser le scoring 1-ply / 2-ply.

## API

```ts
openingBookBonusForRace('Wood Elf', 1, 'PASS')  // → +20
openingBookBonusForRace('Orc', 1, 'PASS')        // → -15
openingBookBonusForRace('Halfling', 5, 'END_TURN') // → -2
openingBookBonusForRace('Skaven', 8, 'PASS')     // → 0 (sortie d'opening)
```

## Test plan

- [x] 12 unit tests : catalogue exposed, lookup, fail-safe undefined, race-specific rules, bornes turnRange + bonus
- [x] 295 sim-engine tests passent
- [x] Typecheck clean
- [ ] Tuning fin à mesurer en Lot 3.A.3 sur la base du benchmark FUMBBL — les bonus actuels sont conservateurs (±5 à ±25)

## Suite

Avec **#682 (weights) + #683 (2-ply) + #684 (opening book)**, l'IA est prête pour le full driver. Lot 3.A.2.a/b/c suivent : orchestrateur headless, MatchEvent emission, roster-aware events.

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_