### PR TITLE
feat(sim-engine): full driver emits MatchEvent[] via state diff (Lot 3.A.2.b)

### DIFF
--- a/packages/sim-engine/src/driver/full-driver-events.test.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests pour `full-driver-events.ts` (Lot 3.A.2.b).
+ *
+ * Vérifie que la diff prev → next produit les events MatchEvent
+ * attendus pour chaque side-effect (TD, CASUALTY, KO, TURNOVER,
+ * HALFTIME, END, TURN_START) ET les events Move-specific (BLOCK,
+ * PASS, DODGE, FOUL).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { setup } from '@bb/game-engine';
+import type { GameState, Move } from '@bb/game-engine';
+
+import { diffStatesToEvents } from './full-driver-events';
+
+function modify(state: GameState, patch: Partial<GameState>): GameState {
+  return { ...state, ...patch };
+}
+
+describe('diffStatesToEvents — Lot 3.A.2.b', () => {
+  it('émet un BLOCK event pour un Move BLOCK', () => {
+    const prev = setup();
+    const next = prev;
+    const move: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const block = events.find((e) => e.type === 'BLOCK');
+    expect(block).toBeDefined();
+    const meta = block?.meta as { attackerId: string; defenderId: string };
+    expect(meta.attackerId).toBe('A1');
+    expect(meta.defenderId).toBe('B1');
+  });
+
+  it('émet un PASS event pour un Move PASS', () => {
+    const prev = setup();
+    const next = prev;
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'PASS')).toBe(true);
+  });
+
+  it('émet un BLOCK event kind=foul pour un Move FOUL', () => {
+    const prev = setup();
+    const next = prev;
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const foul = events.find((e) => e.type === 'BLOCK');
+    expect(foul).toBeDefined();
+    expect((foul?.meta as { kind: string }).kind).toBe('foul');
+  });
+
+  it('émet un TD event quand le score teamA augmente', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA + 1, teamB: prev.score.teamB },
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const td = events.find((e) => e.type === 'TD');
+    expect(td).toBeDefined();
+    expect((td?.meta as { team: string }).team).toBe('home');
+  });
+
+  it('émet un TD event quand le score teamB augmente', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA, teamB: prev.score.teamB + 1 },
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const td = events.find((e) => e.type === 'TD');
+    expect(td).toBeDefined();
+    expect((td?.meta as { team: string }).team).toBe('away');
+  });
+
+  it('émet un CASUALTY quand un joueur passe à state="casualty"', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      players: prev.players.map((p, i) =>
+        i === 0 ? { ...p, state: 'casualty' as const } : p
+      ),
+    });
+    const move: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'CASUALTY')).toBe(true);
+  });
+
+  it('émet un KO quand un joueur passe à state="knocked_out"', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      players: prev.players.map((p, i) =>
+        i === 0 ? { ...p, state: 'knocked_out' as const } : p
+      ),
+    });
+    const move: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'KO')).toBe(true);
+  });
+
+  it('émet un TURNOVER quand isTurnover passe à true', () => {
+    const prev = setup();
+    const next = modify(prev, { isTurnover: true });
+    const move: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'TURNOVER')).toBe(true);
+  });
+
+  it('émet un HALFTIME quand gamePhase passe à halftime', () => {
+    const prev = setup();
+    const next = modify(prev, { gamePhase: 'halftime' as const });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'HALFTIME')).toBe(true);
+  });
+
+  it('émet un END quand gamePhase passe à ended', () => {
+    const prev = setup();
+    const next = modify(prev, { gamePhase: 'ended' as const });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'END')).toBe(true);
+  });
+
+  it('émet un TURN_START quand turn ou half avance', () => {
+    const prev = setup();
+    const next = modify(prev, { turn: prev.turn + 1 });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'TURN_START')).toBe(true);
+  });
+
+  it('aucun event si rien ne change (idempotent)', () => {
+    const prev = setup();
+    const next = prev;
+    const move: Move = { type: 'END_PLAYER_TURN', playerId: 'A1' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events).toEqual([]);
+  });
+
+  it('cumule plusieurs events sur une même transition (TD + TURN_START)', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA + 1, teamB: prev.score.teamB },
+      turn: prev.turn + 1,
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    expect(events.some((e) => e.type === 'TD')).toBe(true);
+    expect(events.some((e) => e.type === 'TURN_START')).toBe(true);
+  });
+});

