### PR TITLE
feat(pro-league): roster coach UI — level / SPP / TV / bonuses (Lot E)

### DIFF
--- a/apps/server/src/services/pro-league-team.test.ts
+++ b/apps/server/src/services/pro-league-team.test.ts
@@ -14,6 +14,7 @@ import { prisma } from "../prisma";
 import {
   ProTeamNotFoundError,
   getProTeamDetail,
+  nextLevelSpp,
 } from "./pro-league-team";
 
 interface MockedPrisma {
@@ -208,5 +209,186 @@ describe("getProTeamDetail — sprint 1.C.2", () => {
     expect(out.roster[1].skills).toEqual(["dodge"]);
     expect(out.roster[1].pa).toBeNull();
     expect(out.roster[1].niggling).toBe(1);
+  });
+});
+
+describe("getProTeamDetail roster — Lot E (progression / TV / career)", () => {
+  it("expose progression {level, spp, nextLevelSpp, tv}", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p1",
+        name: "Veteran",
+        position: "Blitzer",
+        ma: 6,
+        st: 4,
+        ag: 3,
+        pa: 4,
+        av: 10,
+        skills: ["block"],
+        status: "active",
+        form: 50,
+        niggling: 0,
+        spp: 25, // 16 < 25 < 31 → level 3 (rookie + 2 advancements)
+        level: 3,
+        tvCached: 90000,
+        tdCount: 5,
+        casCount: 2,
+        compCount: 0,
+        mvpCount: 1,
+        maBonus: 0,
+        stBonus: 0,
+        agBonus: 0,
+        paBonus: 0,
+        avBonus: 0,
+      },
+    ]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.roster).toHaveLength(1);
+    const p = out.roster[0]!;
+    expect(p.progression.level).toBe(3);
+    expect(p.progression.spp).toBe(25);
+    expect(p.progression.nextLevelSpp).toBe(31);
+    expect(p.progression.tv).toBe(90000);
+  });
+
+  it("recompute le level depuis spp si la colonne level est en retard (legacy)", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p_legacy",
+        name: "Legacy",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: [],
+        status: "active",
+        form: 50,
+        niggling: 0,
+        spp: 50,
+        level: 1, // legacy : pas update par level-up applier
+        tvCached: 50000,
+        tdCount: 0,
+        casCount: 0,
+        compCount: 0,
+        mvpCount: 0,
+        maBonus: 0,
+        stBonus: 0,
+        agBonus: 0,
+        paBonus: 0,
+        avBonus: 0,
+      },
+    ]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    // 50 SPP ⇒ level 4 (passé 16, 31, 51 ? non, 50 < 51 → level 4 = passé 6, 16, 31)
+    expect(out.roster[0]!.progression.level).toBe(4);
+  });
+
+  it("expose statBonuses (Lot 4.D.1) et career counters (Lot 3.C.x)", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p_star",
+        name: "Star",
+        position: "Catcher",
+        ma: 8,
+        st: 2,
+        ag: 4,
+        pa: null,
+        av: 8,
+        skills: ["dodge", "catch"],
+        status: "active",
+        form: 70,
+        niggling: 0,
+        spp: 80,
+        level: 5,
+        tvCached: 130000,
+        tdCount: 12,
+        casCount: 1,
+        compCount: 3,
+        mvpCount: 2,
+        maBonus: 1,
+        stBonus: 0,
+        agBonus: 0,
+        paBonus: 0,
+        avBonus: 0,
+      },
+    ]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    const p = out.roster[0]!;
+    expect(p.statBonuses).toEqual({ ma: 1, st: 0, ag: 0, pa: 0, av: 0 });
+    expect(p.career).toEqual({
+      tdCount: 12,
+      casCount: 1,
+      compCount: 3,
+      mvpCount: 2,
+    });
+  });
+
+  it("fallback sur valeurs par defaut quand colonnes absentes (rosters anciens)", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p_old",
+        name: "Old",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: [],
+        status: "active",
+        form: 50,
+        niggling: 0,
+        // pas de spp / level / tvCached / counters / bonuses : null tous
+        spp: null,
+        level: null,
+        tvCached: null,
+        tdCount: null,
+        casCount: null,
+        compCount: null,
+        mvpCount: null,
+        maBonus: null,
+        stBonus: null,
+        agBonus: null,
+        paBonus: null,
+        avBonus: null,
+      },
+    ]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    const p = out.roster[0]!;
+    expect(p.progression.spp).toBe(0);
+    expect(p.progression.level).toBe(1);
+    expect(p.progression.nextLevelSpp).toBe(6);
+    expect(p.progression.tv).toBe(50000);
+    expect(p.statBonuses).toEqual({ ma: 0, st: 0, ag: 0, pa: 0, av: 0 });
+    expect(p.career).toEqual({
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+    });
+  });
+});
+
+describe("nextLevelSpp — Lot E", () => {
+  it("retourne le prochain seuil BB (6/16/31/51/76/176)", () => {
+    expect(nextLevelSpp(0)).toBe(6);
+    expect(nextLevelSpp(5)).toBe(6);
+    expect(nextLevelSpp(6)).toBe(16);
+    expect(nextLevelSpp(15)).toBe(16);
+    expect(nextLevelSpp(16)).toBe(31);
+    expect(nextLevelSpp(50)).toBe(51);
+    expect(nextLevelSpp(75)).toBe(76);
+    expect(nextLevelSpp(175)).toBe(176);
+  });
+
+  it("retourne null pour un legend (>= 176 SPP)", () => {
+    expect(nextLevelSpp(176)).toBeNull();
+    expect(nextLevelSpp(500)).toBeNull();
   });
 });

