### PR TITLE
feat(web): onboarding modal post-signup sur /me/teams (Lot O.B.3)

### DIFF
--- a/apps/web/app/me/teams/_components/OnboardingModal.test.tsx
+++ b/apps/web/app/me/teams/_components/OnboardingModal.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests pour `OnboardingModal` (Sprint O — Lot O.B.3).
+ *
+ * Conditions d'affichage :
+ *   - `userCreatedAt` recent (< 24h).
+ *   - `teamsCount === 0`.
+ *   - Flag localStorage `onboarding_dismissed_v1` absent.
+ *
+ * Conditions de masquage :
+ *   - `userCreatedAt` null / undefined / invalide.
+ *   - Compte > 24h.
+ *   - `teamsCount > 0`.
+ *   - Flag dismiss deja set.
+ *
+ * Au click sur un CTA ou skip ou X, le flag est set.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import OnboardingModal from "./OnboardingModal";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+const RECENT = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+const OLD = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(); // 48h ago
+
+describe("OnboardingModal — Lot O.B.3", () => {
+  it("s'affiche pour un nouveau coach (createdAt < 24h, 0 equipes)", () => {
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={0} />);
+    expect(screen.getByTestId("onboarding-modal")).toBeTruthy();
+    expect(screen.getByTestId("onboarding-cta-team")).toBeTruthy();
+    expect(screen.getByTestId("onboarding-cta-tutorial")).toBeTruthy();
+    expect(screen.getByTestId("onboarding-cta-pro-league")).toBeTruthy();
+  });
+
+  it("ne s'affiche pas si l'user a deja au moins une equipe", () => {
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={1} />);
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+  });
+
+  it("ne s'affiche pas si le compte a plus de 24h", () => {
+    render(<OnboardingModal userCreatedAt={OLD} teamsCount={0} />);
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+  });
+
+  it("ne s'affiche pas si userCreatedAt est null ou invalide", () => {
+    const { rerender } = render(
+      <OnboardingModal userCreatedAt={null} teamsCount={0} />,
+    );
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+
+    rerender(
+      <OnboardingModal userCreatedAt="not-a-date" teamsCount={0} />,
+    );
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+  });
+
+  it("ne s'affiche pas si le flag dismiss est deja set", () => {
+    window.localStorage.setItem("onboarding_dismissed_v1", "1");
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={0} />);
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+  });
+
+  it("le bouton 'Plus tard' ferme le modal et set le flag dismiss", () => {
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={0} />);
+    fireEvent.click(screen.getByTestId("onboarding-skip"));
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+    expect(window.localStorage.getItem("onboarding_dismissed_v1")).toBe("1");
+  });
+
+  it("le bouton X (fermer) ferme et set le flag dismiss", () => {
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={0} />);
+    fireEvent.click(screen.getByTestId("onboarding-close"));
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+    expect(window.localStorage.getItem("onboarding_dismissed_v1")).toBe("1");
+  });
+
+  it("click sur un CTA ferme aussi le modal (et permet navigation)", () => {
+    render(<OnboardingModal userCreatedAt={RECENT} teamsCount={0} />);
+    fireEvent.click(screen.getByTestId("onboarding-cta-team"));
+    // Le modal disparait du DOM apres dismiss.
+    expect(screen.queryByTestId("onboarding-modal")).toBeNull();
+    expect(window.localStorage.getItem("onboarding_dismissed_v1")).toBe("1");
+  });
+});

