### PR TITLE
feat(sim-engine): roster-aware GameState builder for full driver (Lot 3.A.2.c)

### DIFF
--- a/packages/sim-engine/src/driver/full-driver-roster.test.ts
+++ b/packages/sim-engine/src/driver/full-driver-roster.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests pour `full-driver-roster.ts` (Lot 3.A.2.c).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { SimRosterPlayer } from '../types';
+
+import { buildGameStateFromRosters } from './full-driver-roster';
+
+function rosterPlayer(overrides: Partial<SimRosterPlayer> = {}): SimRosterPlayer {
+  return {
+    id: 'p1',
+    name: 'Player One',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 9,
+    skills: [],
+    ...overrides,
+  };
+}
+
+function buildRoster(prefix: 'home' | 'away', size: number): SimRosterPlayer[] {
+  return Array.from({ length: size }, (_, i) =>
+    rosterPlayer({
+      id: `${prefix}-${i + 1}`,
+      name: `${prefix === 'home' ? 'Home' : 'Away'} #${i + 1}`,
+      number: i + 1,
+    })
+  );
+}
+
+describe('buildGameStateFromRosters — Lot 3.A.2.c', () => {
+  it('produit un GameState avec 11 joueurs par équipe quand le roster a 11+', () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    const teamA = state.players.filter((p) => p.team === 'A');
+    const teamB = state.players.filter((p) => p.team === 'B');
+    expect(teamA).toHaveLength(11);
+    expect(teamB).toHaveLength(11);
+  });
+
+  it('cap à 11 joueurs par équipe même si le roster a plus', () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 16),
+      awayRoster: buildRoster('away', 16),
+      receivingTeam: 'B',
+    });
+    expect(state.players.filter((p) => p.team === 'A')).toHaveLength(11);
+    expect(state.players.filter((p) => p.team === 'B')).toHaveLength(11);
+  });
+
+  it('utilise les vrais ids du roster (pas des A1/B1 synthétiques)', () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    expect(state.players[0].id).toBe('home-1');
+    expect(state.players[11].id).toBe('away-1');
+  });
+
+  it('preserve les stats (ma/st/ag/pa/av) du roster', () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: [
+        rosterPlayer({
+          id: 'home-1',
+          name: 'Bob',
+          ma: 8,
+          st: 5,
+          ag: 4,
+          pa: 5,
+          av: 10,
+        }),
+      ],
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    const bob = state.players.find((p) => p.id === 'home-1');
+    expect(bob).toBeDefined();
+    expect(bob?.ma).toBe(8);
+    expect(bob?.st).toBe(5);
+    expect(bob?.av).toBe(10);
+  });
+
+  it('place le ballon sur le joueur receveur (index 9 de la receiving team)', () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    const carriers = state.players.filter((p) => p.hasBall);
+    expect(carriers).toHaveLength(1);
+    expect(carriers[0].team).toBe('B');
+  });
+
+  it("place les joueurs sur des positions distinctes (pas de doublons)", () => {
+    const state = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    const positions = new Set(
+      state.players.map((p) => `${p.pos.x},${p.pos.y}`)
+    );
+    expect(positions.size).toBe(state.players.length);
+  });
+
+  it("currentPlayer = receivingTeam (l'équipe qui reçoit joue d'abord)", () => {
+    const stateB = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'B',
+    });
+    expect(stateB.currentPlayer).toBe('B');
+
+    const stateA = buildGameStateFromRosters({
+      homeRoster: buildRoster('home', 11),
+      awayRoster: buildRoster('away', 11),
+      receivingTeam: 'A',
+    });
+    expect(stateA.currentPlayer).toBe('A');
+  });
+});

