### PR TITLE
fix(ci): deploy workflow GHCR auth + permissions deployments + retire script_stop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,8 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write  # required to push images to ghcr.io
+  packages: write   # required to push images to ghcr.io
+  deployments: write  # required to POST /repos/.../deployments via github-script
 
 env:
   REGISTRY: ghcr.io
@@ -125,17 +126,30 @@ jobs:
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          # GHCR pull credentials passes via SSH envs. Le GITHUB_TOKEN du
+          # workflow herite des permissions packages:write donc read:packages
+          # implicite, valable ~1h (lifetime du job). Plus propre qu'un PAT
+          # permanent stocke sur la VM.
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_PORT || 22 }}
-          script_stop: true
-          envs: IMAGE_TAG
+          # `set -e` dans le script suffit ; `script_stop` n'est plus une
+          # option valide de appleboy/ssh-action@v1 (warning au runtime).
+          envs: IMAGE_TAG,GHCR_USER,GHCR_TOKEN
           script: |
             set -e
             export IMAGE_TAG="${{ needs.build-and-push.outputs.image_tag }}"
             cd ${{ secrets.DEPLOY_PATH || '~/fantasy-football-game' }}
+
+            # Auth GHCR pour le `docker compose pull` qui suit. Login non
+            # persistent (~/.docker/config.json est ecrase a chaque deploy
+            # mais le token expire avec le job — pas de credential traine).
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
             # Pull last code (for compose files + scripts + prisma schema).
             git fetch origin main


### PR DESCRIPTION
## Summary

Le job `deploy` du workflow **Deploy to Production** échouait avec **3 erreurs distinctes** :

### 1. GHCR pull denied (vrai blocker)

```
server Error Head "https://ghcr.io/v2/ryxeuf/fantasy-football-game/server/manifests/131c1c9": denied: denied
```

La VM prod n'était pas authentifiée auprès de `ghcr.io` → impossible de pull les images privées poussées par le job `build-and-push`.

**Fix** : `docker login ghcr.io` depuis le script SSH avec le `GITHUB_TOKEN` du workflow (qui hérite `read:packages` via la permission `packages:write` déjà présente). Token temporaire (~1h, lifetime du job) — pas de PAT permanent stocké sur la VM, pas de secret à provisionner.

```yaml
env:
  GHCR_USER: ${{ github.actor }}
  GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
# ...
script: |
  echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
  # ... reste inchangé
```

### 2. 403 sur création du GitHub Deployment

```
RequestError [HttpError]: Resource not accessible by integration
url: '/repos/Ryxeuf/fantasy-football-game/deployments'
status: 403
'x-accepted-github-permissions': 'deployments=write'
```

`github-script@v7` appelait `createDeployment` sans la permission requise.

**Fix** : ajout de `deployments: write` dans la section `permissions:`.

### 3. Warning option invalide

```
Warning: Unexpected input(s) 'script_stop'
```

`script_stop: true` n'est plus une option valide de `appleboy/ssh-action@v1`.

**Fix** : retiré. Le `set -e` dans le `script:` suffit pour stopper sur erreur.

## Test plan

- [x] Workflow YAML : syntaxe validée
- [ ] Manuel : re-trigger `Deploy to Production` (workflow_dispatch ou push sur main) → vérifier que le pull GHCR passe + GitHub Deployment créé sans 403 + plus de warning script_stop

## Notes

- **Aucun secret nouveau** : on réutilise `GITHUB_TOKEN` qui existe nativement dans tous les workflows.
- **Aucune action manuelle côté VM** : le `docker login` se fait à chaque deploy, le credential expire avec le job (~1h).
- **`~/.docker/config.json` sur la VM** : sera écrasé à chaque deploy par le login, ce qui est attendu (pas de credential persistant).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_