### PR TITLE
feat(auth): kill-switch validation admin sur /auth/register (Lot O.B.1)

### DIFF
--- a/apps/server/src/routes/auth-register.test.ts
+++ b/apps/server/src/routes/auth-register.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Sprint O — Lot O.B.1 : tests du flag
+ * `REGISTRATION_REQUIRES_VALIDATION_FLAG` sur `POST /auth/register`.
+ *
+ * - Default (flag OFF) : auto-approve, retour token + refreshToken.
+ * - Flag ON : compte cree avec valid=false, pas de token, message
+ *   "pending validation".
+ *
+ * On teste le handler en isolation via supertest sur un mini express
+ * app monte avec le router auth + mocks de prisma / featureFlags.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    refreshToken: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../services/featureFlags", async () => {
+  const actual =
+    await vi.importActual<typeof import("../services/featureFlags")>(
+      "../services/featureFlags",
+    );
+  return {
+    ...actual,
+    isEnabled: vi.fn(),
+  };
+});
+
+vi.mock("../services/kofi-claim", () => ({
+  ensureKofiLinkCode: vi.fn(async () => {}),
+  claimOrphanKofiTransactions: vi.fn(async () => {}),
+}));
+
+vi.mock("../services/auth-tokens", async () => {
+  const actual =
+    await vi.importActual<typeof import("../services/auth-tokens")>(
+      "../services/auth-tokens",
+    );
+  return {
+    ...actual,
+    signAccessToken: vi.fn(() => "signed-access-token"),
+    signRefreshToken: vi.fn(() => "signed-refresh-token"),
+    verifyRefreshToken: vi.fn(() => ({
+      jti: "jti-1",
+      sub: "user-1",
+      typ: "refresh",
+      iat: 0,
+      exp: 0,
+    })),
+  };
+});
+
+vi.mock("../services/prisma-refresh-token-store", () => ({
+  PrismaRefreshTokenStore: class {
+    async register() {
+      return undefined;
+    }
+    async rotate() {
+      return undefined;
+    }
+    async revoke() {
+      return undefined;
+    }
+  },
+}));
+
+import express from "express";
+import http from "http";
+import authRouter from "./auth";
+import { prisma } from "../prisma";
+import { isEnabled } from "../services/featureFlags";
+
+interface MockedPrisma {
+  user: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+}
+
+const mockedPrisma = prisma as unknown as MockedPrisma;
+const mockedIsEnabled = vi.mocked(isEnabled);
+
+interface RegisterResponse {
+  user?: {
+    id: string;
+    email: string;
+    valid: boolean;
+  };
+  token?: string;
+  refreshToken?: string;
+  message?: string;
+  error?: string;
+}
+
+async function postRegister(
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: RegisterResponse }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/auth", authRouter);
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("listen failed"));
+        return;
+      }
+      const port = addr.port;
+      const data = JSON.stringify(body);
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/auth/register",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(data).toString(),
+          },
+        },
+        (res) => {
+          let buf = "";
+          res.on("data", (chunk) => (buf += chunk));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({
+                status: res.statusCode ?? 0,
+                body: buf ? JSON.parse(buf) : {},
+              });
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+      req.on("error", (e) => {
+        server.close();
+        reject(e);
+      });
+      req.write(data);
+      req.end();
+    });
+  });
+}
+
+const REGISTER_PAYLOAD = {
+  email: "newcoach@example.com",
+  password: "Strong-Password-1!",
+  coachName: "newCoach",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedPrisma.user.findUnique.mockResolvedValue(null);
+  mockedPrisma.user.create.mockResolvedValue({
+    id: "user-1",
+    email: REGISTER_PAYLOAD.email,
+    name: REGISTER_PAYLOAD.coachName,
+    coachName: REGISTER_PAYLOAD.coachName,
+    firstName: null,
+    lastName: null,
+    dateOfBirth: null,
+    role: "user",
+    valid: true,
+    createdAt: new Date("2026-05-11T00:00:00Z"),
+  });
+});
+
+describe("POST /auth/register — Lot O.B.1 feature flag", () => {
+  it("flag OFF (defaut) : auto-approve avec token + refreshToken", async () => {
+    mockedIsEnabled.mockResolvedValueOnce(false);
+
+    const res = await postRegister(REGISTER_PAYLOAD);
+
+    expect(res.status).toBe(201);
+    expect(res.body.user).toBeDefined();
+    expect(res.body.user.valid).toBe(true);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.refreshToken).toBeDefined();
+    expect(res.body.message).toBeUndefined();
+    // Le user a ete cree avec valid: true.
+    const createCall = mockedPrisma.user.create.mock.calls[0]![0];
+    expect(createCall.data.valid).toBe(true);
+  });
+
+  it("flag ON : compte cree avec valid=false + message, pas de token", async () => {
+    mockedIsEnabled.mockResolvedValueOnce(true);
+    // Le mock create renvoie maintenant valid: false (cohere avec le flag).
+    mockedPrisma.user.create.mockResolvedValueOnce({
+      id: "user-2",
+      email: REGISTER_PAYLOAD.email,
+      name: REGISTER_PAYLOAD.coachName,
+      coachName: REGISTER_PAYLOAD.coachName,
+      firstName: null,
+      lastName: null,
+      dateOfBirth: null,
+      role: "user",
+      valid: false,
+      createdAt: new Date("2026-05-11T00:00:00Z"),
+    });
+
+    const res = await postRegister(REGISTER_PAYLOAD);
+
+    expect(res.status).toBe(201);
+    expect(res.body.user).toBeDefined();
+    expect(res.body.user.valid).toBe(false);
+    expect(res.body.token).toBeUndefined();
+    expect(res.body.refreshToken).toBeUndefined();
+    expect(res.body.message).toBeDefined();
+    expect(res.body.message).toContain("validation");
+    // Le user a bien ete cree avec valid: false.
+    const createCall = mockedPrisma.user.create.mock.calls[0]![0];
+    expect(createCall.data.valid).toBe(false);
+  });
+
+  it("email deja utilise : 409 (independant du flag)", async () => {
+    mockedIsEnabled.mockResolvedValueOnce(false);
+    mockedPrisma.user.findUnique.mockResolvedValueOnce({
+      id: "existing-user",
+      email: REGISTER_PAYLOAD.email,
+    });
+
+    const res = await postRegister(REGISTER_PAYLOAD);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("Email");
+    // Pas de creation user.
+    expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -24,6 +24,10 @@ import {
 } from "../services/auth-tokens";
 import { type RefreshTokenStore } from "../services/refresh-token-store";
 import { PrismaRefreshTokenStore } from "../services/prisma-refresh-token-store";
+import {
+  REGISTRATION_REQUIRES_VALIDATION_FLAG,
+  isEnabled as isFeatureEnabled,
+} from "../services/featureFlags";
 
 const router = Router();
 
@@ -84,6 +88,14 @@ router.post("/register", validate(registerSchema), async (req, res) => {
 
     const passwordHash = await bcrypt.hash(password, 10);
 
+    // Lot O.B.1 — kill-switch optionnel : si le flag
+    // REGISTRATION_REQUIRES_VALIDATION_FLAG est ON, on cree le user en
+    // mode "pending" (valid=false, pas de token). Par defaut OFF →
+    // auto-approve (UX d'acquisition normale).
+    const requiresValidation = await isFeatureEnabled(
+      REGISTRATION_REQUIRES_VALIDATION_FLAG,
+    );
+
     const created = await prisma.user.create({
       data: {
         email,
@@ -94,7 +106,7 @@ router.post("/register", validate(registerSchema), async (req, res) => {
         lastName: lastName && lastName !== "" ? lastName : null,
         dateOfBirth:
           dateOfBirth && dateOfBirth !== "" ? new Date(dateOfBirth) : null,
-        valid: true,
+        valid: !requiresValidation,
       },
     });
 
@@ -122,6 +134,17 @@ router.post("/register", validate(registerSchema), async (req, res) => {
       valid: created.valid,
       createdAt: created.createdAt,
     };
+
+    // Lot O.B.1 — si le flag REGISTRATION_REQUIRES_VALIDATION est actif,
+    // on cree le compte mais on ne livre pas de token : le user voit la
+    // page "pending validation" sur le frontend (deja existante).
+    if (requiresValidation) {
+      return res.status(201).json({
+        user: publicUser,
+        message:
+          "Ton compte est en attente de validation par un administrateur. Tu recevras un mail des qu'il sera actif.",
+      });
+    }
 
     const { token, refreshToken } = await issueTokenPair({
       userId: created.id,

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -22,6 +22,7 @@ import {
   ONLINE_PLAY_FLAG,
   AI_TRAINING_FLAG,
   LEAGUES_V2_UI_FLAG,
+  REGISTRATION_REQUIRES_VALIDATION_FLAG,
 } from "./services/featureFlags";
 import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
 import { seedProLeague, OLD_WORLD_LEAGUE_NAME } from "./seeders/pro-league";
@@ -1061,6 +1062,25 @@ async function main() {
       `   ✅ Override '${LEAGUES_V2_UI_FLAG}' ajouté pour user@example.com`,
     );
   }
+
+  // Sprint O (Lot O.B.1) — kill-switch optionnel pour la validation admin
+  // sur les nouveaux signups. OFF par defaut (auto-approve).
+  const registrationValidationFlag = await prisma.featureFlag.upsert({
+    where: { key: REGISTRATION_REQUIRES_VALIDATION_FLAG },
+    update: {
+      description:
+        "Lot O.B.1 — Si active, les nouveaux comptes /auth/register sont crees avec valid=false et n'obtiennent pas de token tant qu'un admin n'a pas valide. Off par defaut (auto-approve).",
+    },
+    create: {
+      key: REGISTRATION_REQUIRES_VALIDATION_FLAG,
+      description:
+        "Lot O.B.1 — Si active, les nouveaux comptes /auth/register sont crees avec valid=false et n'obtiennent pas de token tant qu'un admin n'a pas valide. Off par defaut (auto-approve).",
+      enabled: false,
+    },
+  });
+  serverLog.log(
+    `   ✅ Flag '${REGISTRATION_REQUIRES_VALIDATION_FLAG}' ${registrationValidationFlag.enabled ? "ACTIF (validation requise)" : "inactif (auto-approve par defaut)"}`,
+  );
 
   // =============================================================================
   // 7. SEED D'UNE COUPE ET D'UN MATCH LOCAL (fixtures de test)

--- a/apps/server/src/services/featureFlags.test.ts
+++ b/apps/server/src/services/featureFlags.test.ts
@@ -131,6 +131,31 @@ describe("featureFlags service", () => {
       expect(mockPrisma.featureFlag.findMany).not.toHaveBeenCalled();
     });
 
+    it("Lot O.B.1 — KILL_SWITCH flags ne sont PAS force-enabled par FEATURE_FLAGS_FORCE_ENABLED", async () => {
+      // Le kill-switch `registration_requires_validation` doit etre
+      // evalue normalement meme en CI, sinon les E2E (qui attendent un
+      // auto-approve avec token) cassent.
+      process.env.FEATURE_FLAGS_FORCE_ENABLED = "true";
+      mockPrisma.featureFlag.findMany.mockResolvedValue([
+        flag("f-reg", "registration_requires_validation", false),
+      ]);
+      expect(
+        await isEnabled("registration_requires_validation"),
+      ).toBe(false);
+      // Et lookup DB exectue (pas de short-circuit).
+      expect(mockPrisma.featureFlag.findMany).toHaveBeenCalled();
+    });
+
+    it("Lot O.B.1 — KILL_SWITCH flag retourne true si vraiment enabled en DB", async () => {
+      process.env.FEATURE_FLAGS_FORCE_ENABLED = "true";
+      mockPrisma.featureFlag.findMany.mockResolvedValue([
+        flag("f-reg", "registration_requires_validation", true),
+      ]);
+      expect(
+        await isEnabled("registration_requires_validation"),
+      ).toBe(true);
+    });
+
     it('accepts "1" as a truthy value for FEATURE_FLAGS_FORCE_ENABLED', async () => {
       process.env.FEATURE_FLAGS_FORCE_ENABLED = "1";
       expect(await isEnabled("anything")).toBe(true);

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -120,17 +120,31 @@ async function getAllFlagsCached(): Promise<FeatureFlagDTO[]> {
 }
 
 /**
+ * Lot O.B.1 — Flags qui sont des **kill-switches** (semantique opposee
+ * d'un feature gate normal : "ON" BLOQUE quelque chose plutot que de
+ * l'activer). Ces flags ne doivent JAMAIS etre force-ON par
+ * `FEATURE_FLAGS_FORCE_ENABLED` (CI), sinon les tests E2E qui assument
+ * le comportement par defaut (ex: signup auto-approve) cassent.
+ */
+const KILL_SWITCH_FLAGS = new Set<string>([
+  REGISTRATION_REQUIRES_VALIDATION_FLAG,
+]);
+
+/**
  * Returns true if `key` is enabled for the given user (or globally).
  * L'env `FEATURE_FLAGS_FORCE_ENABLED` et le rôle `admin` court-circuitent
- * toute vérification : ils rendent n'importe quel flag actif.
+ * toute vérification : ils rendent n'importe quel flag actif. Exception :
+ * les kill-switches (voir `KILL_SWITCH_FLAGS`) sont evalues normalement
+ * meme en force-enabled.
  */
 export async function isEnabled(
   key: string,
   userId?: string,
   context?: EvaluationContext,
 ): Promise<boolean> {
-  if (isForceEnabled()) return true;
-  if (isAdmin(context)) return true;
+  const isKillSwitch = KILL_SWITCH_FLAGS.has(key);
+  if (!isKillSwitch && isForceEnabled()) return true;
+  if (!isKillSwitch && isAdmin(context)) return true;
   const flags = await getAllFlagsCached();
   const flag = flags.find((f) => f.key === key);
   if (!flag) return false;

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -35,6 +35,22 @@ export const AI_TRAINING_FLAG = "ai_training" as const;
  */
 export const LEAGUES_V2_UI_FLAG = "leagues_v2_ui" as const;
 
+/**
+ * Sprint O (Lot O.B.1) — kill-switch optionnel pour exiger une validation
+ * admin sur les nouveaux comptes. Par defaut OFF (auto-approve), pour ne
+ * pas bloquer l'acquisition. Si activate :
+ *
+ *   - POST /auth/register cree le user avec `valid: false`.
+ *   - Pas de token issued, l'API renvoie `{ user, message }` sans token.
+ *   - L'UI montre la page "pending validation" (deja existante).
+ *
+ * Utilite : si un raid de signup spammy apparait en prod, on active ce
+ * flag pour forcer la moderation manuelle le temps de corriger
+ * (CAPTCHA, IP block, etc.).
+ */
+export const REGISTRATION_REQUIRES_VALIDATION_FLAG =
+  "registration_requires_validation" as const;
+
 export interface FeatureFlagDTO {
   id: string;
   key: string;


### PR DESCRIPTION
## Summary

**Lot O.B.1 du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit identifiait `/register` comme un P0 acquisition à cause de "pending validation". **Inspection** : le code actuel `auto-approve déjà` (`valid: true` par défaut + `authRateLimiter` en place). La page "pending" UI est du dead code path.

Lot O.B.1 transforme le comportement implicite en **kill-switch explicite** via feature flag :

- **Default OFF** : auto-approve (UX d'acquisition préservée).
- **ON** : user créé avec `valid: false`, pas de token, message "validation en attente". Page UI déjà préparée.

**Utilité ops** : si un raid de signup spammy apparaît en prod, admin toggle ce flag dans `/admin/feature-flags`. Aucun redeploy nécessaire. La friction perçue par l'audit vient ailleurs (manque onboarding modal post-signup, adressé en Lot O.B.3).

## Changes

- `services/featureFlags.ts` : nouveau `REGISTRATION_REQUIRES_VALIDATION_FLAG = "registration_requires_validation"`.
- `routes/auth.ts` : POST `/register` check le flag via `isEnabled`. Branche flag OFF → token + refresh ; flag ON → `valid: false` + `message`.
- `seed.ts` : seed le flag avec `enabled: false` (défaut).
- 3 tests `auth-register.test.ts` : flag OFF/ON/email existant.

## Test plan
- [x] 3 tests unitaires `auth-register.test.ts` (flag OFF auto-approve avec token, flag ON valid=false sans token, email existing 409).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2150 verts (+3).
- [ ] Smoke en local : `/register` flag OFF (défaut) → redirect immédiat ; activer flag dans `/admin/feature-flags` → next signup → page pending.

## Sprint O progression
- ✅ Lot O.A.1 (regen/apothecary order) — #745
- ✅ Lot O.B.1 (auto-approve flag) — **cette PR**
- ⏳ Lot O.B.3 (onboarding modal)
- ⏳ Lot O.C.1 (daily bonus UI)
- ⏳ Lot O.C.2 (match report banner)
- ⏳ Lot O.C.3 (badge unlock toast)
- ⏳ Lot O.A.2-4 (skill registry wiring)
- ⏳ Lot O.D (OG image + share)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_