### PR TITLE
feat(broadcaster): pnpm sim:loadtest:broadcaster — scaling probe (Lot 4.C.1)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,6 +18,7 @@
     "db:seed": "tsx src/seed.ts",
     "db:seed:themed-league": "tsx src/seed-themed-league.ts",
     "list:users": "tsx src/list-users.ts",
+    "sim:loadtest:broadcaster": "tsx scripts/loadtest-broadcaster.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "postinstall": "test -f ../../prisma/schema.prisma && prisma generate --schema ../../prisma/schema.prisma || true"

--- a/apps/server/scripts/loadtest-broadcaster.ts
+++ b/apps/server/scripts/loadtest-broadcaster.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * `pnpm sim:loadtest:broadcaster` — Lot 4.C.1.
+ *
+ * Imprime un rapport de saturation du broadcaster Pro League : N
+ * sessions concurrentes × M subscribers × K events. Sert à identifier
+ * le seuil de scaling (lag p99 dépasse 100ms ?) avant de devoir
+ * activer Phase 4.C.2 (Redis pub/sub multi-instance).
+ *
+ * Exécution offline : pas de DB, pas de sim-engine, juste une boucle
+ * dispatch synthétique avec le même contrat que le broadcaster prod.
+ *
+ * Usage examples
+ * --------------
+ *   pnpm sim:loadtest:broadcaster
+ *   pnpm sim:loadtest:broadcaster --matches=10 --subscribers=200 --events=50
+ *   pnpm sim:loadtest:broadcaster --matches=1 --subscribers=2000 --events=100 --json
+ *
+ * Options
+ *   --matches=<n>      Nombre de sessions concurrentes (default 10).
+ *   --subscribers=<n>  Subscribers par session (default 100).
+ *   --events=<n>       Events par session (default 50).
+ *   --spacing=<ms>     Espacement displayAtMs entre events (default 100).
+ *   --tick=<ms>        Granularité du tick interne (default 100).
+ *   --json             Output JSON parsable.
+ *   --help             Affiche l'aide.
+ */
+
+import { parseArgs } from "node:util";
+
+import {
+  formatLoadTestReport,
+  runBroadcasterLoadTest,
+} from "../src/services/pro-league-broadcaster-loadtest";
+
+const HELP = `pnpm sim:loadtest:broadcaster — broadcaster scaling probe
+
+Usage:
+  pnpm sim:loadtest:broadcaster [--matches=<n>] [--subscribers=<n>] [--events=<n>] [--spacing=<ms>] [--tick=<ms>] [--json]
+  pnpm sim:loadtest:broadcaster --help
+`;
+
+interface CliArgs {
+  matches?: string;
+  subscribers?: string;
+  events?: string;
+  spacing?: string;
+  tick?: string;
+  json?: boolean;
+  help?: boolean;
+}
+
+function parseIntStrict(name: string, value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`--${name}=${value} : doit être un entier positif`);
+  }
+  const n = Number.parseInt(value, 10);
+  if (n < 0) throw new Error(`--${name}=${value} : doit être >= 0`);
+  return n;
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      matches: { type: "string" },
+      subscribers: { type: "string" },
+      events: { type: "string" },
+      spacing: { type: "string" },
+      tick: { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean" },
+    },
+  });
+  const args = values as CliArgs;
+  if (args.help) {
+    process.stdout.write(`${HELP}\n`);
+    return;
+  }
+  const config = {
+    matches: parseIntStrict("matches", args.matches, 10),
+    subscribers: parseIntStrict("subscribers", args.subscribers, 100),
+    events: parseIntStrict("events", args.events, 50),
+    eventSpacingMs: parseIntStrict("spacing", args.spacing, 100),
+    tickIntervalMs: parseIntStrict("tick", args.tick, 100),
+  };
+  const result = await runBroadcasterLoadTest(config);
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${formatLoadTestReport(result)}\n`);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Erreur: ${msg}\n`);
+  process.exit(1);
+});

