### PR TITLE
feat(admin): gestion des matchs Pro League (simulate + list + detail)

### DIFF
--- a/apps/server/src/routes/admin-pro-season.test.ts
+++ b/apps/server/src/routes/admin-pro-season.test.ts
@@ -11,10 +11,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../prisma", () => ({
   prisma: {
     proLeagueSeason: { findMany: vi.fn(), findUnique: vi.fn() },
-    proLeagueMatch: { groupBy: vi.fn() },
+    proLeagueMatch: {
+      groupBy: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
     proLeagueRound: { findMany: vi.fn() },
     proLeagueStandings: { findMany: vi.fn() },
   },
+}));
+
+vi.mock("../services/pro-league-sim-runner", () => ({
+  simulateProMatch: vi.fn(),
 }));
 
 vi.mock("../middleware/authUser", () => ({
@@ -74,6 +82,7 @@ import {
   buildProLeagueSchedule as buildMock,
   regenerateProLeagueSchedule as regenerateMock,
 } from "../services/pro-league-scheduler";
+import { simulateProMatch as simulateMock } from "../services/pro-league-sim-runner";
 
 const mockedAudit = vi.mocked(safeRecordAdminActionFromRequest);
 const cloneSeason = vi.mocked(cloneSeasonMock);
@@ -83,13 +92,18 @@ const cancelSeason = vi.mocked(cancelSeasonMock);
 const forceForfeit = vi.mocked(forceForfeitMock);
 const regenerate = vi.mocked(regenerateMock);
 const buildSchedule = vi.mocked(buildMock);
+const simulate = vi.mocked(simulateMock);
 
 interface MockedPrisma {
   proLeagueSeason: {
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
   };
-  proLeagueMatch: { groupBy: ReturnType<typeof vi.fn> };
+  proLeagueMatch: {
+    groupBy: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+  };
   proLeagueRound: { findMany: ReturnType<typeof vi.fn> };
   proLeagueStandings: { findMany: ReturnType<typeof vi.fn> };
 }
@@ -522,5 +536,128 @@ describe("POST /admin/pro-league/matches/:id/force-forfeit", () => {
       winnerSide: "home",
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /admin/pro-league/seasons/:id/matches", () => {
+  it("liste les matches de la saison", async () => {
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m1",
+        status: "scheduled",
+        scheduledAt: new Date(),
+        simulatedAt: null,
+        completedAt: null,
+        scoreHome: null,
+        scoreAway: null,
+        outcome: null,
+        isTest: false,
+        replayId: null,
+        homeTeam: { name: "A", slug: "a" },
+        awayTeam: { name: "B", slug: "b" },
+        round: { roundNumber: 1 },
+      },
+    ]);
+
+    const res = await request("GET", "/seasons/s1/matches");
+    expect(res.status).toBe(200);
+    expect(res.body.matches).toHaveLength(1);
+    const call = mockedPrisma.proLeagueMatch.findMany.mock.calls[0]![0];
+    expect(call.where).toEqual({ seasonId: "s1" });
+  });
+
+  it("applique filtres roundNumber + status", async () => {
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+    const res = await request(
+      "GET",
+      "/seasons/s1/matches?roundNumber=3&status=completed",
+    );
+    expect(res.status).toBe(200);
+    const call = mockedPrisma.proLeagueMatch.findMany.mock.calls[0]![0];
+    expect(call.where).toMatchObject({
+      seasonId: "s1",
+      status: "completed",
+      round: { roundNumber: 3 },
+    });
+  });
+
+  it("400 si roundNumber hors bornes", async () => {
+    const res = await request("GET", "/seasons/s1/matches?roundNumber=100");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /admin/pro-league/matches/:id", () => {
+  it("retourne le detail du match", async () => {
+    mockedPrisma.proLeagueMatch.findUnique.mockResolvedValueOnce({
+      id: "m1",
+      seasonId: "s1",
+      roundId: "r1",
+      status: "completed",
+      scoreHome: 2,
+      scoreAway: 1,
+      outcome: "home",
+      replayId: "replay-1",
+      homeTeam: { id: "t1", name: "A", slug: "a", race: "Orc" },
+      awayTeam: { id: "t2", name: "B", slug: "b", race: "Wood Elf" },
+      round: { id: "r1", roundNumber: 5 },
+      season: {
+        id: "s1",
+        year: 2026,
+        engineVer: "0.16.0",
+        driverKind: "hybrid",
+      },
+    });
+    const res = await request("GET", "/matches/m1");
+    expect(res.status).toBe(200);
+    expect(res.body.match.id).toBe("m1");
+    expect(res.body.match.outcome).toBe("home");
+  });
+
+  it("404 si match inexistant", async () => {
+    mockedPrisma.proLeagueMatch.findUnique.mockResolvedValueOnce(null);
+    const res = await request("GET", "/matches/ghost");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /admin/pro-league/matches/:id/simulate", () => {
+  it("simule un match scheduled + audit log", async () => {
+    simulate.mockResolvedValueOnce(true);
+    const res = await request("POST", "/matches/m1/simulate");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ matchId: "m1", simulated: true });
+    expect(simulate).toHaveBeenCalledWith("m1");
+    expect(mockedAudit).toHaveBeenCalledWith(
+      prisma,
+      expect.anything(),
+      expect.objectContaining({
+        action: "pro-season.simulate-match",
+        entity: "ProLeagueMatch",
+        entityId: "m1",
+        newValue: { simulated: true },
+      }),
+    );
+  });
+
+  it("simulated=false (idempotent) si deja completed", async () => {
+    simulate.mockResolvedValueOnce(false);
+    const res = await request("POST", "/matches/m1/simulate");
+    expect(res.status).toBe(200);
+    expect(res.body.simulated).toBe(false);
+  });
+
+  it("404 si match introuvable (message)", async () => {
+    simulate.mockRejectedValueOnce(new Error("ProLeagueMatch 'ghost' introuvable"));
+    const res = await request("POST", "/matches/ghost/simulate");
+    expect(res.status).toBe(404);
+  });
+
+  it("422 si EngineVersionMismatch", async () => {
+    simulate.mockRejectedValueOnce(
+      new Error("EngineVersionMismatchError: engineVer pinned"),
+    );
+    const res = await request("POST", "/matches/m1/simulate");
+    expect(res.status).toBe(422);
   });
 });

--- a/apps/server/src/routes/admin-pro-season.ts
+++ b/apps/server/src/routes/admin-pro-season.ts
@@ -38,6 +38,7 @@ import {
   buildProLeagueSchedule,
   regenerateProLeagueSchedule,
 } from "../services/pro-league-scheduler";
+import { simulateProMatch } from "../services/pro-league-sim-runner";
 
 const router = Router();
 
@@ -409,5 +410,152 @@ router.post(
     }
   },
 );
