### PR TITLE
fix(ci): deploy workflow filter unit tests metier (drop E2E packages)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,20 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Tests
-        run: pnpm test
+        # Les workspaces e2e/integration (`@bb/tests*`) ont besoin d'infra
+        # specifique (DB Postgres, browsers Playwright, server Next/Express
+        # demarres) absente sur ce runner — leurs jobs dedies tournent dans
+        # `e2e.yml`. On lance uniquement les unit tests des 6 workspaces
+        # metier ; le filtrage explicite evite les echecs silencieux d'un
+        # `|| true` qui masquerait de vrais bugs.
+        run: |
+          pnpm --filter @bb/server \
+               --filter @bb/web \
+               --filter @bb/ui \
+               --filter @bb/game-engine \
+               --filter @bb/sim-engine \
+               --filter @bb/shared-types \
+               run test
 
   # =========================================================================
   # 2. Build & push images Docker vers GHCR.


### PR DESCRIPTION
## Summary

Le workflow **Deploy to Production** échouait depuis longtemps sur le step `Tests` car `pnpm test` lance **tous** les workspaces, y compris les 4 packages e2e/integration (`@bb/tests`, `@bb/tests-e2e-api`, `@bb/tests-e2e-ui`, `@bb/tests-integration`) qui requièrent une infra (DB Postgres, browsers Playwright, server démarré) absente sur le runner.

## Cause

```yaml
# Avant
- name: Tests
  run: pnpm test  # → fail sur les 4 packages E2E
```

`ci.yml` (PRs) avait déjà contourné le problème avec un `|| echo "..."` mais ce pattern **masque silencieusement les vraies erreurs**. `deploy.yml` lui n'avait pas ce fallback — il échouait franchement.

## Fix

Filtrage explicite des **6 workspaces métier** (les seuls qui ont des unit tests sans dépendance infra) :

```yaml
# Après
- name: Tests
  run: |
    pnpm --filter @bb/server \
         --filter @bb/web \
         --filter @bb/ui \
         --filter @bb/game-engine \
         --filter @bb/sim-engine \
         --filter @bb/shared-types \
         run test
```

**Aucun masquage d'erreurs** : si un de ces 6 lance une régression, le deploy s'arrête (comportement souhaité). Les e2e/integration sont couverts dans `e2e.yml` (job dédié avec docker compose pour la stack).

## Test plan

- [x] Vérifié en local : `pnpm --filter ... run test` → 2319 tests OK
- [ ] Re-trigger manuel du workflow `Deploy to Production` (ou push sur main pour validation auto)

## Notes

- **Warning Node.js 20 deprecation** mentionné dans l'erreur d'origine : pas critique avant juin 2026, et concerne les actions tierces (`actions/checkout@v4`, `pnpm/action-setup@v4`, `actions/setup-node@v4`). À traiter dans un lot séparé si tu veux passer à Node 24 maintenant — ça touche `ci.yml`, `deploy.yml`, `e2e.yml`, etc.

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_