### PR TITLE
fix(game-engine): regeneration / apothecary order BB Season 2/3 (Lot O.A.1)

### DIFF
--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -102,6 +102,13 @@ export interface PendingApothecary {
   originalCasualtyRoll?: number;
   originalLastingInjury?: LastingInjuryDetail;
   causedById?: string;
+  /**
+   * Lot O.A.1 — Si vrai, le joueur a la skill Regeneration. Quand le
+   * coach refuse l'apothecaire (`applyApothecaryChoice(_, false, _)`),
+   * la regeneration est tentee en fallback. BB Season 2/3 : apothecaire
+   * propose en premier, regeneration en dernier recours.
+   */
+  fallbackToRegeneration?: boolean;
 }
 
 export interface GameState {

--- a/packages/game-engine/src/mechanics/apothecary.ts
+++ b/packages/game-engine/src/mechanics/apothecary.ts
@@ -12,6 +12,7 @@
 import { GameState, TeamId, RNG, CasualtyOutcome, PendingApothecary } from '../core/types';
 import { movePlayerToDugoutZone } from './dugout';
 import { rollLastingInjuryType } from './injury';
+import { tryRegeneration } from './regeneration';
 import { createLogEntry } from '../utils/logging';
 
 /** Severity ranking for casualty outcomes (lower = less severe) */
@@ -75,6 +76,20 @@ export function applyApothecaryChoice(
       pending.team
     );
     newState.gameLog = [...newState.gameLog, declineLog];
+
+    // Lot O.A.1 — BB Season 2/3 : si le joueur a Regeneration et qu'on
+    // refuse l'apothecaire, la regen est tentee en fallback. Si elle
+    // reussit, le joueur quitte la zone blesses/KO.
+    if (pending.fallbackToRegeneration) {
+      const regenResult = tryRegeneration(
+        newState,
+        pending.playerId,
+        rng,
+        pending.injuryType,
+      );
+      if (regenResult) return regenResult;
+    }
+
     return newState;
   }
 

--- a/packages/game-engine/src/mechanics/injury.ts
+++ b/packages/game-engine/src/mechanics/injury.ts
@@ -90,19 +90,24 @@ function handleKnockedOut(state: GameState, player: Player, rng: RNG): GameState
   );
   newState.gameLog = [...newState.gameLog, koLog];
 
-  // Regeneration check (AVANT l'apothecaire)
-  if (hasRegeneration(newState, player.id)) {
-    const regenResult = tryRegeneration(newState, player.id, rng, 'ko');
-    if (regenResult) return regenResult;
-  }
-
-  // Verifier si l'apothecaire est disponible
+  // Lot O.A.1 — BB Season 2/3 : apothecaire propose en premier, regen
+  // en fallback. Si le coach refuse l'apothecaire, la regen est tentee
+  // dans `applyApothecaryChoice` (flag `fallbackToRegeneration`).
+  const hasRegen = hasRegeneration(newState, player.id);
   if (isApothecaryAvailable(newState, player.id)) {
     newState.pendingApothecary = {
       playerId: player.id,
       team: player.team,
       injuryType: 'ko',
+      fallbackToRegeneration: hasRegen,
     };
+    return newState;
+  }
+
+  // Pas d'apothecaire dispo → tentative de regeneration directe.
+  if (hasRegen) {
+    const regenResult = tryRegeneration(newState, player.id, rng, 'ko');
+    if (regenResult) return regenResult;
   }
 
   return newState;
