### PR TITLE
feat(pro-league): opt-in CPU profile capture pour les slow sims (Lot 4.A.2)

### DIFF
--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -51,6 +51,11 @@ import {
   buildSlowSimLog,
   DEFAULT_SLOW_SIM_THRESHOLD_SEC,
 } from "./sim-error-logger";
+import {
+  captureProfileIfSlow,
+  CpuProfilerSession,
+  nodeInspectorAdapter,
+} from "./sim-cpu-profiler";
 
 /**
  * Lot 4.A.2 — seuil au-dela duquel un sim est considere "slow" et
@@ -61,6 +66,19 @@ const SLOW_SIM_THRESHOLD_SEC = (() => {
   const raw = Number(process.env.PRO_LEAGUE_SLOW_SIM_THRESHOLD_SEC);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_SLOW_SIM_THRESHOLD_SEC;
 })();
+
+/**
+ * Lot 4.A.2 — opt-in CPU profiling pour les slow sims. Off par defaut
+ * (overhead V8 ~5-10%). Quand ON, on capture un .cpuprofile pour
+ * chaque sim et on le garde uniquement si la duree depasse le seuil.
+ *
+ * Set `PRO_LEAGUE_PROFILE_SLOW_SIMS=1` pour activer. Output dans
+ * `PRO_LEAGUE_PROFILE_DIR` (default `/tmp/sim-profiles`). Les
+ * fichiers .cpuprofile sont ouvrables dans Chrome DevTools.
+ */
+const CPU_PROFILE_ENABLED = process.env.PRO_LEAGUE_PROFILE_SLOW_SIMS === "1";
+const CPU_PROFILE_DIR =
+  process.env.PRO_LEAGUE_PROFILE_DIR || "/tmp/sim-profiles";
 
 /** Statuts de match qui n'ont plus besoin d'être simulés. */
 const FINAL_STATUSES = new Set(["ready", "in_progress", "completed"]);
@@ -192,6 +210,28 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
     matchOverride: (match.driverKindOverride as string | null) ?? null,
   });
 
+  // Lot 4.A.2 — opt-in CPU profile : demarre la session avant le sim
+  // et la stoppe apres. On garde uniquement si slow (cf.
+  // captureProfileIfSlow plus bas).
+  let cpuProfilerSession: CpuProfilerSession | null = null;
+  if (CPU_PROFILE_ENABLED) {
+    try {
+      cpuProfilerSession = new CpuProfilerSession(nodeInspectorAdapter());
+      await cpuProfilerSession.start();
+    } catch (err: unknown) {
+      // Best-effort : si le profiler n'arrive pas a demarrer, on
+      // continue sans (logging warn pour visibilite mais pas
+      // bloquant pour le sim).
+      const msg = err instanceof Error ? err.message : "unknown";
+      serverLog.warn(
+        "sim_profiler_start_failed",
+        { event: "sim_profiler_start_failed", matchId, error: msg },
+      );
+      cpuProfilerSession?.dispose();
+      cpuProfilerSession = null;
+    }
+  }
+
   let result: SimResult;
   const simStart = process.hrtime.bigint();
   try {
@@ -218,6 +258,16 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
       }),
     );
     const msg = err instanceof Error ? err.message : "unknown";