+
+/**
+ * GET /admin/pro-league/seasons/:id/matches — liste des matchs d'une saison.
+ *
+ * Filtres optionnels : `?roundNumber=N` (1..15), `?status=scheduled|ready|
+ * in_progress|completed|failed`. Ordre par roundNumber asc puis
+ * scheduledAt asc pour faciliter le triage round-par-round.
+ */
+router.get("/seasons/:id/matches", async (req, res) => {
+  try {
+    const where: {
+      seasonId: string;
+      status?: string;
+      round?: { roundNumber: number };
+    } = { seasonId: req.params.id };
+
+    const roundNumberRaw = req.query.roundNumber as string | undefined;
+    if (roundNumberRaw !== undefined && roundNumberRaw !== "") {
+      const n = parseInt(roundNumberRaw, 10);
+      if (!Number.isInteger(n) || n < 1 || n > 50) {
+        return res.status(400).json({ error: "roundNumber doit etre 1..50" });
+      }
+      where.round = { roundNumber: n };
+    }
+    const statusFilter = req.query.status as string | undefined;
+    if (statusFilter) {
+      where.status = statusFilter;
+    }
+
+    const matches = (await prisma.proLeagueMatch.findMany({
+      where,
+      select: {
+        id: true,
+        status: true,
+        scheduledAt: true,
+        simulatedAt: true,
+        completedAt: true,
+        scoreHome: true,
+        scoreAway: true,
+        outcome: true,
+        isTest: true,
+        replayId: true,
+        homeTeam: { select: { name: true, slug: true } },
+        awayTeam: { select: { name: true, slug: true } },
+        round: { select: { roundNumber: true } },
+      },
+      orderBy: [
+        { round: { roundNumber: "asc" } },
+        { scheduledAt: "asc" },
+      ],
+      take: 500,
+    })) as Array<unknown>;
+
+    res.json({ matches });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de la lecture des matchs" });
+  }
+});
+
+/**
+ * GET /admin/pro-league/matches/:id — detail d'un match Pro League.
+ *
+ * Renvoie : meta complete (status, score, outcome, counters, engineVer),
+ * teams, round, replayId. Utilise par la page detail match + decisions
+ * admin (simulate, force-forfeit).
+ */
+router.get("/matches/:id", async (req, res) => {
+  try {
+    const match = await prisma.proLeagueMatch.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        seasonId: true,
+        roundId: true,
+        status: true,
+        scheduledAt: true,
+        simulatedAt: true,
+        completedAt: true,
+        scoreHome: true,
+        scoreAway: true,
+        outcome: true,
+        touchdownCount: true,
+        casualtyCount: true,
+        turnoverCount: true,
+        nuffleCount: true,
+        isTest: true,
+        engineVer: true,
+        driverKindOverride: true,
+        replayId: true,
+        homeTeam: { select: { id: true, name: true, slug: true, race: true } },
+        awayTeam: { select: { id: true, name: true, slug: true, race: true } },
+        round: { select: { id: true, roundNumber: true } },
+        season: { select: { id: true, year: true, engineVer: true, driverKind: true } },
+      },
+    });
+    if (!match) {
+      return res.status(404).json({ error: "Match introuvable" });
+    }
+    res.json({ match });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors du chargement du match" });
+  }
+});
+
+/**
+ * POST /admin/pro-league/matches/:id/simulate — declenche la simulation
+ * d'un match Pro League individuel.
+ *
+ * Utilise le sim-runner standard (`simulateProMatch`). Idempotent :
+ * retourne `{ simulated: false }` si le match est deja dans un status
+ * final (`completed` / `failed`).
+ *
+ * Le sim peut lever `EngineVersionMismatchError` si le match avait deja
+ * un engineVer pinne different de la version courante. On retourne 422
+ * dans ce cas (le re-sim n'est pas autorise — il faut bouger le match
+ * ou la saison vers la nouvelle version d'abord).
+ */
+router.post("/matches/:id/simulate", async (req, res) => {
+  try {
+    const simulated = await simulateProMatch(req.params.id);
+
+    await safeRecordAdminActionFromRequest(
+      prisma,
+      req as AuthenticatedRequest,
+      {
+        action: "pro-season.simulate-match",
+        entity: "ProLeagueMatch",
+        entityId: req.params.id,
+        newValue: { simulated },
+      },
+    );
+
+    res.json({ matchId: req.params.id, simulated });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Erreur inconnue";
+    if (msg.includes("introuvable") || msg.includes("not found")) {
+      return res.status(404).json({ error: msg });
+    }
+    if (msg.includes("EngineVersionMismatch") || msg.includes("engineVer")) {
+      return res.status(422).json({ error: msg });
+    }
+    serverLog.error(e);
+    res.status(500).json({ error: msg });
+  }
+});
 
 export default router;

