### PR TITLE
feat(pro-league): standings TV column + sort by TV (Lot I)

### DIFF
--- a/apps/server/src/services/pro-league-standings.test.ts
+++ b/apps/server/src/services/pro-league-standings.test.ts
@@ -5,6 +5,7 @@ vi.mock("../prisma", () => ({
     proLeague: { findUnique: vi.fn() },
     proLeagueSeason: { findFirst: vi.fn() },
     proLeagueStandings: { findMany: vi.fn() },
+    proTeamRoster: { groupBy: vi.fn() },
   },
 }));
 
@@ -18,12 +19,16 @@ interface MockedPrisma {
   proLeague: { findUnique: ReturnType<typeof vi.fn> };
   proLeagueSeason: { findFirst: ReturnType<typeof vi.fn> };
   proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
+  proTeamRoster: { groupBy: ReturnType<typeof vi.fn> };
 }
 
 const mocked = prisma as unknown as MockedPrisma;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Lot I — par défaut, aucune équipe n'a de TV agrégée. Les tests
+  // qui veulent une TV peuvent override.
+  mocked.proTeamRoster.groupBy.mockResolvedValue([]);
 });
 
 describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
@@ -62,6 +67,7 @@ describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
         casualtiesAgainst: 1,
         form: '["W","W","L","W","W"]',
         team: {
+          id: "team_buf",
           slug: "buf-snow-ogres",
           name: "Snow Ogres",
           city: "Buffalo",
@@ -82,6 +88,7 @@ describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
         casualtiesAgainst: 5,
         form: '["L","D","L","L","L"]',
         team: {
+          id: "team_gb",
           slug: "gb-cheese-halflings",
           name: "Cheese Halflings",
           city: "Green Bay",
@@ -124,6 +131,7 @@ describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
         casualtiesAgainst: 0,
         form: ["W"], // postgres JSON-natif (pas string)
         team: {
+          id: "team_pit",
           slug: "pit-smashers",
           name: "Smashers",
           city: "Pittsburgh",
@@ -157,6 +165,7 @@ describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
         casualtiesAgainst: 0,
         form: "garbage-not-json",
         team: {
+          id: "team_x",
           slug: "x",
           name: "X",
           city: "X",
@@ -168,5 +177,109 @@ describe("getProLeagueCurrentStandings — sprint 1.C.5", () => {
     ]);
     const out = await getProLeagueCurrentStandings();
     expect(out.rows[0].form).toEqual([]);
+  });
+
+  it("Lot I — agrège la TV team via groupBy(tvCached) status='active'", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 5,
+        wins: 4,
+        draws: 0,
+        losses: 1,
+        points: 12,
+        tdFor: 14,
+        tdAgainst: 6,
+        casualtiesFor: 3,
+        casualtiesAgainst: 1,
+        form: '["W","W","L","W","W"]',
+        team: {
+          id: "team_buf",
+          slug: "buf-snow-ogres",
+          name: "Snow Ogres",
+          city: "Buffalo",
+          race: "Ogre",
+          primaryColor: "#00338D",
+          secondaryColor: "#C60C30",
+        },
+      },
+      {
+        played: 5,
+        wins: 0,
+        draws: 1,
+        losses: 4,
+        points: 1,
+        tdFor: 4,
+        tdAgainst: 12,
+        casualtiesFor: 0,
+        casualtiesAgainst: 5,
+        form: '["L","D","L","L","L"]',
+        team: {
+          id: "team_gb",
+          slug: "gb-cheese-halflings",
+          name: "Cheese Halflings",
+          city: "Green Bay",
+          race: "Halfling",
+          primaryColor: "#203731",
+          secondaryColor: "#FFB612",
+        },
+      },
+    ]);
+    mocked.proTeamRoster.groupBy.mockResolvedValueOnce([
+      { teamId: "team_buf", _sum: { tvCached: 1_150_000 } },
+      { teamId: "team_gb", _sum: { tvCached: 950_000 } },
+    ]);
+
+    const out = await getProLeagueCurrentStandings();
+    expect(out.rows[0].teamValue).toBe(1_150_000);
+    expect(out.rows[1].teamValue).toBe(950_000);
+    // Vérifie qu'on filtre bien sur status='active'
+    expect(mocked.proTeamRoster.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        by: ["teamId"],
+        where: expect.objectContaining({ status: "active" }),
+        _sum: { tvCached: true },
+      }),
+    );
+  });
+
+  it("Lot I — teamValue=0 si aucun joueur actif (aggregate empty)", async () => {
+    mocked.proLeague.findUnique.mockResolvedValue({ slug: "old-world-league" });
+    mocked.proLeagueSeason.findFirst.mockResolvedValue({
+      id: "s1",
+      year: 2026,
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.findMany.mockResolvedValue([
+      {
+        played: 0,
+        wins: 0,
+        draws: 0,
+        losses: 0,
+        points: 0,
+        tdFor: 0,
+        tdAgainst: 0,
+        casualtiesFor: 0,
+        casualtiesAgainst: 0,
+        form: "[]",
+        team: {
+          id: "team_orphan",
+          slug: "orphan",
+          name: "Orphan",
+          city: "Nowhere",
+          race: "Skaven",
+          primaryColor: null,
+          secondaryColor: null,
+        },
+      },
+    ]);
+    mocked.proTeamRoster.groupBy.mockResolvedValueOnce([]);
+    const out = await getProLeagueCurrentStandings();
+    expect(out.rows[0].teamValue).toBe(0);
   });
 });

