### PR TITLE
feat(admin): UI broadcaster load test (Lot J)

### DIFF
--- a/apps/server/src/routes/admin-sim.test.ts
+++ b/apps/server/src/routes/admin-sim.test.ts
@@ -35,6 +35,9 @@ vi.mock("../services/pro-league-admin-tools", async () => {
 vi.mock("../services/pro-league-sim-health", () => ({
   computeSimHealthSnapshot: vi.fn(),
 }));
+vi.mock("../services/pro-league-broadcaster-loadtest", () => ({
+  runBroadcasterLoadTest: vi.fn(),
+}));
 
 import {
   comparisonSchema,
@@ -48,6 +51,8 @@ import {
   handleGetHealthSnapshot,
   handleListTeams,
   handleListTestMatches,
+  handleRunLoadtest,
+  loadtestSchema,
   handleRunComparison,
   handleRunSim,
   runSimSchema,
@@ -67,6 +72,7 @@ import {
   runReplayDiff,
   runVersionComparison,
 } from "../services/pro-league-admin-tools";
+import { runBroadcasterLoadTest } from "../services/pro-league-broadcaster-loadtest";
 import { appMetrics } from "../utils/metrics";
 
 function buildRes(): Response & { statusCode: number; body: unknown } {
@@ -874,6 +880,131 @@ describe("handleDiffReplays — Lot 4.F", () => {
     const res = buildRes();
     await handleDiffReplays(
       { body: { matchIdA: "a", matchIdB: "b" } } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("loadtestSchema — Lot J input validation", () => {
+  it("accepte un payload minimal", () => {
+    const out = loadtestSchema.parse({
+      matches: 2,
+      subscribers: 50,
+      events: 10,
+    });
+    expect(out.matches).toBe(2);
+    expect(out.subscribers).toBe(50);
+    expect(out.events).toBe(10);
+  });
+
+  it("rejette matches > 50 (cap server-side plus strict que CLI)", () => {
+    expect(() =>
+      loadtestSchema.parse({ matches: 51, subscribers: 50, events: 10 }),
+    ).toThrow();
+  });
+
+  it("rejette subscribers > 1000", () => {
+    expect(() =>
+      loadtestSchema.parse({ matches: 1, subscribers: 1001, events: 10 }),
+    ).toThrow();
+  });
+
+  it("rejette events > 200", () => {
+    expect(() =>
+      loadtestSchema.parse({ matches: 1, subscribers: 50, events: 201 }),
+    ).toThrow();
+  });
+
+  it("rejette les valeurs zero (min 1)", () => {
+    expect(() =>
+      loadtestSchema.parse({ matches: 0, subscribers: 50, events: 10 }),
+    ).toThrow();
+    expect(() =>
+      loadtestSchema.parse({ matches: 1, subscribers: 0, events: 10 }),
+    ).toThrow();
+  });
+
+  it("accepte eventSpacingMs et tickIntervalMs optionnels", () => {
+    const out = loadtestSchema.parse({
+      matches: 1,
+      subscribers: 50,
+      events: 10,
+      eventSpacingMs: 50,
+      tickIntervalMs: 25,
+    });
+    expect(out.eventSpacingMs).toBe(50);
+    expect(out.tickIntervalMs).toBe(25);
+  });
+});
+
+describe("handleRunLoadtest — Lot J", () => {
+  it("retourne 200 + LoadTestResult quand le service réussit", async () => {
+    (runBroadcasterLoadTest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      config: { matches: 2, subscribers: 50, events: 10 },
+      totalEventsDispatched: 20,
+      totalListenerInvocations: 1000,
+      dispatchLagMs: { p50: 5, p95: 20, p99: 50, max: 60, mean: 8 },
+      cpuMs: { user: 12, system: 2 },
+      memoryMb: { rss: 90, heapUsed: 8 },
+      durationMs: 1100,
+    });
+    const res = buildRes();
+    await handleRunLoadtest(
+      {
+        body: { matches: 2, subscribers: 50, events: 10 },
+      } as unknown as Request,
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(
+      (res.body as { totalListenerInvocations: number })
+        .totalListenerInvocations,
+    ).toBe(1000);
+    expect(runBroadcasterLoadTest).toHaveBeenCalledWith({
+      matches: 2,
+      subscribers: 50,
+      events: 10,
+    });
+  });
+
+  it("propage eventSpacingMs et tickIntervalMs au service", async () => {
+    (runBroadcasterLoadTest as ReturnType<typeof vi.fn>).mockResolvedValue({
+      config: {},
+      totalEventsDispatched: 0,
+      totalListenerInvocations: 0,
+      dispatchLagMs: { p50: 0, p95: 0, p99: 0, max: 0, mean: 0 },
+      cpuMs: { user: 0, system: 0 },
+      memoryMb: { rss: 0, heapUsed: 0 },
+      durationMs: 0,
+    });
+    const res = buildRes();
+    await handleRunLoadtest(
+      {
+        body: {
+          matches: 1,
+          subscribers: 10,
+          events: 5,
+          eventSpacingMs: 25,
+          tickIntervalMs: 25,
+        },
+      } as unknown as Request,
+      res,
+    );
+    expect(runBroadcasterLoadTest).toHaveBeenCalledWith(
+      expect.objectContaining({ eventSpacingMs: 25, tickIntervalMs: 25 }),
+    );
+  });
+
+  it("retourne 500 sur erreur inattendue", async () => {
+    (runBroadcasterLoadTest as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("event loop saturated"),
+    );
+    const res = buildRes();
+    await handleRunLoadtest(
+      {
+        body: { matches: 1, subscribers: 10, events: 5 },
+      } as unknown as Request,
       res,
     );
     expect(res.statusCode).toBe(500);

--- a/apps/server/src/routes/admin-sim.ts
+++ b/apps/server/src/routes/admin-sim.ts
@@ -24,6 +24,7 @@ import {
   listTestMatches,
 } from "../services/pro-league-sandbox";
 import { computeSimHealthSnapshot } from "../services/pro-league-sim-health";
+import { runBroadcasterLoadTest } from "../services/pro-league-broadcaster-loadtest";
 import { appMetrics } from "../utils/metrics";
 
 /**
@@ -378,6 +379,43 @@ export async function handleDiffReplays(
   }
 }
 
+/**
+ * Schema pour `POST /admin/sim/loadtest` — Lot J (wrappe le CLI 4.C.1).
+ *
+ * Les caps sont volontairement plus stricts que le CLI : la route
+ * tourne dans le process server prod, donc un load test mal
+ * dimensionné saturerait l'event loop. Le CLI offline accepte des
+ * scaling tests plus agressifs.
+ *   - matches ≤ 50 (vs 1000 CLI)
+ *   - subscribers ≤ 1000 (vs 5000 CLI)
+ *   - events ≤ 200 (vs 1000 CLI)
+ *   - durée capée par eventSpacingMs × events × matches (sanity)
+ */
+export const loadtestSchema = z.object({
+  matches: z.number().int().min(1).max(50),
+  subscribers: z.number().int().min(1).max(1000),
+  events: z.number().int().min(1).max(200),
+  eventSpacingMs: z.number().int().min(1).max(1000).optional(),
+  tickIntervalMs: z.number().int().min(1).max(1000).optional(),
+});
+
+export type LoadtestBody = z.infer<typeof loadtestSchema>;
+
+/** Handler `POST /admin/sim/loadtest` — Lot J. */
+export async function handleRunLoadtest(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const body = req.body as LoadtestBody;
+  try {
+    const result = await runBroadcasterLoadTest(body);
+    res.status(200).json(result);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    res.status(500).json({ error: msg });
+  }
+}
+
 const router = Router();
 
 router.use(authUser, adminOnly);
@@ -407,6 +445,11 @@ router.post(
   "/diff-replays",
   validate(diffReplaysSchema),
   handleDiffReplays,
+);
+router.post(
+  "/loadtest",
+  validate(loadtestSchema),
+  handleRunLoadtest,
 );
 
 export default router;

--- a/apps/web/app/admin/sim/health/page.tsx
+++ b/apps/web/app/admin/sim/health/page.tsx
@@ -343,6 +343,9 @@ export default function AdminSimHealthPage() {
         >
           → Broadcaster live stats
         </Link>
+        <Link href={"/admin/sim/loadtest" as never} className="underline">
+          → Broadcaster load test
+        </Link>
         <Link href={"/admin/sim/replays" as never} className="underline">
           → Replays
         </Link>

--- a/apps/web/app/admin/sim/loadtest/page.tsx
+++ b/apps/web/app/admin/sim/loadtest/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Console admin — broadcaster load test (Lot J).
+ *
+ * Wrappe le CLI `pnpm sim:loadtest:broadcaster` (Lot 4.C.1) via la
+ * route `POST /admin/sim/loadtest`. Permet de mesurer le seuil de
+ * scaling depuis le navigateur sans accès shell.
+ *
+ * Caps server-side (volontairement plus stricts que le CLI) :
+ *   - matches ≤ 50, subscribers ≤ 1000, events ≤ 200
+ *
+ * Pour des scaling tests plus agressifs, utiliser le CLI offline.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+import { API_BASE } from "../../../auth-client";
+
+interface PercentileStats {
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+  mean: number;
+}
+
+interface LoadTestResult {
+  config: {
+    matches: number;
+    subscribers: number;
+    events: number;
+    eventSpacingMs?: number;
+    tickIntervalMs?: number;
+  };
+  totalEventsDispatched: number;
+  totalListenerInvocations: number;
+  dispatchLagMs: PercentileStats;
+  cpuMs: { user: number; system: number };
+  memoryMb: { rss: number; heapUsed: number };
+  durationMs: number;
+}
+
+async function postJSON<T>(path: string, body: unknown): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(error.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/** p99 > 100ms (= 1 tick) → flag rouge ; p99 > 50ms → orange. */
+function lagSeverityClass(p99: number): string {
+  if (p99 > 100) return "text-red-700 font-semibold";
+  if (p99 > 50) return "text-orange-600";
+  return "text-emerald-700";
+}
+
+export default function AdminLoadtestPage() {
+  const [matches, setMatches] = useState<number>(10);
+  const [subscribers, setSubscribers] = useState<number>(100);
+  const [events, setEvents] = useState<number>(50);
+  const [eventSpacingMs, setEventSpacingMs] = useState<number>(100);
+  const [tickIntervalMs, setTickIntervalMs] = useState<number>(100);
+  const [result, setResult] = useState<LoadTestResult | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const data = await postJSON<LoadTestResult>("/admin/sim/loadtest", {
+        matches,
+        subscribers,
+        events,
+        eventSpacingMs,
+        tickIntervalMs,
+      });
+      setResult(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const totalSubscribers = matches * subscribers;
+  const estimatedDurationMs = events * eventSpacingMs;
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">
+        Sim engine — broadcaster load test
+      </h1>
+      <p className="text-sm text-gray-600 mb-4">
+        Mesure le seuil de saturation du broadcaster Pro League. Wrappe
+        le CLI offline <code>pnpm sim:loadtest:broadcaster</code>.
+        Caps : matches ≤ 50, subscribers ≤ 1000, events ≤ 200.
+        Pour des scaling tests plus agressifs, utiliser le CLI.
+      </p>
+
+      <div className="grid grid-cols-3 gap-3 items-end mb-4 p-4 border rounded bg-white">
+        <label className="text-sm">
+          <div className="mb-1">Matches concurrents</div>
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={matches}
+            onChange={(e) => setMatches(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Subscribers / match</div>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={subscribers}
+            onChange={(e) => setSubscribers(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Events / match</div>
+          <input
+            type="number"
+            min={1}
+            max={200}
+            value={events}
+            onChange={(e) => setEvents(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Event spacing (ms)</div>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={eventSpacingMs}
+            onChange={(e) => setEventSpacingMs(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <label className="text-sm">
+          <div className="mb-1">Tick interval (ms)</div>
+          <input
+            type="number"
+            min={1}
+            max={1000}
+            value={tickIntervalMs}
+            onChange={(e) => setTickIntervalMs(Number(e.target.value))}
+            className="w-full border rounded p-2"
+          />
+        </label>
+        <div className="text-xs text-gray-500">
+          Total subscribers concurrents :{" "}
+          <strong>{totalSubscribers.toLocaleString()}</strong>
+          <br />
+          Durée estimée : ~
+          <strong>{(estimatedDurationMs / 1000).toFixed(1)}s</strong>
+        </div>
+        <div className="col-span-3 flex justify-end">
+          <button
+            data-testid="run-loadtest"
+            onClick={() => void run()}
+            disabled={loading}
+            className="px-4 py-2 rounded bg-nuffle-gold text-white font-medium disabled:opacity-50"
+          >
+            {loading ? `Compute… (~${(estimatedDurationMs / 1000).toFixed(0)}s)` : "Run load test"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 border border-red-300 bg-red-50 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div data-testid="loadtest-result" className="space-y-4">
+          <div className="p-3 border rounded bg-gray-50 text-sm">
+            <div>
+              Config : {result.config.matches} matches ×{" "}
+              {result.config.subscribers} subscribers ={" "}
+              <strong>
+                {(
+                  result.config.matches * result.config.subscribers
+                ).toLocaleString()}
+              </strong>{" "}
+              total · {result.config.events} events
+            </div>
+            <div>
+              Durée : <strong>{result.durationMs}ms</strong> · Events
+              dispatched :{" "}
+              <strong>{result.totalEventsDispatched.toLocaleString()}</strong>{" "}
+              · Listener invocations :{" "}
+              <strong>
+                {result.totalListenerInvocations.toLocaleString()}
+              </strong>
+            </div>
+          </div>
+
+          <div className="p-3 border rounded bg-white">
+            <h2 className="font-medium mb-2">Dispatch lag (ms)</h2>
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b bg-gray-50 text-xs uppercase text-gray-500">
+                  <th className="text-right p-2">p50</th>
+                  <th className="text-right p-2">p95</th>
+                  <th
+                    className="text-right p-2"
+                    title="Critère SLO : p99 ≤ 1 tick (= 100ms par défaut)"
+                  >
+                    p99
+                  </th>
+                  <th className="text-right p-2">max</th>
+                  <th className="text-right p-2">mean</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-2 text-right font-mono">
+                    {result.dispatchLagMs.p50.toFixed(1)}
+                  </td>
+                  <td className="p-2 text-right font-mono">
+                    {result.dispatchLagMs.p95.toFixed(1)}
+                  </td>
+                  <td
+                    data-testid="lag-p99"
+                    className={`p-2 text-right font-mono ${lagSeverityClass(result.dispatchLagMs.p99)}`}
+                  >
+                    {result.dispatchLagMs.p99.toFixed(1)}
+                  </td>
+                  <td className="p-2 text-right font-mono">
+                    {result.dispatchLagMs.max.toFixed(1)}
+                  </td>
+                  <td className="p-2 text-right font-mono">
+                    {result.dispatchLagMs.mean.toFixed(1)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="p-3 border rounded bg-white text-sm">
+            <h2 className="font-medium mb-2">Resource usage</h2>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                CPU user : <strong>{result.cpuMs.user.toFixed(1)}ms</strong>
+                <br />
+                CPU system :{" "}
+                <strong>{result.cpuMs.system.toFixed(1)}ms</strong>
+              </div>
+              <div>
+                RSS : <strong>{result.memoryMb.rss}MB</strong>
+                <br />
+                heapUsed : <strong>{result.memoryMb.heapUsed}MB</strong>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <nav className="mt-8 flex flex-wrap gap-3 text-xs text-gray-600 border-t pt-4">
+        <Link href={"/admin/sim/health" as never} className="underline">
+          → Sim health dashboard
+        </Link>
+        <Link href={"/admin/sim/broadcaster" as never} className="underline">
+          → Broadcaster live stats
+        </Link>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Wrappe le CLI offline `pnpm sim:loadtest:broadcaster` (Lot 4.C.1) en route admin authentifiée + page Next.js. L'admin peut désormais piloter le scaling probe depuis le navigateur sans accès shell.

### Backend (`apps/server`)
- Nouvelle route `POST /admin/sim/loadtest` : délègue à `runBroadcasterLoadTest()`.
- Schema Zod avec caps server-side **plus stricts** que le CLI :
  matches ≤ 50, subscribers ≤ 1000, events ≤ 200. Évite de saturer
  l'event loop du process server prod.
- Pour des scaling tests plus agressifs (1000+ subs concurrents),
  rester sur le CLI offline.

### Frontend (`apps/web`)
- `/admin/sim/loadtest` : form (matches × subscribers × events +
  spacing/tick), preview total subscribers concurrents et durée
  estimée, table dispatch lag percentiles (p50/p95/p99/max/mean),
  CPU + RAM. **p99 colorisé** : vert (<50ms), orange (50-100ms), rouge
  (>100ms = sature 1 tick).
- Cross-link ajouté depuis `/admin/sim/health` ("Broadcaster load test").

## Test plan
- [x] 9 tests `admin-sim.test.ts` :
  - `loadtestSchema` (caps, validation min/max, optionnels).
  - `handleRunLoadtest` (200, propagation eventSpacingMs/tickIntervalMs, 500).
- [x] `pnpm --filter @bb/server test` — 2125 verts.
- [x] `pnpm --filter @bb/web test` — 886 verts.
- [x] `pnpm typecheck` — clean.
- [ ] Smoke `/admin/sim/loadtest` : form → run → table résultats.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_