### PR TITLE
feat(pro-league): niggling TV malus + cron sweepRecomputeTvs (Lot 4.D.3)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -839,6 +839,48 @@ if (!inTestLevelUpEnv && levelUpTickMs > 0) {
 
 
 // =============================================================================
+// Pro League TV recompute cron (Lot 4.D.3).
+// =============================================================================
+// Sweep les rosters `active` et reconcilie `tvCached` apres :
+//   - les level-ups (skills appris -> +20k chacun)
+//   - les casualties (niggling +1 -> -10k chacun)
+// Le level-up applier recompute deja inline lors d'un level-up, mais
+// les niggling sont incrementes par le casualty cron sans toucher
+// la TV. Ce cron rattrape le drift en regime stable.
+//
+// Idempotent : `recomputePlayerTv` no-op si tvCached deja correct.
+//
+// Tick par defaut : 30 min. Configurable via PRO_LEAGUE_TV_TICK_MS.
+// Mettre = 0 pour desactiver (CI / dev local).
+const inTestTvEnv =
+  process.env.NODE_ENV === "test" || process.env.TEST_SQLITE === "1";
+const tvTickMsEnv = Number(process.env.PRO_LEAGUE_TV_TICK_MS);
+const tvTickMs = Number.isFinite(tvTickMsEnv)
+  ? tvTickMsEnv
+  : 30 * 60 * 1000;
+if (!inTestTvEnv && tvTickMs > 0) {
+  void import("./services/pro-roster-tv").then(({ sweepRecomputeTvs }) => {
+    const tick = async () => {
+      try {
+        const out = await sweepRecomputeTvs();
+        if (out.processed > 0 || out.failed > 0) {
+          serverLog.info(
+            `[pro-tv] sweep: processed=${out.processed} failed=${out.failed} (inspected=${out.inspected})`,
+          );
+        }
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "unknown";
+        serverLog.error(`[pro-tv] sweep failed: ${msg}`);
+      }
+    };
+    setInterval(() => {
+      void tick();
+    }, tvTickMs).unref();
+  });
+}
+
+
+// =============================================================================
 // Pro League rookie replenish cron (sprint 1.E.6).
 // =============================================================================
 // Sweep les equipes Pro dont le roster `active` est sous la cible

--- a/apps/server/src/services/pro-roster-level-up.ts
+++ b/apps/server/src/services/pro-roster-level-up.ts
@@ -257,6 +257,9 @@ export async function applyLevelUps(
       paBonus: true,
       avBonus: true,
       stBonus: true,
+      // Lot 4.D.3 — niggling lu pour appliquer le malus -10k/niggling
+      // dans le tvCached recompute.
+      niggling: true,
     },
   });
   if (!roster) {
@@ -349,8 +352,10 @@ export async function applyLevelUps(
   }
 
   const newSkills = [...skills, ...newSkillsAcc];
-  // Lot 3.C.5 + 4.D.1 — recompute TV inline avec stat bonuses
-  // accumules dans la session de level-up + ceux deja persistes.
+  // Lot 3.C.5 + 4.D.1 + 4.D.3 — recompute TV inline avec stat bonuses
+  // accumules dans la session de level-up + ceux deja persistes +
+  // malus niggling courant (le casualty applier peut avoir incremente
+  // niggling avant le tick level-up).
   const totalStatBonuses: StatBonuses = {
     ma: ((roster.maBonus as number) ?? 0) + accruedStats.ma,
     ag: ((roster.agBonus as number) ?? 0) + accruedStats.ag,
@@ -361,6 +366,7 @@ export async function applyLevelUps(
   const newTvCached = computePlayerTv(
     (roster.position as string) ?? "",
     newSkills.length,
+    (roster.niggling as number) ?? 0,
     totalStatBonuses,
   );
   await prisma.proTeamRoster.update({

--- a/apps/server/src/services/pro-roster-tv.test.ts
+++ b/apps/server/src/services/pro-roster-tv.test.ts
@@ -23,6 +23,7 @@ import {
   computePlayerTv,
   computeStatBonusCost,
   DEFAULT_POSITION_COST,
+  NIGGLING_MALUS,
   recomputePlayerTv,
   RecomputeTvError,
   SKILL_COST,
@@ -104,15 +105,39 @@ describe("computePlayerTv — Lot 3.C.5", () => {
     expect(computeStatBonusCost({ ma: -3 })).toBe(0);
   });
 
-  it("Lot 4.D.1 — computePlayerTv inclut les stat bonuses", () => {
-    // Lineman 50k + 1 skill 20k + 1 MA 30k = 100k.
+  it("Lot 4.D.1 — computePlayerTv inclut les stat bonuses (apres niggling param)", () => {
+    // Lineman 50k + 1 skill 20k + 1 MA 30k = 100k. Niggling=0.
     expect(
-      computePlayerTv("Lineman", 1, { ma: 1 }),
+      computePlayerTv("Lineman", 1, 0, { ma: 1 }),
     ).toBe(100_000);
   });
 
   it("Lot 4.D.1 — stat bonuses default {} pour rétrocompat", () => {
     expect(computePlayerTv("Lineman", 2)).toBe(50_000 + 2 * SKILL_COST);
+  });
+
+  it("Lot 4.D.3 — niggling=1 retire NIGGLING_MALUS du total", () => {
+    expect(computePlayerTv("Lineman", 0, 1)).toBe(50_000 - NIGGLING_MALUS);
+    expect(NIGGLING_MALUS).toBe(10_000);
+  });
+
+  it("Lot 4.D.3 — niggling=3 retire 3 * NIGGLING_MALUS", () => {
+    expect(computePlayerTv("Big Guy", 1, 3)).toBe(
+      140_000 + SKILL_COST - 3 * NIGGLING_MALUS,
+    );
+  });
+
+  it("Lot 4.D.3 — niggling default 0 (rétrocompat)", () => {
+    expect(computePlayerTv("Lineman", 2)).toBe(50_000 + 2 * SKILL_COST);
+  });
+
+  it("Lot 4.D.3 — niggling negatif traite comme 0", () => {
+    expect(computePlayerTv("Lineman", 0, -3)).toBe(50_000);
+  });
+
+  it("Lot 4.D.3 — TV clampe a 0 si niggling depasse base + skills", () => {
+    // 5 niggling sur Lineman 50k + 0 skill = -50k -> clampe a 0.
+    expect(computePlayerTv("Lineman", 0, 6)).toBe(0);
   });
 });
 
@@ -177,6 +202,19 @@ describe("recomputePlayerTv — Lot 3.C.5", () => {
     });
     const out = await recomputePlayerTv("r4");
     expect(out.newTv).toBe(140_000);
+  });
+
+  it("Lot 4.D.3 — applique le malus niggling depuis le DB", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValue({
+      id: "r_inj",
+      position: "Lineman",
+      skills: ["block", "tackle"],
+      niggling: 2,
+      tvCached: 0,
+    });
+    const out = await recomputePlayerTv("r_inj");
+    // 50k Lineman + 2 skills * 20k - 2 niggling * 10k = 70k
+    expect(out.newTv).toBe(70_000);
   });
 });
 

--- a/apps/server/src/services/pro-roster-tv.ts
+++ b/apps/server/src/services/pro-roster-tv.ts
@@ -104,6 +104,16 @@ export function computeStatBonusCost(bonuses: StatBonuses): number {
   );
 }
 
