### PR TITLE
feat(pro-league): structured sim error logs + slow sim warn + drift alerts (Lot 4.A)

### DIFF
--- a/apps/server/src/services/pro-league-engine-drift-watcher.test.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.test.ts
@@ -27,8 +27,14 @@ import {
   buildDriftSamples,
   computeEngineDrift,
   computeRelativeDrift,
+  countAlertsBySeverity,
+  detectDriftAlerts,
+  DRIFT_CRITICAL_THRESHOLD,
+  DRIFT_WARN_THRESHOLD,
+  MIN_MATCHES_FOR_ALERT,
   runDriftTick,
   startDriftWatcher,
+  type DriftSample,
 } from "./pro-league-engine-drift-watcher";
 import { appMetrics } from "../utils/metrics";
 
@@ -314,5 +320,103 @@ describe("startDriftWatcher", () => {
     // Si un timer avait démarré, stop() le clearInterval. Smoke test :
     // pas d'erreur = OK.
     expect(true).toBe(true);
+  });
+});
+
+describe("detectDriftAlerts — Lot 4.A.3", () => {
+  function sample(
+    overrides: Partial<DriftSample> = {},
+  ): DriftSample {
+    return {
+      metric: "tdMean",
+      race: "Wood Elf",
+      seasonId: "s_2026",
+      observed: 2.5,
+      reference: 2.4,
+      drift: 0.04,
+      samples: 50,
+      ...overrides,
+    };
+  }
+
+  it("seuils par defaut respectent FUMBBL_TOLERANCE (10%) + critical (25%)", () => {
+    expect(DRIFT_WARN_THRESHOLD).toBe(0.1);
+    expect(DRIFT_CRITICAL_THRESHOLD).toBe(0.25);
+    expect(MIN_MATCHES_FOR_ALERT).toBe(5);
+  });
+
+  it("aucune alerte sous le seuil warn (10%)", () => {
+    expect(detectDriftAlerts([sample({ drift: 0.05 })])).toEqual([]);
+    expect(detectDriftAlerts([sample({ drift: -0.09 })])).toEqual([]);
+  });
+
+  it("warn si |drift| > 10% et < 25% (signe ne change pas la severite)", () => {
+    const alerts = detectDriftAlerts([
+      sample({ drift: 0.15, race: "Halfling" }),
+      sample({ drift: -0.2, race: "Chaos Dwarf" }),
+    ]);
+    expect(alerts.map((a) => a.severity)).toEqual(["warn", "warn"]);
+  });
+
+  it("critical si |drift| > 25%", () => {
+    const alerts = detectDriftAlerts([sample({ drift: 0.3, race: "Halfling" })]);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("critical");
+  });
+
+  it("ignore les samples sous MIN_MATCHES_FOR_ALERT (variance trop forte)", () => {
+    expect(
+      detectDriftAlerts([sample({ drift: 0.5, samples: 3 })]),
+    ).toEqual([]);
+  });
+
+  it("override des seuils via options", () => {
+    const alerts = detectDriftAlerts(
+      [sample({ drift: 0.06 })],
+      { warnThreshold: 0.05 },
+    );
+    expect(alerts).toHaveLength(1);
+  });
+});
+
+describe("countAlertsBySeverity — Lot 4.A.3", () => {
+  it("compte par severite", () => {
+    const result = countAlertsBySeverity([
+      {
+        severity: "warn",
+        metric: "tdMean",
+        race: "Halfling",
+        seasonId: "s",
+        drift: 0.15,
+        observed: 2,
+        reference: 1.8,
+        samples: 50,
+      },
+      {
+        severity: "critical",
+        metric: "winRate",
+        race: "Chaos",
+        seasonId: "s",
+        drift: 0.3,
+        observed: 0.7,
+        reference: 0.55,
+        samples: 50,
+      },
+      {
+        severity: "warn",
+        metric: "casualtyMean",
+        race: "Orc",
+        seasonId: "s",
+        drift: 0.12,
+        observed: 1.5,
+        reference: 1.34,
+        samples: 50,
+      },
+    ]);
+    expect(result).toEqual({ warn: 2, critical: 1 });
+  });
+
+  it("0/0 sur liste vide", () => {
+    expect(countAlertsBySeverity([])).toEqual({ warn: 0, critical: 0 });
   });
 });