--- a/apps/web/app/admin/pro-league/seasons/[id]/_components/SeasonMatches.test.tsx
+++ b/apps/web/app/admin/pro-league/seasons/[id]/_components/SeasonMatches.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests du composant SeasonMatches.
+ *
+ * Couvre : fetch initial, application des filtres roundNumber/status,
+ * bouton Simuler (POST + reload), idempotent (alert si simulated=false),
+ * lien Replay si replayId.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import SeasonMatches from "./SeasonMatches";
+
+const originalFetch = global.fetch;
+
+const sampleMatches = [
+  {
+    id: "m1",
+    status: "scheduled",
+    scheduledAt: "2026-05-12T20:00:00Z",
+    simulatedAt: null,
+    completedAt: null,
+    scoreHome: null,
+    scoreAway: null,
+    outcome: null,
+    isTest: false,
+    replayId: null,
+    homeTeam: { name: "Reikland", slug: "rei" },
+    awayTeam: { name: "Skavenblight", slug: "ska" },
+    round: { roundNumber: 1 },
+  },
+  {
+    id: "m2",
+    status: "completed",
+    scheduledAt: "2026-05-12T20:00:00Z",
+    simulatedAt: "2026-05-12T20:01:00Z",
+    completedAt: "2026-05-12T20:01:30Z",
+    scoreHome: 2,
+    scoreAway: 1,
+    outcome: "home",
+    isTest: false,
+    replayId: "replay-abc",
+    homeTeam: { name: "Bright Crusaders", slug: "bri" },
+    awayTeam: { name: "Reikland", slug: "rei" },
+    round: { roundNumber: 1 },
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+  vi.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("SeasonMatches", () => {
+  it("liste les matchs apres fetch initial", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ matches: sampleMatches }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<SeasonMatches seasonId="s1" totalRounds={15} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("match-row-m1")).toBeTruthy();
+      expect(screen.getByTestId("match-row-m2")).toBeTruthy();
+    });
+  });
+
+  it("affiche le score pour les matchs completed", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ matches: sampleMatches }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    const { container } = render(
+      <SeasonMatches seasonId="s1" totalRounds={15} />,
+    );
+
+    await waitFor(() => {
+      const row = screen.getByTestId("match-row-m2");
+      expect(row.textContent).toContain("2 - 1");
+    });
+    // Pas de bouton Simuler sur match completed.
+    expect(container.querySelector("[data-testid='btn-simulate-m2']")).toBeNull();
+  });
+
+  it("bouton Simuler envoie POST + reload", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ matches: sampleMatches }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ matchId: "m1", simulated: true }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ matches: sampleMatches }),
+      } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SeasonMatches seasonId="s1" totalRounds={15} />);
+    await waitFor(() => screen.getByTestId("btn-simulate-m1"));
+    fireEvent.click(screen.getByTestId("btn-simulate-m1"));
+
+    await waitFor(() => {
+      // 1 fetch initial + 1 POST + 1 reload = 3 calls
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const postCall = fetchMock.mock.calls[1];
+      expect(postCall[0]).toContain("/admin/pro-league/matches/m1/simulate");
+      expect(postCall[1].method).toBe("POST");
+    });
+  });
+
+  it("filtre roundNumber + status passes en query string", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ matches: [] }),
+      } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SeasonMatches seasonId="s1" totalRounds={5} />);
+    await waitFor(() => screen.getByTestId("round-filter"));
+
+    fireEvent.change(screen.getByTestId("round-filter"), {
+      target: { value: "3" },
+    });
+    fireEvent.change(screen.getByTestId("status-filter"), {
+      target: { value: "completed" },
+    });
+
+    await waitFor(() => {
+      const lastCall =
+        fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0];
+      expect(lastCall).toMatch(/roundNumber=3/);
+      expect(lastCall).toMatch(/status=completed/);
+    });
+  });
+
+  it("lien Replay rendu si replayId existe", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ matches: sampleMatches }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<SeasonMatches seasonId="s1" totalRounds={15} />);
+
+    await waitFor(() => {
+      const row = screen.getByTestId("match-row-m2");
+      const replayLink = row.querySelector("a");
+      expect(replayLink?.getAttribute("href")).toBe(
+        "/pro-league/matches/m2",
+      );
+    });
+  });
+});

