### PR TITLE
feat(pro-league): top earners widget sur team detail (Lot M)

### DIFF
--- a/apps/server/src/services/pro-league-team.test.ts
+++ b/apps/server/src/services/pro-league-team.test.ts
@@ -375,6 +375,129 @@ describe("getProTeamDetail roster — Lot E (progression / TV / career)", () => 
   });
 });
 
+describe("getProTeamDetail topEarners — Lot M", () => {
+  it("retourne le top 5 actifs trié par TV desc", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    const mkRoster = (id: string, name: string, tv: number, status = "active") => ({
+      id,
+      name,
+      position: "Lineman",
+      ma: 5,
+      st: 3,
+      ag: 3,
+      pa: 4,
+      av: 9,
+      skills: [],
+      status,
+      form: 50,
+      niggling: 0,
+      spp: 0,
+      level: 1,
+      tvCached: tv,
+      tdCount: 0,
+      casCount: 0,
+      compCount: 0,
+      mvpCount: 0,
+      maBonus: 0,
+      stBonus: 0,
+      agBonus: 0,
+      paBonus: 0,
+      avBonus: 0,
+    });
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      mkRoster("p1", "Cheap", 50_000),
+      mkRoster("p2", "Mid", 90_000),
+      mkRoster("p3", "Star", 150_000),
+      mkRoster("p4", "Mid2", 95_000),
+      mkRoster("p5", "Mid3", 110_000),
+      mkRoster("p6", "Lineman6", 50_000),
+      mkRoster("p7", "Bench", 60_000),
+    ]);
+
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.topEarners).toHaveLength(5);
+    expect(out.topEarners.map((p) => p.id)).toEqual([
+      "p3",
+      "p5",
+      "p4",
+      "p2",
+      "p7",
+    ]);
+    expect(out.topEarners[0]!.tv).toBe(150_000);
+    expect(out.totalRosterTv).toBe(50_000 + 90_000 + 150_000 + 95_000 + 110_000 + 50_000 + 60_000);
+  });
+
+  it("exclut les joueurs non-active du top earners et du total TV", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([
+      {
+        id: "p_active",
+        name: "Active",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: [],
+        status: "active",
+        form: 50,
+        niggling: 0,
+        spp: 0,
+        level: 1,
+        tvCached: 50000,
+        tdCount: 0,
+        casCount: 0,
+        compCount: 0,
+        mvpCount: 0,
+        maBonus: 0,
+        stBonus: 0,
+        agBonus: 0,
+        paBonus: 0,
+        avBonus: 0,
+      },
+      {
+        id: "p_dead",
+        name: "Dead",
+        position: "Lineman",
+        ma: 5,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 9,
+        skills: [],
+        status: "dead",
+        form: 0,
+        niggling: 0,
+        spp: 100,
+        level: 5,
+        tvCached: 200000,
+        tdCount: 5,
+        casCount: 0,
+        compCount: 0,
+        mvpCount: 0,
+        maBonus: 0,
+        stBonus: 0,
+        agBonus: 0,
+        paBonus: 0,
+        avBonus: 0,
+      },
+    ]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.topEarners).toHaveLength(1);
+    expect(out.topEarners[0]!.id).toBe("p_active");
+    expect(out.totalRosterTv).toBe(50000);
+  });
+
+  it("topEarners=[] si aucun joueur actif", async () => {
+    mocked.proTeam.findUnique.mockResolvedValue(fakeTeam());
+    mocked.proTeamRoster.findMany.mockResolvedValue([]);
+    const out = await getProTeamDetail("buf-snow-ogres");
+    expect(out.topEarners).toEqual([]);
+    expect(out.totalRosterTv).toBe(0);
+  });
+});
+
 describe("nextLevelSpp — Lot E", () => {
   it("retourne le prochain seuil BB (6/16/31/51/76/176)", () => {
     expect(nextLevelSpp(0)).toBe(6);

--- a/apps/server/src/services/pro-league-team.ts
+++ b/apps/server/src/services/pro-league-team.ts
@@ -99,6 +99,20 @@ export interface ProTeamDetailRecord {
   readonly form: readonly ("W" | "D" | "L")[];
 }
 
+/**
+ * Lot M — entrée résumée pour le widget "Top earners" sur la page
+ * équipe. Sous-set de `ProTeamRosterEntry` cible le rendu compact
+ * (image carte + chiffre TV + level).
+ */
+export interface ProTeamTopEarner {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly level: number;
+  readonly tv: number;
+  readonly status: string;
+}
+
 export interface ProTeamDetail {
   readonly slug: string;
   readonly city: string;
@@ -113,6 +127,13 @@ export interface ProTeamDetail {
   readonly seasonYear: number | null;
   readonly record: ProTeamDetailRecord | null;
   readonly roster: readonly ProTeamRosterEntry[];
+  /**
+   * Lot M — Top 5 joueurs actifs par TV (desc), pour mettre en avant
+   * les "stars" du roster sur la page équipe sans scroller la table
+   * complète.
+   */
+  readonly topEarners: readonly ProTeamTopEarner[];
+  readonly totalRosterTv: number;
   readonly upcomingMatches: readonly ProTeamDetailMatch[];
   readonly recentMatches: readonly ProTeamDetailMatch[];
 }
@@ -352,6 +373,24 @@ export async function getProTeamDetail(
 
   const meta = (team.meta as { motto?: string } | null | undefined) ?? null;
 
+  // Lot M — top 5 joueurs actifs par TV desc, sans appel DB additionnel.
+  const activeRoster = roster.filter((p) => p.status === "active");
+  const topEarners: ProTeamTopEarner[] = [...activeRoster]
+    .sort((a, b) => b.progression.tv - a.progression.tv)
+    .slice(0, 5)
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      level: p.progression.level,
+      tv: p.progression.tv,
+      status: p.status,
+    }));
+  const totalRosterTv = activeRoster.reduce(
+    (acc, p) => acc + p.progression.tv,
+    0,
+  );
+
   return {
     slug: team.slug as string,
     city: team.city as string,
@@ -366,6 +405,8 @@ export async function getProTeamDetail(
     seasonYear: season ? (season.year as number) : null,
     record,
     roster,
+    topEarners,
+    totalRosterTv,
     upcomingMatches,
     recentMatches,
   };

--- a/apps/web/app/pro-league/teams/[slug]/page.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.test.tsx
@@ -423,4 +423,50 @@ describe("ProLeagueTeamPage — sprint 1.C.2", () => {
       });
     });
   });
