### PR TITLE
feat(sim-engine): TD scorerId in events + 3 SPP per TD attribution (Lot 3.C.3)

### DIFF
--- a/apps/server/src/services/pro-roster-spp.test.ts
+++ b/apps/server/src/services/pro-roster-spp.test.ts
@@ -215,6 +215,58 @@ describe("attributeSpp — Lot 3.C.2", () => {
     expect(a.rewards).toEqual(b.rewards);
   });
 
+  it("Lot 3.C.3 — TD avec scorerId reel attribue 3 SPP td au porteur", () => {
+    const scorer = realCuid("scorer1");
+    const out = attributeSpp({
+      seed: 1,
+      events: [
+        {
+          type: "TD",
+          meta: { team: "home", scorerId: scorer, scoreAfter: { home: 1, away: 0 } },
+        },
+      ],
+      casualties: [],
+      homeRosterIds: new Set([scorer, realCuid("home2")]),
+      awayRosterIds: new Set([realCuid("away1")]),
+    });
+    const reward = out.rewards.find((r) => r.rosterId === scorer);
+    expect(reward?.tdCount).toBe(1);
+    // Au moins 3 SPP du TD ; le MVP peut s'ajouter (4 de plus).
+    expect(reward?.totalSpp).toBeGreaterThanOrEqual(SPP_VALUES.td);
+  });
+
+  it("Lot 3.C.3 — TD sans scorerId (hybrid driver / state corrompu) -> pas d'attribution", () => {
+    const out = attributeSpp({
+      seed: 1,
+      events: [
+        {
+          type: "TD",
+          meta: { team: "home", scoreAfter: { home: 1, away: 0 } }, // pas de scorerId
+        },
+      ],
+      casualties: [],
+      homeRosterIds: new Set([realCuid("home1"), realCuid("home2")]),
+      awayRosterIds: new Set([realCuid("away1")]),
+    });
+    expect(out.rewards.every((r) => r.tdCount === 0)).toBe(true);
+  });
+
+  it("Lot 3.C.3 — TD avec scorerId synthetique -> pas d'attribution", () => {
+    const out = attributeSpp({
+      seed: 1,
+      events: [
+        {
+          type: "TD",
+          meta: { team: "home", scorerId: "home-3" },
+        },
+      ],
+      casualties: [],
+      homeRosterIds: new Set([realCuid("home1")]),
+      awayRosterIds: new Set([realCuid("away1")]),
+    });
+    expect(out.rewards.every((r) => r.tdCount === 0)).toBe(true);
+  });
+
   it("agrege multi-source : MVP + 2 completions sur le meme joueur", () => {
     const star = realCuid("star1");
     const out = attributeSpp({

--- a/apps/server/src/services/pro-roster-spp.ts
+++ b/apps/server/src/services/pro-roster-spp.ts
@@ -137,21 +137,36 @@ export function attributeSpp(
     acc.set(id, cur);
   };
 
-  // 1) Completions (PASS success, hors handoff).
+  // 1) Completions (PASS success, hors handoff) + TD (scorerId).
+  // Lot 3.C.3 — TD events emis par le full driver (full-driver-events
+  // depuis cette PR) portent maintenant `meta.scorerId` quand un
+  // porteur de balle est identifie. 3 SPP par TD attribues au scorer
+  // s'il appartient au roster de la team. Si scorerId absent
+  // (TD synthetique du hybrid driver, ou state sans porteur identifie),
+  // pas d'attribution — comportement existant preserve.
   for (const ev of input.events) {
     if (!ev || typeof ev !== "object") continue;
     const e = ev as { type?: unknown; meta?: unknown };
-    if (e.type !== "PASS") continue;
-    const meta = (e.meta ?? {}) as {
-      passerId?: unknown;
-      range?: unknown;
-      success?: unknown;
-    };
-    if (meta.success !== true) continue;
-    if (meta.range === "handoff") continue;
-    if (typeof meta.passerId !== "string") continue;
-    if (isSyntheticId(meta.passerId)) continue;
-    bump(meta.passerId, "compCount");
+    if (e.type === "PASS") {
+      const meta = (e.meta ?? {}) as {
+        passerId?: unknown;
+        range?: unknown;
+        success?: unknown;
+      };
+      if (meta.success !== true) continue;
+      if (meta.range === "handoff") continue;
+      if (typeof meta.passerId !== "string") continue;
+      if (isSyntheticId(meta.passerId)) continue;
+      bump(meta.passerId, "compCount");
+      continue;
+    }
+    if (e.type === "TD") {
+      const meta = (e.meta ?? {}) as { scorerId?: unknown };
+      if (typeof meta.scorerId !== "string") continue;
+      if (isSyntheticId(meta.scorerId)) continue;
+      bump(meta.scorerId, "tdCount");
+      continue;
+    }
   }
 
   // 2) Casualties caused : attribue au causedById quand present (CUID

--- a/packages/sim-engine/src/driver/full-driver-events.test.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.test.ts
@@ -88,6 +88,68 @@ describe('diffStatesToEvents — Lot 3.A.2.b', () => {
     expect((td?.meta as { team: string }).team).toBe('away');
   });
 
+  it('Lot 3.C.3 — TD event porte scorerId = porteur de balle dans prev (team A)', () => {
+    const baseline = setup();
+    const carrier = baseline.players.find((p) => p.team === 'A');
+    if (!carrier) throw new Error('No team A player in setup');
+    const prev = modify(baseline, {
+      players: baseline.players.map((p) =>
+        p.id === carrier.id ? { ...p, hasBall: true } : { ...p, hasBall: false },
+      ),
+    });
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA + 1, teamB: prev.score.teamB },
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const td = events.find((e) => e.type === 'TD');
+    expect((td?.meta as { scorerId?: string }).scorerId).toBe(carrier.id);
+  });
+
+  it('Lot 3.C.3 — fallback sur next si hasBall reset post-TD dans prev', () => {
+    const baseline = setup();
+    const carrier = baseline.players.find((p) => p.team === 'B');
+    if (!carrier) throw new Error('No team B player in setup');
+    // Aucun joueur n'a la balle dans prev, mais carrier l'a dans next.
+    const prev = modify(baseline, {
+      players: baseline.players.map((p) => ({ ...p, hasBall: false })),
+    });
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA, teamB: prev.score.teamB + 1 },
+      players: prev.players.map((p) =>
+        p.id === carrier.id ? { ...p, hasBall: true } : p,
+      ),
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(prev, next, {
+      displayAtMs: 1000,
+      move,
+    });
+    const td = events.find((e) => e.type === 'TD');
+    expect((td?.meta as { scorerId?: string }).scorerId).toBe(carrier.id);
+  });
+
+  it('Lot 3.C.3 — pas de scorerId si aucun porteur (state corrompu)', () => {
+    const prev = setup();
+    const next = modify(prev, {
+      score: { teamA: prev.score.teamA + 1, teamB: prev.score.teamB },
+      players: prev.players.map((p) => ({ ...p, hasBall: false })),
+    });
+    const move: Move = { type: 'END_TURN' };
+    const events = diffStatesToEvents(
+      modify(prev, {
+        players: prev.players.map((p) => ({ ...p, hasBall: false })),
+      }),
+      next,
+      { displayAtMs: 1000, move },
+    );
+    const td = events.find((e) => e.type === 'TD');
+    expect((td?.meta as { scorerId?: string }).scorerId).toBeUndefined();
+  });
+
   it('émet un CASUALTY quand un joueur passe à state="casualty"', () => {
     const prev = setup();
     const next = modify(prev, {

--- a/packages/sim-engine/src/driver/full-driver-events.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.ts
@@ -154,7 +154,20 @@ export function diffStatesToEvents(
   if (primary) events.push(primary);
 
   // 2) TD : score changé sur l'une des deux équipes.
+  // Lot 3.C.3 — `scorerId` = playerId du porteur de balle au moment
+  // du TD. Cherche d'abord dans `prev` (le porteur juste avant
+  // d'entrer en endzone) ; fallback sur `next` si le moteur ne reset
+  // pas immediatement le `hasBall` post-TD ; null si aucun porteur
+  // identifie (TD synthetique / state corrompu — le SPP service
+  // tombera en no-op).
+  function scorerFor(team: TeamId): string | undefined {
+    const candidate =
+      prev.players.find((p) => p.team === team && p.hasBall === true) ??
+      next.players.find((p) => p.team === team && p.hasBall === true);
+    return candidate?.id;
+  }
   if (next.score.teamA > prev.score.teamA) {
+    const scorerId = scorerFor('A');
     events.push({
       type: 'TD',
       displayAtMs,
@@ -163,10 +176,12 @@ export function diffStatesToEvents(
         team: 'home',
         half: next.half,
         scoreAfter: { home: next.score.teamA, away: next.score.teamB },
+        ...(scorerId ? { scorerId } : {}),
       },
     });
   }
   if (next.score.teamB > prev.score.teamB) {
+    const scorerId = scorerFor('B');
     events.push({
       type: 'TD',
       displayAtMs,
@@ -175,6 +190,7 @@ export function diffStatesToEvents(
         team: 'away',
         half: next.half,
         scoreAfter: { home: next.score.teamA, away: next.score.teamB },
+        ...(scorerId ? { scorerId } : {}),
       },
     });
   }


### PR DESCRIPTION
## Pourquoi

Lot 3.C.2 livre les SPP MVP/Comp/Cas mais skippait les TD car les events `TD` n'avaient pas de `scorerId`. Sans cette pièce, un star quarterback marquant 5 TD sur la saison ne progresse pas vs un lineman qui tank 5 turnovers. Le full driver doit attribuer les TD au porteur de balle pour que le SPP cumulatif soit fidèle aux règles BB.

## Comment

1. **`full-driver-events.ts`** :
   - Helper `scorerFor(team)` : cherche d'abord dans `prev.players` le joueur de la team scorée avec `hasBall=true` (le porteur juste avant entrée en endzone), fallback sur `next.players` si le game-engine reset le `hasBall` post-TD.
   - `meta.scorerId` ajouté uniquement si un porteur est identifié ; absent sinon (TD synthétique du hybrid driver, ou state sans porteur identifiable).

2. **`pro-roster-spp.ts`** :
   - Boucle d'attribution étendue pour gérer `e.type === 'TD'` : `meta.scorerId` doit être un CUID réel (pas synthétique `home-X`/`away-X`), et appartenir au roster d'une des deux teams. Bumps `tdCount` → 3 SPP/TD.
   - Comportement existant préservé : MVP + Comp + Cas inchangées.

Pas de change côté hybrid driver — il continue d'émettre des TD sans `scorerId` (synthèse archétype, pas de tracking par-joueur). Les TD du hybrid sont donc no-op SPP, ce qui est cohérent : le hybrid n'a pas de notion de "vrais" joueurs.

## Tests

- `full-driver-events.test.ts` : +3 tests (porteur dans prev → scorerId, fallback next, pas de scorerId si state corrompu)
- `pro-roster-spp.test.ts` : +3 tests (scorerId réel → 3 SPP td, pas de scorerId → pas d'attribution, synthétique → pas d'attribution)

### Résultats

- `@bb/sim-engine` : 16 tests `full-driver-events` (+3 nouveaux)
- `@bb/server` : 22 tests `pro-roster-spp` (+3 nouveaux)
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte
- [ ] En prod, après une saison full driver, vérifier que `ProTeamRoster.tdCount` augmente sur les marqueurs réguliers (catchers, blitzers offensifs)
- [ ] Vérifier qu'un match avec 5 TD attribue 5×3=15 SPP à des `ProTeamRoster` réels (pas zéro)

## Hors scope

- Hybrid driver scorer attribution : ne tracke pas la balle au niveau joueur (synthèse archétype). À faire séparément si on veut le SPP TD aussi sur les saisons hybrid (peu de valeur — les SPP servent surtout aux saisons full driver roster-aware).
- Cas multi-TD dans une seule transition : peu probable mais théoriquement possible. Le helper `scorerFor` retournerait le même porteur pour les deux events (⇒ double attribution). Tracking de tickets si jamais ça se produit en prod.

## Refs

- PR #717 (Lot 3.C.2 SPP) — base de cette PR
- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 3.C)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_