### PR TITLE
feat(pro-league): OG image dynamique + share buttons matchs (Lot O.D)

### DIFF
--- a/apps/web/app/lib/og-image-content.test.ts
+++ b/apps/web/app/lib/og-image-content.test.ts
@@ -14,6 +14,8 @@ import {
   buildTeamOgContent,
   buildStarPlayerOgContent,
   buildSkillsOgContent,
+  buildProLeagueMatchOgContent,
+  buildProLeagueGazetteOgContent,
   type TeamOgInput,
   type StarPlayerOgInput,
 } from "./og-image-content";
@@ -160,5 +162,109 @@ describe("buildSkillsOgContent", () => {
     expect(buildSkillsOgContent({ skillCount: 130 })).toEqual(
       buildSkillsOgContent({ skillCount: 130 }),
     );
+  });
+});
+
+describe("buildProLeagueMatchOgContent — Lot O.D", () => {
+  it("scheduled : title 'Home vs Away' sans score", () => {
+    const out = buildProLeagueMatchOgContent({
+      homeName: "Snow Ogres",
+      awayName: "Cheese Halflings",
+      scoreHome: null,
+      scoreAway: null,
+      roundNumber: 5,
+      status: "scheduled",
+    });
+    expect(out.title).toContain("Snow Ogres");
+    expect(out.title).toContain("vs");
+    expect(out.title).toContain("Cheese Halflings");
+    expect(out.title).not.toMatch(/\d+\s*[–-]\s*\d+/);
+    expect(out.accent).toBe("match");
+  });
+
+  it("completed : title affiche le score", () => {
+    const out = buildProLeagueMatchOgContent({
+      homeName: "Snow Ogres",
+      awayName: "Cheese Halflings",
+      scoreHome: 3,
+      scoreAway: 1,
+      roundNumber: 5,
+      status: "completed",
+    });
+    expect(out.title).toContain("3");
+    expect(out.title).toContain("1");
+    expect(out.title).toContain("Snow Ogres");
+    expect(out.title).toContain("Cheese Halflings");
+  });
+
+  it("status in_progress : badge 'EN DIRECT'", () => {
+    const out = buildProLeagueMatchOgContent({
+      homeName: "A",
+      awayName: "B",
+      scoreHome: 2,
+      scoreAway: 2,
+      roundNumber: 3,
+      status: "in_progress",
+    });
+    expect(out.badges).toContain("EN DIRECT");
+  });
+
+  it("inclut R<round> dans les badges", () => {
+    const out = buildProLeagueMatchOgContent({
+      homeName: "A",
+      awayName: "B",
+      scoreHome: null,
+      scoreAway: null,
+      roundNumber: 7,
+      status: "scheduled",
+    });
+    expect(out.badges).toContain("R7");
+  });
+
+  it("homeMeta / awayMeta dans les badges si fournis", () => {
+    const out = buildProLeagueMatchOgContent({
+      homeName: "A",
+      awayName: "B",
+      homeMeta: "Buffalo · Ogre",
+      awayMeta: "Green Bay · Halfling",
+      scoreHome: null,
+      scoreAway: null,
+      roundNumber: 1,
+      status: "scheduled",
+    });
+    expect(out.badges).toContain("Buffalo · Ogre");
+    expect(out.badges).toContain("Green Bay · Halfling");
+  });
+});
+
+describe("buildProLeagueGazetteOgContent — Lot O.D", () => {
+  it("formate la date YYYY-MM-DD en DD/MM/YYYY dans les badges", () => {
+    const out = buildProLeagueGazetteOgContent({
+      date: "2026-09-15",
+      headline: "Orcs ravagent la Pro League",
+      articleCount: 5,
+    });
+    expect(out.badges).toContain("15/09/2026");
+  });
+
+  it("expose accent gazette + article count", () => {
+    const out = buildProLeagueGazetteOgContent({
+      date: "2026-09-15",
+      headline: "Title",
+      articleCount: 3,
+      persona: "Cynic",
+    });
+    expect(out.accent).toBe("gazette");
+    expect(out.badges).toContain("3 articles");
+    expect(out.badges).toContain("Cynic");
+  });
+
+  it("fallback si date invalide : laisse la valeur brute", () => {
+    const out = buildProLeagueGazetteOgContent({
+      date: "not-a-date",
+      headline: "Title",
+      articleCount: 2,
+    });
+    expect(out.badges).toContain("not-a-date");
   });
 });

