### PR TITLE
ci: opt-in Node 24 pour les actions JS (deprecation Node 20)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,6 +17,10 @@ permissions:
   pull-requests: write
   checks: read
 
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ env:
   # Force tous les feature flags à ON pour la CI (build, lint, tests).
   # Cf. apps/server/src/services/featureFlags.ts
   FEATURE_FLAGS_FORCE_ENABLED: "true"
+  # Workaround GitHub Actions deprecation Node 20 (juin 2026 → forced
+  # default Node 24, sept 2026 → Node 20 retire du runner). Opt-in
+  # immediat des actions JS (checkout/setup-node/etc.) sur Node 24
+  # pour valider et eviter le warning "may not work as expected".
+  # Voir https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_WEB: ${{ github.repository }}/web
   IMAGE_SERVER: ${{ github.repository }}/server
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # =========================================================================

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -11,6 +11,8 @@ permissions:
   packages: write
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}/server
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,8 @@ env:
   # Force tous les feature flags à ON pour la CI (E2E API + UI).
   # Cf. apps/server/src/services/featureFlags.ts
   FEATURE_FLAGS_FORCE_ENABLED: "true"
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   # -------------------------------------------------------------------------

--- a/.github/workflows/expo-eas.yml
+++ b/.github/workflows/expo-eas.yml
@@ -5,6 +5,9 @@ on:
   #   tags: [ "mobile-v*" ]
   # Désactiver temporairement en utilisant un événement qui ne se produira jamais
   workflow_dispatch:
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   eas:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-vercel.yml
+++ b/.github/workflows/preview-vercel.yml
@@ -5,6 +5,9 @@ on:
   #   branches: [ main, develop ]
   # Désactiver temporairement en utilisant un événement qui ne se produira jamais
   workflow_dispatch:
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   vercel:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   version-or-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/sim-bench.yml
+++ b/.github/workflows/sim-bench.yml
@@ -20,6 +20,10 @@ concurrency:
   group: sim-bench-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Voir ci.yml — opt-in Node 24 pour les actions JS (deprecation Node 20).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   sim-bench:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Le workflow `Deploy to Production` (et CI en général) affichait :

```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.
```

## Fix

Workaround officiel mentionné dans le warning : env var **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`** qui force les actions JavaScript (`actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, etc.) à tourner sur Node 24 du runner.

Appliqué aux **11 workflows** du repo :
- `ci.yml`, `deploy.yml`, `docker-server.yml`, `e2e.yml` (env block existant enrichi)
- `auto-merge.yml`, `expo-eas.yml`, `labeler.yml`, `preview-vercel.yml`, `release.yml`, `semantic-release.yml`, `sim-bench.yml` (env block créé)

## Test plan

- [x] YAML syntax validé sur tous les workflows
- [ ] Re-trigger CI / deploy → vérifier que le warning a disparu

## Notes

- **Pas de breaking change** : le `node-version` des `setup-node` reste à 20 (notre code métier construit sur Node 20). On force seulement le **runtime des actions** sur Node 24.
- **Migration future** (Node 20 → Node 24 pour le code métier + Dockerfiles) pourra se faire dans un lot dédié quand Node 20 sera vraiment retiré (sept 2026).
- **Validation précoce** : si une des actions JS casse sur Node 24, on le verra maintenant (avant l'enforcement de juin 2026).

Source : https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_