### PR TITLE
docs: session UI polish Pro League 2026-05-10 (12 lots livrés)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,226 @@
+# CLAUDE.md — Memoire / patterns Nuffle Arena
+
+> Fichier de memoire long-terme pour Claude Code. Documente les
+> conventions du repo et les patterns recurrents decouverts au fil
+> des sessions. A relire avant de demarrer du travail non-trivial.
+
+## Layout monorepo
+
+```
+apps/
+  server/       # Express + Prisma (PostgreSQL prod, SQLite tests)
+  web/          # Next.js 14 app router
+  mobile/       # Expo React Native
+packages/
+  sim-engine/   # Sim Pro League (TS, pur)
+  game-engine/  # Match engine BB en ligne (TS, pur)
+  shared-types/ # Types partages
+prisma/         # Schema + migrations
+```
+
+Outils : pnpm workspaces, Turbo pour les tasks, Vitest pour les tests
+(server + web), Playwright pour E2E.
+
+## Conventions code
+
+### Backend (`apps/server`)
+- **Services** : pure logic dans `src/services/*.ts`. Pas d'I/O dans
+  les fonctions exportees marquees "pur".
+- **Routes** : `src/routes/*.ts` avec handler + Zod schema + middleware
+  (`authUser`, `adminOnly`, `validate`).
+- **Erreurs typees** : prefere `class XxxError extends Error` avec un
+  `code` enum string plutot que des chaines. Le handler match sur
+  `instanceof` pour mapper le status HTTP.
+- **Prisma** : preferer `select` (vs include) pour cap les colonnes
+  remontees. Pour les agregats multi-rows, **toujours `groupBy`** au
+  lieu de N+1.
+- **TestSqlite vs Postgres** : les tests utilisent SQLite (`TEST_SQLITE=1`).
+  Les colonnes JSON peuvent etre array natif (PG) ou string serialisee
+  (sqlite mirror). Toujours faire un parser tolerant aux deux.
+
+### Frontend (`apps/web`)
+- Next.js 14 app router, `"use client"` au top pour les pages
+  interactives.
+- `apiRequest<T>(path, init?)` dans `app/lib/api-client.ts` pour les
+  fetchs. `ApiClientError` pour les status non-2xx.
+- i18n via `useLanguage()` (`app/contexts/LanguageContext.tsx`) +
+  `app/i18n/translations.ts`. Pour les pages polish jetable, OK de
+  hardcoder le francais.
+- `data-testid` parlants : `roster-toolbar`, `top-earner-1`,
+  `wallet-tx-bet`. Stables vs text selectors.
+
+## Patterns recurrents
+
+### Caps server-side plus stricts que CLI (J)
+Un wrapper d'un CLI offline doit avoir des caps Zod plus stricts pour
+eviter de saturer l'event loop prod.
+
+```ts
+// CLI accepte matches ≤ 1000, subscribers ≤ 5000
+// Route admin accepte matches ≤ 50, subscribers ≤ 1000
+export const loadtestSchema = z.object({
+  matches: z.number().int().min(1).max(50),
+  subscribers: z.number().int().min(1).max(1000),
+  events: z.number().int().min(1).max(200),
+});
+```
+
+### Aggregation `groupBy` au lieu de N+1 (I, M)
+Pour les agregats par groupe (ex: TV par team), un seul round-trip :
+
+```ts
+const tvAggregates = await prisma.proTeamRoster.groupBy({
+  by: ["teamId"],
+  where: { teamId: { in: teamIds }, status: "active" },
+  _sum: { tvCached: true },
+});
+const tvByTeamId = new Map<string, number>();
+for (const a of tvAggregates) {
+  tvByTeamId.set(a.teamId, a._sum.tvCached ?? 0);
+}
+```
+
+### Reuse de logique pure pour mining read-only (L)
+Quand un service applique une regle (ex: `attributeSpp` calcule les
+SPP per-match), on peut le rappeler en mode read-only sur les replays
+existants pour reconstituer un historique sans nouvelle table.
+
+```ts
+// `attributeSpp` est pur ⇒ on le rappelle pour chaque replay archive
+const { rewards } = attributeSpp({ seed, events, casualties, ... });
+const own = rewards.find((r) => r.rosterId === playerId);
+```
+
+### Fallback retired/dead via teamId (L)
+Pour les services filtrant `status='active'`, prevoir un fallback si
+le rosterId vise est desormais retired/dead :
+
+```ts
+if (!homeIds.has(playerId) && !awayIds.has(playerId)) {
+  if (playerTeamId === match.homeTeamId) homeIds.add(playerId);
+  else if (playerTeamId === match.awayTeamId) awayIds.add(playerId);
+}
+```
+
+### Flag brut + flag computed (K)
+Quand l'API expose une valeur computed pour cacher un lag (ex:
+`level = max(rawDb, computed)`), il faut **aussi** exposer un flag
+brut (`readyToLevelUp`) pour signaliser cote UI l'etat "en attente".
+
+```ts
+const rawDbLevel = (r.level as number | null) ?? 1;
+const computedLevel = levelForSpp(spp);
+const level = Math.max(rawDbLevel, computedLevel);
+const readyToLevelUp = computedLevel > rawDbLevel; // flag brut
+```
+
+### `Promise.all([detail, optional])` (L)
+Charger un endpoint principal + un endpoint optionnel en parallele
+dans le meme `useEffect`. Catch sur l'optionnel ⇒ `[]` au lieu de
+bloquer l'affichage du detail.
+
+```ts
+Promise.all([
+  apiRequest<PlayerDetail>(`/api/pro-league/players/${id}`),
+  apiRequest<HistoryResponse>(`/api/pro-league/players/${id}/history`)
+    .catch(() => ({ matches: [] }) as HistoryResponse),
+]).then(([d, h]) => { setData(d); setHistory(h.matches); });
+```
+
+### Backwards-compat sur champs API ajoutes (K)
+Ajouter un champ optionnel `?` cote UI quand l'API change. Permet de
+deployer le frontend avant la prochaine PR serveur.
+
+```ts
+interface RosterProgression {
+  readonly level: number;
+  readonly spp: number;
+  /** Lot K — applier en retard. Optionnel pour retro-compat pre-K. */
+  readonly readyToLevelUp?: boolean;
+  readonly tv: number;
+}
+```
+
+## Pieges connus
+
+### `nextLevelSpp(spp)` est **strictement** > spp (K)
+La fonction retourne le premier seuil **au-dessus** de `spp`. Donc
+`spp >= nextLevelSpp(spp)` est **toujours faux**. Ne **jamais** s'en
+servir pour detecter "ready to level-up" — utiliser plutot le flag
+brut server-side `levelForSpp(spp) > rawDbLevel`.
+
+### Replay payload est `Buffer` compresse
+`replay.payload` est un `Buffer` ; il faut `await decompressEvents(buf)`
+(`@bb/sim-engine`) avant de lire les events. Toujours catcher
+l'erreur car les replays anciens peuvent avoir un format different.
+
+### Forme JSON sqlite vs postgres
+Les colonnes `form`, `skills`, `meta` peuvent etre `string` (sqlite
+mirror) ou array/object natif (PG). Parser tolerant obligatoire :
+
+```ts
+function parseSkills(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((s) => typeof s === "string");
+  if (typeof raw === "string") {
+    try { return JSON.parse(raw); } catch { return []; }
+  }
+  return [];
+}
+```
+
+## Workflow git
+
+### Branches
+- Branche par lot : `claude/<scope>-<short-desc>`. Ex :
+  `claude/lot-k-applier-audit`, `claude/lot-l-player-match-history`.
+- **Toujours** depuis main : `git checkout main && git pull && git
+  checkout -b ...`.
+- Commit message convention : `feat(scope): description` /
+  `fix(scope): description`. Detail en body. Pas de signature
+  Claude/Anthropic en footer (desactive globalement).
+
+### PR paralleles depuis main
+Plusieurs PR independantes peuvent partir de main et merger en ordre
+arbitraire. Conflits possibles sur composants partages (ex: Lot H
+modifie la signature de `RosterTable`, Lot G aussi) — rebase trivial.
+
+Quand le risque de conflit est gros : sequencer.
+
+### Webhooks PR
+- `subscribe_pr_activity` apres `create_pull_request` ⇒ on recoit les
+  events merge / CI / review en webhook.
+- **Ne pas poller** avec `sleep` — attendre les webhooks.
+
+## Tests
+
+### Coverage cible
+- 80% min globalement, enforce dans common rules.
+- Tests unitaires + integration + E2E (Playwright) selon le scope.
+
+### Mock pattern Prisma
+```ts
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeamRoster: { findUnique: vi.fn(), groupBy: vi.fn() },
+  },
+}));
+```
+
+Le mock doit declarer **toutes** les methodes utilisees, sinon
+`TypeError: Cannot read properties of undefined`.
+
+### Mock services purs reutilises
+Si un service A re-utilise B (ex: Lot L reutilise `attributeSpp` de
+`pro-roster-spp`), mock le module B pour eviter de tester deux fois
+les regles :
+
+```ts
+vi.mock("./pro-roster-spp", () => ({
+  attributeSpp: vi.fn(),
+}));
+```
+
+## Historique sessions
+
+- **2026-05-10** : Pro League UI polish, 12 lots/PRs (#728-#742). Voir
+  [`docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md`](./docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md).

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO — Nuffle Arena (Blood Bowl 3 Online)
 
-> Derniere mise a jour : 2026-05-05
-> Version actuelle : v1.73.0 (beta ouverte au public).
+> Derniere mise a jour : 2026-05-10
+> Version actuelle : v1.74.0 (beta ouverte au public).
 >
 > La roadmap v1 (Sprints 0-23, Phases A-Q, 201 taches livrees) est
 > archivee dans [`docs/roadmap/archive/v1.73/`](./docs/roadmap/archive/v1.73/README.md).
@@ -12,6 +12,14 @@ La nouvelle feuille de route est dans
 [`docs/roadmap/phases.md`](./docs/roadmap/phases.md) (page blanche
 prete a accueillir les phases R+).
 
+## Sessions de polish recentes
+
+- **2026-05-10** — Pro League UI polish (12 lots livres, PRs #728-#742).
+  Ferme les gaps UX residuels des sprints 1.C / 1.D / 2.B / 4.A-F
+  (drill-down joueur, top earners, wallet ledger, broadcaster load
+  test admin, fix badge "ready to level-up" phantom). Detail :
+  [`docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md`](./docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md).
+
 ## Priorite immediate
 
 - [**SPRINT Ligues v2 — Gestion complete des ligues Blood Bowl**](./docs/roadmap/sprints/SPRINT-leagues-v2.md)
@@ -19,15 +27,11 @@ prete a accueillir les phases R+).
   reportes en backlog ci-dessous.
 
 - [**SPRINT Pro League — Championnat virtuel + Paris MVP**](./docs/roadmap/sprints/SPRINT-pro-league.md)
-  — **P1** (post-Ligues v2) — Championnat permanent 16 equipes IA vs IA
-  (hommages NFL × races BB), matchs auto diffuses live le mardi 21h, paris
-  en Crowns, mode spectateur/fan, Nuffle Gazette LLM quotidienne. **Phase 0
-  sim foundation bloquante** (8 sem : behavior trees, profils tactiques,
-  variance Nuffle, bench harness, validation panel humain). **Phase 1 MVP**
-  (4 sem : data model, broadcaster live SSE, UI, paris, Gazette,
-  casualties, HoF light). Calendrier aligne saison NFL 2026-27 (kickoff
-  cible 5 sept 2026). Backlog idees differees (MPG-layer mercato,
-  multi-leagues, weather sync IRL...) consigne dans
+  — **EN COURS** — Phase 0 sim foundation + Phase 1 MVP livres. La
+  session 2026-05-10 a comble les derniers gaps UX. Reste : tuning
+  bench panel humain (Phase 0 gate) et go-live calendrier saison NFL
+  2026-27 (cible kickoff 5 sept 2026). Backlog idees differees
+  consigne dans
   [`docs/roadmap/backlog/future-ideas.md`](./docs/roadmap/backlog/future-ideas.md).
 
 ## Suivi qualite actif
@@ -45,6 +49,16 @@ prete a accueillir les phases R+).
 > (annexe A) le 2026-05-05 :
 > - **A.0** : L2.C.4 Promotion/relegation multi-tier (focus acquisition/retention).
 > - **A.1** : L2.C.7 Mobile parite ligues (priorisation Pro League).