--- a/apps/web/app/me/teams/_components/OnboardingModal.tsx
+++ b/apps/web/app/me/teams/_components/OnboardingModal.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Sprint O — Lot O.B.3 : modal d'onboarding post-signup.
+ *
+ * Affiche un modal welcome avec 3 CTAs quand un nouveau coach
+ * arrive sur /me/teams pour la 1ere fois :
+ *
+ *   - Conditions : `createdAt < 24h` ET `teams.length === 0` ET pas
+ *     deja "dismiss" (flag localStorage `onboarding_dismissed_v1`).
+ *   - 3 CTAs : "Creer mon equipe" (lien /me/teams/new), "Faire le
+ *     tutoriel" (lien /tutoriel), "Voir la Pro League" (lien
+ *     /pro-league).
+ *   - Skip / X : ferme + flag localStorage pour eviter re-affichage.
+ *
+ * Avant Lot O.B.3, un nouveau coach atterrissait sur /me/teams vide
+ * sans guidance → 40% bounce day-0 estime.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const DISMISS_KEY = "onboarding_dismissed_v1";
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+interface OnboardingModalProps {
+  /** Date ISO du `createdAt` du user. Si null, le modal ne s'affiche pas. */
+  readonly userCreatedAt: string | null | undefined;
+  /** Nombre d'equipes de l'user. Modal seulement si 0. */
+  readonly teamsCount: number;
+}
+
+export default function OnboardingModal({
+  userCreatedAt,
+  teamsCount,
+}: OnboardingModalProps): JSX.Element | null {
+  const [open, setOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!userCreatedAt) return;
+    if (teamsCount > 0) return;
+
+    // Skip si deja dismiss.
+    const dismissed = window.localStorage.getItem(DISMISS_KEY);
+    if (dismissed === "1") return;
+
+    // Skip si compte trop ancien (> 24h).
+    const createdMs = new Date(userCreatedAt).getTime();
+    if (Number.isNaN(createdMs)) return;
+    if (Date.now() - createdMs > MAX_AGE_MS) return;
+
+    setOpen(true);
+  }, [userCreatedAt, teamsCount]);
+
+  const dismiss = (): void => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+    }
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="onboarding-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={dismiss}
+    >
+      <div
+        className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          data-testid="onboarding-close"
+          onClick={dismiss}
+          aria-label="Fermer"
+          className="absolute right-3 top-3 rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+
+        <h2
+          id="onboarding-title"
+          className="mb-2 text-2xl font-bold text-slate-900"
+        >
+          Bienvenue dans l'arène, coach !
+        </h2>
+        <p className="mb-6 text-sm text-slate-600">
+          Trois façons de démarrer ton aventure Blood Bowl. Choisis celle qui
+          te tente le plus — tu pourras revenir aux autres après.
+        </p>
+
+        <div className="space-y-3">
+          <Link
+            data-testid="onboarding-cta-team"
+            href="/me/teams/new"
+            onClick={dismiss}
+            className="flex items-center gap-3 rounded-lg border border-emerald-600 bg-emerald-50 p-4 text-left transition hover:bg-emerald-100"
+          >
+            <span className="text-2xl" aria-hidden="true">
+              🛡️
+            </span>
+            <div className="flex-1">
+              <div className="font-semibold text-emerald-900">
+                Crée ta première équipe
+              </div>
+              <div className="text-xs text-emerald-700">
+                30 races jouables · Builder visuel · 1000kPo de budget de
+                base
+              </div>
+            </div>
+            <span className="text-emerald-700" aria-hidden="true">
+              →
+            </span>
+          </Link>
+
+          <Link
+            data-testid="onboarding-cta-tutorial"
+            href="/tutoriel"
+            onClick={dismiss}
+            className="flex items-center gap-3 rounded-lg border border-sky-600 bg-sky-50 p-4 text-left transition hover:bg-sky-100"
+          >
+            <span className="text-2xl" aria-hidden="true">
+              📖
+            </span>
+            <div className="flex-1">
+              <div className="font-semibold text-sky-900">
+                Apprends les règles
+              </div>
+              <div className="text-xs text-sky-700">
+                Tutoriel interactif : block, dodge, GFI, casualties — en 10
+                min
+              </div>
+            </div>
+            <span className="text-sky-700" aria-hidden="true">
+              →
+            </span>
+          </Link>
+
+          <Link
+            data-testid="onboarding-cta-pro-league"
+            href="/pro-league"
+            onClick={dismiss}
+            className="flex items-center gap-3 rounded-lg border border-amber-600 bg-amber-50 p-4 text-left transition hover:bg-amber-100"
+          >
+            <span className="text-2xl" aria-hidden="true">
+              🏆
+            </span>
+            <div className="flex-1">
+              <div className="font-semibold text-amber-900">
+                Suis la Pro League
+              </div>
+              <div className="text-xs text-amber-700">
+                16 équipes IA, matchs live mardi 21h, paris en Crowns +
+                Gazette quotidienne
+              </div>
+            </div>
+            <span className="text-amber-700" aria-hidden="true">
+              →
+            </span>
+          </Link>
+        </div>
+
+        <button
+          data-testid="onboarding-skip"
+          onClick={dismiss}
+          className="mt-5 w-full rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-600 hover:bg-slate-50"
+        >
+          Plus tard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/me/teams/page.tsx
+++ b/apps/web/app/me/teams/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { API_BASE } from "../../auth-client";
 import { apiRequest } from "../../lib/api-client";
 import { useLanguage } from "../../contexts/LanguageContext";
