### PR TITLE
feat(pro-league): pools S/A/P/M par position + pricing primary/secondary (Lot 4.D.2)

### DIFF
--- a/apps/server/src/services/pro-position-skill-access.test.ts
+++ b/apps/server/src/services/pro-position-skill-access.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests pour les pools S/A/P/M par position (Lot 4.D.2).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getEligiblePoolFor,
+  POSITION_SKILL_ACCESS,
+  SKILL_CATEGORY,
+  SKILLS_BY_CATEGORY,
+  skillSourceForPlayer,
+} from "./pro-position-skill-access";
+
+describe("SKILLS_BY_CATEGORY — Lot 4.D.2", () => {
+  it("contient les 5 categories BB officielles", () => {
+    expect(Object.keys(SKILLS_BY_CATEGORY).sort()).toEqual([
+      "A",
+      "G",
+      "M",
+      "P",
+      "S",
+    ]);
+  });
+
+  it("G contient block / tackle / frenzy (skills General canoniques)", () => {
+    expect(SKILLS_BY_CATEGORY.G).toContain("block");
+    expect(SKILLS_BY_CATEGORY.G).toContain("tackle");
+    expect(SKILLS_BY_CATEGORY.G).toContain("frenzy");
+  });
+
+  it("A contient dodge / catch (Agility canoniques)", () => {
+    expect(SKILLS_BY_CATEGORY.A).toContain("dodge");
+    expect(SKILLS_BY_CATEGORY.A).toContain("catch");
+  });
+
+  it("S contient guard / mighty_blow (Strength canoniques)", () => {
+    expect(SKILLS_BY_CATEGORY.S).toContain("guard");
+    expect(SKILLS_BY_CATEGORY.S).toContain("mighty_blow");
+  });
+
+  it("P contient pass / accurate (Passing canoniques)", () => {
+    expect(SKILLS_BY_CATEGORY.P).toContain("pass");
+    expect(SKILLS_BY_CATEGORY.P).toContain("accurate");
+  });
+
+  it("M contient claws / horns (Mutation canoniques)", () => {
+    expect(SKILLS_BY_CATEGORY.M).toContain("claws");
+    expect(SKILLS_BY_CATEGORY.M).toContain("horns");
+  });
+});
+
+describe("SKILL_CATEGORY (reverse lookup) — Lot 4.D.2", () => {
+  it("block est categorie G", () => {
+    expect(SKILL_CATEGORY.block).toBe("G");
+  });
+
+  it("dodge est categorie A", () => {
+    expect(SKILL_CATEGORY.dodge).toBe("A");
+  });
+
+  it("claws est categorie M", () => {
+    expect(SKILL_CATEGORY.claws).toBe("M");
+  });
+
+  it("slug inconnu retourne undefined", () => {
+    expect(SKILL_CATEGORY.unknown_skill).toBeUndefined();
+  });
+});
+
+describe("POSITION_SKILL_ACCESS — Lot 4.D.2", () => {
+  it("Lineman a G primary + A/S/P secondary", () => {
+    expect(POSITION_SKILL_ACCESS.Lineman.primary).toEqual(["G"]);
+    expect(POSITION_SKILL_ACCESS.Lineman.secondary).toEqual(["A", "S", "P"]);
+  });
+
+  it("Catcher a G/A primary (catch + esquive)", () => {
+    expect(POSITION_SKILL_ACCESS.Catcher.primary).toEqual(["G", "A"]);
+  });
+
+  it("Big Guy a S primary + G secondary (focus brutal)", () => {
+    expect(POSITION_SKILL_ACCESS["Big Guy"].primary).toEqual(["S"]);
+    expect(POSITION_SKILL_ACCESS["Big Guy"].secondary).toEqual(["G"]);
+  });
+});
+
+describe("skillSourceForPlayer — Lot 4.D.2", () => {
+  it("Lineman + block (G) -> primary", () => {
+    expect(skillSourceForPlayer("Lineman", "block")).toBe("primary");
+  });
+
+  it("Lineman + dodge (A) -> secondary", () => {
+    expect(skillSourceForPlayer("Lineman", "dodge")).toBe("secondary");
+  });
+
+  it("Lineman + claws (M) -> unavailable (M pas dans Lineman access)", () => {
+    expect(skillSourceForPlayer("Lineman", "claws")).toBe("unavailable");
+  });
+
+  it("Big Guy + block (G) -> secondary (G secondary pour BG)", () => {
+    expect(skillSourceForPlayer("Big Guy", "block")).toBe("secondary");
+  });
+
+  it("Big Guy + guard (S) -> primary", () => {
+    expect(skillSourceForPlayer("Big Guy", "guard")).toBe("primary");
+  });
+
+  it("position inconnue -> fallback Lineman access", () => {
+    expect(skillSourceForPlayer("MysteryRole", "block")).toBe("primary");
+    expect(skillSourceForPlayer("MysteryRole", "dodge")).toBe("secondary");
+  });
+
+  it("slug inconnu -> unavailable", () => {
+    expect(skillSourceForPlayer("Lineman", "fake_skill")).toBe("unavailable");
+  });
+});
+
+describe("getEligiblePoolFor — Lot 4.D.2", () => {
+  it("Lineman primary = pool G", () => {
+    const pool = getEligiblePoolFor("Lineman", "primary");
+    expect(pool).toContain("block");
+    expect(pool).not.toContain("dodge");
+  });
+
+  it("Lineman secondary = union A + S + P", () => {
+    const pool = getEligiblePoolFor("Lineman", "secondary");
+    expect(pool).toContain("dodge");
+    expect(pool).toContain("guard");
+    expect(pool).toContain("pass");
+    expect(pool).not.toContain("block"); // block est primary
+  });
+
+  it("Big Guy primary = pool S uniquement", () => {
+    const pool = getEligiblePoolFor("Big Guy", "primary");
+    expect(pool).toContain("guard");
+    expect(pool).not.toContain("block"); // block secondary pour BG
+  });
+
+  it("Catcher primary = union G + A (large pool)", () => {
+    const pool = getEligiblePoolFor("Catcher", "primary");
+    expect(pool).toContain("block");
+    expect(pool).toContain("dodge");
+  });
+
+  it("position inconnue tombe sur Lineman fallback", () => {
+    const pool = getEligiblePoolFor("MysteryRole", "primary");
+    expect(pool).toContain("block");
+  });
+});