@@ -234,13 +239,10 @@ function handleCasualty(state: GameState, player: Player, rng: RNG, causedById?:
   // Enregistrer le résultat de la blessure dans l'état du jeu
   newState.casualtyResults = { ...newState.casualtyResults, [player.id]: outcome };
 
-  // Regeneration check (AVANT l'apothecaire)
-  if (hasRegeneration(newState, player.id)) {
-    const regenResult = tryRegeneration(newState, player.id, rng, 'casualty');
-    if (regenResult) return regenResult;
-  }
-
-  // Verifier si l'apothecaire est disponible
+  // Lot O.A.1 — BB Season 2/3 : apothecaire propose en premier, regen
+  // en fallback. Si refus apothecaire ET joueur a Regeneration, regen
+  // est tentee dans `applyApothecaryChoice`.
+  const hasRegen = hasRegeneration(newState, player.id);
   if (isApothecaryAvailable(newState, player.id)) {
     const pendingApothecary: PendingApothecary = {
       playerId: player.id,
@@ -249,12 +251,20 @@ function handleCasualty(state: GameState, player: Player, rng: RNG, causedById?:
       originalCasualtyOutcome: outcome,
       originalCasualtyRoll: casualtyRoll,
       causedById,
+      fallbackToRegeneration: hasRegen,
     };
     // Store lasting injury if applicable
     if (newState.lastingInjuryDetails[player.id]) {
       pendingApothecary.originalLastingInjury = { ...newState.lastingInjuryDetails[player.id] };
     }
     newState.pendingApothecary = pendingApothecary;
+    return newState;
+  }
+
+  // Pas d'apothecaire dispo → tentative de regeneration directe.
+  if (hasRegen) {
+    const regenResult = tryRegeneration(newState, player.id, rng, 'casualty');
+    if (regenResult) return regenResult;
   }
 
   return newState;

--- a/packages/game-engine/src/mechanics/regeneration.test.ts
+++ b/packages/game-engine/src/mechanics/regeneration.test.ts
@@ -103,24 +103,24 @@ describe('Regle: Regeneration', () => {
       expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
     });
 
-    it('devrait permettre l\'apothecaire apres echec de regeneration (KO)', () => {
+    it('Lot O.A.1 — apothecaire propose en PREMIER avec flag fallbackToRegeneration (KO)', () => {
+      // BB Season 2/3 : apothecaire est toujours offert en premier si
+      // disponible. La regen sert de fallback si le coach decline.
       const state = createTestState({
         apothecaryAvailable: { teamA: true, teamB: false },
       });
-      let callCount = 0;
-      const rng = () => {
-        callCount++;
-        if (callCount <= 2) return 0.5; // 4+4=8 (KO)
-        return 0.01; // regen fail (roll=1)
-      };
+      const rng = () => 0.5; // 4+4=8 (KO)
       const result = performInjuryRoll(state, state.players[0], rng);
 
-      // Regen failed → apothecary should be offered
+      // Apothecary offered, regen non-encore tentee.
       expect(result.pendingApothecary).toBeDefined();
       expect(result.pendingApothecary!.injuryType).toBe('ko');
+      expect(result.pendingApothecary!.fallbackToRegeneration).toBe(true);
+      // Player still in KO zone, awaiting coach decision.
+      expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
     });
 
-    it('ne devrait PAS proposer l\'apothecaire si regeneration reussit (KO)', () => {
+    it('Lot O.A.1 — refus apothecaire → regen tentee en fallback (succes, KO)', () => {
       const state = createTestState({
         apothecaryAvailable: { teamA: true, teamB: false },
       });
@@ -128,13 +128,34 @@ describe('Regle: Regeneration', () => {
       const rng = () => {
         callCount++;
         if (callCount <= 2) return 0.5; // 4+4=8 (KO)
-        return 0.99; // regen success (roll=6)
+        return 0.99; // regen success on decline (roll=6)
       };
-      const result = performInjuryRoll(state, state.players[0], rng);
+      const intermediate = performInjuryRoll(state, state.players[0], rng);
+      // Coach decline apothecary → regen kicks in via applyApothecaryChoice
+      const result = applyApothecaryChoice(intermediate, false, rng);
 
-      // Regen succeeded → no apothecary needed
-      expect(result.pendingApothecary).toBeUndefined();
+      // Regen succeeded: player goes to reserves
+      expect(result.dugouts.teamA.zones.knockedOut.players).not.toContain('A1');
       expect(result.dugouts.teamA.zones.reserves.players).toContain('A1');
+      expect(result.pendingApothecary).toBeUndefined();
+    });
+
+    it('Lot O.A.1 — refus apothecaire → regen tentee en fallback (echec, KO)', () => {
+      const state = createTestState({
+        apothecaryAvailable: { teamA: true, teamB: false },
+      });
+      let callCount = 0;
+      const rng = () => {
+        callCount++;
+        if (callCount <= 2) return 0.5; // 4+4=8 (KO)
+        return 0.01; // regen fail on decline (roll=1)
+      };
+      const intermediate = performInjuryRoll(state, state.players[0], rng);
+      const result = applyApothecaryChoice(intermediate, false, rng);
+
+      // Regen failed: player stays in KO
+      expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
+      expect(result.pendingApothecary).toBeUndefined();
     });
   });
 
@@ -177,22 +198,25 @@ describe('Regle: Regeneration', () => {
       expect(result.casualtyResults['A1']).toBe('badly_hurt');
     });
 
-    it('devrait permettre l\'apothecaire apres echec de regeneration (Casualty)', () => {
+    it('Lot O.A.1 — apothecaire propose en PREMIER avec fallbackToRegeneration (Casualty)', () => {
+      // BB Season 2/3 : apothecaire offert en premier pour casualty
+      // aussi. Permet au coach de re-roller le D16 (typique pour dead).
       const state = createTestState({
         apothecaryAvailable: { teamA: true, teamB: false },
       });
       let callCount = 0;
       const rng = () => {
         callCount++;
-        if (callCount <= 2) return 0.99; // casualty
+        if (callCount <= 2) return 0.99; // 6+6=12 (casualty)
         if (callCount === 3) return 0.99; // D16 → dead (roll=16)
-        return 0.01; // regen fail
+        return 0.5;
       };
       const result = performInjuryRoll(state, state.players[0], rng);
 
-      // Regen failed → apothecary offered
       expect(result.pendingApothecary).toBeDefined();
       expect(result.pendingApothecary!.injuryType).toBe('casualty');
+      expect(result.pendingApothecary!.fallbackToRegeneration).toBe(true);
+      expect(result.pendingApothecary!.originalCasualtyOutcome).toBe('dead');
     });
 
     it('devrait effacer les lasting injury details si regeneration reussit', () => {


### PR DESCRIPTION
## Summary

**Lot O.A.1 du Sprint O** (cf. [SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md) en attente de merge dans #744).

Bug identifié par l'audit 2026-05-10 : l'ordre regeneration → apothecaire était **inversé** par rapport aux règles BB Season 2/3.

Règle officielle :
1. **Apothecaire offert en premier** (one-shot par match, choix coach).
2. Si **refusé** OU indisponible, ET joueur a Regeneration → regen roll D6 4+.
3. Si regen échoue ou pas de regen → casualty/KO reste.

L'ancien code (`mechanics/injury.ts:93-97` + `:237-241`) vérifiait regen AVANT apothecary → un coach FUMBBL veteran teste, voit "regen automatique, pas d'option apo", → 🔴.

## Changes

- `core/types.ts` : `PendingApothecary` ajoute `fallbackToRegeneration?: boolean`.
- `mechanics/injury.ts` : swap ordre dans `handleKnockedOut` et `handleCasualty` — apo proposé en premier, retour immédiat ; sinon regen directe en fallback (path legacy si pas d'apo).
- `mechanics/apothecary.ts` : `applyApothecaryChoice(state, false, rng)` déclenche regen si `fallbackToRegeneration === true`.

## Test plan
- [x] 4 tests `regeneration.test.ts` rééécrits pour le nouvel ordre (apo first, refus → regen succes/echec, casualty fallback).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/game-engine test` — 4940 verts.
- [x] `pnpm --filter @bb/server test` — 2147 verts.
- [x] `pnpm --filter @bb/web test` — 904 verts.
- [ ] Smoke : créer un match avec joueur Undead + apo dispo → KO → vérifier que l'UI propose apo en premier, refus → regen attempt visible dans log.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_