--- a/packages/sim-engine/src/driver/full-driver-events.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.ts
@@ -1,0 +1,312 @@
+/**
+ * Full driver — wire MatchEvent emission (Lot 3.A.2.b).
+ *
+ * `applyMove` retourne uniquement le nouveau `GameState` ; pour
+ * produire un timeline broadcaster-ready (TURN_START, BLOCK, PASS,
+ * TD, CASUALTY, KO, TURNOVER, HALFTIME, END), on calcule un **diff
+ * d'état** entre `prev` et `next` puis on émet les events
+ * correspondants.
+ *
+ * Convention temporelle
+ * ---------------------
+ * Chaque action consomme `MS_PER_ACTION` (1s par défaut) sur la
+ * timeline. Les events groupés (le coup + ses side-effects comme
+ * une casualty post-block) partagent le même `displayAtMs` pour
+ * que le narrator les regroupe naturellement.
+ *
+ * Couvre
+ * ------
+ * - Move-specific : BLOCK / BLITZ → BLOCK ; PASS / HANDOFF → PASS ;
+ *   DODGE → DODGE ; FOUL → BLOCK kind='foul'.
+ * - Diff side-effects : TD (score change), CASUALTY (player→casualty),
+ *   KO (player→knocked_out), TURNOVER (isTurnover false→true),
+ *   HALFTIME (gamePhase→halftime), END (gamePhase→ended), TURN_START
+ *   (turn/half advance).
+ *
+ * Hors scope
+ * ----------
+ * - MOVE events atomiques : un MOVE Move avance d'1 case ; le hybrid
+ *   driver émet des MOVE events bulk (agrégation par tour, lots
+ *   #4-657). Le full driver ne les émet pas pour l'instant ; le
+ *   timeline reste lisible avec les BLOCK / PASS / TD seuls.
+ * - PLAYER_ACTIVATION : pourrait être ajouté en Lot 3.A.2.c quand
+ *   les rosters réels rendront les playerId narratifs.
+ */
+
+import type { GameState, Move, TeamId } from '@bb/game-engine';
+import type { MatchEvent } from '@bb/shared-types';
+
+import { ENGINE_VER } from '../types';
+
+/** Timestamp incrémenté à chaque action appliquée. */
+export const MS_PER_ACTION = 1_000;
+
+/**
+ * Map TeamId interne (A/B) vers la convention sim-engine (home/away).
+ * Le frontend consomme home/away et ignore A/B.
+ */
+function sideOf(team: TeamId): 'home' | 'away' {
+  return team === 'A' ? 'home' : 'away';
+}
+
+interface DiffContext {
+  /** Wall-clock offset auquel cette transition est observée. */
+  readonly displayAtMs: number;
+  /** Coup appliqué qui a produit `next` à partir de `prev`. */
+  readonly move: Move;
+}
+
+/** Construit l'événement Move-specific en fonction du type de coup. */
+function buildMoveSpecificEvent(
+  ctx: DiffContext,
+  next: GameState
+): MatchEvent | null {
+  const { move, displayAtMs } = ctx;
+  switch (move.type) {
+    case 'BLOCK':
+    case 'BLITZ': {
+      const attackerId = move.playerId;
+      const defenderId = move.targetId;
+      // Resolution non triviale à inférer depuis le diff seul ; on
+      // émet l'event avec ce qu'on a (ids), le narrator humanise.
+      return {
+        type: 'BLOCK',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          attackerId,
+          defenderId,
+          kind: move.type === 'BLITZ' ? 'blitz' : 'block',
+        },
+      };
+    }
+    case 'PASS':
+    case 'HANDOFF': {
+      const passerId = move.playerId;
+      const receiverId = move.targetId;
+      // success approximé : la balle est-elle chez le receiver après
+      // application ? Si oui → caught.
+      const receiver = next.players.find((p) => p.id === receiverId);
+      const success = receiver?.hasBall === true;
+      return {
+        type: 'PASS',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          passerId,
+          receiverId,
+          range: move.type === 'HANDOFF' ? 'handoff' : 'short',
+          success,
+        },
+      };
+    }
+    case 'DODGE': {
+      const playerId = move.playerId;
+      // success approximé : le joueur est-il toujours actif (debout) ?
+      const player = next.players.find((p) => p.id === playerId);
+      const success =
+        player?.state === 'active' && (player as { stunned?: boolean }).stunned !== true;
+      return {
+        type: 'DODGE',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          playerId,
+          to: move.to,
+          success,
+        },
+      };
+    }
+    case 'FOUL': {
+      // Le narrator (`renderBlock`) gère `kind: 'foul'` en réutilisant
+      // l'event BLOCK — on garde ce wrapping pour la compat.
+      return {
+        type: 'BLOCK',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          kind: 'foul',
+          foulerId: move.playerId,
+          victimId: move.targetId,
+        },
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Diff stricte sur les états avant / après un applyMove. Retourne
+ * l'ensemble des MatchEvent à émettre, déjà ordonnés (event "primary"
+ * du Move puis side-effects).
+ */
+export function diffStatesToEvents(
+  prev: GameState,
+  next: GameState,
+  ctx: DiffContext
+): MatchEvent[] {
+  const events: MatchEvent[] = [];
+  const { displayAtMs } = ctx;
+
+  // 1) Event Move-specific (BLOCK / PASS / DODGE / FOUL).
+  const primary = buildMoveSpecificEvent(ctx, next);
+  if (primary) events.push(primary);
+
+  // 2) TD : score changé sur l'une des deux équipes.
+  if (next.score.teamA > prev.score.teamA) {
+    events.push({
+      type: 'TD',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        team: 'home',
+        half: next.half,
+        scoreAfter: { home: next.score.teamA, away: next.score.teamB },
+      },
+    });
+  }
+  if (next.score.teamB > prev.score.teamB) {
+    events.push({
+      type: 'TD',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        team: 'away',
+        half: next.half,
+        scoreAfter: { home: next.score.teamA, away: next.score.teamB },
+      },
+    });
+  }
+
+  // 3) KO / CASUALTY : joueurs qui ont changé de state.
+  const prevById = new Map(prev.players.map((p) => [p.id, p]));
+  for (const p of next.players) {
+    const old = prevById.get(p.id);
+    if (!old) continue;
+    if (p.state === 'casualty' && old.state !== 'casualty') {
+      events.push({
+        type: 'CASUALTY',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          playerId: p.id,
+          team: sideOf(p.team as TeamId),
+        },
+      });
+    } else if (p.state === 'knocked_out' && old.state !== 'knocked_out') {
+      events.push({
+        type: 'KO',
+        displayAtMs,
+        engineVer: ENGINE_VER,
+        meta: {
+          playerId: p.id,
+          team: sideOf(p.team as TeamId),
+        },
+      });
+    }
+  }
+
+  // 4) TURNOVER : isTurnover passé à true.
+  if (next.isTurnover && !prev.isTurnover) {
+    events.push({
+      type: 'TURNOVER',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        // On ne peut pas toujours inférer le cause exact ; le Move
+        // type donne une approximation utile.
+        cause: causeFromMove(ctx.move),
+      },
+    });
+  }
+
+  // 5) HALFTIME : gamePhase changé vers halftime.
+  if (next.gamePhase === 'halftime' && prev.gamePhase !== 'halftime') {
+    events.push({
+      type: 'HALFTIME',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        score: { home: next.score.teamA, away: next.score.teamB },
+      },
+    });
+  }
+
+  // 6) END : gamePhase ended.
+  if (next.gamePhase === 'ended' && prev.gamePhase !== 'ended') {
+    events.push({
+      type: 'END',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        score: { home: next.score.teamA, away: next.score.teamB },
+        outcome:
+          next.score.teamA > next.score.teamB
+            ? 'home'
+            : next.score.teamB > next.score.teamA
+              ? 'away'
+              : 'draw',
+      },
+    });
+  }
+
+  // 7) TURN_START : turn ou half avancé.
+  if (
+    next.gamePhase !== 'ended' &&
+    (next.turn > prev.turn || next.half > prev.half)
+  ) {
+    events.push({
+      type: 'TURN_START',
+      displayAtMs,
+      engineVer: ENGINE_VER,
+      meta: {
+        half: next.half,
+        turn: next.turn,
+        drivingTeam: sideOf(next.currentPlayer as TeamId),
+        score: { home: next.score.teamA, away: next.score.teamB },
+        ballYardline: estimateBallYardline(next),
+      },
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Heuristique : transforme la position de la balle (cellule x) en
+ * yardline 0..26 du modèle hybrid. La position du porteur est
+ * privilégiée si la balle a un porteur.
+ */
+function estimateBallYardline(state: GameState): number {
+  const carrier = state.players.find((p) => p.hasBall);
+  const ballX = carrier?.pos.x ?? state.ball?.x ?? 0;
+  // Le board fait 26 cells de large = yardline.
+  return Math.max(0, Math.min(26, ballX));
+}
+
+/**
+ * Inférence best-effort de la cause d'un turnover à partir du Move
+ * qui l'a déclenché. La taxonomie matche celle du hybrid driver
+ * pour que les consommateurs (narrator, gazette) restent uniformes.
+ */
+function causeFromMove(move: Move): string {
+  switch (move.type) {
+    case 'BLOCK':
+    case 'BLITZ':
+      return 'block_attacker_down';
+    case 'PASS':
+      return 'pass_failed';
+    case 'HANDOFF':
+      return 'handoff_failed';
+    case 'DODGE':
+      return 'dodge_failed';
+    case 'MOVE':
+    case 'LEAP':
+      return 'gfi_failed';
+    case 'FOUL':
+      return 'foul_sent_off';
+    default:
+      return 'unknown';
+  }
+}

--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -67,6 +67,8 @@ import {
 } from '../tactics/tactical-profile';
 import type { MatchEvent } from '@bb/shared-types';
 
+import { MS_PER_ACTION, diffStatesToEvents } from './full-driver-events';
+
 /**
  * Plafond d'actions par match. Sécurité contre une boucle d'IA qui
  * ne progresse pas (deux IAs qui ne s'entendent pas sur un END_TURN).
@@ -231,6 +233,37 @@ export function runFullDriver(input: SimInput): SimResult {
   // des vrais rosters Pro League.
   let state = setup();
 
+  // Lot 3.A.2.b — collect MatchEvent[] via state diff après chaque
+  // applyMove. Le KICKOFF event est émis avant la boucle et l'END
+  // est inféré du diff (gamePhase 'ended').
+  const events: MatchEvent[] = [
+    {
+      type: 'KICKOFF',
+      displayAtMs: 0,
+      engineVer: ENGINE_VER,
+      meta: {
+        home: input.home.id,
+        away: input.away.id,
+        weather: input.weather ?? 'nice',
+        receivingTeam: 'away',
+      },
+    },
+    // TURN_START initial pour le premier tour — sans cet event,
+    // le narrator commence sans header de tour.
+    {
+      type: 'TURN_START',
+      displayAtMs: 0,
+      engineVer: ENGINE_VER,
+      meta: {
+        half: state.half,
+        turn: state.turn,
+        drivingTeam: state.currentPlayer === 'A' ? 'home' : 'away',
+        score: { home: state.score.teamA, away: state.score.teamB },
+        ballYardline: 4,
+      },
+    },
+  ];
+
   let actionsApplied = 0;
   let staleEndTurns = 0;
   let lastTurn = state.turn;
@@ -251,57 +284,69 @@ export function runFullDriver(input: SimInput): SimResult {
       if (staleEndTurns > MAX_STALE_END_TURNS) break;
     }
 
+    const prev = state;
+    let next: GameState;
     try {
-      state = applyMove(state, move, engineRng);
+      next = applyMove(state, move, engineRng);
     } catch {
-      // Le coup retourné par l'IA s'avère illégal (pendingApothecary,
-      // pendingPushChoice, etc. non couverts). On force END_TURN pour
-      // avancer.
+      // Le coup retourné par l'IA s'avère illégal. On force END_TURN
+      // pour avancer.
       try {
-        state = applyMove(state, { type: 'END_TURN' }, engineRng);
+        next = applyMove(state, { type: 'END_TURN' }, engineRng);
       } catch {
         break;
       }
     }
 
+    // Lot 3.A.2.b — diff prev → next pour émettre les events
+    // narratifs (BLOCK/PASS/DODGE/TD/CASUALTY/KO/TURNOVER/HALFTIME/
+    // END/TURN_START). Timestamps incrémentaux 1s/action.
+    const displayAtMs = (actionsApplied + 1) * MS_PER_ACTION;
+    const newEvents = diffStatesToEvents(prev, next, {
+      displayAtMs,
+      move,
+    });
+    events.push(...newEvents);
+
+    state = next;
     lastTurn = state.turn;
     lastHalf = state.half;
     actionsApplied += 1;
+  }
+
+  // Si le match s'est terminé via timeout / break, on émet un END
+  // synthétique pour que le narrator + broadcaster aient leur clôture.
+  if (!events.some((e) => e.type === 'END')) {
+    events.push({
+      type: 'END',
+      displayAtMs: (actionsApplied + 1) * MS_PER_ACTION,
+      engineVer: ENGINE_VER,
+      meta: {
+        score: { home: state.score.teamA, away: state.score.teamB },
+        outcome:
+          state.score.teamA > state.score.teamB
+            ? 'home'
+            : state.score.teamB > state.score.teamA
+              ? 'away'
+              : 'draw',
+      },
+    });
   }
 
   const stats = deriveStats(state);
   const casualties = buildCasualties(state);
   const outcome = deriveOutcome(stats.score);
 
-  // MVP : pas d'events MatchEvent réels (Lot 3.A.2.b les ajoutera).
-  // On émet uniquement les events terminus pour rester compatible
-  // avec l'infrastructure broadcaster qui attend au moins KICKOFF + END.
-  const events: MatchEvent[] = [
-    {
-      type: 'KICKOFF',
-      displayAtMs: 0,
-      engineVer: ENGINE_VER,
-      meta: {
-        home: input.home.id,
-        away: input.away.id,
-        weather: input.weather ?? 'nice',
-        receivingTeam: 'away',
-      },
-    },
-    {
-      type: 'END',
-      displayAtMs: 1,
-      engineVer: ENGINE_VER,
-      meta: { score: stats.score, outcome },
-    },
-  ];
-
+  // Lot 3.A.2.b — `events` a été collecté tour par tour via
+  // diffStatesToEvents au-dessus. On compte les turnovers réels en
+  // post-process pour cohérence avec le hybrid driver summary.
+  const turnoverCount = events.filter((e) => e.type === 'TURNOVER').length;
   const summary: MatchSummary = {
     score: stats.score,
     outcome,
     durationMs: 0,
     touchdownCount: stats.touchdownCount,
-    turnoverCount: stats.turnoverCount,
+    turnoverCount,
     nuffleCount: 0,
     underdogBoostCount: 0,
     momentum: [],


### PR DESCRIPTION
## Summary

Lot 3.A.2.b — branche le pipeline narratif sur le full driver MVP. Là où le MVP n'émettait que `KICKOFF + END`, le driver produit maintenant la suite **MatchEvent[] complète** consommée par narrator + broadcaster + gazette.

> **Dépend de #685** (MVP full driver). À merger après #685.

## Architecture

`applyMove` retourne juste `GameState`. On diff `prev → next` + on inspecte le `Move` appliqué pour inférer les events. Module dédié `full-driver-events.ts` pour la traduction.

## Events couverts

**Move-specific** :
- BLOCK / BLITZ → `BLOCK` event
- PASS / HANDOFF → `PASS` event (success inféré de `hasBall` sur receiver)
- DODGE → `DODGE` event
- FOUL → `BLOCK kind='foul'` (parité narrator)

**Diff side-effects** :
- score change → `TD`
- player → `state='casualty'` → `CASUALTY`
- player → `state='knocked_out'` → `KO`
- `isTurnover false → true` → `TURNOVER` (cause inférée)
- `gamePhase → 'halftime'` → `HALFTIME`
- `gamePhase → 'ended'` → `END`
- `turn` ou `half` avance → `TURN_START` avec `ballYardline` estimé

## Compteurs cohérents

- `summary.turnoverCount` calculé depuis `events.filter(TURNOVER)` au lieu de hardcodé 0
- `summary.touchdownCount` cohérent avec le score réel

## Hors scope (Lot 3.A.2.c)

- MOVE events atomiques (1 case = 1 MOVE) → écrasant. Le hybrid émet des MOVE bulk ; le full pourrait agréger quand les rosters réels donneront du sens aux activations player-by-player.
- PLAYER_ACTIVATION : intéressant uniquement avec roster réels.

## Test plan

- [x] 13 unit tests `diffStatesToEvents` (chaque Move type, chaque side-effect, idempotent, cumul d'events multiples)
- [x] 7 smoke tests `runFullDriver` (verts, MatchEvent[] peuplé)
- [x] 315 sim-engine tests passent
- [x] Typecheck clean

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_