### PR TITLE
feat(pro-league): player detail page (Lot G)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -94,6 +94,10 @@ import {
   ProTeamNotFoundError,
   getProTeamDetail,
 } from "../services/pro-league-team";
+import {
+  ProPlayerNotFoundError,
+  getProPlayerDetail,
+} from "../services/pro-player-detail";
 import { serverLog } from "../utils/server-log";
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -303,6 +307,36 @@ export async function handleGetTeamDetail(
     }
     const msg = err instanceof Error ? err.message : "unknown";
     serverLog.error(`[pro-league/teams/${slug}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Handler `GET /api/pro-league/players/:id` — Lot G.
+ *
+ * Public, pas d'auth. Renvoie l'agrégat fiche joueur :
+ * identité + stats + bonuses + skills + progression + career +
+ * skill access pools + meta équipe.
+ */
+export async function handleGetPlayerDetail(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  if (!id || typeof id !== "string") {
+    res.status(400).json({ error: "missing-id" });
+    return;
+  }
+  try {
+    const data = await getProPlayerDetail(id);
+    res.json(data);
+  } catch (err: unknown) {
+    if (err instanceof ProPlayerNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/players/${id}] failed: ${msg}`);
     res.status(500).json({ error: "internal-error" });
   }
 }
@@ -806,6 +840,7 @@ const router = Router();
 router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
 router.get("/teams/:slug", handleGetTeamDetail);
+router.get("/players/:id", handleGetPlayerDetail);
 router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/markets", handleListMarkets);
 router.get("/matches/:id/stream", handleStreamProMatch);