--- a/apps/server/src/services/pro-league-engine-drift-watcher.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.ts
@@ -287,9 +287,86 @@ function pushDriftToMetrics(samples: readonly DriftSample[]): void {
 }
 
 /**
- * Tick unitaire : compute + push. Erreur isolée — log et continue.
- * Retourne le nombre de samples pushés pour usage dans les tests
- * sans avoir besoin de scrutateur Prometheus.
+ * Lot 4.A.3 — Seuils de severite drift (FUMBBL_TOLERANCE = 10% est
+ * la tolerance "normale" de la PR #655 ; au-dela on alerte).
+ *   - warn     : |drift| > 10% (= FUMBBL_TOLERANCE)
+ *   - critical : |drift| > 25%
+ *
+ * Pas d'alerte sur les samples avec moins de `MIN_MATCHES_FOR_ALERT`
+ * matchs : la variance d'echantillonnage est trop forte pour conclure.
+ */
+export const DRIFT_WARN_THRESHOLD = 0.1;
+export const DRIFT_CRITICAL_THRESHOLD = 0.25;
+export const MIN_MATCHES_FOR_ALERT = 5;
+
+export interface DriftAlert {
+  readonly severity: "warn" | "critical";
+  readonly metric: DriftMetric;
+  readonly race: string;
+  readonly seasonId: string;
+  readonly drift: number;
+  readonly observed: number;
+  readonly reference: number;
+  readonly samples: number;
+}
+
+/**
+ * Pure : a partir des drift samples, retourne la liste des alertes.
+ * Les samples avec moins de `MIN_MATCHES_FOR_ALERT` matchs sont
+ * silencieusement ignores (variance trop forte pour conclure).
+ */
+export function detectDriftAlerts(
+  samples: readonly DriftSample[],
+  options: {
+    readonly warnThreshold?: number;
+    readonly criticalThreshold?: number;
+    readonly minMatches?: number;
+  } = {},
+): DriftAlert[] {
+  const warn = options.warnThreshold ?? DRIFT_WARN_THRESHOLD;
+  const critical = options.criticalThreshold ?? DRIFT_CRITICAL_THRESHOLD;
+  const minMatches = options.minMatches ?? MIN_MATCHES_FOR_ALERT;
+  const alerts: DriftAlert[] = [];
+  for (const s of samples) {
+    if (s.samples < minMatches) continue;
+    const abs = Math.abs(s.drift);
+    if (abs <= warn) continue;
+    alerts.push({
+      severity: abs > critical ? "critical" : "warn",
+      metric: s.metric,
+      race: s.race,
+      seasonId: s.seasonId,
+      drift: s.drift,
+      observed: s.observed,
+      reference: s.reference,
+      samples: s.samples,
+    });
+  }
+  return alerts;
+}
+
+/**
+ * Compte les alertes par severite. Sert au push gauge Prometheus.
+ */
+export function countAlertsBySeverity(
+  alerts: readonly DriftAlert[],
+): { readonly warn: number; readonly critical: number } {
+  let warn = 0;
+  let critical = 0;
+  for (const a of alerts) {
+    if (a.severity === "critical") critical += 1;
+    else warn += 1;
+  }
+  return { warn, critical };
+}
+
+/**
+ * Tick unitaire : compute + push + alert detection. Erreur isolée —
+ * log et continue. Retourne le nombre de samples pushés pour usage
+ * dans les tests sans avoir besoin de scrutateur Prometheus.
+ *
+ * Lot 4.A.3 — emet aussi un `serverLog.warn("drift_alert", ...)` par
+ * alerte detectee, et update les jauges `nuffle_engine_drift_alerts_count`.
  */
 export async function runDriftTick(
   options: ComputeDriftOptions = {},
@@ -297,6 +374,26 @@ export async function runDriftTick(
   try {
     const samples = await computeEngineDrift(options);
     pushDriftToMetrics(samples);
+    const alerts = detectDriftAlerts(samples);
+    const counts = countAlertsBySeverity(alerts);
+    appMetrics.setEngineDriftAlertsCount("warn", counts.warn);
+    appMetrics.setEngineDriftAlertsCount("critical", counts.critical);
+    for (const alert of alerts) {
+      // Log structure pino-friendly : Loki indexera les labels
+      // (severity, metric, race, seasonId, drift) pour les queries
+      // type "alertes critical sur saison s_2026 par race".
+      serverLog.warn("drift_alert", {
+        event: "drift_alert",
+        severity: alert.severity,
+        metric: alert.metric,
+        race: alert.race,
+        seasonId: alert.seasonId,
+        drift: alert.drift,
+        observed: alert.observed,
+        reference: alert.reference,
+        samples: alert.samples,
+      });
+    }
     return samples.length;
   } catch (err: unknown) {
     serverLog.error("[engine-drift-watcher] tick failed", err);

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -39,12 +39,28 @@ import {
 } from "@bb/sim-engine";
 
 import { prisma } from "../prisma";
+import { serverLog } from "../utils/server-log";
 import { appMetrics, type SimDriver, type SimOutcome } from "../utils/metrics";
 import { resolveDriverKind } from "./pro-league-driver-resolver";
 import {
   EngineVersionMismatchError,
   assertSimulationAllowed,
 } from "./pro-league-engine-version";
+import {
+  buildSimErrorLog,
+  buildSlowSimLog,
+  DEFAULT_SLOW_SIM_THRESHOLD_SEC,
+} from "./sim-error-logger";
+
+/**
+ * Lot 4.A.2 — seuil au-dela duquel un sim est considere "slow" et
+ * declenche un log structure pour Loki. Configurable via env pour
+ * tester sans devoir attendre 5s.
+ */
+const SLOW_SIM_THRESHOLD_SEC = (() => {
+  const raw = Number(process.env.PRO_LEAGUE_SLOW_SIM_THRESHOLD_SEC);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_SLOW_SIM_THRESHOLD_SEC;
+})();
 
 /** Statuts de match qui n'ont plus besoin d'être simulés. */
 const FINAL_STATUSES = new Set(["ready", "in_progress", "completed"]);
@@ -187,6 +203,20 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
       elapsedSec,
     );
     appMetrics.recordSimMatch({ status: "failed", driver });
+    // Lot 4.A.1 — log structured pour Loki / Grafana queries.
+    serverLog.error(
+      "sim_error",
+      buildSimErrorLog(err, {
+        matchId,
+        engineVer,
+        driver,
+        seasonId: match.season.id as string,
+        homeTeamId: match.homeTeamId as string,
+        awayTeamId: match.awayTeamId as string,
+        homeRace: homeProfile.race,
+        awayRace: awayProfile.race,
+      }),
+    );
     const msg = err instanceof Error ? err.message : "unknown";
     await prisma.proLeagueMatch.update({
       where: { id: matchId },
@@ -200,6 +230,26 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     elapsedSec,
   );
   appMetrics.recordSimMatch({ status: "success", driver });
+
+  // Lot 4.A.2 — slow sim detection : log structure si > seuil.
+  // Le seuil par defaut (5s) est genereux ; un sim full driver typique
+  // tourne en 1-3s. Au-dela, on veut un trace dans Loki pour
+  // investigation.
+  const slowLog = buildSlowSimLog({
+    matchId,
+    durationSec: elapsedSec,
+    thresholdSec: SLOW_SIM_THRESHOLD_SEC,
+    engineVer,
+    driver,
+    seasonId: match.season.id as string,
+    homeTeamId: match.homeTeamId as string,
+    awayTeamId: match.awayTeamId as string,
+    homeRace: homeProfile.race,
+    awayRace: awayProfile.race,
+  });
+  if (slowLog) {
+    serverLog.warn("sim_slow", slowLog);
+  }
 
   const compressed = await compressEvents(result.events);
   const stats = computeCompressionStats(result.events, compressed);

--- a/apps/server/src/services/sim-error-logger.test.ts
+++ b/apps/server/src/services/sim-error-logger.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests pour le sim error logger structuré (Lot 4.A.1 + 4.A.2).
+ *
+ * Couvre :
+ *   - `buildSimErrorLog` : produit un payload pino-friendly avec les
+ *     bons labels (event, errType, engineVer, driver, race, etc.).
+ *   - `buildSlowSimLog` : seuil franchi -> log warn structuré, sinon
+ *     `null`.
+ *   - Truncation du stack trace (defense-in-depth contre log bloat).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSimErrorLog,
+  buildSlowSimLog,
+  DEFAULT_SLOW_SIM_THRESHOLD_SEC,
+  truncateStack,
+} from "./sim-error-logger";
+
+describe("buildSimErrorLog — Lot 4.A.1", () => {
+  it("retourne un payload structuré avec les labels canoniques", () => {
+    const err = new Error("Sim crashed: tactic invalid");
+    err.stack = "Error: Sim crashed\n    at runFullDriver (full-driver.ts:42)";
+    const payload = buildSimErrorLog(err, {
+      matchId: "m_42",
+      engineVer: "0.16.0",
+      driver: "full",
+      seasonId: "s_2026",
+      homeTeamId: "ph",
+      awayTeamId: "pa",
+      homeRace: "Wood Elf",
+      awayRace: "Orc",
+    });
+    expect(payload).toMatchObject({
+      event: "sim_error",
+      errType: "Error",
+      errMessage: "Sim crashed: tactic invalid",
+      matchId: "m_42",
+      engineVer: "0.16.0",
+      driver: "full",
+      seasonId: "s_2026",
+      homeRace: "Wood Elf",
+      awayRace: "Orc",
+    });
+    // stack present + tronqué.
+    expect(typeof payload.stackTrace).toBe("string");
+  });
+
+  it("supporte les non-Error throws (string / unknown)", () => {
+    const payload = buildSimErrorLog("plain string error", {
+      matchId: "m_1",
+      engineVer: "0.16.0",
+      driver: "hybrid",
+      seasonId: "s_2026",
+      homeTeamId: "h",
+      awayTeamId: "a",
+    });
+    expect(payload.errType).toBe("Unknown");
+    expect(payload.errMessage).toBe("plain string error");
+    expect(payload.stackTrace).toBeUndefined();
+  });
+
+  it("normalise les classes d'erreur custom (preserve err.name)", () => {
+    class EngineVersionMismatchError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "EngineVersionMismatchError";
+      }
+    }
+    const err = new EngineVersionMismatchError("0.15.0 != 0.16.0");
+    const payload = buildSimErrorLog(err, {
+      matchId: "m",
+      engineVer: "0.16.0",
+      driver: "full",
+      seasonId: "s",
+      homeTeamId: "h",
+      awayTeamId: "a",
+    });
+    expect(payload.errType).toBe("EngineVersionMismatchError");
+  });
+});
+
+describe("truncateStack — Lot 4.A.1", () => {
+  it("preserve les stacks courtes", () => {
+    const short = "Error: x\n    at foo";
+    expect(truncateStack(short, 1000)).toBe(short);
+  });
+
+  it("coupe a la limite et ajoute un suffixe", () => {
+    const long = "x".repeat(5000);
+    const out = truncateStack(long, 100);
+    expect(out.length).toBeLessThanOrEqual(100 + 30);
+    expect(out).toMatch(/\[truncated/);
+  });
+
+  it("retourne undefined sur stack vide / null", () => {
+    expect(truncateStack(undefined, 1000)).toBeUndefined();
+    expect(truncateStack("", 1000)).toBeUndefined();
+  });
+});
+
+describe("buildSlowSimLog — Lot 4.A.2", () => {
+  it("retourne null sous le seuil (sim rapide)", () => {
+    const out = buildSlowSimLog({
+      matchId: "m1",
+      durationSec: 1.0,
+      thresholdSec: DEFAULT_SLOW_SIM_THRESHOLD_SEC,
+      engineVer: "0.16.0",
+      driver: "full",
+      seasonId: "s",
+      homeTeamId: "h",
+      awayTeamId: "a",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("retourne un payload structuré au-dessus du seuil", () => {
+    const out = buildSlowSimLog({
+      matchId: "m_slow",
+      durationSec: 7.5,
+      thresholdSec: 5.0,
+      engineVer: "0.16.0",
+      driver: "full",
+      seasonId: "s_2026",
+      homeTeamId: "ph",
+      awayTeamId: "pa",
+      homeRace: "Halfling",
+      awayRace: "Chaos",
+    });
+    expect(out).toMatchObject({
+      event: "sim_slow",
+      matchId: "m_slow",
+      durationSec: 7.5,
+      thresholdSec: 5.0,
+      driver: "full",
+      homeRace: "Halfling",
+      awayRace: "Chaos",
+    });
+  });
+
+  it("seuil exact non considere slow (strict >)", () => {
+    const out = buildSlowSimLog({
+      matchId: "m",
+      durationSec: 5.0,
+      thresholdSec: 5.0,
+      engineVer: "0.16.0",
+      driver: "hybrid",
+      seasonId: "s",
+      homeTeamId: "h",
+      awayTeamId: "a",
+    });
+    expect(out).toBeNull();
+  });
+});

--- a/apps/server/src/services/sim-error-logger.ts
+++ b/apps/server/src/services/sim-error-logger.ts
@@ -1,0 +1,161 @@
+/**
+ * Sim error / slow-sim structured logger (Lot 4.A.1 + 4.A.2).
+ *
+ * Phase 4.A — production hardening : on enrichit les logs sim-engine
+ * avec des labels structurés Loki-friendly pour permettre des queries
+ * du type :
+ *
+ *   {service="bb-server", event="sim_error", driver="full"} | json |
+ *     errType=~"EngineVersionMismatch.*" | line_format "..."
+ *
+ * et des alertes Grafana ciblees par `errType`, `engineVer`, `race`
+ * sans avoir a parser les messages.
+ *
+ * Architecture
+ * ------------
+ *  - `buildSimErrorLog(err, ctx)` : pure, retourne un objet
+ *    pino-serialisable avec les bons labels. Le caller appelle
+ *    `serverLog.error("sim failed", payload)` (pino merge).
+ *  - `buildSlowSimLog({ durationSec, thresholdSec, ... })` : pure,
+ *    retourne `null` si sous le seuil, sinon un payload `event=sim_slow`.
+ *  - `truncateStack(stack, maxLen)` : pure, evite les logs de plusieurs
+ *    Mo si une stack trace devient pathologique (cas d'un sim qui
+ *    crash en cascade dans game-engine).
+ *
+ * Pure — aucun `serverLog.*` ici. Le caller decide du niveau (`.error`
+ * pour sim_error, `.warn` pour sim_slow). Permet d'eviter les
+ * mocks pino dans les tests et de garder ce fichier 100% testable.
+ */
+
+/** Seuil par defaut au-dela duquel un sim est considere "slow" (5s). */
+export const DEFAULT_SLOW_SIM_THRESHOLD_SEC = 5;
+
+/** Limite de chars du stack trace conserves dans le log structure. */
+export const DEFAULT_STACK_TRACE_LIMIT = 2000;
+
+export type SimDriver = "hybrid" | "full";
+
+export interface SimErrorContext {
+  readonly matchId: string;
+  readonly engineVer: string;
+  readonly driver: SimDriver;
+  readonly seasonId: string;
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  readonly homeRace?: string;
+  readonly awayRace?: string;
+}
+
+export interface SimErrorLog {
+  readonly event: "sim_error";
+  readonly errType: string;
+  readonly errMessage: string;
+  readonly stackTrace?: string;
+  readonly matchId: string;
+  readonly engineVer: string;
+  readonly driver: SimDriver;
+  readonly seasonId: string;
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  readonly homeRace?: string;
+  readonly awayRace?: string;
+}
+
+export interface SlowSimLogInput extends SimErrorContext {
+  readonly durationSec: number;
+  readonly thresholdSec: number;
+}
+
+export interface SlowSimLog {
+  readonly event: "sim_slow";
+  readonly matchId: string;
+  readonly durationSec: number;
+  readonly thresholdSec: number;
+  readonly engineVer: string;
+  readonly driver: SimDriver;
+  readonly seasonId: string;
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  readonly homeRace?: string;
+  readonly awayRace?: string;
+}
+
+/**
+ * Tronque un stack trace a `maxLen` chars en preservant le suffixe
+ * `[truncated N chars]`. Retourne undefined sur stack vide / null.
+ */
+export function truncateStack(
+  stack: string | undefined,
+  maxLen: number,
+): string | undefined {
+  if (!stack || stack.length === 0) return undefined;
+  if (stack.length <= maxLen) return stack;
+  const dropped = stack.length - maxLen;
+  return stack.slice(0, maxLen) + ` [truncated ${dropped} chars]`;
+}
+
+/**
+ * Construit le payload pino-friendly pour un sim_error. Le caller
+ * appelle :
+ *
+ *   serverLog.error("Sim failed", buildSimErrorLog(err, ctx))
+ *
+ * Pino merge les champs de l'objet dans le record final, qui est
+ * ensuite ingere par Loki pour les queries structurees.
+ */
+export function buildSimErrorLog(
+  err: unknown,
+  ctx: SimErrorContext,
+): SimErrorLog {
+  const isError = err instanceof Error;
+  const errType = isError ? err.name || "Error" : "Unknown";
+  const errMessage = isError
+    ? err.message
+    : typeof err === "string"
+      ? err
+      : "unknown";
+  const stackTrace = isError
+    ? truncateStack(err.stack, DEFAULT_STACK_TRACE_LIMIT)
+    : undefined;
+  return {
+    event: "sim_error",
+    errType,
+    errMessage,
+    ...(stackTrace ? { stackTrace } : {}),
+    matchId: ctx.matchId,
+    engineVer: ctx.engineVer,
+    driver: ctx.driver,
+    seasonId: ctx.seasonId,
+    homeTeamId: ctx.homeTeamId,
+    awayTeamId: ctx.awayTeamId,
+    ...(ctx.homeRace ? { homeRace: ctx.homeRace } : {}),
+    ...(ctx.awayRace ? { awayRace: ctx.awayRace } : {}),
+  };
+}
+
+/**
+ * Construit le payload pour un sim_slow si la duree depasse strict le
+ * seuil. Sinon retourne `null` (no-op cote caller).
+ *
+ * Strict > permet aux tests deterministes de fixer des seuils a
+ * exactement 5s sans tomber sur la frontiere.
+ */
+export function buildSlowSimLog(input: SlowSimLogInput): SlowSimLog | null {
+  if (!Number.isFinite(input.durationSec) || !Number.isFinite(input.thresholdSec)) {
+    return null;
+  }
+  if (input.durationSec <= input.thresholdSec) return null;
+  return {
+    event: "sim_slow",
+    matchId: input.matchId,
+    durationSec: input.durationSec,
+    thresholdSec: input.thresholdSec,
+    engineVer: input.engineVer,
+    driver: input.driver,
+    seasonId: input.seasonId,
+    homeTeamId: input.homeTeamId,
+    awayTeamId: input.awayTeamId,
+    ...(input.homeRace ? { homeRace: input.homeRace } : {}),
+    ...(input.awayRace ? { awayRace: input.awayRace } : {}),
+  };
+}

--- a/apps/server/src/utils/metrics.test.ts
+++ b/apps/server/src/utils/metrics.test.ts
@@ -231,4 +231,30 @@ describe("metrics registry", () => {
       );
     });
   });
+
+  describe("Pro League drift alerts metrics (Lot 4.A.3)", () => {
+    it("setEngineDriftAlertsCount expose la jauge avec le label severity", async () => {
+      metrics.setEngineDriftAlertsCount("warn", 3);
+      metrics.setEngineDriftAlertsCount("critical", 1);
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(
+        /nuffle_engine_drift_alerts_count\{severity="warn"\} 3/,
+      );
+      expect(text).toMatch(
+        /nuffle_engine_drift_alerts_count\{severity="critical"\} 1/,
+      );
+    });
+
+    it("setEngineDriftAlertsCount clamp les valeurs negatives / NaN à 0", async () => {
+      metrics.setEngineDriftAlertsCount("warn", -5);
+      metrics.setEngineDriftAlertsCount("critical", Number.NaN);
+      const text = await metricsExposition(metrics.registry);
+      expect(text).toMatch(
+        /nuffle_engine_drift_alerts_count\{severity="warn"\} 0/,
+      );
+      expect(text).toMatch(
+        /nuffle_engine_drift_alerts_count\{severity="critical"\} 0/,
+      );
+    });
+  });
 });