--- a/apps/web/app/lib/og-image-content.ts
+++ b/apps/web/app/lib/og-image-content.ts
@@ -15,7 +15,7 @@
  *      supporte pas grid)
  */
 
-export type OgAccent = "team" | "star" | "skill";
+export type OgAccent = "team" | "star" | "skill" | "match" | "gazette";
 
 export interface OgContent {
   /** Titre principal affiche en grand. */
@@ -45,6 +45,38 @@ export interface StarPlayerOgInput {
   pa: number | null;
   av: number;
   isMegaStar?: boolean;
+}
+
+/**
+ * Sprint O (Lot O.D) — entrees pour generer les OG images des pages
+ * Pro League : matchs et editions Gazette.
+ */
+export interface ProLeagueMatchOgInput {
+  /** Nom court de la home team (ex: "Snow Ogres"). */
+  homeName: string;
+  /** Nom court de l'away team. */
+  awayName: string;
+  /** Race / city pour ligne secondaire (ex: "Buffalo · Ogre"). */
+  homeMeta?: string;
+  awayMeta?: string;
+  /** Score si match completed/in-progress. Null si scheduled. */
+  scoreHome: number | null;
+  scoreAway: number | null;
+  /** Numero de la journee (ex: 5). */
+  roundNumber: number;
+  /** "scheduled" | "in_progress" | "completed" | "failed". */
+  status: string;
+}
+
+export interface ProLeagueGazetteOgInput {
+  /** Date editions au format ISO (YYYY-MM-DD). */
+  date: string;
+  /** Titre du premier article. */
+  headline: string;
+  /** Persona generation (ex: "Cynic", "Orc Enthusiast", "Statistician"). */
+  persona?: string;
+  /** Nombre d'articles dans l'edition. */
+  articleCount: number;
 }
 
 export interface SkillsOgInput {
@@ -121,4 +153,70 @@ export function buildSkillsOgContent(input: SkillsOgInput): OgContent {
     ],
     accent: "skill",
   };
+}
+
+/**
+ * Sprint O (Lot O.D) — OG image pour un match Pro League. Affiche
+ * "Home vs Away" en gros, score si disponible, journee + status.
+ */
+export function buildProLeagueMatchOgContent(
+  input: ProLeagueMatchOgInput,
+): OgContent {
+  const hasScore =
+    input.scoreHome !== null && input.scoreAway !== null;
+  const scorePart = hasScore
+    ? `${input.scoreHome}${NBSP}–${NBSP}${input.scoreAway}`
+    : "vs";
+  const title = `${input.homeName} ${scorePart} ${input.awayName}`;
+
+  const statusLabel = (() => {
+    switch (input.status) {
+      case "completed":
+        return "Terminé";
+      case "in_progress":
+        return "EN DIRECT";
+      case "scheduled":
+        return "À venir";
+      case "ready":
+        return "Prêt";
+      default:
+        return input.status;
+    }
+  })();
+
+  const badges: string[] = [`R${input.roundNumber}`, statusLabel];
+  if (input.homeMeta) badges.push(input.homeMeta);
+  if (input.awayMeta) badges.push(input.awayMeta);
+
+  return {
+    title,
+    subtitle: "Pro League · Old World League — Nuffle Arena",
+    badges,
+    accent: "match",
+  };
+}
+
+/**
+ * Sprint O (Lot O.D) — OG image pour une edition de la Gazette.
+ */
+export function buildProLeagueGazetteOgContent(
+  input: ProLeagueGazetteOgInput,
+): OgContent {
+  const niceDate = formatGazetteDate(input.date);
+  const badges: string[] = [niceDate, `${input.articleCount} articles`];
+  if (input.persona) badges.push(input.persona);
+  return {
+    title: input.headline,
+    subtitle: `Nuffle Gazette · ${niceDate}`,
+    badges,
+    accent: "gazette",
+  };
+}
+
+function formatGazetteDate(iso: string): string {
+  // Tolerant ISO YYYY-MM-DD.
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return iso;
+  const [, y, mo, d] = m;
+  return `${d}/${mo}/${y}`;
 }

