### PR TITLE
feat(sim-engine): cross-version baseline comparator + pnpm sim:compare-versions (Lot 4.B.1)

### DIFF
--- a/packages/sim-engine/package.json
+++ b/packages/sim-engine/package.json
@@ -19,6 +19,7 @@
     "sim:bench:ci": "tsx scripts/bench-ci.ts",
     "sim:bench:snapshot": "tsx scripts/bench-baseline-snapshot.ts",
     "sim:compare": "tsx scripts/compare-drivers.ts",
+    "sim:compare-versions": "tsx scripts/compare-versions.ts",
     "sim:perf": "tsx scripts/perf-baseline.ts",
     "sim:replay": "tsx scripts/replay.ts"
   },

--- a/packages/sim-engine/scripts/compare-versions.ts
+++ b/packages/sim-engine/scripts/compare-versions.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+/**
+ * `pnpm sim:compare-versions` — Lot 4.B.1.
+ *
+ * Compare deux snapshots `bench-baseline.json` produits sur des
+ * `engineVer` differents et imprime un rapport de drift.
+ *
+ * Usage typique :
+ *   git checkout v0.15.0
+ *   pnpm sim:bench:snapshot > /tmp/baseline-0.15.0.json
+ *   git checkout v0.16.0
+ *   pnpm sim:bench:snapshot > /tmp/baseline-0.16.0.json
+ *   pnpm sim:compare-versions \
+ *     --base /tmp/baseline-0.15.0.json \
+ *     --head /tmp/baseline-0.16.0.json
+ *
+ * Options
+ * -------
+ *   --base=<path>        Baseline "ancienne version" (required)
+ *   --head=<path>        Baseline "nouvelle version" (required)
+ *   --warn=<n>           Threshold relatif warn (default 0.10 = 10%)
+ *   --critical=<n>       Threshold relatif critical (default 0.25 = 25%)
+ *   --json               Output JSON parsable
+ *   --help               Print this help
+ *
+ * Exit code
+ * ---------
+ *   0 si aucune severity 'critical', 1 sinon. Permet de gater une
+ *   release engine bump dans CI :
+ *     pnpm sim:compare-versions --base ... --head ... || echo "drift critical"
+ */
+
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+import {
+  compareBaselines,
+  formatVersionComparisonReport,
+  parseBenchBaseline,
+} from '../src/index';
+
+const HELP = `pnpm sim:compare-versions — cross-version baseline diff
+
+Usage:
+  pnpm sim:compare-versions --base <path> --head <path> [--warn=<n>] [--critical=<n>] [--json]
+  pnpm sim:compare-versions --help
+`;
+
+interface CliArgs {
+  base?: string;
+  head?: string;
+  warn?: string;
+  critical?: string;
+  json?: boolean;
+  help?: boolean;
+}
+
+function parse(argv: readonly string[]): CliArgs {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      base: { type: 'string' },
+      head: { type: 'string' },
+      warn: { type: 'string' },
+      critical: { type: 'string' },
+      json: { type: 'boolean' },
+      help: { type: 'boolean' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return values as CliArgs;
+}
+
+function loadBaseline(path: string) {
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  return parseBenchBaseline(raw);
+}
+
+function main(argv: readonly string[]): number {
+  let args: CliArgs;
+  try {
+    args = parse(argv);
+  } catch (err: unknown) {
+    process.stderr.write(`compare-versions: ${(err as Error).message}\n\n${HELP}`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (!args.base || !args.head) {
+    process.stderr.write('compare-versions: --base and --head are required\n');
+    return 2;
+  }
+  const base = loadBaseline(args.base);
+  const head = loadBaseline(args.head);
+  const warn = args.warn !== undefined ? Number.parseFloat(args.warn) : undefined;
+  const critical =
+    args.critical !== undefined ? Number.parseFloat(args.critical) : undefined;
+  if (warn !== undefined && !Number.isFinite(warn)) {
+    process.stderr.write('compare-versions: --warn must be a finite number\n');
+    return 2;
+  }
+  if (critical !== undefined && !Number.isFinite(critical)) {
+    process.stderr.write('compare-versions: --critical must be a finite number\n');
+    return 2;
+  }
+
+  const result = compareBaselines(base, head, {
+    warnThreshold: warn,
+    criticalThreshold: critical,
+  });
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stdout.write(formatVersionComparisonReport(result) + '\n');
+  }
+
+  return result.summary.criticalCount > 0 ? 1 : 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/packages/sim-engine/src/bench/version-comparator.test.ts
+++ b/packages/sim-engine/src/bench/version-comparator.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests pour le cross-version comparator (Lot 4.B.1).
+ *
+ * Couvre :
+ *  - compareBaselines : diff par pairing, stats globales (max delta
+ *    par metrique, pairings missing).
+ *  - formatVersionComparisonReport : rendu text deterministe avec
+ *    colonnes alignees.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { BenchBaseline, BenchBaselineEntry } from './baseline';
+import {
+  compareBaselines,
+  formatVersionComparisonReport,
+} from './version-comparator';
+
+function entry(
+  homeId: string,
+  awayId: string,
+  expectedOverrides: Partial<BenchBaselineEntry['expected']> = {},
+): BenchBaselineEntry {
+  return {
+    homeId,
+    awayId,
+    runs: 1000,
+    seedOffset: 0,
+    expected: {
+      tdMean: 2.0,
+      tdStd: 1.0,
+      casualtyMean: 1.5,
+      turnoverMean: 4.0,
+      homeWinRate: 0.5,
+      awayWinRate: 0.4,
+      drawRate: 0.1,
+      ...expectedOverrides,
+    },
+  };
+}
+
+function baseline(
+  engineVer: string,
+  pairings: BenchBaselineEntry[],
+): BenchBaseline {
+  return {
+    engineVer,
+    snapshotAt: '2026-05-09',
+    tolerance: 0.05,
+    pairings,
+  };
+}
+
+describe('compareBaselines — Lot 4.B.1', () => {
+  it('retourne un diff vide quand les deux baselines sont identiques', () => {
+    const a = baseline('0.16.0', [entry('orcs', 'humans')]);
+    const b = baseline('0.16.0', [entry('orcs', 'humans')]);
+    const out = compareBaselines(a, b);
+    expect(out.pairings).toHaveLength(1);
+    expect(out.pairings[0].deltas.tdMean).toBe(0);
+    expect(out.summary.maxAbsDeltaByMetric.tdMean).toBe(0);
+    expect(out.summary.missingInBase).toEqual([]);
+    expect(out.summary.missingInHead).toEqual([]);
+  });
+
+  it('calcule les deltas signed (head - base) par pairing', () => {
+    const a = baseline('0.15.0', [entry('orcs', 'elves', { tdMean: 2.0 })]);
+    const b = baseline('0.16.0', [entry('orcs', 'elves', { tdMean: 2.4 })]);
+    const out = compareBaselines(a, b);
+    expect(out.pairings[0].deltas.tdMean).toBeCloseTo(0.4, 5);
+    expect(out.pairings[0].deltas.tdStd).toBe(0); // pas d'override
+    expect(out.summary.maxAbsDeltaByMetric.tdMean).toBeCloseTo(0.4, 5);
+  });
+
+  it('signale les pairings present dans head mais absents de base', () => {
+    const a = baseline('0.15.0', [entry('orcs', 'elves')]);
+    const b = baseline('0.16.0', [
+      entry('orcs', 'elves'),
+      entry('halflings', 'chaos'),
+    ]);
+    const out = compareBaselines(a, b);
+    expect(out.summary.missingInBase).toEqual([
+      { homeId: 'halflings', awayId: 'chaos' },
+    ]);
+    expect(out.summary.missingInHead).toEqual([]);
+  });
+
+  it('signale les pairings present dans base mais absents de head', () => {
+    const a = baseline('0.15.0', [
+      entry('orcs', 'elves'),
+      entry('skaven', 'goblins'),
+    ]);
+    const b = baseline('0.16.0', [entry('orcs', 'elves')]);
+    const out = compareBaselines(a, b);
+    expect(out.summary.missingInHead).toEqual([
+      { homeId: 'skaven', awayId: 'goblins' },
+    ]);
+  });
+
+  it('aggrege le max abs delta par metrique a travers tous les pairings', () => {
+    const a = baseline('0.15.0', [
+      entry('a', 'b', { homeWinRate: 0.5 }),
+      entry('c', 'd', { homeWinRate: 0.5 }),
+    ]);
+    const b = baseline('0.16.0', [
+      entry('a', 'b', { homeWinRate: 0.55 }), // +0.05
+      entry('c', 'd', { homeWinRate: 0.42 }), // -0.08
+    ]);
+    const out = compareBaselines(a, b);
+    expect(out.summary.maxAbsDeltaByMetric.homeWinRate).toBeCloseTo(0.08, 5);
+  });
+
+  it('tolere les deltas negatifs et zero (signed strict)', () => {
+    const a = baseline('0.15.0', [entry('a', 'b', { tdMean: 3.0 })]);
+    const b = baseline('0.16.0', [entry('a', 'b', { tdMean: 2.7 })]);
+    const out = compareBaselines(a, b);
+    expect(out.pairings[0].deltas.tdMean).toBeCloseTo(-0.3, 5);
+    // Max abs reste positif.
+    expect(out.summary.maxAbsDeltaByMetric.tdMean).toBeCloseTo(0.3, 5);
+  });
+
+  it('flag pairings avec |delta| au-dessus du threshold (severity warn/critical)', () => {
+    const a = baseline('0.15.0', [
+      entry('a', 'b', { tdMean: 2.0 }),
+      entry('c', 'd', { tdMean: 2.0 }),
+      entry('e', 'f', { tdMean: 2.0 }),
+    ]);
+    const b = baseline('0.16.0', [
+      entry('a', 'b', { tdMean: 2.05 }), // +2.5% -> normal
+      entry('c', 'd', { tdMean: 2.3 }), // +15% -> warn
+      entry('e', 'f', { tdMean: 2.6 }), // +30% -> critical
+    ]);
+    const out = compareBaselines(a, b, {
+      warnThreshold: 0.1,
+      criticalThreshold: 0.25,
+    });
+    const severities = out.pairings.map((p) => p.severity);
+    expect(severities).toEqual(['normal', 'warn', 'critical']);
+  });
+});
+
+describe('formatVersionComparisonReport — Lot 4.B.1', () => {
+  it('produit un rapport text avec en-tete des engineVer et un summary', () => {
+    const a = baseline('0.15.0', [entry('orcs', 'elves')]);
+    const b = baseline('0.16.0', [entry('orcs', 'elves', { tdMean: 2.5 })]);
+    const out = compareBaselines(a, b);
+    const text = formatVersionComparisonReport(out);
+    expect(text).toContain('0.15.0');
+    expect(text).toContain('0.16.0');
+    expect(text).toContain('orcs vs elves');
+    expect(text).toMatch(/tdMean.*\+0\.50/);
+  });
+
+  it('signale les pairings missing dans le summary', () => {
+    const a = baseline('0.15.0', [entry('a', 'b')]);
+    const b = baseline('0.16.0', []);
+    const out = compareBaselines(a, b);
+    const text = formatVersionComparisonReport(out);
+    expect(text).toMatch(/missing in head/i);
+    expect(text).toContain('a vs b');
+  });
+});

--- a/packages/sim-engine/src/bench/version-comparator.ts
+++ b/packages/sim-engine/src/bench/version-comparator.ts
@@ -1,0 +1,255 @@
+/**
+ * Cross-version baseline comparator (Lot 4.B.1).
+ *
+ * Pourquoi
+ * --------
+ * Avant chaque bump majeur d'engineVer, on veut visualiser la drift
+ * introduite par les changements. Le bench-baseline.json contient
+ * deja les metriques attendues pour un set fixe de pairings et seeds ;
+ * il suffit de produire deux snapshots (un par version) et de les
+ * diffuser cote pourcentages.
+ *
+ * Workflow recommande :
+ *   1. git checkout v0.15.0
+ *   2. pnpm sim:bench:snapshot > /tmp/baseline-0.15.0.json
+ *   3. git checkout v0.16.0
+ *   4. pnpm sim:bench:snapshot > /tmp/baseline-0.16.0.json
+ *   5. pnpm sim:compare-versions --base /tmp/baseline-0.15.0.json --head /tmp/baseline-0.16.0.json
+ *
+ * Pure : aucune I/O ici. Le CLI lit les deux fichiers via fs et call
+ * `compareBaselines`, puis decide texte ou JSON.
+ */
+
+import type { BenchBaseline, BenchBaselineEntry, ExpectedMetrics } from './baseline';
+
+export type ComparisonSeverity = 'normal' | 'warn' | 'critical';
+
+const METRIC_KEYS: ReadonlyArray<keyof ExpectedMetrics> = [
+  'tdMean',
+  'tdStd',
+  'casualtyMean',
+  'turnoverMean',
+  'homeWinRate',
+  'awayWinRate',
+  'drawRate',
+];
+
+export interface PairingDelta {
+  readonly homeId: string;
+  readonly awayId: string;
+  readonly base: ExpectedMetrics;
+  readonly head: ExpectedMetrics;
+  /** Delta signed (head - base) per metric. */
+  readonly deltas: ExpectedMetrics;
+  /** Severity = max abs(delta_relative) across metrics, vs warn / critical. */
+  readonly severity: ComparisonSeverity;
+  /** Max abs delta relative observed for this pairing (any metric). */
+  readonly maxAbsRelativeDelta: number;
+}
+
+export interface MissingPairing {
+  readonly homeId: string;
+  readonly awayId: string;
+}
+
+export interface ComparisonSummary {
+  /** Max absolute delta across pairings, par metric. */
+  readonly maxAbsDeltaByMetric: ExpectedMetrics;
+  readonly missingInBase: readonly MissingPairing[];
+  readonly missingInHead: readonly MissingPairing[];
+  readonly matchedPairings: number;
+  readonly warnCount: number;
+  readonly criticalCount: number;
+}
+
+export interface VersionComparisonResult {
+  readonly base: { readonly engineVer: string; readonly snapshotAt: string };
+  readonly head: { readonly engineVer: string; readonly snapshotAt: string };
+  readonly pairings: readonly PairingDelta[];
+  readonly summary: ComparisonSummary;
+}
+
+export interface CompareBaselinesOptions {
+  /** Threshold relatif (default 0.1 = 10%) pour severity 'warn'. */
+  readonly warnThreshold?: number;
+  /** Threshold relatif (default 0.25 = 25%) pour severity 'critical'. */
+  readonly criticalThreshold?: number;
+}
+
+const DEFAULT_WARN = 0.1;
+const DEFAULT_CRITICAL = 0.25;
+
+function pairingKey(p: { homeId: string; awayId: string }): string {
+  return `${p.homeId}__${p.awayId}`;
+}
+
+function emptyMetrics(): ExpectedMetrics {
+  return {
+    tdMean: 0,
+    tdStd: 0,
+    casualtyMean: 0,
+    turnoverMean: 0,
+    homeWinRate: 0,
+    awayWinRate: 0,
+    drawRate: 0,
+  };
+}
+
+function computeDeltas(
+  base: ExpectedMetrics,
+  head: ExpectedMetrics,
+): ExpectedMetrics {
+  return {
+    tdMean: head.tdMean - base.tdMean,
+    tdStd: head.tdStd - base.tdStd,
+    casualtyMean: head.casualtyMean - base.casualtyMean,
+    turnoverMean: head.turnoverMean - base.turnoverMean,
+    homeWinRate: head.homeWinRate - base.homeWinRate,
+    awayWinRate: head.awayWinRate - base.awayWinRate,
+    drawRate: head.drawRate - base.drawRate,
+  };
+}
+
+function relativeDelta(base: number, delta: number): number {
+  if (base === 0) return delta === 0 ? 0 : Number.POSITIVE_INFINITY;
+  return Math.abs(delta) / Math.abs(base);
+}
+
+function severityFor(
+  base: ExpectedMetrics,
+  deltas: ExpectedMetrics,
+  warn: number,
+  critical: number,
+): { readonly severity: ComparisonSeverity; readonly maxAbsRel: number } {
+  let maxAbsRel = 0;
+  for (const k of METRIC_KEYS) {
+    const rel = relativeDelta(base[k], deltas[k]);
+    if (rel > maxAbsRel) maxAbsRel = rel;
+  }
+  if (maxAbsRel > critical) return { severity: 'critical', maxAbsRel };
+  if (maxAbsRel > warn) return { severity: 'warn', maxAbsRel };
+  return { severity: 'normal', maxAbsRel };
+}
+
+export function compareBaselines(
+  base: BenchBaseline,
+  head: BenchBaseline,
+  options: CompareBaselinesOptions = {},
+): VersionComparisonResult {
+  const warn = options.warnThreshold ?? DEFAULT_WARN;
+  const critical = options.criticalThreshold ?? DEFAULT_CRITICAL;
+
+  const baseByKey = new Map<string, BenchBaselineEntry>();
+  for (const p of base.pairings) baseByKey.set(pairingKey(p), p);
+  const headByKey = new Map<string, BenchBaselineEntry>();
+  for (const p of head.pairings) headByKey.set(pairingKey(p), p);
+
+  const pairings: PairingDelta[] = [];
+  const missingInBase: MissingPairing[] = [];
+  const missingInHead: MissingPairing[] = [];
+  const maxAbs = emptyMetrics() as Record<keyof ExpectedMetrics, number>;
+  let warnCount = 0;
+  let criticalCount = 0;
+
+  // Iterate union, ordered by (head pairings first, then base-only).
+  const seen = new Set<string>();
+  for (const p of head.pairings) {
+    const key = pairingKey(p);
+    seen.add(key);
+    const basePair = baseByKey.get(key);
+    if (!basePair) {
+      missingInBase.push({ homeId: p.homeId, awayId: p.awayId });
+      continue;
+    }
+    const deltas = computeDeltas(basePair.expected, p.expected);
+    const { severity, maxAbsRel } = severityFor(
+      basePair.expected,
+      deltas,
+      warn,
+      critical,
+    );
+    if (severity === 'warn') warnCount += 1;
+    else if (severity === 'critical') criticalCount += 1;
+    for (const k of METRIC_KEYS) {
+      const abs = Math.abs(deltas[k]);
+      if (abs > maxAbs[k]) maxAbs[k] = abs;
+    }
+    pairings.push({
+      homeId: p.homeId,
+      awayId: p.awayId,
+      base: basePair.expected,
+      head: p.expected,
+      deltas,
+      severity,
+      maxAbsRelativeDelta: maxAbsRel,
+    });
+  }
+  for (const p of base.pairings) {
+    if (!seen.has(pairingKey(p))) {
+      missingInHead.push({ homeId: p.homeId, awayId: p.awayId });
+    }
+  }
+
+  return {
+    base: { engineVer: base.engineVer, snapshotAt: base.snapshotAt },
+    head: { engineVer: head.engineVer, snapshotAt: head.snapshotAt },
+    pairings,
+    summary: {
+      maxAbsDeltaByMetric: maxAbs as ExpectedMetrics,
+      missingInBase,
+      missingInHead,
+      matchedPairings: pairings.length,
+      warnCount,
+      criticalCount,
+    },
+  };
+}
+
+function fmtSigned(n: number, digits = 2): string {
+  const sign = n >= 0 ? '+' : '';
+  return `${sign}${n.toFixed(digits)}`;
+}
+
+export function formatVersionComparisonReport(
+  comparison: VersionComparisonResult,
+): string {
+  const { base, head, pairings, summary } = comparison;
+  const lines: string[] = [
+    `=== Cross-version comparison ===`,
+    `  base : ${base.engineVer}  (snapshot ${base.snapshotAt})`,
+    `  head : ${head.engineVer}  (snapshot ${head.snapshotAt})`,
+    `  matched pairings : ${summary.matchedPairings}`,
+    `  warn : ${summary.warnCount}     critical : ${summary.criticalCount}`,
+    '',
+  ];
+
+  if (pairings.length > 0) {
+    lines.push(`Per-pairing deltas (head - base):`);
+    for (const p of pairings) {
+      const tag = p.severity === 'normal' ? '   ' : `[${p.severity.toUpperCase()}]`;
+      lines.push(
+        `  ${tag} ${p.homeId} vs ${p.awayId}  ` +
+          `tdMean=${fmtSigned(p.deltas.tdMean)}  ` +
+          `casMean=${fmtSigned(p.deltas.casualtyMean)}  ` +
+          `homeWin=${fmtSigned(p.deltas.homeWinRate, 3)}  ` +
+          `awayWin=${fmtSigned(p.deltas.awayWinRate, 3)}`,
+      );
+    }
+  }
+
+  if (summary.missingInBase.length > 0) {
+    lines.push('');
+    lines.push('Missing in base (new pairings in head):');
+    for (const p of summary.missingInBase) {
+      lines.push(`  - ${p.homeId} vs ${p.awayId}`);
+    }
+  }
+  if (summary.missingInHead.length > 0) {
+    lines.push('');
+    lines.push('Missing in head (removed pairings):');
+    for (const p of summary.missingInHead) {
+      lines.push(`  - ${p.homeId} vs ${p.awayId}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -118,6 +118,16 @@ export {
   type ExpectedMetrics,
   type MetricDeviation,
 } from './bench/baseline';
+export {
+  compareBaselines,
+  formatVersionComparisonReport,
+  type ComparisonSeverity,
+  type ComparisonSummary,
+  type CompareBaselinesOptions,
+  type MissingPairing,
+  type PairingDelta,
+  type VersionComparisonResult,
+} from './bench/version-comparator';
 export { narrateMatch, type NarrateOptions } from './replay/narrator';
 export {
   PATTERNS,


### PR DESCRIPTION
## Pourquoi

Avant chaque bump majeur d'`engineVer`, on veut **visualiser la drift** introduite par les changements moteur. Le `bench-baseline.json` contient déjà les métriques attendues pour un set fixe de pairings et seeds (`pnpm sim:bench:snapshot`) ; il suffit de produire deux snapshots et de les diffuser côté pourcentages.

**Aujourd'hui** : pas d'outil pour comparer deux versions. Les release notes sont du œillomètre.

## Comment

1. **`packages/sim-engine/src/bench/version-comparator.ts`** (pure) :
   - `compareBaselines(base, head, options)` retourne `VersionComparisonResult` :
     - `pairings[]` : per-pairing diff signed (`head - base`) sur les 7 métriques (`tdMean`, `tdStd`, `casualtyMean`, `turnoverMean`, 3 outcome rates).
     - `severity` par pairing : `normal` / `warn` (>10% relatif) / `critical` (>25% relatif).
     - `summary.maxAbsDeltaByMetric` : max absolu observé à travers tous les pairings, par métrique. Permet de signaler par exemple *"tdMean a dérivé de 0.4 max sur ce bump"*.
     - `missingInBase` / `missingInHead` : pairings ajoutés/retirés entre les deux versions.
   - `formatVersionComparisonReport(result)` : rendu texte aligné avec en-tête `engineVer` + per-pairing line + summary.

2. **`packages/sim-engine/scripts/compare-versions.ts`** (CLI) :
   - Args : `--base <path>` `--head <path>` `--warn=<n>` `--critical=<n>` `--json` `--help`.
   - Output text human-readable ou JSON parsable.
   - **Exit code 1 si des `critical` sont détectées** → permet de gater une release engine bump dans CI :
     ```bash
     pnpm sim:compare-versions --base ... --head ... || fail
     ```

3. **Workflow recommandé** (documenté dans le header) :
   ```bash
   git checkout v0.15.0
   pnpm sim:bench:snapshot > /tmp/baseline-0.15.0.json
   git checkout v0.16.0
   pnpm sim:bench:snapshot > /tmp/baseline-0.16.0.json
   pnpm sim:compare-versions --base /tmp/baseline-0.15.0.json --head /tmp/baseline-0.16.0.json
   ```

## Tests

9 tests `version-comparator.test.ts` :
- `compareBaselines` : identical → 0 deltas, signed deltas, missing in base, missing in head, max abs aggregate, négatif/zero, severity `warn` / `critical` / `normal`.
- `formatVersionComparisonReport` : header `engineVer` + per-pairing line, signal `missing in head` dans le summary.

### Résultats

- `@bb/sim-engine` : 9 nouveaux tests
- `pnpm typecheck` : clean monorepo
- Smoke CLI sur baseline identique : `matched=3, warn=0, critical=0`.

## Test plan

- [ ] CI verte
- [ ] Sur deux snapshots identiques, le rapport affiche tous les deltas à 0.00
- [ ] `--json` produit un objet parsable par `jq`
- [ ] Modifier manuellement une métrique dans head et relancer → severity `warn`/`critical` apparaît, exit code 1 si critical
- [ ] Pairing ajouté/retiré entre versions → bien listé dans `missingInBase` / `missingInHead`

## Hors scope

- **UI admin** pour visualiser la comparaison : la sprint doc mentionnait *"UI admin qui compare engineVer N vs N+1"* mais une UI HTML demande un endpoint serveur + un composant React. Le CLI et la fonction pure sont la matière première ; l'UI peut être ajoutée séparément quand le besoin est concret (genre dashboard release manager).
- **Replay diff tool (4.B.2)** : different scope (event-by-event diff sur deux replays du même seed). Lot futur.
- **EngineComparison persist** : ce comparator fonctionne sur des baseline JSON **externes** (offline). La table `EngineComparison` de 3.B.2 sert au comparator hybrid vs full à `engineVer` constant ; ne pas confondre.

## Refs

- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 4.B.1)
- Sprint Pro League 0.D.4 (`pnpm sim:bench:snapshot`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_