--- a/apps/server/src/services/pro-league-standings.ts
+++ b/apps/server/src/services/pro-league-standings.ts
@@ -37,6 +37,12 @@ export interface ProLeagueStandingsRow {
   readonly casualtiesFor: number;
   readonly casualtiesAgainst: number;
   readonly casualtiesDiff: number;
+  /**
+   * Lot I — Team Value courante en gold pieces. Somme des `tvCached`
+   * des joueurs actifs (status='active') du roster. Permet aux coachs
+   * de comparer la richesse roster au classement points.
+   */
+  readonly teamValue: number;
   /** Tableau des 5 derniers résultats (W/D/L), ordre du plus ancien
    *  au plus récent. Vide si aucun match joué. */
   readonly form: readonly ("W" | "D" | "L")[];
@@ -137,6 +143,7 @@ export async function getProLeagueCurrentStandings(
       form: true,
       team: {
         select: {
+          id: true,
           slug: true,
           name: true,
           city: true,
@@ -147,6 +154,29 @@ export async function getProLeagueCurrentStandings(
       },
     },
   });
+
+  // Lot I — TV par équipe : somme(tvCached) des joueurs status='active'.
+  // groupBy sert à éviter N+1 requêtes (1 par équipe). Bornée à 16
+  // équipes par ligue donc le tableau reste petit.
+  const teamIds = rowsRaw
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((s: any) => s.team.id as string)
+    .filter((id: string): id is string => typeof id === "string");
+  const tvAggregates = await prisma.proTeamRoster.groupBy({
+    by: ["teamId"],
+    where: {
+      teamId: { in: teamIds },
+      status: "active",
+    },
+    _sum: { tvCached: true },
+  });
+  const tvByTeamId = new Map<string, number>();
+  for (const a of tvAggregates as Array<{
+    teamId: string;
+    _sum: { tvCached: number | null };
+  }>) {
+    tvByTeamId.set(a.teamId, a._sum.tvCached ?? 0);
+  }
 
   return {
     leagueSlug: league.slug as string,
@@ -180,6 +210,7 @@ export async function getProLeagueCurrentStandings(
         casualtiesFor: casFor,
         casualtiesAgainst: casAgainst,
         casualtiesDiff: casFor - casAgainst,
+        teamValue: tvByTeamId.get(s.team.id as string) ?? 0,
         form: parseForm(s.form),
       };
     }),