--- a/apps/server/src/utils/metrics.ts
+++ b/apps/server/src/utils/metrics.ts
@@ -95,6 +95,9 @@ export interface EngineDriftLabels {
   seasonId: string;
 }
 
+/** Lot 4.A.3 — severite d'une alerte drift (warn = >10%, critical = >25%). */
+export type DriftAlertSeverity = "warn" | "critical";
+
 /**
  * Lot 3.B.2 — labels pour les jauges du comparator hybrid vs full.
  * `pairing` est concaténé `<homeTeamId>__<awayTeamId>` côté caller pour
@@ -136,6 +139,8 @@ export interface MetricsRegistry {
   observeBroadcasterDispatchLag(ms: number): void;
   /** Engine drift — set la dérive d'une métrique vs baseline (en delta relatif, ex: 0.04 pour +4%). */
   setEngineDrift(labels: EngineDriftLabels, value: number): void;
+  /** Lot 4.A.3 — set le compteur d'alertes drift par severite. */
+  setEngineDriftAlertsCount(severity: DriftAlertSeverity, count: number): void;
 
   /** Lot 3.B.2 — set les jauges du comparator hybrid vs full pour un pairing. */
   setEngineCompareStats(
@@ -261,6 +266,16 @@ export function buildMetricsRegistry(): MetricsRegistry {
     registers: [registry],
   });
 
