### PR TITLE
feat(pro-league): badge unlock toast + provider global (Lot O.C.3)

### DIFF
--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -41,6 +41,7 @@ import {
   getBetLeaderboard,
 } from "../services/pro-bet-leaderboard";
 import {
+  BADGE_CATALOGUE,
   evaluateBadgesForUser,
   getCatalogueWithStatus,
   listUserBadges,
@@ -640,6 +641,26 @@ export async function handleListMyBets(
 }
 
 /**
+ * Sprint O (Lot O.C.3) — Catalogue public des badges (code + name +
+ * description + emoji). Pas d'auth requis : sert au toast d'unlock
+ * pour afficher le nom + emoji du badge debloque, sans dependre de
+ * l'auth state du user.
+ */
+export function handleGetBadgeCatalogue(
+  _req: Request,
+  res: Response,
+): void {
+  res.json({
+    badges: BADGE_CATALOGUE.map((b) => ({
+      code: b.code,
+      name: b.name,
+      description: b.description,
+      emoji: b.emoji,
+    })),
+  });
+}
+
+/**
  * Sprint 1.D.9 — Liste les badges + statut (earned/not) du user.
  */
 export async function handleListMyBadges(
@@ -904,6 +925,7 @@ router.post("/bets", authUser, handlePlaceBet);
 router.get("/me/bets", authUser, handleListMyBets);
 
 // Sprint 1.D.9 — badges/titres.
+router.get("/badges", handleGetBadgeCatalogue);
 router.get("/me/badges", authUser, handleListMyBadges);
 router.post("/me/badges/evaluate", authUser, handleEvaluateMyBadges);
 

--- a/apps/web/app/pro-league/_components/BadgeToastProvider.test.tsx
+++ b/apps/web/app/pro-league/_components/BadgeToastProvider.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Tests pour `BadgeToastProvider` + `useBadgeNotify` (Sprint O — Lot O.C.3).
+ *
+ * Couvre :
+ *   - Catalogue charge au mount.
+ *   - notifyAndEvaluate() avec newlyEarned=[] → pas de toast.
+ *   - notifyAndEvaluate() avec newlyEarned=["first_kickoff"] → 1 toast.
+ *   - Multiple unlocks → 1 toast par badge.
+ *   - Toast dismiss via bouton X.
+ *   - useBadgeNotify() hors provider → no-op silencieux.
+ *   - notifyAndEvaluate() en erreur API → no-op silencieux (ne crash pas).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+
+vi.mock("../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+  ApiClientError: class ApiClientError extends Error {
+    public readonly status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+      this.name = "ApiClientError";
+    }
+  },
+}));
+
+import { apiRequest } from "../../lib/api-client";
+import {
+  BadgeToastProvider,
+  useBadgeNotify,
+} from "./BadgeToastProvider";
+
+const mockedApi = vi.mocked(apiRequest);
+
+const FAKE_CATALOGUE = {
+  badges: [
+    {
+      code: "first_kickoff",
+      name: "First Kickoff",
+      description: "Premier pari.",
+      emoji: "🥇",
+    },
+    {
+      code: "oracle_of_nuffle",
+      name: "Oracle of Nuffle",
+      description: "10 paris gagnants.",
+      emoji: "🔮",
+    },
+  ],
+};
+
+function TestHarness({
+  triggerCount = 0,
+}: {
+  triggerCount?: number;
+}): JSX.Element {
+  const { notifyAndEvaluate } = useBadgeNotify();
+  return (
+    <button
+      data-testid="trigger-evaluate"
+      onClick={() => void notifyAndEvaluate()}
+    >
+      trigger (count: {triggerCount})
+    </button>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BadgeToastProvider — Lot O.C.3", () => {
+  it("ne montre aucun toast au mount", async () => {
+    mockedApi.mockResolvedValueOnce(FAKE_CATALOGUE);
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await waitFor(() => {
+      // Container existe mais vide.
+      expect(screen.getByTestId("badge-toast-container").children.length).toBe(
+        0,
+      );
+    });
+  });
+
+  it("notifyAndEvaluate() avec newlyEarned=[] → pas de toast", async () => {
+    mockedApi
+      .mockResolvedValueOnce(FAKE_CATALOGUE) // catalogue
+      .mockResolvedValueOnce({ newlyEarned: [] }); // evaluate
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    expect(screen.getByTestId("badge-toast-container").children.length).toBe(
+      0,
+    );
+  });
+
+  it("notifyAndEvaluate() avec newlyEarned=[first_kickoff] → 1 toast avec name + emoji", async () => {
+    mockedApi
+      .mockResolvedValueOnce(FAKE_CATALOGUE)
+      .mockResolvedValueOnce({ newlyEarned: ["first_kickoff"] });
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    // Attendre que le catalogue soit charge
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("badge-toast-first_kickoff")).toBeTruthy();
+    });
+    const toast = screen.getByTestId("badge-toast-first_kickoff");
+    expect(toast.textContent).toContain("First Kickoff");
+    expect(toast.textContent).toContain("🥇");
+  });
+
+  it("multiple unlocks → 1 toast par badge", async () => {
+    mockedApi
+      .mockResolvedValueOnce(FAKE_CATALOGUE)
+      .mockResolvedValueOnce({
+        newlyEarned: ["first_kickoff", "oracle_of_nuffle"],
+      });
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("badge-toast-first_kickoff")).toBeTruthy();
+      expect(screen.getByTestId("badge-toast-oracle_of_nuffle")).toBeTruthy();
+    });
+  });
+
+  it("bouton dismiss ferme un toast individuellement", async () => {
+    mockedApi
+      .mockResolvedValueOnce(FAKE_CATALOGUE)
+      .mockResolvedValueOnce({ newlyEarned: ["first_kickoff"] });
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("badge-toast-first_kickoff")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("badge-toast-dismiss-first_kickoff"));
+    expect(screen.queryByTestId("badge-toast-first_kickoff")).toBeNull();
+  });
+
+  it("erreur API silencieuse : pas de crash, container reste vide", async () => {
+    mockedApi
+      .mockResolvedValueOnce(FAKE_CATALOGUE)
+      .mockRejectedValueOnce(new Error("boom"));
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    expect(screen.getByTestId("badge-toast-container").children.length).toBe(
+      0,
+    );
+  });
+
+  it("useBadgeNotify hors provider : no-op silencieux", async () => {
+    // Pas de BadgeToastProvider — useBadgeNotify renvoie un no-op
+    render(<TestHarness />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    // Pas de crash. Aucun container monte (provider absent).
+    expect(screen.queryByTestId("badge-toast-container")).toBeNull();
+  });
+
+  it("fallback emoji si catalogue indisponible", async () => {
+    mockedApi
+      .mockRejectedValueOnce(new Error("catalogue down"))
+      .mockResolvedValueOnce({ newlyEarned: ["unknown_badge"] });
+    render(
+      <BadgeToastProvider>
+        <TestHarness />
+      </BadgeToastProvider>,
+    );
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger-evaluate"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("badge-toast-unknown_badge")).toBeTruthy();
+    });
+    const toast = screen.getByTestId("badge-toast-unknown_badge");
+    expect(toast.textContent).toContain("🏆"); // fallback emoji
+    expect(toast.textContent).toContain("unknown_badge"); // fallback name = code
+  });
+});

