### PR TITLE
fix(admin): sandbox test-match team slug + cache lien Ligues si online_play OFF

### DIFF
--- a/apps/server/src/services/pro-league-sandbox.test.ts
+++ b/apps/server/src/services/pro-league-sandbox.test.ts
@@ -63,8 +63,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("rejette si aucune saison active", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue(null);
     await expect(
@@ -74,8 +74,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("crée le match avec isTest=true et appelle simulateProMatch", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue({
       id: "season-2026",
@@ -94,8 +94,10 @@ describe("createTestMatch — Lot 2.C.2", () => {
         data: expect.objectContaining({
           seasonId: "season-2026",
           roundId: "round-sandbox",
-          homeTeamId: "t1",
-          awayTeamId: "t2",
+          // L'input passe le slug ("t1"), mais le create stocke l'id
+          // Prisma (cuid) resolu via la lookup proTeam.findMany.
+          homeTeamId: "team-cuid-1",
+          awayTeamId: "team-cuid-2",
           isTest: true,
           status: "scheduled",
         }),
@@ -111,8 +113,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("Lot 3.B.1 — driverKindOverride par défaut null (= inherit saison)", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue({
       id: "season-2026",
@@ -132,8 +134,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("Lot 3.B.1 — propage driverKind='full' dans driverKindOverride", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue({
       id: "season-2026",
@@ -157,8 +159,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("Lot 3.B.1 — driverKind invalide (defense-in-depth) → null", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue({
       id: "season-2026",
@@ -183,8 +185,8 @@ describe("createTestMatch — Lot 2.C.2", () => {
 
   it("upsert le round sandbox (roundNumber=0) si absent", async () => {
     mocked.proTeam.findMany.mockResolvedValue([
-      { id: "t1", slug: "a" },
-      { id: "t2", slug: "b" },
+      { id: "team-cuid-1", slug: "t1" },
+      { id: "team-cuid-2", slug: "t2" },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValue({
       id: "season-2026",

--- a/apps/server/src/services/pro-league-sandbox.ts
+++ b/apps/server/src/services/pro-league-sandbox.ts
@@ -141,18 +141,22 @@ export async function createTestMatch(
     throw new Error("homeTeamId et awayTeamId doivent être distincts");
   }
 
-  // Vérifie l'existence des deux teams en une seule query.
+  // L'UI admin envoie les slugs (PRO_LEAGUE_TEAMS[i].id = slug, ex.
+  // "kc-soaring-hawks"). On resout le slug → id Prisma (cuid) pour
+  // l'insertion dans ProLeagueMatch (FK vers ProTeam.id).
   const teams = (await prisma.proTeam.findMany({
-    where: { id: { in: [input.homeTeamId, input.awayTeamId] } },
+    where: { slug: { in: [input.homeTeamId, input.awayTeamId] } },
     select: { id: true, slug: true },
   })) as Array<{ id: string; slug: string }>;
   if (teams.length !== 2) {
-    const found = new Set(teams.map((t) => t.id));
+    const found = new Set(teams.map((t) => t.slug));
     const missing = [input.homeTeamId, input.awayTeamId].filter(
-      (id) => !found.has(id),
+      (slug) => !found.has(slug),
     );
     throw new Error(`Teams introuvables : ${missing.join(", ")}`);
   }
+  const homeTeam = teams.find((t) => t.slug === input.homeTeamId)!;
+  const awayTeam = teams.find((t) => t.slug === input.awayTeamId)!;
 
   const season = await findLatestActiveSeason();
   const roundId = await ensureSandboxRound(season.id);
@@ -169,8 +173,9 @@ export async function createTestMatch(
     data: {
       seasonId: season.id,
       roundId,
-      homeTeamId: input.homeTeamId,
-      awayTeamId: input.awayTeamId,
+      // FK vers ProTeam.id (cuid), pas le slug.
+      homeTeamId: homeTeam.id,
+      awayTeamId: awayTeam.id,
       status: "scheduled",
       scheduledAt: new Date(),
       isTest: true,

--- a/apps/web/app/components/Header.tsx
+++ b/apps/web/app/components/Header.tsx
@@ -143,7 +143,10 @@ export default function Header() {
             </button>
             {openDropdown === "competitions" && (
               <div className="absolute left-0 top-full mt-2 w-48 bg-white border border-gray-200 rounded-xl shadow-lg z-50 py-1 overflow-hidden">
-                {dropdownItem("/leagues", "🏅", t.nav.leagues)}
+                {/* Le hub /leagues est gate par OnlinePlayGate cote layout.
+                    Sans le flag, le lien menerait a un message "indisponible"
+                    decevant — on le cache pour eviter l'effet tunnel. */}
+                {onlinePlayEnabled && dropdownItem("/leagues", "🏅", t.nav.leagues)}
                 {dropdownItem("/cups", "🏆", t.nav.cups)}
                 {onlinePlayEnabled && dropdownItem("/leaderboard", "📊", t.nav.leaderboard)}
               </div>
@@ -261,13 +264,17 @@ export default function Header() {
               <p className="px-2 pb-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">
                 🏆 {t.nav.competitions}
               </p>
-              <a
-                href="/leagues"
-                onClick={() => setMobileMenuOpen(false)}
-                className="flex items-center gap-2 px-2 py-2.5 text-base font-subtitle font-semibold text-nuffle-bronze hover:text-nuffle-gold transition-colors"
-              >
-                🏅 {t.nav.leagues}
-              </a>
+              {/* Cf. desktop ci-dessus : on cache /leagues quand le flag
+                  online_play est OFF pour eviter le message "indisponible". */}
+              {onlinePlayEnabled && (
+                <a
+                  href="/leagues"
+                  onClick={() => setMobileMenuOpen(false)}
+                  className="flex items-center gap-2 px-2 py-2.5 text-base font-subtitle font-semibold text-nuffle-bronze hover:text-nuffle-gold transition-colors"
+                >
+                  🏅 {t.nav.leagues}
+                </a>
+              )}
               <a
                 href="/cups"
                 onClick={() => setMobileMenuOpen(false)}


### PR DESCRIPTION
## Summary

2 bug fixes :
1. **Sandbox test-match** (`/admin/sim/test-match`) : "Teams introuvables : kc-soaring-hawks, no-voodoo-saints" — résolution slug → id Prisma manquante.
2. **Lien Ligues du menu** (Header desktop + mobile) : exposé sans condition alors que `/leagues` est gated par `OnlinePlayGate`. Effet tunnel : clic → message "La partie en ligne n'est pas disponible".

## Bug 1 — sandbox test-match

`/admin/sim/teams` (handler `handleListTeams`) renvoie `PRO_LEAGUE_TEAMS[i].id` qui est en fait le **slug** (`"kc-soaring-hawks"`). L'UI envoie ce slug comme `homeTeamId`/`awayTeamId` au backend.

Mais `createTestMatch` faisait `prisma.proTeam.findMany({ where: { id: { in: [...] } } })` — la colonne `ProTeam.id` est un cuid généré par Prisma, distinct du slug. → toujours `length !== 2` → "Teams introuvables".

**Fix** : `findMany` sur `slug`, puis résolution slug → id avant `proLeagueMatch.create` (FK vers `ProTeam.id`).

```ts
const teams = await prisma.proTeam.findMany({
  where: { slug: { in: [input.homeTeamId, input.awayTeamId] } },
  select: { id: true, slug: true },
});
// ...
const homeTeam = teams.find((t) => t.slug === input.homeTeamId)!;
const awayTeam = teams.find((t) => t.slug === input.awayTeamId)!;

await prisma.proLeagueMatch.create({
  data: { homeTeamId: homeTeam.id, awayTeamId: awayTeam.id, ... }
});
```

Tests `pro-league-sandbox.test.ts` adaptés : mocks retournent `{ id: "team-cuid-1", slug: "t1" }` + assertions sur `homeTeamId: "team-cuid-1"`.

## Bug 2 — lien Ligues du menu

Le hub `/leagues` est gated par `OnlinePlayGate` côté layout. Le menu Header exposait le lien sans condition → clic → écran "indisponible".

**Fix** : conditionner le `dropdownItem("/leagues", ...)` (desktop ligne 146) et le `<a href="/leagues">` (mobile ligne 264) sur `onlinePlayEnabled` (déjà calculé via `useFeatureFlag(ONLINE_PLAY_FLAG)`). Coupes reste visible (pas gated).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` — OK
- [x] `pnpm --filter @bb/web typecheck` — OK
- [x] `pnpm --filter @bb/server test` — **2242 tests** OK (sandbox 11/11)
- [x] `pnpm --filter @bb/web test` — **1002 tests** OK
- [ ] Manuel : `/admin/sim/test-match` → choisir 2 teams → "Lancer le match test" → succès, redirect vers replay
- [ ] Manuel : flag `online_play` OFF → menu "Compétitions" ne montre plus "Ligues" (desktop + mobile)
- [ ] Manuel : flag `online_play` ON → "Ligues" visible

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_