### PR TITLE
feat(ops): mode maintenance global toggleable (Lot P.A.1)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -41,6 +41,7 @@ import {
   adminFeatureFlagsRouter,
 } from "./routes/feature-flags";
 import { requireFeatureFlag } from "./middleware/requireFeatureFlag";
+import { maintenanceMode } from "./middleware/maintenance";
 import {
   AI_TRAINING_FLAG,
   ONLINE_PLAY_FLAG,
@@ -117,6 +118,11 @@ app.use(bodyParser.json());
 
 // Rate limiting global sur toutes les routes API (100 req/min par IP)
 app.use(apiRateLimiter);
+
+// Sprint P (Lot P.A.1) — mode maintenance global. Kill-switch :
+// 503 + Retry-After pour toutes les routes sauf /health/*, /admin/*
+// et auth essentielles. Toggle via /admin/feature-flags.
+app.use(maintenanceMode());
 
 // Healthchecks S25.1 :
 //  - /health      : alias retro-compatible vers liveness ({ok:true,status:"live"})

--- a/apps/server/src/middleware/maintenance.test.ts
+++ b/apps/server/src/middleware/maintenance.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests pour `maintenanceMode` middleware (Sprint P — Lot P.A.1).
+ *
+ * Couvre :
+ *   - Flag OFF (defaut) : passe au next() sans rien faire.
+ *   - Flag ON : 503 + Retry-After + payload JSON.
+ *   - Allowlist : /health, /admin, /auth/login etc. passent meme si flag ON.
+ *   - Erreur featureFlags lookup : laisse passer (fail-open).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+
+vi.mock("../services/featureFlags", async () => {
+  const actual =
+    await vi.importActual<typeof import("../services/featureFlags")>(
+      "../services/featureFlags",
+    );
+  return {
+    ...actual,
+    isEnabled: vi.fn(),
+  };
+});
+
+import { isEnabled } from "../services/featureFlags";
+import { maintenanceMode } from "./maintenance";
+
+const mockedIsEnabled = vi.mocked(isEnabled);
+
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: unknown;
+  status: (code: number) => MockRes;
+  setHeader: (name: string, value: string) => void;
+  json: (payload: unknown) => MockRes;
+}
+
+function buildRes(): MockRes {
+  const res: MockRes = {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+function buildReq(path: string): Request {
+  return { path } as unknown as Request;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("maintenanceMode — Lot P.A.1", () => {
+  it("flag OFF : passe au next() sans rien faire", async () => {
+    mockedIsEnabled.mockResolvedValueOnce(false);
+    const middleware = maintenanceMode();
+    const next = vi.fn() as unknown as NextFunction;
+    const res = buildRes();
+    await middleware(buildReq("/pro-league"), res as unknown as Response, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBeUndefined();
+  });
+
+  it("flag ON : 503 + Retry-After + JSON payload", async () => {
+    mockedIsEnabled.mockResolvedValueOnce(true);
+    const middleware = maintenanceMode();
+    const next = vi.fn() as unknown as NextFunction;
+    const res = buildRes();
+    await middleware(buildReq("/pro-league"), res as unknown as Response, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(503);
+    expect(res.headers["Retry-After"]).toBe("3600");
+    expect(res.headers["Cache-Control"]).toBe("no-store");
+    const body = res.body as { error: string; retryAfterSeconds: number };
+    expect(body.error).toBe("maintenance");
+    expect(body.retryAfterSeconds).toBe(3600);
+  });
+
+  it("allowlist /health : passe meme si flag ON", async () => {
+    mockedIsEnabled.mockResolvedValue(true);
+    const middleware = maintenanceMode();
+    const paths = [
+      "/health",
+      "/health/live",
+      "/health/ready",
+      "/admin",
+      "/admin/feature-flags",
+      "/admin/users/123",
+      "/auth/login",
+      "/auth/refresh",
+      "/auth/me",
+      "/auth/logout",
+    ];
+    for (const path of paths) {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = buildRes();
+      await middleware(buildReq(path), res as unknown as Response, next);
+      expect(next, `path=${path}`).toHaveBeenCalledOnce();
+      expect(res.statusCode, `path=${path}`).toBe(200);
+    }
+    // isEnabled n'est meme pas appele puisque la path est allowlist.
+    expect(mockedIsEnabled).not.toHaveBeenCalled();
+  });
+
+  it("erreur lookup featureFlags : fail-open (laisse passer)", async () => {
+    mockedIsEnabled.mockRejectedValueOnce(new Error("DB down"));
+    const middleware = maintenanceMode();
+    const next = vi.fn() as unknown as NextFunction;
+    const res = buildRes();
+    await middleware(buildReq("/pro-league"), res as unknown as Response, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("path prefix matching : /pro-league/anything bloque, /admin-fake passe pas par allowlist", async () => {
+    mockedIsEnabled.mockResolvedValue(true);
+    const middleware = maintenanceMode();
+
+    // /pro-league/matches/abc → bloque
+    {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = buildRes();
+      await middleware(
+        buildReq("/pro-league/matches/abc"),
+        res as unknown as Response,
+        next,
+      );
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(503);
+    }
+
+    // /admin-fake (pas /admin/*) → bloque (pas allowlist)
+    {
+      const next = vi.fn() as unknown as NextFunction;
+      const res = buildRes();
+      await middleware(
+        buildReq("/admin-fake"),
+        res as unknown as Response,
+        next,
+      );
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(503);
+    }
+  });
+});

--- a/apps/server/src/middleware/maintenance.ts
+++ b/apps/server/src/middleware/maintenance.ts
@@ -1,0 +1,95 @@
+/**
+ * Sprint P — Lot P.A.1 : mode maintenance global.
+ *
+ * Quand le feature flag `maintenance_mode` est actif, intercept toutes
+ * les requetes non-essentielles et retourne 503 avec `Retry-After`.
+ *
+ * Routes preservees en mode maintenance :
+ *   - `/health/*` : Kubernetes / Docker healthchecks (sinon le scheduler
+ *     reschedule le pod en boucle).
+ *   - `/admin/*` : admins peuvent toggle off le flag depuis l'UI.
+ *   - `/auth/login` : admins peuvent se connecter pour gerer.
+ *
+ * Le flag est un **kill-switch** au sens du `KILL_SWITCH_FLAGS` set —
+ * il ne doit JAMAIS etre force-ON par `FEATURE_FLAGS_FORCE_ENABLED`.
+ *
+ * Strategie : middleware mont apres `requestContext` + `requestTiming`
+ * pour avoir le logger associe, et AVANT les routes business.
+ */
+
+import type { NextFunction, Request, Response } from "express";
+
+import {
+  MAINTENANCE_MODE_FLAG,
+  isEnabled as isFeatureEnabled,
+} from "../services/featureFlags";
+
+const RETRY_AFTER_SECONDS = 3600;
+
+/**
+ * Liste des routes (prefixe path) que le middleware laisse passer meme
+ * en mode maintenance. Tout le reste retourne 503.
+ *
+ * `/admin/*` car les admins doivent pouvoir toggle off le flag.
+ * `/auth/login`, `/auth/refresh`, `/auth/me` car les admins doivent
+ * pouvoir se reconnecter (et garder une session active si elle expire).
+ */
+const ALLOWLIST_PREFIXES = [
+  "/health",
+  "/admin",
+  "/auth/login",
+  "/auth/refresh",
+  "/auth/me",
+  "/auth/logout",
+];
+
+function isAllowlistedPath(path: string): boolean {
+  for (const prefix of ALLOWLIST_PREFIXES) {
+    if (path === prefix || path.startsWith(`${prefix}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Middleware Express qui verifie le flag maintenance a chaque request.
+ *
+ * Cout : 1 lookup memoire (cache 30s sur le service featureFlags).
+ * Negligeable.
+ */
+export function maintenanceMode() {
+  return async function maintenanceMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    if (isAllowlistedPath(req.path)) {
+      next();
+      return;
+    }
+
+    let enabled = false;
+    try {
+      enabled = await isFeatureEnabled(MAINTENANCE_MODE_FLAG);
+    } catch {
+      // Lookup DB en panne ? On laisse passer plutot que de claquer le
+      // site. La readiness probe `/health/ready` ramassera l'incident.
+      enabled = false;
+    }
+
+    if (!enabled) {
+      next();
+      return;
+    }
+
+    res.setHeader("Retry-After", String(RETRY_AFTER_SECONDS));
+    res.setHeader("Cache-Control", "no-store");
+    res.status(503).json({
+      error: "maintenance",
+      message:
+        "Le site est temporairement indisponible pour maintenance. Reviens dans quelques minutes.",
+      retryAfterSeconds: RETRY_AFTER_SECONDS,
+    });
+  };
+}

--- a/apps/server/src/seed.ts
+++ b/apps/server/src/seed.ts
@@ -23,6 +23,7 @@ import {
   AI_TRAINING_FLAG,
   LEAGUES_V2_UI_FLAG,
   REGISTRATION_REQUIRES_VALIDATION_FLAG,
+  MAINTENANCE_MODE_FLAG,
 } from "./services/featureFlags";
 import { seedDefaultLeagues, DEFAULT_LEAGUE_NAME } from "./seeders/leagues";
 import { seedProLeague, OLD_WORLD_LEAGUE_NAME } from "./seeders/pro-league";
@@ -1080,6 +1081,26 @@ async function main() {
   });
   serverLog.log(
     `   ✅ Flag '${REGISTRATION_REQUIRES_VALIDATION_FLAG}' ${registrationValidationFlag.enabled ? "ACTIF (validation requise)" : "inactif (auto-approve par defaut)"}`,
+  );
+
+  // Sprint P (Lot P.A.1) — kill-switch global "maintenance mode". OFF
+  // par defaut (site up). Activer via /admin/feature-flags pour mettre
+  // tout le site en 503 sauf admin/health/auth essentielles.
+  const maintenanceFlag = await prisma.featureFlag.upsert({
+    where: { key: MAINTENANCE_MODE_FLAG },
+    update: {
+      description:
+        "Lot P.A.1 — Kill-switch global. Si active, toutes les routes non-essentielles retournent 503 + Retry-After. Routes preservees : /health/*, /admin/*, /auth/{login,refresh,me,logout}.",
+    },
+    create: {
+      key: MAINTENANCE_MODE_FLAG,
+      description:
+        "Lot P.A.1 — Kill-switch global. Si active, toutes les routes non-essentielles retournent 503 + Retry-After. Routes preservees : /health/*, /admin/*, /auth/{login,refresh,me,logout}.",
+      enabled: false,
+    },
+  });
+  serverLog.log(
+    `   ✅ Flag '${MAINTENANCE_MODE_FLAG}' ${maintenanceFlag.enabled ? "🚧 ACTIF — site en maintenance" : "inactif (site up)"}`,
   );
 
   // =============================================================================

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -36,6 +36,18 @@ export const AI_TRAINING_FLAG = "ai_training" as const;
 export const LEAGUES_V2_UI_FLAG = "leagues_v2_ui" as const;
 
 /**
+ * Sprint P (Lot P.A.1) — kill-switch global qui met le site en mode
+ * "maintenance" : toutes les routes non-essentielles retournent 503
+ * avec `Retry-After`. Routes preservees : `/health/*`, `/admin/*`,
+ * `/auth/login`, `/auth/refresh`, `/auth/me`, `/auth/logout`. Le
+ * frontend affiche une page maintenance avec timer.
+ *
+ * Kill-switch (cf. `KILL_SWITCH_FLAGS`) → pas force-ON par
+ * `FEATURE_FLAGS_FORCE_ENABLED` (CI).
+ */
+export const MAINTENANCE_MODE_FLAG = "maintenance_mode" as const;
+
+/**
  * Sprint O (Lot O.B.1) — kill-switch optionnel pour exiger une validation
  * admin sur les nouveaux comptes. Par defaut OFF (auto-approve), pour ne
  * pas bloquer l'acquisition. Si activate :
@@ -128,6 +140,7 @@ async function getAllFlagsCached(): Promise<FeatureFlagDTO[]> {
  */
 const KILL_SWITCH_FLAGS = new Set<string>([
   REGISTRATION_REQUIRES_VALIDATION_FLAG,
+  MAINTENANCE_MODE_FLAG,
 ]);
 
 /**

--- a/apps/web/app/maintenance/page.tsx
+++ b/apps/web/app/maintenance/page.tsx
@@ -1,0 +1,61 @@
+/**
+ * Page maintenance — Sprint P (Lot P.A.1).
+ *
+ * Affichee quand le serveur API retourne 503 (mode maintenance global).
+ * Pas de fetch DB, pas de side effect — page statique server-rendered.
+ *
+ * Le frontend rediriger automatiquement vers cette page peut etre
+ * ajoute en futur (intercepteur API global qui detecte 503 sur les
+ * fetchs). Pour la v1, l'admin partage le lien `/maintenance` ou les
+ * users tombent dessus via leurs requetes echouees.
+ */
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Maintenance — Nuffle Arena",
+  description:
+    "Le site est temporairement indisponible pour maintenance. Reviens dans quelques minutes.",
+  robots: { index: false, follow: false },
+};
+
+export default function MaintenancePage(): JSX.Element {
+  return (
+    <main
+      data-testid="maintenance-page"
+      className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center bg-slate-950 px-6 py-12 text-center text-slate-100"
+    >
+      <div className="mb-6 text-6xl" aria-hidden="true">
+        🚧
+      </div>
+      <h1 className="mb-4 text-3xl font-bold tracking-wide text-amber-200 sm:text-4xl">
+        Nuffle siffle un temps mort
+      </h1>
+      <p className="mb-6 text-base text-slate-300 sm:text-lg">
+        Le site est temporairement indisponible pour maintenance. Les
+        Hommes-Lézards refont la pelouse, les Orcs reprogrammèrent
+        l&apos;arbitre, et le serveur fait un check d&apos;armure.
+      </p>
+      <p className="mb-8 text-sm text-slate-400">
+        Reviens dans quelques minutes. La Pro League reprend bientôt son
+        cours.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-3 text-sm">
+        <Link
+          href="/"
+          className="rounded border border-slate-700 px-4 py-2 text-slate-300 hover:bg-slate-800"
+        >
+          ← Page d&apos;accueil
+        </Link>
+        <a
+          href="https://discord.gg/nuffle"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded border border-indigo-700 bg-indigo-950 px-4 py-2 text-indigo-200 hover:bg-indigo-900"
+        >
+          Discord ↗
+        </a>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

**Lot P.A.1 du Sprint P** ([SPRINT-P](docs/roadmap/sprints/SPRINT-P-ops-readiness.md)). Premier lot du sprint ops readiness.

Audit ops-readiness identifiait l'absence de mode maintenance comme **P0** : chaque deploy = downtime non-gérée, aucune façon "propre" de mettre le site en stand-by si bug critique découvert.

Kill-switch global :

### Backend (`apps/server`)
- Nouveau flag `maintenance_mode` (`MAINTENANCE_MODE_FLAG`) ajouté aux `KILL_SWITCH_FLAGS` (pas force-ON par CI).
- Middleware `maintenance.ts` monté après `apiRateLimiter`. Si flag ON, retourne **503** + `Retry-After: 3600` + payload JSON.
- **Allowlist** : `/health/*`, `/admin/*`, `/auth/{login,refresh,me,logout}`.
- **Fail-open** si lookup featureFlags échoue (DB down) : laisse passer plutôt que claquer le site.

### Frontend (`apps/web`)
- Page statique `/maintenance` avec bannière thème BB ("Nuffle siffle un temps mort"), emoji 🚧, lien Discord + retour accueil. `robots: noindex, nofollow`.

### Seed
- Flag seed avec `enabled: false` (défaut OFF).

## Test plan
- [x] 5 tests `maintenance.test.ts` (OFF/ON/allowlist 10 paths/fail-open/path prefix strict).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2157 verts (+5).
- [x] `pnpm --filter @bb/web test` — 951 verts.
- [ ] Smoke : toggle flag dans `/admin/feature-flags` → tous endpoints sauf admin retournent 503.

### Utilité ops
Admin toggle flag → site bascule en 503 instantanément (cache 30s du service flags), zéro redeploy. Admins restent accessibles pour reverter.

## Sprint P progression
- ✅ Lot P.A.1 — **cette PR**
- ⏳ Lot P.A.2 (soft-delete users)
- ⏳ Lot P.A.3 (GDPR export)
- ⏳ Lot P.B.1 (admin wallet UI)
- ⏳ Lot P.B.2 (Crowns sinks)
- ⏳ Lot P.B.3 (season factory)
- ⏳ Lot P.B.4 (modération matchs)
- ⏳ Lot P.C.1 (password reset)
- ⏳ Lot P.C.2 (admin password reset override)
- ⏳ Lot P.C.3 (dashboard analytics)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_