--- a/apps/web/app/pro-league/_components/BadgeToastProvider.tsx
+++ b/apps/web/app/pro-league/_components/BadgeToastProvider.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * Sprint O — Lot O.C.3 : provider + toast pour badges Pro League débloqués.
+ *
+ * Backend : `POST /pro-league/me/badges/evaluate` retourne
+ * `{ newlyEarned: string[] }` (codes badges). Le provider expose une
+ * fonction `notifyAndEvaluate()` que les composants appellent apres une
+ * action qui peut debloquer un badge (claim daily, place bet, follow
+ * team) → call API → affiche un toast par badge debloque.
+ *
+ * Avant Lot O.C.3, le debloquage etait silencieux (zero feedback).
+ * Audit 2026-05-10 : satisfaction nulle au unlock, drama opportunity
+ * perdue (variable ratio reward).
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+interface ToastEntry {
+  id: number;
+  code: string;
+  emoji: string;
+  name: string;
+  expiresAt: number;
+}
+
+interface EvaluateResponse {
+  newlyEarned: string[];
+}
+
+interface BadgeCatalogueEntry {
+  code: string;
+  name: string;
+  emoji: string;
+}
+
+interface BadgeCatalogueResponse {
+  badges: BadgeCatalogueEntry[];
+}
+
+interface BadgeToastContextValue {
+  /**
+   * Trigger backend `POST /me/badges/evaluate` puis affiche un toast
+   * pour chaque code retourne. No-op si user non-auth (catch silencieux).
+   */
+  notifyAndEvaluate: () => Promise<void>;
+}
+
+const TOAST_TTL_MS = 6000;
+
+const BadgeToastContext = createContext<BadgeToastContextValue | null>(null);
+
+/**
+ * Fallback minimal si le catalogue n'est pas joignable. Le label restera
+ * le code raw, mais on garde la sequence visuelle (emoji + name).
+ */
+const FALLBACK_EMOJI = "🏆";
+
+export function BadgeToastProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+  const [catalogue, setCatalogue] = useState<
+    Record<string, BadgeCatalogueEntry>
+  >({});
+  const [nextId, setNextId] = useState(1);
+
+  // Charge le catalogue une fois (pas critique, fallback raw code OK).
+  useEffect(() => {
+    let cancelled = false;
+    apiRequest<BadgeCatalogueResponse>("/pro-league/badges")
+      .then((res) => {
+        if (cancelled) return;
+        const map: Record<string, BadgeCatalogueEntry> = {};
+        for (const b of res.badges) map[b.code] = b;
+        setCatalogue(map);
+      })
+      .catch(() => {
+        // Catalogue indispo → fallback raw codes.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Auto-dismiss toasts apres TTL.
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const id = setInterval(() => {
+      const now = Date.now();
+      setToasts((cur) => cur.filter((t) => t.expiresAt > now));
+    }, 500);
+    return () => clearInterval(id);
+  }, [toasts.length]);
+
+  const notifyAndEvaluate = useCallback(async (): Promise<void> => {
+    try {
+      const res = await apiRequest<EvaluateResponse>(
+        "/pro-league/me/badges/evaluate",
+        { method: "POST" },
+      );
+      if (res.newlyEarned.length === 0) return;
+      const now = Date.now();
+      const newToasts: ToastEntry[] = res.newlyEarned.map((code) => {
+        const def = catalogue[code];
+        return {
+          id: 0,
+          code,
+          emoji: def?.emoji ?? FALLBACK_EMOJI,
+          name: def?.name ?? code,
+          expiresAt: now + TOAST_TTL_MS,
+        };
+      });
+      setToasts((cur) => {
+        let id = nextId;
+        const stamped = newToasts.map((t) => ({ ...t, id: id++ }));
+        setNextId(id);
+        return [...cur, ...stamped];
+      });
+    } catch {
+      // Erreur silencieuse — un user non-auth ou un 500 ne doit pas
+      // casser l'action principale qui a appele notifyAndEvaluate.
+    }
+  }, [catalogue, nextId]);
+
+  const dismiss = (id: number): void => {
+    setToasts((cur) => cur.filter((t) => t.id !== id));
+  };
+
+  return (
+    <BadgeToastContext.Provider value={{ notifyAndEvaluate }}>
+      {children}
+      <div
+        data-testid="badge-toast-container"
+        aria-live="polite"
+        aria-atomic="true"
+        className="pointer-events-none fixed bottom-6 right-6 z-50 flex flex-col gap-2"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            data-testid={`badge-toast-${toast.code}`}
+            className="pointer-events-auto flex min-w-[280px] max-w-sm items-center gap-3 rounded-lg border border-amber-500 bg-amber-950/95 px-4 py-3 shadow-xl"
+          >
+            <span className="text-3xl" aria-hidden="true">
+              {toast.emoji}
+            </span>
+            <div className="flex-1">
+              <div className="text-xs uppercase text-amber-400">
+                Badge débloqué !
+              </div>
+              <div className="font-semibold text-amber-100">{toast.name}</div>
+            </div>
+            <button
+              data-testid={`badge-toast-dismiss-${toast.code}`}
+              onClick={() => dismiss(toast.id)}
+              aria-label="Fermer"
+              className="rounded p-1 text-amber-400 hover:bg-amber-900 hover:text-amber-200"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+          </div>
+        ))}
+      </div>
+    </BadgeToastContext.Provider>
+  );
+}
+
+/**
+ * Hook pour declencher l'evaluation + toasts. No-op gracieux si pas
+ * dans un BadgeToastProvider.
+ */
+export function useBadgeNotify(): BadgeToastContextValue {
+  const ctx = useContext(BadgeToastContext);
+  if (!ctx) {
+    return {
+      notifyAndEvaluate: async () => {
+        // Pas de provider monte (ex: tests) → no-op silencieux.
+      },
+    };
+  }
+  return ctx;
+}