--- a/apps/server/src/services/pro-player-detail.test.ts
+++ b/apps/server/src/services/pro-player-detail.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests pour le service `getProPlayerDetail` (Lot G).
+ *
+ * Couvre :
+ *   - happy path : tous les champs (stats, bonuses, progression, career,
+ *     skillAccess, team) sont correctement remontés.
+ *   - 404 : `ProPlayerNotFoundError` si l'id n'existe pas.
+ *   - Recompute legacy : level recompute depuis spp si la colonne level
+ *     n'a pas été migrée.
+ *   - Position inconnue : fallback sur l'accès Lineman.
+ *   - Fallback null sur colonnes optionnelles.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeamRoster: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  ProPlayerNotFoundError,
+  getProPlayerDetail,
+} from "./pro-player-detail";
+
+interface MockedPrisma {
+  proTeamRoster: { findUnique: ReturnType<typeof vi.fn> };
+}
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const FAKE_TEAM = {
+  slug: "buf-snow-ogres",
+  name: "Snow Ogres",
+  city: "Buffalo",
+  race: "Ogre",
+  primaryColor: "#00338D",
+};
+
+describe("getProPlayerDetail — Lot G", () => {
+  it("retourne 404 si l'id n'existe pas", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce(null);
+    await expect(getProPlayerDetail("missing")).rejects.toThrow(
+      ProPlayerNotFoundError,
+    );
+  });
+
+  it("retourne tous les champs pour un Blitzer level 3", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p1",
+      name: "Veteran",
+      position: "Blitzer",
+      ma: 6,
+      st: 4,
+      ag: 3,
+      pa: 4,
+      av: 10,
+      skills: ["block", "tackle"],
+      status: "active",
+      form: 60,
+      niggling: 0,
+      spp: 25,
+      level: 3,
+      tvCached: 110000,
+      tdCount: 5,
+      casCount: 2,
+      compCount: 0,
+      mvpCount: 1,
+      maBonus: 0,
+      stBonus: 0,
+      agBonus: 0,
+      paBonus: 0,
+      avBonus: 0,
+      team: FAKE_TEAM,
+    });
+    const out = await getProPlayerDetail("p1");
+    expect(out.id).toBe("p1");
+    expect(out.name).toBe("Veteran");
+    expect(out.position).toBe("Blitzer");
+    expect(out.skills).toEqual(["block", "tackle"]);
+    expect(out.stats).toEqual({ ma: 6, st: 4, ag: 3, pa: 4, av: 10 });
+    expect(out.statBonuses).toEqual({ ma: 0, st: 0, ag: 0, pa: 0, av: 0 });
+    expect(out.progression).toEqual({
+      level: 3,
+      spp: 25,
+      nextLevelSpp: 31,
+      tv: 110000,
+    });
+    expect(out.career).toEqual({
+      tdCount: 5,
+      casCount: 2,
+      compCount: 0,
+      mvpCount: 1,
+    });
+    // Blitzer → primary G+S, secondary A
+    expect(out.skillAccess.primary).toEqual(["G", "S"]);
+    expect(out.skillAccess.secondary).toEqual(["A"]);
+    expect(out.team).toEqual({
+      slug: "buf-snow-ogres",
+      name: "Snow Ogres",
+      city: "Buffalo",
+      race: "Ogre",
+      primaryColor: "#00338D",
+    });
+  });
+
+  it("recompute le level si la colonne level est en retard (legacy)", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p_legacy",
+      name: "Legacy",
+      position: "Lineman",
+      ma: 5,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [],
+      status: "active",
+      form: 50,
+      niggling: 0,
+      spp: 50, // 50 SPP ⇒ level 4
+      level: 1, // legacy : non MAJ
+      tvCached: 50000,
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+      maBonus: 0,
+      stBonus: 0,
+      agBonus: 0,
+      paBonus: 0,
+      avBonus: 0,
+      team: FAKE_TEAM,
+    });
+    const out = await getProPlayerDetail("p_legacy");
+    expect(out.progression.level).toBe(4);
+  });
+
+  it("expose stat bonuses non-zero (Lot 4.D.1)", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p_star",
+      name: "Star",
+      position: "Catcher",
+      ma: 8,
+      st: 2,
+      ag: 4,
+      pa: null,
+      av: 8,
+      skills: ["dodge", "catch"],
+      status: "active",
+      form: 70,
+      niggling: 0,
+      spp: 80,
+      level: 5,
+      tvCached: 130000,
+      tdCount: 12,
+      casCount: 1,
+      compCount: 3,
+      mvpCount: 2,
+      maBonus: 1,
+      stBonus: 0,
+      agBonus: 1,
+      paBonus: 0,
+      avBonus: 0,
+      team: FAKE_TEAM,
+    });
+    const out = await getProPlayerDetail("p_star");
+    expect(out.statBonuses).toEqual({ ma: 1, st: 0, ag: 1, pa: 0, av: 0 });
+    // Catcher → primary G+A, secondary S+M (selon table BB)
+    expect(out.skillAccess.primary).toEqual(["G", "A"]);
+  });
+
+  it("position inconnue → fallback sur l'accès Lineman", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p_unknown",
+      name: "Mystery",
+      position: "GhostWalker",
+      ma: 5,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [],
+      status: "active",
+      form: 50,
+      niggling: 0,
+      spp: 0,
+      level: 1,
+      tvCached: 50000,
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+      maBonus: 0,
+      stBonus: 0,
+      agBonus: 0,
+      paBonus: 0,
+      avBonus: 0,
+      team: FAKE_TEAM,
+    });
+    const out = await getProPlayerDetail("p_unknown");
+    expect(out.skillAccess.primary).toEqual(["G"]);
+    expect(out.skillAccess.secondary).toEqual(["A", "S", "P"]);
+  });
+
+  it("fallback sur valeurs par défaut quand colonnes nulles", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p_old",
+      name: "Old",
+      position: "Lineman",
+      ma: 5,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [],
+      status: null,
+      form: null,
+      niggling: null,
+      spp: null,
+      level: null,
+      tvCached: null,
+      tdCount: null,
+      casCount: null,
+      compCount: null,
+      mvpCount: null,
+      maBonus: null,
+      stBonus: null,
+      agBonus: null,
+      paBonus: null,
+      avBonus: null,
+      team: FAKE_TEAM,
+    });
+    const out = await getProPlayerDetail("p_old");
+    expect(out.status).toBe("active");
+    expect(out.form).toBe(50);
+    expect(out.niggling).toBe(0);
+    expect(out.progression.spp).toBe(0);
+    expect(out.progression.level).toBe(1);
+    expect(out.progression.nextLevelSpp).toBe(6);
+    expect(out.progression.tv).toBe(50000);
+    expect(out.career).toEqual({
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+    });
+  });
+});

