### PR TITLE
feat(pro-league): player match history avec SPP delta (Lot L)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -98,6 +98,10 @@ import {
   ProPlayerNotFoundError,
   getProPlayerDetail,
 } from "../services/pro-player-detail";
+import {
+  PlayerHistoryNotFoundError,
+  getPlayerMatchHistory,
+} from "../services/pro-player-match-history";
 import { serverLog } from "../utils/server-log";
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -337,6 +341,41 @@ export async function handleGetPlayerDetail(
     }
     const msg = err instanceof Error ? err.message : "unknown";
     serverLog.error(`[pro-league/players/${id}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Handler `GET /api/pro-league/players/:id/history` — Lot L.
+ *
+ * Renvoie les `?limit` (default 5, max 20) derniers matchs de l'équipe
+ * du joueur avec le delta SPP (TD/CAS/COMP/MVP/total) gagné par le
+ * joueur sur chaque match. Pour matchs sans replay, delta=0.
+ */
+export async function handleGetPlayerHistory(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  if (!id || typeof id !== "string") {
+    res.status(400).json({ error: "missing-id" });
+    return;
+  }
+  const limitRaw = req.query.limit;
+  const limit =
+    typeof limitRaw === "string" && /^\d+$/.test(limitRaw)
+      ? Number.parseInt(limitRaw, 10)
+      : undefined;
+  try {
+    const data = await getPlayerMatchHistory(id, limit);
+    res.json({ matches: data });
+  } catch (err: unknown) {
+    if (err instanceof PlayerHistoryNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/players/${id}/history] failed: ${msg}`);
     res.status(500).json({ error: "internal-error" });
   }
 }
@@ -841,6 +880,7 @@ router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
 router.get("/teams/:slug", handleGetTeamDetail);
 router.get("/players/:id", handleGetPlayerDetail);
+router.get("/players/:id/history", handleGetPlayerHistory);
 router.get("/matches/:id", handleGetMatchDetail);
 router.get("/matches/:id/markets", handleListMarkets);
 router.get("/matches/:id/stream", handleStreamProMatch);

