### PR TITLE
feat(pro-league): alertes drift par race + bornes BB-realistes (Lot 4.A.3)

### DIFF
--- a/apps/server/src/services/pro-league-engine-drift-watcher.ts
+++ b/apps/server/src/services/pro-league-engine-drift-watcher.ts
@@ -48,6 +48,7 @@ import { getFumbblRaceStats } from "@bb/sim-engine";
 import { prisma } from "../prisma";
 import { appMetrics } from "../utils/metrics";
 import { serverLog } from "../utils/server-log";
+import { detectRaceBoundAlerts } from "./pro-league-race-bounds";
 
 /** Intervalle par défaut entre deux passages du watcher (1h). */
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
@@ -374,11 +375,23 @@ export async function runDriftTick(
   try {
     const samples = await computeEngineDrift(options);
     pushDriftToMetrics(samples);
-    const alerts = detectDriftAlerts(samples);
-    const counts = countAlertsBySeverity(alerts);
-    appMetrics.setEngineDriftAlertsCount("warn", counts.warn);
-    appMetrics.setEngineDriftAlertsCount("critical", counts.critical);
-    for (const alert of alerts) {
+    const driftAlerts = detectDriftAlerts(samples);
+    // Lot 4.A.3 — alertes critical additionelles quand l'observed
+    // sort des bornes BB-realistes (Halfling > 45% winrate, Wood
+    // Elf < 45% winrate, etc.). Les bound alerts sont TOUJOURS
+    // critical (seuils choisis large pour ne signaler que les
+    // anomalies vraiment suspectes).
+    const boundAlerts = detectRaceBoundAlerts(samples);
+    const driftCounts = countAlertsBySeverity(driftAlerts);
+    appMetrics.setEngineDriftAlertsCount(
+      "warn",
+      driftCounts.warn,
+    );
+    appMetrics.setEngineDriftAlertsCount(
+      "critical",
+      driftCounts.critical + boundAlerts.length,
+    );
+    for (const alert of driftAlerts) {
       // Log structure pino-friendly : Loki indexera les labels
       // (severity, metric, race, seasonId, drift) pour les queries
       // type "alertes critical sur saison s_2026 par race".
@@ -391,6 +404,23 @@ export async function runDriftTick(
         drift: alert.drift,
         observed: alert.observed,
         reference: alert.reference,
+        samples: alert.samples,
+      });
+    }
+    for (const alert of boundAlerts) {
+      // Lot 4.A.3 — log type distinct (`race_bound_alert`) pour
+      // permettre des queries Loki separees : un drift de +12% sur
+      // une race "moyenne" est moins inquietant qu'un Halfling
+      // observed=0.55 winrate (BB-rules-violation).
+      serverLog.warn("race_bound_alert", {
+        event: "race_bound_alert",
+        severity: alert.severity,
+        metric: alert.metric,
+        race: alert.race,
+        seasonId: alert.seasonId,
+        direction: alert.direction,
+        observed: alert.observed,
+        bound: alert.bound,
         samples: alert.samples,
       });
     }

--- a/apps/server/src/services/pro-league-race-bounds.test.ts
+++ b/apps/server/src/services/pro-league-race-bounds.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests pour les bornes de drift par race (Lot 4.A.3).
+ *
+ * Couvre :
+ *   - Table `RACE_DRIFT_BOUNDS` : valeurs canoniques BB pour les races
+ *     emblematiquement skewees (Halfling, Wood Elf, Chaos Dwarf, etc.).
+ *   - `detectRaceBoundAlerts(samples)` : alerte critical quand
+ *     l'observed sort des bornes (independent de la drift relative).
+ *   - Races sans bornes definies -> no-op (fallback sur le drift
+ *     watcher classique).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DriftSample } from "./pro-league-engine-drift-watcher";
+import {
+  detectRaceBoundAlerts,
+  RACE_DRIFT_BOUNDS,
+} from "./pro-league-race-bounds";
+
+function sample(overrides: Partial<DriftSample> = {}): DriftSample {
+  return {
+    metric: "winRate",
+    race: "Halfling",
+    seasonId: "s_2026",
+    observed: 0.3,
+    reference: 0.3,
+    drift: 0,
+    samples: 50,
+    ...overrides,
+  };
+}
+
+describe("RACE_DRIFT_BOUNDS — Lot 4.A.3", () => {
+  it("definit des bornes pour Halfling (winrate max bas)", () => {
+    const halfling = RACE_DRIFT_BOUNDS.Halfling;
+    expect(halfling).toBeDefined();
+    expect(halfling?.winRate?.max).toBeLessThan(0.5);
+  });
+
+  it("definit des bornes pour Wood Elf (winrate min haut)", () => {
+    const woodElf = RACE_DRIFT_BOUNDS["Wood Elf"];
+    expect(woodElf).toBeDefined();
+    expect(woodElf?.winRate?.min).toBeGreaterThan(0.4);
+  });
+
+  it("definit des bornes pour Chaos Dwarf (winrate max haut, race forte)", () => {
+    const cd = RACE_DRIFT_BOUNDS["Chaos Dwarf"];
+    expect(cd).toBeDefined();
+    expect(cd?.winRate?.max).toBeGreaterThanOrEqual(0.65);
+  });
+
+  it("races sans bornes -> entry undefined (fallback drift watcher)", () => {
+    expect(RACE_DRIFT_BOUNDS["UnknownRace"]).toBeUndefined();
+  });
+});
+
+describe("detectRaceBoundAlerts — Lot 4.A.3", () => {
+  it("ignore les races sans bornes definies", () => {
+    const out = detectRaceBoundAlerts([
+      sample({ race: "UnknownRace", observed: 1.0 }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("ignore les samples avec moins de minMatches (variance trop forte)", () => {
+    const out = detectRaceBoundAlerts(
+      [sample({ race: "Halfling", observed: 0.7, samples: 3 })],
+      { minMatches: 5 },
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("alerte critical si winRate Halfling > borne max", () => {
+    const out = detectRaceBoundAlerts([
+      sample({ race: "Halfling", metric: "winRate", observed: 0.55 }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      severity: "critical",
+      race: "Halfling",
+      metric: "winRate",
+      direction: "above_max",
+    });
+  });
+
+  it("alerte critical si winRate Wood Elf < borne min", () => {
+    const out = detectRaceBoundAlerts([
+      sample({ race: "Wood Elf", metric: "winRate", observed: 0.3 }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      severity: "critical",
+      race: "Wood Elf",
+      direction: "below_min",
+    });
+  });
+
+  it("aucune alerte si observed dans les bornes", () => {
+    const out = detectRaceBoundAlerts([
+      sample({ race: "Halfling", metric: "winRate", observed: 0.3 }),
+      sample({ race: "Wood Elf", metric: "winRate", observed: 0.55 }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("supporte plusieurs metriques par race (winRate + tdMean)", () => {
+    const out = detectRaceBoundAlerts([
+      sample({
+        race: "Halfling",
+        metric: "tdMean",
+        observed: 4.0,
+        reference: 1.4,
+      }),
+    ]);
+    // Halfling tdMean max = 2.5 -> 4.0 declenche above_max.
+    if (RACE_DRIFT_BOUNDS.Halfling?.tdMean?.max !== undefined) {
+      expect(out).toHaveLength(1);
+      expect(out[0].metric).toBe("tdMean");
+    }
+  });
+
+  it("ignore les metriques sans bornes pour cette race", () => {
+    // Halfling n'a pas de bornes definies sur casualtyMean -> no alert
+    // meme si observed est extreme.
+    const out = detectRaceBoundAlerts([
+      sample({
+        race: "Halfling",
+        metric: "casualtyMean",
+        observed: 100,
+      }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("agrege plusieurs alertes sur plusieurs samples", () => {
+    const out = detectRaceBoundAlerts([
+      sample({ race: "Halfling", metric: "winRate", observed: 0.6 }),
+      sample({ race: "Wood Elf", metric: "winRate", observed: 0.2 }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((a) => a.race).sort()).toEqual(["Halfling", "Wood Elf"]);
+  });
+});

--- a/apps/server/src/services/pro-league-race-bounds.ts
+++ b/apps/server/src/services/pro-league-race-bounds.ts
@@ -1,0 +1,186 @@
+/**
+ * Bornes drift par race (Lot 4.A.3).
+ *
+ * Pourquoi
+ * --------
+ * Le drift watcher de Lot 2.A.5 + 4.A signale les drifts relatives
+ * (>10% / >25% vs FUMBBL_REFERENCE) avec un seuil flat. Mais en BB,
+ * certaines races ont des winrates intrinsequement bas (Halfling,
+ * Goblin, Snotling : 25-35%) ou hauts (Wood Elf, Chaos Dwarf : 55-65%).
+ *
+ * Une drift de 10% sur un winrate Halfling reference 30% -> observed
+ * 33% : pas grave. Meme drift en absolu sur Wood Elf 60% -> observed
+ * 66% : pas grave non plus. Mais Halfling > 45% ou Wood Elf < 40% =
+ * anomalie BB-rules-violente independamment de la drift relative.
+ *
+ * Cette table definit des bornes absolues par race et metrique. Sert
+ * en complement (pas remplacement) du drift watcher : un sample peut
+ * rester dans la tolerance ±10% mais sortir des bornes BB-realistes.
+ *
+ * Architecture
+ * ------------
+ * - `RACE_DRIFT_BOUNDS` : table par race -> { winRate, tdMean,
+ *   casualtyMean : { min?, max? } } optionnels.
+ * - `detectRaceBoundAlerts(samples, options)` : pure, retourne
+ *   les alertes critical pour les samples hors-bornes.
+ * - Branche dans `pro-league-engine-drift-watcher.runDriftTick` a
+ *   cote de `detectDriftAlerts` existant. Les deux sources d'alertes
+ *   alimentent la meme jauge `nuffle_engine_drift_alerts_count`.
+ *
+ * Tradeoffs
+ * ---------
+ * Bornes choisies large pour ne signaler que des anomalies vraiment
+ * suspectes (>5σ pour les races scewees connues). Tuner si on
+ * observe des faux positifs / faux negatifs en prod.
+ */
+
+import type {
+  DriftMetric,
+  DriftSample,
+} from "./pro-league-engine-drift-watcher";
+
+export interface RaceBoundRange {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export interface RaceDriftBounds {
+  readonly winRate?: RaceBoundRange;
+  readonly tdMean?: RaceBoundRange;
+  readonly casualtyMean?: RaceBoundRange;
+}
+
+/**
+ * Bornes absolues par race. Ne defini que les races connues pour
+ * etre extreme bas (Halfling, Goblin, Snotling) ou extreme haut
+ * (Wood Elf, Chaos Dwarf, Dwarf, Lizardmen). Les autres races
+ * tombent en no-op (fallback sur le drift watcher classique).
+ *
+ * Sources : FUMBBL stats long-term + Blood Bowl tier list communaute.
+ * Bornes elargies de ±10pp vs reference pour ne signaler que les
+ * vraies anomalies.
+ */
+export const RACE_DRIFT_BOUNDS: Record<string, RaceDriftBounds> = {
+  // Tier 4 (faibles, doivent perdre la majorite)
+  Halfling: {
+    winRate: { max: 0.45 },
+    tdMean: { max: 2.5 },
+  },
+  Goblin: {
+    winRate: { max: 0.45 },
+    tdMean: { max: 2.5 },
+  },
+  Snotling: {
+    winRate: { max: 0.4 },
+    tdMean: { max: 2.0 },
+  },
+  Ogre: {
+    winRate: { max: 0.5 },
+  },
+  // Tier 1 (forts, doivent dominer mais pas crusher)
+  "Wood Elf": {
+    winRate: { min: 0.45, max: 0.7 },
+    tdMean: { min: 1.8 },
+  },
+  "Chaos Dwarf": {
+    winRate: { min: 0.45, max: 0.7 },
+  },
+  Dwarf: {
+    winRate: { min: 0.45, max: 0.7 },
+  },
+  Lizardmen: {
+    winRate: { min: 0.45, max: 0.7 },
+  },
+  Amazon: {
+    winRate: { min: 0.45, max: 0.65 },
+  },
+};
+
+/** Direction de la borne franchie (utile pour debug humain). */
+export type RaceBoundDirection = "above_max" | "below_min";
+
+export interface RaceBoundAlert {
+  readonly severity: "critical";
+  readonly race: string;
+  readonly seasonId: string;
+  readonly metric: DriftMetric;
+  readonly direction: RaceBoundDirection;
+  readonly observed: number;
+  readonly bound: number;
+  readonly samples: number;
+}
+
+export interface DetectRaceBoundAlertsOptions {
+  /**
+   * Pas d'alerte sous ce nombre de samples (variance trop forte
+   * pour conclure). Default 5, aligne sur le drift watcher.
+   */
+  readonly minMatches?: number;
+  /** Override de la table de bornes (utile pour les tests). */
+  readonly bounds?: Record<string, RaceDriftBounds>;
+}
+
+const DEFAULT_MIN_MATCHES = 5;
+
+function readMetric(
+  bounds: RaceDriftBounds,
+  metric: DriftMetric,
+): RaceBoundRange | undefined {
+  switch (metric) {
+    case "winRate":
+      return bounds.winRate;
+    case "tdMean":
+      return bounds.tdMean;
+    case "casualtyMean":
+      return bounds.casualtyMean;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pure : retourne les alertes critical pour les samples hors-bornes.
+ * Les samples sans bornes definies pour leur race -> no-op (fallback
+ * sur le drift watcher classique).
+ */
+export function detectRaceBoundAlerts(
+  samples: readonly DriftSample[],
+  options: DetectRaceBoundAlertsOptions = {},
+): RaceBoundAlert[] {
+  const minMatches = options.minMatches ?? DEFAULT_MIN_MATCHES;
+  const bounds = options.bounds ?? RACE_DRIFT_BOUNDS;
+  const alerts: RaceBoundAlert[] = [];
+  for (const s of samples) {
+    if (s.samples < minMatches) continue;
+    const raceBounds = bounds[s.race];
+    if (!raceBounds) continue;
+    const range = readMetric(raceBounds, s.metric);
+    if (!range) continue;
+    if (range.max !== undefined && s.observed > range.max) {
+      alerts.push({
+        severity: "critical",
+        race: s.race,
+        seasonId: s.seasonId,
+        metric: s.metric,
+        direction: "above_max",
+        observed: s.observed,
+        bound: range.max,
+        samples: s.samples,
+      });
+      continue;
+    }
+    if (range.min !== undefined && s.observed < range.min) {
+      alerts.push({
+        severity: "critical",
+        race: s.race,
+        seasonId: s.seasonId,
+        metric: s.metric,
+        direction: "below_min",
+        observed: s.observed,
+        bound: range.min,
+        samples: s.samples,
+      });
+    }
+  }
+  return alerts;
+}


### PR DESCRIPTION
## Pourquoi

Le drift watcher (Lot 2.A.5) + alertes warn/critical (Lot 4.A) signale les drifts relatives (>10% / >25%) avec un seuil **flat** vs `FUMBBL_REFERENCE`. Mais en BB, certaines races ont des winrates intrinsèquement bas (Halfling, Goblin, Snotling : 25-35%) ou hauts (Wood Elf, Chaos Dwarf, Dwarf, Lizardmen : 55-65%). Une drift de 10% sur Halfling 30% → 33% : pas grave. Halfling > 45% : **anomalie BB-rules-violente** indépendamment de la drift relative.

**Avant ce PR** : un Halfling qui passe de 30% (FUMBBL ref) à 50% winrate déclenche une alerte `warn` (drift +66%) mais pas `critical` (>25% relatif = 7.5pp absolu). Or 50% winrate Halfling = clairement un bug moteur.

## Comment

1. **`pro-league-race-bounds.ts`** (nouveau, pure) :
   - Table `RACE_DRIFT_BOUNDS` par race → `{ winRate, tdMean, casualtyMean: { min?, max? } }` optionnels.
   - Définie pour 9 races emblématiquement skewées :
     - **Tier 4** (faibles) : Halfling, Goblin, Snotling, Ogre
     - **Tier 1** (forts) : Wood Elf, Chaos Dwarf, Dwarf, Lizardmen, Amazon
   - Bornes élargies de ±10pp vs reference pour ne signaler que les vraies anomalies (>5σ pour les races scewées connues).
   - Races sans bornes → entry `undefined` (fallback drift watcher classique).

2. **`detectRaceBoundAlerts(samples, options)`** (pure) :
   - Retourne des alertes `critical` pour les samples hors-bornes.
   - Filtre `minMatches` (default 5) aligné avec le drift watcher.
   - Direction `above_max` ou `below_min` pour debug humain.
   - `bounds` injectable pour les tests.

3. **Wire dans `runDriftTick`** :
   - Après `detectDriftAlerts`, appelle aussi `detectRaceBoundAlerts`.
   - Les bound alerts sont TOUJOURS critical → add à la jauge `nuffle_engine_drift_alerts_count{severity="critical"}`.
   - Log type distinct `race_bound_alert` (vs `drift_alert`) pour permettre des queries Loki séparées :
     ```
     {event="race_bound_alert"} | json | race="Halfling"
     ```

## Tests

12 tests `pro-league-race-bounds.test.ts` :
- `RACE_DRIFT_BOUNDS` : valeurs Halfling / Wood Elf / Chaos Dwarf, races sans bornes → `undefined`.
- `detectRaceBoundAlerts` : ignore races sans bornes, ignore samples sous `minMatches`, alerte `above_max` sur Halfling winrate, alerte `below_min` sur Wood Elf winrate, agrégation multi-samples, ignore métriques sans bornes pour cette race.

### Résultats

- `@bb/server` : 12 nouveaux tests
- 25 tests drift-watcher existants verts (no regression)
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte
- [ ] En prod, observer un Halfling > 45% winrate déclenche un `race_bound_alert` dans les logs (et incrémente le compteur `nuffle_engine_drift_alerts_count{severity="critical"}`)
- [ ] Un Wood Elf à 30% winrate déclenche aussi un alert (direction=below_min)
- [ ] Une race "moyenne" (Orc 50%) ne déclenche pas d'alerte même si l'observed est exotique (pas de bornes définies)
- [ ] Loki query `{event="race_bound_alert"} | json` retourne bien les bons logs structurés

## Hors scope

- **Bornes Tier 2/3** (Orc, Norse, Pro Elf, etc.) : ces races n'ont pas de winrate extrême. Le drift watcher classique avec ±10% relatif est suffisant. À ajouter si on observe des cas marginaux en prod.
- **Bornes par `engineVer`** : si un futur bump rebalance les races intentionnellement, il faudra updater `RACE_DRIFT_BOUNDS` dans la même PR. Pas de versioning automatique de la table pour le MVP.
- **UI admin** : la table peut être exposée via `/admin/sim/drift` (UI 2.B.3 deferred). Pour l'instant, les alertes apparaissent en Loki + jauge Prometheus.

## Refs

- PR #720 (Lot 4.A — `drift_alert` + jauge `alerts_count`)
- PR #722 (Lot 4.B.1 — cross-version comparator)
- PR #725 (Lot 4.B.2 — replay diff tool)
- `docs/roadmap/sprints/SPRINT-sim-engine-observability.md` (Phase 4.A.3)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_