--- a/apps/server/src/services/pro-player-detail.ts
+++ b/apps/server/src/services/pro-player-detail.ts
@@ -1,0 +1,208 @@
+/**
+ * Pro player detail — Lot G.
+ *
+ * Service qui agrège les données nécessaires à la page
+ * `/pro-league/teams/:slug/players/:playerId` :
+ *
+ *   - identité (name, position, team meta)
+ *   - stats courantes (ma/st/ag/pa/av) avec les bonus
+ *   - skills acquis
+ *   - status (active / injured / dead / retired)
+ *   - niggling count
+ *   - progression (level, spp, nextLevelSpp, tv)
+ *   - career counters (TD/CAS/COMP/MVP totals)
+ *   - skill access pools (G/A/S/P/M par catégorie)
+ *
+ * Pas de per-match SPP delta dans ce premier jet — il faudrait miner les
+ * replays par playerId, hors scope du lot. La page utilise les career
+ * counters cumulés sur `ProTeamRoster`.
+ */
+
+import { prisma } from "../prisma";
+import {
+  POSITION_SKILL_ACCESS,
+  type SkillCategory,
+} from "./pro-position-skill-access";
+import { nextLevelSpp } from "./pro-league-team";
+import { levelForSpp } from "./pro-roster-level-up";
+
+export class ProPlayerNotFoundError extends Error {
+  constructor(playerId: string) {
+    super(`ProTeamRoster id='${playerId}' introuvable`);
+    this.name = "ProPlayerNotFoundError";
+  }
+}
+
+export interface ProPlayerStats {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number | null;
+  readonly av: number;
+}
+
+export interface ProPlayerStatBonuses {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number;
+  readonly av: number;
+}
+
+export interface ProPlayerProgression {
+  readonly level: number;
+  readonly spp: number;
+  readonly nextLevelSpp: number | null;
+  readonly tv: number;
+}
+
+export interface ProPlayerCareer {
+  readonly tdCount: number;
+  readonly casCount: number;
+  readonly compCount: number;
+  readonly mvpCount: number;
+}
+
+export interface ProPlayerSkillAccess {
+  readonly primary: readonly SkillCategory[];
+  readonly secondary: readonly SkillCategory[];
+}
+
+export interface ProPlayerTeam {
+  readonly slug: string;
+  readonly name: string;
+  readonly city: string;
+  readonly race: string;
+  readonly primaryColor: string | null;
+}
+
+export interface ProPlayerDetail {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly status: string;
+  readonly form: number;
+  readonly niggling: number;
+  readonly skills: readonly string[];
+  readonly stats: ProPlayerStats;
+  readonly statBonuses: ProPlayerStatBonuses;
+  readonly progression: ProPlayerProgression;
+  readonly career: ProPlayerCareer;
+  readonly skillAccess: ProPlayerSkillAccess;
+  readonly team: ProPlayerTeam;
+}
+
+function parseSkills(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((s): s is string => typeof s === "string");
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export async function getProPlayerDetail(
+  playerId: string,
+): Promise<ProPlayerDetail> {
+  const row = (await prisma.proTeamRoster.findUnique({
+    where: { id: playerId },
+    select: {
+      id: true,
+      name: true,
+      position: true,
+      ma: true,
+      st: true,
+      ag: true,
+      pa: true,
+      av: true,
+      skills: true,
+      status: true,
+      form: true,
+      niggling: true,
+      spp: true,
+      level: true,
+      tvCached: true,
+      tdCount: true,
+      casCount: true,
+      compCount: true,
+      mvpCount: true,
+      maBonus: true,
+      stBonus: true,
+      agBonus: true,
+      paBonus: true,
+      avBonus: true,
+      team: {
+        select: {
+          slug: true,
+          name: true,
+          city: true,
+          race: true,
+          primaryColor: true,
+        },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  })) as any;
+  if (!row) {
+    throw new ProPlayerNotFoundError(playerId);
+  }
+  const spp = (row.spp as number | null) ?? 0;
+  const level = Math.max((row.level as number | null) ?? 1, levelForSpp(spp));
+  const access =
+    POSITION_SKILL_ACCESS[row.position as string] ??
+    POSITION_SKILL_ACCESS.Lineman;
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    position: row.position as string,
+    status: (row.status as string) ?? "active",
+    form: (row.form as number) ?? 50,
+    niggling: (row.niggling as number) ?? 0,
+    skills: parseSkills(row.skills),
+    stats: {
+      ma: row.ma as number,
+      st: row.st as number,
+      ag: row.ag as number,
+      pa: (row.pa as number | null) ?? null,
+      av: row.av as number,
+    },
+    statBonuses: {
+      ma: (row.maBonus as number | null) ?? 0,
+      st: (row.stBonus as number | null) ?? 0,
+      ag: (row.agBonus as number | null) ?? 0,
+      pa: (row.paBonus as number | null) ?? 0,
+      av: (row.avBonus as number | null) ?? 0,
+    },
+    progression: {
+      level,
+      spp,
+      nextLevelSpp: nextLevelSpp(spp),
+      tv: (row.tvCached as number | null) ?? 50000,
+    },
+    career: {
+      tdCount: (row.tdCount as number | null) ?? 0,
+      casCount: (row.casCount as number | null) ?? 0,
+      compCount: (row.compCount as number | null) ?? 0,
+      mvpCount: (row.mvpCount as number | null) ?? 0,
+    },
+    skillAccess: {
+      primary: access.primary,
+      secondary: access.secondary,
+    },
+    team: {
+      slug: row.team.slug as string,
+      name: row.team.name as string,
+      city: row.team.city as string,
+      race: row.team.race as string,
+      primaryColor: (row.team.primaryColor as string | null) ?? null,
+    },
+  };
+}

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -258,8 +258,10 @@ function SppProgressBadge({
 
 function RosterTable({
   rows,
+  teamSlug,
 }: {
   rows: readonly RosterEntry[];
+  teamSlug: string;
 }): JSX.Element {
   if (rows.length === 0) {
     return (
@@ -306,7 +308,13 @@ function RosterTable({
               className="border-t border-slate-800 hover:bg-slate-900"
             >
               <td className="px-2 py-2 font-medium text-slate-100">
-                {r.name}
+                <Link
+                  data-testid={`player-link-${r.id}`}
+                  href={`/pro-league/teams/${teamSlug}/players/${r.id}`}
+                  className="hover:text-emerald-300 hover:underline"
+                >
+                  {r.name}
+                </Link>
               </td>
               <td className="px-2 py-2 text-slate-300">{r.position}</td>
               <td
@@ -615,7 +623,7 @@ export default function ProLeagueTeamPage({
               <h2 className="mb-2 text-lg font-semibold text-slate-100">
                 Roster
               </h2>
-              <RosterTable rows={data.roster} />
+              <RosterTable rows={data.roster} teamSlug={params.slug} />
             </section>
 
             <section className="mb-6">

--- a/apps/web/app/pro-league/teams/[slug]/players/[playerId]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/players/[playerId]/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+/**
+ * Page détail d'un joueur Pro League — Lot G.
+ *
+ * Drill-down depuis la roster table de la page équipe (Lot E).
+ * Affiche :
+ *  - Identité (nom, position, équipe avec lien retour)
+ *  - Stats (avec bonus mis en évidence)
+ *  - Skills acquis
+ *  - Progression (level, SPP avec progress bar, TV)
+ *  - Career counters (TD/CAS/COMP/MVP)
+ *  - Pools d'accès skill (G/A/S/P/M primary/secondary)
+ *  - Status / form / niggling
+ *
+ * Public, pas d'auth (cohérent avec /pro-league/teams/[slug]).
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../../../lib/api-client";
+
+type SkillCategory = "G" | "A" | "S" | "P" | "M";
+
+interface PlayerStats {
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+}
+
+interface StatBonuses {
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number;
+  av: number;
+}
+
+interface Progression {
+  level: number;
+  spp: number;
+  nextLevelSpp: number | null;
+  tv: number;
+}
+
+interface Career {
+  tdCount: number;
+  casCount: number;
+  compCount: number;
+  mvpCount: number;
+}
+
+interface SkillAccess {
+  primary: SkillCategory[];
+  secondary: SkillCategory[];
+}
+
+interface PlayerTeam {
+  slug: string;
+  name: string;
+  city: string;
+  race: string;
+  primaryColor: string | null;
+}
+
+interface PlayerDetail {
+  id: string;
+  name: string;
+  position: string;
+  status: string;
+  form: number;
+  niggling: number;
+  skills: string[];
+  stats: PlayerStats;
+  statBonuses: StatBonuses;
+  progression: Progression;
+  career: Career;
+  skillAccess: SkillAccess;
+  team: PlayerTeam;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  active: "bg-emerald-700/30 text-emerald-200",
+  injured: "bg-amber-700/30 text-amber-200",
+  dead: "bg-rose-900/40 text-rose-200",
+  retired: "bg-slate-700/30 text-slate-300",
+};
+
+const CATEGORY_LABELS: Record<SkillCategory, string> = {
+  G: "General",
+  A: "Agility",
+  S: "Strength",
+  P: "Passing",
+  M: "Mutation",
+};
+
+function formatTv(gp: number): string {
+  return `${Math.round(gp / 1000)}k`;
+}
+
+function StatCell({
+  label,
+  value,
+  bonus,
+}: {
+  label: string;
+  value: number | null;
+  bonus: number;
+}): JSX.Element {
+  return (
+    <div className="flex flex-col items-center rounded border border-slate-800 bg-slate-900 p-3">
+      <span className="text-xs uppercase text-slate-500">{label}</span>
+      <span className="font-mono text-2xl text-slate-100">
+        {value ?? "—"}
+        {bonus > 0 && (
+          <span
+            className="ml-1 align-top text-xs text-amber-300"
+            title={`+${bonus} acquis via doubles roll`}
+          >
+            +{bonus}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function SppProgressBar({
+  spp,
+  nextLevelSpp,
+  level,
+}: Progression): JSX.Element {
+  if (nextLevelSpp === null) {
+    return (
+      <div className="rounded border border-amber-600 bg-amber-900/20 p-3 text-sm text-amber-300">
+        ⭐ <strong>Legend</strong> · {spp} SPP cumulés (au-dessus du dernier
+        seuil 176).
+      </div>
+    );
+  }
+  const THRESHOLDS = [0, 6, 16, 31, 51, 76, 176];
+  const prev = THRESHOLDS[level - 1] ?? 0;
+  const range = Math.max(1, nextLevelSpp - prev);
+  const pct = Math.max(0, Math.min(100, ((spp - prev) / range) * 100));
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs text-slate-400">
+        <span>
+          Level {level} → {level + 1}
+        </span>
+        <span className="font-mono">
+          {spp} / {nextLevelSpp} SPP ({Math.round(pct)}%)
+        </span>
+      </div>
+      <div className="h-2 w-full rounded bg-slate-800">
+        <div
+          data-testid="player-spp-bar"
+          className="h-full rounded bg-emerald-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface PlayerPageProps {
+  readonly params: { slug: string; playerId: string };
+}
+
+export default function ProLeaguePlayerPage({
+  params,
+}: PlayerPageProps): JSX.Element {
+  const { slug, playerId } = params;
+  const [data, setData] = useState<PlayerDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<PlayerDetail>(`/api/pro-league/players/${playerId}`)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [playerId]);
+
+  if (loading) {
+    return (
+      <div className="p-6 text-slate-400">
+        <Link
+          href={`/pro-league/teams/${slug}`}
+          className="text-sm text-slate-500 hover:text-slate-300"
+        >
+          ← retour
+        </Link>
+        <div className="mt-4">Chargement…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <Link
+          href={`/pro-league/teams/${slug}`}
+          className="text-sm text-slate-500 hover:text-slate-300"
+        >
+          ← retour
+        </Link>
+        <div className="mt-4 rounded border border-rose-800 bg-rose-950/40 p-3 text-sm text-rose-300">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return <div className="p-6">Joueur introuvable</div>;
+
+  return (
+    <div className="mx-auto max-w-4xl p-6 text-slate-200">
+      <Link
+        href={`/pro-league/teams/${data.team.slug}`}
+        className="text-sm text-slate-500 hover:text-slate-300"
+      >
+        ← {data.team.city} {data.team.name}
+      </Link>
+
+      <header className="mt-4 mb-6 flex items-center gap-4 border-b border-slate-800 pb-4">
+        <div
+          aria-hidden
+          className="h-12 w-2 rounded-full"
+          style={{ background: data.team.primaryColor ?? "#475569" }}
+        />
+        <div className="flex-1">
+          <h1
+            data-testid="player-name"
+            className="text-3xl font-bold text-slate-100"
+          >
+            {data.name}
+          </h1>
+          <div className="mt-1 flex items-center gap-3 text-sm text-slate-400">
+            <span>{data.position}</span>
+            <span aria-hidden>·</span>
+            <span>{data.team.race}</span>
+            <span
+              data-testid="player-status"
+              className={`rounded px-2 py-0.5 text-xs ${STATUS_STYLES[data.status] ?? STATUS_STYLES.active}`}
+            >
+              {data.status}
+            </span>
+            {data.niggling > 0 && (
+              <span
+                className="rounded bg-amber-900/40 px-2 py-0.5 text-xs text-amber-300"
+                title="Niggling injuries (-10k TV chacune)"
+              >
+                {data.niggling} niggling
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase text-slate-500">Level</div>
+          <div
+            data-testid="player-level"
+            className="font-mono text-3xl text-slate-100"
+          >
+            {data.progression.level}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-xs uppercase text-slate-500">TV</div>
+          <div
+            data-testid="player-tv"
+            className="font-mono text-3xl text-slate-100"
+          >
+            {formatTv(data.progression.tv)}
+          </div>
+        </div>
+      </header>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Stats
+        </h2>
+        <div className="grid grid-cols-5 gap-2">
+          <StatCell label="MA" value={data.stats.ma} bonus={data.statBonuses.ma} />
+          <StatCell label="ST" value={data.stats.st} bonus={data.statBonuses.st} />
+          <StatCell label="AG" value={data.stats.ag} bonus={data.statBonuses.ag} />
+          <StatCell label="PA" value={data.stats.pa} bonus={data.statBonuses.pa} />
+          <StatCell label="AV" value={data.stats.av} bonus={data.statBonuses.av} />
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Progression
+        </h2>
+        <div className="rounded border border-slate-800 bg-slate-900 p-4">
+          <SppProgressBar {...data.progression} />
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Carrière
+        </h2>
+        <div
+          data-testid="player-career"
+          className="grid grid-cols-4 gap-2 text-center"
+        >
+          <div className="rounded border border-slate-800 bg-slate-900 p-3">
+            <div className="text-xs uppercase text-slate-500">TD</div>
+            <div className="font-mono text-2xl text-emerald-300">
+              {data.career.tdCount}
+            </div>
+          </div>
+          <div className="rounded border border-slate-800 bg-slate-900 p-3">
+            <div className="text-xs uppercase text-slate-500">CAS</div>
+            <div className="font-mono text-2xl text-rose-300">
+              {data.career.casCount}
+            </div>
+          </div>
+          <div className="rounded border border-slate-800 bg-slate-900 p-3">
+            <div className="text-xs uppercase text-slate-500">COMP</div>
+            <div className="font-mono text-2xl text-sky-300">
+              {data.career.compCount}
+            </div>
+          </div>
+          <div className="rounded border border-slate-800 bg-slate-900 p-3">
+            <div className="text-xs uppercase text-slate-500">MVP</div>
+            <div className="font-mono text-2xl text-amber-300">
+              {data.career.mvpCount}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Skills acquis
+        </h2>
+        {data.skills.length === 0 ? (
+          <p className="text-sm text-slate-500">Aucun skill (rookie).</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {data.skills.map((s) => (
+              <span
+                key={s}
+                className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-200"
+              >
+                {s}
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Pools d&apos;accès skill
+        </h2>
+        <div className="grid grid-cols-2 gap-2 text-sm">
+          <div className="rounded border border-emerald-700 bg-emerald-900/20 p-3">
+            <div className="mb-1 text-xs uppercase text-emerald-300">
+              Primary <span className="text-slate-500">(20k TV / skill)</span>
+            </div>
+            <div data-testid="primary-access">
+              {data.skillAccess.primary
+                .map((c) => `${c} (${CATEGORY_LABELS[c]})`)
+                .join(" · ")}
+            </div>
+          </div>
+          <div className="rounded border border-slate-700 bg-slate-900 p-3">
+            <div className="mb-1 text-xs uppercase text-slate-400">
+              Secondary <span className="text-slate-500">(30k TV / skill)</span>
+            </div>
+            <div data-testid="secondary-access">
+              {data.skillAccess.secondary.length === 0
+                ? "—"
+                : data.skillAccess.secondary
+                    .map((c) => `${c} (${CATEGORY_LABELS[c]})`)
+                    .join(" · ")}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="text-xs text-slate-500">
+        Forme actuelle :{" "}
+        <span className="font-mono text-slate-300">{data.form}/100</span>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Drill-down depuis la roster table de **Lot E** vers une fiche joueur détaillée. L'objectif : un coach (et un visiteur) doit pouvoir cliquer sur un nom de joueur dans la roster et voir l'historique complet — stats, bonuses, skills, progression, carrière, pools d'accès BB.

### Backend (`apps/server`)
- Nouveau service `pro-player-detail` : `getProPlayerDetail(playerId)` agrège
  stats + bonuses + skills + progression + career counters + skill access
  pools (depuis `POSITION_SKILL_ACCESS` Lot 4.D.2) + team meta. Erreur typée
  `ProPlayerNotFoundError`.
- Nouvelle route `GET /api/pro-league/players/:id` (public, pas d'auth,
  cohérent avec `/api/pro-league/teams/:slug`).
- **Recompute défensif** du level depuis `spp` pour les rosters legacy.
- Fallback sur l'accès **Lineman** pour les positions non listées.

### Frontend (`apps/web`)
- Page `/pro-league/teams/[slug]/players/[playerId]` :
  - **Header** : nom + position + race + status + niggling badge, encart
    Level + TV en grand.
  - **Stats** : 5 cards (MA/ST/AG/PA/AV) avec bonus en exposant doré.
  - **Progression** : barre SPP avec % vers level suivant, ou
    "⭐ Legend" pour les level 7.
  - **Carrière** : 4 cards TD/CAS/COMP/MVP colorisées.
  - **Skills acquis** (chips) + **pools d'accès** G/A/S/P/M primary/secondary
    (visualise les coûts 20k vs 30k TV pour un futur level-up).
- Le nom dans la roster table (Lot E) devient un `Link` → fiche joueur.

## Test plan
- [x] 6 tests `pro-player-detail.test.ts` (happy path, 404, recompute
  legacy, stat bonuses, fallback Lineman, fallback null).
- [x] `pnpm --filter @bb/server test` — 2122 verts.
- [x] `pnpm --filter @bb/web test` — 886 verts.
- [x] `pnpm typecheck` — clean.
- [ ] Smoke `/pro-league/teams/<slug>` → click sur un joueur → fiche
  player avec progress bar SPP + bonuses + skills.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_