--- a/apps/web/app/pro-league/_components/BetSlip.tsx
+++ b/apps/web/app/pro-league/_components/BetSlip.tsx
@@ -5,6 +5,7 @@ import { useEffect, useId, useMemo, useState } from "react";
 import { useLanguage } from "../../contexts/LanguageContext";
 import { ApiClientError, apiRequest } from "../../lib/api-client";
 import { useWallet } from "../../lib/use-wallet";
+import { useBadgeNotify } from "./BadgeToastProvider";
 
 /**
  * Modale de pose de pari — sprint 1.D.7.
@@ -73,6 +74,7 @@ export function BetSlip({
 }: BetSlipProps): JSX.Element {
   const { t } = useLanguage();
   const wallet = useWallet();
+  const badgeNotify = useBadgeNotify();
   const dialogId = useId();
   const [stake, setStake] = useState(50);
   const [pending, setPending] = useState(false);
@@ -116,6 +118,10 @@ export function BetSlip({
       });
       // Actualise wallet en arrière-plan.
       void wallet.refresh();
+      // Lot O.C.3 — apres un pari place, lance l'evaluation badges :
+      // peut debloquer "first_kickoff" (1er pari) ou continuer streak
+      // pour "oracle_of_nuffle". Toast affiche par le provider.
+      void badgeNotify.notifyAndEvaluate();
     } catch (e: unknown) {
       const code =
         e instanceof ApiClientError && typeof e.message === "string"

--- a/apps/web/app/pro-league/layout.tsx
+++ b/apps/web/app/pro-league/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import ProLeagueStructuredData from "./_components/ProLeagueStructuredData";
+import { BadgeToastProvider } from "./_components/BadgeToastProvider";
 
 export const metadata: Metadata = {
   title: "Pro League — Old World League | Nuffle Arena",
@@ -30,9 +31,9 @@ export default function ProLeagueLayout({
   children: React.ReactNode;
 }): JSX.Element {
   return (
-    <>
+    <BadgeToastProvider>
       <ProLeagueStructuredData />
       {children}
-    </>
+    </BadgeToastProvider>
   );
 }


### PR DESCRIPTION
## Summary

**Lot O.C.3 du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit 2026-05-10 identifiait le déblocage de badges comme un hook rétention manquant : le service `pro-badges.evaluateBadgesForUser` débloque silencieusement, l'user n'a **aucun feedback**. Drama opportunity perdue (variable ratio reward, satisfaction nulle).

Système de notification global :

### Backend
- Nouvelle route **publique** `GET /pro-league/badges` qui expose le catalogue (code/name/description/emoji) sans auth. Permet au toast d'afficher le nom + emoji.

### Frontend
- **`BadgeToastProvider`** : context React, charge catalogue au mount, expose `notifyAndEvaluate()` qui appelle `POST /me/badges/evaluate` et affiche un toast par badge dans `newlyEarned`. Auto-dismiss 6s + bouton X. Erreur API silencieuse.
- **`useBadgeNotify()`** hook : no-op silencieux hors provider (flexibilité tests).
- Monté dans `pro-league/layout.tsx` → tout composant Pro League a accès.
- **Intégration BetSlip** : appel `notifyAndEvaluate()` après POST `/pro-league/bets` réussi → toast "first_kickoff" (1er pari) ou "oracle_of_nuffle" (streak 10).

A11y : `aria-live="polite"`, `aria-atomic`, dismiss button labellisé.

## Test plan
- [x] 8 tests `BadgeToastProvider.test.tsx` (mount no toast, unlock 0/1/N, dismiss, erreur silencieuse, hook hors provider, fallback emoji).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2147 verts.
- [x] `pnpm --filter @bb/web test` — 912 verts (+8).
- [ ] Smoke : se connecter, placer 1er pari → toast "🥇 First Kickoff débloqué !".

## Sprint O progression
- ✅ Lot O.A.1 (#745 mergé)
- ✅ Lot O.B.1 (#746 mergé)
- ✅ Lot O.B.3 (#747)
- ✅ Lot O.C.1 (#748)
- ✅ Lot O.C.3 — **cette PR**
- ⏳ Lot O.C.2 (match report banner)
- ⏳ Lot O.D (OG image + share)
- ⏳ Lot O.A.2-4 (skill registry wiring)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_