--- a/apps/web/app/admin/pro-league/seasons/[id]/_components/SeasonMatches.tsx
+++ b/apps/web/app/admin/pro-league/seasons/[id]/_components/SeasonMatches.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+/**
+ * Section "Matchs" pour la page detail saison admin Pro League.
+ *
+ * Filtres : roundNumber (select), status (select). Affiche la liste
+ * paginee par roundNumber asc puis scheduledAt asc. Action "Simuler"
+ * par ligne pour les matchs non-finaux + lien vers replay si replayId.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { API_BASE } from "../../../../../auth-client";
+
+interface MatchRow {
+  id: string;
+  status: string;
+  scheduledAt: string;
+  simulatedAt: string | null;
+  completedAt: string | null;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  isTest: boolean;
+  replayId: string | null;
+  homeTeam: { name: string; slug: string };
+  awayTeam: { name: string; slug: string };
+  round: { roundNumber: number };
+}
+
+interface SeasonMatchesProps {
+  seasonId: string;
+  /** Total des rounds dans la saison (pour le select). */
+  totalRounds: number;
+}
+
+async function fetchJSON(path: string, options?: RequestInit) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: token ? `Bearer ${token}` : "",
+      "Content-Type": "application/json",
+    },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json?.error || `Erreur ${res.status}`);
+  return json;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  scheduled: "bg-gray-100 text-gray-700",
+  ready: "bg-yellow-100 text-yellow-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  completed: "bg-green-100 text-green-800",
+  failed: "bg-red-100 text-red-800",
+};
+
+const FINAL_STATUSES = new Set(["completed", "failed"]);
+
+export default function SeasonMatches({
+  seasonId,
+  totalRounds,
+}: SeasonMatchesProps) {
+  const [matches, setMatches] = useState<MatchRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [roundFilter, setRoundFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [simulating, setSimulating] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (roundFilter) params.append("roundNumber", roundFilter);
+      if (statusFilter) params.append("status", statusFilter);
+      const qs = params.toString() ? `?${params.toString()}` : "";
+      const data = await fetchJSON(
+        `/admin/pro-league/seasons/${seasonId}/matches${qs}`,
+      );
+      setMatches(data.matches ?? []);
+    } catch (e: any) {
+      setError(e.message || "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [seasonId, roundFilter, statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSimulate = async (matchId: string) => {
+    if (!confirm("Simuler ce match maintenant ?")) return;
+    setSimulating(matchId);
+    try {
+      const result = await fetchJSON(
+        `/admin/pro-league/matches/${matchId}/simulate`,
+        { method: "POST", body: "{}" },
+      );
+      if (result.simulated === false) {
+        alert("Le match est deja dans un status final.");
+      }
+      await load();
+    } catch (e: any) {
+      alert(e.message || "Erreur lors de la simulation");
+    } finally {
+      setSimulating(null);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow border border-gray-200 p-4">
+      <div className="flex items-center justify-between flex-wrap gap-3 mb-3">
+        <h2 className="text-lg font-semibold">Matchs</h2>
+        <div className="flex gap-2 items-center">
+          <select
+            data-testid="round-filter"
+            value={roundFilter}
+            onChange={(e) => setRoundFilter(e.target.value)}
+            className="text-sm border border-gray-300 rounded-lg px-2 py-1"
+          >
+            <option value="">Tous les rounds</option>
+            {Array.from({ length: totalRounds }, (_, i) => i + 1).map((n) => (
+              <option key={n} value={String(n)}>
+                Round {n}
+              </option>
+            ))}
+          </select>
+          <select
+            data-testid="status-filter"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="text-sm border border-gray-300 rounded-lg px-2 py-1"
+          >
+            <option value="">Tous les statuts</option>
+            <option value="scheduled">scheduled</option>
+            <option value="ready">ready</option>
+            <option value="in_progress">in_progress</option>
+            <option value="completed">completed</option>
+            <option value="failed">failed</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 mb-2">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500 italic">Chargement…</p>
+      ) : matches.length === 0 ? (
+        <p className="text-sm text-gray-500 italic">
+          Aucun match avec ces filtres.
+        </p>
+      ) : (
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left p-2">Round</th>
+              <th className="text-left p-2">Equipes</th>
+              <th className="text-left p-2">Statut</th>
+              <th className="text-right p-2">Score</th>
+              <th className="text-left p-2">Programme</th>
+              <th className="text-left p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matches.map((m) => {
+              const isFinal = FINAL_STATUSES.has(m.status);
+              const score =
+                m.scoreHome !== null && m.scoreAway !== null
+                  ? `${m.scoreHome} - ${m.scoreAway}`
+                  : "—";
+              return (
+                <tr
+                  key={m.id}
+                  data-testid={`match-row-${m.id}`}
+                  className="border-t border-gray-100"
+                >
+                  <td className="p-2 font-semibold">{m.round.roundNumber}</td>
+                  <td className="p-2">
+                    <span className="font-medium">{m.homeTeam.name}</span>{" "}
+                    <span className="text-gray-400">vs</span>{" "}
+                    <span className="font-medium">{m.awayTeam.name}</span>
+                  </td>
+                  <td className="p-2">
+                    <span
+                      className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
+                        STATUS_COLORS[m.status] ?? "bg-gray-100"
+                      }`}
+                    >
+                      {m.status}
+                    </span>
+                  </td>
+                  <td className="p-2 text-right font-mono">{score}</td>
+                  <td className="p-2 text-xs text-gray-600">
+                    {new Date(m.scheduledAt).toLocaleString("fr-FR")}
+                  </td>
+                  <td className="p-2">
+                    <div className="flex gap-2 flex-wrap">
+                      {!isFinal && (
+                        <button
+                          onClick={() => handleSimulate(m.id)}
+                          disabled={simulating === m.id}
+                          data-testid={`btn-simulate-${m.id}`}
+                          className="px-2 py-1 text-xs text-white bg-purple-600 hover:bg-purple-700 rounded disabled:opacity-50"
+                        >
+                          {simulating === m.id ? "…" : "Simuler"}
+                        </button>
+                      )}
+                      {m.replayId && (
+                        <a
+                          href={`/pro-league/matches/${m.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="px-2 py-1 text-xs text-blue-600 hover:text-blue-800 underline"
+                        >
+                          Replay
+                        </a>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/seasons/[id]/page.tsx
+++ b/apps/web/app/admin/pro-league/seasons/[id]/page.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { API_BASE } from "../../../../auth-client";
+import SeasonMatches from "./_components/SeasonMatches";
 
 interface SeasonDetail {
   season: {
@@ -195,6 +196,8 @@ export default function AdminProSeasonDetailPage() {
           </table>
         )}
       </div>
+
+      <SeasonMatches seasonId={season.id} totalRounds={rounds.length} />
 
       <div className="bg-white rounded-xl shadow border border-gray-200 p-4">
         <h2 className="text-lg font-semibold mb-3">


### PR DESCRIPTION
## Summary

Suite logique du hub admin Pro League (#765) : permet à un admin de **voir la liste complète des matchs d'une saison** et de **simuler un match individuel à la demande** (sans attendre le cron sim-runner).

## Endpoints

- `GET /admin/pro-league/seasons/:id/matches` — liste paginée. Filtres optionnels `?roundNumber=N` (1..50) et `?status=scheduled|ready|in_progress|completed|failed`. Ordre par `roundNumber` asc puis `scheduledAt` asc.
- `GET /admin/pro-league/matches/:id` — détail (meta complète, teams, round, season, replayId).
- `POST /admin/pro-league/matches/:id/simulate` — déclenche `simulateProMatch(matchId)`. Idempotent : retourne `{ simulated: false }` si déjà final. Mappe `EngineVersionMismatchError` → 422. Audit log `pro-season.simulate-match`.

## UI

Nouveau composant `SeasonMatches.tsx` intégré dans `/admin/pro-league/seasons/[id]` (au-dessus du classement) :
- Filtres select roundNumber + status
- Tableau : Round / Équipes / Statut coloré / Score / Programmé / Actions
- Bouton "Simuler" sur les matchs non-finaux (avec confirm)
- Lien "Replay" sur les matchs avec `replayId` (ouvre `/pro-league/matches/[id]` dans un nouvel onglet)

## Test plan

- [x] `pnpm --filter @bb/server typecheck` — OK
- [x] `pnpm --filter @bb/web typecheck` — OK
- [x] `pnpm --filter @bb/server test` — **2301 tests** (+9)
- [x] `pnpm --filter @bb/web test` — **1026 tests** (+5)
- [ ] Manuel : `/admin/pro-league/seasons/[id]` → section "Matchs" → filtres fonctionnels
- [ ] Manuel : Simuler un match `scheduled` → status devient `completed`, score s'affiche, lien Replay apparaît
- [ ] Manuel : Re-simuler un match déjà completed → alert "déjà final"
- [ ] Manuel : Filtrer par round 1 + status completed → résultats cohérents

## Tests ajoutés

- `admin-pro-season.test.ts` : +9 tests (34 total). Liste avec/sans filtres, 400 si `roundNumber` hors bornes, detail OK + 404, simulate OK (idempotent + audit), 404, 422 `EngineVersionMismatch`.
- `SeasonMatches.test.tsx` : 5 tests (render initial, score completed, simulate POST + reload, filtres query string, lien Replay).

## Différé sprints futurs

- Bulk action "simuler tous les matchs scheduled d'un round" (1 clic = 8 matchs)
- Édition des stats post-match (corriger un score)
- Re-simulation avec nouveau seed (clear replay + relance)
- Gestion rosters par team (regenerate, edit skills/stats)
- Édition branding teams (couleurs, motto)
- Gestion bet markets (close/settle manuel)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_