--- a/apps/server/src/services/pro-league-broadcaster-loadtest.test.ts
+++ b/apps/server/src/services/pro-league-broadcaster-loadtest.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests pour le harnais de load test broadcaster (Lot 4.C.1).
+ *
+ * On reste sur des configs très petites (1-3 matches × 10-50
+ * subscribers × 5-10 events) pour rester sous quelques centaines de
+ * ms. Les tests couvrent :
+ *
+ *   - sortie cohérente (totalListenerInvocations = matches × subscribers
+ *     × events, dispatch lag p99 borné).
+ *   - cas zero : `matches=0` resolve immédiatement avec 0 dispatched.
+ *   - les percentiles sont correctement calculés.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatLoadTestReport,
+  runBroadcasterLoadTest,
+} from "./pro-league-broadcaster-loadtest";
+
+describe("runBroadcasterLoadTest — Lot 4.C.1", () => {
+  it("dispatch tous les events à chaque subscriber", async () => {
+    const out = await runBroadcasterLoadTest({
+      matches: 2,
+      subscribers: 5,
+      events: 4,
+      eventSpacingMs: 10,
+      tickIntervalMs: 10,
+    });
+    // Chaque event est dispatché 1 fois par session, l'emitter.emit
+    // invoque chaque listener (= subscribers).
+    expect(out.totalEventsDispatched).toBe(2 * 4);
+    expect(out.totalListenerInvocations).toBe(2 * 5 * 4);
+    expect(out.dispatchLagMs.max).toBeGreaterThanOrEqual(0);
+    expect(out.dispatchLagMs.p99).toBeGreaterThanOrEqual(out.dispatchLagMs.p50);
+    expect(out.config.matches).toBe(2);
+  });
+
+  it("matches=0 resolve immédiatement", async () => {
+    const out = await runBroadcasterLoadTest({
+      matches: 0,
+      subscribers: 100,
+      events: 50,
+    });
+    expect(out.totalEventsDispatched).toBe(0);
+    expect(out.totalListenerInvocations).toBe(0);
+    expect(out.durationMs).toBeLessThan(50);
+  });
+
+  it("scale les listener invocations linéairement avec subscribers", async () => {
+    const small = await runBroadcasterLoadTest({
+      matches: 1,
+      subscribers: 10,
+      events: 3,
+      eventSpacingMs: 5,
+      tickIntervalMs: 5,
+    });
+    const big = await runBroadcasterLoadTest({
+      matches: 1,
+      subscribers: 50,
+      events: 3,
+      eventSpacingMs: 5,
+      tickIntervalMs: 5,
+    });
+    // 5x plus de subscribers = 5x plus d'invocations pour le même
+    // nombre d'events.
+    expect(big.totalListenerInvocations).toBe(5 * small.totalListenerInvocations);
+  });
+
+  it("expose CPU + memory dans le résultat", async () => {
+    const out = await runBroadcasterLoadTest({
+      matches: 1,
+      subscribers: 20,
+      events: 3,
+      eventSpacingMs: 5,
+      tickIntervalMs: 5,
+    });
+    expect(out.cpuMs.user).toBeGreaterThanOrEqual(0);
+    expect(out.cpuMs.system).toBeGreaterThanOrEqual(0);
+    expect(out.memoryMb.rss).toBeGreaterThan(0);
+    expect(out.memoryMb.heapUsed).toBeGreaterThan(0);
+  });
+});
+
+describe("formatLoadTestReport — Lot 4.C.1", () => {
+  it("imprime config + percentiles + ressources", async () => {
+    const result = await runBroadcasterLoadTest({
+      matches: 1,
+      subscribers: 10,
+      events: 3,
+      eventSpacingMs: 5,
+      tickIntervalMs: 5,
+    });
+    const report = formatLoadTestReport(result);
+    expect(report).toContain("Broadcaster load test");
+    expect(report).toContain("matches × 10 subscribers");
+    expect(report).toContain("Dispatch lag (ms)");
+    expect(report).toContain("CPU user/system");
+    expect(report).toContain("RSS / heapUsed");
+  });
+});

