### PR TITLE
feat(admin): UI cross-version compare + replay diff (Lot 4.F)

### DIFF
--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -22,10 +22,24 @@ vi.mock("../services/pro-league-sandbox", () => ({
 vi.mock("../services/engine-comparison", () => ({
   runEngineComparison: vi.fn(),
 }));
+vi.mock("../services/pro-league-admin-tools", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/pro-league-admin-tools")
+  >("../services/pro-league-admin-tools");
+  return {
+    ...actual,
+    runVersionComparison: vi.fn(),
+    runReplayDiff: vi.fn(),
+  };
+});
 
 import {
   comparisonSchema,
+  compareVersionsSchema,
+  diffReplaysSchema,
+  handleCompareVersions,
   handleCreateTestMatch,
+  handleDiffReplays,
   handleGetBroadcasterStats,
   handleGetDrift,
   handleListTeams,
@@ -43,6 +57,11 @@ import {
   listTestMatches,
 } from "../services/pro-league-sandbox";
 import { runEngineComparison } from "../services/engine-comparison";
+import {
+  AdminToolsError,
+  runReplayDiff,
+  runVersionComparison,
+} from "../services/pro-league-admin-tools";
 import { appMetrics } from "../utils/metrics";
 
 function buildRes(): Response & { statusCode: number; body: unknown } {
@@ -564,6 +583,228 @@ describe("handleRunComparison — Lot 3.B.2", () => {
           seedOffset: 0,
         },
       } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("compareVersionsSchema — Lot 4.F input validation", () => {
+  it("accepte un payload minimal (baseRaw + headRaw)", () => {
+    const out = compareVersionsSchema.parse({
+      baseRaw: { engineVer: "0.15.0" },
+      headRaw: { engineVer: "0.16.0" },
+    });
+    expect(out.baseRaw).toBeDefined();
+    expect(out.headRaw).toBeDefined();
+  });
+
+  it("accepte des thresholds entre 0 et 1", () => {
+    const out = compareVersionsSchema.parse({
+      baseRaw: {},
+      headRaw: {},
+      warnThreshold: 0.1,
+      criticalThreshold: 0.25,
+    });
+    expect(out.warnThreshold).toBe(0.1);
+    expect(out.criticalThreshold).toBe(0.25);
+  });
+
+  it("rejette warnThreshold >= 1 (% relatif borné)", () => {
+    expect(() =>
+      compareVersionsSchema.parse({
+        baseRaw: {},
+        headRaw: {},
+        warnThreshold: 1,
+      }),
+    ).toThrow();
+  });
+
+  it("rejette criticalThreshold <= 0", () => {
+    expect(() =>
+      compareVersionsSchema.parse({
+        baseRaw: {},
+        headRaw: {},
+        criticalThreshold: 0,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("handleCompareVersions — Lot 4.F", () => {
+  it("retourne 200 + result quand les baselines sont valides", async () => {
+    (runVersionComparison as ReturnType<typeof vi.fn>).mockReturnValue({
+      base: { engineVer: "0.15.0", snapshotAt: "2026-01-01" },
+      head: { engineVer: "0.16.0", snapshotAt: "2026-05-01" },
+      pairings: [],
+      summary: {
+        maxAbsDeltaByMetric: {
+          tdMean: 0,
+          tdStd: 0,
+          casualtyMean: 0,
+          turnoverMean: 0,
+          homeWinRate: 0,
+          awayWinRate: 0,
+          drawRate: 0,
+        },
+        missingInBase: [],
+        missingInHead: [],
+        matchedPairings: 0,
+        warnCount: 0,
+        criticalCount: 0,
+      },
+    });
+    const res = buildRes();
+    await handleCompareVersions(
+      {
+        body: { baseRaw: {}, headRaw: {} },
+      } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { head: { engineVer: string } }).head.engineVer).toBe(
+      "0.16.0",
+    );
+    expect(runVersionComparison).toHaveBeenCalledWith({
+      baseRaw: {},
+      headRaw: {},
+    });
+  });
+
+  it("retourne 400 + code quand AdminToolsError INVALID_BASELINE", async () => {
+    (runVersionComparison as ReturnType<typeof vi.fn>).mockImplementation(
+      () => {
+        throw new AdminToolsError(
+          "INVALID_BASELINE",
+          "INVALID_BASELINE: base — schema KO",
+        );
+      },
+    );
+    const res = buildRes();
+    await handleCompareVersions(
+      { body: { baseRaw: {}, headRaw: {} } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { code: string }).code).toBe("INVALID_BASELINE");
+  });
+
+  it("retourne 500 sur erreur inattendue (non typée)", async () => {
+    (runVersionComparison as ReturnType<typeof vi.fn>).mockImplementation(
+      () => {
+        throw new Error("oops");
+      },
+    );
+    const res = buildRes();
+    await handleCompareVersions(
+      { body: { baseRaw: {}, headRaw: {} } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("diffReplaysSchema — Lot 4.F input validation", () => {
+  it("accepte un payload valide", () => {
+    const out = diffReplaysSchema.parse({
+      matchIdA: "a",
+      matchIdB: "b",
+    });
+    expect(out.matchIdA).toBe("a");
+    expect(out.matchIdB).toBe("b");
+  });
+
+  it("rejette les ids vides", () => {
+    expect(() =>
+      diffReplaysSchema.parse({ matchIdA: "", matchIdB: "b" }),
+    ).toThrow();
+  });
+
+  it("rejette maxDivergences > 1000", () => {
+    expect(() =>
+      diffReplaysSchema.parse({
+        matchIdA: "a",
+        matchIdB: "b",
+        maxDivergences: 5000,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("handleDiffReplays — Lot 4.F", () => {
+  it("retourne 200 + diff quand le service réussit", async () => {
+    (runReplayDiff as ReturnType<typeof vi.fn>).mockResolvedValue({
+      matchA: { id: "a", engineVer: "0.15.0", scoreHome: 2, scoreAway: 1 },
+      matchB: { id: "b", engineVer: "0.16.0", scoreHome: 2, scoreAway: 1 },
+      diff: {
+        divergences: [],
+        summary: {
+          totalA: 10,
+          totalB: 10,
+          matchedCount: 10,
+          divergenceCount: 0,
+          firstDivergenceIndex: null,
+        },
+      },
+    });
+    const res = buildRes();
+    await handleDiffReplays(
+      { body: { matchIdA: "a", matchIdB: "b" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(
+      (res.body as { diff: { summary: { totalA: number } } }).diff.summary
+        .totalA,
+    ).toBe(10);
+  });
+
+  it("retourne 404 + code quand AdminToolsError MATCH_NOT_FOUND", async () => {
+    (runReplayDiff as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AdminToolsError("MATCH_NOT_FOUND", "Match introuvable"),
+    );
+    const res = buildRes();
+    await handleDiffReplays(
+      { body: { matchIdA: "a", matchIdB: "b" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+    expect((res.body as { code: string }).code).toBe("MATCH_NOT_FOUND");
+  });
+
+  it("retourne 404 + code quand AdminToolsError REPLAY_NOT_FOUND", async () => {
+    (runReplayDiff as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AdminToolsError("REPLAY_NOT_FOUND", "Replay manquant"),
+    );
+    const res = buildRes();
+    await handleDiffReplays(
+      { body: { matchIdA: "a", matchIdB: "b" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+    expect((res.body as { code: string }).code).toBe("REPLAY_NOT_FOUND");
+  });
+
+  it("retourne 400 quand AdminToolsError INVALID_INPUT (matchIdA === matchIdB)", async () => {
+    (runReplayDiff as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AdminToolsError("INVALID_INPUT", "matchIdA et matchIdB doivent etre distincts"),
+    );
+    const res = buildRes();
+    await handleDiffReplays(
+      { body: { matchIdA: "x", matchIdB: "x" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { code: string }).code).toBe("INVALID_INPUT");
+  });
+
+  it("retourne 500 sur erreur inattendue", async () => {
+    (runReplayDiff as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("DB pool exhausted"),
+    );
+    const res = buildRes();
+    await handleDiffReplays(
+      { body: { matchIdA: "a", matchIdB: "b" } } as unknown as Request,
       res,
     );
     expect(res.statusCode).toBe(500);

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -15,6 +15,11 @@ import { runEngineComparison } from "../services/engine-comparison";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
 import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
 import {
+  AdminToolsError,
+  runReplayDiff,
+  runVersionComparison,
+} from "../services/pro-league-admin-tools";
+import {
   createTestMatch,
   listTestMatches,
 } from "../services/pro-league-sandbox";
@@ -274,6 +279,77 @@ export async function handleRunComparison(
   }
 }
 
+/**
+ * Schema pour `POST /admin/sim/compare-versions` — Lot 4.F.
+ *
+ * Recoit 2 baselines JSON (Bench snapshot files) + thresholds optionnels.
+ * Le service service valide les schemas Zod et delegue a `compareBaselines`.
+ */
+export const compareVersionsSchema = z.object({
+  baseRaw: z.unknown(),
+  headRaw: z.unknown(),
+  warnThreshold: z.number().positive().lt(1).optional(),
+  criticalThreshold: z.number().positive().lt(1).optional(),
+});
+
+export type CompareVersionsBody = z.infer<typeof compareVersionsSchema>;
+
+/** Handler `POST /admin/sim/compare-versions` — Lot 4.F. */
+export async function handleCompareVersions(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const body = req.body as CompareVersionsBody;
+  try {
+    const result = runVersionComparison(body);
+    res.status(200).json(result);
+  } catch (err: unknown) {
+    if (err instanceof AdminToolsError) {
+      res.status(400).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    res.status(500).json({ error: msg });
+  }
+}
+
+/**
+ * Schema pour `POST /admin/sim/diff-replays` — Lot 4.F.
+ *
+ * Recoit 2 matchIds (cuids) ; le service charge les Replay.payload
+ * de la DB, les decompresse et runne `diffReplayEvents`.
+ */
+export const diffReplaysSchema = z.object({
+  matchIdA: z.string().min(1),
+  matchIdB: z.string().min(1),
+  maxDivergences: z.number().int().min(1).max(1000).optional(),
+});
+
+export type DiffReplaysBody = z.infer<typeof diffReplaysSchema>;
+
+/** Handler `POST /admin/sim/diff-replays` — Lot 4.F. */
+export async function handleDiffReplays(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const body = req.body as DiffReplaysBody;
+  try {
+    const result = await runReplayDiff(body);
+    res.status(200).json(result);
+  } catch (err: unknown) {
+    if (err instanceof AdminToolsError) {
+      const status =
+        err.code === "MATCH_NOT_FOUND" || err.code === "REPLAY_NOT_FOUND"
+          ? 404
+          : 400;
+      res.status(status).json({ error: err.message, code: err.code });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    res.status(500).json({ error: msg });
+  }
+}
+
 const router = Router();
 
 router.use(authUser, adminOnly);
@@ -292,6 +368,16 @@ router.post(
   "/comparison",
   validate(comparisonSchema),
   handleRunComparison,
+);
+router.post(
+  "/compare-versions",
+  validate(compareVersionsSchema),
+  handleCompareVersions,
+);
+router.post(
+  "/diff-replays",
+  validate(diffReplaysSchema),
+  handleDiffReplays,
 );
 
 export default router;

--- a/apps/server/src/services/pro-league-admin-tools.test.ts
+++ b/apps/server/src/services/pro-league-admin-tools.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests pour le service admin tools (Lot 4.F).
+ *
+ * Couvre :
+ *   - `runVersionComparison` : valide les 2 baselines + delegue a
+ *     `compareBaselines`. Erreur typee si JSON invalide.
+ *   - `runReplayDiff` : lit 2 replays de la DB, decompresse, delegue
+ *     a `diffReplayEvents`. Erreurs : MATCH_NOT_FOUND, REPLAY_NOT_FOUND.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findUnique: vi.fn() },
+    replay: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("@bb/sim-engine", async () => {
+  const actual = await vi.importActual<typeof import("@bb/sim-engine")>(
+    "@bb/sim-engine",
+  );
+  return {
+    ...actual,
+    decompressEvents: vi.fn(),
+  };
+});
+
+import { prisma } from "../prisma";
+import { decompressEvents } from "@bb/sim-engine";
+import {
+  AdminToolsError,
+  runReplayDiff,
+  runVersionComparison,
+} from "./pro-league-admin-tools";
+
+interface MockedPrisma {
+  proLeagueMatch: { findUnique: ReturnType<typeof vi.fn> };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+const mockedDecompress = vi.mocked(decompressEvents);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const VALID_BASELINE = {
+  engineVer: "0.16.0",
+  snapshotAt: "2026-05-07",
+  tolerance: 0.05,
+  pairings: [
+    {
+      homeId: "pit-smashers",
+      awayId: "kc-soaring-hawks",
+      runs: 1000,
+      seedOffset: 0,
+      expected: {
+        tdMean: 2.4,
+        tdStd: 1.2,
+        casualtyMean: 1.5,
+        turnoverMean: 4,
+        homeWinRate: 0.5,
+        awayWinRate: 0.4,
+        drawRate: 0.1,
+      },
+    },
+  ],
+};
+
+describe("runVersionComparison — Lot 4.F", () => {
+  it("retourne un VersionComparisonResult sur 2 baselines valides", () => {
+    const out = runVersionComparison({
+      baseRaw: VALID_BASELINE,
+      headRaw: VALID_BASELINE,
+    });
+    expect(out.summary.matchedPairings).toBe(1);
+    expect(out.summary.warnCount).toBe(0);
+    expect(out.summary.criticalCount).toBe(0);
+  });
+
+  it("INVALID_BASELINE si base raw n'est pas conforme au schema", () => {
+    expect(() =>
+      runVersionComparison({
+        baseRaw: { foo: "bar" },
+        headRaw: VALID_BASELINE,
+      }),
+    ).toThrow(AdminToolsError);
+    expect(() =>
+      runVersionComparison({
+        baseRaw: { foo: "bar" },
+        headRaw: VALID_BASELINE,
+      }),
+    ).toThrow(/INVALID_BASELINE.*base/i);
+  });
+
+  it("INVALID_BASELINE si head raw n'est pas conforme", () => {
+    expect(() =>
+      runVersionComparison({
+        baseRaw: VALID_BASELINE,
+        headRaw: null,
+      }),
+    ).toThrow(/INVALID_BASELINE.*head/i);
+  });
+
+  it("propage warnThreshold et criticalThreshold", () => {
+    const headWithDrift = {
+      ...VALID_BASELINE,
+      pairings: [
+        {
+          ...VALID_BASELINE.pairings[0],
+          expected: {
+            ...VALID_BASELINE.pairings[0].expected,
+            tdMean: 2.7, // +12.5% vs 2.4
+          },
+        },
+      ],
+    };
+    const out = runVersionComparison({
+      baseRaw: VALID_BASELINE,
+      headRaw: headWithDrift,
+      warnThreshold: 0.1,
+      criticalThreshold: 0.2,
+    });
+    expect(out.summary.warnCount).toBe(1);
+  });
+});
+
+describe("runReplayDiff — Lot 4.F", () => {
+  it("MATCH_NOT_FOUND si l'id A n'existe pas", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      runReplayDiff({ matchIdA: "missing", matchIdB: "ok" }),
+    ).rejects.toMatchObject({ code: "MATCH_NOT_FOUND" });
+  });
+
+  it("REPLAY_NOT_FOUND si l'un des matchs n'a pas de replay", async () => {
+    mocked.proLeagueMatch.findUnique
+      .mockResolvedValueOnce({ id: "a", engineVer: "0.16.0" })
+      .mockResolvedValueOnce({ id: "b", engineVer: "0.16.0" });
+    mocked.replay.findUnique
+      .mockResolvedValueOnce({ payload: Buffer.from([]) })
+      .mockResolvedValueOnce(null);
+    await expect(
+      runReplayDiff({ matchIdA: "a", matchIdB: "b" }),
+    ).rejects.toMatchObject({ code: "REPLAY_NOT_FOUND" });
+  });
+
+  it("retourne un ReplayDiffResult quand les deux replays existent", async () => {
+    mocked.proLeagueMatch.findUnique
+      .mockResolvedValueOnce({ id: "a", engineVer: "0.15.0" })
+      .mockResolvedValueOnce({ id: "b", engineVer: "0.16.0" });
+    mocked.replay.findUnique
+      .mockResolvedValueOnce({ payload: Buffer.from([1]) })
+      .mockResolvedValueOnce({ payload: Buffer.from([2]) });
+    const eventsA = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.15.0",
+        meta: {},
+      },
+      { type: "TD", displayAtMs: 1000, engineVer: "0.15.0", meta: {} },
+    ];
+    const eventsB = [
+      {
+        type: "KICKOFF",
+        displayAtMs: 0,
+        engineVer: "0.16.0",
+        meta: {},
+      },
+      { type: "TURNOVER", displayAtMs: 1000, engineVer: "0.16.0", meta: {} },
+    ];
+    mockedDecompress
+      .mockResolvedValueOnce(eventsA as never)
+      .mockResolvedValueOnce(eventsB as never);
+
+    const out = await runReplayDiff({ matchIdA: "a", matchIdB: "b" });
+    expect(out.diff.summary.totalA).toBe(2);
+    expect(out.diff.summary.totalB).toBe(2);
+    expect(out.diff.summary.divergenceCount).toBeGreaterThan(0);
+    expect(out.matchA).toMatchObject({ id: "a", engineVer: "0.15.0" });
+    expect(out.matchB).toMatchObject({ id: "b", engineVer: "0.16.0" });
+  });
+
+  it("rejette si matchIdA === matchIdB", async () => {
+    await expect(
+      runReplayDiff({ matchIdA: "x", matchIdB: "x" }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+});

--- a/apps/server/src/services/pro-league-admin-tools.ts
+++ b/apps/server/src/services/pro-league-admin-tools.ts
@@ -1,0 +1,148 @@
+/**
+ * Service admin tools — wrappers backend pour les CLI sim-engine
+ * (Lot 4.F).
+ *
+ * Pourquoi
+ * --------
+ * `pnpm sim:compare-versions` (PR #722) et `pnpm sim:diff-replays`
+ * (PR #725) sont des CLIs utiles aux developpeurs locaux, mais le
+ * release manager / admin operationnel n'a pas toujours acces au
+ * shell. Ce service expose les memes capacites via des routes admin
+ * authentifiees pour pouvoir piloter depuis le navigateur.
+ *
+ * - `runVersionComparison({ baseRaw, headRaw })` : valide les 2 JSON
+ *   baselines via `parseBenchBaseline` (Zod) puis delegue a
+ *   `compareBaselines`. Erreur typee `INVALID_BASELINE` si schema KO.
+ * - `runReplayDiff({ matchIdA, matchIdB })` : lit les 2 replays de la
+ *   DB via `Replay.payload`, decompresse, runne `diffReplayEvents`.
+ *   Renvoie aussi les metadonnees match (engineVer, scores) pour
+ *   contextualiser le diff cote UI.
+ *
+ * Pure cote logique, I/O cote replay diff (lecture DB + decompression).
+ */
+
+import {
+  compareBaselines,
+  decompressEvents,
+  diffReplayEvents,
+  parseBenchBaseline,
+  type MatchEvent,
+  type ReplayDiffResult,
+  type VersionComparisonResult,
+} from "@bb/sim-engine";
+
+import { prisma } from "../prisma";
+
+export type AdminToolsErrorCode =
+  | "INVALID_BASELINE"
+  | "INVALID_INPUT"
+  | "MATCH_NOT_FOUND"
+  | "REPLAY_NOT_FOUND";
+
+export class AdminToolsError extends Error {
+  constructor(
+    public readonly code: AdminToolsErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AdminToolsError";
+  }
+}
+
+export interface RunVersionComparisonInput {
+  readonly baseRaw: unknown;
+  readonly headRaw: unknown;
+  readonly warnThreshold?: number;
+  readonly criticalThreshold?: number;
+}
+
+export function runVersionComparison(
+  input: RunVersionComparisonInput,
+): VersionComparisonResult {
+  let base, head;
+  try {
+    base = parseBenchBaseline(input.baseRaw);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    throw new AdminToolsError(
+      "INVALID_BASELINE",
+      `INVALID_BASELINE: base — ${msg}`,
+    );
+  }
+  try {
+    head = parseBenchBaseline(input.headRaw);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    throw new AdminToolsError(
+      "INVALID_BASELINE",
+      `INVALID_BASELINE: head — ${msg}`,
+    );
+  }
+  return compareBaselines(base, head, {
+    warnThreshold: input.warnThreshold,
+    criticalThreshold: input.criticalThreshold,
+  });
+}
+
+export interface RunReplayDiffInput {
+  readonly matchIdA: string;
+  readonly matchIdB: string;
+  readonly maxDivergences?: number;
+}
+
+export interface MatchMeta {
+  readonly id: string;
+  readonly engineVer: string | null;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+}
+
+export interface RunReplayDiffResult {
+  readonly matchA: MatchMeta;
+  readonly matchB: MatchMeta;
+  readonly diff: ReplayDiffResult;
+}
+
+async function loadMatchAndReplay(
+  matchId: string,
+): Promise<{ match: MatchMeta; events: readonly MatchEvent[] }> {
+  const match = (await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: { id: true, engineVer: true, scoreHome: true, scoreAway: true },
+  })) as MatchMeta | null;
+  if (!match) {
+    throw new AdminToolsError(
+      "MATCH_NOT_FOUND",
+      `ProLeagueMatch '${matchId}' introuvable`,
+    );
+  }
+  const replay = (await prisma.replay.findUnique({
+    where: { matchId },
+    select: { payload: true },
+  })) as { payload: Buffer } | null;
+  if (!replay) {
+    throw new AdminToolsError(
+      "REPLAY_NOT_FOUND",
+      `Replay manquant pour match '${matchId}'`,
+    );
+  }
+  const events = (await decompressEvents(replay.payload)) as readonly MatchEvent[];
+  return { match, events };
+}
+
+export async function runReplayDiff(
+  input: RunReplayDiffInput,
+): Promise<RunReplayDiffResult> {
+  if (input.matchIdA === input.matchIdB) {
+    throw new AdminToolsError(
+      "INVALID_INPUT",
+      "matchIdA et matchIdB doivent etre distincts",
+    );
+  }
+  const a = await loadMatchAndReplay(input.matchIdA);
+  const b = await loadMatchAndReplay(input.matchIdB);
+  const diff = diffReplayEvents(a.events, b.events, {
+    maxDivergences: input.maxDivergences,
+  });
+  return { matchA: a.match, matchB: b.match, diff };
+}

--- a/apps/web/app/admin/sim/compare-versions/page.tsx
+++ b/apps/web/app/admin/sim/compare-versions/page.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+/**
+ * Console admin — cross-version baseline comparator (Lot 4.F).
+ *
+ * Wrappe le CLI `pnpm sim:compare-versions` (PR #722) en HTML : 2
+ * inputs file pour les snapshots `bench-baseline.json`, render
+ * du `VersionComparisonResult` avec table per-pairing colorée par
+ * severity (warn / critical).
+ *
+ * Workflow recommandé :
+ *   1. git checkout v0.15.0 ; pnpm sim:bench:snapshot > /tmp/v0.15.0.json
+ *   2. git checkout v0.16.0 ; pnpm sim:bench:snapshot > /tmp/v0.16.0.json
+ *   3. Drop les 2 fichiers ici → rapport instantané.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+interface ExpectedMetrics {
+  tdMean: number;
+  tdStd: number;
+  casualtyMean: number;
+  turnoverMean: number;
+  homeWinRate: number;
+  awayWinRate: number;
+  drawRate: number;
+}
+
+interface PairingDelta {
+  homeId: string;
+  awayId: string;
+  base: ExpectedMetrics;
+  head: ExpectedMetrics;
+  deltas: ExpectedMetrics;
+  severity: "normal" | "warn" | "critical";
+  maxAbsRelativeDelta: number;
+}
+
+interface ComparisonResult {
+  base: { engineVer: string; snapshotAt: string };
+  head: { engineVer: string; snapshotAt: string };
+  pairings: PairingDelta[];
+  summary: {
+    maxAbsDeltaByMetric: ExpectedMetrics;
+    missingInBase: Array<{ homeId: string; awayId: string }>;
+    missingInHead: Array<{ homeId: string; awayId: string }>;
+    matchedPairings: number;
+    warnCount: number;
+    criticalCount: number;
+  };
+}
+
+async function postJSON<T>(path: string, body: unknown): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function readFileAsJson(file: File): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        resolve(JSON.parse(String(reader.result ?? "")));
+      } catch (err) {
+        reject(new Error(`JSON parse failed: ${(err as Error).message}`));
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
+function fmtSigned(n: number, digits = 2): string {
+  const sign = n >= 0 ? "+" : "";
+  return `${sign}${n.toFixed(digits)}`;
+}
+
+function severityColor(s: PairingDelta["severity"]): string {
+  if (s === "critical") return "bg-red-100 text-red-900";
+  if (s === "warn") return "bg-yellow-100 text-yellow-900";
+  return "";
+}
+
+export default function AdminCompareVersionsPage() {
+  const [baseRaw, setBaseRaw] = useState<unknown>(null);
+  const [headRaw, setHeadRaw] = useState<unknown>(null);
+  const [baseName, setBaseName] = useState<string>("");
+  const [headName, setHeadName] = useState<string>("");
+  const [warnPct, setWarnPct] = useState<number>(10);
+  const [criticalPct, setCriticalPct] = useState<number>(25);
+  const [result, setResult] = useState<ComparisonResult | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleBaseUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    try {
+      const json = await readFileAsJson(f);
+      setBaseRaw(json);
+      setBaseName(f.name);
+      setError(null);
+    } catch (err) {
+      setError(`base: ${(err as Error).message}`);
+    }
+  };
+
+  const handleHeadUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): Promise<void> => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    try {
+      const json = await readFileAsJson(f);
+      setHeadRaw(json);
+      setHeadName(f.name);
+      setError(null);
+    } catch (err) {
+      setError(`head: ${(err as Error).message}`);
+    }
+  };
+
+  const compare = async (): Promise<void> => {
+    if (!baseRaw || !headRaw) {
+      setError("Charge les 2 baselines (base + head).");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const data = await postJSON<ComparisonResult>(
+        "/admin/sim/compare-versions",
+        {
+          baseRaw,
+          headRaw,
+          warnThreshold: warnPct / 100,
+          criticalThreshold: criticalPct / 100,
+        },
+      );
+      setResult(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">
+        Sim engine — cross-version comparator
+      </h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Compare deux snapshots <code>bench-baseline.json</code> produits sur
+        des <code>engineVer</code> différents et visualise la drift par
+        pairing. Workflow : <code>pnpm sim:bench:snapshot</code> sur 2
+        versions, charge les fichiers, click compare.
+      </p>
+
+      <div className="grid grid-cols-2 gap-4 mb-4 p-4 border rounded bg-white">
+        <label className="text-sm">
+          <div className="mb-1 font-medium">Base baseline (ancienne version)</div>
+          <input
+            type="file"
+            accept=".json"
+            onChange={(e) => void handleBaseUpload(e)}
+            className="w-full"
+          />
+          {baseName && (
+            <div className="mt-1 text-xs text-gray-500">{baseName}</div>
+          )}
+        </label>
+        <label className="text-sm">
+          <div className="mb-1 font-medium">Head baseline (nouvelle version)</div>
+          <input
+            type="file"
+            accept=".json"
+            onChange={(e) => void handleHeadUpload(e)}
+            className="w-full"
+          />
+          {headName && (
+            <div className="mt-1 text-xs text-gray-500">{headName}</div>
+          )}
+        </label>
+
+        <label className="text-sm">
+          <div className="mb-1">Warn threshold (% relatif)</div>
+          <input
+            type="number"
+            min={1}
+            max={100}
+            step={1}
+            value={warnPct}
+            onChange={(e) => setWarnPct(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Critical threshold (% relatif)</div>
+          <input
+            type="number"
+            min={1}
+            max={100}
+            step={1}
+            value={criticalPct}
+            onChange={(e) => setCriticalPct(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+
+        <div className="col-span-2 flex justify-end">
+          <button
+            onClick={() => void compare()}
+            disabled={loading || !baseRaw || !headRaw}
+            className="px-4 py-2 rounded bg-nuffle-gold text-white font-medium disabled:opacity-50"
+          >
+            {loading ? "Compute…" : "Compare"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div>
+          <div className="mb-4 p-3 border rounded bg-gray-50 text-sm">
+            <div>
+              base: <code>{result.base.engineVer}</code> (snapshot{" "}
+              {result.base.snapshotAt})
+            </div>
+            <div>
+              head: <code>{result.head.engineVer}</code> (snapshot{" "}
+              {result.head.snapshotAt})
+            </div>
+            <div>
+              matched pairings :{" "}
+              <strong>{result.summary.matchedPairings}</strong> · warn :{" "}
+              <strong className="text-yellow-700">
+                {result.summary.warnCount}
+              </strong>{" "}
+              · critical :{" "}
+              <strong className="text-red-700">
+                {result.summary.criticalCount}
+              </strong>
+            </div>
+          </div>
+
+          {result.pairings.length > 0 && (
+            <table className="w-full border-collapse text-sm mb-4">
+              <thead>
+                <tr className="border-b bg-gray-100">
+                  <th className="text-left p-2">Pairing</th>
+                  <th className="text-right p-2">tdMean Δ</th>
+                  <th className="text-right p-2">casMean Δ</th>
+                  <th className="text-right p-2">homeWin Δ</th>
+                  <th className="text-right p-2">awayWin Δ</th>
+                  <th className="text-right p-2">max abs (rel)</th>
+                  <th className="text-right p-2">severity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.pairings.map((p) => (
+                  <tr
+                    key={`${p.homeId}__${p.awayId}`}
+                    className={`border-b ${severityColor(p.severity)}`}
+                  >
+                    <td className="p-2">
+                      {p.homeId} vs {p.awayId}
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {fmtSigned(p.deltas.tdMean)}
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {fmtSigned(p.deltas.casualtyMean)}
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {fmtSigned(p.deltas.homeWinRate, 3)}
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {fmtSigned(p.deltas.awayWinRate, 3)}
+                    </td>
+                    <td className="p-2 text-right font-mono">
+                      {(p.maxAbsRelativeDelta * 100).toFixed(1)}%
+                    </td>
+                    <td className="p-2 text-right uppercase">{p.severity}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {result.summary.missingInBase.length > 0 && (
+            <div className="mb-2 text-sm">
+              <strong>Nouveaux pairings dans head :</strong>{" "}
+              {result.summary.missingInBase
+                .map((p) => `${p.homeId} vs ${p.awayId}`)
+                .join(", ")}
+            </div>
+          )}
+          {result.summary.missingInHead.length > 0 && (
+            <div className="mb-2 text-sm">
+              <strong>Pairings retirés de head :</strong>{" "}
+              {result.summary.missingInHead
+                .map((p) => `${p.homeId} vs ${p.awayId}`)
+                .join(", ")}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="mt-6 text-xs text-gray-500">
+        <Link
+          href={"/admin/sim/diff-replays" as never}
+          className="underline mr-3"
+        >
+          → Replay diff
+        </Link>
+        <Link href={"/admin/sim/health" as never} className="underline">
+          → Sim health dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/sim/diff-replays/page.tsx
+++ b/apps/web/app/admin/sim/diff-replays/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+/**
+ * Console admin — replay diff event-by-event (Lot 4.F).
+ *
+ * Wrappe le CLI `pnpm sim:diff-replays` (PR #725) en HTML : 2 inputs
+ * matchId, le serveur charge les Replay.payload, decompresse, runne
+ * `diffReplayEvents`. Render des metadonnees match + listing des
+ * divergences avec colorisation par kind.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+type DivergenceKind = "mismatch" | "missing_a" | "missing_b";
+
+interface MatchEventLite {
+  type: string;
+  displayAtMs: number;
+  meta?: Record<string, unknown>;
+}
+
+interface ReplayDivergence {
+  index: number;
+  kind: DivergenceKind;
+  a: MatchEventLite | null;
+  b: MatchEventLite | null;
+}
+
+interface ReplayDiffSummary {
+  totalA: number;
+  totalB: number;
+  matchedCount: number;
+  divergenceCount: number;
+  firstDivergenceIndex: number | null;
+}
+
+interface MatchMeta {
+  id: string;
+  engineVer: string | null;
+  scoreHome: number | null;
+  scoreAway: number | null;
+}
+
+interface ReplayDiffResult {
+  matchA: MatchMeta;
+  matchB: MatchMeta;
+  diff: {
+    divergences: ReplayDivergence[];
+    summary: ReplayDiffSummary;
+  };
+}
+
+async function postJSON<T>(path: string, body: unknown): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function describeEvent(e: MatchEventLite | null): string {
+  if (!e) return "(none)";
+  const metaStr = JSON.stringify(e.meta ?? {});
+  const trimmed = metaStr.length > 60 ? `${metaStr.slice(0, 60)}…` : metaStr;
+  return `${e.type} @${e.displayAtMs}ms ${trimmed}`;
+}
+
+function kindColor(k: DivergenceKind): string {
+  if (k === "mismatch") return "bg-yellow-50 text-yellow-900";
+  if (k === "missing_a") return "bg-blue-50 text-blue-900";
+  return "bg-purple-50 text-purple-900"; // missing_b
+}
+
+export default function AdminDiffReplaysPage() {
+  const [matchIdA, setMatchIdA] = useState<string>("");
+  const [matchIdB, setMatchIdB] = useState<string>("");
+  const [maxDivergences, setMaxDivergences] = useState<number>(50);
+  const [result, setResult] = useState<ReplayDiffResult | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const diff = async (): Promise<void> => {
+    if (!matchIdA || !matchIdB) {
+      setError("Renseigne 2 matchIds.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const data = await postJSON<ReplayDiffResult>(
+        "/admin/sim/diff-replays",
+        { matchIdA, matchIdB, maxDivergences },
+      );
+      setResult(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">Sim engine — replay diff</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Diff event-par-event entre 2 replays produits avec le même seed sur
+        2 versions / 2 refacto. Sert à pointer précisément où la simulation
+        diverge.
+      </p>
+
+      <div className="grid grid-cols-3 gap-3 items-end mb-4 p-4 border rounded bg-white">
+        <label className="text-sm">
+          <div className="mb-1">Match ID A</div>
+          <input
+            type="text"
+            value={matchIdA}
+            onChange={(e) => setMatchIdA(e.target.value.trim())}
+            placeholder="cuid…"
+            className="w-full border rounded p-2 font-mono text-xs"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Match ID B</div>
+          <input
+            type="text"
+            value={matchIdB}
+            onChange={(e) => setMatchIdB(e.target.value.trim())}
+            placeholder="cuid…"
+            className="w-full border rounded p-2 font-mono text-xs"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Max divergences à charger</div>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            step={10}
+            value={maxDivergences}
+            onChange={(e) => setMaxDivergences(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <div className="col-span-3 flex justify-end">
+          <button
+            onClick={() => void diff()}
+            disabled={loading || matchIdA === matchIdB}
+            className="px-4 py-2 rounded bg-nuffle-gold text-white font-medium disabled:opacity-50"
+          >
+            {loading ? "Compute…" : "Diff replays"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div>
+          <div className="mb-4 grid grid-cols-2 gap-3">
+            <div className="p-3 border rounded bg-gray-50 text-sm">
+              <div className="font-medium">Match A</div>
+              <div>id: <code className="text-xs">{result.matchA.id}</code></div>
+              <div>engineVer: <code>{result.matchA.engineVer ?? "—"}</code></div>
+              <div>
+                score: {result.matchA.scoreHome ?? "—"} -{" "}
+                {result.matchA.scoreAway ?? "—"}
+              </div>
+            </div>
+            <div className="p-3 border rounded bg-gray-50 text-sm">
+              <div className="font-medium">Match B</div>
+              <div>id: <code className="text-xs">{result.matchB.id}</code></div>
+              <div>engineVer: <code>{result.matchB.engineVer ?? "—"}</code></div>
+              <div>
+                score: {result.matchB.scoreHome ?? "—"} -{" "}
+                {result.matchB.scoreAway ?? "—"}
+              </div>
+            </div>
+          </div>
+
+          <div className="mb-4 p-3 border rounded bg-gray-50 text-sm">
+            totalA = <strong>{result.diff.summary.totalA}</strong> · totalB ={" "}
+            <strong>{result.diff.summary.totalB}</strong> · matched ={" "}
+            <strong>{result.diff.summary.matchedCount}</strong> · divergences ={" "}
+            <strong className="text-red-700">
+              {result.diff.summary.divergenceCount}
+            </strong>{" "}
+            · first divergence index ={" "}
+            <strong>
+              {result.diff.summary.firstDivergenceIndex ?? "none"}
+            </strong>
+          </div>
+
+          {result.diff.divergences.length === 0 ? (
+            <div className="text-sm text-green-700">
+              Pas de divergence détectée. Replays identiques.
+            </div>
+          ) : (
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b bg-gray-100">
+                  <th className="text-left p-2">idx</th>
+                  <th className="text-left p-2">kind</th>
+                  <th className="text-left p-2">A</th>
+                  <th className="text-left p-2">B</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.diff.divergences.map((d) => (
+                  <tr
+                    key={`${d.index}-${d.kind}`}
+                    className={`border-b ${kindColor(d.kind)}`}
+                  >
+                    <td className="p-2 font-mono">{d.index}</td>
+                    <td className="p-2 uppercase">{d.kind}</td>
+                    <td className="p-2 font-mono">{describeEvent(d.a)}</td>
+                    <td className="p-2 font-mono">{describeEvent(d.b)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {result.diff.divergences.length <
+            result.diff.summary.divergenceCount && (
+            <div className="mt-2 text-xs text-gray-500">
+              … {result.diff.summary.divergenceCount -
+                result.diff.divergences.length}{" "}
+              autres divergences cappées (augmente Max divergences).
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="mt-6 text-xs text-gray-500">
+        <Link
+          href={"/admin/sim/compare-versions" as never}
+          className="underline mr-3"
+        >
+          → Cross-version compare
+        </Link>
+        <Link href={"/admin/sim/health" as never} className="underline">
+          → Sim health dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Wrappe les CLIs `pnpm sim:compare-versions` (#722) et `pnpm sim:diff-replays` (#725) en routes admin authentifiées + pages Next.js, pour piloter ces outils depuis le navigateur sans accès shell.

### Backend (`apps/server`)
- Nouveau service `pro-league-admin-tools` :
  - `runVersionComparison({ baseRaw, headRaw, warnThreshold?, criticalThreshold? })` valide les baselines via `parseBenchBaseline` (Zod) puis délègue à `compareBaselines`.
  - `runReplayDiff({ matchIdA, matchIdB, maxDivergences? })` lit les `Replay.payload` en DB, décompresse, délègue à `diffReplayEvents` ; renvoie aussi les métadonnées match (`engineVer`, `scoreHome`, `scoreAway`).
  - Erreurs typées `AdminToolsError` : `INVALID_BASELINE`, `INVALID_INPUT`, `MATCH_NOT_FOUND`, `REPLAY_NOT_FOUND`.
- 2 routes ajoutées :
  - `POST /admin/sim/compare-versions` (Zod : 2 raw JSON + thresholds < 1) → 200 / 400 / 500.
  - `POST /admin/sim/diff-replays` (Zod : 2 matchIds non-vides + max divergences ≤ 1000) → 200 / 400 / 404 / 500.

### Frontend (`apps/web`)
- `/admin/sim/compare-versions` : 2 file inputs JSON + thresholds (% relatifs), table par pairing colorée par severity (warn / critical), liste des pairings ajoutés/retirés vs base.
- `/admin/sim/diff-replays` : 2 inputs `matchId` + max divergences, cartes match A/B (id, engineVer, score) + table divergences colorée par kind (`mismatch` jaune, `missing_a` bleu, `missing_b` violet).

### Workflow opérationnel
```
git checkout v0.15.0 ; pnpm sim:bench:snapshot > /tmp/v0.15.0.json
git checkout v0.16.0 ; pnpm sim:bench:snapshot > /tmp/v0.16.0.json
# → drag les 2 fichiers dans /admin/sim/compare-versions → rapport instantané
```

## Test plan
- [x] `pnpm --filter @bb/server test` — 2096 tests verts (8 nouveaux pour le service, 15 pour les handlers/schemas).
- [x] `pnpm typecheck` — clean (server + web + sim-engine).
- [ ] Smoke manuel : drag 2 baselines `/admin/sim/compare-versions` → table de diff.
- [ ] Smoke manuel : 2 matchIds existants `/admin/sim/diff-replays` → table de divergences ou "replays identiques".
- [ ] Vérifier 404 si matchId / replay introuvable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_