+  // Lot 4.A.3 — compteur d'alertes drift par severite (warn / critical).
+  // Permet a Grafana de declencher une notif Discord quand le compteur
+  // augmente plus rapidement que threshold/h sur une fenetre glissante.
+  const engineDriftAlertsCount = new Gauge({
+    name: "nuffle_engine_drift_alerts_count",
+    help: "Nombre d'alertes drift actuellement actives par severite (Lot 4.A.3)",
+    labelNames: ["severity"],
+    registers: [registry],
+  });
+
   // Lot 3.B.2 — jauges comparator hybrid vs full driver, par pairing.
   const engineCompareScoreDeltaMean = new Gauge({
     name: "nuffle_engine_compare_score_delta_mean",
@@ -360,6 +375,11 @@ export function buildMetricsRegistry(): MetricsRegistry {
         },
         safe,
       );
+    },
+    setEngineDriftAlertsCount(severity, count) {
+      const safe =
+        Number.isFinite(count) && count >= 0 ? Math.floor(count) : 0;
+      engineDriftAlertsCount.set({ severity }, safe);
     },
     setEngineCompareStats(labels, stats) {
       const safe = (n: number): number => (Number.isFinite(n) ? n : 0);


### PR DESCRIPTION
## Pourquoi

Phase 4.A — production hardening / observability. Aujourd'hui :
- Les sim errors arrivent dans pino comme **strings opaques**. Les queries Loki *"alertes critical sur engineVer 0.16.0"* sont impossibles sans labels structurés.
- **Aucun seuil "slow sim"** : un full driver qui prend 30s passe sous le radar tant qu'il ne crash pas.
- Le drift watcher (Lot 2.A.5) push des gauges mais ne déclenche aucune **alerte structurée** quand une race sort des bornes `FUMBBL_TOLERANCE`.

Ce lot ferme ces 3 gaps en une PR cohérente.

## Comment

1. **`sim-error-logger.ts`** (nouveau, pure) :
   - `buildSimErrorLog(err, ctx)` : payload pino-friendly avec labels (`event`, `errType`, `errMessage`, `engineVer`, `driver`, `seasonId`, `matchId`, `homeRace`, `awayRace`, `stackTrace`). Stack tronqué à 2000 chars pour éviter les log bloats.
   - `buildSlowSimLog({ durationSec, thresholdSec, ... })` : retourne `null` sous le seuil (no-op caller), sinon payload `event=sim_slow`.
   - `truncateStack` helper pure.
   - Default seuil 5s, override `PRO_LEAGUE_SLOW_SIM_THRESHOLD_SEC`.

2. **Wiring dans `pro-league-sim-runner.ts`** :
   - Catch sim error → `serverLog.error("sim_error", buildSimErrorLog(...))`. Le payload ajoute `homeRace` / `awayRace` lus des `PRO_LEAGUE_TEAM_BY_ID` pour permettre les queries Loki *"errors par race"*.
   - Après sim success, calcule `buildSlowSimLog` ; si > seuil, `serverLog.warn("sim_slow", ...)`.

3. **`pro-league-engine-drift-watcher.ts`** étendu :
   - Constants `DRIFT_WARN_THRESHOLD = 0.1`, `DRIFT_CRITICAL_THRESHOLD = 0.25`, `MIN_MATCHES_FOR_ALERT = 5` (variance trop forte sous ce nb d'échantillons).
   - `detectDriftAlerts(samples, options)` (pure) : transforme les drift samples en alertes typées `{ severity, metric, race, ... }`.
   - `countAlertsBySeverity(alerts)` (pure) : agrège pour push gauge.
   - `runDriftTick` étend l'output : appelle `detectDriftAlerts`, émet `serverLog.warn("drift_alert", ...)` par alerte détectée, update les jauges `nuffle_engine_drift_alerts_count{severity}`.

4. **Metrics** (`utils/metrics.ts`) :
   - Nouvelle gauge `nuffle_engine_drift_alerts_count{severity}` : warn / critical. Permet à Grafana de déclencher des notifs quand le compteur augmente.
   - `setEngineDriftAlertsCount(severity, count)` sur `MetricsRegistry`.

## Tests

- `sim-error-logger.test.ts` : 9 tests (payload structure, non-Error throws, custom `err.name`, stack truncation).
- `pro-league-engine-drift-watcher.test.ts` : +9 tests (`detectDriftAlerts` seuils, `MIN_MATCHES_FOR_ALERT`, override seuils, `countAlertsBySeverity`).
- `metrics.test.ts` : +2 tests (gauge alert counter, NaN clamp).
- `pro-league-sim-runner.test.ts` : 18 tests existants verts (le structured log apparaît bien dans le stdout test).

### Résultats

- `@bb/server` : 70 tests verts sur les 4 suites touchées (+20 nouveaux)
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte (typecheck + tests)
- [ ] En prod, un sim qui crash produit un log `event="sim_error"` avec tous les labels (errType, engineVer, driver, race, etc.)
- [ ] Forcer un slow sim via `PRO_LEAGUE_SLOW_SIM_THRESHOLD_SEC=0.001` → log `event="sim_slow"` apparaît à chaque sim
- [ ] Après une saison full driver, vérifier que `nuffle_engine_drift_alerts_count{severity="warn"}` reflète bien le nombre de races > 10% drift
- [ ] Loki query `{event="sim_error"} | json | errType="EngineVersionMismatchError"` retourne les bons logs

## Hors scope

- **Grafana alert rules** : à configurer côté infra Grafana, pas dans le code. La gauge `nuffle_engine_drift_alerts_count` + les logs structurés `event=drift_alert | event=sim_error | event=sim_slow` sont la matière première ; les seuils de notification (Discord webhook, etc.) seront déclarés en YAML Grafana côté ops.
- **Stack trace profiling pour les slow sims** : on log la durée mais pas une stack samplée. `console.profile`-style sampling demanderait un Node.js profiler agent (clinic, 0x...) trop intrusif pour cette PR. Le `matchId` loggé permet de re-rouler en local et profiler.
- **Loki structured queries documentation** : à ajouter au runbook ops quand on aura branché Grafana.

## Refs

- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 4.A)
- Lot 2.A.5 (drift watcher initial)
- PR #717 (Lot 3.C.2 SPP) — pattern de structured logging aligné

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_