### PR TITLE
feat(admin): sim health = drift + alerts + last-sim + cross-links (Lot 2.B.3+)

### DIFF
--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -32,6 +32,9 @@ vi.mock("../services/pro-league-admin-tools", async () => {
     runReplayDiff: vi.fn(),
   };
 });
+vi.mock("../services/pro-league-sim-health", () => ({
+  computeSimHealthSnapshot: vi.fn(),
+}));
 
 import {
   comparisonSchema,
@@ -42,6 +45,7 @@ import {
   handleDiffReplays,
   handleGetBroadcasterStats,
   handleGetDrift,
+  handleGetHealthSnapshot,
   handleListTeams,
   handleListTestMatches,
   handleRunComparison,
@@ -51,6 +55,7 @@ import {
   type RunSimBody,
 } from "./admin-sim";
 import { computeEngineDrift } from "../services/pro-league-engine-drift-watcher";
+import { computeSimHealthSnapshot } from "../services/pro-league-sim-health";
 import { getBroadcasterStats } from "../services/pro-league-match-broadcaster";
 import {
   createTestMatch,
@@ -258,6 +263,70 @@ describe("handleGetDrift — Lot 2.A.5", () => {
       res,
     );
     expect(computeEngineDrift).toHaveBeenCalledWith({
+      windowMs: undefined,
+      seasonId: undefined,
+    });
+  });
+});
+
+describe("handleGetHealthSnapshot — Lot 2.B.3", () => {
+  it("retourne le snapshot complet du service", async () => {
+    (computeSimHealthSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue({
+      samples: [],
+      driftAlerts: [],
+      boundAlerts: [],
+      counts: { warn: 0, critical: 0 },
+      lastSimAt: "2026-05-09T10:00:00.000Z",
+      computedAt: "2026-05-10T11:00:00.000Z",
+    });
+    const res = buildRes();
+    await handleGetHealthSnapshot({ query: {} } as unknown as Request, res);
+    const body = res.body as { lastSimAt: string; counts: { warn: number } };
+    expect(body.lastSimAt).toBe("2026-05-09T10:00:00.000Z");
+    expect(body.counts.warn).toBe(0);
+    expect(computeSimHealthSnapshot).toHaveBeenCalledWith({
+      windowMs: undefined,
+      seasonId: undefined,
+    });
+  });
+
+  it("forwarde windowMs et seasonId quand fournis en query string", async () => {
+    (computeSimHealthSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue({
+      samples: [],
+      driftAlerts: [],
+      boundAlerts: [],
+      counts: { warn: 0, critical: 0 },
+      lastSimAt: null,
+      computedAt: "2026-05-10T11:00:00.000Z",
+    });
+    const res = buildRes();
+    await handleGetHealthSnapshot(
+      {
+        query: { windowMs: "86400000", seasonId: "S2027" },
+      } as unknown as Request,
+      res,
+    );
+    expect(computeSimHealthSnapshot).toHaveBeenCalledWith({
+      windowMs: 86400000,
+      seasonId: "S2027",
+    });
+  });
+
+  it("ignore windowMs non-numérique", async () => {
+    (computeSimHealthSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue({
+      samples: [],
+      driftAlerts: [],
+      boundAlerts: [],
+      counts: { warn: 0, critical: 0 },
+      lastSimAt: null,
+      computedAt: "2026-05-10T11:00:00.000Z",
+    });
+    const res = buildRes();
+    await handleGetHealthSnapshot(
+      { query: { windowMs: "abc" } } as unknown as Request,
+      res,
+    );
+    expect(computeSimHealthSnapshot).toHaveBeenCalledWith({
       windowMs: undefined,
       seasonId: undefined,
     });

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -23,6 +23,7 @@ import {
   createTestMatch,
   listTestMatches,
 } from "../services/pro-league-sandbox";
+import { computeSimHealthSnapshot } from "../services/pro-league-sim-health";
 import { appMetrics } from "../utils/metrics";
 
 /**
@@ -123,6 +124,33 @@ export async function handleGetDrift(req: Request, res: Response): Promise<void>
     samples,
     computedAt: new Date().toISOString(),
   });
+}
+
+/**
+ * Handler for `GET /admin/sim/health-snapshot` — Lot 2.B.3 (extension 4.A.3).
+ *
+ * Snapshot agrégé : drift samples + drift alerts + bound alerts +
+ * timestamp dernier match. Sert au dashboard admin `/admin/sim/health`
+ * en remplaçant les 3 round-trips drift / alerts / last-sim par un
+ * unique appel cohérent (même `samples` / même `now()`).
+ *
+ * Query params identiques à `/admin/sim/drift` (`windowMs`, `seasonId`).
+ */
+export async function handleGetHealthSnapshot(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const windowMsRaw = req.query.windowMs;
+  const seasonId =
+    typeof req.query.seasonId === "string" && req.query.seasonId.length > 0
+      ? req.query.seasonId
+      : undefined;
+  const windowMs =
+    typeof windowMsRaw === "string" && /^\d+$/.test(windowMsRaw)
+      ? Number.parseInt(windowMsRaw, 10)
+      : undefined;
+  const snapshot = await computeSimHealthSnapshot({ windowMs, seasonId });
+  res.json(snapshot);
 }
 
 /**
@@ -357,6 +385,7 @@ router.use(authUser, adminOnly);
 router.get("/teams", handleListTeams);
 router.post("/run", validate(runSimSchema), handleRunSim);
 router.get("/drift", handleGetDrift);
+router.get("/health-snapshot", handleGetHealthSnapshot);
 router.get("/broadcaster", handleGetBroadcasterStats);
 router.post(
   "/test-match",

--- a/apps/server/src/services/pro-league-sim-health.test.ts
+++ b/apps/server/src/services/pro-league-sim-health.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests pour le snapshot health (Lot 2.B.3 + extension 4.A.3).
+ *
+ * Couvre :
+ *   - aggregation drift samples + drift alerts + bound alerts en un
+ *     seul payload cohérent.
+ *   - `counts.critical` = drift critical + bound alerts (qui sont
+ *     toujours critical par construction Lot 4.A.3).
+ *   - `lastSimAt` lit le dernier `proLeagueMatch.updatedAt` filtré sur
+ *     `status='completed'` et `isTest=false`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueMatch: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("./pro-league-engine-drift-watcher", async () => {
+  const actual = await vi.importActual<
+    typeof import("./pro-league-engine-drift-watcher")
+  >("./pro-league-engine-drift-watcher");
+  return {
+    ...actual,
+    computeEngineDrift: vi.fn(),
+  };
+});
+
+vi.mock("./pro-league-race-bounds", async () => {
+  const actual = await vi.importActual<
+    typeof import("./pro-league-race-bounds")
+  >("./pro-league-race-bounds");
+  return {
+    ...actual,
+    detectRaceBoundAlerts: vi.fn(),
+  };
+});
+
+import { prisma } from "../prisma";
+import { computeEngineDrift } from "./pro-league-engine-drift-watcher";
+import { detectRaceBoundAlerts } from "./pro-league-race-bounds";
+import { computeSimHealthSnapshot } from "./pro-league-sim-health";
+
+interface MockedPrisma {
+  proLeagueMatch: { findFirst: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+const mockedDrift = vi.mocked(computeEngineDrift);
+const mockedBounds = vi.mocked(detectRaceBoundAlerts);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("computeSimHealthSnapshot — Lot 2.B.3", () => {
+  it("aggrège samples + alerts + lastSimAt en un seul payload", async () => {
+    mockedDrift.mockResolvedValueOnce([
+      {
+        metric: "tdMean",
+        race: "Wood Elf",
+        seasonId: "S2026",
+        observed: 2.5,
+        reference: 2.4,
+        drift: 0.04,
+        samples: 12,
+      },
+      // sample en drift critical (>25%) + samples >=5
+      {
+        metric: "tdMean",
+        race: "Halfling",
+        seasonId: "S2026",
+        observed: 3.5,
+        reference: 1.0,
+        drift: 2.5,
+        samples: 10,
+      },
+    ]);
+    mockedBounds.mockReturnValueOnce([
+      {
+        severity: "critical",
+        race: "Halfling",
+        seasonId: "S2026",
+        metric: "tdMean",
+        direction: "above_max",
+        observed: 3.5,
+        bound: 1.5,
+        samples: 10,
+      },
+    ]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce({
+      updatedAt: new Date("2026-05-09T10:00:00Z"),
+    });
+
+    const out = await computeSimHealthSnapshot();
+    expect(out.samples).toHaveLength(2);
+    expect(out.driftAlerts).toHaveLength(1);
+    expect(out.driftAlerts[0]?.severity).toBe("critical");
+    expect(out.boundAlerts).toHaveLength(1);
+    // Lot 4.A.3 — `counts.critical` cumule drift critical + bound alerts.
+    expect(out.counts.critical).toBe(2);
+    expect(out.counts.warn).toBe(0);
+    expect(out.lastSimAt).toBe("2026-05-09T10:00:00.000Z");
+    expect(typeof out.computedAt).toBe("string");
+  });
+
+  it("retourne lastSimAt=null si aucun match completed", async () => {
+    mockedDrift.mockResolvedValueOnce([]);
+    mockedBounds.mockReturnValueOnce([]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce(null);
+    const out = await computeSimHealthSnapshot();
+    expect(out.lastSimAt).toBeNull();
+    expect(out.samples).toEqual([]);
+    expect(out.driftAlerts).toEqual([]);
+    expect(out.counts).toEqual({ warn: 0, critical: 0 });
+  });
+
+  it("filtre lastSimAt sur isTest=false (sandbox matches exclus)", async () => {
+    mockedDrift.mockResolvedValueOnce([]);
+    mockedBounds.mockReturnValueOnce([]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce(null);
+    await computeSimHealthSnapshot();
+    expect(mocked.proLeagueMatch.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "completed",
+          isTest: false,
+        }),
+      }),
+    );
+  });
+
+  it("propage seasonId au filtre lastSimAt", async () => {
+    mockedDrift.mockResolvedValueOnce([]);
+    mockedBounds.mockReturnValueOnce([]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce(null);
+    await computeSimHealthSnapshot({ seasonId: "S2027" });
+    expect(mocked.proLeagueMatch.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ seasonId: "S2027" }),
+      }),
+    );
+  });
+
+  it("propage now() override à computedAt", async () => {
+    mockedDrift.mockResolvedValueOnce([]);
+    mockedBounds.mockReturnValueOnce([]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce(null);
+    const fixed = new Date("2026-01-01T00:00:00Z");
+    const out = await computeSimHealthSnapshot({ now: fixed });
+    expect(out.computedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("compte 0 critical quand pas d'alerte (drift dans tolerance)", async () => {
+    mockedDrift.mockResolvedValueOnce([
+      {
+        metric: "tdMean",
+        race: "Wood Elf",
+        seasonId: "S2026",
+        observed: 2.5,
+        reference: 2.4,
+        drift: 0.04,
+        samples: 20,
+      },
+    ]);
+    mockedBounds.mockReturnValueOnce([]);
+    mocked.proLeagueMatch.findFirst.mockResolvedValueOnce({
+      updatedAt: new Date("2026-05-08T00:00:00Z"),
+    });
+    const out = await computeSimHealthSnapshot();
+    expect(out.counts.critical).toBe(0);
+    expect(out.counts.warn).toBe(0);
+  });
+});

--- a/apps/server/src/services/pro-league-sim-health.ts
+++ b/apps/server/src/services/pro-league-sim-health.ts
@@ -1,0 +1,79 @@
+/**
+ * Pro League sim health snapshot — Lot 2.B.3 (extension Lot 4.A.3).
+ *
+ * Ce service fournit une vue agrégée pour le dashboard admin
+ * `/admin/sim/health`, en combinant :
+ *
+ *   - les `DriftSample` (pareil que `GET /admin/sim/drift`),
+ *   - les `DriftAlert` issues de `detectDriftAlerts` (Lot 4.A.3),
+ *   - les `RaceBoundAlert` issues de `detectRaceBoundAlerts` (Lot 4.A.3),
+ *   - le timestamp `lastSimAt` du dernier match Pro League completé.
+ *
+ * Pourquoi un service séparé plutôt qu'un fan-out côté UI ?
+ *   - 1 round-trip réseau au lieu de 3 (drift + alerts + last-sim).
+ *   - Cohérence temporelle : tous les chiffres affichés sont calculés
+ *     sur le même `samples` et le même `now()`.
+ *   - Le client ne connaît rien des seuils 10/25% et des bornes BB —
+ *     seul le serveur les applique.
+ */
+
+import { prisma } from "../prisma";
+import {
+  computeEngineDrift,
+  countAlertsBySeverity,
+  detectDriftAlerts,
+  type ComputeDriftOptions,
+  type DriftAlert,
+  type DriftSample,
+} from "./pro-league-engine-drift-watcher";
+import {
+  detectRaceBoundAlerts,
+  type RaceBoundAlert,
+} from "./pro-league-race-bounds";
+
+export interface SimHealthSnapshot {
+  readonly samples: readonly DriftSample[];
+  readonly driftAlerts: readonly DriftAlert[];
+  readonly boundAlerts: readonly RaceBoundAlert[];
+  readonly counts: {
+    readonly warn: number;
+    readonly critical: number;
+  };
+  /** ISO datetime du dernier match Pro League non-test completé. `null` si aucun. */
+  readonly lastSimAt: string | null;
+  readonly computedAt: string;
+}
+
+async function fetchLastSimAt(seasonId?: string): Promise<string | null> {
+  const last = await prisma.proLeagueMatch.findFirst({
+    where: {
+      status: "completed",
+      isTest: false,
+      ...(seasonId ? { seasonId } : {}),
+    },
+    orderBy: { updatedAt: "desc" },
+    select: { updatedAt: true },
+  });
+  return last ? last.updatedAt.toISOString() : null;
+}
+
+export async function computeSimHealthSnapshot(
+  options: ComputeDriftOptions = {},
+): Promise<SimHealthSnapshot> {
+  const samples = await computeEngineDrift(options);
+  const driftAlerts = detectDriftAlerts(samples);
+  const boundAlerts = detectRaceBoundAlerts(samples);
+  const driftCounts = countAlertsBySeverity(driftAlerts);
+  const lastSimAt = await fetchLastSimAt(options.seasonId);
+  return {
+    samples,
+    driftAlerts,
+    boundAlerts,
+    counts: {
+      warn: driftCounts.warn,
+      critical: driftCounts.critical + boundAlerts.length,
+    },
+    lastSimAt,
+    computedAt: (options.now ?? new Date()).toISOString(),
+  };
+}

--- a/apps/web/app/admin/sim/health/page.tsx
+++ b/apps/web/app/admin/sim/health/page.tsx
@@ -1,24 +1,31 @@
 "use client";
 
 /**
- * Console admin — sim engine health (Lot 2.B.3).
+ * Console admin — sim engine health (Lot 2.B.3, augmenté Lot 4.A.3).
  *
- * Affiche la drift courante du moteur (rolling 7j) par race vs
- * référence FUMBBL. Sert de fallback quand Grafana est down ou pour
- * un rapide sanity check sans quitter l'app.
+ * Hub d'observabilité du sim engine côté UI :
  *
- * Code couleur :
- *   🟢  drift ∈ ]−5%, +5%[
- *   🟡  drift ∈ ]−10%, +10%[
- *   🔴  drift au-delà de ±10%
+ *   1. **Active alerts** — drift alerts (warn / critical, |drift| >
+ *      10% / 25%) + race-bound alerts (Lot 4.A.3) au-dessus de la
+ *      table.
+ *   2. **Last sim** — timestamp du dernier match Pro League completé,
+ *      avec ago humain.
+ *   3. **Drift table** par race vs FUMBBL (rolling 7j default), avec
+ *      🟢🟡🔴 par métrique (tdMean / casualtyMean / winRate).
+ *   4. **Cross-links** — entry points vers les autres consoles
+ *      `/admin/sim/{broadcaster, replays, test-match,
+ *      compare-versions, diff-replays}`.
  *
- * Lecture seule. Source : `GET /admin/sim/drift`.
+ * Lecture seule. Source : `GET /admin/sim/health-snapshot`.
  */
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { API_BASE } from "../../../auth-client";
 
 type DriftMetric = "tdMean" | "casualtyMean" | "winRate";
+type AlertSeverity = "warn" | "critical";
+type RaceBoundDirection = "above_max" | "below_min";
 
 interface DriftSample {
   metric: DriftMetric;
@@ -30,8 +37,34 @@ interface DriftSample {
   samples: number;
 }
 
-interface DriftPayload {
+interface DriftAlert {
+  severity: AlertSeverity;
+  metric: DriftMetric;
+  race: string;
+  seasonId: string;
+  drift: number;
+  observed: number;
+  reference: number;
+  samples: number;
+}
+
+interface RaceBoundAlert {
+  severity: "critical";
+  race: string;
+  seasonId: string;
+  metric: DriftMetric;
+  direction: RaceBoundDirection;
+  observed: number;
+  bound: number;
+  samples: number;
+}
+
+interface HealthSnapshot {
   samples: DriftSample[];
+  driftAlerts: DriftAlert[];
+  boundAlerts: RaceBoundAlert[];
+  counts: { warn: number; critical: number };
+  lastSimAt: string | null;
   computedAt: string;
 }
 
@@ -75,6 +108,19 @@ function formatPct(drift: number): string {
   return `${sign}${(drift * 100).toFixed(1)}%`;
 }
 
+function formatAgo(iso: string | null): string {
+  if (!iso) return "jamais";
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (diffMs < 0) return "à l'instant";
+  const min = Math.floor(diffMs / 60000);
+  if (min < 1) return "<1 min";
+  if (min < 60) return `il y a ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `il y a ${h}h`;
+  const d = Math.floor(h / 24);
+  return `il y a ${d}j`;
+}
+
 interface RaceSummary {
   race: string;
   seasonId: string;
@@ -101,19 +147,25 @@ function groupByRace(samples: readonly DriftSample[]): RaceSummary[] {
   return Array.from(map.values()).sort((a, b) => a.race.localeCompare(b.race));
 }
 
+function severityClass(s: AlertSeverity): string {
+  return s === "critical"
+    ? "border-red-300 bg-red-50 text-red-900"
+    : "border-yellow-300 bg-yellow-50 text-yellow-900";
+}
+
 export default function AdminSimHealthPage() {
-  const [data, setData] = useState<DriftPayload | null>(null);
+  const [data, setData] = useState<HealthSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [windowDays, setWindowDays] = useState<number>(7);
 
-  const refresh = async (days: number) => {
+  const refresh = async (days: number): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
       const windowMs = days * 24 * 60 * 60 * 1000;
-      const payload = await fetchJSON<DriftPayload>(
-        `/admin/sim/drift?windowMs=${windowMs}`,
+      const payload = await fetchJSON<HealthSnapshot>(
+        `/admin/sim/health-snapshot?windowMs=${windowMs}`,
       );
       setData(payload);
     } catch (e) {
@@ -138,7 +190,7 @@ export default function AdminSimHealthPage() {
         FUMBBL. 🟢 ∈ ±5% · 🟡 ∈ ±10% · 🔴 au-delà.
       </p>
 
-      <div className="flex gap-3 items-center mb-6">
+      <div className="flex flex-wrap gap-3 items-center mb-6">
         <label className="text-sm">
           Fenêtre :
           <select
@@ -164,9 +216,22 @@ export default function AdminSimHealthPage() {
           {loading ? "…" : "Rafraîchir"}
         </button>
         {data && (
-          <span className="text-xs text-gray-500">
-            Calculé : {new Date(data.computedAt).toLocaleString()}
-          </span>
+          <>
+            <span className="text-xs text-gray-500">
+              Calculé : {new Date(data.computedAt).toLocaleString()}
+            </span>
+            <span className="text-xs text-gray-500">
+              Dernier match : {formatAgo(data.lastSimAt)}
+            </span>
+            <span className="ml-auto inline-flex gap-2 text-xs">
+              <span className="px-2 py-1 rounded bg-yellow-100 text-yellow-900">
+                ⚠ {data.counts.warn} warn
+              </span>
+              <span className="px-2 py-1 rounded bg-red-100 text-red-900">
+                🔴 {data.counts.critical} critical
+              </span>
+            </span>
+          </>
         )}
       </div>
 
@@ -176,11 +241,47 @@ export default function AdminSimHealthPage() {
         </div>
       )}
 
-      {data && races.length === 0 && (
-        <div className="p-4 bg-gray-50 border rounded text-sm text-gray-600">
-          Aucun match dans la fenêtre — pas de drift à mesurer.
-        </div>
-      )}
+      {data &&
+        (data.driftAlerts.length > 0 || data.boundAlerts.length > 0) && (
+          <section className="mb-6">
+            <h2 className="text-lg font-semibold mb-2">Active alerts</h2>
+            <ul className="space-y-2 text-sm">
+              {data.driftAlerts.map((a, i) => (
+                <li
+                  key={`drift-${i}`}
+                  className={`border rounded p-2 ${severityClass(a.severity)}`}
+                >
+                  <strong className="uppercase">{a.severity}</strong> · drift{" "}
+                  <code>{a.metric}</code> {a.race} ({a.seasonId}) :{" "}
+                  observed <strong>{a.observed.toFixed(2)}</strong> vs ref{" "}
+                  {a.reference.toFixed(2)} ({formatPct(a.drift)}, {a.samples}{" "}
+                  matchs)
+                </li>
+              ))}
+              {data.boundAlerts.map((a, i) => (
+                <li
+                  key={`bound-${i}`}
+                  className={`border rounded p-2 ${severityClass("critical")}`}
+                >
+                  <strong className="uppercase">CRITICAL</strong> · borne BB{" "}
+                  <code>{a.metric}</code> {a.race} ({a.seasonId}) :{" "}
+                  observed <strong>{a.observed.toFixed(2)}</strong>{" "}
+                  {a.direction === "above_max" ? ">" : "<"} {a.bound.toFixed(2)}{" "}
+                  ({a.samples} matchs)
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+      {data &&
+        races.length === 0 &&
+        data.driftAlerts.length === 0 &&
+        data.boundAlerts.length === 0 && (
+          <div className="p-4 bg-gray-50 border rounded text-sm text-gray-600">
+            Aucun match dans la fenêtre — pas de drift à mesurer.
+          </div>
+        )}
 
       {races.length > 0 && (
         <table className="w-full border-collapse text-sm">
@@ -235,6 +336,33 @@ export default function AdminSimHealthPage() {
         </table>
       )}
 
+      <nav className="mt-8 flex flex-wrap gap-3 text-xs text-gray-600 border-t pt-4">
+        <Link
+          href={"/admin/sim/broadcaster" as never}
+          className="underline"
+        >
+          → Broadcaster live stats
+        </Link>
+        <Link href={"/admin/sim/replays" as never} className="underline">
+          → Replays
+        </Link>
+        <Link href={"/admin/sim/test-match" as never} className="underline">
+          → Sandbox test match
+        </Link>
+        <Link
+          href={"/admin/sim/compare-versions" as never}
+          className="underline"
+        >
+          → Cross-version compare
+        </Link>
+        <Link
+          href={"/admin/sim/diff-replays" as never}
+          className="underline"
+        >
+          → Replay diff
+        </Link>
+      </nav>
+
       <details className="mt-6 text-xs text-gray-600">
         <summary className="cursor-pointer">Méthodologie</summary>
         <p className="mt-2">
@@ -242,7 +370,11 @@ export default function AdminSimHealthPage() {
           awayRace). Les casualties sont split 50/50 entre les deux équipes
           (donnée per-team non disponible sur ProLeagueMatch). La drift est
           relative : <code>(observed − reference) / reference</code>. Une
-          race sans match dans la fenêtre n&apos;apparaît pas.
+          race sans match dans la fenêtre n&apos;apparaît pas. Alertes
+          drift : warn |drift|&gt;10%, critical |drift|&gt;25%, minimum 5
+          matchs. Bornes BB-réalistes (Lot 4.A.3) : alertes critical quand
+          l&apos;observed sort des plages canoniques par race
+          (ex. Halfling winrate &gt; 45% suspect).
         </p>
       </details>
     </div>


### PR DESCRIPTION
## Summary

Étend le dashboard `/admin/sim/health` (livré PR #673) avec :
- l'intégration des alertes drift / bornes BB de **Lot 4.A.3**,
- l'horodatage du **dernier match** Pro League completé,
- les **entry points cross-console** vers les autres pages sim admin.

L'admin a désormais un hub unique pour l'observabilité du moteur sans Grafana.

### Backend (`apps/server`)
- Nouveau service `pro-league-sim-health` : `computeSimHealthSnapshot()` agrège
  `computeEngineDrift` + `detectDriftAlerts` + `detectRaceBoundAlerts` + le
  dernier match Pro League completé (`isTest=false`). Sortie cohérente
  (même `samples` / même `now()`).
- Nouvelle route `GET /admin/sim/health-snapshot` (`windowMs`, `seasonId`).
- `counts.critical` cumule drift critical + bound alerts (toujours critical
  par construction 4.A.3).

### Frontend (`apps/web`)
- Section **Active alerts** au-dessus de la table, colorisée par severity.
- **Badges** warn / critical dans le header.
- "**Dernier match : il y a Xh**" (formatAgo).
- **Footer de navigation** vers `broadcaster`, `replays`, `test-match`,
  `compare-versions`, `diff-replays`.

## Test plan
- [x] 6 tests `pro-league-sim-health.test.ts` (aggregation, lastSimAt filter
  `isTest=false`, propagation seasonId/now, counts cumul critical+bounds).
- [x] 3 tests `handleGetHealthSnapshot` (200 default, query params, ignore
  windowMs non-numérique).
- [x] `pnpm --filter @bb/server test` — 2082 tests verts.
- [x] `pnpm typecheck` — clean.
- [ ] Smoke `/admin/sim/health` : ouvrir → drift + alerts + last-sim + footer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_