### PR TITLE
feat(admin): dashboard analytics business (Lot P.C.3)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import matchRoutes from "./routes/match";
 import adminRoutes from "./routes/admin";
 import adminDataRoutes from "./routes/admin-data";
 import adminLeaguesRoutes from "./routes/admin-leagues";
+import adminAnalyticsRoutes from "./routes/admin-analytics";
 import adminSimRoutes from "./routes/admin-sim";
 import adminSimReplaysRoutes from "./routes/admin-sim-replays";
 import userRoutes from "./routes/user";
@@ -213,6 +214,7 @@ app.use("/admin/feature-flags", adminFeatureFlagsRouter);
 // L2.C.6 — admin leagues : reservation aux admins, route distincte
 // pour ne pas polluer /admin (qui devient un sac fourre-tout).
 app.use("/admin/leagues", adminLeaguesRoutes);
+app.use("/admin", adminAnalyticsRoutes);
 app.use("/admin/sim", adminSimRoutes);
 // Sprint Pro League 0.E.2 / 0.E.3 — exposition lecture seule des replays
 // panel pour la validation C6-C9 du gate Phase 0 → Phase 1 (cf.

--- a/apps/server/src/routes/admin-analytics.ts
+++ b/apps/server/src/routes/admin-analytics.ts
@@ -1,0 +1,35 @@
+/**
+ * Sprint P (Lot P.C.3) — Routes admin analytics.
+ *
+ * `GET /admin/analytics` retourne le snapshot (DAU/MAU/funnel/crowns).
+ * Auth admin required (le router parent monte deja `adminOnly`).
+ */
+
+import { Router, type Request, type Response } from "express";
+
+import { adminOnly } from "../middleware/adminOnly";
+import { authUser } from "../middleware/authUser";
+import { getAnalyticsSnapshot } from "../services/admin-analytics";
+import { serverLog } from "../utils/server-log";
+
+export async function handleGetAnalytics(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const snapshot = await getAnalyticsSnapshot();
+    res.json(snapshot);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[admin/analytics] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+router.get("/analytics", handleGetAnalytics);
+
+export default router;

--- a/apps/server/src/services/admin-analytics.test.ts
+++ b/apps/server/src/services/admin-analytics.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests pour `getAnalyticsSnapshot` (Sprint P — Lot P.C.3).
+ *
+ * Strategy : mock prisma counts/aggregates et verifie la composition
+ * des 4 metriques (DAU, MAU, signupFunnel, crowns) + le calcul du
+ * delta% / conversion%.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    user: { count: vi.fn() },
+    proTransaction: { aggregate: vi.fn() },
+    proWallet: { aggregate: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import { getAnalyticsSnapshot } from "./admin-analytics";
+
+interface MockedPrisma {
+  user: { count: ReturnType<typeof vi.fn> };
+  proTransaction: { aggregate: ReturnType<typeof vi.fn> };
+  proWallet: { aggregate: ReturnType<typeof vi.fn> };
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getAnalyticsSnapshot — Lot P.C.3", () => {
+  it("compose DAU/MAU/funnel/crowns avec deltas %", async () => {
+    // 7 user.count calls in order : dau, dauPrev, mau, mauPrev,
+    // signups, signupsWithTeam, signupsWithMatch
+    mocked.user.count
+      .mockResolvedValueOnce(150) // DAU
+      .mockResolvedValueOnce(120) // DAU prev
+      .mockResolvedValueOnce(800) // MAU
+      .mockResolvedValueOnce(600) // MAU prev
+      .mockResolvedValueOnce(200) // signups 30j
+      .mockResolvedValueOnce(140) // withTeam
+      .mockResolvedValueOnce(80); // withMatch
+    mocked.proTransaction.aggregate
+      .mockResolvedValueOnce({ _sum: { amount: 50000 } }) // credits in
+      .mockResolvedValueOnce({ _sum: { amount: -30000 } }); // debits out (signed neg)
+    mocked.proWallet.aggregate.mockResolvedValueOnce({
+      _sum: { crowns: 250000 },
+    });
+
+    const out = await getAnalyticsSnapshot(
+      new Date("2026-05-11T10:00:00Z"),
+    );
+
+    expect(out.dau.count).toBe(150);
+    expect(out.dau.prevCount).toBe(120);
+    expect(out.dau.deltaPct).toBe(25.0); // (150-120)/120 = 25%
+
+    expect(out.mau.count).toBe(800);
+    expect(out.mau.deltaPct).toBeCloseTo(33.3, 1);
+
+    expect(out.signupFunnel.signups).toBe(200);
+    expect(out.signupFunnel.withTeam).toBe(140);
+    expect(out.signupFunnel.withMatch).toBe(80);
+    expect(out.signupFunnel.conversionTeam).toBe(70); // 140/200 = 70%
+    expect(out.signupFunnel.conversionFirstMatch).toBe(40); // 80/200 = 40%
+
+    expect(out.crowns.totalIn).toBe(50000);
+    expect(out.crowns.totalOut).toBe(30000); // abs(-30000)
+    expect(out.crowns.netInflation).toBe(20000);
+    expect(out.crowns.currentSupply).toBe(250000);
+  });
+
+  it("gere 0 prev pour eviter division par zero", async () => {
+    mocked.user.count
+      .mockResolvedValueOnce(50) // DAU
+      .mockResolvedValueOnce(0) // DAU prev = 0
+      .mockResolvedValueOnce(100)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0) // signups = 0
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+    mocked.proTransaction.aggregate
+      .mockResolvedValue({ _sum: { amount: 0 } });
+    mocked.proWallet.aggregate.mockResolvedValue({ _sum: { crowns: 0 } });
+
+    const out = await getAnalyticsSnapshot();
+    expect(out.dau.deltaPct).toBe(100); // prev=0, current>0 → 100% growth
+    expect(out.mau.deltaPct).toBe(100);
+    expect(out.signupFunnel.conversionTeam).toBe(0); // signups=0 → 0%
+    expect(out.signupFunnel.conversionFirstMatch).toBe(0);
+  });
+
+  it("gere null des sums (DB vide)", async () => {
+    mocked.user.count.mockResolvedValue(0);
+    mocked.proTransaction.aggregate
+      .mockResolvedValue({ _sum: { amount: null } });
+    mocked.proWallet.aggregate.mockResolvedValue({ _sum: { crowns: null } });
+
+    const out = await getAnalyticsSnapshot();
+    expect(out.crowns.totalIn).toBe(0);
+    expect(out.crowns.totalOut).toBe(0);
+    expect(out.crowns.netInflation).toBe(0);
+    expect(out.crowns.currentSupply).toBe(0);
+  });
+
+  it("expose computedAt en ISO 8601", async () => {
+    mocked.user.count.mockResolvedValue(0);
+    mocked.proTransaction.aggregate.mockResolvedValue({
+      _sum: { amount: 0 },
+    });
+    mocked.proWallet.aggregate.mockResolvedValue({ _sum: { crowns: 0 } });
+
+    const at = new Date("2026-05-11T10:30:00Z");
+    const out = await getAnalyticsSnapshot(at);
+    expect(out.computedAt).toBe("2026-05-11T10:30:00.000Z");
+  });
+
+  it("appelle user.count avec lastLoginAt range pour DAU", async () => {
+    mocked.user.count.mockResolvedValue(0);
+    mocked.proTransaction.aggregate.mockResolvedValue({
+      _sum: { amount: 0 },
+    });
+    mocked.proWallet.aggregate.mockResolvedValue({ _sum: { crowns: 0 } });
+
+    const at = new Date("2026-05-11T10:00:00Z");
+    await getAnalyticsSnapshot(at);
+
+    const firstCall = mocked.user.count.mock.calls[0]![0];
+    expect(firstCall.where.lastLoginAt).toBeDefined();
+    expect(firstCall.where.lastLoginAt.gte).toBeInstanceOf(Date);
+    // gte = 24h avant `at`
+    const diff = at.getTime() - firstCall.where.lastLoginAt.gte.getTime();
+    expect(diff).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("filtre signups par createdAt + relations teams/matches", async () => {
+    mocked.user.count.mockResolvedValue(0);
+    mocked.proTransaction.aggregate.mockResolvedValue({
+      _sum: { amount: 0 },
+    });
+    mocked.proWallet.aggregate.mockResolvedValue({ _sum: { crowns: 0 } });
+
+    await getAnalyticsSnapshot();
+
+    const signupCall = mocked.user.count.mock.calls[4]![0];
+    expect(signupCall.where.createdAt.gte).toBeInstanceOf(Date);
+
+    const teamCall = mocked.user.count.mock.calls[5]![0];
+    expect(teamCall.where.teams).toEqual({ some: {} });
+
+    const matchCall = mocked.user.count.mock.calls[6]![0];
+    expect(matchCall.where.matches).toEqual({ some: {} });
+  });
+});

--- a/apps/server/src/services/admin-analytics.ts
+++ b/apps/server/src/services/admin-analytics.ts
@@ -1,0 +1,190 @@
+/**
+ * Sprint P (Lot P.C.3) — Dashboard analytics admin.
+ *
+ * Agrege les metriques business minimales pour piloter le scaling :
+ *
+ *   - **DAU** (Daily Active Users) : users avec lastLoginAt sur les
+ *     dernieres 24h. Approximation : on assume que login = activite
+ *     minimale ; les sessions persistantes ne tracent pas chaque
+ *     interaction, donc DAU ≈ lower bound.
+ *   - **MAU** (Monthly Active Users) : 30 jours rolling.
+ *   - **Signup funnel** : signups N derniers jours, taux de "premiere
+ *     equipe creee", taux de "premier match joue".
+ *   - **Crowns inflation** : sum(credits) - sum(debits) sur N jours,
+ *     plus le total supply courant (sum(ProWallet.crowns)).
+ *
+ * Pas de cache : les requetes sont count/groupBy, optimisees par
+ * index. A 10k users on est sub-100ms. Si plus, cache 1min suffit.
+ */
+
+import { prisma } from "../prisma";
+
+export interface AnalyticsSnapshot {
+  /** Genere le snapshot a `now` (ISO). */
+  readonly computedAt: string;
+  readonly dau: {
+    /** Last 24h. */
+    readonly count: number;
+    /** Previous 24h (24h-48h ago) — pour calculer le delta jour-jour. */
+    readonly prevCount: number;
+    readonly deltaPct: number;
+  };
+  readonly mau: {
+    /** Last 30 days rolling. */
+    readonly count: number;
+    /** Previous 30 days (30-60j) — delta mois sur mois. */
+    readonly prevCount: number;
+    readonly deltaPct: number;
+  };
+  readonly signupFunnel: {
+    /** Signups dans la fenetre. */
+    readonly signups: number;
+    /** Window en jours (par defaut 30). */
+    readonly windowDays: number;
+    /** Signups qui ont cree au moins 1 equipe. */
+    readonly withTeam: number;
+    /** Signups qui ont joue au moins 1 match. */
+    readonly withMatch: number;
+    /** Conversion signup → equipe (%). */
+    readonly conversionTeam: number;
+    /** Conversion signup → first match (%). */
+    readonly conversionFirstMatch: number;
+  };
+  readonly crowns: {
+    /** Window en jours (par defaut 30). */
+    readonly windowDays: number;
+    /** Total credit emis (REWARD + DAILY + WIN + BADGE) sur la fenetre. */
+    readonly totalIn: number;
+    /** Total debits / sinks (BET + SINK) sur la fenetre. */
+    readonly totalOut: number;
+    /** Net = in - out. Positif = inflation. */
+    readonly netInflation: number;
+    /** Supply totale courante (sum ProWallet.crowns). */
+    readonly currentSupply: number;
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function deltaPct(current: number, prev: number): number {
+  if (prev === 0) return current > 0 ? 100 : 0;
+  return Math.round(((current - prev) / prev) * 1000) / 10;
+}
+
+/**
+ * Renvoie le snapshot complet. Toutes les sous-queries tournent en
+ * parallele via `Promise.all` — typiquement 5 round-trips DB.
+ */
+export async function getAnalyticsSnapshot(
+  now: Date = new Date(),
+): Promise<AnalyticsSnapshot> {
+  const tsNow = now.getTime();
+  const t24 = new Date(tsNow - DAY_MS);
+  const t48 = new Date(tsNow - 2 * DAY_MS);
+  const t30d = new Date(tsNow - 30 * DAY_MS);
+  const t60d = new Date(tsNow - 60 * DAY_MS);
+
+  const [
+    dauCount,
+    dauPrev,
+    mauCount,
+    mauPrev,
+    signups,
+    signupsWithTeam,
+    signupsWithMatch,
+    crownsCredits,
+    crownsDebits,
+    walletSupply,
+  ] = await Promise.all([
+    // DAU : last 24h
+    prisma.user.count({
+      where: { lastLoginAt: { gte: t24, lte: now } },
+    }),
+    // DAU prev : 24h-48h ago
+    prisma.user.count({
+      where: { lastLoginAt: { gte: t48, lt: t24 } },
+    }),
+    // MAU : last 30d
+    prisma.user.count({
+      where: { lastLoginAt: { gte: t30d, lte: now } },
+    }),
+    // MAU prev : 30-60j ago
+    prisma.user.count({
+      where: { lastLoginAt: { gte: t60d, lt: t30d } },
+    }),
+    // Signups 30j
+    prisma.user.count({
+      where: { createdAt: { gte: t30d, lte: now } },
+    }),
+    // Signups 30j qui ont cree au moins 1 equipe
+    prisma.user.count({
+      where: {
+        createdAt: { gte: t30d, lte: now },
+        teams: { some: {} },
+      },
+    }),
+    // Signups 30j qui ont joue au moins 1 match
+    prisma.user.count({
+      where: {
+        createdAt: { gte: t30d, lte: now },
+        matches: { some: {} },
+      },
+    }),
+    // Crowns IN 30j (credits = amount > 0)
+    prisma.proTransaction.aggregate({
+      _sum: { amount: true },
+      where: { createdAt: { gte: t30d, lte: now }, amount: { gt: 0 } },
+    }),
+    // Crowns OUT 30j (debits = amount < 0)
+    prisma.proTransaction.aggregate({
+      _sum: { amount: true },
+      where: { createdAt: { gte: t30d, lte: now }, amount: { lt: 0 } },
+    }),
+    // Supply totale courante
+    prisma.proWallet.aggregate({
+      _sum: { crowns: true },
+    }),
+  ]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const credits = (crownsCredits as any)?._sum?.amount ?? 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const debits = (crownsDebits as any)?._sum?.amount ?? 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const supply = (walletSupply as any)?._sum?.crowns ?? 0;
+
+  // debits est deja signe negatif → totalOut = abs(debits).
+  const totalIn = credits as number;
+  const totalOut = Math.abs(debits as number);
+  const netInflation = totalIn - totalOut;
+
+  return {
+    computedAt: now.toISOString(),
+    dau: {
+      count: dauCount,
+      prevCount: dauPrev,
+      deltaPct: deltaPct(dauCount, dauPrev),
+    },
+    mau: {
+      count: mauCount,
+      prevCount: mauPrev,
+      deltaPct: deltaPct(mauCount, mauPrev),
+    },
+    signupFunnel: {
+      signups,
+      windowDays: 30,
+      withTeam: signupsWithTeam,
+      withMatch: signupsWithMatch,
+      conversionTeam: signups === 0 ? 0 : Math.round((signupsWithTeam / signups) * 1000) / 10,
+      conversionFirstMatch:
+        signups === 0 ? 0 : Math.round((signupsWithMatch / signups) * 1000) / 10,
+    },
+    crowns: {
+      windowDays: 30,
+      totalIn,
+      totalOut,
+      netInflation,
+      currentSupply: supply as number,
+    },
+  };
+}

--- a/apps/web/app/admin/analytics/page.tsx
+++ b/apps/web/app/admin/analytics/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+/**
+ * Page admin Analytics — Sprint P (Lot P.C.3).
+ *
+ * Affiche 4 metriques business :
+ *   - DAU last 24h + delta jour-jour.
+ *   - MAU rolling 30j + delta mois-mois.
+ *   - Funnel signups → equipe → premier match (conversion %).
+ *   - Crowns IN / OUT / net inflation + total supply.
+ *
+ * Surface admin-only (gating via `/admin/*` middleware serveur). Pas
+ * de chart lib pour rester leger — affichage en cards lisibles.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+interface AnalyticsSnapshot {
+  computedAt: string;
+  dau: { count: number; prevCount: number; deltaPct: number };
+  mau: { count: number; prevCount: number; deltaPct: number };
+  signupFunnel: {
+    signups: number;
+    windowDays: number;
+    withTeam: number;
+    withMatch: number;
+    conversionTeam: number;
+    conversionFirstMatch: number;
+  };
+  crowns: {
+    windowDays: number;
+    totalIn: number;
+    totalOut: number;
+    netInflation: number;
+    currentSupply: number;
+  };
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString("fr-FR");
+}
+
+function formatDelta(pct: number): { label: string; tone: string } {
+  if (pct > 0) {
+    return { label: `+${pct}%`, tone: "text-emerald-600" };
+  }
+  if (pct < 0) {
+    return { label: `${pct}%`, tone: "text-rose-600" };
+  }
+  return { label: "=", tone: "text-slate-500" };
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString("fr-FR", {
+      day: "2-digit",
+      month: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface MetricCardProps {
+  readonly label: string;
+  readonly value: number;
+  readonly deltaPct?: number;
+  readonly subtitle?: string;
+  readonly testId?: string;
+}
+
+function MetricCard({
+  label,
+  value,
+  deltaPct,
+  subtitle,
+  testId,
+}: MetricCardProps): JSX.Element {
+  const delta = deltaPct === undefined ? null : formatDelta(deltaPct);
+  return (
+    <div
+      data-testid={testId}
+      className="rounded border bg-white p-4 shadow-sm"
+    >
+      <div className="text-xs uppercase text-gray-500">{label}</div>
+      <div className="mt-1 font-mono text-3xl font-bold text-gray-900">
+        {formatNumber(value)}
+      </div>
+      {delta && (
+        <div className={`mt-1 text-sm font-semibold ${delta.tone}`}>
+          {delta.label} <span className="text-xs text-gray-400">vs précédent</span>
+        </div>
+      )}
+      {subtitle && (
+        <div className="mt-1 text-xs text-gray-500">{subtitle}</div>
+      )}
+    </div>
+  );
+}
+
+export default function AdminAnalyticsPage(): JSX.Element {
+  const [data, setData] = useState<AnalyticsSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<AnalyticsSnapshot>("/admin/analytics")
+      .then((s) => {
+        if (cancelled) return;
+        setData(s);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTick]);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Analytics — Tableau de bord
+          </h1>
+          {data && (
+            <p className="mt-1 text-xs text-gray-500">
+              Calculé le {formatDate(data.computedAt)}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setRefreshTick((n) => n + 1)}
+            disabled={loading}
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            {loading ? "…" : "Rafraîchir"}
+          </button>
+          <Link
+            href="/admin"
+            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+          >
+            ← Admin
+          </Link>
+        </div>
+      </header>
+
+      {error && (
+        <p
+          role="alert"
+          className="mb-4 rounded border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-700"
+        >
+          {error}
+        </p>
+      )}
+
+      {loading && !data && (
+        <p className="text-sm text-gray-500">Chargement…</p>
+      )}
+
+      {data && (
+        <>
+          <section className="mb-6">
+            <h2 className="mb-3 text-lg font-semibold text-gray-800">
+              Activité utilisateurs
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <MetricCard
+                testId="metric-dau"
+                label="Daily Active Users (24h)"
+                value={data.dau.count}
+                deltaPct={data.dau.deltaPct}
+                subtitle={`vs ${formatNumber(data.dau.prevCount)} il y a 24h`}
+              />
+              <MetricCard
+                testId="metric-mau"
+                label="Monthly Active Users (30j)"
+                value={data.mau.count}
+                deltaPct={data.mau.deltaPct}
+                subtitle={`vs ${formatNumber(data.mau.prevCount)} le mois précédent`}
+              />
+            </div>
+          </section>
+
+          <section className="mb-6">
+            <h2 className="mb-3 text-lg font-semibold text-gray-800">
+              Funnel signups (
+              {data.signupFunnel.windowDays} derniers jours)
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <MetricCard
+                testId="metric-signups"
+                label="Signups"
+                value={data.signupFunnel.signups}
+                subtitle="Nouveaux comptes créés"
+              />
+              <MetricCard
+                testId="metric-with-team"
+                label="→ équipe créée"
+                value={data.signupFunnel.withTeam}
+                subtitle={`${data.signupFunnel.conversionTeam}% de conversion`}
+              />
+              <MetricCard
+                testId="metric-with-match"
+                label="→ premier match joué"
+                value={data.signupFunnel.withMatch}
+                subtitle={`${data.signupFunnel.conversionFirstMatch}% de conversion`}
+              />
+            </div>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-lg font-semibold text-gray-800">
+              Économie Crowns ({data.crowns.windowDays} derniers jours)
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <MetricCard
+                testId="metric-crowns-in"
+                label="Crowns émis (IN)"
+                value={data.crowns.totalIn}
+                subtitle="REWARD + DAILY + WIN + BADGE"
+              />
+              <MetricCard
+                testId="metric-crowns-out"
+                label="Crowns dépensés (OUT)"
+                value={data.crowns.totalOut}
+                subtitle="BET + SINK"
+              />
+              <MetricCard
+                testId="metric-crowns-net"
+                label="Inflation nette"
+                value={data.crowns.netInflation}
+                subtitle={
+                  data.crowns.netInflation > 0
+                    ? "Inflation positive — surveiller"
+                    : "Économie saine"
+                }
+              />
+              <MetricCard
+                testId="metric-crowns-supply"
+                label="Supply totale"
+                value={data.crowns.currentSupply}
+                subtitle="Tous wallets confondus"
+              />
+            </div>
+            {data.crowns.netInflation > 0 && (
+              <p
+                role="status"
+                className="mt-3 rounded border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+              >
+                ⚠ L&apos;inflation est positive sur la fenêtre. Considérer
+                d&apos;ajouter des sinks (lot P.B.2 et suivants) ou
+                réduire les bonus si la tendance persiste.
+              </p>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

**Lot P.C.3 du Sprint P** ([SPRINT-P](docs/roadmap/sprints/SPRINT-P-ops-readiness.md)).

L'audit ops-readiness identifiait l'absence de dashboard business comme **P0** : pas de DAU/MAU, pas de funnel signup→first match, pas d'observation de l'inflation Crowns. Décisions de scaling prises à l'aveugle.

Dashboard admin avec 4 métriques :

### Backend
- `services/admin-analytics.ts` :
  - **DAU** (24h) + delta jour-jour vs 24h-48h précédentes
  - **MAU** (30j rolling) + delta mois-mois
  - **Signup funnel** (signups 30j → équipe créée → premier match joué) avec taux conversion %
  - **Crowns IN** (REWARD+DAILY+WIN+BADGE) / **OUT** (BET+SINK) / net inflation + supply totale
  - 10 sub-queries en parallèle via `Promise.all`.
- `routes/admin-analytics.ts` : `GET /admin/analytics` (admin only).

### Frontend
- `/admin/analytics` : 3 sections (Activité, Funnel, Économie).
  - Delta colorisé : vert (croissance) / rose (décroissance) / gris (=)
  - Warning visible si inflation > 0 (suggère ajouter des sinks).
- Bouton "Rafraîchir" sans reload.

## Test plan
- [x] 6 tests `admin-analytics.test.ts` (composition, 0 prev division par zéro, null Prisma sums, ISO date, DAU window, funnel relations).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm --filter @bb/server test` — 2163 verts (+6).
- [x] `pnpm --filter @bb/web test` — 951 verts.
- [ ] Smoke : login admin → `/admin/analytics` → 4 sections cards visibles.

### Utilité ops
Voir DAU/MAU trend (mesurer impact bonus O.C.1), funnel acquisition (mesurer onboarding O.B.3), inflation Crowns (réagir si > 0 → ajouter sinks P.B.2+).

## Sprint P progression
- ✅ Lot P.A.1 (mode maintenance, #753 mergé)
- ✅ Lot P.B.2 (Crowns sinks HoF, #754)
- ✅ Lot P.C.3 — **cette PR**
- ⏳ Lot P.A.2 (soft-delete users)
- ⏳ Lot P.A.3 (GDPR export)
- ⏳ Lot P.B.1 (admin wallet UI)
- ⏳ Lot P.B.3 (season factory)
- ⏳ Lot P.B.4 (modération matchs)
- ⏳ Lot P.C.1 (password reset)
- ⏳ Lot P.C.2 (admin password reset override)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkgYA5qVw3a1J99c3wSNj3)_