--- a/packages/sim-engine/src/driver/full-driver-roster.ts
+++ b/packages/sim-engine/src/driver/full-driver-roster.ts
@@ -1,0 +1,158 @@
+/**
+ * Full driver — roster-aware GameState builder (Lot 3.A.2.c).
+ *
+ * Convertit un `SimRosterPlayer[]` (snapshot de roster Pro League)
+ * en `Player[]` placé sur le terrain BB, prêt à être consommé par
+ * le full driver IA-vs-IA.
+ *
+ * Pourquoi
+ * --------
+ * Le MVP (Lot 3.A.2.a) utilisait `setup()` du game-engine : 6 joueurs
+ * synthétiques avec des ids `A1`/`B1` et des noms hardcodés. Les
+ * events MatchEvent[] qui en sortaient portaient des `playerId`
+ * non-narratifs ("A1 plaque B2") au lieu de "Bob le Blitzer plaque
+ * Carla la Thrower". Ce module mappe les vrais joueurs.
+ *
+ * Scope
+ * -----
+ * - Mapping pur SimRosterPlayer → game-engine Player
+ * - Placement basique en formation 3-3-2-3 (LOS / wings / backfield)
+ *   sur la moitié défensive du terrain. Le hybrid driver ne fait pas
+ *   mieux ; le full driver gagne juste l'identité narrative.
+ * - L'équipe receveuse (away par convention) a le ballon.
+ *
+ * Hors scope
+ * ----------
+ * - Kickoff scatter / weather / fan factor : skip pour MVP, le
+ *   match commence directement en `gamePhase='playing'`.
+ * - Setup phase interactive : le full driver est headless ; on
+ *   place de force.
+ * - Animosité, special rules de roster : tracées dans roster.skills
+ *   et lues plus tard quand le scoring AI les exploitera.
+ */
+
+import type { Player, TeamId, GameState } from '@bb/game-engine';
+import { setup } from '@bb/game-engine';
+
+import type { SimRosterPlayer } from '../types';
+
+/** Nombre max de joueurs placés par équipe. BB = 11 sur le terrain. */
+const MAX_PLAYERS_ON_FIELD = 11;
+
+/**
+ * Positions LOS (line of scrimmage) + backfield pour 11 joueurs.
+ * Coordonnées x/y sur un terrain 26×15 :
+ *   - team A defensive line à x=12 (LOS adverse)
+ *   - team B defensive line à x=13
+ *   - center y=7, wings y=4 et y=10
+ */
+const TEAM_A_FORMATION: ReadonlyArray<{ x: number; y: number }> = Object.freeze([
+  // 3 LOS centrals
+  { x: 11, y: 6 },
+  { x: 11, y: 7 },
+  { x: 11, y: 8 },
+  // 2 wings
+  { x: 10, y: 4 },
+  { x: 10, y: 10 },
+  // 3 mid
+  { x: 8, y: 5 },
+  { x: 8, y: 7 },
+  { x: 8, y: 9 },
+  // 3 backfield
+  { x: 4, y: 4 },
+  { x: 4, y: 7 },
+  { x: 4, y: 10 },
+]);
+
+const TEAM_B_FORMATION: ReadonlyArray<{ x: number; y: number }> = Object.freeze([
+  // 3 LOS centrals
+  { x: 14, y: 6 },
+  { x: 14, y: 7 },
+  { x: 14, y: 8 },
+  // 2 wings
+  { x: 15, y: 4 },
+  { x: 15, y: 10 },
+  // 3 mid
+  { x: 17, y: 5 },
+  { x: 17, y: 7 },
+  { x: 17, y: 9 },
+  // 3 backfield (le porteur initial dans la stack — index 9 par convention)
+  { x: 21, y: 4 },
+  { x: 21, y: 7 }, // ball carrier (receiving team = away = B)
+  { x: 21, y: 10 },
+]);
+
+/**
+ * Mappe un joueur du roster vers un `Player` game-engine. Le `team`
+ * est imposé par la fonction parente (le roster ne porte pas le
+ * teamId — il est rattaché à une équipe par contexte).
+ */
+function rosterPlayerToGameEnginePlayer(
+  roster: SimRosterPlayer,
+  team: TeamId,
+  pos: { x: number; y: number },
+  hasBall: boolean
+): Player {
+  return {
+    id: roster.id,
+    team,
+    pos: { x: pos.x, y: pos.y },
+    name: roster.name,
+    number: roster.number,
+    position: roster.position,
+    ma: roster.ma,
+    st: roster.st,
+    ag: roster.ag,
+    pa: roster.pa,
+    av: roster.av,
+    skills: roster.skills ? [...roster.skills] : [],
+    pm: roster.ma,
+    state: 'active',
+    hasBall,
+  };
+}
+
+/**
+ * Construit un GameState complet à partir des deux rosters. L'équipe
+ * `receivingTeam` reçoit le coup d'envoi (et donc la balle).
+ *
+ * On part de `setup()` pour réutiliser la structure complète (dugouts,
+ * apothecaryAvailable, gamePhase, etc.) puis on remplace les
+ * `players` + `ball` par notre composition roster-based.
+ */
+export function buildGameStateFromRosters(input: {
+  homeRoster: readonly SimRosterPlayer[];
+  awayRoster: readonly SimRosterPlayer[];
+  homeName?: string;
+  awayName?: string;
+  receivingTeam: TeamId;
+}): GameState {
+  const baseline = setup();
+  const teamAPlayers = input.homeRoster
+    .slice(0, MAX_PLAYERS_ON_FIELD)
+    .map((roster, idx) => {
+      const pos = TEAM_A_FORMATION[idx];
+      const hasBall = input.receivingTeam === 'A' && idx === 9;
+      return rosterPlayerToGameEnginePlayer(roster, 'A', pos, hasBall);
+    });
+  const teamBPlayers = input.awayRoster
+    .slice(0, MAX_PLAYERS_ON_FIELD)
+    .map((roster, idx) => {
+      const pos = TEAM_B_FORMATION[idx];
+      const hasBall = input.receivingTeam === 'B' && idx === 9;
+      return rosterPlayerToGameEnginePlayer(roster, 'B', pos, hasBall);
+    });
+
+  const carrier =
+    input.receivingTeam === 'A'
+      ? teamAPlayers[9]
+      : teamBPlayers[9];
+  const ball = carrier ? { x: carrier.pos.x, y: carrier.pos.y } : undefined;
+
+  return {
+    ...baseline,
+    players: [...teamAPlayers, ...teamBPlayers],
+    ball,
+    currentPlayer: input.receivingTeam,
+  };
+}

