### PR TITLE
feat(pro-league): daily bonus claim UI sur /me/wallet (Lot O.C.1)

### DIFF
--- a/apps/web/app/pro-league/me/wallet/_components/DailyBonusCard.test.tsx
+++ b/apps/web/app/pro-league/me/wallet/_components/DailyBonusCard.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Tests pour `DailyBonusCard` (Sprint O — Lot O.C.1).
+ *
+ * Couvre :
+ *   - Loading state au mount.
+ *   - canClaim=true → bouton "Reclamer +50".
+ *   - Click claim → granted=true → message succes + onClaimed callback.
+ *   - canClaim=false → countdown affiche.
+ *   - 500 / error → message d'erreur.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {
+    public readonly status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+      this.name = "ApiClientError";
+    }
+  },
+}));
+
+import { apiRequest } from "../../../../lib/api-client";
+import DailyBonusCard from "./DailyBonusCard";
+
+const mockedApi = vi.mocked(apiRequest);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DailyBonusCard — Lot O.C.1", () => {
+  it("affiche loading au mount", () => {
+    mockedApi.mockReturnValue(new Promise(() => undefined));
+    render(<DailyBonusCard />);
+    expect(screen.getByTestId("daily-bonus-card").textContent).toContain(
+      "Chargement",
+    );
+  });
+
+  it("canClaim=true : affiche le bouton 'Reclamer +50'", async () => {
+    mockedApi.mockResolvedValueOnce({
+      canClaim: true,
+      nextEligibleAt: null,
+    });
+    render(<DailyBonusCard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("daily-bonus-claim")).toBeTruthy();
+    });
+    expect(screen.getByTestId("daily-bonus-claim").textContent).toContain(
+      "Réclamer +50",
+    );
+  });
+
+  it("click 'Reclamer' → granted=true → affiche message succes + appelle onClaimed", async () => {
+    mockedApi.mockResolvedValueOnce({
+      canClaim: true,
+      nextEligibleAt: null,
+    });
+    const onClaimed = vi.fn();
+    render(<DailyBonusCard onClaimed={onClaimed} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("daily-bonus-claim")).toBeTruthy();
+    });
+
+    // 2eme call = POST claim
+    mockedApi.mockResolvedValueOnce({
+      granted: true,
+      balance: 1050,
+      amount: 50,
+      nextEligibleAt: new Date(Date.now() + 24 * 3600_000).toISOString(),
+    });
+    fireEvent.click(screen.getByTestId("daily-bonus-claim"));
+
+    await waitFor(() => {
+      const card = screen.getByTestId("daily-bonus-card");
+      expect(card.textContent).toContain("+50 Crowns");
+    });
+    expect(onClaimed).toHaveBeenCalledTimes(1);
+  });
+
+  it("canClaim=false : affiche un countdown", async () => {
+    const nextAt = new Date(Date.now() + 5 * 3600_000).toISOString(); // 5h
+    mockedApi.mockResolvedValueOnce({
+      canClaim: false,
+      nextEligibleAt: nextAt,
+    });
+    render(<DailyBonusCard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("daily-bonus-countdown")).toBeTruthy();
+    });
+    // 5h doit afficher "5h00" ou similaire
+    expect(screen.getByTestId("daily-bonus-countdown").textContent).toMatch(
+      /^[45]h/,
+    );
+  });
+
+  it("erreur API → message d'erreur", async () => {
+    mockedApi.mockRejectedValueOnce(new Error("boom"));
+    render(<DailyBonusCard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("daily-bonus-card").textContent).toContain(
+        "Bonus quotidien indisponible",
+      );
+    });
+  });
+
+  it("granted=false defensive : refresh status sans message succes", async () => {
+    mockedApi.mockResolvedValueOnce({
+      canClaim: true,
+      nextEligibleAt: null,
+    });
+    const onClaimed = vi.fn();
+    render(<DailyBonusCard onClaimed={onClaimed} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("daily-bonus-claim")).toBeTruthy();
+    });
+
+    // Race condition : POST renvoie granted=false (already claimed in another tab)
+    mockedApi.mockResolvedValueOnce({
+      granted: false,
+      balance: 1000,
+      amount: 0,
+      nextEligibleAt: new Date(Date.now() + 23 * 3600_000).toISOString(),
+    });
+    fireEvent.click(screen.getByTestId("daily-bonus-claim"));
+
+    await waitFor(() => {
+      // Affiche countdown, pas message succes
+      expect(screen.queryByTestId("daily-bonus-countdown")).toBeTruthy();
+    });
+    expect(onClaimed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/pro-league/me/wallet/_components/DailyBonusCard.tsx
+++ b/apps/web/app/pro-league/me/wallet/_components/DailyBonusCard.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+/**
+ * Sprint O — Lot O.C.1 : carte "Daily bonus" sur la page wallet.
+ *
+ * Le service backend `pro-wallet-rewards.claimDailyBonus` existe depuis
+ * Lot 1.D.6 (route `POST /pro-league/me/wallet/daily-bonus`) mais
+ * aucune UI ne l'expose. L'audit 2026-05-10 identifiait ca comme un
+ * hook retention manquant (+40% DAU attendu).
+ *
+ * Affiche :
+ *   - Streak (si tu reviens N jours d'affilee) — Lot futur si on
+ *     persiste un streak ; pour O.C.1 on affiche juste l'etat claim.
+ *   - Bouton "Reclamer +50 Crowns" si claimable.
+ *   - Compte a rebours "Disponible dans Xh" si deja claim.
+ *   - Toast / message de succes apres claim.
+ *
+ * Endpoints :
+ *   - `GET /pro-league/me/wallet/daily-bonus` → `{ canClaim, nextEligibleAt? }`
+ *   - `POST /pro-league/me/wallet/daily-bonus` → `{ granted, balance, amount, nextEligibleAt }`
+ */
+
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../../lib/api-client";
+
+interface DailyBonusStatus {
+  canClaim: boolean;
+  nextEligibleAt: string | null;
+  amount?: number;
+}
+
+interface ClaimOutcome {
+  granted: boolean;
+  balance: number;
+  amount: number;
+  nextEligibleAt: string | null;
+}
+
+interface DailyBonusCardProps {
+  /**
+   * Callback appele apres un claim reussi (granted=true) pour rafraichir
+   * le wallet parent (balance + transactions).
+   */
+  readonly onClaimed?: () => void;
+}
+
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return "maintenant";
+  const totalMin = Math.floor(ms / 60000);
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (h >= 1) return `${h}h${m.toString().padStart(2, "0")}`;
+  return `${m} min`;
+}
+
+export default function DailyBonusCard({
+  onClaimed,
+}: DailyBonusCardProps): JSX.Element {
+  const [status, setStatus] = useState<DailyBonusStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [claiming, setClaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [justClaimed, setJustClaimed] = useState<number | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  // Refresh status au mount.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    apiRequest<DailyBonusStatus>("/pro-league/me/wallet/daily-bonus")
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Tick toutes les 30s pour rafraichir le countdown.
+  useEffect(() => {
+    if (!status || status.canClaim) return;
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  const claim = async (): Promise<void> => {
+    setClaiming(true);
+    setError(null);
+    try {
+      const out = await apiRequest<ClaimOutcome>(
+        "/pro-league/me/wallet/daily-bonus",
+        { method: "POST" },
+      );
+      if (out.granted) {
+        setJustClaimed(out.amount);
+        setStatus({
+          canClaim: false,
+          nextEligibleAt: out.nextEligibleAt,
+        });
+        onClaimed?.();
+      } else {
+        // Defensive : si pas granted (race condition), refresh status.
+        setStatus({
+          canClaim: false,
+          nextEligibleAt: out.nextEligibleAt,
+        });
+      }
+    } catch (e: unknown) {
+      setError((e as Error).message);
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <section
+        data-testid="daily-bonus-card"
+        className="mb-4 rounded border border-slate-800 bg-slate-900 px-4 py-3 text-sm text-slate-400"
+      >
+        Chargement du bonus quotidien…
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section
+        data-testid="daily-bonus-card"
+        className="mb-4 rounded border border-rose-800 bg-rose-950/40 px-4 py-3 text-sm text-rose-200"
+      >
+        Bonus quotidien indisponible : {error}
+      </section>
+    );
+  }
+
+  if (!status) return <></>;
+
+  // Just claimed → message de succes.
+  if (justClaimed !== null) {
+    return (
+      <section
+        data-testid="daily-bonus-card"
+        className="mb-4 rounded border border-emerald-700 bg-emerald-950/40 px-4 py-3"
+      >
+        <div className="text-xs uppercase text-emerald-400">
+          Bonus quotidien réclamé
+        </div>
+        <div className="mt-1 font-mono text-2xl text-emerald-200">
+          +{justClaimed} Crowns 🎉
+        </div>
+        <div className="mt-1 text-xs text-emerald-500">
+          Reviens demain pour ton prochain bonus !
+        </div>
+      </section>
+    );
+  }
+
+  // Status disponible.
+  if (status.canClaim) {
+    return (
+      <section
+        data-testid="daily-bonus-card"
+        className="mb-4 flex items-center justify-between rounded border border-amber-700 bg-amber-950/40 px-4 py-3"
+      >
+        <div>
+          <div className="text-xs uppercase text-amber-400">
+            Bonus quotidien
+          </div>
+          <div className="mt-1 text-sm text-amber-100">
+            Réclame ton bonus quotidien : <strong>+50 Crowns</strong>
+          </div>
+        </div>
+        <button
+          data-testid="daily-bonus-claim"
+          onClick={() => void claim()}
+          disabled={claiming}
+          className="rounded border border-amber-500 bg-amber-600 px-4 py-2 text-sm font-semibold text-amber-50 hover:bg-amber-500 disabled:opacity-50"
+        >
+          {claiming ? "Claim…" : "Réclamer +50"}
+        </button>
+      </section>
+    );
+  }
+
+  // Pas encore claimable : countdown.
+  const nextAt = status.nextEligibleAt
+    ? new Date(status.nextEligibleAt).getTime()
+    : null;
+  const remaining = nextAt ? nextAt - now : 0;
+  return (
+    <section
+      data-testid="daily-bonus-card"
+      className="mb-4 rounded border border-slate-800 bg-slate-900 px-4 py-3 text-sm text-slate-400"
+    >
+      <div className="text-xs uppercase text-slate-500">Bonus quotidien</div>
+      <div className="mt-1 text-slate-300">
+        Déjà réclamé aujourd'hui. Prochain bonus dans{" "}
+        <strong
+          data-testid="daily-bonus-countdown"
+          className="font-mono text-slate-100"
+        >
+          {formatCountdown(remaining)}
+        </strong>
+        .
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/pro-league/me/wallet/page.tsx
+++ b/apps/web/app/pro-league/me/wallet/page.tsx
@@ -21,6 +21,7 @@ import { ApiClientError, apiRequest } from "../../../lib/api-client";
 import { useWallet } from "../../../lib/use-wallet";
 
 import { WalletBadge } from "../../_components/WalletBadge";
+import DailyBonusCard from "./_components/DailyBonusCard";
 
 type ProTxType = "BET" | "WIN" | "REWARD" | "DAILY" | "BADGE";
 
@@ -95,6 +96,8 @@ export default function ProLeagueWalletPage(): JSX.Element {
   const [data, setData] = useState<WalletSnapshotResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  /** Lot O.C.1 — increment apres claim daily bonus → relance le fetch wallet. */
+  const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -120,7 +123,7 @@ export default function ProLeagueWalletPage(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [wallet.balance]);
+  }, [wallet.balance, refreshTick]);
 
   return (
     <main className="mx-auto flex min-h-screen max-w-3xl flex-col bg-slate-950 px-4 py-6 text-slate-100">
@@ -162,6 +165,8 @@ export default function ProLeagueWalletPage(): JSX.Element {
         </p>
       ) : !data ? null : (
         <>
+          <DailyBonusCard onClaimed={() => setRefreshTick((n) => n + 1)} />
+
           <section
             data-testid="wallet-balance"
             className="mb-6 rounded border border-amber-700 bg-amber-950/30 px-4 py-4"


### PR DESCRIPTION
## Summary

**Lot O.C.1 du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit 2026-05-10 identifiait le daily bonus comme un hook rétention manquant : le backend (`pro-wallet-rewards.claimDailyBonus` + routes GET/POST `/pro-league/me/wallet/daily-bonus`) existe depuis Lot 1.D.6, mais **aucune UI ne l'expose**. Gain attendu : +40% DAU.

Carte "Bonus quotidien" sur `/pro-league/me/wallet` au-dessus du solde :
- **canClaim=true** → bouton "Réclamer +50" (style amber/gold).
- Click → POST claim → message succès "+50 Crowns" + callback `onClaimed` rafraîchit le wallet.
- **canClaim=false** → "Déjà réclamé aujourd'hui, prochain bonus dans Xh" avec countdown live (tick 30s).
- **Défensif** : si POST renvoie `granted=false` (race condition entre tabs), bascule en countdown sans message succès.
- Erreur API → message "Bonus quotidien indisponible".

## Test plan
- [x] 6 tests `DailyBonusCard.test.tsx` (loading, canClaim+claim+success+onClaimed, countdown, error, defensive race).
- [x] 6 tests `page.test.tsx` existant restent verts.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/web test` — 910 verts (+6).
- [ ] Smoke en local : se connecter → `/pro-league/me/wallet` → carte avec bouton "Réclamer +50" → click → solde +50, message succès → refresh page → countdown.

## Sprint O progression
- ✅ Lot O.A.1 (regen/apothecary order) — #745
- ✅ Lot O.B.1 (auto-approve flag + kill-switch fix) — #746
- ✅ Lot O.B.3 (onboarding modal) — #747
- ✅ Lot O.C.1 (daily bonus UI) — **cette PR**
- ⏳ Lot O.C.2 (match report banner)
- ⏳ Lot O.C.3 (badge unlock toast)
- ⏳ Lot O.A.2-4 (skill registry wiring)
- ⏳ Lot O.D (OG image + share)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_