--- a/apps/web/app/pro-league/standings/page.test.tsx
+++ b/apps/web/app/pro-league/standings/page.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 vi.mock("../../lib/api-client", () => ({
   apiRequest: vi.fn(),
@@ -43,6 +43,7 @@ function makeData(rows: number = 2): unknown {
       casualtiesFor: 3,
       casualtiesAgainst: 1,
       casualtiesDiff: 2,
+      teamValue: 1_150_000,
       form: ["W", "W", "L", "W", "W"],
     },
     {
@@ -66,6 +67,7 @@ function makeData(rows: number = 2): unknown {
       casualtiesFor: 0,
       casualtiesAgainst: 5,
       casualtiesDiff: -5,
+      teamValue: 1_400_000,
       form: ["L", "D", "L", "L", "L"],
     },
   ];
@@ -137,5 +139,83 @@ describe("ProLeagueStandingsPage — sprint 1.C.5", () => {
       expect(screen.getByRole("alert")).toBeTruthy();
     });
     expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+
+  describe("Lot I — TV column + sort by TV", () => {
+    it("affiche la colonne TV avec le formatage 'Xk' par équipe", async () => {
+      mockedApi.mockResolvedValue(makeData());
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByTestId("standings-tv-header")).toBeTruthy();
+      });
+      expect(
+        screen.getByTestId("standings-tv-buf-snow-ogres").textContent,
+      ).toBe("1150k");
+      expect(
+        screen.getByTestId("standings-tv-gb-cheese-halflings").textContent,
+      ).toBe("1400k");
+    });
+
+    it("trie par TV desc quand on click le header TV", async () => {
+      mockedApi.mockResolvedValue(makeData());
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByTestId("standings-table")).toBeTruthy();
+      });
+      // Default rank order : Buffalo (1150k) avant Green Bay (1400k)
+      // Après click TV : Green Bay (1400k) avant Buffalo (1150k)
+      const tvHeader = screen.getByTestId("standings-tv-header");
+      fireEvent.click(tvHeader);
+      const halflingsToOgres = screen
+        .getByText("Cheese Halflings")
+        .compareDocumentPosition(screen.getByText("Snow Ogres"));
+      expect(halflingsToOgres & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+      // Re-click → retour à l'ordre rank
+      fireEvent.click(tvHeader);
+      const ogresToHalflings = screen
+        .getByText("Snow Ogres")
+        .compareDocumentPosition(screen.getByText("Cheese Halflings"));
+      expect(ogresToHalflings & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("affiche '—' si teamValue=0 (équipe sans roster actif)", async () => {
+      mockedApi.mockResolvedValue({
+        leagueSlug: "old-world-league",
+        seasonId: "s1",
+        seasonYear: 2026,
+        seasonStatus: "in_progress",
+        rows: [
+          {
+            rank: 1,
+            team: {
+              slug: "orphan",
+              name: "Orphan",
+              city: "X",
+              race: "X",
+              primaryColor: null,
+              secondaryColor: null,
+            },
+            played: 0,
+            wins: 0,
+            draws: 0,
+            losses: 0,
+            points: 0,
+            tdFor: 0,
+            tdAgainst: 0,
+            tdDiff: 0,
+            casualtiesFor: 0,
+            casualtiesAgainst: 0,
+            casualtiesDiff: 0,
+            teamValue: 0,
+            form: [],
+          },
+        ],
+      });
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByTestId("standings-tv-orphan")).toBeTruthy();
+      });
+      expect(screen.getByTestId("standings-tv-orphan").textContent).toBe("—");
+    });
   });
 });

