### PR TITLE
feat(pro-league): Hall of Fame dedications — Crowns sink (Lot P.B.2)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -74,6 +74,7 @@ model User {
   proWallet                   ProWallet?
   proBets                     ProBet[]
   proUserBadges               ProUserBadge[]
+  proHofDedications           ProHallOfFameDedication[]
 }
 
 /// S26.3l — mirror SQLite de l'historique ELO Postgres (snapshot par mise a jour).
@@ -1147,7 +1148,7 @@ model ProGazetteArticle {
 }
 
 model ProHallOfFame {
-  id          String   @id @default(cuid())
+  id          String                     @id @default(cuid())
   rosterId    String
   teamSlug    String
   teamName    String
@@ -1163,12 +1164,35 @@ model ProHallOfFame {
   careerStats String
   reason      String
   citation    String?
-  inductedAt  DateTime @default(now())
+  inductedAt  DateTime                   @default(now())
+  /// Sprint P (Lot P.B.2) — dedications fans payees en Crowns.
+  dedications ProHallOfFameDedication[]
 
   @@unique([rosterId, reason])
   @@index([teamSlug])
   @@index([reason])
   @@index([inductedAt])
+}
+
+/// Sprint P (Lot P.B.2) — Dedications sur les entrees Hall of Fame.
+/// Sink Crowns : un user paie 500 Crowns pour epingler un message
+/// custom (max 280 chars) sur une entree HoF. 1 dedicace par user
+/// par entree (unique[hallOfFameId, userId]). Sert de Crowns sink
+/// pour prevenir l'hyperinflation introduite par les daily bonus +
+/// gains de paris.
+model ProHallOfFameDedication {
+  id           String        @id @default(cuid())
+  hallOfFameId String
+  hallOfFame   ProHallOfFame @relation(fields: [hallOfFameId], references: [id], onDelete: Cascade)
+  userId       String
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  message      String        // max 280 chars (validated cote service)
+  costCrowns   Int           // montant debite (500 par defaut)
+  createdAt    DateTime      @default(now())
+
+  @@unique([hallOfFameId, userId])
+  @@index([userId])
+  @@index([hallOfFameId, createdAt])
 }
 
 // S27.6 — Audit log admin. Schema SQLite : `oldValue`/`newValue`

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -54,6 +54,12 @@ import {
 } from "../services/pro-gazette";
 import { listHallOfFame } from "../services/pro-hall-of-fame";
 import {
+  DEDICATE_COST_CROWNS,
+  DedicateError,
+  dedicateHallOfFame,
+  listDedications,
+} from "../services/pro-hall-of-fame-dedicate";
+import {
   InsufficientFundsError,
   getBalance,
   getRecentTransactions,
@@ -763,6 +769,87 @@ export async function handleListHallOfFame(
 }
 
 /**
+ * Sprint P (Lot P.B.2) — Liste publique des dedications d'une entree
+ * Hall of Fame. Pas d'auth requise. Pagination via `?limit=N`.
+ */
+export async function handleListHallOfFameDedications(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const id = req.params.id;
+  if (!id || typeof id !== "string") {
+    res.status(400).json({ error: "missing-id" });
+    return;
+  }
+  const limit =
+    typeof req.query.limit === "string"
+      ? Number.parseInt(req.query.limit, 10)
+      : 50;
+  try {
+    const dedications = await listDedications(id, limit);
+    res.json({ dedications, costCrowns: DEDICATE_COST_CROWNS });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(
+      `[pro-league/hall-of-fame/${id}/dedications] failed: ${msg}`,
+    );
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint P (Lot P.B.2) — Dedicace une entree HoF en payant 500 Crowns.
+ * Auth requise. Body `{ message: string }` (max 280 chars).
+ *
+ * Codes erreur :
+ *  - 400 INVALID_MESSAGE / MESSAGE_TOO_LONG
+ *  - 402 WALLET_INSUFFICIENT_FUNDS (mapping cote handler)
+ *  - 404 HOF_NOT_FOUND
+ */
+export async function handleDedicateHallOfFame(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: "unauthenticated" });
+    return;
+  }
+  const id = req.params.id;
+  if (!id || typeof id !== "string") {
+    res.status(400).json({ error: "missing-id" });
+    return;
+  }
+  const message = (req.body as { message?: unknown })?.message;
+  if (typeof message !== "string") {
+    res.status(400).json({ error: "INVALID_MESSAGE", code: "INVALID_MESSAGE" });
+    return;
+  }
+  try {
+    const out = await dedicateHallOfFame(userId, id, message);
+    res.status(out.granted ? 201 : 200).json(out);
+  } catch (err: unknown) {
+    if (err instanceof DedicateError) {
+      const status = err.code === "HOF_NOT_FOUND" ? 404 : 400;
+      res.status(status).json({ error: err.message, code: err.code });
+      return;
+    }
+    if (err instanceof InsufficientFundsError) {
+      res.status(402).json({
+        error: err.message,
+        code: "WALLET_INSUFFICIENT_FUNDS",
+      });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(
+      `[pro-league/hall-of-fame/${id}/dedicate] failed: ${msg}`,
+    );
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
  * Sprint 1.E.2 — Liste les dates publiées (archive). `?limit=N`.
  */
 export async function handleListEditionDates(
@@ -911,6 +998,15 @@ router.get("/gazette/latest", handleGetLatestEdition);
 router.get("/gazette/dates", handleListEditionDates);
 router.get("/gazette/:date", handleGetEditionByDate);
 router.get("/hall-of-fame", handleListHallOfFame);
+router.get(
+  "/hall-of-fame/:id/dedications",
+  handleListHallOfFameDedications,
+);
+router.post(
+  "/hall-of-fame/:id/dedicate",
+  authUser,
+  handleDedicateHallOfFame,
+);
 router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
 
 // Sprint 1.C.4 — endpoints auth-protected pour le mode "fan".

--- a/apps/server/src/services/pro-hall-of-fame-dedicate.test.ts
+++ b/apps/server/src/services/pro-hall-of-fame-dedicate.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests pour `dedicateHallOfFame` + `listDedications` (Sprint P — Lot P.B.2).
+ *
+ * Couvre :
+ *   - 404 HOF_NOT_FOUND.
+ *   - INVALID_MESSAGE (vide / trim).
+ *   - MESSAGE_TOO_LONG (>280 chars).
+ *   - InsufficientFundsError (<500 Crowns).
+ *   - Happy path : granted=true, balance debite, ref correct.
+ *   - Idempotence : 2eme call meme user/hof → granted=false, pas de nouveau debit.
+ *   - listDedications : tri desc, limit cap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proHallOfFame: { findUnique: vi.fn() },
+    proHallOfFameDedication: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    proWallet: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn(),
+      create: vi.fn(),
+    },
+    proTransaction: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("./pro-wallet", async () => {
+  const actual =
+    await vi.importActual<typeof import("./pro-wallet")>("./pro-wallet");
+  return {
+    ...actual,
+    getOrCreateWallet: vi.fn(),
+  };
+});
+
+import { prisma } from "../prisma";
+import { getOrCreateWallet, InsufficientFundsError } from "./pro-wallet";
+import {
+  DEDICATE_COST_CROWNS,
+  DedicateError,
+  dedicateHallOfFame,
+  listDedications,
+} from "./pro-hall-of-fame-dedicate";
+
+interface MockedPrisma {
+  proHallOfFame: { findUnique: ReturnType<typeof vi.fn> };
+  proHallOfFameDedication: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  proWallet: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  proTransaction: { create: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+const mockedGetWallet = vi.mocked(getOrCreateWallet);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetWallet.mockResolvedValue({ userId: "u1", crowns: 1000 });
+  mocked.proHallOfFame.findUnique.mockResolvedValue({ id: "hof_1" });
+});
+
+describe("dedicateHallOfFame — Lot P.B.2", () => {
+  it("404 HOF_NOT_FOUND si l'entree n'existe pas", async () => {
+    mocked.proHallOfFame.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      dedicateHallOfFame("u1", "missing", "Hello"),
+    ).rejects.toThrow(DedicateError);
+  });
+
+  it("INVALID_MESSAGE si message vide / whitespace", async () => {
+    for (const empty of ["", "   ", "\n\t"]) {
+      await expect(
+        dedicateHallOfFame("u1", "hof_1", empty),
+      ).rejects.toThrow(/vide/i);
+    }
+  });
+
+  it("MESSAGE_TOO_LONG si > 280 chars", async () => {
+    const long = "a".repeat(281);
+    await expect(
+      dedicateHallOfFame("u1", "hof_1", long),
+    ).rejects.toMatchObject({ code: "MESSAGE_TOO_LONG" });
+  });
+
+  it("InsufficientFundsError si solde < 500", async () => {
+    mocked.proHallOfFameDedication.findUnique.mockResolvedValueOnce(null);
+    mocked.$transaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        proWallet: {
+          findUnique: vi.fn().mockResolvedValue({ crowns: 100 }), // insufficient
+          update: vi.fn(),
+        },
+        proTransaction: { create: vi.fn() },
+        proHallOfFameDedication: { create: vi.fn() },
+      };
+      return cb(tx);
+    });
+    await expect(
+      dedicateHallOfFame("u1", "hof_1", "Hello"),
+    ).rejects.toThrow(InsufficientFundsError);
+  });
+
+  it("happy path : granted=true + debit + ref + dedication cree", async () => {
+    mocked.proHallOfFameDedication.findUnique.mockResolvedValueOnce(null);
+    const txCreate = vi.fn().mockResolvedValue({ id: "tx_1" });
+    const dedCreate = vi.fn().mockResolvedValue({
+      id: "ded_1",
+      createdAt: new Date("2026-05-11T08:00:00Z"),
+    });
+    const walletUpdate = vi.fn().mockResolvedValue({ crowns: 500 });
+    mocked.$transaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        proWallet: {
+          findUnique: vi.fn().mockResolvedValue({ crowns: 1000 }),
+          update: walletUpdate,
+        },
+        proTransaction: { create: txCreate },
+        proHallOfFameDedication: { create: dedCreate },
+      };
+      return cb(tx);
+    });
+
+    const out = await dedicateHallOfFame("u1", "hof_1", "Pour Grom, le meilleur");
+    expect(out.granted).toBe(true);
+    expect(out.dedicationId).toBe("ded_1");
+    expect(out.message).toBe("Pour Grom, le meilleur");
+    expect(out.costCrowns).toBe(DEDICATE_COST_CROWNS);
+    expect(out.balance).toBe(500);
+    expect(walletUpdate).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      data: { crowns: 500 },
+      select: { crowns: true },
+    });
+    expect(txCreate).toHaveBeenCalledWith({
+      data: {
+        walletId: "u1",
+        type: "SINK",
+        amount: -500,
+        ref: "hof-dedicate:hof_1",
+      },
+    });
+    expect(dedCreate).toHaveBeenCalledWith({
+      data: {
+        hallOfFameId: "hof_1",
+        userId: "u1",
+        message: "Pour Grom, le meilleur",
+        costCrowns: 500,
+      },
+      select: { id: true, createdAt: true },
+    });
+  });
+
+  it("idempotent : 2eme call meme user/hof → granted=false, pas de nouveau debit", async () => {
+    mocked.proHallOfFameDedication.findUnique.mockResolvedValueOnce({
+      id: "ded_existing",
+      message: "Already there",
+      costCrowns: 500,
+      createdAt: new Date("2026-05-10T12:00:00Z"),
+    });
+    const out = await dedicateHallOfFame("u1", "hof_1", "New message");
+    expect(out.granted).toBe(false);
+    expect(out.dedicationId).toBe("ded_existing");
+    expect(out.message).toBe("Already there"); // ancien message preserve, pas update gratuit
+    expect(mocked.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("trim le message avant validation et insert", async () => {
+    mocked.proHallOfFameDedication.findUnique.mockResolvedValueOnce(null);
+    const dedCreate = vi.fn().mockResolvedValue({
+      id: "ded_x",
+      createdAt: new Date(),
+    });
+    mocked.$transaction.mockImplementationOnce(async (cb) => {
+      const tx = {
+        proWallet: {
+          findUnique: vi.fn().mockResolvedValue({ crowns: 1000 }),
+          update: vi.fn().mockResolvedValue({ crowns: 500 }),
+        },
+        proTransaction: { create: vi.fn() },
+        proHallOfFameDedication: { create: dedCreate },
+      };
+      return cb(tx);
+    });
+    await dedicateHallOfFame("u1", "hof_1", "  Hello world  ");
+    expect(dedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ message: "Hello world" }),
+      }),
+    );
+  });
+});
+
+describe("listDedications — Lot P.B.2", () => {
+  it("retourne les dedications triees desc par createdAt", async () => {
+    mocked.proHallOfFameDedication.findMany.mockResolvedValueOnce([
+      {
+        id: "d1",
+        userId: "u1",
+        message: "Hommage",
+        costCrowns: 500,
+        createdAt: new Date("2026-05-11T08:00:00Z"),
+        user: { coachName: "Alice" },
+      },
+      {
+        id: "d2",
+        userId: "u2",
+        message: "Legend",
+        costCrowns: 500,
+        createdAt: new Date("2026-05-10T12:00:00Z"),
+        user: { coachName: "Bob" },
+      },
+    ]);
+    const out = await listDedications("hof_1");
+    expect(out).toHaveLength(2);
+    expect(out[0]!.coachName).toBe("Alice");
+    expect(out[0]!.message).toBe("Hommage");
+    expect(out[1]!.coachName).toBe("Bob");
+    expect(mocked.proHallOfFameDedication.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { hallOfFameId: "hof_1" },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+      }),
+    );
+  });
+
+  it("clamp limit entre 1 et 200", async () => {
+    mocked.proHallOfFameDedication.findMany.mockResolvedValue([]);
+    await listDedications("hof_1", 9999);
+    expect(mocked.proHallOfFameDedication.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 200 }),
+    );
+    await listDedications("hof_1", 0);
+    expect(mocked.proHallOfFameDedication.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ take: 1 }),
+    );
+  });
+});