--- a/apps/server/src/services/pro-league-team.ts
+++ b/apps/server/src/services/pro-league-team.ts
@@ -14,6 +14,10 @@
 import { prisma } from "../prisma";
 
 import { OLD_WORLD_LEAGUE_SLUG } from "./pro-league-hub";
+import {
+  SPP_LEVEL_THRESHOLDS,
+  levelForSpp,
+} from "./pro-roster-level-up";
 
 const UPCOMING_LIMIT = 5;
 const RECENT_LIMIT = 5;
@@ -39,6 +43,32 @@ export interface ProTeamDetailMatch {
   readonly outcome: string | null;
 }
 
+export interface ProTeamRosterStatBonuses {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number;
+  readonly av: number;
+}
+
+export interface ProTeamRosterCareer {
+  readonly tdCount: number;
+  readonly casCount: number;
+  readonly compCount: number;
+  readonly mvpCount: number;
+}
+
+export interface ProTeamRosterProgression {
+  /** Niveau (1..7) calculé à partir du SPP via la table BB. */
+  readonly level: number;
+  /** SPP cumulés. */
+  readonly spp: number;
+  /** Prochain seuil SPP (null si déjà legend, level 7). */
+  readonly nextLevelSpp: number | null;
+  /** TV individuelle (gp), recomputée par le level-up applier (Lot 3.C.5+). */
+  readonly tv: number;
+}
+
 export interface ProTeamRosterEntry {
   readonly id: string;
   readonly name: string;
@@ -52,6 +82,10 @@ export interface ProTeamRosterEntry {
   readonly status: string;
   readonly form: number;
   readonly niggling: number;
+  /** Lot E — affichage fiche coach. */
+  readonly progression: ProTeamRosterProgression;
+  readonly statBonuses: ProTeamRosterStatBonuses;
+  readonly career: ProTeamRosterCareer;
 }
 
 export interface ProTeamDetailRecord {
@@ -88,6 +122,17 @@ export class ProTeamNotFoundError extends Error {
     super(`ProTeam slug='${slug}' introuvable`);
     this.name = "ProTeamNotFoundError";
   }
+}
+
+/**
+ * Lot E — prochain seuil SPP pour passer au level suivant. `null` si
+ * le joueur est déjà legend (level 7 = au-dessus de 176 SPP).
+ */
+export function nextLevelSpp(spp: number): number | null {
+  for (const threshold of SPP_LEVEL_THRESHOLDS) {
+    if (spp < threshold) return threshold;
+  }
+  return null;
 }
 
 function parseSkills(raw: unknown): string[] {
@@ -250,23 +295,60 @@ export async function getProTeamDetail(
       status: true,
       form: true,
       niggling: true,
+      spp: true,
+      level: true,
+      tvCached: true,
+      tdCount: true,
+      casCount: true,
+      compCount: true,
+      mvpCount: true,
+      maBonus: true,
+      stBonus: true,
+      agBonus: true,
+      paBonus: true,
+      avBonus: true,
     },
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const roster: ProTeamRosterEntry[] = rosterRaw.map((r: any) => ({
-    id: r.id as string,
-    name: r.name as string,
-    position: r.position as string,
-    ma: r.ma as number,
-    st: r.st as number,
-    ag: r.ag as number,
-    pa: (r.pa as number | null) ?? null,
-    av: r.av as number,
-    skills: parseSkills(r.skills),
-    status: (r.status as string) ?? "active",
-    form: (r.form as number) ?? 50,
-    niggling: (r.niggling as number) ?? 0,
-  }));
+  const roster: ProTeamRosterEntry[] = rosterRaw.map((r: any) => {
+    const spp = (r.spp as number | null) ?? 0;
+    // Toujours prendre le level recompute pour rester cohérent même si
+    // la colonne `level` n'a pas été migrée (rosters legacy avant 3.C.4).
+    const level = Math.max((r.level as number | null) ?? 1, levelForSpp(spp));
+    return {
+      id: r.id as string,
+      name: r.name as string,
+      position: r.position as string,
+      ma: r.ma as number,
+      st: r.st as number,
+      ag: r.ag as number,
+      pa: (r.pa as number | null) ?? null,
+      av: r.av as number,
+      skills: parseSkills(r.skills),
+      status: (r.status as string) ?? "active",
+      form: (r.form as number) ?? 50,
+      niggling: (r.niggling as number) ?? 0,
+      progression: {
+        level,
+        spp,
+        nextLevelSpp: nextLevelSpp(spp),
+        tv: (r.tvCached as number | null) ?? 50000,
+      },
+      statBonuses: {
+        ma: (r.maBonus as number | null) ?? 0,
+        st: (r.stBonus as number | null) ?? 0,
+        ag: (r.agBonus as number | null) ?? 0,
+        pa: (r.paBonus as number | null) ?? 0,
+        av: (r.avBonus as number | null) ?? 0,
+      },
+      career: {
+        tdCount: (r.tdCount as number | null) ?? 0,
+        casCount: (r.casCount as number | null) ?? 0,
+        compCount: (r.compCount as number | null) ?? 0,
+        mvpCount: (r.mvpCount as number | null) ?? 0,
+      },
+    };
+  });
 
   const meta = (team.meta as { motto?: string } | null | undefined) ?? null;
 

--- a/apps/web/app/pro-league/teams/[slug]/page.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.test.tsx
@@ -48,6 +48,9 @@ function makeTeam(overrides: Record<string, unknown> = {}): unknown {
         status: "active",
         form: 60,
         niggling: 0,
+        progression: { level: 2, spp: 10, nextLevelSpp: 16, tv: 70000 },
+        statBonuses: { ma: 0, st: 0, ag: 0, pa: 0, av: 0 },
+        career: { tdCount: 1, casCount: 0, compCount: 0, mvpCount: 0 },
       },
     ],
     upcomingMatches: [
@@ -139,6 +142,82 @@ describe("ProLeagueTeamPage — sprint 1.C.2", () => {
     expect(screen.getByText("Grim")).toBeTruthy();
     expect(screen.getByText("Lineman")).toBeTruthy();
     expect(screen.getByText("block")).toBeTruthy();
+  });
+
+  it("Lot E — affiche level / SPP progress / TV / career counters", async () => {
+    mockedApi.mockResolvedValue(makeTeam());
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("roster-level").textContent).toBe("2");
+    expect(screen.getByTestId("roster-tv").textContent).toBe("70k");
+    // Progress badge contient "10/16"
+    expect(screen.getByText("10/16")).toBeTruthy();
+    // Career counters tdCount/casCount/compCount/mvpCount
+    expect(screen.getByText("1/0/0/0")).toBeTruthy();
+  });
+
+  it("Lot E — affiche les stat bonuses quand non-zero", async () => {
+    mockedApi.mockResolvedValue(
+      makeTeam({
+        roster: [
+          {
+            id: "p1",
+            name: "Star",
+            position: "Catcher",
+            ma: 8,
+            st: 2,
+            ag: 4,
+            pa: null,
+            av: 8,
+            skills: ["dodge"],
+            status: "active",
+            form: 70,
+            niggling: 0,
+            progression: { level: 5, spp: 80, nextLevelSpp: 176, tv: 130000 },
+            statBonuses: { ma: 1, st: 0, ag: 1, pa: 0, av: 0 },
+            career: { tdCount: 12, casCount: 1, compCount: 3, mvpCount: 2 },
+          },
+        ],
+      }),
+    );
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("roster-bonuses").textContent).toBe("+1MA +1AG");
+  });
+
+  it("Lot E — legend (nextLevelSpp=null) affiche ⭐ + total SPP", async () => {
+    mockedApi.mockResolvedValue(
+      makeTeam({
+        roster: [
+          {
+            id: "p1",
+            name: "Legend",
+            position: "Blitzer",
+            ma: 7,
+            st: 4,
+            ag: 4,
+            pa: 4,
+            av: 10,
+            skills: ["block", "dodge", "tackle"],
+            status: "active",
+            form: 80,
+            niggling: 0,
+            progression: { level: 7, spp: 200, nextLevelSpp: null, tv: 180000 },
+            statBonuses: { ma: 0, st: 1, ag: 0, pa: 0, av: 0 },
+            career: { tdCount: 30, casCount: 10, compCount: 0, mvpCount: 5 },
+          },
+        ],
+      }),
+    );
+    render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-table")).toBeTruthy();
+    });
+    expect(screen.getByText(/⭐ 200 SPP/)).toBeTruthy();
   });
 
   it("affiche placeholder roster si vide", async () => {

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -40,6 +40,28 @@ interface DetailMatch {
   readonly outcome: string | null;
 }
 
+interface RosterStatBonuses {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number;
+  readonly av: number;
+}
+
+interface RosterCareer {
+  readonly tdCount: number;
+  readonly casCount: number;
+  readonly compCount: number;
+  readonly mvpCount: number;
+}
+
+interface RosterProgression {
+  readonly level: number;
+  readonly spp: number;
+  readonly nextLevelSpp: number | null;
+  readonly tv: number;
+}
+
 interface RosterEntry {
   readonly id: string;
   readonly name: string;
@@ -53,6 +75,9 @@ interface RosterEntry {
   readonly status: string;
   readonly form: number;
   readonly niggling: number;
+  readonly progression: RosterProgression;
+  readonly statBonuses: RosterStatBonuses;
+  readonly career: RosterCareer;
 }
 
 interface DetailRecord {
@@ -173,6 +198,64 @@ function MatchRow({ match }: { match: DetailMatch }): JSX.Element {
   );
 }
 
+/** Lot E — formate "+1MA" / "+2ST" si bonuses non-zéro, sinon "—". */
+function formatStatBonuses(b: RosterStatBonuses): string {
+  const parts: string[] = [];
+  if (b.ma > 0) parts.push(`+${b.ma}MA`);
+  if (b.st > 0) parts.push(`+${b.st}ST`);
+  if (b.ag > 0) parts.push(`+${b.ag}AG`);
+  if (b.pa > 0) parts.push(`+${b.pa}PA`);
+  if (b.av > 0) parts.push(`+${b.av}AV`);
+  return parts.length === 0 ? "—" : parts.join(" ");
+}
+
+/** Formatte 90000 → "90k". */
+function formatTv(gp: number): string {
+  return `${Math.round(gp / 1000)}k`;
+}
+
+/**
+ * Lot E — barre de progression SPP. Affiche `cur / next` avec une barre
+ * qui montre l'avancement entre le seuil précédent (= cur du level
+ * actuel) et le prochain seuil. `null` next ⇒ legend (level 7).
+ */
+function SppProgressBadge({
+  spp,
+  nextLevelSpp,
+  level,
+}: RosterProgression): JSX.Element {
+  if (nextLevelSpp === null) {
+    return (
+      <span className="text-xs text-amber-300" title="Legend (level 7)">
+        ⭐ {spp} SPP
+      </span>
+    );
+  }
+  // Seuils précédents pour calculer le pct entre (prev, next).
+  const THRESHOLDS = [0, 6, 16, 31, 51, 76, 176];
+  const prev = THRESHOLDS[level - 1] ?? 0;
+  const range = Math.max(1, nextLevelSpp - prev);
+  const pct = Math.max(0, Math.min(100, ((spp - prev) / range) * 100));
+  return (
+    <div
+      className="flex flex-col gap-0.5 text-[10px] text-slate-400"
+      title={`SPP ${spp} / ${nextLevelSpp} pour level ${level + 1}`}
+    >
+      <div className="flex items-center justify-between font-mono">
+        <span>
+          {spp}/{nextLevelSpp}
+        </span>
+      </div>
+      <div className="h-1 w-full rounded bg-slate-800">
+        <div
+          className="h-full rounded bg-emerald-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function RosterTable({
   rows,
 }: {
@@ -193,12 +276,25 @@ function RosterTable({
           <tr>
             <th className="px-2 py-2 text-left">Nom</th>
             <th className="px-2 py-2 text-left">Position</th>
+            <th className="w-10 px-2 py-2 text-center" title="Niveau (1=rookie, 7=legend)">
+              Lvl
+            </th>
+            <th className="w-24 px-2 py-2 text-center" title="Star Player Points">
+              SPP
+            </th>
+            <th className="w-12 px-2 py-2 text-center">TV</th>
             <th className="w-10 px-2 py-2 text-center">MA</th>
             <th className="w-10 px-2 py-2 text-center">ST</th>
             <th className="w-10 px-2 py-2 text-center">AG</th>
             <th className="w-10 px-2 py-2 text-center">PA</th>
             <th className="w-10 px-2 py-2 text-center">AV</th>
+            <th className="w-20 px-2 py-2 text-left" title="Stat increases gagnés via doubles roll">
+              Bonus
+            </th>
             <th className="px-2 py-2 text-left">Skills</th>
+            <th className="w-24 px-2 py-2 text-left" title="TD / CAS / COMP / MVP carriere">
+              Carrière
+            </th>
             <th className="w-20 px-2 py-2 text-center">Status</th>
             <th className="w-12 px-2 py-2 text-center">Forme</th>
           </tr>
@@ -213,6 +309,21 @@ function RosterTable({
                 {r.name}
               </td>
               <td className="px-2 py-2 text-slate-300">{r.position}</td>
+              <td
+                data-testid="roster-level"
+                className="px-2 py-2 text-center font-mono text-slate-100"
+              >
+                {r.progression.level}
+              </td>
+              <td className="px-2 py-2">
+                <SppProgressBadge {...r.progression} />
+              </td>
+              <td
+                data-testid="roster-tv"
+                className="px-2 py-2 text-center font-mono text-slate-300"
+              >
+                {formatTv(r.progression.tv)}
+              </td>
               <td className="px-2 py-2 text-center font-mono text-slate-300">
                 {r.ma}
               </td>
@@ -228,8 +339,20 @@ function RosterTable({
               <td className="px-2 py-2 text-center font-mono text-slate-300">
                 {r.av}
               </td>
+              <td
+                data-testid="roster-bonuses"
+                className="px-2 py-2 font-mono text-xs text-amber-300"
+              >
+                {formatStatBonuses(r.statBonuses)}
+              </td>
               <td className="px-2 py-2 text-xs text-slate-400">
                 {r.skills.length === 0 ? "—" : r.skills.join(", ")}
+              </td>
+              <td className="px-2 py-2 text-xs text-slate-400">
+                <span className="font-mono">
+                  {r.career.tdCount}/{r.career.casCount}/{r.career.compCount}/
+                  {r.career.mvpCount}
+                </span>
               </td>
               <td className="px-2 py-2 text-center">
                 <span


### PR DESCRIPTION
## Summary

Expose la fiche coach **par joueur** sur la page d'équipe Pro League. Le schema `ProTeamRoster` avait déjà les colonnes (`spp`, `level`, `tvCached`, `tdCount/casCount/compCount/mvpCount`, `maBonus/stBonus/...`) peuplées par le level-up applier (Lot 3.C.4) et le casualty applier — mais aucune n'était affichée. Le coach voyait `block, dodge` mais ne savait ni le SPP, ni le level, ni la TV individuelle.

### Backend (`apps/server/src/services/pro-league-team.ts`)
- `ProTeamRosterEntry` étendu avec :
  - `progression: { level, spp, nextLevelSpp, tv }`
  - `statBonuses: { ma, st, ag, pa, av }` *(Lot 4.D.1)*
  - `career: { tdCount, casCount, compCount, mvpCount }` *(Lot 3.C.x)*
- Helper exporté `nextLevelSpp(spp)` → prochain seuil BB
  (6/16/31/51/76/176) ou `null` pour un legend.
- **Defensive** : si la colonne `level` n'a pas suivi `spp` (rosters
  legacy avant 3.C.4), on recompute via `levelForSpp` côté lecture.

### Frontend (`/pro-league/teams/[slug]`)
- Roster table augmentée :
  - **Lvl** (1-7).
  - **SPP** avec progress bar entre seuil précédent et prochain (`10/16`).
    Legend → `⭐ X SPP` en doré.
  - **TV** (`90k`).
  - **Bonus** stat increases (`+1MA +1AG`) en doré quand non-zéro.
  - **Carrière** compacte `TD/CAS/COMP/MVP`.

## Test plan
- [x] 6 nouveaux tests `pro-league-team.test.ts` (progression, stat bonuses,
  career, recompute level legacy, fallback null, helper `nextLevelSpp`).
- [x] 3 nouveaux tests UI `page.test.tsx` (level/SPP/TV/career, stat bonuses,
  legend ⭐).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2079 verts.
- [x] `pnpm --filter @bb/web test` — 886 verts.
- [ ] Smoke `/pro-league/teams/<slug>` : nouvelles colonnes lvl/SPP/TV/bonus/carrière.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_