### PR TITLE
feat(web): match report banner sur /me/teams/[id] (Lot O.C.2)

### DIFF
--- a/apps/server/src/routes/match-details-handlers.ts
+++ b/apps/server/src/routes/match-details-handlers.ts
@@ -327,6 +327,9 @@ export async function handleListMyMatches(
         turn,
         myTeam: mySelection
           ? {
+              // Lot O.C.2 — expose `teamId` pour filtrer "mes matchs sur
+              // cette equipe" depuis /me/teams/[id].
+              teamId: mySelection.teamRef?.id ?? null,
               coachName: mySelection.user.coachName,
               teamName: mySelection.teamRef?.name || mySelection.team,
               rosterName: mySelection.teamRef?.roster,

--- a/apps/web/app/me/teams/[id]/MatchReportBanner.test.tsx
+++ b/apps/web/app/me/teams/[id]/MatchReportBanner.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Tests pour `MatchReportBanner` (Sprint O — Lot O.C.2).
+ *
+ * Couvre :
+ *   - Filtre par teamId : skip si match.myTeam.teamId !== teamId.
+ *   - Filtre status=completed : skip in_progress/scheduled.
+ *   - Filtre fenetre 7j : skip > 7 jours.
+ *   - Won / Drew / Lost → couleurs + emoji corrects.
+ *   - Dismiss button → flag localStorage + hide.
+ *   - Lien "Voir details".
+ *   - Empty / API error : pas de banner.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../../lib/api-client", () => ({
+  apiRequest: vi.fn(),
+}));
+
+import { apiRequest } from "../../../lib/api-client";
+import { MatchReportBanner } from "./MatchReportBanner";
+
+const mockedApi = vi.mocked(apiRequest);
+const TEAM_ID = "team_buf_1";
+
+interface MatchPayload {
+  id: string;
+  status: string;
+  createdAt: string;
+  lastMoveAt: string | null;
+  myScore: number;
+  opponentScore: number;
+  myTeam: { teamId: string | null; teamName: string; coachName: string } | null;
+  opponent: { teamName: string; coachName: string } | null;
+}
+
+function makeMatch(overrides: Partial<MatchPayload> = {}): MatchPayload {
+  return {
+    id: "match-1",
+    status: "completed",
+    createdAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    lastMoveAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    myScore: 3,
+    opponentScore: 1,
+    myTeam: {
+      teamId: TEAM_ID,
+      teamName: "Snow Ogres",
+      coachName: "Coach A",
+    },
+    opponent: { teamName: "Cheese Halflings", coachName: "Coach B" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("MatchReportBanner — Lot O.C.2", () => {
+  it("affiche le banner pour un match completed recent (won)", async () => {
+    mockedApi.mockResolvedValueOnce({ matches: [makeMatch()] });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-banner")).toBeTruthy();
+    });
+    expect(screen.getByTestId("match-report-score").textContent).toContain(
+      "3",
+    );
+    expect(screen.getByTestId("match-report-score").textContent).toContain(
+      "1",
+    );
+    expect(screen.getByTestId("match-report-banner").textContent).toContain(
+      "Victoire",
+    );
+    expect(screen.getByTestId("match-report-banner").textContent).toContain(
+      "Cheese Halflings",
+    );
+  });
+
+  it("affiche 'Defaite' si myScore < opponentScore", async () => {
+    mockedApi.mockResolvedValueOnce({
+      matches: [makeMatch({ myScore: 0, opponentScore: 2 })],
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-banner")).toBeTruthy();
+    });
+    expect(screen.getByTestId("match-report-banner").textContent).toContain(
+      "Défaite",
+    );
+  });
+
+  it("affiche 'Match nul' si scores egaux", async () => {
+    mockedApi.mockResolvedValueOnce({
+      matches: [makeMatch({ myScore: 1, opponentScore: 1 })],
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-banner")).toBeTruthy();
+    });
+    expect(screen.getByTestId("match-report-banner").textContent).toContain(
+      "Match nul",
+    );
+  });
+
+  it("skip si match.myTeam.teamId !== teamId", async () => {
+    mockedApi.mockResolvedValueOnce({
+      matches: [
+        makeMatch({
+          myTeam: {
+            teamId: "other-team",
+            teamName: "Other",
+            coachName: "C",
+          },
+        }),
+      ],
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+  });
+
+  it("skip si status !== completed (ex: in_progress)", async () => {
+    mockedApi.mockResolvedValueOnce({
+      matches: [makeMatch({ status: "in_progress" })],
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+  });
+
+  it("skip si match > 7 jours", async () => {
+    const old = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+    mockedApi.mockResolvedValueOnce({
+      matches: [makeMatch({ lastMoveAt: old, createdAt: old })],
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+  });
+
+  it("dismiss button → flag localStorage + masque banner", async () => {
+    mockedApi.mockResolvedValueOnce({ matches: [makeMatch()] });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-banner")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("match-report-dismiss"));
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        `match_report_dismissed:${TEAM_ID}:match-1`,
+      ),
+    ).toBe("1");
+  });
+
+  it("re-affichage masque si flag dismiss deja set", async () => {
+    window.localStorage.setItem(
+      `match_report_dismissed:${TEAM_ID}:match-1`,
+      "1",
+    );
+    mockedApi.mockResolvedValueOnce({ matches: [makeMatch()] });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+  });
+
+  it("lien 'Voir details' pointe vers /match/[id]/details", async () => {
+    mockedApi.mockResolvedValueOnce({ matches: [makeMatch()] });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-details")).toBeTruthy();
+    });
+    const link = screen.getByTestId(
+      "match-report-details",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/match/match-1/details");
+  });
+
+  it("erreur API silencieuse → pas de banner", async () => {
+    mockedApi.mockRejectedValueOnce(new Error("boom"));
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(mockedApi).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("match-report-banner")).toBeNull();
+  });
+
+  it("supporte l'envelope { success, data: { matches } }", async () => {
+    mockedApi.mockResolvedValueOnce({
+      success: true,
+      data: { matches: [makeMatch()] },
+    });
+    render(<MatchReportBanner teamId={TEAM_ID} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("match-report-banner")).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/me/teams/[id]/MatchReportBanner.tsx
+++ b/apps/web/app/me/teams/[id]/MatchReportBanner.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * Sprint O — Lot O.C.2 : banner "Dernier match" sur la page d'une
+ * equipe.
+ *
+ * Affiche le dernier match (status=completed) joue dans les 7 derniers
+ * jours par l'utilisateur courant avec cette equipe :
+ *
+ *   - Score (myScore - opponentScore) colorise selon victoire/defaite/nul.
+ *   - Coach + nom de l'equipe adverse.
+ *   - Date relative ("il y a 2j").
+ *   - Bouton "Voir details" → /match/[id]/details.
+ *   - Dismiss avec flag localStorage par teamId+matchId (eviter
+ *     re-affichage permanent).
+ *
+ * Coupling avec `PendingAdvancementsBanner` : ce composant est
+ * **complementaire**. Si advancements en attente, l'autre banner
+ * apparait au-dessus avec son propre CTA.
+ *
+ * Backend : reuse `GET /match/my-matches` (existing) + filtre par
+ * `myTeam.teamId === teamId` (champ ajoute par Lot O.C.2 dans
+ * `match-details-handlers.ts`).
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../lib/api-client";
+
+interface MyMatch {
+  id: string;
+  status: string;
+  createdAt: string;
+  lastMoveAt: string | null;
+  myScore: number;
+  opponentScore: number;
+  myTeam: {
+    teamId: string | null;
+    teamName: string;
+    coachName: string;
+  } | null;
+  opponent: {
+    teamName: string;
+    coachName: string;
+  } | null;
+}
+
+interface MyMatchesResponse {
+  matches: MyMatch[];
+}
+
+interface ApiEnvelope<T> {
+  success?: boolean;
+  data?: T;
+}
+
+interface Props {
+  teamId: string;
+}
+
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function dismissKey(teamId: string, matchId: string): string {
+  return `match_report_dismissed:${teamId}:${matchId}`;
+}
+
+function isDismissed(teamId: string, matchId: string): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(dismissKey(teamId, matchId)) === "1";
+}
+
+function markDismissed(teamId: string, matchId: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(dismissKey(teamId, matchId), "1");
+}
+
+function formatRelative(iso: string, now: number): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const diff = now - t;
+  if (diff < 0) return "à l'instant";
+  const hours = Math.floor(diff / 3_600_000);
+  if (hours < 1) return "il y a < 1h";
+  if (hours < 24) return `il y a ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `il y a ${days}j`;
+}
+
+export function MatchReportBanner({ teamId }: Props): JSX.Element | null {
+  const [match, setMatch] = useState<MyMatch | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [dismissed, setDismissed] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!teamId) return;
+    let cancelled = false;
+    setLoading(true);
+    apiRequest<ApiEnvelope<MyMatchesResponse> | MyMatchesResponse>(
+      "/match/my-matches",
+    )
+      .then((response) => {
+        if (cancelled) return;
+        // L'endpoint utilise un envelope { success, data: { matches } }.
+        const data =
+          "data" in response && response.data ? response.data : response;
+        const matches =
+          (data as MyMatchesResponse).matches ?? ([] as MyMatch[]);
+        const now = Date.now();
+        const recent = matches.find((m) => {
+          if (m.status !== "completed") return false;
+          if (m.myTeam?.teamId !== teamId) return false;
+          const at = new Date(m.lastMoveAt ?? m.createdAt).getTime();
+          if (Number.isNaN(at)) return false;
+          return now - at <= RECENT_WINDOW_MS;
+        });
+        if (recent && !isDismissed(teamId, recent.id)) {
+          setMatch(recent);
+        }
+      })
+      .catch(() => {
+        // Erreur silencieuse — non-critique pour la page.
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  if (loading || dismissed || !match) return null;
+
+  const won = match.myScore > match.opponentScore;
+  const drew = match.myScore === match.opponentScore;
+  const resultLabel = won ? "Victoire" : drew ? "Match nul" : "Défaite";
+  const resultEmoji = won ? "🏆" : drew ? "🤝" : "💀";
+  const tone = won
+    ? "border-emerald-700 bg-emerald-950/40 text-emerald-100"
+    : drew
+      ? "border-slate-600 bg-slate-900 text-slate-100"
+      : "border-rose-800 bg-rose-950/40 text-rose-100";
+  const scoreTone = won
+    ? "text-emerald-300"
+    : drew
+      ? "text-slate-200"
+      : "text-rose-300";
+
+  const opponentLabel =
+    match.opponent?.teamName ?? match.opponent?.coachName ?? "Adversaire";
+  const relative = formatRelative(
+    match.lastMoveAt ?? match.createdAt,
+    Date.now(),
+  );
+
+  return (
+    <section
+      data-testid="match-report-banner"
+      className={`mb-4 flex flex-col gap-2 rounded border px-4 py-3 sm:flex-row sm:items-center sm:gap-4 ${tone}`}
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-2xl" aria-hidden="true">
+          {resultEmoji}
+        </span>
+        <div>
+          <div className="text-xs uppercase opacity-80">
+            Dernier match {relative}
+          </div>
+          <div className="text-sm font-semibold">
+            {resultLabel} contre{" "}
+            <span className="font-bold">{opponentLabel}</span>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-1 items-center justify-end gap-3">
+        <span
+          data-testid="match-report-score"
+          className={`font-mono text-2xl font-bold ${scoreTone}`}
+        >
+          {match.myScore} – {match.opponentScore}
+        </span>
+        <Link
+          data-testid="match-report-details"
+          href={`/match/${match.id}/details`}
+          className="rounded border border-white/30 px-3 py-1.5 text-xs font-semibold hover:bg-white/10"
+        >
+          Voir détails →
+        </Link>
+        <button
+          type="button"
+          data-testid="match-report-dismiss"
+          onClick={() => {
+            markDismissed(teamId, match.id);
+            setDismissed(true);
+          }}
+          aria-label="Masquer ce résumé"
+          className="rounded p-1 opacity-60 hover:opacity-100"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/me/teams/[id]/page.tsx
+++ b/apps/web/app/me/teams/[id]/page.tsx
@@ -11,6 +11,7 @@ import { UMAMI_EVENTS, trackUmamiEvent } from "../../../lib/umami-events";
 import { useFeatureFlag } from "../../../hooks/useFeatureFlag";
 import { LEAGUES_V2_UI_FLAG } from "../../../lib/featureFlagKeys";
 import { PendingAdvancementsBanner } from "./PendingAdvancementsBanner";
+import { MatchReportBanner } from "./MatchReportBanner";
 
 async function fetchJSON(path: string) {
   const token = localStorage.getItem("auth_token");
@@ -164,6 +165,7 @@ export default function TeamDetailPage() {
   return (
     <div className="w-full p-4 sm:p-6 space-y-4 sm:space-y-6">
       {v2UiEnabled && id ? <PendingAdvancementsBanner teamId={id} /> : null}
+      {id ? <MatchReportBanner teamId={id} /> : null}
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
         <div className="flex-1">
           <h1 className="text-2xl sm:text-3xl font-bold">{team?.name || t.teams.team}</h1>


### PR DESCRIPTION
## Summary

**Lot O.C.2 du Sprint O** ([SPRINT-O](docs/roadmap/sprints/SPRINT-O-bug-fixes-acquisition.md)).

L'audit 2026-05-10 identifiait l'absence de "post-match report" comme hook rétention : le score s'affichait sur la page match mais zéro indice sur la page équipe pour rappeler "votre dernier match était victoire 3-1 contre Cheese Halflings il y a 2j".

Banner "Dernier match" sur `/me/teams/[id]` :
- Filtre : `status=completed`, `myTeam.teamId === currentTeamId`, fenêtre 7 jours, pas déjà dismiss.
- Affiche : emoji résultat (🏆 / 🤝 / 💀), label "Victoire/Match nul/Défaite", score colorisé (vert/slate/rose), opponent name, date relative ("il y a 2j"), bouton "Voir détails" → `/match/[id]/details`, bouton dismiss.
- Dismiss persiste via `localStorage` par `teamId+matchId`.
- Erreur API silencieuse → banner masqué, page non-bloquante.

### Backend
- `match-details-handlers.handleListMyMatches` : ajoute `myTeam.teamId` au response shape pour permettre le filtre côté client. Pas de breaking change.

### Frontend
- Nouveau `/me/teams/[id]/MatchReportBanner.tsx`.
- Monté dans `page.tsx` au-dessus de la fiche équipe, en-dessous de `PendingAdvancementsBanner` (complémentaires).

## Test plan
- [x] 11 tests `MatchReportBanner.test.tsx` (won/draw/lost, filtres teamId/status/window, dismiss persistance, lien détails, erreur silencieuse, envelope `{ success, data }`).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2152 verts.
- [x] `pnpm --filter @bb/web test` — 923 verts (+11).
- [ ] Smoke : jouer un match → aller sur `/me/teams/[id]` → banner avec score + résultat + bouton détails.

## Sprint O — bilan
- ✅ Lot O.A.1 (regen/apothecary order, #745 mergé)
- ✅ Lot O.B.1 (auto-approve flag + kill-switch CI fix, #746 mergé)
- ✅ Lot O.B.3 (onboarding modal, #747 mergé)
- ✅ Lot O.C.1 (daily bonus UI, #748)
- ✅ Lot O.C.3 (badge unlock toast, #749)
- ✅ Lot O.D (OG image + share buttons, #750)
- ✅ Lot O.C.2 (match report banner — **cette PR**)
- ⏳ Lot O.A.2-4 (skill registry wiring) — différé à session dédiée pour focus engine

**7 PR Sprint O créées en une session** sur la base de l'audit 7 agents.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_