+/**
+ * Lot 4.D.3 — malus par niggling injury (BB rules : -10k TV par
+ * niggling pour le matchmaking). Le joueur reste actif mais "fragile"
+ * et compte moins dans le TV total. Le casualty applier (Lot 3.C.1)
+ * incremente `ProTeamRoster.niggling` lors d'une injury "niggling"
+ * post-match ; `recomputePlayerTv` doit lire ce compteur pour
+ * reconciler la TV.
+ */
+export const NIGGLING_MALUS = 10_000;
+
 export type RecomputeTvErrorCode = "ROSTER_NOT_FOUND";
 
 export class RecomputeTvError extends Error {
@@ -118,22 +128,35 @@ export class RecomputeTvError extends Error {
 
 /**
  * Pure : calcule la TV individuelle a partir de la position, du nombre
- * de skills, et des stat bonuses (Lot 4.D.1).
+ * de skills, du nombre de niggling injuries, et des stat bonuses.
  *
- * Formule : `base + skills * SKILL_COST + sum(statBonuses * STAT_COSTS)`.
+ * Formule : `base + skills * SKILL_COST + sum(statBonuses * STAT_COSTS)
+ *           - niggling * NIGGLING_MALUS`.
  *
  * Tous les arguments numeriques negatifs sont traites comme 0
- * (defense-in-depth).
+ * (defense-in-depth). Le total est clampe a 0 (un joueur ne peut
+ * jamais avoir une TV negative).
+ *
+ * Lot 4.D.1 — stat bonuses ajoutes.
+ * Lot 4.D.3 — niggling malus ajoute.
  */
 export function computePlayerTv(
   position: string,
   skillCount: number,
+  niggling: number = 0,
   statBonuses: StatBonuses = {},
 ): number {
   const base = BASE_POSITION_COST[position] ?? DEFAULT_POSITION_COST;
-  const safeCount =
+  const safeSkills =
     Number.isFinite(skillCount) && skillCount > 0 ? skillCount : 0;
-  return base + safeCount * SKILL_COST + computeStatBonusCost(statBonuses);
+  const safeNiggling =
+    Number.isFinite(niggling) && niggling > 0 ? niggling : 0;
+  const tv =
+    base +
+    safeSkills * SKILL_COST +
+    computeStatBonusCost(statBonuses) -
+    safeNiggling * NIGGLING_MALUS;
+  return tv > 0 ? tv : 0;
 }
 
 /**
@@ -187,6 +210,8 @@ export async function recomputePlayerTv(
       paBonus: true,
       avBonus: true,
       stBonus: true,
+      // Lot 4.D.3 — niggling lu pour appliquer le malus -10k/niggling.
+      niggling: true,
     },
   });
   if (!roster) {
@@ -197,13 +222,18 @@ export async function recomputePlayerTv(
   }
 
   const skills = parseSkillsJson(roster.skills);
-  const newTv = computePlayerTv(roster.position as string, skills.length, {
-    ma: (roster.maBonus as number) ?? 0,
-    ag: (roster.agBonus as number) ?? 0,
-    pa: (roster.paBonus as number) ?? 0,
-    av: (roster.avBonus as number) ?? 0,
-    st: (roster.stBonus as number) ?? 0,
-  });
+  const newTv = computePlayerTv(
+    roster.position as string,
+    skills.length,
+    (roster.niggling as number) ?? 0,
+    {
+      ma: (roster.maBonus as number) ?? 0,
+      ag: (roster.agBonus as number) ?? 0,
+      pa: (roster.paBonus as number) ?? 0,
+      av: (roster.avBonus as number) ?? 0,
+      st: (roster.stBonus as number) ?? 0,
+    },
+  );
   const oldTv = (roster.tvCached as number) ?? 0;
 
   if (newTv === oldTv) {


### PR DESCRIPTION
## Pourquoi

Lot 3.C.5 (PR #723) a livré la TV cachée + recompute inline au level-up. Mais deux gaps subsistaient :

1. **Pas de malus niggling** : BB applique -10k TV par niggling pour le matchmaking (joueur encore actif mais "fragile"). Notre `computePlayerTv` ne faisait que `base + skills * 20k`.
2. **Pas de cron** : `sweepRecomputeTvs` était livré comme helper mais aucun `setInterval` ne l'appelait. Quand le casualty cron incrémente `niggling` post-match, la TV restait drift sans réconcilier jusqu'au prochain level-up (qui peut ne jamais arriver pour un Lineman peu performant).

## Comment

1. **`computePlayerTv(position, skills, niggling = 0)`** :
   - Nouvelle constante `NIGGLING_MALUS = 10_000` (BB rules).
   - Formule : `base + skills * SKILL_COST - niggling * NIGGLING_MALUS`.
   - `niggling` default 0 (rétrocompat) ; négatif clampé à 0 (defense-in-depth).
   - Total clampé à 0 (un Lineman 50k avec 6 niggling descendrait sous zéro, ininterprétable).

2. **`recomputePlayerTv` lit `niggling` du DB** :
   - Select étendu pour inclure le champ.
   - Passe à `computePlayerTv` → recompute correct après une casualty.

3. **`pro-roster-level-up.ts` propage niggling** :
   - Select `niggling: true` ajouté pour le wire-up inline.
   - `computePlayerTv(position, newSkills.length, niggling)` → applique le malus à chaque level-up (level-up après casualty préserve la TV réduite).

4. **Cron `sweepRecomputeTvs` dans `index.ts`** :
   - Pattern aligné sur les autres crons (rookie, casualty, level-up).
   - Tick 30min défaut, override `PRO_LEAGUE_TV_TICK_MS`.
   - Désactivé en `NODE_ENV=test` ou `TEST_SQLITE=1`.
   - Placé après le level-up cron (ordre logique : niggling appliqué par casualty → level-up applique skills + tv → tv cron rattrape les drifts).

## Tests

- `pro-roster-tv.test.ts` : +6 tests (niggling=1, =3, default 0, négatif, TV clampé à 0, recompute applique malus depuis DB).
- `pro-roster-level-up.test.ts` : 22 tests existants verts (no regression — `niggling` lu via Prisma mock, default undefined).

### Résultats

- `@bb/server` : 22 tests TV (+6 nouveaux) + 22 level-up inchangés
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte
- [ ] Migration applicable (rosters existants conservent `tvCached` actuel)
- [ ] En prod, après une saison full driver avec casualties, vérifier que `ProTeamRoster.tvCached` reflète bien le malus niggling
- [ ] Logs `[pro-tv] sweep: processed=N` apparaissent toutes les 30min
- [ ] Setting `PRO_LEAGUE_TV_TICK_MS=0` désactive bien le cron

## Hors scope

- **Forme (`form` 0-100)** impact sur TV : pas dans BB rules classique. Reste à 50 par défaut sans usage.
- **Stat reductions** (-MA / -ST / -AG / -AV) : actuellement trackées via `maReduction`/etc. dans le casualty applier mais pas encore déductibles de la TV. À faire si on observe que les joueurs "diminués" gardent une TV pleine en prod.
- **Dead/retired malus** : ces statuts retirent le joueur du roster actif. Le sweep filtre `status='active'` donc les morts sont automatiquement exclus de la somme TV team.

## Refs

- PR #723 (Lot 3.C.5 — TV recalc initial)
- PR #716 (Lot 3.C.1 — casualty applier qui incrémente niggling)
- Sprint Lot 4.D.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_