### PR TITLE
feat(admin): season factory Pro League (Lot P.B.3)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import adminSimRoutes from "./routes/admin-sim";
 import adminSimReplaysRoutes from "./routes/admin-sim-replays";
 import adminWalletRoutes from "./routes/admin-wallet";
 import adminUtilitiesRoutes from "./routes/admin-utilities";
+import adminProSeasonRoutes from "./routes/admin-pro-season";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -229,6 +230,9 @@ app.use("/admin/sim-replays", adminSimReplaysRoutes);
 app.use("/admin", adminWalletRoutes);
 // Utilitaires admin (seed, etc.) — endpoints idempotents avec audit log.
 app.use("/admin/utilities", adminUtilitiesRoutes);
+// Lot P.B.3 — season factory Pro League (clone, reset standings, force
+// forfeit, cancel season). Audit log strict sur toutes les actions.
+app.use("/admin/pro-league", adminProSeasonRoutes);
 // Feedback public : pas d'auth, captcha + rate limiter dedies dans le router.
 app.use("/feedback", feedbackPublicRouter);
 app.use("/pro-league", proLeagueRoutes);

--- a/apps/server/src/routes/admin-pro-season.test.ts
+++ b/apps/server/src/routes/admin-pro-season.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Lot P.B.3 — Tests integration des endpoints admin-pro-season.
+ *
+ * Couvre les 6 endpoints : GET list, clone, regenerate-schedule,
+ * reset-standings, cancel, force-forfeit. Verifie audit log + mapping
+ * SeasonFactoryError → HTTP status.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: { findMany: vi.fn() },
+    proLeagueMatch: { groupBy: vi.fn() },
+  },
+}));
+
+vi.mock("../middleware/authUser", () => ({
+  authUser: (req: any, _res: any, next: any) => {
+    req.user = { id: "admin-1", role: "admin", roles: ["admin"] };
+    return next();
+  },
+}));
+
+vi.mock("../middleware/adminOnly", () => ({
+  adminOnly: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../services/audit-log", () => ({
+  safeRecordAdminActionFromRequest: vi.fn(async () => {}),
+}));
+
+vi.mock("../services/pro-season-factory", () => {
+  class SeasonFactoryError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "SeasonFactoryError";
+    }
+  }
+  return {
+    cloneSeason: vi.fn(),
+    resetStandings: vi.fn(),
+    cancelSeason: vi.fn(),
+    forceForfeit: vi.fn(),
+    SeasonFactoryError,
+  };
+});
+
+vi.mock("../services/pro-league-scheduler", () => ({
+  regenerateProLeagueSchedule: vi.fn(),
+}));
+
+import express from "express";
+import http from "http";
+import seasonRouter from "./admin-pro-season";
+import { prisma } from "../prisma";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+import {
+  cloneSeason as cloneSeasonMock,
+  resetStandings as resetStandingsMock,
+  cancelSeason as cancelSeasonMock,
+  forceForfeit as forceForfeitMock,
+  SeasonFactoryError,
+} from "../services/pro-season-factory";
+import { regenerateProLeagueSchedule as regenerateMock } from "../services/pro-league-scheduler";
+
+const mockedAudit = vi.mocked(safeRecordAdminActionFromRequest);
+const cloneSeason = vi.mocked(cloneSeasonMock);
+const resetStandings = vi.mocked(resetStandingsMock);
+const cancelSeason = vi.mocked(cancelSeasonMock);
+const forceForfeit = vi.mocked(forceForfeitMock);
+const regenerate = vi.mocked(regenerateMock);
+
+interface MockedPrisma {
+  proLeagueSeason: { findMany: ReturnType<typeof vi.fn> };
+  proLeagueMatch: { groupBy: ReturnType<typeof vi.fn> };
+}
+
+const mockedPrisma = prisma as unknown as MockedPrisma;
+
+async function request(
+  method: "GET" | "POST",
+  path: string,
+  body: Record<string, unknown> | null = null,
+): Promise<{ status: number; body: any }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/admin/pro-league", seasonRouter);
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("listen failed"));
+        return;
+      }
+      const data = body !== null ? JSON.stringify(body) : "";
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: `/admin/pro-league${path}`,
+          method,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(data).toString(),
+            Authorization: "Bearer dummy",
+          },
+        },
+        (res) => {
+          let buf = "";
+          res.on("data", (c) => (buf += c));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({
+                status: res.statusCode ?? 0,
+                body: buf ? JSON.parse(buf) : {},
+              });
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+      req.on("error", (e) => {
+        server.close();
+        reject(e);
+      });
+      if (data) req.write(data);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /admin/pro-league/seasons", () => {
+  it("liste les saisons avec counters", async () => {
+    mockedPrisma.proLeagueSeason.findMany.mockResolvedValueOnce([
+      {
+        id: "s1",
+        leagueId: "l1",
+        year: 2026,
+        status: "in_progress",
+        driverKind: "hybrid",
+        engineVer: "0.16.0",
+        startsAt: null,
+        endsAt: null,
+        createdAt: new Date("2026-01-01"),
+        _count: { rounds: 15, matches: 120 },
+      },
+    ]);
+    mockedPrisma.proLeagueMatch.groupBy.mockResolvedValueOnce([
+      { seasonId: "s1", _count: { _all: 80 } },
+    ]);
+
+    const res = await request("GET", "/seasons");
+
+    expect(res.status).toBe(200);
+    expect(res.body.seasons).toHaveLength(1);
+    expect(res.body.seasons[0]).toMatchObject({
+      id: "s1",
+      year: 2026,
+      roundCount: 15,
+      matchCount: 120,
+      playedCount: 80,
+    });
+  });
+
+  it("liste vide si aucune saison (pas de groupBy inutile)", async () => {
+    mockedPrisma.proLeagueSeason.findMany.mockResolvedValueOnce([]);
+
+    const res = await request("GET", "/seasons");
+
+    expect(res.status).toBe(200);
+    expect(res.body.seasons).toEqual([]);
+    expect(mockedPrisma.proLeagueMatch.groupBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /admin/pro-league/seasons/clone", () => {
+  it("clone OK : audit log + result", async () => {
+    cloneSeason.mockResolvedValueOnce({
+      newSeasonId: "new-s",
+      fromSeasonId: "s1",
+      year: 2027,
+    });
+
+    const res = await request("POST", "/seasons/clone", {
+      fromSeasonId: "s1",
+      year: 2027,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newSeasonId).toBe("new-s");
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({ action: "pro-season.clone" }),
+    );
+  });
+
+  it("400 si schema invalide (year manquant)", async () => {
+    const res = await request("POST", "/seasons/clone", { fromSeasonId: "s1" });
+    expect(res.status).toBe(400);
+    expect(cloneSeason).not.toHaveBeenCalled();
+  });
+
+  it("409 si DUPLICATE_YEAR", async () => {
+    cloneSeason.mockRejectedValueOnce(
+      new SeasonFactoryError("DUPLICATE_YEAR", "year deja pris"),
+    );
+    const res = await request("POST", "/seasons/clone", {
+      fromSeasonId: "s1",
+      year: 2026,
+    });
+    expect(res.status).toBe(409);
+    expect(mockedAudit).not.toHaveBeenCalled();
+  });
+
+  it("404 si SEASON_NOT_FOUND", async () => {
+    cloneSeason.mockRejectedValueOnce(
+      new SeasonFactoryError("SEASON_NOT_FOUND", "introuvable"),
+    );
+    const res = await request("POST", "/seasons/clone", {
+      fromSeasonId: "ghost",
+      year: 2027,
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /admin/pro-league/seasons/:id/regenerate-schedule", () => {
+  it("regenere OK", async () => {
+    regenerate.mockResolvedValueOnce({
+      seasonId: "s1",
+      roundsCreated: 15,
+      matchesCreated: 120,
+      idempotentSkip: false,
+    });
+    const res = await request("POST", "/seasons/s1/regenerate-schedule");
+    expect(res.status).toBe(200);
+    expect(res.body.roundsCreated).toBe(15);
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({
+        action: "pro-season.regenerate-schedule",
+        newValue: expect.objectContaining({ roundsCreated: 15 }),
+      }),
+    );
+  });
+
+  it("404 si saison introuvable (message contient 'introuvable')", async () => {
+    regenerate.mockRejectedValueOnce(new Error("Saison 'ghost' introuvable"));
+    const res = await request("POST", "/seasons/ghost/regenerate-schedule");
+    expect(res.status).toBe(404);
+  });
+
+  it("409 si match deja simule", async () => {
+    regenerate.mockRejectedValueOnce(
+      new Error("Impossible de régénérer : 1 match(s) déjà simulé(s)"),
+    );
+    const res = await request("POST", "/seasons/s1/regenerate-schedule");
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("POST /admin/pro-league/seasons/:id/reset-standings", () => {
+  it("reset OK + audit", async () => {
+    resetStandings.mockResolvedValueOnce({ seasonId: "s1", resetCount: 16 });
+    const res = await request("POST", "/seasons/s1/reset-standings");
+    expect(res.status).toBe(200);
+    expect(res.body.resetCount).toBe(16);
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({ action: "pro-season.reset-standings" }),
+    );
+  });
+
+  it("404 si SEASON_NOT_FOUND", async () => {
+    resetStandings.mockRejectedValueOnce(
+      new SeasonFactoryError("SEASON_NOT_FOUND", "x"),
+    );
+    const res = await request("POST", "/seasons/ghost/reset-standings");
+    expect(res.status).toBe(404);
+  });
+
+  it("409 si SEASON_HAS_RESULTS (archived)", async () => {
+    resetStandings.mockRejectedValueOnce(
+      new SeasonFactoryError("SEASON_HAS_RESULTS", "archived"),
+    );
+    const res = await request("POST", "/seasons/s1/reset-standings");
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("POST /admin/pro-league/seasons/:id/cancel", () => {
+  it("cancel OK", async () => {
+    cancelSeason.mockResolvedValueOnce({
+      seasonId: "s1",
+      previousStatus: "in_progress",
+    });
+    const res = await request("POST", "/seasons/s1/cancel");
+    expect(res.status).toBe(200);
+    expect(res.body.previousStatus).toBe("in_progress");
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({
+        action: "pro-season.cancel",
+        newValue: { status: "cancelled" },
+      }),
+    );
+  });
+});
+
+describe("POST /admin/pro-league/matches/:id/force-forfeit", () => {
+  it("forfait home OK + audit", async () => {
+    forceForfeit.mockResolvedValueOnce({
+      matchId: "m1",
+      winnerSide: "home",
+      previousStatus: "scheduled",
+    });
+    const res = await request("POST", "/matches/m1/force-forfeit", {
+      winnerSide: "home",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.winnerSide).toBe("home");
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({
+        action: "pro-season.force-forfeit",
+        newValue: expect.objectContaining({ winnerSide: "home" }),
+      }),
+    );
+  });
+
+  it("400 si winnerSide invalide", async () => {
+    const res = await request("POST", "/matches/m1/force-forfeit", {
+      winnerSide: "neutral",
+    });
+    expect(res.status).toBe(400);
+    expect(forceForfeit).not.toHaveBeenCalled();
+  });
+
+  it("409 si MATCH_ALREADY_COMPLETED", async () => {
+    forceForfeit.mockRejectedValueOnce(
+      new SeasonFactoryError("MATCH_ALREADY_COMPLETED", "deja"),
+    );
+    const res = await request("POST", "/matches/m1/force-forfeit", {
+      winnerSide: "away",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("404 si MATCH_NOT_FOUND", async () => {
+    forceForfeit.mockRejectedValueOnce(
+      new SeasonFactoryError("MATCH_NOT_FOUND", "introuvable"),
+    );
+    const res = await request("POST", "/matches/ghost/force-forfeit", {
+      winnerSide: "home",
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/server/src/routes/admin-pro-season.ts
+++ b/apps/server/src/routes/admin-pro-season.ts
@@ -1,0 +1,281 @@
+/**
+ * Lot P.B.3 — Endpoints admin pour la season factory Pro League.
+ *
+ * Endpoints :
+ *  - GET   /admin/pro-league/seasons                       — liste des saisons + counters
+ *  - POST  /admin/pro-league/seasons/clone                 — clone une saison (new year)
+ *  - POST  /admin/pro-league/seasons/:id/regenerate-schedule
+ *  - POST  /admin/pro-league/seasons/:id/reset-standings
+ *  - POST  /admin/pro-league/seasons/:id/cancel
+ *  - POST  /admin/pro-league/matches/:id/force-forfeit     — { winnerSide }
+ *
+ * Tous les endpoints qui modifient l'etat tracent un audit log strict.
+ * Les erreurs `SeasonFactoryError` sont mappees au HTTP status correspondant.
+ */
+
+import { Router } from "express";
+import { prisma } from "../prisma";
+import { authUser } from "../middleware/authUser";
+import { adminOnly } from "../middleware/adminOnly";
+import { validate } from "../middleware/validate";
+import {
+  adminCloneSeasonSchema,
+  adminForceForfeitSchema,
+} from "../schemas/admin.schemas";
+import { serverLog } from "../utils/server-log";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+import type { AuthenticatedRequest } from "../middleware/authUser";
+import {
+  cloneSeason,
+  resetStandings,
+  cancelSeason,
+  forceForfeit,
+  SeasonFactoryError,
+} from "../services/pro-season-factory";
+import { regenerateProLeagueSchedule } from "../services/pro-league-scheduler";
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+/** Mappe une `SeasonFactoryError` au status HTTP approprie. */
+function errorStatus(code: SeasonFactoryError["code"]): number {
+  switch (code) {
+    case "SEASON_NOT_FOUND":
+    case "MATCH_NOT_FOUND":
+      return 404;
+    case "MATCH_ALREADY_COMPLETED":
+    case "DUPLICATE_YEAR":
+    case "SEASON_HAS_RESULTS":
+      return 409;
+    case "INVALID_INPUT":
+      return 400;
+    default:
+      return 500;
+  }
+}
+
+/**
+ * GET /admin/pro-league/seasons — liste des saisons.
+ *
+ * Pour chaque saison : id, leagueId, year, status, driverKind, engineVer,
+ * + compteurs `roundCount`, `matchCount`, `playedCount`. Ordre :
+ * (status asc puis year desc) → in_progress / scheduled en haut.
+ */
+router.get("/seasons", async (_req, res) => {
+  try {
+    const seasons = (await prisma.proLeagueSeason.findMany({
+      select: {
+        id: true,
+        leagueId: true,
+        year: true,
+        status: true,
+        driverKind: true,
+        engineVer: true,
+        startsAt: true,
+        endsAt: true,
+        createdAt: true,
+        _count: { select: { rounds: true, matches: true } },
+      },
+      orderBy: [{ status: "asc" }, { year: "desc" }],
+    })) as Array<{
+      id: string;
+      leagueId: string;
+      year: number;
+      status: string;
+      driverKind: string;
+      engineVer: string;
+      startsAt: Date | null;
+      endsAt: Date | null;
+      createdAt: Date;
+      _count: { rounds: number; matches: number };
+    }>;
+
+    // Comptage des matchs joues (status != 'scheduled') en batch via groupBy.
+    const seasonIds = seasons.map((s) => s.id);
+    const playedAgg = seasonIds.length
+      ? ((await prisma.proLeagueMatch.groupBy({
+          by: ["seasonId"],
+          where: { seasonId: { in: seasonIds }, NOT: { status: "scheduled" } },
+          _count: { _all: true },
+        })) as Array<{ seasonId: string; _count: { _all: number } }>)
+      : [];
+    const playedBySeason = new Map<string, number>();
+    for (const row of playedAgg) {
+      playedBySeason.set(row.seasonId, row._count._all);
+    }
+
+    res.json({
+      seasons: seasons.map((s) => ({
+        id: s.id,
+        leagueId: s.leagueId,
+        year: s.year,
+        status: s.status,
+        driverKind: s.driverKind,
+        engineVer: s.engineVer,
+        startsAt: s.startsAt,
+        endsAt: s.endsAt,
+        roundCount: s._count.rounds,
+        matchCount: s._count.matches,
+        playedCount: playedBySeason.get(s.id) ?? 0,
+        createdAt: s.createdAt,
+      })),
+    });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de la lecture des saisons" });
+  }
+});
+
+/**
+ * POST /admin/pro-league/seasons/clone — clone une saison existante.
+ *
+ * Cree une nouvelle ProLeagueSeason avec une `year` distincte +
+ * initialise les standings (zero) pour toutes les teams de la ligue.
+ * Le schedule n'est PAS clone — appeler ensuite regenerate-schedule.
+ */
+router.post(
+  "/seasons/clone",
+  validate(adminCloneSeasonSchema),
+  async (req, res) => {
+    try {
+      const result = await cloneSeason(req.body);
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-season.clone",
+          entity: "ProLeagueSeason",
+          entityId: result.newSeasonId,
+          newValue: {
+            fromSeasonId: result.fromSeasonId,
+            year: result.year,
+          },
+        },
+      );
+      res.json(result);
+    } catch (e) {
+      if (e instanceof SeasonFactoryError) {
+        return res.status(errorStatus(e.code)).json({ error: e.message });
+      }
+      serverLog.error(e);
+      res.status(500).json({ error: "Erreur lors du clone" });
+    }
+  },
+);
+
+/** POST /admin/pro-league/seasons/:id/regenerate-schedule */
+router.post("/seasons/:id/regenerate-schedule", async (req, res) => {
+  try {
+    const result = await regenerateProLeagueSchedule({ seasonId: req.params.id });
+    await safeRecordAdminActionFromRequest(
+      prisma,
+      req as AuthenticatedRequest,
+      {
+        action: "pro-season.regenerate-schedule",
+        entity: "ProLeagueSeason",
+        entityId: req.params.id,
+        newValue: {
+          roundsCreated: result.roundsCreated,
+          matchesCreated: result.matchesCreated,
+        },
+      },
+    );
+    res.json(result);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Erreur inconnue";
+    // Le scheduler throw un Error standard avec un message lisible (ex.
+    // "match deja simule"). On retourne 409 pour ces cas business + 500 sinon.
+    if (msg.includes("introuvable")) {
+      return res.status(404).json({ error: msg });
+    }
+    if (msg.includes("Impossible") || msg.includes("deja")) {
+      return res.status(409).json({ error: msg });
+    }
+    serverLog.error(e);
+    res.status(500).json({ error: msg });
+  }
+});
+
+/** POST /admin/pro-league/seasons/:id/reset-standings */
+router.post("/seasons/:id/reset-standings", async (req, res) => {
+  try {
+    const result = await resetStandings(req.params.id);
+    await safeRecordAdminActionFromRequest(
+      prisma,
+      req as AuthenticatedRequest,
+      {
+        action: "pro-season.reset-standings",
+        entity: "ProLeagueSeason",
+        entityId: req.params.id,
+        newValue: { resetCount: result.resetCount },
+      },
+    );
+    res.json(result);
+  } catch (e) {
+    if (e instanceof SeasonFactoryError) {
+      return res.status(errorStatus(e.code)).json({ error: e.message });
+    }
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors du reset des standings" });
+  }
+});
+
+/** POST /admin/pro-league/seasons/:id/cancel */
+router.post("/seasons/:id/cancel", async (req, res) => {
+  try {
+    const result = await cancelSeason(req.params.id);
+    await safeRecordAdminActionFromRequest(
+      prisma,
+      req as AuthenticatedRequest,
+      {
+        action: "pro-season.cancel",
+        entity: "ProLeagueSeason",
+        entityId: req.params.id,
+        oldValue: { status: result.previousStatus },
+        newValue: { status: "cancelled" },
+      },
+    );
+    res.json(result);
+  } catch (e) {
+    if (e instanceof SeasonFactoryError) {
+      return res.status(errorStatus(e.code)).json({ error: e.message });
+    }
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de l'annulation" });
+  }
+});
+
+/** POST /admin/pro-league/matches/:id/force-forfeit — { winnerSide } */
+router.post(
+  "/matches/:id/force-forfeit",
+  validate(adminForceForfeitSchema),
+  async (req, res) => {
+    try {
+      const result = await forceForfeit({
+        matchId: req.params.id,
+        winnerSide: req.body.winnerSide,
+      });
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-season.force-forfeit",
+          entity: "ProLeagueMatch",
+          entityId: req.params.id,
+          oldValue: { status: result.previousStatus },
+          newValue: { status: "completed", winnerSide: result.winnerSide },
+        },
+      );
+      res.json(result);
+    } catch (e) {
+      if (e instanceof SeasonFactoryError) {
+        return res.status(errorStatus(e.code)).json({ error: e.message });
+      }
+      serverLog.error(e);
+      res.status(500).json({ error: "Erreur lors du forfait" });
+    }
+  },
+);
+
+export default router;

--- a/apps/server/src/schemas/admin.schemas.ts
+++ b/apps/server/src/schemas/admin.schemas.ts
@@ -123,3 +123,22 @@ export const adminBetRefundSchema = z.object({
     .min(3, "raison trop courte (3 chars min)")
     .max(500, "raison trop longue (500 chars max)"),
 });
+
+// ── Lot P.B.3 — Pro League season factory ──
+
+/** Clone d'une saison Pro League. La saison source doit exister. Le
+ *  `year` cible doit etre unique dans la ligue (sinon DUPLICATE_YEAR
+ *  cote service). `driverKind` optionnel = inherit la valeur source. */
+export const adminCloneSeasonSchema = z.object({
+  fromSeasonId: z.string().min(1, "fromSeasonId requis"),
+  year: z.number().int().min(2020).max(2100),
+  driverKind: z.enum(["hybrid", "full"]).optional(),
+});
+
+/** Force forfait d'un match Pro League. Le service refuse si match
+ *  est deja `completed`. `winnerSide` obligatoire. */
+export const adminForceForfeitSchema = z.object({
+  winnerSide: z.enum(["home", "away"], {
+    message: "winnerSide doit etre 'home' ou 'away'",
+  }),
+});

--- a/apps/server/src/services/pro-season-factory.test.ts
+++ b/apps/server/src/services/pro-season-factory.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Lot P.B.3 — Tests du service pro-season-factory.
+ *
+ * Couvre :
+ *  - resetStandings : success, season not found, season archived
+ *  - cancelSeason : success, idempotent (deja cancelled), archived refus
+ *  - forceForfeit : home/away, already completed (409), invalid input,
+ *    match not found
+ *  - cloneSeason : success (teams + standings), duplicate year, from
+ *    not found
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proLeagueSeason: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+    proLeagueStandings: { updateMany: vi.fn(), createMany: vi.fn() },
+    proLeagueMatch: { findUnique: vi.fn(), update: vi.fn() },
+    proTeam: { findMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  resetStandings,
+  cancelSeason,
+  forceForfeit,
+  cloneSeason,
+  SeasonFactoryError,
+} from "./pro-season-factory";
+
+interface MockedPrisma {
+  proLeagueSeason: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  proLeagueStandings: {
+    updateMany: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  proTeam: { findMany: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+}
+
+const mocked = prisma as unknown as MockedPrisma;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resetStandings", () => {
+  it("zero out tous les standings de la saison", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "in_progress",
+    });
+    mocked.proLeagueStandings.updateMany.mockResolvedValueOnce({ count: 16 });
+
+    const result = await resetStandings("s1");
+
+    expect(result).toEqual({ seasonId: "s1", resetCount: 16 });
+    const call = mocked.proLeagueStandings.updateMany.mock.calls[0]![0];
+    expect(call.where).toEqual({ seasonId: "s1" });
+    expect(call.data.played).toBe(0);
+    expect(call.data.points).toBe(0);
+    expect(call.data.form).toEqual([]);
+  });
+
+  it("SEASON_NOT_FOUND si saison inexistante", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    await expect(resetStandings("ghost")).rejects.toMatchObject({
+      code: "SEASON_NOT_FOUND",
+    });
+    expect(mocked.proLeagueStandings.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("SEASON_HAS_RESULTS si archived", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "archived",
+    });
+    await expect(resetStandings("s1")).rejects.toMatchObject({
+      code: "SEASON_HAS_RESULTS",
+    });
+  });
+});
+
+describe("cancelSeason", () => {
+  it("passe la saison a 'cancelled'", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "in_progress",
+    });
+    mocked.proLeagueSeason.update.mockResolvedValueOnce({});
+
+    const result = await cancelSeason("s1");
+
+    expect(result).toEqual({ seasonId: "s1", previousStatus: "in_progress" });
+    expect(mocked.proLeagueSeason.update).toHaveBeenCalledWith({
+      where: { id: "s1" },
+      data: { status: "cancelled" },
+    });
+  });
+
+  it("idempotent si deja cancelled (no update call)", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "cancelled",
+    });
+    const result = await cancelSeason("s1");
+    expect(result.previousStatus).toBe("cancelled");
+    expect(mocked.proLeagueSeason.update).not.toHaveBeenCalled();
+  });
+
+  it("refuse si archived", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "archived",
+    });
+    await expect(cancelSeason("s1")).rejects.toMatchObject({
+      code: "SEASON_HAS_RESULTS",
+    });
+  });
+
+  it("SEASON_NOT_FOUND si inexistante", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    await expect(cancelSeason("ghost")).rejects.toMatchObject({
+      code: "SEASON_NOT_FOUND",
+    });
+  });
+});
+
+describe("forceForfeit", () => {
+  it("home winner : status=completed, outcome=home, scores 1-0", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValueOnce({
+      id: "m1",
+      status: "scheduled",
+    });
+    mocked.proLeagueMatch.update.mockResolvedValueOnce({});
+
+    const result = await forceForfeit({ matchId: "m1", winnerSide: "home" });
+
+    expect(result.previousStatus).toBe("scheduled");
+    const call = mocked.proLeagueMatch.update.mock.calls[0]![0];
+    expect(call.data.status).toBe("completed");
+    expect(call.data.outcome).toBe("home");
+    expect(call.data.scoreHome).toBe(1);
+    expect(call.data.scoreAway).toBe(0);
+    expect(call.data.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("away winner : scores 0-1", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValueOnce({
+      id: "m1",
+      status: "ready",
+    });
+    mocked.proLeagueMatch.update.mockResolvedValueOnce({});
+    await forceForfeit({ matchId: "m1", winnerSide: "away" });
+    const call = mocked.proLeagueMatch.update.mock.calls[0]![0];
+    expect(call.data.scoreHome).toBe(0);
+    expect(call.data.scoreAway).toBe(1);
+    expect(call.data.outcome).toBe("away");
+  });
+
+  it("refuse si match deja completed", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValueOnce({
+      id: "m1",
+      status: "completed",
+    });
+    await expect(
+      forceForfeit({ matchId: "m1", winnerSide: "home" }),
+    ).rejects.toMatchObject({ code: "MATCH_ALREADY_COMPLETED" });
+    expect(mocked.proLeagueMatch.update).not.toHaveBeenCalled();
+  });
+
+  it("MATCH_NOT_FOUND si inexistant", async () => {
+    mocked.proLeagueMatch.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      forceForfeit({ matchId: "ghost", winnerSide: "home" }),
+    ).rejects.toMatchObject({ code: "MATCH_NOT_FOUND" });
+  });
+
+  it("INVALID_INPUT si winnerSide invalide", async () => {
+    await expect(
+      forceForfeit({
+        matchId: "m1",
+        // @ts-expect-error test runtime validation
+        winnerSide: "neutral",
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(mocked.proLeagueMatch.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("cloneSeason", () => {
+  it("clone : new season + standings init pour toutes les teams", async () => {
+    mocked.proLeagueSeason.findUnique
+      .mockResolvedValueOnce({
+        id: "s1",
+        leagueId: "league-1",
+        engineVer: "0.16.0",
+        driverKind: "hybrid",
+      })
+      // duplicate check
+      .mockResolvedValueOnce(null);
+    mocked.proTeam.findMany.mockResolvedValueOnce([
+      { id: "t1" },
+      { id: "t2" },
+      { id: "t3" },
+    ]);
+    mocked.$transaction.mockImplementationOnce(async (fn: any) =>
+      fn({
+        proLeagueSeason: {
+          create: vi.fn().mockResolvedValueOnce({ id: "new-s" }),
+        },
+        proLeagueStandings: {
+          createMany: vi.fn().mockResolvedValueOnce({ count: 3 }),
+        },
+      }),
+    );
+
+    const result = await cloneSeason({
+      fromSeasonId: "s1",
+      year: 2027,
+    });
+
+    expect(result).toEqual({
+      newSeasonId: "new-s",
+      fromSeasonId: "s1",
+      year: 2027,
+    });
+  });
+
+  it("DUPLICATE_YEAR si une saison existe deja avec ce year", async () => {
+    mocked.proLeagueSeason.findUnique
+      .mockResolvedValueOnce({
+        id: "s1",
+        leagueId: "league-1",
+        engineVer: "0.16.0",
+        driverKind: "hybrid",
+      })
+      .mockResolvedValueOnce({ id: "duplicate" });
+
+    await expect(
+      cloneSeason({ fromSeasonId: "s1", year: 2026 }),
+    ).rejects.toMatchObject({ code: "DUPLICATE_YEAR" });
+    expect(mocked.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("SEASON_NOT_FOUND si la saison source n'existe pas", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      cloneSeason({ fromSeasonId: "ghost", year: 2027 }),
+    ).rejects.toMatchObject({ code: "SEASON_NOT_FOUND" });
+  });
+
+  it("override driverKind si fourni", async () => {
+    mocked.proLeagueSeason.findUnique
+      .mockResolvedValueOnce({
+        id: "s1",
+        leagueId: "league-1",
+        engineVer: "0.16.0",
+        driverKind: "hybrid",
+      })
+      .mockResolvedValueOnce(null);
+    mocked.proTeam.findMany.mockResolvedValueOnce([]);
+    const seasonCreate = vi.fn().mockResolvedValueOnce({ id: "new-s" });
+    mocked.$transaction.mockImplementationOnce(async (fn: any) =>
+      fn({
+        proLeagueSeason: { create: seasonCreate },
+        proLeagueStandings: { createMany: vi.fn() },
+      }),
+    );
+
+    await cloneSeason({
+      fromSeasonId: "s1",
+      year: 2027,
+      driverKind: "full",
+    });
+
+    const call = seasonCreate.mock.calls[0][0];
+    expect(call.data.driverKind).toBe("full");
+  });
+
+  it("expose SeasonFactoryError class", () => {
+    const e = new SeasonFactoryError("INVALID_INPUT", "test");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe("INVALID_INPUT");
+    expect(e.name).toBe("SeasonFactoryError");
+  });
+});

--- a/apps/server/src/services/pro-season-factory.ts
+++ b/apps/server/src/services/pro-season-factory.ts
@@ -1,0 +1,305 @@
+/**
+ * Lot P.B.3 — Pro League season factory.
+ *
+ * Operations administrateur sur les saisons Pro League. Chaque fonction
+ * est idempotente OU refuse l'action si elle est destructrice et que le
+ * pre-requis n'est pas rempli (ex: refuse `regenerateSchedule` si un
+ * match a deja ete simule, cf. `pro-league-scheduler.ts`).
+ *
+ * Compose avec :
+ *  - `buildProLeagueSchedule` / `regenerateProLeagueSchedule` (deja existants)
+ *    pour la generation du round-robin.
+ *
+ * Toutes les operations qui touchent la DB le font via une seule
+ * `$transaction` quand plusieurs tables sont impactees, pour garantir
+ * l'atomicite (pas d'etat intermediaire visible).
+ */
+
+import { prisma } from "../prisma";
+
+export class SeasonFactoryError extends Error {
+  constructor(
+    public readonly code:
+      | "SEASON_NOT_FOUND"
+      | "SEASON_HAS_RESULTS"
+      | "MATCH_NOT_FOUND"
+      | "MATCH_ALREADY_COMPLETED"
+      | "INVALID_INPUT"
+      | "DUPLICATE_YEAR",
+    message: string,
+  ) {
+    super(message);
+    this.name = "SeasonFactoryError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resetStandings
+// ---------------------------------------------------------------------------
+
+export interface ResetStandingsResult {
+  readonly seasonId: string;
+  readonly resetCount: number;
+}
+
+/**
+ * Remet a zero tous les `ProLeagueStandings` d'une saison (played, wins,
+ * draws, losses, points, td*, casualties*, form vide). Conserve les
+ * lignes (un standings par team x saison) car elles peuvent etre
+ * referencees ailleurs ; on les vide sans les supprimer.
+ *
+ * Refuse si la saison est `archived` (donnees historiques figees).
+ */
+export async function resetStandings(
+  seasonId: string,
+): Promise<ResetStandingsResult> {
+  const season = await prisma.proLeagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { id: true, status: true },
+  });
+  if (!season) {
+    throw new SeasonFactoryError(
+      "SEASON_NOT_FOUND",
+      `Saison '${seasonId}' introuvable`,
+    );
+  }
+  if (season.status === "archived") {
+    throw new SeasonFactoryError(
+      "SEASON_HAS_RESULTS",
+      "Impossible de reset une saison archivee",
+    );
+  }
+
+  const result = await prisma.proLeagueStandings.updateMany({
+    where: { seasonId },
+    data: {
+      played: 0,
+      wins: 0,
+      draws: 0,
+      losses: 0,
+      points: 0,
+      tdFor: 0,
+      tdAgainst: 0,
+      casualtiesFor: 0,
+      casualtiesAgainst: 0,
+      form: [],
+    },
+  });
+
+  return { seasonId, resetCount: result.count };
+}
+
+// ---------------------------------------------------------------------------
+// cancelSeason
+// ---------------------------------------------------------------------------
+
+export interface CancelSeasonResult {
+  readonly seasonId: string;
+  readonly previousStatus: string;
+}
+
+/**
+ * Annule une saison : passe `status` a "cancelled". Idempotent : appel
+ * sur une saison deja annulee renvoie le previous status (= "cancelled").
+ * Refuse `archived` (intouchable).
+ */
+export async function cancelSeason(
+  seasonId: string,
+): Promise<CancelSeasonResult> {
+  const season = await prisma.proLeagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { id: true, status: true },
+  });
+  if (!season) {
+    throw new SeasonFactoryError(
+      "SEASON_NOT_FOUND",
+      `Saison '${seasonId}' introuvable`,
+    );
+  }
+  if (season.status === "archived") {
+    throw new SeasonFactoryError(
+      "SEASON_HAS_RESULTS",
+      "Impossible d'annuler une saison archivee",
+    );
+  }
+
+  const previousStatus = season.status;
+  if (previousStatus !== "cancelled") {
+    await prisma.proLeagueSeason.update({
+      where: { id: seasonId },
+      data: { status: "cancelled" },
+    });
+  }
+  return { seasonId, previousStatus };
+}
+
+// ---------------------------------------------------------------------------
+// forceForfeit
+// ---------------------------------------------------------------------------
+
+export type WinnerSide = "home" | "away";
+
+export interface ForceForfeitInput {
+  readonly matchId: string;
+  readonly winnerSide: WinnerSide;
+}
+
+export interface ForceForfeitResult {
+  readonly matchId: string;
+  readonly winnerSide: WinnerSide;
+  readonly previousStatus: string;
+}
+
+/**
+ * Forfait administratif sur un match Pro League : passe `status` a
+ * "completed" avec `outcome` = "home" | "away" et `scoreHome/Away` mis
+ * a (1, 0) ou (0, 1). N'execute pas le sim-engine et ne genere pas de
+ * replay — c'est une decision purement administrative.
+ *
+ * Refuse si le match est deja `completed` (idempotence stricte ; pour
+ * corriger un resultat, utiliser un endpoint dedie ulterieur).
+ */
+export async function forceForfeit(
+  input: ForceForfeitInput,
+): Promise<ForceForfeitResult> {
+  const { matchId, winnerSide } = input;
+  if (winnerSide !== "home" && winnerSide !== "away") {
+    throw new SeasonFactoryError(
+      "INVALID_INPUT",
+      "winnerSide doit etre 'home' ou 'away'",
+    );
+  }
+
+  const match = await prisma.proLeagueMatch.findUnique({
+    where: { id: matchId },
+    select: { id: true, status: true },
+  });
+  if (!match) {
+    throw new SeasonFactoryError(
+      "MATCH_NOT_FOUND",
+      `Match '${matchId}' introuvable`,
+    );
+  }
+  if (match.status === "completed") {
+    throw new SeasonFactoryError(
+      "MATCH_ALREADY_COMPLETED",
+      "Le match est deja completed",
+    );
+  }
+
+  const now = new Date();
+  await prisma.proLeagueMatch.update({
+    where: { id: matchId },
+    data: {
+      status: "completed",
+      outcome: winnerSide,
+      scoreHome: winnerSide === "home" ? 1 : 0,
+      scoreAway: winnerSide === "away" ? 1 : 0,
+      simulatedAt: now,
+      completedAt: now,
+    },
+  });
+
+  return {
+    matchId,
+    winnerSide,
+    previousStatus: match.status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// cloneSeason
+// ---------------------------------------------------------------------------
+
+export interface CloneSeasonInput {
+  readonly fromSeasonId: string;
+  readonly year: number;
+  /** Si null, hérite `driverKind` de la saison source. */
+  readonly driverKind?: "hybrid" | "full" | null;
+}
+
+export interface CloneSeasonResult {
+  readonly newSeasonId: string;
+  readonly fromSeasonId: string;
+  readonly year: number;
+}
+
+/**
+ * Clone une saison Pro League : copie la `ProLeagueSeason` (meme league,
+ * meme driverKind, meme engineVer) en pointant sur une nouvelle `year`.
+ * Les `ProLeagueStandings` sont initialisees a zero pour les memes 16
+ * teams. Les rounds + matches NE sont PAS clones — appeler ensuite
+ * `regenerateProLeagueSchedule(newSeasonId)` pour generer un calendrier
+ * fresh.
+ *
+ * Idempotence : refuse si une saison avec (leagueId, year) existe deja.
+ */
+export async function cloneSeason(
+  input: CloneSeasonInput,
+): Promise<CloneSeasonResult> {
+  const from = await prisma.proLeagueSeason.findUnique({
+    where: { id: input.fromSeasonId },
+    select: {
+      id: true,
+      leagueId: true,
+      engineVer: true,
+      driverKind: true,
+    },
+  });
+  if (!from) {
+    throw new SeasonFactoryError(
+      "SEASON_NOT_FOUND",
+      `Saison '${input.fromSeasonId}' introuvable`,
+    );
+  }
+
+  const duplicate = await prisma.proLeagueSeason.findUnique({
+    where: {
+      leagueId_year: { leagueId: from.leagueId, year: input.year },
+    },
+    select: { id: true },
+  });
+  if (duplicate) {
+    throw new SeasonFactoryError(
+      "DUPLICATE_YEAR",
+      `Une saison existe deja pour leagueId=${from.leagueId} year=${input.year}`,
+    );
+  }
+
+  // Recupere les teams pour initialiser le standings.
+  const teams = (await prisma.proTeam.findMany({
+    where: { leagueId: from.leagueId },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const created = await prisma.$transaction(async (tx: any) => {
+    const newSeason = await tx.proLeagueSeason.create({
+      data: {
+        leagueId: from.leagueId,
+        year: input.year,
+        status: "scheduled",
+        engineVer: from.engineVer,
+        driverKind: input.driverKind ?? from.driverKind,
+      },
+      select: { id: true },
+    });
+
+    if (teams.length > 0) {
+      await tx.proLeagueStandings.createMany({
+        data: teams.map((team) => ({
+          seasonId: newSeason.id as string,
+          teamId: team.id,
+        })),
+      });
+    }
+
+    return newSeason;
+  });
+
+  return {
+    newSeasonId: created.id as string,
+    fromSeasonId: from.id as string,
+    year: input.year,
+  };
+}

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -81,6 +81,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/sim/health", "Sim Health", "❤️")}
               {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
               {navItem("/admin/sim/test-match", "Test Match", "🧪")}
+              {navItem("/admin/pro-league/seasons", "Saisons Pro League", "🏆")}
               {navItem("/admin/feedback", "Feedback", "💬")}
               {navItem("/admin/audit-log", "Journal d'audit", "📜")}
               {navItem("/admin/routes", "Routes", "📋")}

--- a/apps/web/app/admin/pro-league/seasons/_components/CloneSeasonModal.test.tsx
+++ b/apps/web/app/admin/pro-league/seasons/_components/CloneSeasonModal.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Lot P.B.3 — Tests du CloneSeasonModal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import CloneSeasonModal from "./CloneSeasonModal";
+
+const defaultProps = {
+  open: true,
+  sourceSeasonId: "season-abc12345",
+  sourceSeasonLabel: "Saison 2026 (in_progress)",
+  loading: false,
+  onClose: () => {},
+  onConfirm: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CloneSeasonModal (Lot P.B.3)", () => {
+  it("ne rend rien quand open=false", () => {
+    const { container } = render(
+      <CloneSeasonModal {...defaultProps} open={false} />,
+    );
+    expect(container.querySelector("[data-testid='clone-season-modal']")).toBeNull();
+  });
+
+  it("year default = currentYear + 1 a l'ouverture", () => {
+    render(<CloneSeasonModal {...defaultProps} />);
+    const input = screen.getByTestId("clone-year") as HTMLInputElement;
+    expect(parseInt(input.value, 10)).toBe(new Date().getFullYear() + 1);
+  });
+
+  it("submit disabled si year hors bornes", () => {
+    render(<CloneSeasonModal {...defaultProps} />);
+    fireEvent.change(screen.getByTestId("clone-year"), { target: { value: "1999" } });
+    const btn = screen.getByTestId("clone-submit") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("submit envoie year (driverKind omis si inherit)", async () => {
+    const onConfirm = vi.fn();
+    render(<CloneSeasonModal {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByTestId("clone-year"), { target: { value: "2027" } });
+    fireEvent.click(screen.getByTestId("clone-submit"));
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith({ year: 2027 });
+    });
+  });
+
+  it("submit envoie driverKind si selection explicite", async () => {
+    const onConfirm = vi.fn();
+    render(<CloneSeasonModal {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByTestId("clone-year"), { target: { value: "2027" } });
+    fireEvent.click(screen.getByTestId("clone-driver-full"));
+    fireEvent.click(screen.getByTestId("clone-submit"));
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith({ year: 2027, driverKind: "full" });
+    });
+  });
+
+  it("loading=true desactive submit + label", () => {
+    render(<CloneSeasonModal {...defaultProps} loading={true} />);
+    const btn = screen.getByTestId("clone-submit") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toMatch(/clone/i);
+  });
+
+  it("reset year + driver entre 2 ouvertures", () => {
+    const { rerender } = render(
+      <CloneSeasonModal {...defaultProps} sourceSeasonId="s1" />,
+    );
+    fireEvent.change(screen.getByTestId("clone-year"), { target: { value: "2030" } });
+    fireEvent.click(screen.getByTestId("clone-driver-hybrid"));
+
+    rerender(<CloneSeasonModal {...defaultProps} sourceSeasonId="s2" />);
+    const input = screen.getByTestId("clone-year") as HTMLInputElement;
+    // Default revient a currentYear + 1.
+    expect(parseInt(input.value, 10)).toBe(new Date().getFullYear() + 1);
+    // Driver revient a "inherit".
+    const inheritBtn = screen.getByTestId("clone-driver-inherit");
+    expect(inheritBtn.className).toMatch(/bg-nuffle-gold/);
+  });
+
+  it("bouton Annuler appelle onClose", () => {
+    const onClose = vi.fn();
+    render(<CloneSeasonModal {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /^annuler$/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/admin/pro-league/seasons/_components/CloneSeasonModal.tsx
+++ b/apps/web/app/admin/pro-league/seasons/_components/CloneSeasonModal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Lot P.B.3 — Modal de clone d'une saison Pro League.
+ *
+ * Inputs : year cible (entier 2020..2100, unique). Le service refuse
+ * cote serveur si DUPLICATE_YEAR.
+ */
+
+interface CloneSeasonModalProps {
+  open: boolean;
+  sourceSeasonId: string | null;
+  sourceSeasonLabel: string;
+  loading: boolean;
+  onClose: () => void;
+  onConfirm: (payload: { year: number; driverKind?: "hybrid" | "full" }) => void | Promise<void>;
+}
+
+export default function CloneSeasonModal({
+  open,
+  sourceSeasonId,
+  sourceSeasonLabel,
+  loading,
+  onClose,
+  onConfirm,
+}: CloneSeasonModalProps) {
+  const [yearStr, setYearStr] = useState("");
+  const [driverKind, setDriverKind] = useState<"inherit" | "hybrid" | "full">(
+    "inherit",
+  );
+
+  useEffect(() => {
+    if (open) {
+      const next = new Date().getFullYear() + 1;
+      setYearStr(String(next));
+      setDriverKind("inherit");
+    }
+  }, [open, sourceSeasonId]);
+
+  if (!open) return null;
+
+  const yearParsed = Number.parseInt(yearStr, 10);
+  const yearValid =
+    Number.isInteger(yearParsed) && yearParsed >= 2020 && yearParsed <= 2100;
+  const canSubmit = yearValid && !loading;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    onConfirm({
+      year: yearParsed,
+      driverKind:
+        driverKind === "inherit" ? undefined : driverKind,
+    });
+  };
+
+  return (
+    <div
+      data-testid="clone-season-modal"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md">
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-heading font-bold text-nuffle-anthracite">
+              Cloner une saison
+            </h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Source : {sourceSeasonLabel}{" "}
+              <span className="font-mono">
+                ({sourceSeasonId?.slice(0, 8)}…)
+              </span>
+            </p>
+            <p className="text-sm text-gray-700 mt-2">
+              Cree une nouvelle saison avec les memes equipes et standings a
+              zero. Le schedule n&apos;est <strong>pas</strong> clone — utilise
+              ensuite &laquo;Regenerer le calendrier&raquo;.
+            </p>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">
+              Annee cible
+            </span>
+            <input
+              type="number"
+              data-testid="clone-year"
+              value={yearStr}
+              onChange={(e) => setYearStr(e.target.value)}
+              min={2020}
+              max={2100}
+              required
+              className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-nuffle-gold focus:outline-none"
+            />
+          </label>
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-gray-700">
+              Driver de simulation
+            </legend>
+            <div className="grid grid-cols-3 gap-2">
+              {(["inherit", "hybrid", "full"] as const).map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  data-testid={`clone-driver-${opt}`}
+                  onClick={() => setDriverKind(opt)}
+                  className={`px-3 py-2 rounded-lg border text-sm ${
+                    driverKind === opt
+                      ? "bg-nuffle-gold text-white border-nuffle-gold"
+                      : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              data-testid="clone-submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50"
+            >
+              {loading ? "Clone…" : "Cloner"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/seasons/page.tsx
+++ b/apps/web/app/admin/pro-league/seasons/page.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+/**
+ * Lot P.B.3 — Page admin de gestion des saisons Pro League.
+ *
+ * Liste les saisons avec leurs counters (rounds, matches, played) et
+ * un menu d'actions par ligne :
+ *  - Cloner (modal year input)
+ *  - Regenerer le calendrier (confirm)
+ *  - Reset standings (confirm)
+ *  - Annuler la saison (confirm)
+ *
+ * Chaque action declenche un POST audit-loggue cote serveur. Apres
+ * succes, la liste est rechargee pour refleter le nouvel etat.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { API_BASE } from "../../../auth-client";
+import CloneSeasonModal from "./_components/CloneSeasonModal";
+
+interface Season {
+  id: string;
+  leagueId: string;
+  year: number;
+  status: string;
+  driverKind: string;
+  engineVer: string;
+  startsAt: string | null;
+  endsAt: string | null;
+  roundCount: number;
+  matchCount: number;
+  playedCount: number;
+  createdAt: string;
+}
+
+async function fetchJSON(path: string, options?: RequestInit) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: token ? `Bearer ${token}` : "",
+      "Content-Type": "application/json",
+    },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(json?.error || `Erreur ${res.status}`);
+  }
+  return json;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  scheduled: "bg-yellow-100 text-yellow-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  completed: "bg-green-100 text-green-800",
+  archived: "bg-gray-100 text-gray-800",
+  cancelled: "bg-red-100 text-red-800",
+};
+
+export default function AdminProLeagueSeasonsPage() {
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [cloneSource, setCloneSource] = useState<Season | null>(null);
+  const [cloneLoading, setCloneLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchJSON("/admin/pro-league/seasons");
+      setSeasons(data.seasons ?? []);
+    } catch (e: any) {
+      setError(e.message || "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAction = async (
+    seasonId: string,
+    action: "regenerate-schedule" | "reset-standings" | "cancel",
+    confirmMessage: string,
+  ) => {
+    if (!confirm(confirmMessage)) return;
+    setActionLoading(`${seasonId}:${action}`);
+    try {
+      await fetchJSON(`/admin/pro-league/seasons/${seasonId}/${action}`, {
+        method: "POST",
+        body: "{}",
+      });
+      await load();
+    } catch (e: any) {
+      alert(e.message || `Erreur lors de ${action}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleCloneConfirm = async (payload: {
+    year: number;
+    driverKind?: "hybrid" | "full";
+  }) => {
+    if (!cloneSource) return;
+    setCloneLoading(true);
+    try {
+      await fetchJSON("/admin/pro-league/seasons/clone", {
+        method: "POST",
+        body: JSON.stringify({
+          fromSeasonId: cloneSource.id,
+          year: payload.year,
+          ...(payload.driverKind ? { driverKind: payload.driverKind } : {}),
+        }),
+      });
+      setCloneSource(null);
+      await load();
+    } catch (e: any) {
+      alert(e.message || "Erreur lors du clone");
+    } finally {
+      setCloneLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-nuffle-gold mb-4" />
+          <p className="text-gray-600">Chargement…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          🏆 Saisons Pro League
+        </h1>
+        <p className="text-sm text-gray-600">
+          Gestion administrative des saisons : clone, regeneration de
+          calendrier, reset des standings, annulation.
+        </p>
+      </div>
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left p-3">Annee</th>
+              <th className="text-left p-3">Statut</th>
+              <th className="text-left p-3">Driver</th>
+              <th className="text-left p-3">Engine</th>
+              <th className="text-right p-3">Rounds</th>
+              <th className="text-right p-3">Matches</th>
+              <th className="text-right p-3">Joues</th>
+              <th className="text-left p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {seasons.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="p-6 text-center text-gray-500 italic">
+                  Aucune saison.
+                </td>
+              </tr>
+            ) : (
+              seasons.map((s) => {
+                const loadingKey = (action: string) =>
+                  actionLoading === `${s.id}:${action}`;
+                const anyLoading = actionLoading?.startsWith(`${s.id}:`);
+                const canModify =
+                  s.status !== "archived" && s.status !== "cancelled";
+
+                return (
+                  <tr
+                    key={s.id}
+                    data-testid={`season-row-${s.id}`}
+                    className="border-t border-gray-100"
+                  >
+                    <td className="p-3 font-semibold">{s.year}</td>
+                    <td className="p-3">
+                      <span
+                        className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                          STATUS_COLORS[s.status] ?? "bg-gray-100 text-gray-800"
+                        }`}
+                      >
+                        {s.status}
+                      </span>
+                    </td>
+                    <td className="p-3 font-mono text-xs">{s.driverKind}</td>
+                    <td className="p-3 font-mono text-xs">{s.engineVer}</td>
+                    <td className="p-3 text-right">{s.roundCount}</td>
+                    <td className="p-3 text-right">{s.matchCount}</td>
+                    <td className="p-3 text-right">
+                      {s.playedCount}
+                      {s.matchCount > 0 && (
+                        <span className="text-xs text-gray-400 ml-1">
+                          / {s.matchCount}
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3">
+                      <div className="flex flex-wrap gap-1">
+                        <button
+                          onClick={() => setCloneSource(s)}
+                          disabled={!!anyLoading}
+                          data-testid={`btn-clone-${s.id}`}
+                          className="px-2 py-1 text-xs text-white bg-blue-600 hover:bg-blue-700 rounded disabled:opacity-50"
+                        >
+                          Cloner
+                        </button>
+                        {canModify && (
+                          <>
+                            <button
+                              onClick={() =>
+                                handleAction(
+                                  s.id,
+                                  "regenerate-schedule",
+                                  `Regenerer le calendrier de la saison ${s.year} ? Tous les matchs scheduled seront recrees.`,
+                                )
+                              }
+                              disabled={!!anyLoading}
+                              data-testid={`btn-regen-${s.id}`}
+                              className="px-2 py-1 text-xs text-white bg-purple-600 hover:bg-purple-700 rounded disabled:opacity-50"
+                            >
+                              {loadingKey("regenerate-schedule")
+                                ? "…"
+                                : "Regenerer"}
+                            </button>
+                            <button
+                              onClick={() =>
+                                handleAction(
+                                  s.id,
+                                  "reset-standings",
+                                  `Reset les standings de la saison ${s.year} ? Tous les compteurs (points, wins, etc.) repartent a zero.`,
+                                )
+                              }
+                              disabled={!!anyLoading}
+                              data-testid={`btn-reset-${s.id}`}
+                              className="px-2 py-1 text-xs text-white bg-orange-600 hover:bg-orange-700 rounded disabled:opacity-50"
+                            >
+                              {loadingKey("reset-standings")
+                                ? "…"
+                                : "Reset"}
+                            </button>
+                            <button
+                              onClick={() =>
+                                handleAction(
+                                  s.id,
+                                  "cancel",
+                                  `Annuler la saison ${s.year} ? Le statut passera a "cancelled".`,
+                                )
+                              }
+                              disabled={!!anyLoading}
+                              data-testid={`btn-cancel-${s.id}`}
+                              className="px-2 py-1 text-xs text-white bg-red-600 hover:bg-red-700 rounded disabled:opacity-50"
+                            >
+                              {loadingKey("cancel") ? "…" : "Annuler"}
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <CloneSeasonModal
+        open={cloneSource !== null}
+        sourceSeasonId={cloneSource?.id ?? null}
+        sourceSeasonLabel={
+          cloneSource ? `Saison ${cloneSource.year} (${cloneSource.status})` : ""
+        }
+        loading={cloneLoading}
+        onClose={() => setCloneSource(null)}
+        onConfirm={handleCloneConfirm}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Sprint P lot P.B.3 — donne au support les leviers admin sur les saisons Pro League sans avoir à faire du SQL manuel : clone d'une saison existante, régénération du calendrier, reset des standings, annulation, forfait forcé d'un match.

## Surfaces

**Service** — `apps/server/src/services/pro-season-factory.ts` :
- `cloneSeason({ fromSeasonId, year, driverKind? })` — crée une `ProLeagueSeason` + standings init zero pour les mêmes teams. Schedule **pas** cloné (chaîner ensuite `regenerate-schedule`).
- `resetStandings(seasonId)` — `updateMany` sur `ProLeagueStandings` (zero out played/wins/draws/losses/points/td*/casualties*/form).
- `cancelSeason(seasonId)` — `status='cancelled'`. Idempotent. Refuse archived.
- `forceForfeit({ matchId, winnerSide })` — `status='completed'` + outcome + score 1-0/0-1. Refuse si déjà completed.
- `SeasonFactoryError` class avec `code` enum (`SEASON_NOT_FOUND`, `MATCH_NOT_FOUND`, `MATCH_ALREADY_COMPLETED`, `INVALID_INPUT`, `DUPLICATE_YEAR`, `SEASON_HAS_RESULTS`).

**Router** — `apps/server/src/routes/admin-pro-season.ts` (6 endpoints) :
- `GET  /admin/pro-league/seasons` — liste + counters (rounds/matches/joués)
- `POST /admin/pro-league/seasons/clone`
- `POST /admin/pro-league/seasons/:id/regenerate-schedule` (wrap de l'existant)
- `POST /admin/pro-league/seasons/:id/reset-standings`
- `POST /admin/pro-league/seasons/:id/cancel`
- `POST /admin/pro-league/matches/:id/force-forfeit`

Audit log strict sur chaque action (`pro-season.clone`, `.regenerate-schedule`, `.reset-standings`, `.cancel`, `.force-forfeit`). `SeasonFactoryError` mappée au HTTP status (404 / 409 / 400 / 500).

**UI** — `apps/web/app/admin/pro-league/seasons/page.tsx` :
- Table avec 1 ligne par saison (year, status coloré, driver, engine, counters), actions par ligne. Actions disabled sur archived/cancelled (sauf "Cloner").
- `CloneSeasonModal` — input year (2020-2100) + radio driverKind (inherit/hybrid/full).
- Lien dans sidebar admin (`/admin/pro-league/seasons`, 🏆).

## Test plan

- [x] `pnpm --filter @bb/server typecheck` — OK
- [x] `pnpm --filter @bb/web typecheck` — OK
- [x] `pnpm --filter @bb/server test` — **2278 tests** (+34)
- [x] `pnpm --filter @bb/web test` — **1014 tests** (+8)
- [ ] Manuel staging : cloner une saison → succès, nouvelle saison apparaît dans la liste
- [ ] Manuel : regenerate-schedule sur la nouvelle saison → 15 rounds + 120 matches
- [ ] Manuel : reset-standings → tous les counters à 0
- [ ] Manuel : force-forfeit d'un match scheduled → status="completed" + score 1-0
- [ ] Manuel : tenter `force-forfeit` sur un match `completed` → 409
- [ ] Manuel : tenter cloner avec un year déjà pris → 409

## Tests ajoutés

- `pro-season-factory.test.ts` — 17 tests (4 fonctions × edge cases : NOT_FOUND, DUPLICATE_YEAR, MATCH_ALREADY_COMPLETED, INVALID_INPUT, archived refus, idempotent cancel).
- `admin-pro-season.test.ts` — 17 tests (6 endpoints via `http.createServer`, audit log assertions, mapping erreurs vers HTTP status).
- `CloneSeasonModal.test.tsx` — 8 tests (year default, bornes, driver inherit/full, loading, reset entre 2 ouvertures).

## Notes / différé

- **CLI `pnpm pro:season:clone --from=...`** : différé post-MVP. L'UI couvre les cas usuels.
- **Bulk action "clone + regenerate"** : possible en un click ultérieur (workflow courant).
- **Action de "rejouer un match"** : hors scope P.B.3 (force-forfeit suffit pour les cas frauduleux/bugés ; pour rejouer proprement il faudra simuler à nouveau avec un nouveau seed — autre lot).

Lien Sprint : [SPRINT-P-ops-readiness.md](docs/roadmap/sprints/SPRINT-P-ops-readiness.md) lot P.B.3.

**Sprint P : 10/10 lots livrés** 🎉

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_