+import OnboardingModal from "./_components/OnboardingModal";
 
 type Team = {
   id: string;
@@ -46,6 +47,8 @@ export default function MyTeamsPage() {
   const [rosterNames, setRosterNames] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  /** Lot O.B.3 — `createdAt` du user pour decider d'afficher le modal welcome. */
+  const [userCreatedAt, setUserCreatedAt] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -76,6 +79,10 @@ export default function MyTeamsPage() {
           return;
         }
 
+        // Lot O.B.3 — `createdAt` est expose par /auth/me (cf. auth.ts).
+        if (typeof me.user.createdAt === "string") {
+          setUserCreatedAt(me.user.createdAt);
+        }
         setTeams(mine?.teams ?? []);
 
         if (rostersResponse && rostersResponse.ok) {
@@ -98,6 +105,12 @@ export default function MyTeamsPage() {
 
   return (
     <div className="w-full p-4 sm:p-6 space-y-4 sm:space-y-6">
+      {!loading && (
+        <OnboardingModal
+          userCreatedAt={userCreatedAt}
+          teamsCount={teams.length}
+        />
+      )}
       <h1 className="text-xl sm:text-2xl font-bold">{t.teams.title}</h1>
       {error && <p className="text-red-600 text-sm">{error}</p>}
       {loading && <TeamsSkeleton />}


### PR DESCRIPTION
## Summary

**Lot O.B.3 du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit 2026-05-10 identifiait `/register` + `/me/teams` comme le P0 acquisition : un nouveau coach atterrissait sur teams vide sans guidance → 40% bounce day-0 estimé.

Modal welcome qui s'affiche au premier passage sur `/me/teams` pour les nouveaux comptes :

- **Conditions** : `createdAt < 24h` ET `teams.length === 0` ET pas déjà dismiss (flag `localStorage[onboarding_dismissed_v1]`).
- **3 CTAs** avec teaser engageant :
  - 🛡️ **Crée ta première équipe** — 30 races, builder visuel, 1000kPo.
  - 📖 **Apprends les règles** — Tutoriel interactif 10 min.
  - 🏆 **Suis la Pro League** — 16 équipes IA, mardi 21h, paris Crowns + Gazette.
- Bouton "Plus tard" + X + click backdrop → ferme + flag dismiss.

A11y : `role="dialog"`, `aria-modal`, `aria-labelledby`, keyboard nav OK.

## Test plan
- [x] 8 tests `OnboardingModal.test.tsx` (recent + 0 teams = visible ; 1 team / 48h / null / dismissed = invisible ; skip / X / CTA → flag set + close).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/web test` — 912 verts (+8).
- [ ] Smoke : créer compte test → /me/teams → modal visible avec 3 CTAs → click "Plus tard" → modal disparaît → refresh page → modal pas re-affiché.

## Sprint O progression
- ✅ Lot O.A.1 (regen/apothecary order) — #745
- ✅ Lot O.B.1 (auto-approve flag) — #746 (+ follow-up fix kill-switch CI)
- ✅ Lot O.B.3 (onboarding modal) — **cette PR**
- ⏳ Lot O.C.1 (daily bonus UI)
- ⏳ Lot O.C.2 (match report banner)
- ⏳ Lot O.C.3 (badge unlock toast)
- ⏳ Lot O.A.2-4 (skill registry wiring)
- ⏳ Lot O.D (OG image + share)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_