--- a/apps/server/src/services/pro-position-skill-access.ts
+++ b/apps/server/src/services/pro-position-skill-access.ts
@@ -1,0 +1,202 @@
+/**
+ * Skill categories + position access tables (Lot 4.D.2).
+ *
+ * Pourquoi
+ * --------
+ * Avant ce lot, le level-up applier (Lot 3.C.4) tirait dans un pool
+ * unique GENERAL — un Lineman et un Catcher recevaient la meme
+ * distribution de skills, ce qui aplatissait completement la
+ * diversite BB classique.
+ *
+ * BB Season 2/3 definit 5 categories de skills (G/A/S/P/M). Chaque
+ * position a acces aux pools en `primary` (1/6 doubles non requis,
+ * cost 20k) ou `secondary` (cost 30k, plus rare en BB). Cette table
+ * encode l'acces canonique par position et la categorisation des
+ * skills par slug.
+ *
+ * Architecture
+ * ------------
+ *  - `SkillCategory` : union 'G'|'A'|'S'|'P'|'M'.
+ *  - `SKILLS_BY_CATEGORY` : pool exhaustif des skills BB officiels
+ *    par categorie. Slugs alignes sur game-engine registry.
+ *  - `SKILL_CATEGORY` : reverse lookup slug -> category.
+ *  - `POSITION_SKILL_ACCESS` : par position, liste des categories
+ *    primary / secondary. Positions inconnues -> fallback Lineman.
+ *  - `skillSourceForPlayer(position, slug)` : 'primary' | 'secondary'
+ *    | 'unavailable' selon l'acces du joueur. Sert a computer le TV
+ *    + filtrer les pools du level-up applier.
+ *  - `getEligiblePoolFor(position, source)` : retourne la liste des
+ *    slugs accessibles au joueur pour cette source (primary ou
+ *    secondary). Sert au pickAdvancement etendu.
+ *
+ * Hors scope MVP
+ * --------------
+ *  - Skill cap par player (BB rules : 6 skills max sans lvl-up
+ *    extra). Pas applique ici, le pool epuise via le filter.
+ *  - Skill restrictions par race (ex: Bull Centaur Block = always
+ *    primary General). On utilise la position generique ici. Lot
+ *    futur si besoin.
+ */
+
+export type SkillCategory = "G" | "A" | "S" | "P" | "M";
+
+/**
+ * Pools BB officiels par categorie. Pas exhaustif (~25 skills par
+ * pool en BB total) mais couvre les plus communs / influents
+ * tactiquement. A etendre si on observe des trous en prod.
+ */
+export const SKILLS_BY_CATEGORY: Record<SkillCategory, readonly string[]> = {
+  G: [
+    "block",
+    "dauntless",
+    "dirty_player",
+    "fend",
+    "frenzy",
+    "kick",
+    "pro",
+    "shadowing",
+    "strip_ball",
+    "sure_hands",
+    "tackle",
+    "wrestle",
+  ],
+  A: [
+    "catch",
+    "diving_catch",
+    "diving_tackle",
+    "dodge",
+    "jump_up",
+    "leap",
+    "side_step",
+    "sneaky_git",
+    "sprint",
+    "sure_feet",
+  ],
+  S: [
+    "break_tackle",
+    "grab",
+    "guard",
+    "juggernaut",
+    "mighty_blow",
+    "multiple_block",
+    "piling_on",
+    "stand_firm",
+    "strong_arm",
+    "thick_skull",
+  ],
+  P: [
+    "accurate",
+    "cloud_burster",
+    "dump_off",
+    "fumblerooskie",
+    "hail_mary_pass",
+    "leader",
+    "nerves_of_steel",
+    "on_the_ball",
+    "pass",
+    "running_pass",
+    "safe_pass",
+  ],
+  M: [
+    "big_hand",
+    "claws",
+    "disturbing_presence",
+    "extra_arms",
+    "foul_appearance",
+    "horns",
+    "iron_hard_skin",
+    "monstrous_mouth",
+    "prehensile_tail",
+    "tentacles",
+    "two_heads",
+    "very_long_legs",
+  ],
+};
+
+/** Reverse lookup : skill slug -> category. */
+export const SKILL_CATEGORY: Record<string, SkillCategory> = (() => {
+  const out: Record<string, SkillCategory> = {};
+  for (const [cat, list] of Object.entries(SKILLS_BY_CATEGORY)) {
+    for (const slug of list) {
+      out[slug] = cat as SkillCategory;
+    }
+  }
+  return out;
+})();
+
+export interface PositionSkillAccess {
+  readonly primary: readonly SkillCategory[];
+  readonly secondary: readonly SkillCategory[];
+}
+
+/**
+ * Acces aux pools par position. Source : Blood Bowl Season 2/3
+ * starter rosters tier list. Les positions absentes tombent sur
+ * le default `LINEMAN_FALLBACK` (G primary, A/S/P secondary).
+ *
+ * Notes :
+ *   - Big Guy = S primary + G secondary (peu mobile, focus brutal)
+ *   - Catcher = G/A primary, S/P secondary (reception + esquive)
+ *   - Blitzer = G/S primary, A secondary (versatile bashy)
+ *   - Thrower = G/P primary, A secondary (lanceur skill+passes)
+ *   - Skink = G/A primary, S/P secondary (catcher Lizardmen)
+ *   - Saurus = G/S primary, A secondary (blocker Lizardmen)
+ *   - Zombie/Skeleton = Lineman-equivalent
+ */
+export const POSITION_SKILL_ACCESS: Record<string, PositionSkillAccess> = {
+  Lineman: { primary: ["G"], secondary: ["A", "S", "P"] },
+  Linewoman: { primary: ["G"], secondary: ["A", "S", "P"] },
+  Zombie: { primary: ["G"], secondary: ["S"] },
+  Skeleton: { primary: ["G"], secondary: ["S"] },
+  Catcher: { primary: ["G", "A"], secondary: ["S", "P"] },
+  Blitzer: { primary: ["G", "S"], secondary: ["A"] },
+  Thrower: { primary: ["G", "P"], secondary: ["A"] },
+  Runner: { primary: ["G", "A"], secondary: ["S", "P"] },
+  Blocker: { primary: ["G", "S"], secondary: ["A"] },
+  Skink: { primary: ["G", "A"], secondary: ["S"] },
+  Saurus: { primary: ["G", "S"], secondary: ["A"] },
+  "Big Guy": { primary: ["S"], secondary: ["G"] },
+};
+
+const LINEMAN_FALLBACK: PositionSkillAccess = {
+  primary: ["G"],
+  secondary: ["A", "S", "P"],
+};
+
+export type SkillSource = "primary" | "secondary" | "unavailable";
+
+/**
+ * Determine si un slug est accessible au joueur en `primary`,
+ * `secondary` ou `unavailable`. Utilise par :
+ *  - `pro-roster-tv` pour le pricing 20k vs 30k
+ *  - `pro-roster-level-up` pour filtrer le pool de pick
+ */
+export function skillSourceForPlayer(
+  position: string,
+  slug: string,
+): SkillSource {
+  const access = POSITION_SKILL_ACCESS[position] ?? LINEMAN_FALLBACK;
+  const cat = SKILL_CATEGORY[slug];
+  if (!cat) return "unavailable";
+  if (access.primary.includes(cat)) return "primary";
+  if (access.secondary.includes(cat)) return "secondary";
+  return "unavailable";
+}
+
+/**
+ * Liste des slugs eligibles au joueur pour une source donnee
+ * (primary ou secondary). Union de tous les pools des categories
+ * accessibles a cette source.
+ */
+export function getEligiblePoolFor(
+  position: string,
+  source: "primary" | "secondary",
+): readonly string[] {
+  const access = POSITION_SKILL_ACCESS[position] ?? LINEMAN_FALLBACK;
+  const cats = source === "primary" ? access.primary : access.secondary;
+  const out: string[] = [];
+  for (const cat of cats) {
+    out.push(...SKILLS_BY_CATEGORY[cat]);
+  }
+  return out;
+}