+
+  describe("Lot M — Top earners widget", () => {
+    it("affiche 5 cards (top earners) ordonnées par TV desc", async () => {
+      mockedApi.mockResolvedValue(
+        makeTeam({
+          topEarners: [
+            { id: "p3", name: "Star", position: "Blitzer", level: 5, tv: 150_000, status: "active" },
+            { id: "p5", name: "Mid3", position: "Catcher", level: 3, tv: 110_000, status: "active" },
+            { id: "p4", name: "Mid2", position: "Lineman", level: 2, tv: 95_000, status: "active" },
+            { id: "p2", name: "Mid", position: "Lineman", level: 2, tv: 90_000, status: "active" },
+            { id: "p7", name: "Bench", position: "Lineman", level: 1, tv: 60_000, status: "active" },
+          ],
+          totalRosterTv: 555_000,
+        }),
+      );
+      render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("top-earners")).toBeTruthy();
+      });
+      // Compteurs sur les 5 cards
+      expect(screen.getByTestId("top-earner-1").textContent).toContain("Star");
+      expect(screen.getByTestId("top-earner-1").textContent).toContain("150k");
+      expect(screen.getByTestId("top-earner-5").textContent).toContain("Bench");
+      // Roster total visible
+      expect(screen.getByText(/555k/)).toBeTruthy();
+    });
+
+    it("masque la section si topEarners est absent", async () => {
+      mockedApi.mockResolvedValue(makeTeam({ topEarners: undefined }));
+      render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+      await waitFor(() => {
+        expect(screen.getByTestId("roster-table")).toBeTruthy();
+      });
+      expect(screen.queryByTestId("top-earners")).toBeNull();
+    });
+
+    it("masque la section si topEarners est vide (no active roster)", async () => {
+      mockedApi.mockResolvedValue(
+        makeTeam({ topEarners: [], totalRosterTv: 0 }),
+      );
+      render(<ProLeagueTeamPage params={{ slug: "buf-snow-ogres" }} />);
+      await waitFor(() => {
+        expect(screen.queryByTestId("top-earners")).toBeNull();
+      });
+    });
+  });
 });

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -91,6 +91,15 @@ interface DetailRecord {
   readonly form: readonly FormChar[];
 }
 