+    // Lot 4.A.2 — cleanup CPU profiler en cas d'erreur sim, sinon le
+    // session reste hanging et fuite de la memoire V8.
+    if (cpuProfilerSession) {
+      try {
+        await cpuProfilerSession.stop();
+      } catch {
+        /* best-effort */
+      }
+      cpuProfilerSession.dispose();
+    }
     await prisma.proLeagueMatch.update({
       where: { id: matchId },
       data: { status: "failed", simulatedAt: new Date() },
@@ -249,6 +299,54 @@ export async function simulateProMatch(matchId: string): Promise<boolean> {
   });
   if (slowLog) {
     serverLog.warn("sim_slow", slowLog);
+  }
+
+  // Lot 4.A.2 — stop CPU profile + dump si slow.
+  if (cpuProfilerSession) {
+    try {
+      const profile = await cpuProfilerSession.stop();
+      const { writeFile } = await import("node:fs/promises");
+      const { mkdir } = await import("node:fs/promises");
+      // mkdir best-effort : si le repertoire existe deja, on ignore
+      // l'erreur EEXIST.
+      try {
+        await mkdir(CPU_PROFILE_DIR, { recursive: true });
+      } catch {
+        /* ignore */
+      }
+      const captured = await captureProfileIfSlow({
+        profile,
+        matchId,
+        durationSec: elapsedSec,
+        thresholdSec: SLOW_SIM_THRESHOLD_SEC,
+        profileDir: CPU_PROFILE_DIR,
+        writeFile: (path, data) => writeFile(path, data, "utf-8"),
+      });
+      if (captured.saved && captured.path) {
+        serverLog.info("sim_profile_captured", {
+          event: "sim_profile_captured",
+          matchId,
+          path: captured.path,
+          durationSec: elapsedSec,
+          driver,
+        });
+      } else if (captured.error) {
+        serverLog.warn("sim_profile_capture_failed", {
+          event: "sim_profile_capture_failed",
+          matchId,
+          error: captured.error,
+        });
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "unknown";
+      serverLog.warn("sim_profiler_stop_failed", {
+        event: "sim_profiler_stop_failed",
+        matchId,
+        error: msg,
+      });
+    } finally {
+      cpuProfilerSession.dispose();
+    }
   }
 
   const compressed = await compressEvents(result.events);

--- a/apps/server/src/services/sim-cpu-profiler.test.ts
+++ b/apps/server/src/services/sim-cpu-profiler.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests pour le CPU profiler des slow sims (Lot 4.A.2).
+ *
+ * Le profiler est branche sur `node:inspector`. Pour rester unit-testable
+ * sans demarrer une vraie session V8, on injecte un `InspectorAdapter`
+ * mockable.
+ *
+ * Couvre :
+ *   - FSM start -> recording -> stop avec un adapter mock.
+ *   - `captureProfileIfSlow` n'ecrit le profile que si duration > seuil.
+ *   - Defense-in-depth : un crash de l'adapter ne propage pas (best
+ *     effort logging).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildProfileFilename,
+  captureProfileIfSlow,
+  CpuProfilerSession,
+  type InspectorAdapter,
+} from "./sim-cpu-profiler";
+
+function buildMockAdapter(): {
+  adapter: InspectorAdapter;
+  calls: { start: number; stop: number; lastProfile: object | null };
+} {
+  const calls = { start: 0, stop: 0, lastProfile: null as object | null };
+  const fakeProfile = { nodes: [], samples: [], timeDeltas: [] };
+  const adapter: InspectorAdapter = {
+    async start() {
+      calls.start += 1;
+    },
+    async stop() {
+      calls.stop += 1;
+      calls.lastProfile = fakeProfile;
+      return fakeProfile;
+    },
+    dispose() {
+      /* no-op */
+    },
+  };
+  return { adapter, calls };
+}
+
+describe("CpuProfilerSession — Lot 4.A.2", () => {
+  it("FSM : idle -> recording -> stopped", async () => {
+    const { adapter, calls } = buildMockAdapter();
+    const session = new CpuProfilerSession(adapter);
+
+    expect(session.state).toBe("idle");
+    await session.start();
+    expect(session.state).toBe("recording");
+    expect(calls.start).toBe(1);
+
+    const profile = await session.stop();
+    expect(session.state).toBe("stopped");
+    expect(calls.stop).toBe(1);
+    expect(profile).toBeDefined();
+  });
+
+  it("rejette stop avant start", async () => {
+    const { adapter } = buildMockAdapter();
+    const session = new CpuProfilerSession(adapter);
+    await expect(session.stop()).rejects.toThrow(/not recording/i);
+  });
+
+  it("rejette double start (FSM strict)", async () => {
+    const { adapter } = buildMockAdapter();
+    const session = new CpuProfilerSession(adapter);
+    await session.start();
+    await expect(session.start()).rejects.toThrow(/already recording/i);
+  });
+
+  it("dispose appelle adapter.dispose", async () => {
+    const adapter = buildMockAdapter().adapter;
+    const disposeSpy = vi.fn();
+    const session = new CpuProfilerSession({
+      ...adapter,
+      dispose: disposeSpy,
+    });
+    session.dispose();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe("buildProfileFilename — Lot 4.A.2", () => {
+  it("inclut matchId + timestamp ISO + extension .cpuprofile", () => {
+    const at = new Date("2026-05-09T12:34:56.789Z");
+    const out = buildProfileFilename("m_abc123", at);
+    expect(out).toContain("m_abc123");
+    expect(out).toContain("2026-05-09T12-34-56");
+    expect(out.endsWith(".cpuprofile")).toBe(true);
+  });
+
+  it("sanitize les caracteres interdits dans le matchId", () => {
+    const at = new Date("2026-05-09T00:00:00Z");
+    // Un matchId avec slash / colon est theoriquement impossible (cuid)
+    // mais on se protège en runtime.
+    const out = buildProfileFilename("a/b:c", at);
+    expect(out).not.toMatch(/[/:]/);
+  });
+});
+
+describe("captureProfileIfSlow — Lot 4.A.2", () => {
+  it("ne sauvegarde pas si durationSec <= thresholdSec", async () => {
+    const writes: Array<{ path: string; data: string }> = [];
+    const out = await captureProfileIfSlow({
+      profile: { nodes: [] },
+      matchId: "m1",
+      durationSec: 1.0,
+      thresholdSec: 5.0,
+      profileDir: "/tmp/sim-profiles",
+      writeFile: async (path, data) => {
+        writes.push({ path, data });
+      },
+    });
+    expect(out.saved).toBe(false);
+    expect(out.path).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+
+  it("sauvegarde le profile JSON quand le sim est slow", async () => {
+    const writes: Array<{ path: string; data: string }> = [];
+    const profile = { nodes: [{ id: 1 }], samples: [1] };
+    const out = await captureProfileIfSlow({
+      profile,
+      matchId: "m_slow",
+      durationSec: 7.5,
+      thresholdSec: 5.0,
+      profileDir: "/tmp/sim-profiles",
+      writeFile: async (path, data) => {
+        writes.push({ path, data });
+      },
+    });
+    expect(out.saved).toBe(true);
+    expect(out.path).toMatch(/m_slow/);
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0].data)).toEqual(profile);
+  });
+
+  it("propage l'erreur du writeFile sans crasher (returns saved=false)", async () => {
+    const out = await captureProfileIfSlow({
+      profile: { nodes: [] },
+      matchId: "m_slow",
+      durationSec: 7.5,
+      thresholdSec: 5.0,
+      profileDir: "/tmp/sim-profiles",
+      writeFile: async () => {
+        throw new Error("disk full");
+      },
+    });
+    expect(out.saved).toBe(false);
+    expect(out.error).toMatch(/disk full/);
+  });
+
+  it("ne sauvegarde pas si profile est null/undefined", async () => {
+    const writes: Array<{ path: string; data: string }> = [];
+    const out = await captureProfileIfSlow({
+      profile: null,
+      matchId: "m",
+      durationSec: 7.5,
+      thresholdSec: 5.0,
+      profileDir: "/tmp/sim-profiles",
+      writeFile: async (path, data) => {
+        writes.push({ path, data });
+      },
+    });
+    expect(out.saved).toBe(false);
+    expect(out.path).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/apps/server/src/services/sim-cpu-profiler.ts
+++ b/apps/server/src/services/sim-cpu-profiler.ts
@@ -1,0 +1,195 @@
+/**
+ * CPU profiler pour les slow sims (Lot 4.A.2).
+ *
+ * Strategie
+ * ---------
+ * Quand `PRO_LEAGUE_PROFILE_SLOW_SIMS=1` est positionne, on :
+ *  1. demarre une session inspector V8 avant `simulateMatch`,
+ *  2. l'arrete apres la sim (recupere le profile),
+ *  3. ne le sauvegarde sur disque QUE si la duree depasse le seuil
+ *     (sinon on jette le profile pour ne pas saturer le disque).
+ *
+ * Le `.cpuprofile` produit est ouvrable directement dans Chrome
+ * DevTools (Performance > Load profile...) pour identifier les
+ * fonctions qui consomment le plus de temps.
+ *
+ * Architecture
+ * ------------
+ *  - `InspectorAdapter` : interface DI pour `node:inspector` Session.
+ *    Permet de mocker dans les tests sans demarrer une vraie session V8.
+ *  - `nodeInspectorAdapter()` : factory qui retourne un adapter reel.
+ *  - `CpuProfilerSession` : FSM idle -> recording -> stopped.
+ *  - `captureProfileIfSlow()` : decide save/discard selon le seuil.
+ *  - `buildProfileFilename()` : pure, formatte le path canonical.
+ *
+ * Tradeoffs
+ * ---------
+ * Le profiler V8 a un overhead de ~5-10% sur le temps CPU. On l'active
+ * uniquement quand opt-in (env), et seul un sample par tick (single-
+ * threaded) au max. Les tests Vitest n'allument pas le real adapter.
+ */
+
+import { Session } from "node:inspector";
+
+/** Adapter pour `node:inspector`, mockable en test. */
+export interface InspectorAdapter {
+  /** Demarre Profiler.enable + Profiler.start. */
+  start(): Promise<void>;
+  /** Stop Profiler, retourne le profile JSON brut. */
+  stop(): Promise<object>;
+  /** Disconnect la session inspector (optionnel). */
+  dispose(): void;
+}
+
+/**
+ * Factory pour un adapter `node:inspector` reel. A utiliser uniquement
+ * cote prod / dev local — les tests injectent un mock.
+ */
+export function nodeInspectorAdapter(): InspectorAdapter {
+  const session = new Session();
+  let connected = false;
+
+  function ensureConnected(): void {
+    if (!connected) {
+      session.connect();
+      connected = true;
+    }
+  }
+
+  return {
+    async start() {
+      ensureConnected();
+      await new Promise<void>((resolve, reject) => {
+        session.post("Profiler.enable", (err) =>
+          err ? reject(err) : resolve(),
+        );
+      });
+      await new Promise<void>((resolve, reject) => {
+        session.post("Profiler.start", (err) =>
+          err ? reject(err) : resolve(),
+        );
+      });
+    },
+    async stop() {
+      const result = await new Promise<{ profile: object }>(
+        (resolve, reject) => {
+          session.post("Profiler.stop", (err, params) =>
+            err ? reject(err) : resolve(params as { profile: object }),
+          );
+        },
+      );
+      return result.profile;
+    },
+    dispose() {
+      if (connected) {
+        session.disconnect();
+        connected = false;
+      }
+    },
+  };
+}
+
+export type CpuProfilerState = "idle" | "recording" | "stopped";
+
+/**
+ * Wrapper FSM autour d'un `InspectorAdapter`. Une instance correspond
+ * a une seule sim (start -> stop). Apres `stop`, l'instance est
+ * inutilisable — creer un nouveau session pour le sim suivant.
+ */
+export class CpuProfilerSession {
+  private _state: CpuProfilerState = "idle";
+
+  constructor(private readonly adapter: InspectorAdapter) {}
+
+  get state(): CpuProfilerState {
+    return this._state;
+  }
+
+  async start(): Promise<void> {
+    if (this._state !== "idle") {
+      throw new Error(
+        `CpuProfilerSession: cannot start, already ${this._state}`,
+      );
+    }
+    await this.adapter.start();
+    this._state = "recording";
+  }
+
+  async stop(): Promise<object> {
+    if (this._state !== "recording") {
+      throw new Error(
+        `CpuProfilerSession: not recording (state=${this._state})`,
+      );
+    }
+    const profile = await this.adapter.stop();
+    this._state = "stopped";
+    return profile;
+  }
+
+  dispose(): void {
+    this.adapter.dispose();
+  }
+}
+
+/**
+ * Construit le filename canonical pour un profile : `<matchId>-<timestamp>.cpuprofile`.
+ * Sanitize les caracteres interdits sur certains FS (slash, colon, espace).
+ */
+export function buildProfileFilename(matchId: string, at: Date): string {
+  const safeId = matchId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  // ISO sans le `.NNNZ` final + colons remplaces (FS Windows-friendly).
+  const iso = at.toISOString().slice(0, 19).replace(/:/g, "-");
+  return `${safeId}-${iso}.cpuprofile`;
+}
+
+export interface CaptureProfileIfSlowInput {
+  readonly profile: object | null | undefined;
+  readonly matchId: string;
+  readonly durationSec: number;
+  readonly thresholdSec: number;
+  readonly profileDir: string;
+  /** DI : permet aux tests d'eviter le vrai writeFile. */
+  readonly writeFile: (path: string, data: string) => Promise<void>;
+  /** DI : override de `new Date()` pour la determinisme test. */
+  readonly now?: () => Date;
+}
+
+export interface CaptureProfileIfSlowResult {
+  readonly saved: boolean;
+  readonly path: string | null;
+  readonly error?: string;
+}
+
+/**
+ * Decide save/discard du profile selon le seuil. Si saved, ecrit le
+ * profile JSON dans `<profileDir>/<filename>` via le `writeFile`
+ * injecte. Erreur isolee : ne propage pas, retourne `error` dans le
+ * resultat (pour que le caller sim-runner ne crashe pas a cause d'un
+ * disque plein ou similaire).
+ */
+export async function captureProfileIfSlow(
+  input: CaptureProfileIfSlowInput,
+): Promise<CaptureProfileIfSlowResult> {
+  if (input.durationSec <= input.thresholdSec) {
+    return { saved: false, path: null };
+  }
+  if (!input.profile) {
+    return { saved: false, path: null };
+  }
+  const at = input.now ? input.now() : new Date();
+  const filename = buildProfileFilename(input.matchId, at);
+  // Path naïf (no `path.join` pour rester pure / sans node:path) — le
+  // profileDir peut deja se terminer par "/".
+  const sep = input.profileDir.endsWith("/") ? "" : "/";
+  const fullPath = `${input.profileDir}${sep}${filename}`;
+  try {
+    await input.writeFile(fullPath, JSON.stringify(input.profile));
+    return { saved: true, path: fullPath };
+  } catch (err: unknown) {
+    return {
+      saved: false,
+      path: null,
+      error: err instanceof Error ? err.message : "unknown",
+    };
+  }
+}


### PR DESCRIPTION
## Pourquoi

Lot 4.A précédent (PR #720) détecte les slow sims et émet un log structuré `event=sim_slow`. Mais on n'a aucun moyen de comprendre **pourquoi** un sim donné a dépassé le seuil — quelle fonction du full driver / game-engine consomme le temps ?

Ce lot ajoute un **CPU profile capture opt-in** qui produit un fichier `.cpuprofile` ouvrable dans Chrome DevTools (Performance > Load profile…). On garde uniquement les profiles des sims slow pour limiter le disk usage.

## Comment

1. **`sim-cpu-profiler.ts`** (nouveau) :
   - `InspectorAdapter` : interface DI pour `node:inspector` Session (mockable en test).
   - `nodeInspectorAdapter()` : factory réelle, gère `Profiler.enable` + `Profiler.start` + `Profiler.stop` async via `session.post`.
   - `CpuProfilerSession` : FSM strict `idle → recording → stopped`. Reject double start, stop avant start.
   - `buildProfileFilename(matchId, at)` : pure, retourne `<safeId>-<iso-no-colons>.cpuprofile`.
   - `captureProfileIfSlow({ profile, durationSec, thresholdSec, … })` : no-op si sous le seuil OU profile null. Sinon écrit le JSON via le `writeFile` injecté. Erreur isolée : retourne `error`, **ne propage pas** (disque plein → log warn, sim continue).

2. **Wiring dans `pro-league-sim-runner.ts`** :
   - `PRO_LEAGUE_PROFILE_SLOW_SIMS=1` (env, **off par défaut**) active le profiler. Overhead V8 ~5-10% donc opt-in.
   - `PRO_LEAGUE_PROFILE_DIR` (default `/tmp/sim-profiles`) : répertoire d'output, créé avec `mkdir -p` au runtime.
   - Séquence :
     - **avant sim** : `new CpuProfilerSession(nodeInspectorAdapter())` + `.start()`. Best-effort : si start échoue → log `sim_profiler_start_failed` et continue sans profiler.
     - **après sim success** : `.stop()` + `captureProfileIfSlow` + log `sim_profile_captured` avec le path.
     - **sur sim error** : `.stop()` + `.dispose()` dans le catch pour éviter une fuite mémoire V8.

## Tests

`sim-cpu-profiler.test.ts` — 10 tests :
- FSM `idle → recording → stopped` via mock adapter.
- Reject stop avant start, double start.
- `dispose` appelle `adapter.dispose`.
- `buildProfileFilename` : matchId sanitize, ISO sans colons.
- `captureProfileIfSlow` : skip sous seuil, save au-dessus, profile null skip, error `writeFile` capturé en `error`.

### Résultats

- `@bb/server` : 10 nouveaux tests
- `pnpm typecheck` : clean monorepo
- Tests existants (`sim-runner`, `sim-error-logger`) : 37 verts

## Test plan

- [ ] CI verte (typecheck + tests)
- [ ] En prod avec `PRO_LEAGUE_PROFILE_SLOW_SIMS=1` + `PRO_LEAGUE_SLOW_SIM_THRESHOLD_SEC=0.001`, chaque sim génère un `.cpuprofile` dans `/tmp/sim-profiles`
- [ ] Charger un `.cpuprofile` dans Chrome DevTools (Performance) montre la stack avec les noms de fonction sim-engine / game-engine
- [ ] Sans le flag, `process.memoryUsage()` reste stable (pas de session inspector qui fuite)
- [ ] Un sim qui crash dispose bien le profiler (vérifier via repeated runs)

## Hors scope

- **Sampling au lieu de full profile** : Node inspector capture une trace complète par défaut. Pour un sim de 5s, ~50KB JSON. OK pour le MVP. Si on profile tous les sims (1000+/saison), passer à un sampler ad-hoc.
- **Auto-cleanup vieux profiles** : aucun TTL sur les fichiers écrits dans `/tmp/sim-profiles`. À faire via un cron systemd ou un job applicatif si le répertoire déborde.
- **Upload vers S3 / object storage** : les profiles restent locaux au pod. Pour une investigation post-mortem, télécharger via SSH ou exposer via une route admin authentifiée (lot futur).

## Refs

- PR #720 (Lot 4.A — structured logs)
- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 4.A.2)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_