--- a/apps/server/src/services/pro-player-match-history.test.ts
+++ b/apps/server/src/services/pro-player-match-history.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests pour `getPlayerMatchHistory` (Lot L).
+ *
+ * Strategie : on mocke `prisma`, `decompressEvents` et `attributeSpp`
+ * (le service réutilise la logique pure de pro-roster-spp). On vérifie
+ * la composition (loop matches → mine replay → filter rewards by
+ * rosterId) sans recoder les regles SPP.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeamRoster: { findUnique: vi.fn(), findMany: vi.fn() },
+    proLeagueMatch: { findMany: vi.fn() },
+    replay: { findUnique: vi.fn() },
+  },
+}));
+vi.mock("@bb/sim-engine", () => ({
+  decompressEvents: vi.fn(),
+}));
+vi.mock("./pro-roster-spp", () => ({
+  attributeSpp: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import { decompressEvents } from "@bb/sim-engine";
+import { attributeSpp } from "./pro-roster-spp";
+import {
+  PlayerHistoryNotFoundError,
+  getPlayerMatchHistory,
+} from "./pro-player-match-history";
+
+interface MockedPrisma {
+  proTeamRoster: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+  replay: { findUnique: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+const mockedDecompress = vi.mocked(decompressEvents);
+const mockedAttribute = vi.mocked(attributeSpp);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const FAKE_MATCH = {
+  id: "m1",
+  status: "completed",
+  scheduledAt: new Date("2026-09-15T21:00:00Z"),
+  homeTeamId: "team_buf",
+  awayTeamId: "team_gb",
+  scoreHome: 3,
+  scoreAway: 1,
+  outcome: "home",
+  seed: 42,
+  round: { roundNumber: 4 },
+  homeTeam: {
+    slug: "buf-snow-ogres",
+    name: "Snow Ogres",
+    city: "Buffalo",
+    primaryColor: "#00338D",
+  },
+  awayTeam: {
+    slug: "gb-cheese-halflings",
+    name: "Cheese Halflings",
+    city: "Green Bay",
+    primaryColor: "#203731",
+  },
+};
+
+describe("getPlayerMatchHistory — Lot L", () => {
+  it("404 si le joueur n'existe pas", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce(null);
+    await expect(getPlayerMatchHistory("missing")).rejects.toThrow(
+      PlayerHistoryNotFoundError,
+    );
+  });
+
+  it("retourne les rewards du joueur depuis attributeSpp", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([FAKE_MATCH]);
+    mocked.replay.findUnique.mockResolvedValueOnce({
+      payload: Buffer.from("compressed"),
+    });
+    mockedDecompress.mockResolvedValueOnce([]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([{ id: "p_self" }]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([{ id: "p_other" }]);
+    mockedAttribute.mockReturnValueOnce({
+      rewards: [
+        {
+          rosterId: "p_self",
+          side: "home",
+          tdCount: 1,
+          casCount: 0,
+          compCount: 1,
+          mvpCount: 0,
+          totalSpp: 4,
+        },
+        {
+          rosterId: "p_other",
+          side: "away",
+          tdCount: 0,
+          casCount: 1,
+          compCount: 0,
+          mvpCount: 0,
+          totalSpp: 2,
+        },
+      ],
+    });
+
+    const out = await getPlayerMatchHistory("p_self");
+    expect(out).toHaveLength(1);
+    expect(out[0]!.matchId).toBe("m1");
+    expect(out[0]!.isHome).toBe(true);
+    expect(out[0]!.opponent.slug).toBe("gb-cheese-halflings");
+    expect(out[0]!.scoreHome).toBe(3);
+    expect(out[0]!.spp).toEqual({
+      tdCount: 1,
+      casCount: 0,
+      compCount: 1,
+      mvpCount: 0,
+      totalSpp: 4,
+    });
+  });
+
+  it("retourne SPP delta=0 si pas de reward pour ce joueur", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([FAKE_MATCH]);
+    mocked.replay.findUnique.mockResolvedValueOnce({
+      payload: Buffer.from("compressed"),
+    });
+    mockedDecompress.mockResolvedValueOnce([]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([{ id: "p_self" }]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([]);
+    mockedAttribute.mockReturnValueOnce({
+      rewards: [
+        {
+          rosterId: "p_other",
+          side: "away",
+          tdCount: 1,
+          casCount: 0,
+          compCount: 0,
+          mvpCount: 0,
+          totalSpp: 3,
+        },
+      ],
+    });
+    const out = await getPlayerMatchHistory("p_self");
+    expect(out[0]!.spp).toEqual({
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+      totalSpp: 0,
+    });
+  });
+
+  it("isHome=false si la team du joueur est awayTeam", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_gb",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([FAKE_MATCH]);
+    mocked.replay.findUnique.mockResolvedValueOnce({
+      payload: Buffer.from("c"),
+    });
+    mockedDecompress.mockResolvedValueOnce([]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([{ id: "p_self" }]);
+    mockedAttribute.mockReturnValueOnce({ rewards: [] });
+
+    const out = await getPlayerMatchHistory("p_self");
+    expect(out[0]!.isHome).toBe(false);
+    expect(out[0]!.opponent.slug).toBe("buf-snow-ogres");
+  });
+
+  it("SPP=0 si pas de replay (ex: match scheduled rejoué)", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([FAKE_MATCH]);
+    mocked.replay.findUnique.mockResolvedValueOnce(null);
+
+    const out = await getPlayerMatchHistory("p_self");
+    expect(out[0]!.spp.totalSpp).toBe(0);
+    // attributeSpp NE doit PAS être appelé si pas de replay
+    expect(mockedAttribute).not.toHaveBeenCalled();
+  });
+
+  it("clamp limit à MAX_LIMIT=20 et utilise default=5", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+    await getPlayerMatchHistory("p_self", 100);
+    expect(mocked.proLeagueMatch.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 20 }),
+    );
+
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+    await getPlayerMatchHistory("p_self");
+    expect(mocked.proLeagueMatch.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ take: 5 }),
+    );
+  });
+
+  it("dedupe le sort par scheduledAt desc + status filter", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+    await getPlayerMatchHistory("p_self");
+    const call = mocked.proLeagueMatch.findMany.mock.calls[0]![0];
+    expect(call.orderBy).toEqual({ scheduledAt: "desc" });
+    expect(call.where.status).toEqual({ in: ["completed", "ready"] });
+    expect(call.where.OR).toEqual([
+      { homeTeamId: "team_buf" },
+      { awayTeamId: "team_buf" },
+    ]);
+  });
+
+  it("inclut le joueur retired/dead dans les sets via fallback teamId", async () => {
+    mocked.proTeamRoster.findUnique.mockResolvedValueOnce({
+      teamId: "team_buf",
+    });
+    mocked.proLeagueMatch.findMany.mockResolvedValueOnce([FAKE_MATCH]);
+    mocked.replay.findUnique.mockResolvedValueOnce({
+      payload: Buffer.from("c"),
+    });
+    mockedDecompress.mockResolvedValueOnce([]);
+    // Le joueur a été retired → absent des deux sets actifs
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([
+      { id: "p_other_home" },
+    ]);
+    mocked.proTeamRoster.findMany.mockResolvedValueOnce([
+      { id: "p_other_away" },
+    ]);
+    mockedAttribute.mockReturnValueOnce({ rewards: [] });
+
+    await getPlayerMatchHistory("p_retired");
+    // Le set home passé à attributeSpp doit contenir p_retired (fallback)
+    const args = mockedAttribute.mock.calls[0]![0];
+    expect(args.homeRosterIds.has("p_retired")).toBe(true);
+  });
+});