--- a/apps/web/app/pro-league/standings/page.tsx
+++ b/apps/web/app/pro-league/standings/page.tsx
@@ -43,7 +43,15 @@ interface StandingsRow {
   readonly casualtiesFor: number;
   readonly casualtiesAgainst: number;
   readonly casualtiesDiff: number;
+  readonly teamValue: number;
   readonly form: readonly FormChar[];
+}
+
+type StandingsSortKey = "rank" | "tv";
+
+function formatTv(gp: number): string {
+  if (gp === 0) return "—";
+  return `${(gp / 1000).toFixed(0)}k`;
 }
 
 interface StandingsSnapshot {
@@ -101,6 +109,7 @@ export default function ProLeagueStandingsPage(): JSX.Element {
   const [data, setData] = useState<StandingsSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<StandingsSortKey>("rank");
 
   useEffect(() => {
     let cancelled = false;
@@ -201,13 +210,30 @@ export default function ProLeagueStandingsPage(): JSX.Element {
                 <th className="w-12 px-2 py-2 text-center">
                   {t.proLeague.standings.thDiff}
                 </th>
+                <th
+                  data-testid="standings-tv-header"
+                  className={`w-14 cursor-pointer px-2 py-2 text-center hover:bg-slate-800 ${
+                    sortKey === "tv" ? "text-amber-300" : ""
+                  }`}
+                  title="Lot I — Team Value totale (somme tvCached actifs). Click pour trier."
+                  onClick={() =>
+                    setSortKey((k) => (k === "tv" ? "rank" : "tv"))
+                  }
+                >
+                  TV {sortKey === "tv" ? "↓" : ""}
+                </th>
                 <th className="w-24 px-2 py-2 text-center">
                   {t.proLeague.standings.thForm}
                 </th>
               </tr>
             </thead>
             <tbody>
-              {data.rows.map((r) => (
+              {(sortKey === "tv"
+                ? [...data.rows].sort(
+                    (a, b) => b.teamValue - a.teamValue,
+                  )
+                : data.rows
+              ).map((r) => (
                 <tr
                   key={r.team.slug}
                   className="border-t border-slate-800 hover:bg-slate-900"
@@ -264,6 +290,14 @@ export default function ProLeagueStandingsPage(): JSX.Element {
                     className={`px-2 py-2 text-center font-mono ${diffColorClass(r.casualtiesDiff)}`}
                   >
                     {formatDiff(r.casualtiesDiff)}
+                  </td>
+                  <td
+                    data-testid={`standings-tv-${r.team.slug}`}
+                    className={`px-2 py-2 text-center font-mono ${
+                      sortKey === "tv" ? "text-amber-300" : "text-slate-300"
+                    }`}
+                  >
+                    {formatTv(r.teamValue)}
                   </td>
                   <td className="px-2 py-2">
                     <div className="flex justify-center">


### PR DESCRIPTION
## Summary

Le classement Pro League montre désormais la **Team Value totale** par équipe avec un tri secondaire optionnel par TV. Permet aux coachs et visiteurs de voir d'un coup d'œil les disparités budgétaires : une équipe en bas de classement peut avoir une TV élevée (roster star + résultats récents en baisse) ou faible (rookies fresh).

### Backend (`apps/server`)
- `ProLeagueStandingsRow` ajoute `teamValue: number` (gp).
- Calcul via `prisma.proTeamRoster.groupBy({ by: ['teamId'], _sum: { tvCached: true }, where: { teamId: in [...], status: 'active' } })` : un seul round-trip pour les 16 équipes, filtre `status='active'` pour exclure injured/dead/retired.
- Map `teamId → tv` injectée dans chaque row.

### Frontend (`apps/web/.../standings/page.tsx`)
- Nouvelle colonne **TV** entre Cas diff et Form.
- **Header TV cliquable** → toggle tri par TV desc / retour à rank.
- Quand sort actif, header + cells colorisés en doré.
- Format `1150k` / `—` si `teamValue=0` (orphan team).

## Test plan
- [x] 2 tests `pro-league-standings.test.ts` (aggregation `groupBy`
  filtré `status='active'`, fallback 0 sur aggregate vide).
- [x] 3 tests UI `page.test.tsx` (colonne TV, click header → tri desc
  puis retour rank, "—" si teamValue=0).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2127 verts.
- [x] `pnpm --filter @bb/web test` — 889 verts (886 + 3).
- [ ] Smoke `/pro-league/standings` : colonne TV visible, click header
  → tri desc, retour ordre rank.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_