+interface TopEarner {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly level: number;
+  readonly tv: number;
+  readonly status: string;
+}
+
 interface TeamDetail {
   readonly slug: string;
   readonly city: string;
@@ -105,6 +114,9 @@ interface TeamDetail {
   readonly seasonYear: number | null;
   readonly record: DetailRecord | null;
   readonly roster: readonly RosterEntry[];
+  /** Lot M — top 5 actifs par TV. */
+  readonly topEarners?: readonly TopEarner[];
+  readonly totalRosterTv?: number;
   readonly upcomingMatches: readonly DetailMatch[];
   readonly recentMatches: readonly DetailMatch[];
 }
@@ -195,6 +207,45 @@ function MatchRow({ match }: { match: DetailMatch }): JSX.Element {
         <span className="text-xs text-slate-500">{formattedDate}</span>
       </div>
     </Link>
+  );
+}
+
+/**
+ * Lot M — carte "Top earner" (top 5 par TV). Cliquable vers la fiche
+ * joueur. Affiche rank + nom + position + level + TV.
+ */
+function TopEarnerCard({
+  rank,
+  player,
+  teamSlug,
+}: {
+  rank: number;
+  player: TopEarner;
+  teamSlug: string;
+}): JSX.Element {
+  return (
+    <li
+      data-testid={`top-earner-${rank}`}
+      className="rounded border border-slate-800 bg-slate-900 hover:bg-slate-800"
+    >
+      <Link
+        href={`/pro-league/teams/${teamSlug}/players/${player.id}`}
+        className="flex items-center gap-3 px-3 py-2 text-sm"
+      >
+        <span className="w-6 font-mono text-xs text-slate-500">
+          #{rank}
+        </span>
+        <div className="flex-1">
+          <div className="font-medium text-slate-100">{player.name}</div>
+          <div className="text-xs text-slate-500">
+            {player.position} · Lv {player.level}
+          </div>
+        </div>
+        <span className="font-mono text-base text-amber-300">
+          {formatTv(player.tv)}
+        </span>
+      </Link>
+    </li>
   );
 }
 
@@ -787,6 +838,36 @@ export default function ProLeagueTeamPage({
                 </div>
               </section>
             ) : null}
+
+            {data.topEarners && data.topEarners.length > 0 && (
+              <section className="mb-6">
+                <h2 className="mb-2 text-lg font-semibold text-slate-100">
+                  Top earners{" "}
+                  {typeof data.totalRosterTv === "number" && (
+                    <span className="ml-2 text-sm font-normal text-slate-500">
+                      (roster total :{" "}
+                      <span className="font-mono text-slate-300">
+                        {formatTv(data.totalRosterTv)}
+                      </span>
+                      )
+                    </span>
+                  )}
+                </h2>
+                <ol
+                  data-testid="top-earners"
+                  className="grid gap-2 sm:grid-cols-2"
+                >
+                  {data.topEarners.map((p, idx) => (
+                    <TopEarnerCard
+                      key={p.id}
+                      rank={idx + 1}
+                      player={p}
+                      teamSlug={params.slug}
+                    />
+                  ))}
+                </ol>
+              </section>
+            )}
 
             <section className="mb-6">
               <h2 className="mb-2 text-lg font-semibold text-slate-100">


### PR DESCRIPTION
## Summary

Met en avant les "stars" du roster sur la page équipe sans avoir à scroller la table complète. Sert aux coachs à identifier les piliers budgétaires (qui s'effondrent vite si nigglés ou tués), et au visiteur à comprendre le profil de l'équipe d'un coup d'œil.

### Backend (`apps/server`)
- `ProTeamDetail` ajoute :
  - `topEarners: ProTeamTopEarner[]` — top 5 actifs par TV desc
    (`id/name/position/level/tv/status`).
  - `totalRosterTv: number` — somme(tvCached) actifs, pour
    contextualiser.
- Calculé **en mémoire** depuis `roster` déjà chargé, pas de query
  additionnelle. Filtre `status='active'` (cohérent avec Lot I
  standings).

### Frontend (`apps/web`)
- Section "Top earners" insérée au-dessus du roster table :
  - Header avec le total roster TV en exposant.
  - 5 cards cliquables → fiche joueur Lot G.
  - Chaque card : `#N` + nom + position + level + TV en doré.
- Section **masquée** si `topEarners` absent (rétrocompat) ou vide.

## Test plan
- [x] 3 tests `pro-league-team.test.ts` (tri TV desc, filtre actif/dead,
  totalRosterTv, équipe vide).
- [x] 3 tests `page.test.tsx` (rendu 5 cards + total, masquage si
  absent ou vide).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2136 verts (+3).
- [x] `pnpm --filter @bb/web test` — 898 verts (+3).
- [ ] Smoke `/pro-league/teams/<slug>` : section "Top earners" au-dessus
  du roster, click → fiche joueur.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_