--- a/apps/server/src/services/pro-player-match-history.ts
+++ b/apps/server/src/services/pro-player-match-history.ts
@@ -1,0 +1,265 @@
+/**
+ * Pro player match history — Lot L.
+ *
+ * Service qui mine les replays Pro League par playerId pour
+ * reconstituer l'historique per-match d'un joueur :
+ *
+ *   - opponent + isHome + score + outcome + scheduledAt
+ *   - SPP gagnés ce match (ventilé en TD / CAS / COMP / MVP)
+ *
+ * On reutilise `attributeSpp` (pur) sur le replay decompresse
+ * de chaque match. Coût borné par `limit` (default 5, max 20).
+ *
+ * Pas de table dediee `ProMatchPlayerStat` :
+ *
+ *   - Bornage à 5 matchs ⇒ 5 round-trips DB max + 5 attributeSpp.
+ *   - Pas de migration / backfill de l'historique existant.
+ *   - Évite la divergence avec `attributeSpp` (single source of truth).
+ *
+ * Si le besoin grossit (graphique d'évolution sur 30 matchs, leaderboard
+ * SPP-by-period, etc.), créer un cache dédié devient pertinent.
+ */
+
+import { prisma } from "../prisma";
+import { decompressEvents } from "@bb/sim-engine";
+
+import { attributeSpp } from "./pro-roster-spp";
+
+export class PlayerHistoryNotFoundError extends Error {
+  constructor(playerId: string) {
+    super(`ProTeamRoster id='${playerId}' introuvable`);
+    this.name = "PlayerHistoryNotFoundError";
+  }
+}
+
+export interface PlayerMatchSppDelta {
+  readonly tdCount: number;
+  readonly casCount: number;
+  readonly compCount: number;
+  readonly mvpCount: number;
+  readonly totalSpp: number;
+}
+
+export interface PlayerMatchHistoryEntry {
+  readonly matchId: string;
+  readonly roundNumber: number;
+  readonly scheduledAt: string;
+  readonly status: string;
+  readonly isHome: boolean;
+  readonly opponent: {
+    readonly slug: string;
+    readonly name: string;
+    readonly city: string;
+    readonly primaryColor: string | null;
+  };
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: string | null;
+  readonly spp: PlayerMatchSppDelta;
+}
+
+const ZERO_DELTA: PlayerMatchSppDelta = {
+  tdCount: 0,
+  casCount: 0,
+  compCount: 0,
+  mvpCount: 0,
+  totalSpp: 0,
+};
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+interface ReplayMineRow {
+  payload: Buffer | null;
+}
+
+interface RawMatch {
+  id: string;
+  status: string;
+  scheduledAt: Date | null;
+  homeTeamId: string;
+  awayTeamId: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  seed: bigint | number | null;
+  round: { roundNumber: number } | null;
+  homeTeam: {
+    slug: string;
+    name: string;
+    city: string;
+    primaryColor: string | null;
+  };
+  awayTeam: {
+    slug: string;
+    name: string;
+    city: string;
+    primaryColor: string | null;
+  };
+}
+
+async function deltaForMatch(
+  match: RawMatch,
+  playerId: string,
+  playerTeamId: string,
+): Promise<PlayerMatchSppDelta> {
+  if (match.status !== "completed" && match.status !== "ready") {
+    return ZERO_DELTA;
+  }
+  const replay = (await prisma.replay.findUnique({
+    where: { matchId: match.id },
+    select: { payload: true },
+  })) as ReplayMineRow | null;
+  if (!replay || !replay.payload) return ZERO_DELTA;
+
+  let events: readonly unknown[];
+  try {
+    events = await decompressEvents(replay.payload);
+  } catch {
+    return ZERO_DELTA;
+  }
+
+  // Casualties extraites depuis les events (le replay est la verite).
+  const casualtiesFromEvents: Array<{
+    playerId: string;
+    team: string;
+    causedById?: string;
+    outcome: string;
+  }> = [];
+  for (const ev of events) {
+    if (!ev || typeof ev !== "object") continue;
+    const e = ev as { type?: unknown; meta?: unknown };
+    if (e.type !== "CASUALTY") continue;
+    const meta = (e.meta ?? {}) as Record<string, unknown>;
+    const causedBy =
+      typeof meta.causedBy === "string"
+        ? meta.causedBy
+        : typeof meta.causedById === "string"
+          ? meta.causedById
+          : undefined;
+    casualtiesFromEvents.push({
+      playerId: String(meta.playerId ?? ""),
+      team: String(meta.team ?? ""),
+      causedById: causedBy,
+      outcome: String(meta.outcome ?? "badly_hurt"),
+    });
+  }
+
+  // Pour le scoring MVP, attributeSpp a besoin des sets home/away.
+  // On charge les rosters actifs des 2 teams.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const home = (await prisma.proTeamRoster.findMany({
+    where: { teamId: match.homeTeamId, status: "active" },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const away = (await prisma.proTeamRoster.findMany({
+    where: { teamId: match.awayTeamId, status: "active" },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+  const homeIds = new Set(home.map((r) => r.id));
+  const awayIds = new Set(away.map((r) => r.id));
+
+  // Si le joueur a été retired/dead entre temps, il ne sera plus dans les
+  // sets — on l'ajoute manuellement côté correct pour qu'attributeSpp
+  // identifie les rewards le concernant.
+  if (!homeIds.has(playerId) && !awayIds.has(playerId)) {
+    if (playerTeamId === match.homeTeamId) homeIds.add(playerId);
+    else if (playerTeamId === match.awayTeamId) awayIds.add(playerId);
+  }
+
+  const seedNum =
+    typeof match.seed === "bigint"
+      ? Number(match.seed)
+      : Number(match.seed ?? 0);
+
+  const { rewards } = attributeSpp({
+    seed: seedNum,
+    events,
+    casualties: casualtiesFromEvents,
+    homeRosterIds: homeIds,
+    awayRosterIds: awayIds,
+  });
+  const own = rewards.find((r) => r.rosterId === playerId);
+  if (!own) return ZERO_DELTA;
+  return {
+    tdCount: own.tdCount,
+    casCount: own.casCount,
+    compCount: own.compCount,
+    mvpCount: own.mvpCount,
+    totalSpp: own.totalSpp,
+  };
+}
+
+export async function getPlayerMatchHistory(
+  playerId: string,
+  limit = DEFAULT_LIMIT,
+): Promise<readonly PlayerMatchHistoryEntry[]> {
+  const cap = Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const player = (await prisma.proTeamRoster.findUnique({
+    where: { id: playerId },
+    select: { teamId: true },
+  })) as { teamId: string } | null;
+  if (!player) {
+    throw new PlayerHistoryNotFoundError(playerId);
+  }
+
+  // Derniers matchs joués par l'équipe du joueur, status completed/ready.
+  const matchesRaw = (await prisma.proLeagueMatch.findMany({
+    where: {
+      OR: [{ homeTeamId: player.teamId }, { awayTeamId: player.teamId }],
+      status: { in: ["completed", "ready"] },
+    },
+    orderBy: { scheduledAt: "desc" },
+    take: cap,
+    select: {
+      id: true,
+      status: true,
+      scheduledAt: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      seed: true,
+      round: { select: { roundNumber: true } },
+      homeTeam: {
+        select: { slug: true, name: true, city: true, primaryColor: true },
+      },
+      awayTeam: {
+        select: { slug: true, name: true, city: true, primaryColor: true },
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  })) as any as RawMatch[];
+
+  const out: PlayerMatchHistoryEntry[] = [];
+  for (const match of matchesRaw) {
+    const isHome = match.homeTeamId === player.teamId;
+    const opponent = isHome ? match.awayTeam : match.homeTeam;
+    const delta = await deltaForMatch(match, playerId, player.teamId);
+    out.push({
+      matchId: match.id,
+      roundNumber: match.round?.roundNumber ?? 0,
+      scheduledAt:
+        match.scheduledAt instanceof Date
+          ? match.scheduledAt.toISOString()
+          : new Date(match.scheduledAt as unknown as string).toISOString(),
+      status: match.status,
+      isHome,
+      opponent: {
+        slug: opponent.slug,
+        name: opponent.name,
+        city: opponent.city,
+        primaryColor: opponent.primaryColor,
+      },
+      scoreHome: match.scoreHome,
+      scoreAway: match.scoreAway,
+      outcome: match.outcome,
+      spp: delta,
+    });
+  }
+  return out;
+}

--- a/apps/web/app/pro-league/teams/[slug]/players/[playerId]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/players/[playerId]/page.tsx
@@ -170,11 +170,42 @@ interface PlayerPageProps {
   readonly params: { slug: string; playerId: string };
 }
 
+interface PlayerMatchSpp {
+  tdCount: number;
+  casCount: number;
+  compCount: number;
+  mvpCount: number;
+  totalSpp: number;
+}
+
+interface PlayerMatchHistoryEntry {
+  matchId: string;
+  roundNumber: number;
+  scheduledAt: string;
+  status: string;
+  isHome: boolean;
+  opponent: {
+    slug: string;
+    name: string;
+    city: string;
+    primaryColor: string | null;
+  };
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  spp: PlayerMatchSpp;
+}
+
+interface PlayerHistoryResponse {
+  matches: PlayerMatchHistoryEntry[];
+}
+
 export default function ProLeaguePlayerPage({
   params,
 }: PlayerPageProps): JSX.Element {
   const { slug, playerId } = params;
   const [data, setData] = useState<PlayerDetail | null>(null);
+  const [history, setHistory] = useState<PlayerMatchHistoryEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -182,9 +213,16 @@ export default function ProLeaguePlayerPage({
     let cancelled = false;
     setLoading(true);
     setError(null);
-    apiRequest<PlayerDetail>(`/api/pro-league/players/${playerId}`)
-      .then((d) => {
-        if (!cancelled) setData(d);
+    Promise.all([
+      apiRequest<PlayerDetail>(`/api/pro-league/players/${playerId}`),
+      apiRequest<PlayerHistoryResponse>(
+        `/api/pro-league/players/${playerId}/history`,
+      ).catch(() => ({ matches: [] }) as PlayerHistoryResponse),
+    ])
+      .then(([d, h]) => {
+        if (cancelled) return;
+        setData(d);
+        setHistory(h.matches);
       })
       .catch((e: unknown) => {
         if (!cancelled) setError((e as Error).message);
@@ -398,10 +436,106 @@ export default function ProLeaguePlayerPage({
         </div>
       </section>
 
+      <section className="mb-6">
+        <h2 className="mb-2 text-sm font-medium uppercase text-slate-400">
+          Derniers matchs (5)
+        </h2>
+        {history.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            Aucun match joué pour ce joueur — ou les replays ne sont plus
+            disponibles.
+          </p>
+        ) : (
+          <ul data-testid="player-history" className="space-y-1.5">
+            {history.map((m) => (
+              <PlayerHistoryRow key={m.matchId} match={m} />
+            ))}
+          </ul>
+        )}
+      </section>
+
       <section className="text-xs text-slate-500">
         Forme actuelle :{" "}
         <span className="font-mono text-slate-300">{data.form}/100</span>
       </section>
     </div>
+  );
+}
+
+function PlayerHistoryRow({
+  match,
+}: {
+  match: PlayerMatchHistoryEntry;
+}): JSX.Element {
+  const at = new Date(match.scheduledAt);
+  const formattedDate = at.toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+  const finished = match.status === "completed";
+  const myScore = match.isHome ? match.scoreHome : match.scoreAway;
+  const oppScore = match.isHome ? match.scoreAway : match.scoreHome;
+  const won =
+    finished &&
+    ((match.isHome && match.outcome === "home") ||
+      (!match.isHome && match.outcome === "away"));
+  const drew = finished && match.outcome === "draw";
+  const resultClass = finished
+    ? won
+      ? "text-emerald-300"
+      : drew
+        ? "text-slate-300"
+        : "text-rose-300"
+    : "text-slate-500";
+
+  const sppParts: string[] = [];
+  if (match.spp.tdCount > 0) sppParts.push(`${match.spp.tdCount} TD`);
+  if (match.spp.casCount > 0) sppParts.push(`${match.spp.casCount} CAS`);
+  if (match.spp.compCount > 0) sppParts.push(`${match.spp.compCount} COMP`);
+  if (match.spp.mvpCount > 0) sppParts.push(`${match.spp.mvpCount} MVP`);
+  const sppDetail = sppParts.length > 0 ? ` (${sppParts.join(", ")})` : "";
+  const sppSummary =
+    match.spp.totalSpp > 0
+      ? `+${match.spp.totalSpp} SPP${sppDetail}`
+      : finished
+        ? "+0 SPP"
+        : "—";
+
+  return (
+    <li
+      data-testid="player-history-row"
+      className="flex items-center justify-between rounded border border-slate-800 bg-slate-900 px-3 py-2 text-sm"
+    >
+      <div className="flex items-center gap-3">
+        <span className="w-12 text-xs uppercase text-slate-500">
+          R{match.roundNumber} · {match.isHome ? "H" : "A"}
+        </span>
+        <span
+          aria-hidden
+          className="inline-block h-3 w-3 rounded-full ring-1 ring-slate-700"
+          style={{ background: match.opponent.primaryColor ?? "#475569" }}
+        />
+        <span className="font-medium text-slate-100">
+          {match.opponent.name}
+        </span>
+        <span className="text-xs text-slate-500">{formattedDate}</span>
+      </div>
+      <div className="flex items-center gap-3">
+        {finished && myScore !== null && oppScore !== null && (
+          <span className={`font-mono text-sm ${resultClass}`}>
+            {myScore}–{oppScore}
+          </span>
+        )}
+        <span
+          data-testid="player-history-spp"
+          className={`font-mono text-xs ${
+            match.spp.totalSpp > 0 ? "text-emerald-300" : "text-slate-500"
+          }`}
+        >
+          {sppSummary}
+        </span>
+      </div>
+    </li>
   );
 }


### PR DESCRIPTION
## Summary

Ferme le gap UX laissé par **Lot G** : la fiche joueur expose maintenant les 5 derniers matchs joués avec le SPP delta (TD/CAS/COMP/MVP/total) gagné sur chacun. Le coach voit la trajectoire de progression sans deviner.

### Backend (`apps/server`)
- Nouveau service `pro-player-match-history` : `getPlayerMatchHistory(playerId, limit=5, max=20)` mine les replays Pro League et **réutilise `attributeSpp`** (pur) pour extraire les rewards filtrées par `rosterId`. Bornage cap=20 pour éviter un mining O(N) sur l'historique entier.
- **Pas de table `ProMatchPlayerStat`** : on garde `attributeSpp` comme single source of truth, et le bornage rend le mining acceptable (5 replays décompressés max). Si besoin grossit ⇒ cache matérialisé dans un futur lot.
- **Fallback retired/dead** : un rosterId absent des sets actifs est rattaché manuellement via `teamId` pour garder le scoring MVP cohérent.
- Nouvelle route `GET /api/pro-league/players/:id/history?limit=N` (public).

### Frontend (`apps/web`)
- Page joueur charge `detail + history` en **parallèle** dans le même `useEffect`.
- Section "Derniers matchs" : row par match avec round, H/A, opponent (color dot + nom + date), score colorisé W/D/L, SPP delta avec breakdown si non-zéro (`+4 SPP (1 TD, 1 COMP)`).
- History fetch tolérant : un fail silencieux ⇒ liste vide, pas d'erreur globale (le détail reste affiché).

## Test plan
- [x] 8 tests `pro-player-match-history.test.ts` (404, happy path, delta=0, isHome=false, no replay → no attribute call, clamp limit, sort/where, fallback retired).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2141 verts (+8 vs main).
- [x] `pnpm --filter @bb/web test` — 895 verts.
- [ ] Smoke `/pro-league/teams/<slug>/players/<id>` : 5 derniers matchs avec SPP gagnés visibles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_