### PR TITLE
feat(sim-engine): replay diff tool event-by-event + pnpm sim:diff-replays (Lot 4.B.2)

### DIFF
--- a/packages/sim-engine/package.json
+++ b/packages/sim-engine/package.json
@@ -20,6 +20,7 @@
     "sim:bench:snapshot": "tsx scripts/bench-baseline-snapshot.ts",
     "sim:compare": "tsx scripts/compare-drivers.ts",
     "sim:compare-versions": "tsx scripts/compare-versions.ts",
+    "sim:diff-replays": "tsx scripts/diff-replays.ts",
     "sim:perf": "tsx scripts/perf-baseline.ts",
     "sim:replay": "tsx scripts/replay.ts"
   },

--- a/packages/sim-engine/scripts/diff-replays.ts
+++ b/packages/sim-engine/scripts/diff-replays.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env tsx
+/**
+ * `pnpm sim:diff-replays` — Lot 4.B.2.
+ *
+ * Compare deux replays (events JSON) et imprime un rapport de
+ * divergence event-par-event. Utile pour debugger une regression
+ * deterministe entre deux engineVer ou deux refacto du driver.
+ *
+ * Usage typique :
+ *   git checkout v0.15.0
+ *   pnpm sim:replay --seed=42 --teamA=pit-smashers --teamB=kc-soaring-hawks --json > /tmp/replay-0.15.json
+ *   git checkout v0.16.0
+ *   pnpm sim:replay --seed=42 --teamA=pit-smashers --teamB=kc-soaring-hawks --json > /tmp/replay-0.16.json
+ *   pnpm sim:diff-replays --a /tmp/replay-0.15.json --b /tmp/replay-0.16.json
+ *
+ * Format d'entree
+ * ---------------
+ * Chaque fichier doit etre un JSON top-level avec un champ
+ * `events: MatchEvent[]`. Compatible avec la sortie de `pnpm sim:replay
+ * --json` et avec un dump direct de `SimResult`.
+ *
+ * Options
+ * -------
+ *   --a=<path>            Replay A (required)
+ *   --b=<path>            Replay B (required)
+ *   --max-divergences=<n> Cap des divergences stockees (default 200)
+ *   --max-lines=<n>       Cap des lignes affichees (default 20)
+ *   --json                Output JSON parsable
+ *   --help                Print this help
+ *
+ * Exit code
+ * ---------
+ *   0 si aucune divergence, 1 sinon. Permet de gater une release dans
+ *   CI : `pnpm sim:diff-replays ... || fail`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+import {
+  diffReplayEvents,
+  formatReplayDiffReport,
+} from '../src/replay/replay-diff';
+import type { MatchEvent } from '../src/types';
+
+const HELP = `pnpm sim:diff-replays — replay event-by-event diff
+
+Usage:
+  pnpm sim:diff-replays --a <path> --b <path> [--max-divergences=<n>] [--max-lines=<n>] [--json]
+  pnpm sim:diff-replays --help
+`;
+
+interface CliArgs {
+  a?: string;
+  b?: string;
+  'max-divergences'?: string;
+  'max-lines'?: string;
+  json?: boolean;
+  help?: boolean;
+}
+
+function parse(argv: readonly string[]): CliArgs {
+  const { values } = parseArgs({
+    args: [...argv],
+    options: {
+      a: { type: 'string' },
+      b: { type: 'string' },
+      'max-divergences': { type: 'string' },
+      'max-lines': { type: 'string' },
+      json: { type: 'boolean' },
+      help: { type: 'boolean' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return values as CliArgs;
+}
+
+function loadReplayEvents(path: string): readonly MatchEvent[] {
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Invalid replay file ${path}: not an object`);
+  }
+  const events = (raw as { events?: unknown }).events;
+  if (!Array.isArray(events)) {
+    throw new Error(`Invalid replay file ${path}: missing events array`);
+  }
+  return events as readonly MatchEvent[];
+}
+
+function parsePositiveInt(name: string, raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return n;
+}
+
+function main(argv: readonly string[]): number {
+  let args: CliArgs;
+  try {
+    args = parse(argv);
+  } catch (err: unknown) {
+    process.stderr.write(`diff-replays: ${(err as Error).message}\n\n${HELP}`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (!args.a || !args.b) {
+    process.stderr.write('diff-replays: --a and --b are required\n');
+    return 2;
+  }
+
+  let maxDivergences: number | undefined;
+  let maxLines: number | undefined;
+  try {
+    maxDivergences = parsePositiveInt('max-divergences', args['max-divergences']);
+    maxLines = parsePositiveInt('max-lines', args['max-lines']);
+  } catch (err: unknown) {
+    process.stderr.write(`diff-replays: ${(err as Error).message}\n`);
+    return 2;
+  }
+
+  const eventsA = loadReplayEvents(args.a);
+  const eventsB = loadReplayEvents(args.b);
+  const result = diffReplayEvents(eventsA, eventsB, { maxDivergences });
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      formatReplayDiffReport(result, { maxLinesShown: maxLines }) + '\n',
+    );
+  }
+
+  return result.summary.divergenceCount > 0 ? 1 : 0;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/packages/sim-engine/src/index.ts
+++ b/packages/sim-engine/src/index.ts
@@ -218,6 +218,17 @@ export {
 } from './replay/compress';
 
 export {
+  diffReplayEvents,
+  formatReplayDiffReport,
+  type DiffReplayEventsOptions,
+  type FormatReplayDiffReportOptions,
+  type ReplayDiffResult,
+  type ReplayDiffSummary,
+  type ReplayDivergence,
+  type ReplayDivergenceKind,
+} from './replay/replay-diff';
+
+export {
   aggregateComparisons,
   compareDriversOnce,
   type CompareDriverKind,

--- a/packages/sim-engine/src/replay/replay-diff.test.ts
+++ b/packages/sim-engine/src/replay/replay-diff.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests pour le replay diff tool (Lot 4.B.2).
+ *
+ * Couvre :
+ *   - `diffReplayEvents` : alignment par index, detection mismatch
+ *     (type, displayAtMs, meta) et longueur asymetrique.
+ *   - `formatReplayDiffReport` : rendu text aligne avec les premieres
+ *     divergences highlightees.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { MatchEvent } from '../types';
+import {
+  diffReplayEvents,
+  formatReplayDiffReport,
+} from './replay-diff';
+
+function ev(
+  type: MatchEvent['type'],
+  displayAtMs: number,
+  meta: Record<string, unknown> = {},
+): MatchEvent {
+  return {
+    type,
+    displayAtMs,
+    engineVer: '0.16.0',
+    meta,
+  } as MatchEvent;
+}
+
+describe('diffReplayEvents — Lot 4.B.2', () => {
+  it('aucune divergence si les deux replays sont identiques', () => {
+    const events = [
+      ev('KICKOFF', 0, { home: 'A', away: 'B' }),
+      ev('TURN_START', 0, { half: 1, turn: 1 }),
+      ev('END', 1000, { outcome: 'draw' }),
+    ];
+    const out = diffReplayEvents(events, events);
+    expect(out.divergences).toEqual([]);
+    expect(out.summary).toMatchObject({
+      totalA: 3,
+      totalB: 3,
+      matchedCount: 3,
+      divergenceCount: 0,
+      firstDivergenceIndex: null,
+    });
+  });
+
+  it('detecte un mismatch sur le type', () => {
+    const a = [ev('KICKOFF', 0), ev('TURN_START', 0), ev('TD', 1000)];
+    const b = [ev('KICKOFF', 0), ev('TURN_START', 0), ev('TURNOVER', 1000)];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toHaveLength(1);
+    expect(out.divergences[0]).toMatchObject({
+      index: 2,
+      kind: 'mismatch',
+    });
+    expect(out.summary.firstDivergenceIndex).toBe(2);
+  });
+
+  it('detecte un mismatch sur displayAtMs (timing diverge)', () => {
+    const a = [ev('TD', 1000)];
+    const b = [ev('TD', 2000)];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences[0].kind).toBe('mismatch');
+  });
+
+  it('detecte un mismatch sur meta (sous-champ different)', () => {
+    const a = [ev('TD', 1000, { team: 'home', scorerId: 'X' })];
+    const b = [ev('TD', 1000, { team: 'home', scorerId: 'Y' })];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toHaveLength(1);
+    expect(out.divergences[0].kind).toBe('mismatch');
+  });
+
+  it('considere meta semantiquement equivalente (ordre de champs)', () => {
+    const a = [ev('TD', 1000, { team: 'home', scorerId: 'X' })];
+    const b = [ev('TD', 1000, { scorerId: 'X', team: 'home' })];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toEqual([]);
+  });
+
+  it('detecte longueur asymetrique : events extra dans B (missing_a)', () => {
+    const a = [ev('KICKOFF', 0)];
+    const b = [ev('KICKOFF', 0), ev('TURN_START', 0), ev('END', 1000)];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toHaveLength(2);
+    expect(out.divergences[0].kind).toBe('missing_a');
+    expect(out.divergences[1].kind).toBe('missing_a');
+  });
+
+  it('detecte longueur asymetrique : events extra dans A (missing_b)', () => {
+    const a = [ev('KICKOFF', 0), ev('TURN_START', 0), ev('END', 1000)];
+    const b = [ev('KICKOFF', 0)];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toHaveLength(2);
+    expect(out.divergences[0].kind).toBe('missing_b');
+    expect(out.divergences[1].kind).toBe('missing_b');
+  });
+
+  it('multi-divergences : compte tous les mismatches dans summary', () => {
+    const a = [ev('TD', 1000), ev('TURNOVER', 2000), ev('END', 3000)];
+    const b = [ev('TURNOVER', 1000), ev('TD', 2000), ev('END', 3000)];
+    const out = diffReplayEvents(a, b);
+    expect(out.divergences).toHaveLength(2);
+    expect(out.summary.divergenceCount).toBe(2);
+    expect(out.summary.firstDivergenceIndex).toBe(0);
+    expect(out.summary.matchedCount).toBe(1);
+  });
+
+  it('limite par maxDivergences si fournie (anti-runaway)', () => {
+    const a = Array.from({ length: 10 }, (_, i) => ev('TD', i * 100));
+    const b = Array.from({ length: 10 }, (_, i) => ev('TURNOVER', i * 100));
+    const out = diffReplayEvents(a, b, { maxDivergences: 3 });
+    expect(out.divergences).toHaveLength(3);
+    expect(out.summary.divergenceCount).toBe(10); // count complet
+  });
+
+  it('runs vides : 0 divergence', () => {
+    const out = diffReplayEvents([], []);
+    expect(out.divergences).toEqual([]);
+    expect(out.summary.totalA).toBe(0);
+    expect(out.summary.totalB).toBe(0);
+  });
+});
+
+describe('formatReplayDiffReport — Lot 4.B.2', () => {
+  it('imprime un summary lisible avec count + first divergence index', () => {
+    const a = [ev('KICKOFF', 0), ev('TD', 1000)];
+    const b = [ev('KICKOFF', 0), ev('TURNOVER', 1000)];
+    const out = diffReplayEvents(a, b);
+    const text = formatReplayDiffReport(out);
+    expect(text).toContain('totalA=2');
+    expect(text).toContain('totalB=2');
+    expect(text).toContain('divergences=1');
+    expect(text).toContain('firstDivergenceIndex=1');
+  });
+
+  it('liste les premieres divergences avec type a / b', () => {
+    const a = [ev('TD', 1000)];
+    const b = [ev('TURNOVER', 1000)];
+    const out = diffReplayEvents(a, b);
+    const text = formatReplayDiffReport(out);
+    expect(text).toMatch(/index=0/);
+    expect(text).toMatch(/TD/);
+    expect(text).toMatch(/TURNOVER/);
+  });
+
+  it('cap visualisation à maxLinesShown', () => {
+    const a = Array.from({ length: 50 }, (_, i) => ev('TD', i * 100));
+    const b = Array.from({ length: 50 }, (_, i) => ev('TURNOVER', i * 100));
+    const out = diffReplayEvents(a, b);
+    const text = formatReplayDiffReport(out, { maxLinesShown: 5 });
+    // Compte les lignes "index=" pour s'assurer du capping.
+    const lines = text.split('\n').filter((l) => l.startsWith('  index='));
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(text).toMatch(/\.{3}\s*\(\d+\s+more\)/);
+  });
+});

--- a/packages/sim-engine/src/replay/replay-diff.ts
+++ b/packages/sim-engine/src/replay/replay-diff.ts
@@ -1,0 +1,194 @@
+/**
+ * Replay diff tool (Lot 4.B.2).
+ *
+ * Pourquoi
+ * --------
+ * Le cross-version baseline comparator (Lot 4.B.1) compare des stats
+ * agregees (tdMean, winrate, etc.) entre deux engineVer. Quand un
+ * pairing diverge "globalement", la question naturelle est "OU
+ * exactement diverge la simulation ?". Un diff event-par-event sur
+ * deux replays produits avec le meme seed permet de pointer
+ * precisement le tour ou le coup ou la divergence est apparue.
+ *
+ * Workflow recommande :
+ *   git checkout v0.15.0
+ *   pnpm sim:replay --seed=42 --teamA=... --teamB=... --json > /tmp/replay-0.15.json
+ *   git checkout v0.16.0
+ *   pnpm sim:replay --seed=42 --teamA=... --teamB=... --json > /tmp/replay-0.16.json
+ *   pnpm sim:diff-replays --a /tmp/replay-0.15.json --b /tmp/replay-0.16.json
+ *
+ * Architecture
+ * ------------
+ * - `diffReplayEvents(a, b, options)` (pure) : aligne les events par
+ *   index, detecte mismatch (type / displayAtMs / meta) et longueurs
+ *   asymetriques. Borne via `maxDivergences` pour eviter un OOM si
+ *   les deux replays divergent totalement (ex: seed mismatch).
+ * - `formatReplayDiffReport(result, options)` (pure) : rendu text
+ *   avec en-tete summary + premieres divergences listees.
+ *
+ * Limitations MVP
+ * ---------------
+ * - Comparaison index-aligned (pas LCS). Si une seule action est
+ *   inseree dans B, toute la suite est marquee comme mismatch. Pour
+ *   un alignment plus tolerant, brancher un algorithme Myers diff
+ *   plus tard. En pratique sur les replays sim-engine seedes, les
+ *   divergences sont rares et localisees.
+ * - Meta deep equality via JSON.stringify avec keys triees. Pas
+ *   robuste si meta contient des fonctions ou des cycles, mais
+ *   MatchEvent.meta est always serializable (record string -> JSON
+ *   primitives).
+ */
+
+import type { MatchEvent } from '../types';
+
+export type ReplayDivergenceKind = 'mismatch' | 'missing_a' | 'missing_b';
+
+export interface ReplayDivergence {
+  readonly index: number;
+  readonly kind: ReplayDivergenceKind;
+  readonly a: MatchEvent | null;
+  readonly b: MatchEvent | null;
+}
+
+export interface ReplayDiffSummary {
+  readonly totalA: number;
+  readonly totalB: number;
+  readonly matchedCount: number;
+  readonly divergenceCount: number;
+  readonly firstDivergenceIndex: number | null;
+}
+
+export interface ReplayDiffResult {
+  readonly divergences: readonly ReplayDivergence[];
+  readonly summary: ReplayDiffSummary;
+}
+
+export interface DiffReplayEventsOptions {
+  /**
+   * Cap le nombre de divergences stockees pour eviter une RAM
+   * spike si les deux replays divergent totalement (ex: seed
+   * different). Le `summary.divergenceCount` reste exact.
+   */
+  readonly maxDivergences?: number;
+}
+
+const DEFAULT_MAX_DIVERGENCES = 200;
+
+/**
+ * Compare deux events par valeur. type + displayAtMs + meta deep
+ * equality (JSON canonical pour ignorer l'ordre des cles).
+ */
+function eventsEqual(a: MatchEvent, b: MatchEvent): boolean {
+  if (a.type !== b.type) return false;
+  if (a.displayAtMs !== b.displayAtMs) return false;
+  return canonicalJson(a.meta) === canonicalJson(b.meta);
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  return JSON.stringify(value, replacerSortedKeys);
+}
+
+function replacerSortedKeys(_key: string, value: unknown): unknown {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, k) => {
+        acc[k] = obj[k];
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+export function diffReplayEvents(
+  a: readonly MatchEvent[],
+  b: readonly MatchEvent[],
+  options: DiffReplayEventsOptions = {},
+): ReplayDiffResult {
+  const maxDivergences = options.maxDivergences ?? DEFAULT_MAX_DIVERGENCES;
+  const divergences: ReplayDivergence[] = [];
+  let divergenceCount = 0;
+  let matchedCount = 0;
+  let firstDivergenceIndex: number | null = null;
+  const longest = Math.max(a.length, b.length);
+
+  const pushDiv = (div: ReplayDivergence): void => {
+    divergenceCount += 1;
+    if (firstDivergenceIndex === null) firstDivergenceIndex = div.index;
+    if (divergences.length < maxDivergences) {
+      divergences.push(div);
+    }
+  };
+
+  for (let i = 0; i < longest; i += 1) {
+    const ea = i < a.length ? a[i] : null;
+    const eb = i < b.length ? b[i] : null;
+    if (ea && eb) {
+      if (eventsEqual(ea, eb)) {
+        matchedCount += 1;
+      } else {
+        pushDiv({ index: i, kind: 'mismatch', a: ea, b: eb });
+      }
+    } else if (!ea && eb) {
+      pushDiv({ index: i, kind: 'missing_a', a: null, b: eb });
+    } else if (ea && !eb) {
+      pushDiv({ index: i, kind: 'missing_b', a: ea, b: null });
+    }
+  }
+
+  return {
+    divergences,
+    summary: {
+      totalA: a.length,
+      totalB: b.length,
+      matchedCount,
+      divergenceCount,
+      firstDivergenceIndex,
+    },
+  };
+}
+
+export interface FormatReplayDiffReportOptions {
+  readonly maxLinesShown?: number;
+}
+
+const DEFAULT_MAX_LINES_SHOWN = 20;
+
+function describeEvent(e: MatchEvent | null): string {
+  if (!e) return '(none)';
+  const metaSummary = canonicalJson(e.meta).slice(0, 80);
+  return `${e.type} @${e.displayAtMs}ms ${metaSummary}`;
+}
+
+export function formatReplayDiffReport(
+  result: ReplayDiffResult,
+  options: FormatReplayDiffReportOptions = {},
+): string {
+  const max = options.maxLinesShown ?? DEFAULT_MAX_LINES_SHOWN;
+  const { summary, divergences } = result;
+  const lines: string[] = [
+    '=== Replay diff ===',
+    `  totalA=${summary.totalA}  totalB=${summary.totalB}  matched=${summary.matchedCount}  divergences=${summary.divergenceCount}  firstDivergenceIndex=${summary.firstDivergenceIndex ?? 'none'}`,
+    '',
+  ];
+  if (divergences.length === 0) {
+    lines.push('  (no divergence)');
+    return lines.join('\n');
+  }
+  const visible = divergences.slice(0, max);
+  for (const d of visible) {
+    lines.push(
+      `  index=${d.index}  ${d.kind}\n    a: ${describeEvent(d.a)}\n    b: ${describeEvent(d.b)}`,
+    );
+  }
+  if (divergences.length > max) {
+    lines.push(`  ... (${divergences.length - max} more)`);
+  } else if (summary.divergenceCount > divergences.length) {
+    lines.push(
+      `  ... (${summary.divergenceCount - divergences.length} more — capped by maxDivergences)`,
+    );
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Pourquoi

Le cross-version baseline comparator (Lot 4.B.1, PR #722) compare des **stats agrégées** (tdMean, winrate, etc.) entre deux `engineVer`. Quand un pairing diverge globalement, la question naturelle est *"OÙ exactement diverge la simulation ?"*. Un **diff event-par-event** sur deux replays produits avec le même seed permet de pointer précisément le tour ou le coup où la divergence est apparue.

## Comment

1. **`packages/sim-engine/src/replay/replay-diff.ts`** (pure) :
   - `diffReplayEvents(a, b, options)` aligne les events par index et détecte 3 kinds de divergence : `mismatch` (index commun mais events différents), `missing_a` (event B mais pas A), `missing_b` (event A mais pas B).
   - Comparaison via `eventsEqual` : strict sur `type` + `displayAtMs` + `meta` deep equality (canonical JSON, ordre de clés ignoré).
   - Cap par `maxDivergences` (default 200) pour éviter une RAM spike si les deux replays divergent totalement (ex: seed mismatch). Le `summary.divergenceCount` reste exact.
   - `formatReplayDiffReport(result, options)` rendu text avec en-tête summary + premières divergences listées.

2. **`packages/sim-engine/scripts/diff-replays.ts`** (CLI) :
   - Args : `--a <path>` `--b <path>` `--max-divergences=<n>` `--max-lines=<n>` `--json` `--help`.
   - Format d'entrée : JSON top-level avec `events: MatchEvent[]`. Compatible avec `pnpm sim:replay --json` ou un dump direct de `SimResult`.
   - **Exit code 1 si des divergences sont détectées** → permet de gater une release dans CI : `pnpm sim:diff-replays --a ... --b ... || fail`.

3. **Workflow recommandé** (documenté dans le header) :
   ```bash
   git checkout v0.15.0
   pnpm sim:replay --seed=42 --json > /tmp/replay-0.15.json
   git checkout v0.16.0
   pnpm sim:replay --seed=42 --json > /tmp/replay-0.16.json
   pnpm sim:diff-replays --a /tmp/replay-0.15.json --b /tmp/replay-0.16.json
   ```

## Tests

13 tests `replay-diff.test.ts` :
- `diffReplayEvents` : identical → 0 divergence, mismatch sur type / displayAtMs / meta, meta key-order tolerance, longueurs asymétriques (missing_a / missing_b), multi-divergences, `maxDivergences` cap, runs vides.
- `formatReplayDiffReport` : summary lisible, listing premières divergences, cap `maxLinesShown` avec `... (N more)`.

### Résultats

- `@bb/sim-engine` : 13 nouveaux tests
- `pnpm typecheck` : clean monorepo
- Smoke CLI : 3 events vs 4 events → `totalA=3 totalB=4 matched=1 divergences=3`, listing aligné par index, exit code 1.

## Test plan

- [ ] CI verte
- [ ] Sur deux replays identiques, `divergenceCount=0` + exit 0
- [ ] Sur deux replays divergents, listing aligné par index + exit 1
- [ ] `--json` produit un objet parsable par `jq`
- [ ] `--max-divergences=5` borne le tableau `divergences[]` mais le `summary.divergenceCount` reste exact

## Hors scope

- **Algorithme Myers diff** : l'alignment est strict par index. Si une seule action est insérée dans B (ex: event MOVE en plus), tout ce qui suit est marqué comme mismatch. En pratique sur les replays sim-engine seedés, les divergences sont rares et localisées ; les cas d'insertion sont gérables avec un re-tag explicite. Si on tape des replays beaucoup plus longs, brancher Myers ou un edit distance LCS plus tard.
- **UI admin** : le CLI suffit pour l'instant. Un panel HTML qui consomme le JSON output peut être ajouté si besoin opérationnel récurrent.
- **Diff de payload compressé** : le CLI consomme du JSON déjà décompressé. Si on veut diffuser des `Replay.payload` directs (CBOR+gzip), wrapper avec `decompressEvents` côté caller ou ajouter une option `--decompress`.

## Refs

- PR #722 (Lot 4.B.1 cross-version baseline comparator)
- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 4.B.2)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_