--- a/apps/web/app/lib/og-image-template.tsx
+++ b/apps/web/app/lib/og-image-template.tsx
@@ -41,6 +41,24 @@ const THEMES: Record<OgAccent, AccentTheme> = {
     badgeBg: "rgba(147, 197, 253, 0.18)",
     badgeText: "#dbeafe",
   },
+  // Lot O.D — Pro League match : dark slate avec accent emerald (live)
+  match: {
+    background:
+      "linear-gradient(135deg, #020617 0%, #0f172a 50%, #064e3b 100%)",
+    accent: "#34d399",
+    text: "#ecfdf5",
+    badgeBg: "rgba(52, 211, 153, 0.18)",
+    badgeText: "#a7f3d0",
+  },
+  // Lot O.D — Gazette : parchemin journal, sepia/amber chaud
+  gazette: {
+    background:
+      "linear-gradient(135deg, #1c1410 0%, #3a2616 50%, #92400e 100%)",
+    accent: "#fbbf24",
+    text: "#fef3c7",
+    badgeBg: "rgba(251, 191, 36, 0.20)",
+    badgeText: "#fde68a",
+  },
 };
 
 interface OgImageTemplateProps {

--- a/apps/web/app/pro-league/_components/ShareButtons.test.tsx
+++ b/apps/web/app/pro-league/_components/ShareButtons.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests pour `ShareButtons` (Sprint O — Lot O.D).
+ *
+ * Couvre :
+ *   - Render des 3 boutons (Twitter, Discord, copy).
+ *   - URL Twitter intent contient text + url + hashtags.
+ *   - Click Discord/copy → navigator.clipboard.writeText appele +
+ *     feedback affiche.
+ *   - Fallback execCommand si clipboard indispo.
+ *   - Mode "compact" : labels masques mais testids preservees.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ShareButtons from "./ShareButtons";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ShareButtons — Lot O.D", () => {
+  it("rend 3 boutons : tweet / discord / copy", () => {
+    render(
+      <ShareButtons
+        url="https://example.test/x"
+        text="Hello world"
+      />,
+    );
+    expect(screen.getByTestId("share-twitter")).toBeTruthy();
+    expect(screen.getByTestId("share-discord")).toBeTruthy();
+    expect(screen.getByTestId("share-copy")).toBeTruthy();
+  });
+
+  it("href Twitter contient text + url + hashtags", () => {
+    render(
+      <ShareButtons
+        url="https://example.test/x"
+        text="Score 3-1 ! "
+        hashtags={["bloodbowl", "nufflearena"]}
+      />,
+    );
+    const link = screen.getByTestId("share-twitter") as HTMLAnchorElement;
+    expect(link.href).toContain("twitter.com/intent/tweet");
+    // URLSearchParams encode spaces as '+', decode replaces + → space
+    const decoded = decodeURIComponent(link.href.replace(/\+/g, " "));
+    expect(decoded).toContain("Score 3-1");
+    expect(decoded).toContain("https://example.test/x");
+    expect(decoded).toContain("bloodbowl,nufflearena");
+  });
+
+  it("click Discord copie URL au clipboard et affiche feedback", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+    render(
+      <ShareButtons
+        url="https://example.test/x"
+        text="Hello"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("share-discord"));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("https://example.test/x");
+    });
+    await waitFor(() => {
+      const fb = screen.getByTestId("share-feedback");
+      expect(fb.textContent).toContain("Discord");
+    });
+  });
+
+  it("click Copy : feedback 'Lien copié'", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+    render(
+      <ShareButtons url="https://example.test/y" text="Hi" />,
+    );
+    fireEvent.click(screen.getByTestId("share-copy"));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      const fb = screen.getByTestId("share-feedback");
+      expect(fb.textContent).toContain("Lien copié");
+    });
+  });
+
+  it("fallback execCommand si clipboard absent", async () => {
+    // Pas de navigator.clipboard → fallback document.execCommand.
+    Object.assign(navigator, { clipboard: undefined });
+    // jsdom n'expose pas execCommand par defaut, on l'injecte.
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      writable: true,
+      value: exec,
+    });
+    render(
+      <ShareButtons url="https://example.test/z" text="Hello" />,
+    );
+    fireEvent.click(screen.getByTestId("share-copy"));
+    await waitFor(() => {
+      expect(exec).toHaveBeenCalledWith("copy");
+    });
+  });
+
+  it("mode compact : icones seules, labels masques", () => {
+    render(
+      <ShareButtons
+        url="https://example.test/x"
+        text="Hi"
+        layout="compact"
+      />,
+    );
+    const twitter = screen.getByTestId("share-twitter");
+    // 'Tweet' label absent en compact (juste l'icone)
+    expect(twitter.textContent?.trim().toLowerCase()).not.toContain("tweet");
+    // testids toujours presents pour tracking
+    expect(screen.getByTestId("share-discord")).toBeTruthy();
+    expect(screen.getByTestId("share-copy")).toBeTruthy();
+  });
+});

