### PR TITLE
feat(admin): bootstrap Pro League — create season + hub + season detail

### DIFF
--- a/apps/server/src/routes/admin-pro-season.test.ts
+++ b/apps/server/src/routes/admin-pro-season.test.ts
@@ -10,8 +10,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../prisma", () => ({
   prisma: {
-    proLeagueSeason: { findMany: vi.fn() },
+    proLeagueSeason: { findMany: vi.fn(), findUnique: vi.fn() },
     proLeagueMatch: { groupBy: vi.fn() },
+    proLeagueRound: { findMany: vi.fn() },
+    proLeagueStandings: { findMany: vi.fn() },
   },
 }));
 
@@ -42,6 +44,7 @@ vi.mock("../services/pro-season-factory", () => {
   }
   return {
     cloneSeason: vi.fn(),
+    createSeason: vi.fn(),
     resetStandings: vi.fn(),
     cancelSeason: vi.fn(),
     forceForfeit: vi.fn(),
@@ -50,6 +53,7 @@ vi.mock("../services/pro-season-factory", () => {
 });
 
 vi.mock("../services/pro-league-scheduler", () => ({
+  buildProLeagueSchedule: vi.fn(),
   regenerateProLeagueSchedule: vi.fn(),
 }));
 
@@ -60,23 +64,34 @@ import { prisma } from "../prisma";
 import { safeRecordAdminActionFromRequest } from "../services/audit-log";
 import {
   cloneSeason as cloneSeasonMock,
+  createSeason as createSeasonMock,
   resetStandings as resetStandingsMock,
   cancelSeason as cancelSeasonMock,
   forceForfeit as forceForfeitMock,
   SeasonFactoryError,
 } from "../services/pro-season-factory";
-import { regenerateProLeagueSchedule as regenerateMock } from "../services/pro-league-scheduler";
+import {
+  buildProLeagueSchedule as buildMock,
+  regenerateProLeagueSchedule as regenerateMock,
+} from "../services/pro-league-scheduler";
 
 const mockedAudit = vi.mocked(safeRecordAdminActionFromRequest);
 const cloneSeason = vi.mocked(cloneSeasonMock);
+const createSeasonFn = vi.mocked(createSeasonMock);
 const resetStandings = vi.mocked(resetStandingsMock);
 const cancelSeason = vi.mocked(cancelSeasonMock);
 const forceForfeit = vi.mocked(forceForfeitMock);
 const regenerate = vi.mocked(regenerateMock);
+const buildSchedule = vi.mocked(buildMock);
 
 interface MockedPrisma {
-  proLeagueSeason: { findMany: ReturnType<typeof vi.fn> };
+  proLeagueSeason: {
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+  };
   proLeagueMatch: { groupBy: ReturnType<typeof vi.fn> };
+  proLeagueRound: { findMany: ReturnType<typeof vi.fn> };
+  proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
 }
 
 const mockedPrisma = prisma as unknown as MockedPrisma;
@@ -182,6 +197,142 @@ describe("GET /admin/pro-league/seasons", () => {
     expect(res.status).toBe(200);
     expect(res.body.seasons).toEqual([]);
     expect(mockedPrisma.proLeagueMatch.groupBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /admin/pro-league/seasons/:id", () => {
+  it("retourne season + rounds + standings ordonnees", async () => {
+    mockedPrisma.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      leagueId: "l1",
+      year: 2026,
+      status: "in_progress",
+      driverKind: "hybrid",
+      engineVer: "0.16.0",
+      startsAt: null,
+      endsAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    mockedPrisma.proLeagueRound.findMany.mockResolvedValueOnce([
+      {
+        id: "r1",
+        roundNumber: 1,
+        status: "pending",
+        scheduledAt: new Date(),
+        _count: { matches: 8 },
+      },
+    ]);
+    mockedPrisma.proLeagueStandings.findMany.mockResolvedValueOnce([
+      {
+        teamId: "t1",
+        played: 1,
+        wins: 1,
+        draws: 0,
+        losses: 0,
+        points: 3,
+        tdFor: 2,
+        tdAgainst: 0,
+        team: { name: "A", slug: "a", race: "Orc" },
+      },
+    ]);
+
+    const res = await request("GET", "/seasons/s1");
+    expect(res.status).toBe(200);
+    expect(res.body.season.id).toBe("s1");
+    expect(res.body.rounds).toHaveLength(1);
+    expect(res.body.standings).toHaveLength(1);
+  });
+
+  it("404 si saison inexistante", async () => {
+    mockedPrisma.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    const res = await request("GET", "/seasons/ghost");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /admin/pro-league/seasons", () => {
+  it("cree saison (sans autoSchedule) + audit", async () => {
+    createSeasonFn.mockResolvedValueOnce({
+      seasonId: "new-s",
+      leagueId: "l1",
+      year: 2027,
+      engineVer: "0.16.0",
+      driverKind: "hybrid",
+    });
+
+    const res = await request("POST", "/seasons", { year: 2027 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.seasonId).toBe("new-s");
+    expect(res.body.scheduled).toBeNull();
+    expect(buildSchedule).not.toHaveBeenCalled();
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({
+        action: "pro-season.create",
+        newValue: expect.objectContaining({ year: 2027, autoSchedule: false }),
+      }),
+    );
+  });
+
+  it("autoSchedule=true enchaine buildProLeagueSchedule", async () => {
+    createSeasonFn.mockResolvedValueOnce({
+      seasonId: "new-s",
+      leagueId: "l1",
+      year: 2027,
+      engineVer: "0.16.0",
+      driverKind: "hybrid",
+    });
+    buildSchedule.mockResolvedValueOnce({
+      seasonId: "new-s",
+      roundsCreated: 15,
+      matchesCreated: 120,
+      idempotentSkip: false,
+    });
+
+    const res = await request("POST", "/seasons", {
+      year: 2027,
+      autoSchedule: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.scheduled).toEqual({
+      roundsCreated: 15,
+      matchesCreated: 120,
+    });
+    expect(buildSchedule).toHaveBeenCalledWith({ seasonId: "new-s" });
+  });
+
+  it("404 si LEAGUE_NOT_FOUND", async () => {
+    createSeasonFn.mockRejectedValueOnce(
+      new SeasonFactoryError("LEAGUE_NOT_FOUND", "no league"),
+    );
+    const res = await request("POST", "/seasons", { year: 2027 });
+    expect(res.status).toBe(404);
+  });
+
+  it("409 si DUPLICATE_YEAR", async () => {
+    createSeasonFn.mockRejectedValueOnce(
+      new SeasonFactoryError("DUPLICATE_YEAR", "already"),
+    );
+    const res = await request("POST", "/seasons", { year: 2026 });
+    expect(res.status).toBe(409);
+  });
+
+  it("422 si NO_TEAMS", async () => {
+    createSeasonFn.mockRejectedValueOnce(
+      new SeasonFactoryError("NO_TEAMS", "seed"),
+    );
+    const res = await request("POST", "/seasons", { year: 2027 });
+    expect(res.status).toBe(422);
+  });
+
+  it("400 si year invalide (Zod)", async () => {
+    const res = await request("POST", "/seasons", { year: 1999 });
+    expect(res.status).toBe(400);
+    expect(createSeasonFn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/routes/admin-pro-season.ts
+++ b/apps/server/src/routes/admin-pro-season.ts
@@ -20,6 +20,7 @@ import { adminOnly } from "../middleware/adminOnly";
 import { validate } from "../middleware/validate";
 import {
   adminCloneSeasonSchema,
+  adminCreateSeasonSchema,
   adminForceForfeitSchema,
 } from "../schemas/admin.schemas";
 import { serverLog } from "../utils/server-log";
@@ -27,12 +28,16 @@ import { safeRecordAdminActionFromRequest } from "../services/audit-log";
 import type { AuthenticatedRequest } from "../middleware/authUser";
 import {
   cloneSeason,
+  createSeason,
   resetStandings,
   cancelSeason,
   forceForfeit,
   SeasonFactoryError,
 } from "../services/pro-season-factory";
-import { regenerateProLeagueSchedule } from "../services/pro-league-scheduler";
+import {
+  buildProLeagueSchedule,
+  regenerateProLeagueSchedule,
+} from "../services/pro-league-scheduler";
 
 const router = Router();
 
@@ -43,6 +48,7 @@ function errorStatus(code: SeasonFactoryError["code"]): number {
   switch (code) {
     case "SEASON_NOT_FOUND":
     case "MATCH_NOT_FOUND":
+    case "LEAGUE_NOT_FOUND":
       return 404;
     case "MATCH_ALREADY_COMPLETED":
     case "DUPLICATE_YEAR":
@@ -50,6 +56,8 @@ function errorStatus(code: SeasonFactoryError["code"]): number {
       return 409;
     case "INVALID_INPUT":
       return 400;
+    case "NO_TEAMS":
+      return 422;
     default:
       return 500;
   }
@@ -126,6 +134,130 @@ router.get("/seasons", async (_req, res) => {
     res.status(500).json({ error: "Erreur lors de la lecture des saisons" });
   }
 });
+
+/**
+ * GET /admin/pro-league/seasons/:id — detail saison.
+ *
+ * Retourne : season meta + rounds (1..N avec status, scheduledAt et
+ * counters matches) + standings ordonnees par points desc.
+ */
+router.get("/seasons/:id", async (req, res) => {
+  try {
+    const season = await prisma.proLeagueSeason.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        leagueId: true,
+        year: true,
+        status: true,
+        driverKind: true,
+        engineVer: true,
+        startsAt: true,
+        endsAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (!season) {
+      return res.status(404).json({ error: "Saison introuvable" });
+    }
+
+    const [rounds, standings] = await Promise.all([
+      prisma.proLeagueRound.findMany({
+        where: { seasonId: req.params.id },
+        select: {
+          id: true,
+          roundNumber: true,
+          status: true,
+          scheduledAt: true,
+          startedAt: true,
+          completedAt: true,
+          _count: { select: { matches: true } },
+        },
+        orderBy: { roundNumber: "asc" },
+      }),
+      prisma.proLeagueStandings.findMany({
+        where: { seasonId: req.params.id },
+        select: {
+          teamId: true,
+          played: true,
+          wins: true,
+          draws: true,
+          losses: true,
+          points: true,
+          tdFor: true,
+          tdAgainst: true,
+          team: { select: { name: true, slug: true, race: true } },
+        },
+        orderBy: [{ points: "desc" }, { tdFor: "desc" }],
+      }),
+    ]);
+
+    res.json({ season, rounds, standings });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors du chargement de la saison" });
+  }
+});
+
+/**
+ * POST /admin/pro-league/seasons — cree une saison from scratch.
+ *
+ * `autoSchedule: true` enchaine `buildProLeagueSchedule` apres la
+ * creation, ce qui genere les 15 rounds + 120 matches du round-robin
+ * (en utilisant le defaut "prochain mardi 21h00 UTC" comme date du
+ * round 1).
+ */
+router.post(
+  "/seasons",
+  validate(adminCreateSeasonSchema),
+  async (req, res) => {
+    try {
+      const { autoSchedule = false, ...createInput } = req.body as {
+        year: number;
+        driverKind?: "hybrid" | "full";
+        engineVer?: string;
+        autoSchedule?: boolean;
+      };
+      const created = await createSeason(createInput);
+
+      let scheduled: { roundsCreated: number; matchesCreated: number } | null =
+        null;
+      if (autoSchedule) {
+        const build = await buildProLeagueSchedule({ seasonId: created.seasonId });
+        scheduled = {
+          roundsCreated: build.roundsCreated,
+          matchesCreated: build.matchesCreated,
+        };
+      }
+
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-season.create",
+          entity: "ProLeagueSeason",
+          entityId: created.seasonId,
+          newValue: {
+            year: created.year,
+            driverKind: created.driverKind,
+            engineVer: created.engineVer,
+            autoSchedule,
+            scheduled,
+          },
+        },
+      );
+
+      res.json({ ...created, scheduled });
+    } catch (e) {
+      if (e instanceof SeasonFactoryError) {
+        return res.status(errorStatus(e.code)).json({ error: e.message });
+      }
+      serverLog.error(e);
+      res.status(500).json({ error: "Erreur lors de la creation de la saison" });
+    }
+  },
+);
 
 /**
  * POST /admin/pro-league/seasons/clone — clone une saison existante.

--- a/apps/server/src/schemas/admin.schemas.ts
+++ b/apps/server/src/schemas/admin.schemas.ts
@@ -126,6 +126,17 @@ export const adminBetRefundSchema = z.object({
 
 // ── Lot P.B.3 — Pro League season factory ──
 
+/** Creation d'une saison Pro League from scratch.
+ *  Initialise les standings a zero. Le schedule est genere si
+ *  `autoSchedule: true` (par defaut false — l'admin appellera
+ *  regenerate-schedule plus tard si besoin de personnaliser la date). */
+export const adminCreateSeasonSchema = z.object({
+  year: z.number().int().min(2020).max(2100),
+  driverKind: z.enum(["hybrid", "full"]).optional(),
+  engineVer: z.string().min(1).max(50).optional(),
+  autoSchedule: z.boolean().optional().default(false),
+});
+
 /** Clone d'une saison Pro League. La saison source doit exister. Le
  *  `year` cible doit etre unique dans la ligue (sinon DUPLICATE_YEAR
  *  cote service). `driverKind` optionnel = inherit la valeur source. */

--- a/apps/server/src/services/pro-season-factory.test.ts
+++ b/apps/server/src/services/pro-season-factory.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../prisma", () => ({
   prisma: {
+    proLeague: { findUnique: vi.fn() },
     proLeagueSeason: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
     proLeagueStandings: { updateMany: vi.fn(), createMany: vi.fn() },
     proLeagueMatch: { findUnique: vi.fn(), update: vi.fn() },
@@ -22,16 +23,26 @@ vi.mock("../prisma", () => ({
   },
 }));
 
+vi.mock("@bb/sim-engine", () => ({
+  ENGINE_VER: "1.0.0-test",
+}));
+
+vi.mock("../seeders/pro-league", () => ({
+  OLD_WORLD_LEAGUE_SLUG: "old-world-league",
+}));
+
 import { prisma } from "../prisma";
 import {
   resetStandings,
   cancelSeason,
   forceForfeit,
   cloneSeason,
+  createSeason,
   SeasonFactoryError,
 } from "./pro-season-factory";
 
 interface MockedPrisma {
+  proLeague: { findUnique: ReturnType<typeof vi.fn> };
   proLeagueSeason: {
     findUnique: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -295,5 +306,96 @@ describe("cloneSeason", () => {
     expect(e).toBeInstanceOf(Error);
     expect(e.code).toBe("INVALID_INPUT");
     expect(e.name).toBe("SeasonFactoryError");
+  });
+});
+
+describe("createSeason", () => {
+  it("cree saison + init standings pour toutes les teams", async () => {
+    mocked.proLeague.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    mocked.proTeam.findMany.mockResolvedValueOnce([
+      { id: "t1" },
+      { id: "t2" },
+      { id: "t3" },
+    ]);
+    const seasonCreate = vi.fn().mockResolvedValueOnce({ id: "new-s" });
+    const standingsCreateMany = vi.fn().mockResolvedValueOnce({ count: 3 });
+    mocked.$transaction.mockImplementationOnce(async (fn: any) =>
+      fn({
+        proLeagueSeason: { create: seasonCreate },
+        proLeagueStandings: { createMany: standingsCreateMany },
+      }),
+    );
+
+    const result = await createSeason({ year: 2027 });
+
+    expect(result.year).toBe(2027);
+    expect(result.engineVer).toBe("1.0.0-test");
+    expect(result.driverKind).toBe("hybrid");
+    expect(result.seasonId).toBe("new-s");
+    expect(seasonCreate.mock.calls[0][0].data).toMatchObject({
+      leagueId: "l1",
+      year: 2027,
+      status: "scheduled",
+      engineVer: "1.0.0-test",
+      driverKind: "hybrid",
+    });
+    expect(standingsCreateMany.mock.calls[0][0].data).toHaveLength(3);
+  });
+
+  it("override driverKind + engineVer si fournis", async () => {
+    mocked.proLeague.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    mocked.proTeam.findMany.mockResolvedValueOnce([{ id: "t1" }]);
+    const seasonCreate = vi.fn().mockResolvedValueOnce({ id: "new-s" });
+    mocked.$transaction.mockImplementationOnce(async (fn: any) =>
+      fn({
+        proLeagueSeason: { create: seasonCreate },
+        proLeagueStandings: { createMany: vi.fn() },
+      }),
+    );
+
+    await createSeason({
+      year: 2027,
+      driverKind: "full",
+      engineVer: "0.99.0",
+    });
+
+    expect(seasonCreate.mock.calls[0][0].data.driverKind).toBe("full");
+    expect(seasonCreate.mock.calls[0][0].data.engineVer).toBe("0.99.0");
+  });
+
+  it("INVALID_INPUT si year < 2020 ou > 2100", async () => {
+    await expect(createSeason({ year: 1999 })).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    });
+    await expect(createSeason({ year: 3000 })).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    });
+  });
+
+  it("LEAGUE_NOT_FOUND si la ligue singleton n'est pas seedee", async () => {
+    mocked.proLeague.findUnique.mockResolvedValueOnce(null);
+    await expect(createSeason({ year: 2027 })).rejects.toMatchObject({
+      code: "LEAGUE_NOT_FOUND",
+    });
+  });
+
+  it("DUPLICATE_YEAR si une saison existe deja", async () => {
+    mocked.proLeague.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({ id: "dup" });
+    await expect(createSeason({ year: 2026 })).rejects.toMatchObject({
+      code: "DUPLICATE_YEAR",
+    });
+    expect(mocked.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("NO_TEAMS si aucune team en DB", async () => {
+    mocked.proLeague.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce(null);
+    mocked.proTeam.findMany.mockResolvedValueOnce([]);
+    await expect(createSeason({ year: 2027 })).rejects.toMatchObject({
+      code: "NO_TEAMS",
+    });
   });
 });

--- a/apps/server/src/services/pro-season-factory.ts
+++ b/apps/server/src/services/pro-season-factory.ts
@@ -16,6 +16,8 @@
  */
 
 import { prisma } from "../prisma";
+import { ENGINE_VER as CURRENT_ENGINE_VER } from "@bb/sim-engine";
+import { OLD_WORLD_LEAGUE_SLUG } from "../seeders/pro-league";
 
 export class SeasonFactoryError extends Error {
   constructor(
@@ -25,12 +27,125 @@ export class SeasonFactoryError extends Error {
       | "MATCH_NOT_FOUND"
       | "MATCH_ALREADY_COMPLETED"
       | "INVALID_INPUT"
-      | "DUPLICATE_YEAR",
+      | "DUPLICATE_YEAR"
+      | "LEAGUE_NOT_FOUND"
+      | "NO_TEAMS",
     message: string,
   ) {
     super(message);
     this.name = "SeasonFactoryError";
   }
+}
+
+// ---------------------------------------------------------------------------
+// createSeason — bootstrap d'une saison Pro League from scratch
+// ---------------------------------------------------------------------------
+
+export interface CreateSeasonInput {
+  /** Annee de la saison (2020..2100, unique par ligue). */
+  readonly year: number;
+  /** Driver de simulation : default "hybrid". */
+  readonly driverKind?: "hybrid" | "full";
+  /** engineVer pinne : default CURRENT_ENGINE_VER de @bb/sim-engine. */
+  readonly engineVer?: string;
+}
+
+export interface CreateSeasonResult {
+  readonly seasonId: string;
+  readonly leagueId: string;
+  readonly year: number;
+  readonly engineVer: string;
+  readonly driverKind: string;
+}
+
+/**
+ * Cree une nouvelle saison Pro League pour la ligue singleton
+ * `old-world-league`. Initialise les `ProLeagueStandings` a zero pour
+ * les 16 teams (ou ce qui est en DB).
+ *
+ * Le schedule n'est PAS genere ici — appeler ensuite
+ * `buildProLeagueSchedule({ seasonId })` pour creer les 15 rounds + 120
+ * matches du round-robin.
+ *
+ * Refuse si :
+ *  - la ligue singleton n'est pas seedee (LEAGUE_NOT_FOUND) ;
+ *  - une saison avec ce `year` existe deja (DUPLICATE_YEAR) ;
+ *  - aucune team n'est en DB (NO_TEAMS).
+ */
+export async function createSeason(
+  input: CreateSeasonInput,
+): Promise<CreateSeasonResult> {
+  if (!Number.isInteger(input.year) || input.year < 2020 || input.year > 2100) {
+    throw new SeasonFactoryError(
+      "INVALID_INPUT",
+      `year doit etre un entier 2020..2100 (recu: ${input.year})`,
+    );
+  }
+
+  const league = await prisma.proLeague.findUnique({
+    where: { slug: OLD_WORLD_LEAGUE_SLUG },
+    select: { id: true },
+  });
+  if (!league) {
+    throw new SeasonFactoryError(
+      "LEAGUE_NOT_FOUND",
+      `Ligue '${OLD_WORLD_LEAGUE_SLUG}' introuvable. Lance d'abord le seed (Utilitaires → Reseed Pro League).`,
+    );
+  }
+
+  const duplicate = await prisma.proLeagueSeason.findUnique({
+    where: { leagueId_year: { leagueId: league.id, year: input.year } },
+    select: { id: true },
+  });
+  if (duplicate) {
+    throw new SeasonFactoryError(
+      "DUPLICATE_YEAR",
+      `Une saison existe deja pour year=${input.year}`,
+    );
+  }
+
+  const teams = (await prisma.proTeam.findMany({
+    where: { leagueId: league.id },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+  if (teams.length === 0) {
+    throw new SeasonFactoryError(
+      "NO_TEAMS",
+      "Aucune equipe en DB. Lance d'abord le seed (Utilitaires → Reseed Pro League).",
+    );
+  }
+
+  const driverKind = input.driverKind ?? "hybrid";
+  const engineVer = input.engineVer ?? CURRENT_ENGINE_VER;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const created = await prisma.$transaction(async (tx: any) => {
+    const newSeason = await tx.proLeagueSeason.create({
+      data: {
+        leagueId: league.id,
+        year: input.year,
+        status: "scheduled",
+        engineVer,
+        driverKind,
+      },
+      select: { id: true },
+    });
+    await tx.proLeagueStandings.createMany({
+      data: teams.map((team) => ({
+        seasonId: newSeason.id as string,
+        teamId: team.id,
+      })),
+    });
+    return newSeason;
+  });
+
+  return {
+    seasonId: created.id as string,
+    leagueId: league.id,
+    year: input.year,
+    engineVer,
+    driverKind,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -81,6 +81,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               {navItem("/admin/sim/health", "Sim Health", "❤️")}
               {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
               {navItem("/admin/sim/test-match", "Test Match", "🧪")}
+              {navItem("/admin/pro-league", "Hub Pro League", "🏈")}
               {navItem("/admin/pro-league/seasons", "Saisons Pro League", "🏆")}
               {navItem("/admin/feedback", "Feedback", "💬")}
               {navItem("/admin/audit-log", "Journal d'audit", "📜")}

--- a/apps/web/app/admin/pro-league/page.tsx
+++ b/apps/web/app/admin/pro-league/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * Hub admin Pro League : regroupe les liens vers tous les outils
+ * admin Pro League (saisons, sim, broadcaster, replays, health, sandbox).
+ *
+ * Architecture : une simple grille de cards avec icone + titre +
+ * description. Pas de donnees fetch (purement navigation).
+ */
+
+import Link from "next/link";
+
+interface HubLink {
+  readonly href: string;
+  readonly icon: string;
+  readonly title: string;
+  readonly description: string;
+  /** "stable" = production-ready, "beta" = utilisable mais limite. */
+  readonly status?: "stable" | "beta";
+}
+
+const LINKS: ReadonlyArray<HubLink> = [
+  {
+    href: "/admin/pro-league/seasons",
+    icon: "🏆",
+    title: "Saisons",
+    description:
+      "Creation, clone, regeneration du calendrier, reset des standings, annulation. Detail par saison.",
+    status: "stable",
+  },
+  {
+    href: "/admin/sim",
+    icon: "🎲",
+    title: "Sim Pro League",
+    description:
+      "Drift watcher, comparaison versions engine, run sim ponctuel. Vue d'ensemble du sim-runner.",
+    status: "stable",
+  },
+  {
+    href: "/admin/sim/health",
+    icon: "❤️",
+    title: "Sim Health",
+    description:
+      "Snapshot des sous-systemes (season, simRunner, gazette, bets). Probes prod-ready.",
+    status: "stable",
+  },
+  {
+    href: "/admin/sim/broadcaster",
+    icon: "📡",
+    title: "Broadcaster",
+    description:
+      "Stats du broadcaster temps-reel (matches actifs, viewers, push events). Load testing.",
+    status: "stable",
+  },
+  {
+    href: "/admin/sim/replays",
+    icon: "📜",
+    title: "Replays Panel",
+    description:
+      "Lecture seule des replays panel (validation C6-C9). Pour debug visuel sans toucher prod.",
+    status: "stable",
+  },
+  {
+    href: "/admin/sim/test-match",
+    icon: "🧪",
+    title: "Sandbox Test Match",
+    description:
+      "Lance un match Pro League sans impact ELO/standings/paris. ~50ms, replay immediat.",
+    status: "stable",
+  },
+];
+
+const STATUS_BADGE: Record<NonNullable<HubLink["status"]>, string> = {
+  stable: "bg-green-100 text-green-800",
+  beta: "bg-yellow-100 text-yellow-800",
+};
+
+export default function AdminProLeagueHubPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          🏈 Admin Pro League
+        </h1>
+        <p className="text-sm text-gray-600">
+          Outils de gestion de la ligue virtuelle. Toute action est tracee
+          dans le journal d&apos;audit admin.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {LINKS.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href as any}
+            data-testid={`hub-link-${link.href.replace(/\//g, "-")}`}
+            className="p-5 rounded-xl border bg-white border-gray-200 shadow-sm hover:shadow-md hover:border-nuffle-gold transition-all"
+          >
+            <div className="flex items-start gap-3">
+              <span className="text-3xl">{link.icon}</span>
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="font-semibold text-nuffle-anthracite">
+                    {link.title}
+                  </h2>
+                  {link.status && (
+                    <span
+                      className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${STATUS_BADGE[link.status]}`}
+                    >
+                      {link.status}
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-gray-700 mt-1">
+                  {link.description}
+                </p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800">
+        <strong>Roadmap admin Pro League</strong> : a venir dans les
+        prochains sprints : gestion fine des rosters (re-generer joueurs,
+        editer skills), edition branding teams, re-simulation d&apos;un
+        match avec nouveau seed, gestion des bet markets.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/seasons/[id]/page.tsx
+++ b/apps/web/app/admin/pro-league/seasons/[id]/page.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+/**
+ * Page admin de detail d'une saison Pro League.
+ *
+ * Affiche : meta saison, liste des rounds (avec compteur matches),
+ * standings ordonnees par points. Liens vers les pages associees
+ * (admin/sim/replays filtrees, gestion de rounds — futur).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { API_BASE } from "../../../../auth-client";
+
+interface SeasonDetail {
+  season: {
+    id: string;
+    leagueId: string;
+    year: number;
+    status: string;
+    driverKind: string;
+    engineVer: string;
+    startsAt: string | null;
+    endsAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  rounds: Array<{
+    id: string;
+    roundNumber: number;
+    status: string;
+    scheduledAt: string | null;
+    startedAt: string | null;
+    completedAt: string | null;
+    _count: { matches: number };
+  }>;
+  standings: Array<{
+    teamId: string;
+    played: number;
+    wins: number;
+    draws: number;
+    losses: number;
+    points: number;
+    tdFor: number;
+    tdAgainst: number;
+    team: { name: string; slug: string; race: string };
+  }>;
+}
+
+async function fetchJSON(path: string) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { Authorization: token ? `Bearer ${token}` : "" },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json?.error || `Erreur ${res.status}`);
+  return json;
+}
+
+const ROUND_STATUS_COLORS: Record<string, string> = {
+  pending: "bg-gray-100 text-gray-700",
+  in_progress: "bg-blue-100 text-blue-800",
+  completed: "bg-green-100 text-green-800",
+};
+
+export default function AdminProSeasonDetailPage() {
+  const params = useParams();
+  const seasonId = typeof params.id === "string" ? params.id : "";
+
+  const [data, setData] = useState<SeasonDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const fetched = await fetchJSON(`/admin/pro-league/seasons/${seasonId}`);
+      setData(fetched);
+    } catch (e: any) {
+      setError(e.message || "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [seasonId]);
+
+  useEffect(() => {
+    if (seasonId) load();
+  }, [load, seasonId]);
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-nuffle-gold mb-4" />
+          <p className="text-gray-600">Chargement…</p>
+        </div>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        {error}
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const { season, rounds, standings } = data;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite">
+            Saison {season.year}
+          </h1>
+          <p className="text-sm text-gray-600 font-mono">{season.id}</p>
+        </div>
+        <Link
+          href="/admin/pro-league/seasons"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          ← Liste des saisons
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-200 p-4 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div>
+          <div className="text-gray-600">Statut</div>
+          <div className="font-bold">{season.status}</div>
+        </div>
+        <div>
+          <div className="text-gray-600">Driver</div>
+          <div className="font-bold font-mono">{season.driverKind}</div>
+        </div>
+        <div>
+          <div className="text-gray-600">Engine</div>
+          <div className="font-bold font-mono">{season.engineVer}</div>
+        </div>
+        <div>
+          <div className="text-gray-600">Cree le</div>
+          <div className="font-bold">
+            {new Date(season.createdAt).toLocaleDateString("fr-FR")}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold mb-3">
+          Rounds ({rounds.length})
+        </h2>
+        {rounds.length === 0 ? (
+          <p className="text-sm text-gray-500 italic">
+            Aucun round. Genere le calendrier depuis la liste des saisons.
+          </p>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left p-2">#</th>
+                <th className="text-left p-2">Statut</th>
+                <th className="text-left p-2">Programme</th>
+                <th className="text-right p-2">Matches</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rounds.map((r) => (
+                <tr
+                  key={r.id}
+                  data-testid={`round-row-${r.id}`}
+                  className="border-t border-gray-100"
+                >
+                  <td className="p-2 font-semibold">{r.roundNumber}</td>
+                  <td className="p-2">
+                    <span
+                      className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                        ROUND_STATUS_COLORS[r.status] ?? "bg-gray-100"
+                      }`}
+                    >
+                      {r.status}
+                    </span>
+                  </td>
+                  <td className="p-2 text-xs text-gray-600">
+                    {r.scheduledAt
+                      ? new Date(r.scheduledAt).toLocaleString("fr-FR")
+                      : "—"}
+                  </td>
+                  <td className="p-2 text-right">{r._count.matches}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="bg-white rounded-xl shadow border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold mb-3">
+          Classement ({standings.length})
+        </h2>
+        {standings.length === 0 ? (
+          <p className="text-sm text-gray-500 italic">Aucun standing.</p>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left p-2">#</th>
+                <th className="text-left p-2">Equipe</th>
+                <th className="text-left p-2">Race</th>
+                <th className="text-right p-2">J</th>
+                <th className="text-right p-2">V</th>
+                <th className="text-right p-2">N</th>
+                <th className="text-right p-2">D</th>
+                <th className="text-right p-2">TD+</th>
+                <th className="text-right p-2">TD-</th>
+                <th className="text-right p-2">Pts</th>
+              </tr>
+            </thead>
+            <tbody>
+              {standings.map((s, idx) => (
+                <tr
+                  key={s.teamId}
+                  data-testid={`standing-row-${s.teamId}`}
+                  className="border-t border-gray-100"
+                >
+                  <td className="p-2 text-gray-500">{idx + 1}</td>
+                  <td className="p-2 font-medium">{s.team.name}</td>
+                  <td className="p-2 text-xs text-gray-600">{s.team.race}</td>
+                  <td className="p-2 text-right">{s.played}</td>
+                  <td className="p-2 text-right">{s.wins}</td>
+                  <td className="p-2 text-right">{s.draws}</td>
+                  <td className="p-2 text-right">{s.losses}</td>
+                  <td className="p-2 text-right">{s.tdFor}</td>
+                  <td className="p-2 text-right">{s.tdAgainst}</td>
+                  <td className="p-2 text-right font-bold">{s.points}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/seasons/_components/CreateSeasonModal.test.tsx
+++ b/apps/web/app/admin/pro-league/seasons/_components/CreateSeasonModal.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests du CreateSeasonModal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import CreateSeasonModal from "./CreateSeasonModal";
+
+const defaultProps = {
+  open: true,
+  loading: false,
+  onClose: () => {},
+  onConfirm: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CreateSeasonModal", () => {
+  it("ne rend rien si open=false", () => {
+    const { container } = render(
+      <CreateSeasonModal {...defaultProps} open={false} />,
+    );
+    expect(
+      container.querySelector("[data-testid='create-season-modal']"),
+    ).toBeNull();
+  });
+
+  it("year default = currentYear, autoSchedule default = true", () => {
+    render(<CreateSeasonModal {...defaultProps} />);
+    const input = screen.getByTestId("create-year") as HTMLInputElement;
+    expect(parseInt(input.value, 10)).toBe(new Date().getFullYear());
+    const cb = screen.getByTestId("create-auto-schedule") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("submit envoie year + driverKind + autoSchedule", async () => {
+    const onConfirm = vi.fn();
+    render(<CreateSeasonModal {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByTestId("create-year"), {
+      target: { value: "2027" },
+    });
+    fireEvent.click(screen.getByTestId("create-driver-full"));
+    fireEvent.click(screen.getByTestId("create-auto-schedule")); // uncheck
+    fireEvent.click(screen.getByTestId("create-submit"));
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith({
+        year: 2027,
+        driverKind: "full",
+        autoSchedule: false,
+      });
+    });
+  });
+
+  it("submit disabled si year hors bornes (<2020)", () => {
+    render(<CreateSeasonModal {...defaultProps} />);
+    fireEvent.change(screen.getByTestId("create-year"), {
+      target: { value: "1999" },
+    });
+    const btn = screen.getByTestId("create-submit") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("loading=true desactive submit + label", () => {
+    render(<CreateSeasonModal {...defaultProps} loading={true} />);
+    const btn = screen.getByTestId("create-submit") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toMatch(/creation/i);
+  });
+
+  it("reset year + autoSchedule entre 2 ouvertures", () => {
+    const { rerender } = render(
+      <CreateSeasonModal {...defaultProps} open={true} />,
+    );
+    fireEvent.change(screen.getByTestId("create-year"), {
+      target: { value: "2030" },
+    });
+    fireEvent.click(screen.getByTestId("create-auto-schedule")); // uncheck
+
+    rerender(<CreateSeasonModal {...defaultProps} open={false} />);
+    rerender(<CreateSeasonModal {...defaultProps} open={true} />);
+
+    const input = screen.getByTestId("create-year") as HTMLInputElement;
+    expect(parseInt(input.value, 10)).toBe(new Date().getFullYear());
+    const cb = screen.getByTestId("create-auto-schedule") as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+  });
+
+  it("bouton Annuler appelle onClose", () => {
+    const onClose = vi.fn();
+    render(<CreateSeasonModal {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /^annuler$/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/admin/pro-league/seasons/_components/CreateSeasonModal.tsx
+++ b/apps/web/app/admin/pro-league/seasons/_components/CreateSeasonModal.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Modal de creation d'une saison Pro League from scratch.
+ *
+ * Inputs : year (2020..2100, unique), driverKind (hybrid|full),
+ * autoSchedule (cocher pour enchainer la generation du calendrier
+ * immediatement apres la creation — utile pour les saisons rapides
+ * de tests).
+ */
+
+interface CreateSeasonModalProps {
+  open: boolean;
+  loading: boolean;
+  onClose: () => void;
+  onConfirm: (payload: {
+    year: number;
+    driverKind?: "hybrid" | "full";
+    autoSchedule: boolean;
+  }) => void | Promise<void>;
+}
+
+export default function CreateSeasonModal({
+  open,
+  loading,
+  onClose,
+  onConfirm,
+}: CreateSeasonModalProps) {
+  const [yearStr, setYearStr] = useState("");
+  const [driverKind, setDriverKind] = useState<"hybrid" | "full">("hybrid");
+  const [autoSchedule, setAutoSchedule] = useState(true);
+
+  useEffect(() => {
+    if (open) {
+      setYearStr(String(new Date().getFullYear()));
+      setDriverKind("hybrid");
+      setAutoSchedule(true);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const yearParsed = Number.parseInt(yearStr, 10);
+  const yearValid =
+    Number.isInteger(yearParsed) && yearParsed >= 2020 && yearParsed <= 2100;
+  const canSubmit = yearValid && !loading;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    onConfirm({ year: yearParsed, driverKind, autoSchedule });
+  };
+
+  return (
+    <div
+      data-testid="create-season-modal"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md">
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-heading font-bold text-nuffle-anthracite">
+              Creer une saison Pro League
+            </h2>
+            <p className="text-sm text-gray-700 mt-2">
+              Initialise une nouvelle saison avec les 16 equipes seedees.
+              Standings a zero. Le calendrier (15 rounds × 8 matches) est
+              genere automatiquement si la case est cochee.
+            </p>
+          </div>
+
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700">Annee</span>
+            <input
+              type="number"
+              data-testid="create-year"
+              value={yearStr}
+              onChange={(e) => setYearStr(e.target.value)}
+              min={2020}
+              max={2100}
+              required
+              className="mt-1 w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-nuffle-gold focus:outline-none"
+            />
+          </label>
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium text-gray-700">
+              Driver de simulation
+            </legend>
+            <div className="grid grid-cols-2 gap-2">
+              {(["hybrid", "full"] as const).map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  data-testid={`create-driver-${opt}`}
+                  onClick={() => setDriverKind(opt)}
+                  className={`px-3 py-2 rounded-lg border text-sm ${
+                    driverKind === opt
+                      ? "bg-nuffle-gold text-white border-nuffle-gold"
+                      : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              data-testid="create-auto-schedule"
+              checked={autoSchedule}
+              onChange={(e) => setAutoSchedule(e.target.checked)}
+            />
+            <span>
+              Generer le calendrier immediatement (15 rounds, premier
+              mardi 21h UTC)
+            </span>
+          </label>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              data-testid="create-submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg disabled:opacity-50"
+            >
+              {loading ? "Creation…" : "Creer la saison"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/seasons/page.tsx
+++ b/apps/web/app/admin/pro-league/seasons/page.tsx
@@ -15,8 +15,10 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { API_BASE } from "../../../auth-client";
 import CloneSeasonModal from "./_components/CloneSeasonModal";
+import CreateSeasonModal from "./_components/CreateSeasonModal";
 
 interface Season {
   id: string;
@@ -65,6 +67,8 @@ export default function AdminProLeagueSeasonsPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [cloneSource, setCloneSource] = useState<Season | null>(null);
   const [cloneLoading, setCloneLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -100,6 +104,26 @@ export default function AdminProLeagueSeasonsPage() {
       alert(e.message || `Erreur lors de ${action}`);
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const handleCreateConfirm = async (payload: {
+    year: number;
+    driverKind?: "hybrid" | "full";
+    autoSchedule: boolean;
+  }) => {
+    setCreateLoading(true);
+    try {
+      await fetchJSON("/admin/pro-league/seasons", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      setCreateOpen(false);
+      await load();
+    } catch (e: any) {
+      alert(e.message || "Erreur lors de la creation");
+    } finally {
+      setCreateLoading(false);
     }
   };
 
@@ -140,14 +164,23 @@ export default function AdminProLeagueSeasonsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
-          🏆 Saisons Pro League
-        </h1>
-        <p className="text-sm text-gray-600">
-          Gestion administrative des saisons : clone, regeneration de
-          calendrier, reset des standings, annulation.
-        </p>
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+            🏆 Saisons Pro League
+          </h1>
+          <p className="text-sm text-gray-600">
+            Gestion administrative des saisons : creation, clone, regeneration
+            de calendrier, reset des standings, annulation.
+          </p>
+        </div>
+        <button
+          onClick={() => setCreateOpen(true)}
+          data-testid="btn-create-season"
+          className="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg shadow-sm"
+        >
+          + Creer une saison
+        </button>
       </div>
 
       {error && (
@@ -191,7 +224,14 @@ export default function AdminProLeagueSeasonsPage() {
                     data-testid={`season-row-${s.id}`}
                     className="border-t border-gray-100"
                   >
-                    <td className="p-3 font-semibold">{s.year}</td>
+                    <td className="p-3 font-semibold">
+                      <Link
+                        href={`/admin/pro-league/seasons/${s.id}` as any}
+                        className="text-blue-600 hover:text-blue-800 hover:underline"
+                      >
+                        {s.year}
+                      </Link>
+                    </td>
                     <td className="p-3">
                       <span
                         className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
@@ -282,6 +322,13 @@ export default function AdminProLeagueSeasonsPage() {
           </tbody>
         </table>
       </div>
+
+      <CreateSeasonModal
+        open={createOpen}
+        loading={createLoading}
+        onClose={() => setCreateOpen(false)}
+        onConfirm={handleCreateConfirm}
+      />
 
       <CloneSeasonModal
         open={cloneSource !== null}


### PR DESCRIPTION
## Summary

Débloque `/admin/sim/test-match` qui crashait avec "Aucune saison active" et pose les fondations d'une admin Pro League complète (Hub + détail saison).

## Bug fixé

`/admin/sim/test-match` cherchait une saison active mais **aucun endpoint** ne permettait d'en créer une from scratch. Bootstrap impossible sans SQL manuel.

## Service

`pro-season-factory.ts` :
- `createSeason({ year, driverKind?, engineVer? })` — crée une `ProLeagueSeason` `status=scheduled` + init standings zero pour les teams seedées.
- Codes d'erreur : `INVALID_INPUT` (year < 2020 ou > 2100), `LEAGUE_NOT_FOUND` (seed pas lancé), `DUPLICATE_YEAR`, `NO_TEAMS`.

## Endpoints

- `POST /admin/pro-league/seasons` — body `{ year, driverKind?, engineVer?, autoSchedule? }`. Si `autoSchedule=true`, enchaîne `buildProLeagueSchedule` (15 rounds × 8 matches).
- `GET /admin/pro-league/seasons/:id` — détail : meta + rounds (asc) + standings (par points desc).

Mapping HTTP : `LEAGUE_NOT_FOUND` → 404, `NO_TEAMS` → 422, `DUPLICATE_YEAR` → 409, `INVALID_INPUT` → 400.

## UI admin

- **Hub** `/admin/pro-league/page.tsx` — cards regroupant tous les outils Pro League existants (saisons, sim, broadcaster, replays, health, sandbox) avec status badges + roadmap des outils à venir.
- **Détail saison** `/admin/pro-league/seasons/[id]/page.tsx` — meta + rounds + standings classés.
- **Liste saisons** (existante) : bouton "+ Créer une saison" en header + lien sur la `year` vers le détail.
- **CreateSeasonModal** : year (default currentYear) + driver radio + case "Générer le calendrier immédiatement" (default ON).
- Sidebar admin : ajout "🏈 Hub Pro League".

## Test plan

- [x] `pnpm --filter @bb/server typecheck` — OK
- [x] `pnpm --filter @bb/web typecheck` — OK
- [x] `pnpm --filter @bb/server test` — **2292 tests** (+14)
- [x] `pnpm --filter @bb/web test` — **1021 tests** (+7)
- [ ] Manuel : `/admin/pro-league` → cards affichées, liens fonctionnels
- [ ] Manuel : `/admin/pro-league/seasons` → bouton "+ Créer une saison" → modal → year courant + autoSchedule ON → submit → saison + 15 rounds + 120 matches créés
- [ ] Manuel : cliquer sur la `year` → page détail avec rounds + standings
- [ ] Manuel : `/admin/sim/test-match` → choisir 2 teams → "Lancer" → succès (plus de "Aucune saison active")
- [ ] Manuel : tenter `POST /seasons` avec `year=1999` → 400 ; `year=2026` doublon → 409 ; sans seed teams → 422

## Tests ajoutés

- `pro-season-factory.test.ts` : +6 tests createSeason (success, override driverKind+engineVer, INVALID_INPUT bornes, LEAGUE_NOT_FOUND, DUPLICATE_YEAR, NO_TEAMS).
- `admin-pro-season.test.ts` : +8 tests (GET detail OK/404 + POST seasons with/without autoSchedule + erreurs 404/409/422/400).
- `CreateSeasonModal.test.tsx` : 7 tests (defaults, submit payload, bornes, loading, reset).

## Différé sprints futurs (admin Pro League "complète")

- Gestion fine des rosters (re-générer joueurs d'une team, éditer skills/stats).
- Edition branding teams (couleurs, motto, NFL flavor).
- Re-simulation d'un match avec nouveau seed (post-bug fix).
- Gestion des bet markets (close, settle manuellement).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_