+
+### Pro League — idees post-MVP
+
+> Issues de la session 2026-05-10 mais hors scope MVP :
+> - Cache materialise `ProMatchPlayerStat` si le mining replay (Lot L)
+>   devient trop couteux (>5 matchs ou usage frequent).
+> - Graphique evolution SPP / TV par joueur (timeline sur saison).
+> - Top earners par equipe sur la page standings (Lot I + Lot M
+>   combine).
+> - Wallet : pagination des transactions au-dela des 20 dernieres.
 
 ### Autres
 

--- a/docs/ROADMAP_DONE.md
+++ b/docs/ROADMAP_DONE.md
@@ -1,5 +1,25 @@
 # Roadmap — Tâches terminées
 
+## Session UI/Polish Pro League — 2026-05-10
+
+12 lots livrés en une seule session (PRs #728-#742). Détail :
+[`docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md`](./roadmap/sessions/2026-05-10-pro-league-ui-polish.md).
+
+- [x] **Lot F** : `/admin/sim/health` — hub d'observabilité sim engine (drift + alerts + cross-links). PR #728.
+- [x] **Lot A** : Drift watcher + race-bound alerts au-dessus de la table. PR #732.
+- [x] **Lot C** : `/admin/sim/compare-versions` UI (wrapping `compareBaselines`). PR #730.
+- [x] **Lot E** : Roster enrichi sur `/pro-league/teams/[slug]` — level, SPP progress bar, TV, stat bonuses, career counters. PR #731.
+- [x] **Lot J** : `/admin/sim/loadtest` UI (wrap CLI `pnpm sim:loadtest:broadcaster` avec caps server-side stricts). PR #735.
+- [x] **Lot G** : `/pro-league/teams/[slug]/players/[playerId]` — fiche joueur (stats + bonuses + skills + progression + carrière + pools d'accès G/A/S/P/M). PR #736.
+- [x] **Lot H** : Roster filters (Tous/Actifs/Blessés) + tri (Nom/Position/Level/SPP/TV) + badge ⬆ ready. PR #737.
+- [x] **Lot I** : Colonne TV sur `/pro-league/standings` + sort by TV (via `groupBy(tvCached)` filtre active). PR #738.
+- [x] **Lot K** : Fix bug logique Lot H — le badge "ready to level-up" ne se déclenchait jamais. Flag `readyToLevelUp` server-side (`levelForSpp(spp) > rawDbLevel`). PR #739.
+- [x] **Lot L** : Player match history (5 derniers matchs avec SPP delta TD/CAS/COMP/MVP via mining replay + `attributeSpp`). PR #740.
+- [x] **Lot M** : Top earners widget sur page équipe (top 5 actifs par TV + total roster TV). PR #741.
+- [x] **Lot N** : `/pro-league/me/wallet` — balance + ledger 20 dernières transactions colorisées par type (BET/WIN/REWARD/DAILY/BADGE). PR #742.
+
+Tests : **2141 serveur (+61)** + **901 web (+31)**, typecheck clean.
+
 ## Sprint 0 — Bugfixes critiques & sécurité
 
 - [x] **BUG-1** : Fix `armorSuccess = true` hardcodé dans actions.ts — les dodges ratés causent maintenant des blessures

--- a/docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md
+++ b/docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md
@@ -1,0 +1,132 @@
+# Session UI/Polish Pro League — 2026-05-10
+
+> 12 lots livres en une seule session (Claude Code). Branche directe
+> sur main, PR independantes, merges sequentiels.
+>
+> Source : suite des sprints 1.C / 1.D / 2.B / 4.A-F deja livres. Cette
+> session ferme des gaps UX residuels (drill-down joueur, top earners,
+> wallet, broadcaster load test) et corrige un bug logique introduit
+> par Lot H (badge "ready" jamais declenche).
+
+## Recap des 12 lots
+
+| Lot | Titre | Surface | PR |
+|-----|-------|---------|----|
+| **F** | Sim health hub | admin | #728 |
+| **A** | Drift watcher + alerts | admin | #732 |
+| **C** | Compare engine versions UI | admin | #730 |
+| **E** | Roster level/SPP/TV/bonuses/career | pro-league/teams | #731 |
+| **J** | Broadcaster load test UI | admin | #735 |
+| **G** | Player detail page | pro-league/teams/:slug/players/:id | #736 |
+| **H** | Roster filters/sort + ready badge | pro-league/teams/:slug | #737 |
+| **I** | Standings TV column + sort by TV | pro-league/standings | #738 |
+| **K** | Fix ready badge phantom (audit applier) | pro-league | #739 |
+| **L** | Player match history (per-match SPP delta) | pro-league/players | #740 |
+| **M** | Top earners widget | pro-league/teams/:slug | #741 |
+| **N** | Wallet page + ledger transactions | pro-league/me/wallet | #742 |
+
+## Surfaces backend touchees
+
+### Nouveaux services
+- `pro-league-sim-health` (F) — snapshot drift + bound alerts + last sim.
+- `pro-league-broadcaster-loadtest` (J — deja existant, expose via route).
+- `pro-player-detail` (G) — fiche joueur agregee.
+- `pro-player-match-history` (L) — mine replays + reutilise `attributeSpp`.
+
+### Services etendus
+- `pro-league-team` : +`topEarners` (M), +`totalRosterTv` (M),
+  +`progression.readyToLevelUp` (K).
+- `pro-league-standings` : +`teamValue` via `groupBy(tvCached)` filtre
+  status='active' (I).
+- `admin-tools` : `compareBaselines` expose (C).
+
+### Nouvelles routes
+| Route | Lot | Auth |
+|-------|-----|------|
+| `POST /admin/sim/loadtest` | J | admin |
+| `GET /api/pro-league/players/:id` | G | public |
+| `GET /api/pro-league/players/:id/history?limit=N` | L | public |
+
+### Bug fix critique
+- **Lot K** : `nextLevelSpp(spp)` retourne le seuil **strictement
+  superieur** a spp. La condition `spp >= nextLevelSpp` de Lot H etait
+  donc mathematiquement impossible et le badge ne se declenchait
+  jamais. Fix : flag `readyToLevelUp` calcule server-side via
+  `levelForSpp(spp) > rawDbLevel`.
+
+## Surfaces frontend touchees
+
+### Nouvelles pages
+- `/admin/sim/loadtest` (J).
+- `/pro-league/teams/[slug]/players/[playerId]` (G).
+- `/pro-league/me/wallet` (N).
+
+### Pages enrichies
+- `/admin/sim/health` (F, K, J) — alerts + cross-links.
+- `/pro-league/standings` (I) — colonne TV + sort.
+- `/pro-league/teams/[slug]` (E, G, H, M) — roster enrichi + filtres/
+  sort + top earners widget + link nom joueur.
+
+## Tests
+
+| Domaine | Avant session | Apres session |
+|---------|---------------|---------------|
+| `@bb/server` | ~2080 | **2141** |
+| `@bb/web` | ~870 | **901** |
+
+Tous typecheck OK, aucun commentaire de review en attente.
+
+## Patterns recurrents (a reutiliser)
+
+### Backend
+- **Caps server-side stricts** (Lot J) : un wrapper d'un CLI offline
+  doit avoir des caps Zod plus stricts pour eviter de saturer
+  l'event loop prod (matches ≤ 50, subscribers ≤ 1000 vs CLI 5000).
+- **Aggregation `groupBy` au lieu de N+1** (Lot I, M) :
+  `prisma.proTeamRoster.groupBy({ by: ['teamId'], _sum: { tvCached: true } })`
+  pour 16 equipes = 1 round-trip.
+- **Reuse de logique pure** (Lot L) : `attributeSpp(events, casualties)`
+  est pur ⇒ on peut le rappeler en read-only sur les replays existants
+  sans dupliquer les regles BB.
+- **Fallback retired/dead** (Lot L) : pour les services qui filtrent par
+  `status='active'`, prevoir un fallback si le rosterId vise est
+  desormais retired (ex: SPP history). Ajout manuel cote correct via
+  `teamId`.
+- **Flag brut + flag computed** (Lot K) : quand l'API expose une valeur
+  computed pour cacher un lag (ex: `level = max(rawDb, computed)`), il
+  faut **aussi** exposer un flag brut (`readyToLevelUp`) pour
+  signaliser cote UI l'etat "en attente".
+
+### Frontend
+- **Promise.all([detail, optional])** (Lot L) : charger un endpoint
+  principal + un endpoint optionnel en parallele dans le meme
+  `useEffect`. Catch sur l'optionnel ⇒ `[]` au lieu de bloquer
+  l'affichage du detail.
+- **Backwards-compat** : ajouter un champ optionnel `?` cote UI quand
+  l'API change. Permet de deployer le frontend avant la prochaine PR
+  serveur si besoin.
+- **`data-testid` parlants** : `roster-toolbar`, `top-earner-1`,
+  `player-history-row`, `wallet-tx-bet`. Plus stables que les texte
+  selectors avec i18n.
+
+### Git workflow
+- **PRs paralleles depuis main** : les 4 PR F/A/C/E ont ete creees
+  toutes depuis main sans rebase. Conflits potentiels resolus en M
+  qui touchait des composants partages (RosterTable signature). Quand
+  c'est trop risque, sequencer.
+- **`git checkout main && git pull && git checkout -b claude/lot-X`**
+  systematiquement entre chaque lot pour repartir propre.
+
+## Cumul cibles roadmap
+
+Ces 12 lots etendent les sprints :
+- **Sprint Pro League** lots **1.C** (UI), **1.D** (paris/wallet),
+  **2.B** (admin observability), **4.A-F** (drift / replay tools).
+- **Pas de scope nouveau** vs `SPRINT-pro-league.md` — pure
+  consolidation UX.
+
+## Liens
+
+- [Sprint Pro League](../sprints/SPRINT-pro-league.md) — sprint
+  d'origine (Phase 0 + Phase 1 livres).
+- [TODO.md](../../../TODO.md)


### PR DESCRIPTION
## Summary

Met à jour la documentation après la **session UI polish Pro League du 2026-05-10** (12 lots livrés en 12 PRs #728-#742 toutes mergées).

### Fichiers modifiés
- **TODO.md** : section "Sessions de polish récentes" pointant vers le log détaillé. Backlog Pro League post-MVP enrichi (cache replay mining, graphique évolution SPP, top earners sur standings, pagination wallet).
- **docs/ROADMAP_DONE.md** : entrée datée 2026-05-10 avec le récap des 12 lots et les chiffres de tests (2141 serveur, 901 web).
- **docs/roadmap/sessions/2026-05-10-pro-league-ui-polish.md** *(nouveau)* : log session complet avec table des lots, surfaces touchées, patterns récurrents, lien vers le sprint d'origine.
- **CLAUDE.md** *(nouveau, racine repo)* : mémoire long-terme. Documente :
  - Layout monorepo + conventions code (server/frontend).
  - Patterns récurrents extraits de la session : caps server-side > CLI, `groupBy` vs N+1, reuse de logique pure pour mining read-only, fallback retired/dead via `teamId`, flag brut + computed, `Promise.all([detail, optional])`, backwards-compat sur champs API.
  - Pièges connus : `nextLevelSpp` strictement >, replay payload `Buffer` compressé, forme JSON sqlite/postgres.
  - Workflow git : branches par lot, webhooks PR, pas de poll `sleep`.
  - Conventions tests : mock Prisma complet, mock services purs réutilisés.
  - Historique sessions.

## Test plan
- [x] Pas de code → pas de tests à run.
- [x] Markdown valid (rendu standard).
- [ ] Smoke : ouvrir `CLAUDE.md`, `TODO.md` et le session log dans le navigateur GitHub pour vérifier le rendu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_