--- a/apps/server/src/services/pro-league-broadcaster-loadtest.ts
+++ b/apps/server/src/services/pro-league-broadcaster-loadtest.ts
@@ -1,0 +1,228 @@
+/**
+ * Pro League broadcaster load test — Lot 4.C.1.
+ *
+ * Pourquoi
+ * --------
+ * Le broadcaster (`pro-league-match-broadcaster.ts`) tient un MVP
+ * `EventEmitter` in-process avec `setInterval` toutes les 100ms. La
+ * roadmap Phase 4.C.1 demande de mesurer **où** ce design sature :
+ * combien de subscribers concurrents avant que le dispatch lag p99
+ * dépasse les 100ms, et combien de RAM consomme N sessions actives.
+ *
+ * Ce module fournit un harnais **synthétique et offline** :
+ *   1. Pas de DB — on construit les events en mémoire.
+ *   2. Pas de sim-engine — on instancie directement des `EventEmitter`
+ *      avec le même contrat de dispatch que le broadcaster prod.
+ *   3. Mesure CPU + RSS + percentiles dispatch lag.
+ *
+ * Le harnais est **pur côté logique** (entrée : config, sortie :
+ * résultat), ce qui le rend testable. Le CLI (`scripts/loadtest-
+ * broadcaster.ts`) ne fait qu'appeler `runBroadcasterLoadTest` et
+ * imprime le rapport.
+ *
+ * Choix de design
+ * ---------------
+ * - Le harnais ne touche **pas** le module broadcaster prod : on
+ *   recrée la même boucle dispatch (setInterval + scan d'events
+ *   classés par `displayAtMs`) pour mesurer son comportement intrinsèque
+ *   sans dépendre de l'état global `sessions Map`. Si la boucle prod
+ *   est refactorée, le test continuera à mesurer un dispatch
+ *   in-process représentatif (les chiffres seront comparables si
+ *   l'architecture EventEmitter est conservée).
+ * - On accepte que la mesure soit influencée par l'event loop Node.js :
+ *   c'est exactement ce qu'on cherche à observer en prod.
+ */
+
+import { EventEmitter } from "node:events";
+
+export interface LoadTestConfig {
+  /** Nombre de sessions concurrentes (matchs simulés). */
+  readonly matches: number;
+  /** Subscribers par session. */
+  readonly subscribers: number;
+  /** Events par session. Tous espacés de `eventSpacingMs`. */
+  readonly events: number;
+  /** Espacement entre events successifs (ms). Default 100ms. */
+  readonly eventSpacingMs?: number;
+  /** Granularité du tick interne (ms). Default 100ms (= prod). */
+  readonly tickIntervalMs?: number;
+}
+
+export interface PercentileStats {
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+  readonly max: number;
+  readonly mean: number;
+}
+
+export interface LoadTestResult {
+  readonly config: LoadTestConfig;
+  readonly totalEventsDispatched: number;
+  readonly totalListenerInvocations: number;
+  readonly dispatchLagMs: PercentileStats;
+  readonly cpuMs: { readonly user: number; readonly system: number };
+  readonly memoryMb: { readonly rss: number; readonly heapUsed: number };
+  readonly durationMs: number;
+}
+
+const DEFAULT_TICK_MS = 100;
+const DEFAULT_SPACING_MS = 100;
+
+function computePercentiles(samples: readonly number[]): PercentileStats {
+  if (samples.length === 0) {
+    return { p50: 0, p95: 0, p99: 0, max: 0, mean: 0 };
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  const pick = (q: number): number => {
+    const idx = Math.min(sorted.length - 1, Math.floor(q * sorted.length));
+    return sorted[idx]!;
+  };
+  let sum = 0;
+  for (const s of sorted) sum += s;
+  return {
+    p50: pick(0.5),
+    p95: pick(0.95),
+    p99: pick(0.99),
+    max: sorted[sorted.length - 1]!,
+    mean: sum / sorted.length,
+  };
+}
+
+interface SyntheticEvent {
+  readonly displayAtMs: number;
+}
+
+interface SyntheticSession {
+  readonly events: readonly SyntheticEvent[];
+  readonly startedAt: number;
+  nextIndex: number;
+  readonly emitter: EventEmitter;
+  timer?: NodeJS.Timeout;
+}
+
+/**
+ * Harnais de load test — exécute N sessions × M subscribers en
+ * parallèle et capture les statistiques. Resolve quand toutes les
+ * sessions ont dispatché tous leurs events.
+ */
+export function runBroadcasterLoadTest(
+  config: LoadTestConfig,
+): Promise<LoadTestResult> {
+  const tickMs = config.tickIntervalMs ?? DEFAULT_TICK_MS;
+  const spacingMs = config.eventSpacingMs ?? DEFAULT_SPACING_MS;
+  const startCpu = process.cpuUsage();
+  const startWall = Date.now();
+  const lagSamples: number[] = [];
+  let totalEventsDispatched = 0;
+  let totalListenerInvocations = 0;
+
+  const buildEvents = (): SyntheticEvent[] => {
+    const out: SyntheticEvent[] = [];
+    for (let i = 0; i < config.events; i += 1) {
+      out.push({ displayAtMs: i * spacingMs });
+    }
+    return out;
+  };
+
+  return new Promise<LoadTestResult>((resolve) => {
+    let sessionsRemaining = config.matches;
+    if (sessionsRemaining === 0) {
+      resolve({
+        config,
+        totalEventsDispatched: 0,
+        totalListenerInvocations: 0,
+        dispatchLagMs: computePercentiles([]),
+        cpuMs: { user: 0, system: 0 },
+        memoryMb: snapshotMemoryMb(),
+        durationMs: 0,
+      });
+      return;
+    }
+
+    const finalize = (): void => {
+      const cpu = process.cpuUsage(startCpu);
+      const result: LoadTestResult = {
+        config,
+        totalEventsDispatched,
+        totalListenerInvocations,
+        dispatchLagMs: computePercentiles(lagSamples),
+        cpuMs: { user: cpu.user / 1000, system: cpu.system / 1000 },
+        memoryMb: snapshotMemoryMb(),
+        durationMs: Date.now() - startWall,
+      };
+      resolve(result);
+    };
+
+    for (let s = 0; s < config.matches; s += 1) {
+      const session: SyntheticSession = {
+        events: buildEvents(),
+        startedAt: Date.now(),
+        nextIndex: 0,
+        emitter: new EventEmitter(),
+      };
+      session.emitter.setMaxListeners(config.subscribers + 16);
+      for (let l = 0; l < config.subscribers; l += 1) {
+        session.emitter.on("event", () => {
+          totalListenerInvocations += 1;
+        });
+      }
+      const tick = (): void => {
+        const elapsed = Date.now() - session.startedAt;
+        while (
+          session.nextIndex < session.events.length &&
+          session.events[session.nextIndex]!.displayAtMs <= elapsed
+        ) {
+          const ev = session.events[session.nextIndex]!;
+          lagSamples.push(elapsed - ev.displayAtMs);
+          session.emitter.emit("event", ev);
+          totalEventsDispatched += 1;
+          session.nextIndex += 1;
+        }
+        if (session.nextIndex >= session.events.length && session.timer) {
+          clearInterval(session.timer);
+          session.timer = undefined;
+          session.emitter.removeAllListeners();
+          sessionsRemaining -= 1;
+          if (sessionsRemaining === 0) finalize();
+        }
+      };
+      session.timer = setInterval(tick, tickMs);
+      // Pas de `unref()` ici (contrairement au broadcaster prod) : on
+      // veut que Node reste éveillé tant que les sessions n'ont pas
+      // toutes dispatché leurs events. Le harnais est one-shot et
+      // resolve() une fois finished.
+    }
+  });
+}
+
+function snapshotMemoryMb(): { readonly rss: number; readonly heapUsed: number } {
+  const m = process.memoryUsage();
+  return {
+    rss: Math.round((m.rss / (1024 * 1024)) * 100) / 100,
+    heapUsed: Math.round((m.heapUsed / (1024 * 1024)) * 100) / 100,
+  };
+}
+
+/** Format un rapport texte concis du résultat (pour le CLI). */
+export function formatLoadTestReport(result: LoadTestResult): string {
+  const { config, dispatchLagMs, cpuMs, memoryMb } = result;
+  const totalSubscribers = config.matches * config.subscribers;
+  return [
+    `=== Broadcaster load test — Lot 4.C.1 ===`,
+    `Config: ${config.matches} matches × ${config.subscribers} subscribers (= ${totalSubscribers} total) × ${config.events} events`,
+    `Tick interval: ${config.tickIntervalMs ?? DEFAULT_TICK_MS}ms · Event spacing: ${config.eventSpacingMs ?? DEFAULT_SPACING_MS}ms`,
+    `Duration: ${result.durationMs}ms`,
+    ``,
+    `Dispatch:`,
+    `  events dispatched      : ${result.totalEventsDispatched}`,
+    `  listener invocations   : ${result.totalListenerInvocations}`,
+    ``,
+    `Dispatch lag (ms):`,
+    `  p50 ${dispatchLagMs.p50.toFixed(1)}  p95 ${dispatchLagMs.p95.toFixed(1)}  p99 ${dispatchLagMs.p99.toFixed(1)}  max ${dispatchLagMs.max.toFixed(1)}  mean ${dispatchLagMs.mean.toFixed(1)}`,
+    ``,
+    `Resource usage:`,
+    `  CPU user/system : ${cpuMs.user.toFixed(1)}ms / ${cpuMs.system.toFixed(1)}ms`,
+    `  RSS / heapUsed  : ${memoryMb.rss}MB / ${memoryMb.heapUsed}MB`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

Identifie le seuil de saturation du broadcaster Pro League **avant** d'avoir à activer Phase 4.C.2 (Redis pub/sub multi-instance). Le harnais simule N sessions × M subscribers en parallèle et capture lag dispatch p99, CPU et RAM, **sans DB ni sim-engine**.

### Backend (`apps/server`)
- Nouveau service `pro-league-broadcaster-loadtest` :
  - `runBroadcasterLoadTest(config)` — pur côté logique. Spawn `matches`
    `EventEmitter`s synthétiques avec `subscribers` listeners chacun,
    schedule `events` par session via `setInterval` (même 100ms que prod),
    capture `(receivedAt − displayAtMs)` pour chaque dispatch. Resolve
    quand toutes les sessions ont dispatché.
  - `formatLoadTestReport(result)` — rapport texte (config, percentiles
    p50/p95/p99/max, CPU user+system, RSS+heapUsed).
- Nouveau CLI `apps/server/scripts/loadtest-broadcaster.ts` invoqué via
  `pnpm sim:loadtest:broadcaster` (script ajouté au `package.json`).

### Choix de design
- Le harnais **ne touche pas** le module broadcaster prod (recrée la même
  boucle dispatch indépendamment). Pas d'export test-only, pas d'effet de
  bord sur la `sessions` Map globale.
- Pas d'`unref()` dans le harnais (one-shot) contrairement au prod daemon
  (sinon Node exit avant le `finalize()`).

### Smoke run
```
$ pnpm sim:loadtest:broadcaster --matches=10 --subscribers=200 --events=50
=== Broadcaster load test — Lot 4.C.1 ===
Config: 10 matches × 200 subscribers (= 2000 total) × 50 events
Duration: 4912ms

Dispatch lag (ms):
  p50 7.0  p95 10.0  p99 100.0  max 102.0  mean 8.1

Resource usage:
  CPU user/system : 20.8ms / 1.2ms
  RSS / heapUsed  : 88.86MB / 8.12MB
```

⇒ Le broadcaster MVP supporte au moins **2000 subscribers concurrents** in-process avec p99 lag = 100ms (= 1 tick) et heapUsed ~8MB. Phase 4.C.2 (Redis) reste différable.

## Test plan
- [x] 5 tests `pro-league-broadcaster-loadtest.test.ts` (dispatch, matches=0,
  scaling listeners, CPU/memory exposés, format).
- [x] `pnpm --filter @bb/server test` — 2078 tests verts.
- [x] `pnpm typecheck` — clean.
- [x] Smoke CLI `--matches=10 --subscribers=200 --events=50` → 100k listener
  invocations OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_