--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -68,6 +68,7 @@ import {
 import type { MatchEvent } from '@bb/shared-types';
 
 import { MS_PER_ACTION, diffStatesToEvents } from './full-driver-events';
+import { buildGameStateFromRosters } from './full-driver-roster';
 
 /**
  * Plafond d'actions par match. Sécurité contre une boucle d'IA qui
@@ -228,10 +229,22 @@ export function runFullDriver(input: SimInput): SimResult {
   const rng = createRng(input.seed);
   const engineRng = adaptRng(rng);
 
-  // MVP : `setup()` produit un état avec quelques joueurs par équipe
-  // et une balle prête. Lot 3.A.2.c remplacera par un setup à partir
-  // des vrais rosters Pro League.
-  let state = setup();
+  // Lot 3.A.2.c — quand des rosters complets sont fournis dans
+  // SimInput, on construit le GameState depuis eux pour que les
+  // events portent les vrais playerId / playerName. Sinon on
+  // retombe sur `setup()` minimal (legacy MVP).
+  const homeRoster = input.home.roster;
+  const awayRoster = input.away.roster;
+  let state =
+    homeRoster && homeRoster.length > 0 && awayRoster && awayRoster.length > 0
+      ? buildGameStateFromRosters({
+          homeRoster,
+          awayRoster,
+          homeName: input.home.name,
+          awayName: input.away.name,
+          receivingTeam: 'B', // away receives par convention sim-engine
+        })
+      : setup();
 
   // Lot 3.A.2.b — collect MatchEvent[] via state diff après chaque
   // applyMove. Le KICKOFF event est émis avant la boucle et l'END

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -9,6 +9,7 @@
 export { simulateMatch } from './simulate-match';
 export { runHybridDriver, type DriverOptions } from './driver/hybrid-driver';
 export { runFullDriver } from './driver/full-driver';
+export { buildGameStateFromRosters } from './driver/full-driver-roster';
 export {
   DEFAULT_TACTICAL_PROFILE,
   TACTICAL_PROFILE_PARAMETERS,
@@ -152,6 +153,7 @@ export {
   type MatchSummary,
   type SimInput,
   type SimResult,
+  type SimRosterPlayer,
   type SimTeamInput,
 } from './types';
 export {

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -31,12 +31,47 @@ export interface MatchScore {
  * profile (lot 0.B.2) is optional — when omitted, the driver behaves as
  * if the team used `DEFAULT_TACTICAL_PROFILE` (every parameter at 50).
  */
+/**
+ * Snapshot d'un joueur du roster passé au full driver pour produire
+ * des MatchEvent[] roster-aware (Lot 3.A.2.c).
+ *
+ * Le hybrid driver n'utilise pas ce champ — il génère ses propres
+ * `home-LOS` / `away-LOS` synthétiques. Le full driver, lui, mappe
+ * cette snapshot vers les `Player` de game-engine pour que les
+ * events portent les vrais playerId / playerName.
+ */
+export interface SimRosterPlayer {
+  /** ID stable (ex: cuid Prisma `proTeamRoster.id`). */
+  id: string;
+  /** Nom complet (lisible par le narrator). */
+  name: string;
+  /** Numéro du jersey (1-16). */
+  number: number;
+  /** Poste BB ('Lineman', 'Blitzer', 'Thrower', ...). */
+  position: string;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number;
+  av: number;
+  /** Liste de skills (slugs). */
+  skills?: readonly string[];
+}
+
 export interface SimTeamInput {
   id: string;
   name: string;
   side: 'home' | 'away';
   /** Roster id list — actual roster lookup is consumer-side for now. */
   rosterIds?: readonly string[];
+  /**
+   * Lot 3.A.2.c — snapshot du roster passé au full driver pour
+   * piloter le sim avec les vrais joueurs. Optionnel : si absent,
+   * le full driver retombe sur `setup()` minimal (~6 joueurs
+   * synthétiques) ; si présent, les events MatchEvent[] portent
+   * les vrais ids/names du roster.
+   */
+  roster?: readonly SimRosterPlayer[];
   /** Validated tactical fingerprint — see `tactical-profile.ts` (0.B.2).
    *  Apps/server validates the JSON via `tacticalProfileSchema` before
    *  reaching the sim-engine. */


### PR DESCRIPTION
## Summary

**Lot 3.A.2.c — dernière brique de Phase 3.A.2**. Remplace le `setup()` minimal du MVP par une construction GameState depuis les vrais rosters Pro League. Les `MatchEvent[]` portent maintenant les `playerId` / `playerName` réels.

> **Dépend de #687** (event mapping). À merger après #687.

## Wire format

Nouveau type `SimRosterPlayer` sur `SimTeamInput.roster?` (optionnel) :

```ts
interface SimRosterPlayer {
  id: string;       // cuid Prisma stable
  name: string;     // "Bob the Blitzer"
  number: number;
  position: string;
  ma, st, ag, pa, av;
  skills?: string[];
}
```

**Backward compat strict** : si `roster` absent, fallback sur `setup()` (Lot 3.A.2.a inchangé). Le hybrid driver n'utilise pas ce champ.

## Builder `buildGameStateFromRosters`

- Cap à **11 joueurs/équipe** (BB max sur le terrain)
- Formation 3 LOS / 2 wings / 3 mid / 3 backfield
- Joueur **index 9** de la receiving team = carrier (a la balle)
- Positions distinctes (anti-collision)
- Réutilise `setup()` comme baseline puis remplace `players` + `ball`
- `currentPlayer = receivingTeam`

## Hors scope (lots futurs)

- **Lot 3.C.1** : casualty propagation au roster persisté
- Kickoff scatter / weather / fan factor : MVP les skip
- Setup phase interactive : le driver est headless
- Animosité / special rules : tracées dans skills, scoring AI futur

## Test plan

- [x] 7 unit tests : cap 11, vrais ids, stats préservées, ball placement, positions distinctes, currentPlayer
- [x] Smoke tests full-driver toujours verts (roster optionnel)
- [x] 322 sim-engine tests passent
- [x] Typecheck clean

## Phase 3.A.2 complète

3 lots livrés successivement (3.A.2.a/b/c) :
- ✅ MVP orchestrator (#685)
- ✅ MatchEvent emission (#687)
- ✅ Roster-aware events (this PR)

**Prochaines étapes** :
- **Lot 3.B.1** : toggle `season.driverKind`
- **Lot 3.B.2** : A/B test infra
- **Lot 3.B.3** : perf baseline + replay size

https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4TGYTWsvLahmA1xXTAY7J)_