### PR TITLE
feat(sim-engine): hybrid driver attribue scorerId pondere par position (Lot 4.D.4)

### DIFF
--- a/packages/sim-engine/src/driver/hybrid-driver.test.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.test.ts
@@ -498,3 +498,109 @@ describe('runHybridDriver — yards as narrated MOVE events (#4)', () => {
   });
 });
 
+describe('runHybridDriver — TD scorerId attribution (Lot 4.D.4)', () => {
+  function rosterFor(prefix: string) {
+    return [
+      {
+        id: `${prefix}-cat`,
+        name: `${prefix} Catcher`,
+        number: 1,
+        position: 'Catcher',
+        ma: 8,
+        st: 2,
+        ag: 4,
+        pa: 3,
+        av: 8,
+      },
+      {
+        id: `${prefix}-blz`,
+        name: `${prefix} Blitzer`,
+        number: 2,
+        position: 'Blitzer',
+        ma: 7,
+        st: 4,
+        ag: 3,
+        pa: 4,
+        av: 9,
+      },
+      {
+        id: `${prefix}-lin`,
+        name: `${prefix} Lineman`,
+        number: 3,
+        position: 'Lineman',
+        ma: 6,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+      },
+    ];
+  }
+
+  it('attribue scorerId aux TD events quand un roster est fourni', () => {
+    const out = runHybridDriver(
+      baseInput({
+        seed: 42,
+        home: {
+          id: 'home',
+          name: 'Home',
+          side: 'home',
+          roster: rosterFor('h'),
+        },
+        away: {
+          id: 'away',
+          name: 'Away',
+          side: 'away',
+          roster: rosterFor('a'),
+        },
+      }),
+    );
+    const tds = out.events.filter((e) => e.type === 'TD');
+    if (tds.length > 0) {
+      // Tous les TD doivent avoir scorerId, et l'id doit appartenir
+      // au roster de la team scoring.
+      for (const td of tds) {
+        const meta = (td.meta ?? {}) as Record<string, unknown>;
+        expect(typeof meta.scorerId).toBe('string');
+        const team = meta.team as 'home' | 'away';
+        const expected = (team === 'home' ? 'h' : 'a') + '-';
+        expect((meta.scorerId as string).startsWith(expected)).toBe(true);
+      }
+    }
+  });
+
+  it('omet scorerId quand aucun roster fourni (mode legacy archetype)', () => {
+    const out = runHybridDriver(baseInput({ seed: 42 }));
+    const tds = out.events.filter((e) => e.type === 'TD');
+    for (const td of tds) {
+      const meta = (td.meta ?? {}) as Record<string, unknown>;
+      expect(meta.scorerId).toBeUndefined();
+    }
+  });
+
+  it('deterministe : meme seed + roster -> meme scorerId par TD', () => {
+    const seed = 7;
+    const home = {
+      id: 'h',
+      name: 'H',
+      side: 'home' as const,
+      roster: rosterFor('h'),
+    };
+    const away = {
+      id: 'a',
+      name: 'A',
+      side: 'away' as const,
+      roster: rosterFor('a'),
+    };
+    const a = runHybridDriver(baseInput({ seed, home, away }));
+    const b = runHybridDriver(baseInput({ seed, home, away }));
+    const scorersA = a.events
+      .filter((e) => e.type === 'TD')
+      .map((e) => (e.meta as { scorerId?: string })?.scorerId);
+    const scorersB = b.events
+      .filter((e) => e.type === 'TD')
+      .map((e) => (e.meta as { scorerId?: string })?.scorerId);
+    expect(scorersB).toEqual(scorersA);
+  });
+});
+

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -60,7 +60,9 @@ import {
   type MatchSummary,
   type SimInput,
   type SimResult,
+  type SimRosterPlayer,
 } from '../types';
+import { pickHybridScorer } from './hybrid-scorer';
 
 const TURNS_PER_HALF = 8;
 const FIELD_YARDS = 26;
@@ -170,6 +172,9 @@ interface DriverRng {
    *  triggers the silent retry. Independent so toggling the boost
    *  on/off doesn't shift any other stream. */
   luck: Rng;
+  /** Lot 4.D.4 — scorer attribution for hybrid driver. Independent
+   *  so adding it doesn't shift any other stream (replay-stable). */
+  scorer: Rng;
 }
 
 function forkRngs(rootSeed: number): DriverRng {
@@ -184,6 +189,7 @@ function forkRngs(rootSeed: number): DriverRng {
     strategic: root.fork('strategic-decisions'),
     nuffle: root.fork('nuffle-events'),
     luck: root.fork('underdog-luck'),
+    scorer: root.fork('hybrid-scorer'),
   };
 }
 