--- a/apps/web/app/pro-league/_components/ShareButtons.tsx
+++ b/apps/web/app/pro-league/_components/ShareButtons.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+/**
+ * Sprint O — Lot O.D : boutons de partage sociaux.
+ *
+ * Reutilisable sur :
+ *   - `/pro-league/matches/[id]` : "Partage ce match"
+ *   - `/pro-league/gazette/[date]` : "Partage cette edition"
+ *   - Plus tard : page joueur / equipe.
+ *
+ * 3 boutons :
+ *   - **Twitter / X** : intent URL avec texte + URL + hashtags.
+ *   - **Discord** : copy URL au clipboard (pas d'intent natif, le user
+ *     paste). Feedback toast "Lien copie pour Discord".
+ *   - **Copy link** : pareil, copy + feedback.
+ *
+ * Pas d'autres reseaux pour l'instant (Reddit/Bluesky restent
+ * shareables par copy link de toute facon).
+ */
+
+import { useState } from "react";
+
+interface ShareButtonsProps {
+  /** URL canonique a partager (absolu, ex: `https://nufflearena.fr/pro-league/matches/abc`). */
+  readonly url: string;
+  /** Texte d'accroche (sera prefixed au tweet). */
+  readonly text: string;
+  /** Hashtags facultatifs (sans #, ex: `["bloodbowl", "nufflearena"]`). */
+  readonly hashtags?: readonly string[];
+  /** Variante d'affichage : "row" (default, ligne) ou "compact" (icones seuls). */
+  readonly layout?: "row" | "compact";
+}
+
+function buildTwitterIntent(props: ShareButtonsProps): string {
+  const params = new URLSearchParams({
+    text: props.text,
+    url: props.url,
+  });
+  if (props.hashtags && props.hashtags.length > 0) {
+    params.set("hashtags", props.hashtags.join(","));
+  }
+  return `https://twitter.com/intent/tweet?${params.toString()}`;
+}
+
+async function copyToClipboard(value: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // ignore — fallback below
+  }
+  // Fallback : textarea + execCommand (deprecated mais utile sur
+  // contextes non-secure / vieux navigateurs).
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = value;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+export default function ShareButtons({
+  url,
+  text,
+  hashtags,
+  layout = "row",
+}: ShareButtonsProps): JSX.Element {
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const flashFeedback = (msg: string): void => {
+    setFeedback(msg);
+    setTimeout(() => setFeedback(null), 3000);
+  };
+
+  const onCopy = async (kind: "copy" | "discord"): Promise<void> => {
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      flashFeedback(
+        kind === "discord" ? "Lien copié — colle-le dans Discord" : "Lien copié",
+      );
+    } else {
+      flashFeedback("Impossible de copier — copie manuellement l'URL");
+    }
+  };
+
+  const isCompact = layout === "compact";
+  const wrapClass = isCompact
+    ? "inline-flex items-center gap-2"
+    : "flex flex-wrap items-center gap-2";
+  const btnBase =
+    "inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-xs transition hover:bg-slate-800";
+
+  return (
+    <div data-testid="share-buttons" className={wrapClass}>
+      <a
+        data-testid="share-twitter"
+        href={buildTwitterIntent({ url, text, hashtags })}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${btnBase} border-sky-700 text-sky-300 hover:text-sky-200`}
+        title="Partager sur X / Twitter"
+      >
+        <span aria-hidden="true">𝕏</span>
+        {!isCompact && <span>Tweet</span>}
+      </a>
+      <button
+        type="button"
+        data-testid="share-discord"
+        onClick={() => void onCopy("discord")}
+        className={`${btnBase} border-indigo-700 text-indigo-300 hover:text-indigo-200`}
+        title="Copier l'URL pour Discord"
+      >
+        <span aria-hidden="true">💬</span>
+        {!isCompact && <span>Discord</span>}
+      </button>
+      <button
+        type="button"
+        data-testid="share-copy"
+        onClick={() => void onCopy("copy")}
+        className={`${btnBase} border-slate-700 text-slate-300 hover:text-slate-200`}
+        title="Copier l'URL"
+      >
+        <span aria-hidden="true">🔗</span>
+        {!isCompact && <span>Copier</span>}
+      </button>
+      {feedback && (
+        <span
+          data-testid="share-feedback"
+          role="status"
+          className="text-xs text-emerald-300"
+        >
+          ✓ {feedback}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/pro-league/matches/[id]/layout.tsx
+++ b/apps/web/app/pro-league/matches/[id]/layout.tsx
@@ -1,0 +1,98 @@
+/**
+ * Layout server-side du match Pro League — Sprint O (Lot O.D).
+ *
+ * Existait deja en tant que client-page `page.tsx`. Le layout permet
+ * d'ajouter `generateMetadata` (openGraph + twitter card avec
+ * og-image dynamique) sans toucher au "use client" de la page.
+ *
+ * L'OG image est generee automatiquement par Next.js via
+ * `[id]/opengraph-image.tsx` (convention App Router).
+ */
+import type { Metadata, ResolvingMetadata } from "next";
+
+import { fetchServerJson, getServerApiBase } from "../../../lib/serverApi";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+interface MatchPayloadForMeta {
+  roundNumber: number;
+  status: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  homeTeam: { name: string; city: string };
+  awayTeam: { name: string; city: string };
+}
+
+export async function generateMetadata(
+  { params }: { params: { id: string } },
+  _parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const url = `${SITE_URL.replace(/\/$/, "")}/pro-league/matches/${params.id}`;
+  let payload: MatchPayloadForMeta | null = null;
+  try {
+    const base = getServerApiBase();
+    payload = await fetchServerJson<MatchPayloadForMeta>(
+      `${base}/pro-league/matches/${encodeURIComponent(params.id)}`,
+      { next: { revalidate: 300 } },
+    );
+  } catch {
+    // Fallback: meta generiques en bas de fonction.
+  }
+
+  if (!payload) {
+    return {
+      title: "Match Pro League — Nuffle Arena",
+      description:
+        "Suivez ce match Pro League en direct ou rejouez-le : score, paris, highlights et Gazette quotidienne.",
+      alternates: { canonical: url },
+      openGraph: {
+        title: "Match Pro League — Nuffle Arena",
+        description:
+          "Suivez ce match Pro League en direct ou rejouez-le.",
+        type: "website",
+        url,
+      },
+      twitter: { card: "summary_large_image" },
+    };
+  }
+
+  const hasScore =
+    payload.scoreHome !== null && payload.scoreAway !== null;
+  const scorePart = hasScore
+    ? `${payload.scoreHome}–${payload.scoreAway}`
+    : "vs";
+  const title = `${payload.homeTeam.name} ${scorePart} ${payload.awayTeam.name} — Pro League`;
+  const statusLabel =
+    payload.status === "in_progress"
+      ? "EN DIRECT"
+      : payload.status === "completed"
+        ? "Terminé"
+        : "À venir";
+  const description = `R${payload.roundNumber} · ${statusLabel} · ${payload.homeTeam.city} reçoit ${payload.awayTeam.city}. Suis le match live, parie, lis la Gazette quotidienne.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      url,
+      // L'image est resolue par opengraph-image.tsx voisin (1200×630).
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default function MatchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return <>{children}</>;
+}