--- a/apps/server/src/services/pro-hall-of-fame-dedicate.ts
+++ b/apps/server/src/services/pro-hall-of-fame-dedicate.ts
@@ -1,0 +1,219 @@
+/**
+ * Service Hall of Fame dedications — Sprint P (Lot P.B.2).
+ *
+ * Permet a un user de payer 500 Crowns pour epingler un message
+ * custom (max 280 chars) sur une entree Hall of Fame. **Sink Crowns**
+ * volontaire — sert a equilibrer l'inflation introduite par les
+ * daily bonus + paris gagnes.
+ *
+ * Idempotent : un user ne peut dedier qu'une seule fois par entree
+ * (`unique[hallOfFameId, userId]`). Re-appel renvoie la dedication
+ * existante sans nouveau debit.
+ *
+ * Atomique : debit wallet + insert dedication dans la meme
+ * `$transaction`. Si l'insert echoue (unique violation, etc.), le
+ * debit est rollback.
+ */
+
+import { prisma } from "../prisma";
+import { InsufficientFundsError, getOrCreateWallet } from "./pro-wallet";
+
+export const DEDICATE_COST_CROWNS = 500;
+export const DEDICATION_MAX_LENGTH = 280;
+
+export type DedicateErrorCode =
+  | "HOF_NOT_FOUND"
+  | "INVALID_MESSAGE"
+  | "MESSAGE_TOO_LONG";
+
+export class DedicateError extends Error {
+  constructor(
+    public readonly code: DedicateErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DedicateError";
+  }
+}
+
+export interface DedicateOutcome {
+  /** True si une nouvelle dedication a ete creee (et 500 Crowns debites). */
+  readonly granted: boolean;
+  readonly dedicationId: string;
+  readonly message: string;
+  readonly costCrowns: number;
+  /** Solde apres operation. */
+  readonly balance: number;
+  readonly createdAt: string;
+}
+
+/**
+ * Dedie une entree Hall of Fame avec un message custom. Idempotent.
+ *
+ * @throws {DedicateError} HOF_NOT_FOUND si l'id n'existe pas.
+ * @throws {DedicateError} INVALID_MESSAGE si message vide/trim.
+ * @throws {DedicateError} MESSAGE_TOO_LONG si > 280 chars.
+ * @throws {InsufficientFundsError} si solde < 500.
+ */
+export async function dedicateHallOfFame(
+  userId: string,
+  hallOfFameId: string,
+  rawMessage: string,
+): Promise<DedicateOutcome> {
+  // Validation message
+  const message = (rawMessage ?? "").trim();
+  if (message.length === 0) {
+    throw new DedicateError(
+      "INVALID_MESSAGE",
+      "Le message ne peut pas etre vide",
+    );
+  }
+  if (message.length > DEDICATION_MAX_LENGTH) {
+    throw new DedicateError(
+      "MESSAGE_TOO_LONG",
+      `Le message ne peut depasser ${DEDICATION_MAX_LENGTH} caracteres`,
+    );
+  }
+
+  // Verifie que l'entree HoF existe (pas dedier dans le vide).
+  const hof = await prisma.proHallOfFame.findUnique({
+    where: { id: hallOfFameId },
+    select: { id: true },
+  });
+  if (!hof) {
+    throw new DedicateError(
+      "HOF_NOT_FOUND",
+      `ProHallOfFame id='${hallOfFameId}' introuvable`,
+    );
+  }
+
+  // Idempotence : si dedicace existe deja pour ce (user, hof), renvoie-la
+  // sans nouveau debit. Pas de mise a jour du message (pour rester
+  // sink-only, sinon on detournerait le pattern via update gratuit).
+  const existing = await prisma.proHallOfFameDedication.findUnique({
+    where: {
+      hallOfFameId_userId: { hallOfFameId, userId },
+    },
+    select: {
+      id: true,
+      message: true,
+      costCrowns: true,
+      createdAt: true,
+    },
+  });
+  if (existing) {
+    const w = await getOrCreateWallet(userId);
+    return {
+      granted: false,
+      dedicationId: existing.id as string,
+      message: existing.message as string,
+      costCrowns: existing.costCrowns as number,
+      balance: w.crowns,
+      createdAt: (existing.createdAt as Date).toISOString(),
+    };
+  }
+
+  // Garantit le wallet (creation silencieuse si absent).
+  await getOrCreateWallet(userId);
+
+  // Atomique : check solde + decremente wallet + cree tx + insert
+  // dedication dans la meme $transaction. Si l'insert dedication
+  // echoue (race condition sur unique), tout rollback.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (await prisma.$transaction(async (tx: any) => {
+    const w = await tx.proWallet.findUnique({
+      where: { userId },
+      select: { crowns: true },
+    });
+    const current = (w?.crowns as number | undefined) ?? 0;
+    if (current < DEDICATE_COST_CROWNS) {
+      throw new InsufficientFundsError(current, DEDICATE_COST_CROWNS);
+    }
+    const updated = await tx.proWallet.update({
+      where: { userId },
+      data: { crowns: current - DEDICATE_COST_CROWNS },
+      select: { crowns: true },
+    });
+    await tx.proTransaction.create({
+      data: {
+        walletId: userId,
+        type: "SINK",
+        amount: -DEDICATE_COST_CROWNS,
+        ref: `hof-dedicate:${hallOfFameId}`,
+      },
+    });
+    const created = await tx.proHallOfFameDedication.create({
+      data: {
+        hallOfFameId,
+        userId,
+        message,
+        costCrowns: DEDICATE_COST_CROWNS,
+      },
+      select: { id: true, createdAt: true },
+    });
+    return {
+      dedicationId: created.id as string,
+      createdAt: (created.createdAt as Date).toISOString(),
+      balance: updated.crowns as number,
+    };
+  })) as { dedicationId: string; createdAt: string; balance: number };
+
+  return {
+    granted: true,
+    dedicationId: result.dedicationId,
+    message,
+    costCrowns: DEDICATE_COST_CROWNS,
+    balance: result.balance,
+    createdAt: result.createdAt,
+  };
+}
+
+export interface DedicationEntry {
+  readonly id: string;
+  readonly userId: string;
+  readonly coachName: string;
+  readonly message: string;
+  readonly costCrowns: number;
+  readonly createdAt: string;
+}
+
+/**
+ * Liste les dedications d'une entree Hall of Fame (paginees, plus
+ * recentes en premier). Public, pas d'auth requis.
+ */
+export async function listDedications(
+  hallOfFameId: string,
+  limit = 50,
+): Promise<readonly DedicationEntry[]> {
+  const cap = Math.min(Math.max(1, Math.floor(limit)), 200);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (await prisma.proHallOfFameDedication.findMany({
+    where: { hallOfFameId },
+    orderBy: { createdAt: "desc" },
+    take: cap,
+    select: {
+      id: true,
+      userId: true,
+      message: true,
+      costCrowns: true,
+      createdAt: true,
+      user: { select: { coachName: true } },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  })) as any as Array<{
+    id: string;
+    userId: string;
+    message: string;
+    costCrowns: number;
+    createdAt: Date;
+    user: { coachName: string };
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    userId: r.userId,
+    coachName: r.user.coachName,
+    message: r.message,
+    costCrowns: r.costCrowns,
+    createdAt: r.createdAt.toISOString(),
+  }));
+}