@@ -492,6 +498,12 @@ interface MutableMatch {
   /** Per-player momentum tracker (lot 0.B.4). The MVP synthesises LOS
    *  player IDs ; the full driver (post-MVP) will plug real roster IDs. */
   momentum: MomentumTracker;
+  /** Lot 4.D.4 — rosters reels passes via SimInput.{home,away}.roster.
+   *  Permettent au hybrid driver d'attribuer un `scorerId` pseudo-
+   *  aleatoire pondere par position sur les TD events. Vide en mode
+   *  archetype-vs-archetype (legacy) — emitTd skip le scorerId. */
+  homeRoster: readonly SimRosterPlayer[];
+  awayRoster: readonly SimRosterPlayer[];
 }
 
 function emitTurnStart(m: MutableMatch): void {
@@ -509,7 +521,23 @@ function emitTurnStart(m: MutableMatch): void {
   });
 }
 
-function emitTd(m: MutableMatch, scoringTeam: Side, displayAtMs: number): void {
+function emitTd(
+  m: MutableMatch,
+  scoringTeam: Side,
+  displayAtMs: number,
+  rngs: DriverRng,
+): void {
+  // Lot 4.D.4 — quand un roster reel est fourni cote `SimInput`, on
+  // attribue un `scorerId` pseudo-aleatoire pondere par position
+  // (Catcher / Runner > Lineman > Big Guy). Sans roster (mode legacy
+  // archetype-vs-archetype), on omet `scorerId` -> SPP service
+  // ignore le TD.
+  const roster =
+    scoringTeam === 'home' ? m.homeRoster : m.awayRoster;
+  const scorerId =
+    roster.length > 0
+      ? pickHybridScorer(roster, () => rngs.scorer.next())
+      : null;
   m.events.push({
     type: 'TD',
     displayAtMs,
@@ -519,6 +547,7 @@ function emitTd(m: MutableMatch, scoringTeam: Side, displayAtMs: number): void {
       half: m.state.half,
       turn: m.state.turn,
       scoreAfter: { home: m.state.scoreHome, away: m.state.scoreAway },
+      ...(scorerId ? { scorerId } : {}),
     },
   });
 }
@@ -697,7 +726,7 @@ function processTurn(
         else m.state = { ...m.state, scoreAway: m.state.scoreAway + 1 };
         m.touchdowns += 1;
         recordTouchdown(m.momentum, drivingPlayerId);
-        emitTd(m, scoring, momentAtMs);
+        emitTd(m, scoring, momentAtMs, rngs);
         m.state = { ...m.state, drive: nextDrive(m.state.drive) };
         // A scoring play ends the team's turn ; treat it like a
         // turnover-on-the-positive-side so the bulk yard advancement
@@ -762,7 +791,7 @@ function processTurn(
       else m.state = { ...m.state, scoreAway: m.state.scoreAway + 1 };
       m.touchdowns += 1;
       recordTouchdown(m.momentum, `${scoring}-LOS`);
-      emitTd(m, scoring, bulkAtMs);
+      emitTd(m, scoring, bulkAtMs, rngs);
       m.state = { ...m.state, drive: nextDrive(m.state.drive) };
     } else {
       m.state = {
@@ -824,6 +853,10 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
     nuffleEvents: 0,
     underdogBoosts: 0,
     momentum: createMomentumTracker(),
+    // Lot 4.D.4 — rosters reels propages depuis SimInput. Vide quand
+    // le caller utilise le hybrid driver en mode legacy archetype.
+    homeRoster: input.home.roster ?? [],
+    awayRoster: input.away.roster ?? [],
   };
 
   // First half.

--- a/packages/sim-engine/src/driver/hybrid-scorer.test.ts
+++ b/packages/sim-engine/src/driver/hybrid-scorer.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests pour le pickHybridScorer (Lot 4.D.4).
+ *
+ * Couvre la fonction pure qui choisit un scorer pseudo-aleatoire
+ * pondere par position parmi un roster, pour permettre au hybrid
+ * driver d'attribuer un `scorerId` realiste sur les TD events.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  HYBRID_SCORER_POSITION_WEIGHTS,
+  pickHybridScorer,
+} from './hybrid-scorer';
+import type { SimRosterPlayer } from '../types';
+
+function player(
+  overrides: Partial<SimRosterPlayer> = {},
+): SimRosterPlayer {
+  return {
+    id: 'p',
+    name: 'Player',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 9,
+    ...overrides,
+  };
+}
+
+function mulberry(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe('HYBRID_SCORER_POSITION_WEIGHTS — Lot 4.D.4', () => {
+  it('Catcher / Runner ont un poids superieur a Lineman', () => {
+    expect(HYBRID_SCORER_POSITION_WEIGHTS.Catcher).toBeGreaterThan(
+      HYBRID_SCORER_POSITION_WEIGHTS.Lineman,
+    );
+    expect(HYBRID_SCORER_POSITION_WEIGHTS.Runner).toBeGreaterThan(
+      HYBRID_SCORER_POSITION_WEIGHTS.Lineman,
+    );
+  });
+
+  it('Big Guy a un poids tres faible (rarement scorer)', () => {
+    expect(HYBRID_SCORER_POSITION_WEIGHTS['Big Guy']).toBeLessThan(
+      HYBRID_SCORER_POSITION_WEIGHTS.Lineman,
+    );
+  });
+
+  it('Blitzer / Thrower / Skink presents (scorers credibles)', () => {
+    expect(HYBRID_SCORER_POSITION_WEIGHTS.Blitzer).toBeGreaterThan(0);
+    expect(HYBRID_SCORER_POSITION_WEIGHTS.Thrower).toBeGreaterThan(0);
+    expect(HYBRID_SCORER_POSITION_WEIGHTS.Skink).toBeGreaterThan(0);
+  });
+});
+
+describe('pickHybridScorer — Lot 4.D.4', () => {
+  it('null sur roster vide', () => {
+    expect(pickHybridScorer([], mulberry(1))).toBeNull();
+  });
+
+  it('retourne le seul joueur si le roster en contient un', () => {
+    const roster = [player({ id: 'p1', position: 'Lineman' })];
+    expect(pickHybridScorer(roster, mulberry(1))).toBe('p1');
+  });
+
+  it('deterministe pour un meme rng', () => {
+    const roster = [
+      player({ id: 'L1', position: 'Lineman' }),
+      player({ id: 'C1', position: 'Catcher' }),
+      player({ id: 'B1', position: 'Big Guy' }),
+    ];
+    const a = pickHybridScorer(roster, mulberry(42));
+    const b = pickHybridScorer(roster, mulberry(42));
+    expect(a).toBe(b);
+  });
+
+  it('biais par position : Catcher pris plus souvent que Big Guy sur 1000 runs', () => {
+    const roster = [
+      player({ id: 'cat', position: 'Catcher' }),
+      player({ id: 'big', position: 'Big Guy' }),
+    ];
+    let catWins = 0;
+    let bigWins = 0;
+    for (let i = 0; i < 1000; i += 1) {
+      const pick = pickHybridScorer(roster, mulberry(i));
+      if (pick === 'cat') catWins += 1;
+      else if (pick === 'big') bigWins += 1;
+    }
+    // Catcher (poids ~5) doit etre pris >= 4x plus souvent que Big Guy (~1).
+    expect(catWins).toBeGreaterThan(bigWins * 3);
+  });
+
+  it('exclut les positions de poids 0 sauf si seules options', () => {
+    // Position inconnue -> poids defaut. Tous les joueurs avec une
+    // position connue (Catcher) devraient etre pris en priorite.
+    const roster = [
+      player({ id: 'cat', position: 'Catcher' }),
+      player({ id: 'unknown', position: 'WeirdPosition' }),
+    ];
+    let catCount = 0;
+    for (let i = 0; i < 200; i += 1) {
+      if (pickHybridScorer(roster, mulberry(i)) === 'cat') catCount += 1;
+    }
+    // Catcher (poids ~5) >> WeirdPosition (poids defaut faible).
+    expect(catCount).toBeGreaterThan(120);
+  });
+
+  it('positions inconnues fallback : roster ne contenant que des positions inconnues retourne quand meme un id', () => {
+    const roster = [
+      player({ id: 'a', position: 'Foo' }),
+      player({ id: 'b', position: 'Bar' }),
+    ];
+    const pick = pickHybridScorer(roster, mulberry(1));
+    expect(['a', 'b']).toContain(pick);
+  });
+});

--- a/packages/sim-engine/src/driver/hybrid-scorer.ts
+++ b/packages/sim-engine/src/driver/hybrid-scorer.ts
@@ -1,0 +1,97 @@
+/**
+ * Pick d'un scorer pseudo-aleatoire dans un roster pour le hybrid
+ * driver (Lot 4.D.4).
+ *
+ * Pourquoi
+ * --------
+ * Le hybrid driver synthetise les TDs (`emitTd`) sans tracker quel
+ * joueur exact a marque (synthese archetype-vs-archetype). En 3.C.3
+ * on a ajoute `scorerId` aux TD events du **full driver** pour
+ * permettre au SPP service d'attribuer +3 SPP au porteur. Le hybrid
+ * driver continuait d'emettre des TD sans `scorerId` -> 0 SPP TD en
+ * mode hybrid.
+ *
+ * Solution : quand le `SimInput.home.roster` est fourni, on choisit
+ * un scorer pseudo-aleatoire pondere par position (Catcher / Runner
+ * dominent, Lineman moyen, Big Guy rare). Deterministe via le RNG
+ * partage du driver -> meme seed = meme scorer = replay-stable.
+ *
+ * Hors scope
+ * ----------
+ * - Pondertaion par stats individuelles (MA, AG) : poids plat par
+ *   position pour le MVP. Si une saison a un Lineman avec MA10
+ *   buffe (lvl-up + stat increase 4.D.1), il restera "Lineman" du
+ *   point de vue du picker.
+ * - Filtre joueurs "actifs" (non casualty) : le roster passe ici a
+ *   deja ete filtre cote sim-runner. Defense-in-depth : fallback sur
+ *   tous les joueurs si le filtre rate.
+ */
+
+import type { SimRosterPlayer } from '../types';
+
+/**
+ * Poids de selection par position. Source : intuition BB +
+ * statistique FUMBBL. Catcher / Runner dominent, Skink (Lizardmen)
+ * marqueur agile, Lineman moyen, Big Guy rare (peu mobile).
+ *
+ * Les positions absentes de cette table tombent sur DEFAULT_WEIGHT
+ * (3 = niveau Lineman). Permet au picker de gerer des rosters
+ * exotiques (Star Players, mercenaires, etc.) sans crasher.
+ */
+export const HYBRID_SCORER_POSITION_WEIGHTS: Record<string, number> = {
+  // Tres mobiles, designed-to-score
+  Catcher: 8,
+  Runner: 8,
+  Skink: 7,
+  // Designed-to-fight + occasionally score
+  Blitzer: 4,
+  Thrower: 4,
+  // Lineman generique
+  Lineman: 3,
+  Linewoman: 3,
+  Zombie: 3,
+  Skeleton: 3,
+  Saurus: 3,
+  // Big Guys
+  'Big Guy': 1,
+  Blocker: 2,
+};
+
+const DEFAULT_WEIGHT = 3;
+
+function weightFor(position: string): number {
+  return HYBRID_SCORER_POSITION_WEIGHTS[position] ?? DEFAULT_WEIGHT;
+}
+
+/**
+ * Choisit un scorer dans `roster` via un sample pondere par position.
+ * Retourne `null` si le roster est vide.
+ *
+ * Le `rng` doit etre une fonction `() => number` produisant des
+ * valeurs dans `[0, 1)`. Le caller fournit le RNG du driver pour
+ * preserver la determinisme du replay (meme seed -> meme scorer).
+ */
+export function pickHybridScorer(
+  roster: readonly SimRosterPlayer[],
+  rng: () => number,
+): string | null {
+  if (roster.length === 0) return null;
+  if (roster.length === 1) return roster[0].id;
+
+  let totalWeight = 0;
+  for (const p of roster) totalWeight += weightFor(p.position);
+  // Tous poids 0 (impossible avec DEFAULT_WEIGHT > 0 mais defense) :
+  // tirer uniformement.
+  if (totalWeight <= 0) {
+    return roster[Math.floor(rng() * roster.length)].id;
+  }
+
+  const target = rng() * totalWeight;
+  let cumulative = 0;
+  for (const p of roster) {
+    cumulative += weightFor(p.position);
+    if (target < cumulative) return p.id;
+  }
+  // Edge case rounding : retombe sur le dernier.
+  return roster[roster.length - 1].id;
+}


### PR DESCRIPTION
## Pourquoi

Lot 3.C.3 (PR #718) a ajouté `scorerId` aux TD events du **full driver** uniquement. Le hybrid driver synthétise les TDs (archétype-vs-archétype) sans tracker quel joueur a marqué, donc :
- les TD du hybrid driver n'ont pas de `scorerId` → **0 SPP TD attribué en mode hybrid**
- un coach qui passe d'hybrid à full voit ses meilleurs scorers stagner pendant la phase hybrid puis bondir d'un coup en full

Ce lot ferme le gap : quand `SimInput.{home,away}.roster` est fourni (ce que le sim-runner fait depuis 3.A.2.c), le hybrid driver choisit un scorer pseudo-aléatoire pondéré par position parmi le roster correspondant.

## Comment

1. **Pure helper `hybrid-scorer.ts`** :
   - `HYBRID_SCORER_POSITION_WEIGHTS` table : Catcher 8, Runner 8, Skink 7, Blitzer 4, Thrower 4, Lineman 3, Big Guy 1, Blocker 2. Poids défaut 3 (Lineman générique) pour positions inconnues.
   - `pickHybridScorer(roster, rng)` : sample pondéré via rng. `null` sur roster vide. Retourne id directement quand `roster.length=1`.
   - 100% pure : `rng` injectable → testable + replay-stable.

2. **Wiring dans `hybrid-driver.ts`** :
   - Nouveau RNG stream `scorer` (forké indépendant : l'ajouter ne décale aucun autre stream → replay-stable des replays existants).
   - `MutableMatch` étendu : `homeRoster` + `awayRoster` lus depuis `input.{home,away}.roster ?? []`.
   - `emitTd(m, scoringTeam, displayAtMs, rngs)` : choisit le `scorerId` via `pickHybridScorer` quand un roster existe, sinon omet le champ (mode legacy archétype-vs-archétype préservé).
   - 2 callers de `emitTd` mis à jour (TD via momentum + TD via bulk advance).

3. **SPP attribution** : aucune modification côté `pro-roster-spp.ts`. Le service consomme `meta.scorerId` quel que soit le driver → les TDs hybrid avec scorerId sont automatiquement créditeurs de 3 SPP au porteur.

## Tests

- `hybrid-scorer.test.ts` : 9 tests
  - Table de poids : Catcher > Lineman > Big Guy.
  - `pickHybridScorer` : null sur vide, déterministe, biais pondéré sur 1000 runs (Catcher >> Big Guy ×3+), positions inconnues fallback.
- `hybrid-driver.test.ts` : +3 tests
  - TD events portent `scorerId` quand roster fourni, et l'id appartient au roster de la team scoring.
  - Mode legacy (sans roster) : `scorerId` omis (rétrocompat).
  - Déterminisme : même seed + roster → mêmes `scorerIds` par TD.

### Résultats

- `@bb/sim-engine` : 12 nouveaux tests (9 hybrid-scorer + 3 hybrid-driver)
- Total : 42 tests verts sur les 2 fichiers
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte
- [ ] En prod, après une saison hybrid driver, vérifier que `ProTeamRoster.tdCount` augmente sur les Catchers/Runners/Blitzers (et reste bas sur Big Guys/Linemen)
- [ ] Replay d'un match hybrid pré-PR : tous les TD events ont `meta.scorerId` undefined (rétrocompat)
- [ ] Replay d'un match hybrid post-PR avec roster : tous les TD events ont `meta.scorerId` valide

## Hors scope

- **Pondération par stats individuelles (MA, AG)** : poids plat par position pour le MVP. Si une saison a un Lineman avec MA10 buffé (lvl-up + stat increase 4.D.1), il restera "Lineman" du point de vue du picker.
- **Filtre joueurs casualty** : le picker prend tout le roster fourni. Le caller côté sim-runner peut filtrer `status='active'` avant de passer le roster à `SimInput`. À faire si on observe des `scorerId` sur des morts en prod (peu probable car le roster cache est rebâti à chaque match).
- **Hybrid driver verbose mode** : pas de trace de *"pourquoi Bob plutôt qu'Alice ?"*. Pour debug, le RNG stream `scorer` est reproducible via le seed.

## Refs

- PR #718 (Lot 3.C.3 — TD scorerId full driver)
- PR #717 (Lot 3.C.2 — SPP service consommateur)
- Sprint Lot 4.D.4

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_