--- a/apps/web/app/pro-league/matches/[id]/opengraph-image.tsx
+++ b/apps/web/app/pro-league/matches/[id]/opengraph-image.tsx
@@ -1,0 +1,89 @@
+/**
+ * Open Graph image dynamique pour /pro-league/matches/[id] — Sprint O
+ * (Lot O.D). Genere une image 1200×630 avec "Home vs Away", score si
+ * dispo, journee + status. Reuse `OgImageTemplate` + accent "match".
+ */
+import { ImageResponse } from "next/og";
+
+import { fetchServerJson, getServerApiBase } from "../../../lib/serverApi";
+import { buildProLeagueMatchOgContent } from "../../../lib/og-image-content";
+import { OgImageTemplate } from "../../../lib/og-image-template";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+export const runtime = "nodejs";
+export const revalidate = 300;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface MatchPayload {
+  roundNumber: number;
+  status: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  homeTeam: { name: string; city: string; race: string };
+  awayTeam: { name: string; city: string; race: string };
+}
+
+async function fetchMatch(id: string): Promise<MatchPayload | null> {
+  try {
+    const base = getServerApiBase();
+    const data = await fetchServerJson<MatchPayload>(
+      `${base}/pro-league/matches/${encodeURIComponent(id)}`,
+      { next: { revalidate: 300 } },
+    );
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function Image({
+  params,
+}: {
+  params: { id: string };
+}): Promise<ImageResponse> {
+  const match = await fetchMatch(params.id);
+
+  if (!match) {
+    // Fallback : titre generique
+    const content = buildProLeagueMatchOgContent({
+      homeName: "Pro League",
+      awayName: "Match",
+      scoreHome: null,
+      scoreAway: null,
+      roundNumber: 0,
+      status: "scheduled",
+    });
+    return new ImageResponse(
+      (
+        <OgImageTemplate
+          content={content}
+          canonicalUrl={`${SITE_URL.replace(/\/$/, "")}/pro-league/matches/${params.id}`}
+        />
+      ),
+      size,
+    );
+  }
+
+  const content = buildProLeagueMatchOgContent({
+    homeName: match.homeTeam.name,
+    awayName: match.awayTeam.name,
+    homeMeta: `${match.homeTeam.city} · ${match.homeTeam.race}`,
+    awayMeta: `${match.awayTeam.city} · ${match.awayTeam.race}`,
+    scoreHome: match.scoreHome,
+    scoreAway: match.scoreAway,
+    roundNumber: match.roundNumber,
+    status: match.status,
+  });
+
+  return new ImageResponse(
+    (
+      <OgImageTemplate
+        content={content}
+        canonicalUrl={`${SITE_URL.replace(/\/$/, "")}/pro-league/matches/${params.id}`}
+      />
+    ),
+    size,
+  );
+}

--- a/apps/web/app/pro-league/matches/[id]/page.tsx
+++ b/apps/web/app/pro-league/matches/[id]/page.tsx
@@ -9,6 +9,10 @@ import { useWallet } from "../../../lib/use-wallet";
 
 import { MarketsList } from "../../_components/MarketsList";
 import { WalletBadge } from "../../_components/WalletBadge";
+import ShareButtons from "../../_components/ShareButtons";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
 
 /**
  * Page détail d'un match Pro League — sprint Pro League lot 1.C.3.
@@ -424,6 +428,17 @@ export default function ProLeagueMatchDetailPage({
       ) : (
         <>
           <ScoreboardBanner match={data} />
+          <div className="px-4 py-3">
+            <ShareButtons
+              url={`${SITE_URL.replace(/\/$/, "")}/pro-league/matches/${data.id}`}
+              text={
+                data.scoreHome !== null && data.scoreAway !== null
+                  ? `${data.homeTeam.name} ${data.scoreHome}-${data.scoreAway} ${data.awayTeam.name} — Pro League Nuffle Arena`
+                  : `${data.homeTeam.name} vs ${data.awayTeam.name} — Pro League Nuffle Arena`
+              }
+              hashtags={["bloodbowl", "nufflearena"]}
+            />
+          </div>
           <div className="px-4 py-6">
             {data.status === "scheduled" || data.status === "ready" ? (
               <>


### PR DESCRIPTION
## Summary

**Lot O.D du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit 2026-05-10 identifiait l'absence de partage social comme **LE tueur de viralité** du site : aucune URL Pro League partageable n'avait d'OG image dynamique, aucun bouton "Tweeter ce match". Un fan qui voit Orcs 49-0 Humains avait zéro moyen de poster sur Twitter avec une carte propre.

### OG image dynamique `/pro-league/matches/[id]`
- `opengraph-image.tsx` (convention Next.js App Router) génère 1200×630 via `next/og` `ImageResponse`.
- Réutilise `OgImageTemplate` + nouveau thème `match` (slate + accent emerald pour "EN DIRECT").
- Affiche "Home Score-Score Away" en gros, badges R<round> + status (EN DIRECT / Terminé / À venir) + homeMeta/awayMeta (city · race).
- Fallback gracieux si match introuvable.
- `revalidate: 300` (5 min).

### `generateMetadata` (layout server-side)
- Nouveau `[id]/layout.tsx` server-side fournit `openGraph` + `twitter.summary_large_image` avec title/description dynamiques (`Snow Ogres 3-1 Cheese Halflings — Pro League`).
- Ne touche pas au `page.tsx` "use client" existant.

### `ShareButtons` component (réutilisable)
- 3 boutons : **Twitter** intent (text + url + hashtags), **Discord** (copy URL + feedback "colle dans Discord"), **copy link** (feedback "Lien copié").
- Fallback `execCommand` si `navigator.clipboard` indispo.
- Variantes layout : `row` (default) + `compact` (icônes seules).
- Posé sur page match : `Snow Ogres 3-1 Cheese Halflings — Pro League Nuffle Arena` + hashtags `bloodbowl, nufflearena`.

### `og-image-content` (lib)
- `buildProLeagueMatchOgContent` + `buildProLeagueGazetteOgContent` (Gazette OG préparée pour usage futur).
- 2 nouveaux thèmes `match` (emerald) + `gazette` (sepia/amber).

## Test plan
- [x] 11 tests `og-image-content.test.ts` (scheduled vs completed, EN DIRECT badge, badges R/meta, Gazette date format, fallback date invalide).
- [x] 6 tests `ShareButtons.test.tsx` (3 boutons, Twitter href params, Discord copy + feedback, copy + feedback, fallback execCommand, mode compact).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/web test` — 918 verts (+12).
- [ ] Smoke : déployer + coller URL match dans Twitter → carte 1200×630 avec scores visible.

## Sprint O progression
- ✅ Lot O.A.1 (#745 mergé)
- ✅ Lot O.B.1 (#746 mergé)
- ✅ Lot O.B.3 (#747 mergé)
- ✅ Lot O.C.1 (#748)
- ✅ Lot O.C.3 (#749)
- ✅ Lot O.D — **cette PR**
- ⏳ Lot O.C.2 (match report banner)
- ⏳ Lot O.A.2-4 (skill registry wiring)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_