--- a/apps/server/src/services/pro-wallet.ts
+++ b/apps/server/src/services/pro-wallet.ts
@@ -33,7 +33,14 @@
 import { prisma } from "../prisma";
 
 /** Types valides pour `ProTransaction.type`. */
-export type ProTxType = "BET" | "WIN" | "REWARD" | "DAILY" | "BADGE";
+/**
+ * Sprint P (Lot P.B.2) — `SINK` ajoute pour les Crowns sinks
+ * volontaires (HoF dedication, tournament entry, cosmetics).
+ * Differencie d'un `BET` qui est lui aussi un debit mais avec
+ * promesse de gain. Un `SINK` est un "depense pour fun/prestige" sans
+ * payout possible.
+ */
+export type ProTxType = "BET" | "WIN" | "REWARD" | "DAILY" | "BADGE" | "SINK";
 
 const VALID_TX_TYPES: ReadonlySet<ProTxType> = new Set([
   "BET",
@@ -41,6 +48,7 @@ const VALID_TX_TYPES: ReadonlySet<ProTxType> = new Set([
   "REWARD",
   "DAILY",
   "BADGE",
+  "SINK",
 ]);
 
 export interface ProWalletSnapshot {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ model User {
   proWallet                   ProWallet?
   proBets                     ProBet[]
   proUserBadges               ProUserBadge[]
+  proHofDedications           ProHallOfFameDedication[]
 }
 
 /// S26.3l — Historique ELO du coach. Une ligne par mise a jour ELO (donc 2
@@ -1644,11 +1645,36 @@ model ProHallOfFame {
   /// Description humaine optionnelle (pour rendu UI).
   citation    String?
   inductedAt  DateTime @default(now())
+  /// Sprint P (Lot P.B.2) — dedications fans payees en Crowns.
+  dedications ProHallOfFameDedication[]
 
   @@unique([rosterId, reason])
   @@index([teamSlug])
   @@index([reason])
   @@index([inductedAt])
+}
+
+/// Sprint P (Lot P.B.2) — Dedications sur les entrees Hall of Fame.
+/// Sink Crowns : un user paie 500 Crowns pour epingler un message
+/// custom (max 280 chars) sur une entree HoF. 1 dedicace par user
+/// par entree (unique[hallOfFameId, userId]). Sert de Crowns sink
+/// pour prevenir l'hyperinflation introduite par les daily bonus +
+/// gains de paris.
+model ProHallOfFameDedication {
+  id           String        @id @default(cuid())
+  hallOfFameId String
+  hallOfFame   ProHallOfFame @relation(fields: [hallOfFameId], references: [id], onDelete: Cascade)
+  userId       String
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  /// Texte custom max 280 chars (validation Zod cote service).
+  message      String        @db.VarChar(280)
+  /// Crowns debites au moment de la dedicace (500 par defaut).
+  costCrowns   Int
+  createdAt    DateTime      @default(now())
+
+  @@unique([hallOfFameId, userId])
+  @@index([userId])
+  @@index([hallOfFameId, createdAt])
 }
 
 /// S27.6 — Trace immuable des actions admin (compliance + tracabilite).


### PR DESCRIPTION
## Summary

**Lot P.B.2 du Sprint P** ([SPRINT-P](docs/roadmap/sprints/SPRINT-P-ops-readiness.md)).

Premier sink Crowns volontaire pour prévenir l'hyperinflation introduite par les daily bonus (Lot O.C.1) + gains de paris.

Un user peut payer **500 Crowns** pour épingler un message custom (max 280 chars) sur une entrée Hall of Fame. **Idempotent** : 1 dédicace par (user, hof) — re-call renvoie la dédication existante sans nouveau débit (pas de free update du message).

### Schema (prisma + sqlite)
- Nouveau modèle `ProHallOfFameDedication` avec relation cascade vers `User` et `ProHallOfFame`. `unique[hallOfFameId, userId]` + index[userId] + index[hallOfFameId, createdAt].

### Service
- `dedicateHallOfFame(userId, hofId, message)` atomique (`$transaction`) : check existence HoF, idempotence, debit 500 Crowns avec `type="SINK"` + `ref="hof-dedicate:<id>"`, insert dédication.
- `listDedications(hofId, limit)` public, tri desc createdAt, clamp 1..200.
- Erreurs typées : `DedicateError{ code: HOF_NOT_FOUND | INVALID_MESSAGE | MESSAGE_TOO_LONG }` + propage `InsufficientFundsError`.

### ProTxType
- Ajoute `SINK` au type union + `VALID_TX_TYPES`. Différencie d'un `BET` (debit avec promesse de gain).

### Routes
- `GET /pro-league/hall-of-fame/:id/dedications?limit=N` (public).
- `POST /pro-league/hall-of-fame/:id/dedicate` (auth) — body `{ message }`.

## Test plan
- [x] 9 tests `pro-hall-of-fame-dedicate.test.ts` (404, message vide/long, insufficient funds, happy path, idempotence, trim, listDedications sort + clamp).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2161 verts (+9).
- [ ] Smoke : signup user → claim daily 50 Crowns × 10 jours → naviguer vers `/pro-league/hall-of-fame/[id]/dedications` (UI suit en PR).

## Sprint P progression
- ✅ Lot P.A.1 (mode maintenance, #753)
- ✅ Lot P.B.2 (Crowns sinks HoF — **cette PR**)
- ⏳ Lot P.A.2 (soft-delete users)
- ⏳ Lot P.A.3 (GDPR export)
- ⏳ Lot P.B.1 (admin wallet UI)
- ⏳ Lot P.B.3 (season factory)
- ⏳ Lot P.B.4 (modération matchs)
- ⏳ Lot P.C.1 (password reset)
- ⏳ Lot P.C.2 (admin password reset override)
- ⏳ Lot P.C.3 (dashboard analytics)

**Note UI :** la couche frontend (`/pro-league/hall-of-fame/[id]` bouton "Dédier") sera ajoutée en PR de suivi. Le backend est complet et ready pour intégration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_