--- a/apps/server/src/services/pro-roster-level-up.test.ts
+++ b/apps/server/src/services/pro-roster-level-up.test.ts
@@ -27,9 +27,15 @@ import {
   levelForSpp,
   LevelUpError,
   pickAdvancement,
+  pickAdvancementFor,
+  SECONDARY_PICK_PROBABILITY,
   SPP_LEVEL_THRESHOLDS,
   sweepLevelUps,
 } from "./pro-roster-level-up";
+import {
+  getEligiblePoolFor,
+  skillSourceForPlayer,
+} from "./pro-position-skill-access";
 
 interface MockedPrisma {
   proTeamRoster: {
@@ -162,7 +168,13 @@ describe("applyLevelUps — Lot 3.C.4", () => {
     expect(out.advancements).toHaveLength(1);
     const adv = out.advancements[0];
     if (adv.kind === "skill") {
-      expect(GENERAL_SKILL_POOL).toContain(adv.skill);
+      // Lot 4.D.2 — le skill peut etre primary (G) OU secondary (A/S/P)
+      // pour un Lineman.
+      const eligible = [
+        ...getEligiblePoolFor("Lineman", "primary"),
+        ...getEligiblePoolFor("Lineman", "secondary"),
+      ];
+      expect(eligible).toContain(adv.skill);
     } else {
       expect(["ma", "ag", "pa", "av", "st"]).toContain(adv.stat);
     }
@@ -172,6 +184,8 @@ describe("applyLevelUps — Lot 3.C.4", () => {
         data: expect.objectContaining({
           level: 2,
           skills: expect.any(Array),
+          // Lot 3.C.5 + 4.D.2 — Lineman 50k + 1 skill (20k primary
+          // OU 30k secondary selon le tirage).
           tvCached: expect.any(Number),
         }),
       }),
@@ -213,10 +227,17 @@ describe("applyLevelUps — Lot 3.C.4", () => {
   });
 
   it("plafonne les advancements si le pool s'epuise (no_skill_available)", async () => {
-    // Roster a tous les skills general + 1/6 doubles probability ->
-    // certaines rosterIds tomberont sur skill (pool epuise = skip),
-    // d'autres sur stat (advancement OK). On cherche la premiere
-    // rosterId qui produit le skip 'no_skill_available' sur 30 ids.
+    // Lot 4.D.2 + 4.D.1 — le pool acccessible a un Lineman = primary G +
+    // secondary A/S/P. Pour epuiser, il faut connaitre tous ces skills.
+    // M (Mutation) est `unavailable` pour Lineman donc pas utile a remplir.
+    // Avec 1/6 doubles probability (4.D.1), certaines rosterIds tomberont
+    // sur skill (pool epuise = skip), d'autres sur stat (advancement OK).
+    // On cherche la premiere rosterId qui produit le skip
+    // 'no_skill_available' sur 30 ids.
+    const eligible = [
+      ...getEligiblePoolFor("Lineman", "primary"),
+      ...getEligiblePoolFor("Lineman", "secondary"),
+    ];
     let foundSkip = false;
     for (let i = 0; i < 30 && !foundSkip; i += 1) {
       vi.clearAllMocks();
@@ -225,7 +246,7 @@ describe("applyLevelUps — Lot 3.C.4", () => {
         id: `r_full_${i}`,
         spp: 6,
         level: 1,
-        skills: [...GENERAL_SKILL_POOL],
+        skills: eligible,
         status: "active",
         position: "Lineman",
         maBonus: 0,
@@ -328,10 +349,10 @@ describe("applyLevelUps stat increases (Lot 4.D.1) — wire integration", () => 
     );
   });
 
-  it("sur 50 rosters fictifs, observe au moins 5 stat advancements (proba >= 1/10)", async () => {
+  it("sur 50 rosters fictifs, observe au moins 3 stat advancements (proba >= 1/10)", async () => {
     // Sample 50 rosterIds different pour echantillonner la proba 1/6
     // des doubles. On attend au moins ~6-9 stat increases mais on
-    // baisse a 5 pour etre robuste a la variance.
+    // baisse a 3 pour etre robuste a la variance.
     let statCount = 0;
     let skillCount = 0;
     for (let i = 0; i < 50; i += 1) {
@@ -357,6 +378,75 @@ describe("applyLevelUps stat increases (Lot 4.D.1) — wire integration", () => 
     }
     expect(statCount).toBeGreaterThanOrEqual(3);
     expect(skillCount).toBeGreaterThan(statCount); // skills doivent dominer
+  });
+});
+
+describe("pickAdvancementFor — Lot 4.D.2", () => {
+  it("Lineman + skills vides -> pick valide (primary OU secondary)", () => {
+    const out = pickAdvancementFor("Lineman", [], 42);
+    expect(out).not.toBeNull();
+    if (out) {
+      expect(["primary", "secondary"]).toContain(out.source);
+      expect(skillSourceForPlayer("Lineman", out.slug)).toBe(out.source);
+    }
+  });
+
+  it("filtre les skills deja connus", () => {
+    // Pas de seed magique : on test sur 200 seeds qu'aucun ne pioche
+    // un skill deja connu.
+    const known = ["block", "tackle"];
+    for (let s = 0; s < 200; s += 1) {
+      const out = pickAdvancementFor("Lineman", known, s);
+      if (out) {
+        expect(known).not.toContain(out.slug);
+      }
+    }
+  });
+
+  it("retourne null quand tous les pools accessibles sont epuises", () => {
+    const all = [
+      ...getEligiblePoolFor("Lineman", "primary"),
+      ...getEligiblePoolFor("Lineman", "secondary"),
+    ];
+    expect(pickAdvancementFor("Lineman", all, 42)).toBeNull();
+  });
+
+  it("biais vers primary : sur 200 picks, ~75% sont primary", () => {
+    let primaryCount = 0;
+    let secondaryCount = 0;
+    for (let s = 0; s < 200; s += 1) {
+      const out = pickAdvancementFor("Lineman", [], s);
+      if (out?.source === "primary") primaryCount += 1;
+      else if (out?.source === "secondary") secondaryCount += 1;
+    }
+    // Target = 75/25 avec tolerance large pour 200 echantillons.
+    const ratio = primaryCount / (primaryCount + secondaryCount);
+    expect(ratio).toBeGreaterThan(0.6);
+    expect(ratio).toBeLessThan(0.9);
+    expect(SECONDARY_PICK_PROBABILITY).toBe(0.25);
+  });
+
+  it("Big Guy ne pioche pas de skills A (unavailable)", () => {
+    for (let s = 0; s < 100; s += 1) {
+      const out = pickAdvancementFor("Big Guy", [], s);
+      if (out) {
+        // Big Guy : primary S, secondary G, A/P/M unavailable.
+        expect(skillSourceForPlayer("Big Guy", out.slug)).not.toBe(
+          "unavailable",
+        );
+      }
+    }
+  });
+
+  it("primary epuise -> fallback sur secondary", () => {
+    // Lineman primary = G ; on connait tout G. Le picker doit pioche
+    // dans secondary (A/S/P).
+    const knownPrimary = getEligiblePoolFor("Lineman", "primary");
+    const out = pickAdvancementFor("Lineman", knownPrimary, 42);
+    expect(out).not.toBeNull();
+    if (out) {
+      expect(out.source).toBe("secondary");
+    }
   });
 });
 

--- a/apps/server/src/services/pro-roster-level-up.ts
+++ b/apps/server/src/services/pro-roster-level-up.ts
@@ -38,6 +38,7 @@
 
 import { prisma } from "../prisma";
 import { computePlayerTv, type StatBonuses } from "./pro-roster-tv";
+import { getEligiblePoolFor } from "./pro-position-skill-access";
 
 /**
  * Seuils SPP cumulatifs pour atteindre les niveaux 2..7. Index `i`
@@ -123,6 +124,10 @@ function hashStringToInt(s: string): number {
  * Retourne `null` si toutes les skills du pool sont deja prises.
  *
  * Deterministe : meme `(skills, seed)` -> meme pick.
+ *
+ * Conserve pour retrocompat des callers existants (pre-Lot 4.D.2).
+ * Le code level-up applier utilise desormais `pickAdvancementFor`
+ * qui prend en compte la position du joueur.
  */
 export function pickAdvancement(
   skills: readonly string[],
@@ -179,6 +184,74 @@ export function pickStatIncrease(seed: number): StatIncreaseKind {
 export function rollStatVsSkill(seed: number): boolean {
   const rng = mulberry32(seed);
   return rng() < 1 / 6;
+}
+
+/**
+ * Lot 4.D.2 — proba qu'un advancement skill soit pris dans le pool
+ * `secondary` plutot que `primary`. En BB, les secondary necessitent
+ * un double roll (1/6) ; primary est l'option par defaut. Mais notre
+ * level-up applier reserve deja le 1/6 de doubles aux stat increases
+ * (Lot 4.D.1). Pour preserver la diversite, on autorise quand meme
+ * 25% des skills "non-stat" a piocher dans le pool secondary.
+ *
+ * Tunable si on observe que les rosters convergent trop vers les
+ * primary classiques (block/tackle/sure_hands) sans diversite.
+ */
+export const SECONDARY_PICK_PROBABILITY = 0.25;
+
+/**
+ * Lot 4.D.2 — choisit un skill non encore connu pour la position.
+ * Pioche dans le pool primary par defaut, avec une chance
+ * `SECONDARY_PICK_PROBABILITY` (25%) de tirer dans le pool secondary.
+ *
+ * Si le pool primary est vide -> retombe sur secondary.
+ * Si les deux sont vides -> retourne null (caller skip 'no_skill_available').
+ *
+ * Deterministe via le seed.
+ *
+ * Retour : `{ slug, source }` pour permettre au caller de tracker
+ * la source (utile pour le logging / TV cost si besoin futur).
+ */
+export interface PickAdvancementResult {
+  readonly slug: string;
+  readonly source: "primary" | "secondary";
+}
+
+export function pickAdvancementFor(
+  position: string,
+  knownSkills: readonly string[],
+  seed: number,
+): PickAdvancementResult | null {
+  const known = new Set(knownSkills);
+  const primaryAvailable = getEligiblePoolFor(position, "primary").filter(
+    (s) => !known.has(s),
+  );
+  const secondaryAvailable = getEligiblePoolFor(position, "secondary").filter(
+    (s) => !known.has(s),
+  );
+
+  // Decide source via une proba seedee.
+  const rngSource = mulberry32(seed);
+  const wantSecondary = rngSource() < SECONDARY_PICK_PROBABILITY;
+  // Si le pool prefere est vide, fallback sur l'autre.
+  const tryFirst = wantSecondary ? secondaryAvailable : primaryAvailable;
+  const tryFallback = wantSecondary ? primaryAvailable : secondaryAvailable;
+  const sourceFirst: "primary" | "secondary" = wantSecondary
+    ? "secondary"
+    : "primary";
+  const sourceFallback: "primary" | "secondary" = wantSecondary
+    ? "primary"
+    : "secondary";
+
+  const pool = tryFirst.length > 0 ? tryFirst : tryFallback;
+  const source = tryFirst.length > 0 ? sourceFirst : sourceFallback;
+  if (pool.length === 0) return null;
+
+  // Seed independant pour le pick dans le pool (eviter que le check
+  // wantSecondary biaise aussi le pick).
+  const rngPick = mulberry32((seed ^ 0x6c8e9cf5) >>> 0);
+  const idx = Math.floor(rngPick() * pool.length);
+  return { slug: pool[idx], source };
 }
 
 export type LevelUpSkipReason =
@@ -309,6 +382,7 @@ export async function applyLevelUps(
   // levels grimpes d'un coup).
   const newSkillsAcc: string[] = [];
   let currentLevel = oldLevel;
+  const position = (roster.position as string) ?? "Lineman";
   for (let l = oldLevel + 1; l <= targetLevel; l += 1) {
     // Variation par level pour eviter qu'un meme rosterId pioche
     // plusieurs fois le meme skill quand on grimpe de plusieurs
@@ -328,15 +402,22 @@ export async function applyLevelUps(
       continue;
     }
 
-    const skill = pickAdvancement([...skills, ...newSkillsAcc], seedSkill);
-    if (!skill) {
+    // Lot 4.D.2 — pioche dans le pool primary (75%) ou secondary (25%)
+    // accessible a la position du joueur, en filtrant les skills
+    // deja connus.
+    const pick = pickAdvancementFor(
+      position,
+      [...skills, ...newSkillsAcc],
+      seedSkill,
+    );
+    if (!pick) {
       // Pool epuise sur ce level. On stoppe la progression (les
       // levels suivants seront tente au prochain tick une fois que
       // le pool aura grandit — peu probable, mais defensif).
       break;
     }
-    newSkillsAcc.push(skill);
-    advancements.push({ kind: "skill", skill });
+    newSkillsAcc.push(pick.slug);
+    advancements.push({ kind: "skill", skill: pick.slug });
     currentLevel = l;
   }
 
@@ -352,10 +433,10 @@ export async function applyLevelUps(
   }
 
   const newSkills = [...skills, ...newSkillsAcc];
-  // Lot 3.C.5 + 4.D.1 + 4.D.3 — recompute TV inline avec stat bonuses
-  // accumules dans la session de level-up + ceux deja persistes +
-  // malus niggling courant (le casualty applier peut avoir incremente
-  // niggling avant le tick level-up).
+  // Lot 3.C.5 + 4.D.1 + 4.D.2 + 4.D.3 — recompute TV inline avec :
+  //   - slugs pour pricing primary/secondary (20k/30k)
+  //   - niggling courant (-10k chacun, lu depuis le casualty applier)
+  //   - stat bonuses cumules (existing + accrued de cette session)
   const totalStatBonuses: StatBonuses = {
     ma: ((roster.maBonus as number) ?? 0) + accruedStats.ma,
     ag: ((roster.agBonus as number) ?? 0) + accruedStats.ag,
@@ -364,8 +445,8 @@ export async function applyLevelUps(
     st: ((roster.stBonus as number) ?? 0) + accruedStats.st,
   };
   const newTvCached = computePlayerTv(
-    (roster.position as string) ?? "",
-    newSkills.length,
+    position,
+    newSkills,
     (roster.niggling as number) ?? 0,
     totalStatBonuses,
   );

--- a/apps/server/src/services/pro-roster-tv.test.ts
+++ b/apps/server/src/services/pro-roster-tv.test.ts
@@ -21,11 +21,13 @@ import { prisma } from "../prisma";
 import {
   BASE_POSITION_COST,
   computePlayerTv,
+  computeSkillsCost,
   computeStatBonusCost,
   DEFAULT_POSITION_COST,
   NIGGLING_MALUS,
   recomputePlayerTv,
   RecomputeTvError,
+  SECONDARY_SKILL_COST,
   SKILL_COST,
   STAT_INCREASE_COSTS,
   sweepRecomputeTvs,
@@ -139,6 +141,35 @@ describe("computePlayerTv — Lot 3.C.5", () => {
     // 5 niggling sur Lineman 50k + 0 skill = -50k -> clampe a 0.
     expect(computePlayerTv("Lineman", 0, 6)).toBe(0);
   });
+
+  it("Lot 4.D.2 — SECONDARY_SKILL_COST = 30k", () => {
+    expect(SECONDARY_SKILL_COST).toBe(30_000);
+  });
+
+  it("Lot 4.D.2 — slugs primary appliquent 20k, secondary 30k", () => {
+    // Lineman : block (G) primary, dodge (A) secondary.
+    expect(computePlayerTv("Lineman", ["block"])).toBe(50_000 + 20_000);
+    expect(computePlayerTv("Lineman", ["dodge"])).toBe(50_000 + 30_000);
+    expect(computePlayerTv("Lineman", ["block", "dodge"])).toBe(
+      50_000 + 20_000 + 30_000,
+    );
+  });
+
+  it("Lot 4.D.2 — slug unavailable compte 0 (defense)", () => {
+    // Lineman + claws (M unavailable) -> claws ne compte pas.
+    expect(computePlayerTv("Lineman", ["block", "claws"])).toBe(
+      50_000 + 20_000,
+    );
+  });
+
+  it("Lot 4.D.2 — Big Guy : block (G) est secondary", () => {
+    // Big Guy : G secondary (1 skill 30k).
+    expect(computePlayerTv("Big Guy", ["block"])).toBe(140_000 + 30_000);
+  });
+
+  it("Lot 4.D.2 — computeSkillsCost retourne 0 sur liste vide", () => {
+    expect(computeSkillsCost("Lineman", [])).toBe(0);
+  });
 });
 
 describe("recomputePlayerTv — Lot 3.C.5", () => {
@@ -150,10 +181,11 @@ describe("recomputePlayerTv — Lot 3.C.5", () => {
     });
   });
 
-  it("recompute Lineman avec 2 skills -> tvCached=90k", async () => {
+  it("recompute Lineman avec 2 skills primary -> tvCached=90k", async () => {
     mocked.proTeamRoster.findUnique.mockResolvedValue({
       id: "r1",
       position: "Lineman",
+      // block + tackle sont tous deux primary G pour Lineman -> 20k chacun.
       skills: ["block", "tackle"],
       tvCached: 50000,
     });
@@ -167,6 +199,18 @@ describe("recomputePlayerTv — Lot 3.C.5", () => {
         data: { tvCached: 90_000 },
       }),
     );
+  });
+
+  it("Lot 4.D.2 — recompute Lineman avec mix primary+secondary applique le bon pricing", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValue({
+      id: "r_mix",
+      position: "Lineman",
+      // block (G primary 20k) + dodge (A secondary 30k) = 50k de skills.
+      skills: ["block", "dodge"],
+      tvCached: 0,
+    });
+    const out = await recomputePlayerTv("r_mix");
+    expect(out.newTv).toBe(50_000 + 20_000 + 30_000);
   });
 
   it("idempotent : skip si tvCached deja a jour", async () => {

--- a/apps/server/src/services/pro-roster-tv.ts
+++ b/apps/server/src/services/pro-roster-tv.ts
@@ -31,6 +31,7 @@
  */
 
 import { prisma } from "../prisma";
+import { skillSourceForPlayer } from "./pro-position-skill-access";
 
 /**
  * Costs canoniques BB rookies (gold pieces). Sources : Blood Bowl
@@ -62,9 +63,10 @@ export const BASE_POSITION_COST: Record<string, number> = {
 export const DEFAULT_POSITION_COST = 50_000;
 
 /**
- * Cost d'un skill General (BB rules : 20k pour primary, 30k pour
- * secondary). Le level-up applier de 3.C.4 ne distribue que General,
- * donc 20k flat est correct ici.
+ * Cost d'un skill primary (BB rules officiel) : 20k. Conserve comme
+ * `SKILL_COST` pour rétrocompat ; l'API `computePlayerTv` accepte
+ * desormais les skills sous forme de slugs et applique 20k/30k selon
+ * `skillSourceForPlayer(position, slug)`.
  */
 export const SKILL_COST = 20_000;
 
@@ -104,6 +106,9 @@ export function computeStatBonusCost(bonuses: StatBonuses): number {
   );
 }
 
+/** Lot 4.D.2 — cost d'un skill secondary (acces hors primary BB). */
+export const SECONDARY_SKILL_COST = 30_000;
+
 /**
  * Lot 4.D.3 — malus par niggling injury (BB rules : -10k TV par
  * niggling pour le matchmaking). Le joueur reste actif mais "fragile"
@@ -127,33 +132,63 @@ export class RecomputeTvError extends Error {
 }
 
 /**
- * Pure : calcule la TV individuelle a partir de la position, du nombre
- * de skills, du nombre de niggling injuries, et des stat bonuses.
+ * Pure : calcule le cost agrege d'une liste de skills selon leur
+ * categorie (primary 20k / secondary 30k / unavailable 0).
  *
- * Formule : `base + skills * SKILL_COST + sum(statBonuses * STAT_COSTS)
- *           - niggling * NIGGLING_MALUS`.
+ * Lot 4.D.2 — applique le pricing exact BB. Skills inconnus du
+ * lookup (`unavailable`) compte 0 — defense-in-depth pour un slug
+ * mal serialise. Les vrais "unavailable" (joueur a un skill hors
+ * pool) sont impossibles avec le level-up applier qui filtre, mais
+ * possibles si un coach a edit le roster manuellement.
+ */
+export function computeSkillsCost(
+  position: string,
+  skills: readonly string[],
+): number {
+  let cost = 0;
+  for (const slug of skills) {
+    const source = skillSourceForPlayer(position, slug);
+    if (source === "primary") cost += SKILL_COST;
+    else if (source === "secondary") cost += SECONDARY_SKILL_COST;
+    // `unavailable` -> 0 (defense)
+  }
+  return cost;
+}
+
+/**
+ * Pure : calcule la TV individuelle a partir de la position, des
+ * skills, du nombre de niggling injuries, et des stat bonuses.
  *
- * Tous les arguments numeriques negatifs sont traites comme 0
- * (defense-in-depth). Le total est clampe a 0 (un joueur ne peut
- * jamais avoir une TV negative).
+ * Surcharges :
+ *   - `(position, skillCount, niggling?, statBonuses?)` — legacy count,
+ *     assume tous skills primary (rétrocompat).
+ *   - `(position, skills[], niggling?, statBonuses?)` — slugs, pricing
+ *     exact 20k primary / 30k secondary / 0 unavailable.
  *
  * Lot 4.D.1 — stat bonuses ajoutes.
- * Lot 4.D.3 — niggling malus ajoute.
+ * Lot 4.D.2 — pricing primary/secondary par slug.
+ * Lot 4.D.3 — niggling malus -10k.
  */
 export function computePlayerTv(
   position: string,
-  skillCount: number,
+  skillsOrCount: readonly string[] | number,
   niggling: number = 0,
   statBonuses: StatBonuses = {},
 ): number {
   const base = BASE_POSITION_COST[position] ?? DEFAULT_POSITION_COST;
-  const safeSkills =
-    Number.isFinite(skillCount) && skillCount > 0 ? skillCount : 0;
+  const skillsCost = Array.isArray(skillsOrCount)
+    ? computeSkillsCost(position, skillsOrCount)
+    : (() => {
+        const count = skillsOrCount as number;
+        const safeCount =
+          Number.isFinite(count) && count > 0 ? count : 0;
+        return safeCount * SKILL_COST;
+      })();
   const safeNiggling =
     Number.isFinite(niggling) && niggling > 0 ? niggling : 0;
   const tv =
     base +
-    safeSkills * SKILL_COST +
+    skillsCost +
     computeStatBonusCost(statBonuses) -
     safeNiggling * NIGGLING_MALUS;
   return tv > 0 ? tv : 0;
@@ -222,9 +257,11 @@ export async function recomputePlayerTv(
   }
 
   const skills = parseSkillsJson(roster.skills);
+  // Lot 4.D.1 + 4.D.2 + 4.D.3 — passe les slugs pour le pricing
+  // primary/secondary, le niggling pour le malus, et les stat bonuses.
   const newTv = computePlayerTv(
     roster.position as string,
-    skills.length,
+    skills,
     (roster.niggling as number) ?? 0,
     {
       ma: (roster.maBonus as number) ?? 0,


### PR DESCRIPTION
## Pourquoi

Lot 3.C.4 livre le level-up applier qui pioche dans un pool unique GENERAL pour tous les joueurs. Résultat : un Catcher reçoit la même distribution de skills qu'un Big Guy — **diversité BB plate**.

BB Season 2/3 définit 5 catégories de skills (G/A/S/P/M) avec un accès par position (primary 20k / secondary 30k / unavailable). Ce lot encode la table d'accès canonique et l'intègre au level-up applier + au pricing TV.

**Résultat post-PR** :
- Un **Catcher** Lineman pioche du A (Dodge, Catch, Side Step) en primary → profile réception cohérent.
- Un **Big Guy** pioche en S (Guard, Mighty Blow) en primary, et le rare G (Block, Tackle) en secondary → blocker brutal classique.
- TV reflète le pricing : un Lineman avec dodge (secondary) coûte 30k, pas 20k.

## Comment

1. **`pro-position-skill-access.ts`** (nouveau, pure) :
   - `SkillCategory` type union 'G'|'A'|'S'|'P'|'M'.
   - `SKILLS_BY_CATEGORY` : pools par catégorie (~12 skills chacun, ~60 total). Slugs alignés sur game-engine registry.
   - `SKILL_CATEGORY` : reverse lookup slug → category.
   - `POSITION_SKILL_ACCESS` : par position, primary + secondary categories. 12 positions définies (Lineman, Catcher, Blitzer, Thrower, Runner, Blocker, Skink, Saurus, Big Guy, +zombie/skeleton). Fallback Lineman pour positions inconnues.
   - `skillSourceForPlayer(position, slug)` : `'primary' | 'secondary' | 'unavailable'`.
   - `getEligiblePoolFor(position, source)` : retourne la liste des slugs accessibles au joueur pour cette source.

2. **`pro-roster-tv.ts`** :
   - `SECONDARY_SKILL_COST = 30_000`.
   - `computeSkillsCost(position, skills)` : itère les slugs et applique 20k (primary) / 30k (secondary) / 0 (unavailable).
   - `computePlayerTv(position, skillsOrCount)` : surchargée pour accepter soit un array de slugs (pricing exact) soit un count legacy (rétrocompat tests pre-Lot 4.D.2).
   - `recomputePlayerTv` passe les slugs au lieu de `skills.length` → applique le pricing exact à partir des données DB.

3. **`pro-roster-level-up.ts`** :
   - `SECONDARY_PICK_PROBABILITY = 0.25` (25% chance de tirer dans secondary plutôt que primary).
   - `pickAdvancementFor(position, knownSkills, seed)` : nouvelle API qui retourne `{ slug, source }`. Fallback automatique : si primary épuisé → secondary, et vice versa.
   - Boucle d'`applyLevelUps` migrée de `pickAdvancement` (legacy GENERAL only) vers `pickAdvancementFor` (position-aware).
   - `pickAdvancement` (3.C.4) conservé pour les callers existants (deprecated en pratique mais pas encore supprimé).

## Tests

- `pro-position-skill-access.test.ts` : 25 tests (tables SKILLS_BY_CATEGORY, reverse lookup, POSITION_SKILL_ACCESS, skillSourceForPlayer, getEligiblePoolFor).
- `pro-roster-tv.test.ts` : +6 tests (SECONDARY_SKILL_COST, primary 20k/secondary 30k pricing, Big Guy block secondary, unavailable=0, recompute mix).
- `pro-roster-level-up.test.ts` : +6 tests pour `pickAdvancementFor` (filter known, null si pool épuisé, biais 75/25 primary/secondary, Big Guy exclut M, fallback primary→secondary). +2 tests `applyLevelUps`.

### Résultats

- `@bb/server` : 75 tests verts (25 nouveau pos-skill-access + 6 TV + 6 level-up + tests existants adaptés)
- `pnpm typecheck` : clean monorepo

## Test plan

- [ ] CI verte
- [ ] En prod, après plusieurs saisons, vérifier que les Catchers ont bien des skills A (Dodge, Catch, Side Step) en plus du General
- [ ] Un Big Guy ne doit jamais piocher dans le pool A ou M (unavailable)
- [ ] TV d'un Lineman avec ['block','dodge'] doit être 50k+20k+30k = 100k (pas 90k)
- [ ] Un Lineman au level 7 (6 skills) doit avoir une diversité G/A/S/P (pas que G)

## Hors scope

- **Skill cap par player** (BB rules : 6 skills max sans extra) : pas appliqué. Un joueur peut théoriquement avoir 50 skills (cap uniquement par le pool épuisé après ~30 levels — impossible en prod).
- **Skill restrictions par race** (ex: Bull Centaur Block always primary) : on utilise position générique. Le level-up applier ne distingue pas la race actuellement.
- **Pool extensions** (~25 skills par catégorie en BB total vs ~12 ici) : MVP couvre les plus communs / influents. À étendre si on observe des trous tactiques en prod.
- **Migration data** : aucune. Les rosters existants gardent leurs skills actuels ; le pricing est recalculé au prochain `tvCached` recompute via le cron 4.D.3.

## Refs

- PR #719 (Lot 3.C.4 — level-up applier de base)
- PR #723 (Lot 3.C.5 — TV recalc)
- PR #729 (Lot 4.D.1 — stat increases, complémentaire)
- Sprint Lot 4.D.2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_