### PR TITLE
feat(admin): edition branding teams Pro League

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,6 +16,7 @@ import adminSimReplaysRoutes from "./routes/admin-sim-replays";
 import adminWalletRoutes from "./routes/admin-wallet";
 import adminUtilitiesRoutes from "./routes/admin-utilities";
 import adminProSeasonRoutes from "./routes/admin-pro-season";
+import adminProTeamRoutes from "./routes/admin-pro-team";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -233,6 +234,8 @@ app.use("/admin/utilities", adminUtilitiesRoutes);
 // Lot P.B.3 — season factory Pro League (clone, reset standings, force
 // forfeit, cancel season). Audit log strict sur toutes les actions.
 app.use("/admin/pro-league", adminProSeasonRoutes);
+// Branding teams Pro League (couleurs / motto / headline).
+app.use("/admin/pro-league", adminProTeamRoutes);
 // Feedback public : pas d'auth, captcha + rate limiter dedies dans le router.
 app.use("/feedback", feedbackPublicRouter);
 app.use("/pro-league", proLeagueRoutes);

--- a/apps/server/src/routes/admin-pro-team.test.ts
+++ b/apps/server/src/routes/admin-pro-team.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests integration des endpoints admin-pro-team (branding).
+ *
+ * Couvre : GET liste/detail, PATCH branding (succes, validation,
+ * 404, audit log, merge meta).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../middleware/authUser", () => ({
+  authUser: (req: any, _res: any, next: any) => {
+    req.user = { id: "admin-1", role: "admin", roles: ["admin"] };
+    return next();
+  },
+}));
+
+vi.mock("../middleware/adminOnly", () => ({
+  adminOnly: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../services/audit-log", () => ({
+  safeRecordAdminActionFromRequest: vi.fn(async () => {}),
+}));
+
+import express from "express";
+import http from "http";
+import teamRouter from "./admin-pro-team";
+import { prisma } from "../prisma";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+
+const mockedAudit = vi.mocked(safeRecordAdminActionFromRequest);
+
+interface MockedPrisma {
+  proTeam: {
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+
+const mockedPrisma = prisma as unknown as MockedPrisma;
+
+async function request(
+  method: "GET" | "POST" | "PATCH",
+  path: string,
+  body: Record<string, unknown> | null = null,
+): Promise<{ status: number; body: any }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/admin/pro-league", teamRouter);
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("listen failed"));
+        return;
+      }
+      const data = body !== null ? JSON.stringify(body) : "";
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: `/admin/pro-league${path}`,
+          method,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(data).toString(),
+            Authorization: "Bearer dummy",
+          },
+        },
+        (res) => {
+          let buf = "";
+          res.on("data", (c) => (buf += c));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({
+                status: res.statusCode ?? 0,
+                body: buf ? JSON.parse(buf) : {},
+              });
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+      req.on("error", (e) => {
+        server.close();
+        reject(e);
+      });
+      if (data) req.write(data);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const teamFixture = {
+  id: "t1",
+  leagueId: "l1",
+  slug: "pit-smashers",
+  city: "Pittsburgh",
+  name: "Smashers",
+  race: "Orc",
+  nflFlavor: "Steelers",
+  primaryColor: "#000000",
+  secondaryColor: "#FFB612",
+  baseTv: 1000,
+  meta: { motto: "Smash hour", fanbase: 5000 },
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+describe("GET /admin/pro-league/teams", () => {
+  it("liste toutes les teams (sans filtre leagueId)", async () => {
+    mockedPrisma.proTeam.findMany.mockResolvedValueOnce([teamFixture]);
+
+    const res = await request("GET", "/teams");
+
+    expect(res.status).toBe(200);
+    expect(res.body.teams).toHaveLength(1);
+    expect(res.body.teams[0]).toMatchObject({
+      id: "t1",
+      slug: "pit-smashers",
+      city: "Pittsburgh",
+      primaryColor: "#000000",
+      motto: "Smash hour",
+    });
+    expect(mockedPrisma.proTeam.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: {} }),
+    );
+  });
+
+  it("filtre par leagueId quand fourni", async () => {
+    mockedPrisma.proTeam.findMany.mockResolvedValueOnce([]);
+    await request("GET", "/teams?leagueId=l99");
+    expect(mockedPrisma.proTeam.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { leagueId: "l99" } }),
+    );
+  });
+
+  it("expose motto/headline depuis meta string sqlite", async () => {
+    mockedPrisma.proTeam.findMany.mockResolvedValueOnce([
+      { ...teamFixture, meta: JSON.stringify({ motto: "from-string" }) },
+    ]);
+    const res = await request("GET", "/teams");
+    expect(res.body.teams[0].motto).toBe("from-string");
+  });
+});
+
+describe("GET /admin/pro-league/teams/:id", () => {
+  it("retourne le detail d'une team", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    const res = await request("GET", "/teams/t1");
+    expect(res.status).toBe(200);
+    expect(res.body.team).toMatchObject({ id: "t1", motto: "Smash hour" });
+  });
+
+  it("404 si team introuvable", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(null);
+    const res = await request("GET", "/teams/missing");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/introuvable/);
+  });
+});
+
+describe("PATCH /admin/pro-league/teams/:id", () => {
+  it("met a jour les couleurs et trace audit", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockResolvedValueOnce({
+      ...teamFixture,
+      primaryColor: "#FF0000",
+      secondaryColor: "#00FF00",
+    });
+
+    const res = await request("PATCH", "/teams/t1", {
+      primaryColor: "#FF0000",
+      secondaryColor: "#00FF00",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.team).toMatchObject({
+      primaryColor: "#FF0000",
+      secondaryColor: "#00FF00",
+    });
+    expect(mockedPrisma.proTeam.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: { primaryColor: "#FF0000", secondaryColor: "#00FF00" },
+    });
+    expect(mockedAudit).toHaveBeenCalledTimes(1);
+    const auditArg = mockedAudit.mock.calls[0][2];
+    expect(auditArg).toMatchObject({
+      action: "pro-team.branding.update",
+      entity: "ProTeam",
+      entityId: "t1",
+    });
+    expect(auditArg.oldValue).toMatchObject({ primaryColor: "#000000" });
+    expect(auditArg.newValue).toMatchObject({ primaryColor: "#FF0000" });
+  });
+
+  it("merge motto sans ecraser fanbase", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockImplementationOnce(async ({ data }: any) => ({
+      ...teamFixture,
+      meta: data.meta,
+    }));
+
+    const res = await request("PATCH", "/teams/t1", {
+      motto: "New rallying cry",
+    });
+
+    expect(res.status).toBe(200);
+    const updateCall = mockedPrisma.proTeam.update.mock.calls[0][0];
+    expect(updateCall.data.meta).toEqual({
+      motto: "New rallying cry",
+      fanbase: 5000,
+    });
+  });
+
+  it("efface motto quand null explicite", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockImplementationOnce(async ({ data }: any) => ({
+      ...teamFixture,
+      meta: data.meta,
+    }));
+
+    await request("PATCH", "/teams/t1", { motto: null });
+
+    const updateCall = mockedPrisma.proTeam.update.mock.calls[0][0];
+    expect(updateCall.data.meta).toEqual({ fanbase: 5000 });
+    expect("motto" in updateCall.data.meta).toBe(false);
+  });
+
+  it("met a jour city + name + nflFlavor", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockResolvedValueOnce({
+      ...teamFixture,
+      city: "New City",
+      name: "Renamed",
+      nflFlavor: "Cowboys",
+    });
+
+    const res = await request("PATCH", "/teams/t1", {
+      city: "New City",
+      name: "Renamed",
+      nflFlavor: "Cowboys",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.team).toMatchObject({
+      city: "New City",
+      name: "Renamed",
+      nflFlavor: "Cowboys",
+    });
+  });
+
+  it("rejette une couleur au format invalide (400)", async () => {
+    const res = await request("PATCH", "/teams/t1", {
+      primaryColor: "red",
+    });
+    expect(res.status).toBe(400);
+    expect(mockedPrisma.proTeam.update).not.toHaveBeenCalled();
+  });
+
+  it("rejette une couleur trop courte", async () => {
+    const res = await request("PATCH", "/teams/t1", {
+      primaryColor: "#F00",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejette un body vide (au moins un champ requis)", async () => {
+    const res = await request("PATCH", "/teams/t1", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("404 si team introuvable", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(null);
+    const res = await request("PATCH", "/teams/missing", {
+      motto: "x",
+    });
+    expect(res.status).toBe(404);
+    expect(mockedPrisma.proTeam.update).not.toHaveBeenCalled();
+  });
+
+  it("ne touche pas a meta si ni motto ni headline fournis", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockResolvedValueOnce(teamFixture);
+
+    await request("PATCH", "/teams/t1", { primaryColor: "#ABCDEF" });
+
+    const updateCall = mockedPrisma.proTeam.update.mock.calls[0][0];
+    expect("meta" in updateCall.data).toBe(false);
+  });
+
+  it("efface nflFlavor avec null explicite", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeam.update.mockImplementationOnce(async ({ data }: any) => ({
+      ...teamFixture,
+      ...data,
+    }));
+
+    await request("PATCH", "/teams/t1", { nflFlavor: null });
+
+    const updateCall = mockedPrisma.proTeam.update.mock.calls[0][0];
+    expect(updateCall.data.nflFlavor).toBeNull();
+  });
+});

--- a/apps/server/src/routes/admin-pro-team.ts
+++ b/apps/server/src/routes/admin-pro-team.ts
@@ -1,0 +1,211 @@
+/**
+ * Admin Pro League — branding teams.
+ *
+ * Endpoints :
+ *  - GET   /admin/pro-league/teams           — liste teams (par leagueId)
+ *  - GET   /admin/pro-league/teams/:id       — detail team avec branding
+ *  - PATCH /admin/pro-league/teams/:id       — update branding (couleurs,
+ *                                              motto, headline, nflFlavor,
+ *                                              city, name)
+ *
+ * Toutes les mutations tracent un audit log strict (oldValue / newValue
+ * limites aux champs branding).
+ */
+
+import { Router } from "express";
+import { prisma } from "../prisma";
+import { authUser } from "../middleware/authUser";
+import { adminOnly } from "../middleware/adminOnly";
+import { validate } from "../middleware/validate";
+import { adminProTeamBrandingSchema } from "../schemas/admin.schemas";
+import { serverLog } from "../utils/server-log";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+import type { AuthenticatedRequest } from "../middleware/authUser";
+import {
+  parseProTeamMeta,
+  applyBrandingMeta,
+} from "../services/pro-team-branding";
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+interface ProTeamRow {
+  id: string;
+  leagueId: string;
+  slug: string;
+  city: string;
+  name: string;
+  race: string;
+  nflFlavor: string | null;
+  primaryColor: string | null;
+  secondaryColor: string | null;
+  baseTv: number;
+  meta: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function serializeTeam(team: ProTeamRow): {
+  id: string;
+  leagueId: string;
+  slug: string;
+  city: string;
+  name: string;
+  race: string;
+  nflFlavor: string | null;
+  primaryColor: string | null;
+  secondaryColor: string | null;
+  baseTv: number;
+  motto: string | null;
+  headline: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+} {
+  const meta = parseProTeamMeta(team.meta);
+  return {
+    id: team.id,
+    leagueId: team.leagueId,
+    slug: team.slug,
+    city: team.city,
+    name: team.name,
+    race: team.race,
+    nflFlavor: team.nflFlavor,
+    primaryColor: team.primaryColor,
+    secondaryColor: team.secondaryColor,
+    baseTv: team.baseTv,
+    motto: typeof meta.motto === "string" ? meta.motto : null,
+    headline: typeof meta.headline === "string" ? meta.headline : null,
+    createdAt: team.createdAt,
+    updatedAt: team.updatedAt,
+  };
+}
+
+/**
+ * GET /admin/pro-league/teams — liste des teams.
+ *
+ * Filtre optionnel `?leagueId=...`. Ordre alphabetique par city puis name.
+ */
+router.get("/teams", async (req, res) => {
+  try {
+    const leagueId = req.query.leagueId as string | undefined;
+    const where = leagueId ? { leagueId } : {};
+    const teams = (await prisma.proTeam.findMany({
+      where,
+      orderBy: [{ city: "asc" }, { name: "asc" }],
+    })) as ProTeamRow[];
+    res.json({ teams: teams.map(serializeTeam) });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de la lecture des teams" });
+  }
+});
+
+/** GET /admin/pro-league/teams/:id — detail team avec branding. */
+router.get("/teams/:id", async (req, res) => {
+  try {
+    const team = (await prisma.proTeam.findUnique({
+      where: { id: req.params.id },
+    })) as ProTeamRow | null;
+    if (!team) {
+      return res.status(404).json({ error: "Team introuvable" });
+    }
+    res.json({ team: serializeTeam(team) });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de la lecture de la team" });
+  }
+});
+
+/**
+ * PATCH /admin/pro-league/teams/:id — update branding.
+ *
+ * Champs supportes : city, name, nflFlavor, primaryColor, secondaryColor,
+ * motto, headline. Tous optionnels. `null` explicite efface le champ
+ * (sauf city/name qui sont required dans le schema). meta (motto/headline)
+ * est merge — les autres entrees meta ne sont pas touchees.
+ */
+router.patch(
+  "/teams/:id",
+  validate(adminProTeamBrandingSchema),
+  async (req, res) => {
+    try {
+      const existing = (await prisma.proTeam.findUnique({
+        where: { id: req.params.id },
+      })) as ProTeamRow | null;
+      if (!existing) {
+        return res.status(404).json({ error: "Team introuvable" });
+      }
+
+      const body = req.body as {
+        city?: string;
+        name?: string;
+        nflFlavor?: string | null;
+        primaryColor?: string | null;
+        secondaryColor?: string | null;
+        motto?: string | null;
+        headline?: string | null;
+      };
+
+      const data: Record<string, unknown> = {};
+      if (body.city !== undefined) data.city = body.city;
+      if (body.name !== undefined) data.name = body.name;
+      if (body.nflFlavor !== undefined) data.nflFlavor = body.nflFlavor;
+      if (body.primaryColor !== undefined) data.primaryColor = body.primaryColor;
+      if (body.secondaryColor !== undefined) {
+        data.secondaryColor = body.secondaryColor;
+      }
+
+      const metaTouched = "motto" in body || "headline" in body;
+      if (metaTouched) {
+        data.meta = applyBrandingMeta(existing.meta, {
+          motto: body.motto,
+          headline: body.headline,
+        });
+      }
+
+      const updated = (await prisma.proTeam.update({
+        where: { id: req.params.id },
+        data,
+      })) as ProTeamRow;
+
+      const previous = serializeTeam(existing);
+      const next = serializeTeam(updated);
+
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-team.branding.update",
+          entity: "ProTeam",
+          entityId: req.params.id,
+          oldValue: {
+            city: previous.city,
+            name: previous.name,
+            nflFlavor: previous.nflFlavor,
+            primaryColor: previous.primaryColor,
+            secondaryColor: previous.secondaryColor,
+            motto: previous.motto,
+            headline: previous.headline,
+          },
+          newValue: {
+            city: next.city,
+            name: next.name,
+            nflFlavor: next.nflFlavor,
+            primaryColor: next.primaryColor,
+            secondaryColor: next.secondaryColor,
+            motto: next.motto,
+            headline: next.headline,
+          },
+        },
+      );
+
+      res.json({ team: next });
+    } catch (e) {
+      serverLog.error(e);
+      res.status(500).json({ error: "Erreur lors de la mise a jour" });
+    }
+  },
+);
+
+export default router;

--- a/apps/server/src/schemas/admin.schemas.ts
+++ b/apps/server/src/schemas/admin.schemas.ts
@@ -165,3 +165,31 @@ export const adminForceForfeitSchema = z.object({
     message: "winnerSide doit etre 'home' ou 'away'",
   }),
 });
+
+/** Branding admin d'une ProTeam : couleurs, motto, headline, nflFlavor.
+ *  Tous les champs sont optionnels — l'endpoint applique seulement ceux
+ *  fournis, ne touche pas aux autres. `null` explicite = effacer le champ. */
+const hexColorRegex = /^#[0-9a-fA-F]{6}$/;
+
+export const adminProTeamBrandingSchema = z
+  .object({
+    city: z.string().min(1).max(80).optional(),
+    name: z.string().min(1).max(120).optional(),
+    nflFlavor: z.string().max(120).nullable().optional(),
+    primaryColor: z
+      .string()
+      .regex(hexColorRegex, "Format attendu : #RRGGBB")
+      .nullable()
+      .optional(),
+    secondaryColor: z
+      .string()
+      .regex(hexColorRegex, "Format attendu : #RRGGBB")
+      .nullable()
+      .optional(),
+    motto: z.string().max(200).nullable().optional(),
+    headline: z.string().max(200).nullable().optional(),
+  })
+  .refine(
+    (data) => Object.keys(data).length > 0,
+    { message: "Au moins un champ doit etre fourni" },
+  );

--- a/apps/server/src/services/pro-team-branding.test.ts
+++ b/apps/server/src/services/pro-team-branding.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseProTeamMeta,
+  applyBrandingMeta,
+} from "./pro-team-branding";
+
+describe("parseProTeamMeta", () => {
+  it("retourne {} pour null/undefined", () => {
+    expect(parseProTeamMeta(null)).toEqual({});
+    expect(parseProTeamMeta(undefined)).toEqual({});
+  });
+
+  it("parse une string JSON sqlite mirror", () => {
+    const raw = JSON.stringify({ motto: "We hit hard.", fanbase: 42 });
+    expect(parseProTeamMeta(raw)).toEqual({
+      motto: "We hit hard.",
+      fanbase: 42,
+    });
+  });
+
+  it("retourne {} pour string JSON invalide", () => {
+    expect(parseProTeamMeta("{not json")).toEqual({});
+  });
+
+  it("retourne {} pour string JSON qui n'est pas un objet (array)", () => {
+    expect(parseProTeamMeta("[1,2,3]")).toEqual({});
+  });
+
+  it("retourne l'objet natif PG tel quel", () => {
+    const obj = { motto: "Block first", headline: "Smash hour" };
+    expect(parseProTeamMeta(obj)).toEqual(obj);
+  });
+
+  it("retourne {} pour array natif (PG)", () => {
+    expect(parseProTeamMeta([1, 2, 3])).toEqual({});
+  });
+
+  it("retourne {} pour primitives non-objet", () => {
+    expect(parseProTeamMeta(42)).toEqual({});
+    expect(parseProTeamMeta(true)).toEqual({});
+  });
+});
+
+describe("applyBrandingMeta", () => {
+  it("preserve les autres entrees meta non touchees", () => {
+    const current = { fanbase: 5000, skills: ["block", "tackle"] };
+    const result = applyBrandingMeta(current, { motto: "Hut hut" });
+    expect(result).toEqual({
+      fanbase: 5000,
+      skills: ["block", "tackle"],
+      motto: "Hut hut",
+    });
+  });
+
+  it("met a jour motto et headline quand fournis", () => {
+    const result = applyBrandingMeta(
+      { motto: "old" },
+      { motto: "new", headline: "Headline X" },
+    );
+    expect(result).toEqual({ motto: "new", headline: "Headline X" });
+  });
+
+  it("efface motto quand null explicite", () => {
+    const result = applyBrandingMeta(
+      { motto: "to delete", fanbase: 42 },
+      { motto: null },
+    );
+    expect(result).toEqual({ fanbase: 42 });
+    expect("motto" in result).toBe(false);
+  });
+
+  it("efface headline quand null explicite", () => {
+    const result = applyBrandingMeta(
+      { headline: "to delete" },
+      { headline: null },
+    );
+    expect("headline" in result).toBe(false);
+  });
+
+  it("ignore les champs undefined ou non fournis", () => {
+    const current = { motto: "kept", headline: "also kept" };
+    expect(applyBrandingMeta(current, {})).toEqual(current);
+    expect(applyBrandingMeta(current, { motto: undefined })).toEqual(current);
+  });
+
+  it("fonctionne avec meta=null en entree", () => {
+    expect(applyBrandingMeta(null, { motto: "fresh" })).toEqual({
+      motto: "fresh",
+    });
+  });
+
+  it("fonctionne avec meta=string sqlite en entree", () => {
+    const raw = JSON.stringify({ fanbase: 100 });
+    const result = applyBrandingMeta(raw, { motto: "via string" });
+    expect(result).toEqual({ fanbase: 100, motto: "via string" });
+  });
+});

--- a/apps/server/src/services/pro-team-branding.ts
+++ b/apps/server/src/services/pro-team-branding.ts
@@ -1,0 +1,69 @@
+/**
+ * Service pur — branding ProTeam.
+ *
+ * Helpers pour parser/serialiser le champ `meta` (Json libre, format
+ * arbitraire historiquement) et appliquer un patch branding partiel
+ * sans ecraser les autres entrees meta (skills inheritance, fanbase,
+ * etc.).
+ *
+ * `meta` peut etre : objet natif (PG), string serialisee (sqlite mirror),
+ * null, ou autre. Le parser est tolerant et renvoie `{}` en fallback.
+ */
+
+export interface ProTeamMeta {
+  motto?: string | null;
+  headline?: string | null;
+  [key: string]: unknown;
+}
+
+export function parseProTeamMeta(raw: unknown): ProTeamMeta {
+  if (raw == null) return {};
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as ProTeamMeta;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+  if (typeof raw === "object" && !Array.isArray(raw)) {
+    return raw as ProTeamMeta;
+  }
+  return {};
+}
+
+export interface BrandingPatch {
+  motto?: string | null;
+  headline?: string | null;
+}
+
+/** Applique un patch motto/headline sans ecraser les autres entrees meta.
+ *  Une valeur `null` efface explicitement la cle. Une valeur `undefined`
+ *  ou non fournie laisse l'existant tel quel. */
+export function applyBrandingMeta(
+  current: unknown,
+  patch: BrandingPatch,
+): ProTeamMeta {
+  const merged: ProTeamMeta = { ...parseProTeamMeta(current) };
+
+  if ("motto" in patch) {
+    if (patch.motto === null) {
+      delete merged.motto;
+    } else if (patch.motto !== undefined) {
+      merged.motto = patch.motto;
+    }
+  }
+
+  if ("headline" in patch) {
+    if (patch.headline === null) {
+      delete merged.headline;
+    } else if (patch.headline !== undefined) {
+      merged.headline = patch.headline;
+    }
+  }
+
+  return merged;
+}

--- a/apps/web/app/admin/pro-league/page.tsx
+++ b/apps/web/app/admin/pro-league/page.tsx
@@ -29,6 +29,14 @@ const LINKS: ReadonlyArray<HubLink> = [
     status: "stable",
   },
   {
+    href: "/admin/pro-league/teams",
+    icon: "🎨",
+    title: "Branding teams",
+    description:
+      "Editer les couleurs (primaire/secondaire), motto, headline, ville/nom, flavor NFL d'une team.",
+    status: "stable",
+  },
+  {
     href: "/admin/sim",
     icon: "🎲",
     title: "Sim Pro League",
@@ -123,8 +131,8 @@ export default function AdminProLeagueHubPage() {
       <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800">
         <strong>Roadmap admin Pro League</strong> : a venir dans les
         prochains sprints : gestion fine des rosters (re-generer joueurs,
-        editer skills), edition branding teams, re-simulation d&apos;un
-        match avec nouveau seed, gestion des bet markets.
+        editer skills), re-simulation d&apos;un match avec nouveau seed,
+        gestion des bet markets.
       </div>
     </div>
   );

--- a/apps/web/app/admin/pro-league/teams/[id]/page.test.tsx
+++ b/apps/web/app/admin/pro-league/teams/[id]/page.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Tests de la page admin/pro-league/teams/[id] (edition branding).
+ *
+ * Couvre : chargement detail, edition form + diff/patch, validation
+ * couleur, success message, reset, erreur PATCH.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "t1" }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import AdminProLeagueTeamEditPage from "./page";
+
+const originalFetch = global.fetch;
+
+const teamFixture = {
+  id: "t1",
+  leagueId: "l1",
+  slug: "pit-smashers",
+  city: "Pittsburgh",
+  name: "Smashers",
+  race: "Orc",
+  nflFlavor: "Steelers",
+  primaryColor: "#000000",
+  secondaryColor: "#FFB612",
+  motto: "Smash hour",
+  headline: null,
+  baseTv: 1000,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy-token",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function mockGetTeam(team = teamFixture) {
+  return vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ team }),
+  } as unknown as Response);
+}
+
+describe("AdminProLeagueTeamEditPage", () => {
+  it("affiche le form pre-rempli avec les valeurs serveur", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("input-city")).toBeTruthy();
+    });
+    expect((screen.getByTestId("input-city") as HTMLInputElement).value).toBe(
+      "Pittsburgh",
+    );
+    expect((screen.getByTestId("input-name") as HTMLInputElement).value).toBe(
+      "Smashers",
+    );
+    expect(
+      (screen.getByTestId("input-primary") as HTMLInputElement).value,
+    ).toBe("#000000");
+    expect((screen.getByTestId("input-motto") as HTMLInputElement).value).toBe(
+      "Smash hour",
+    );
+  });
+
+  it("dirty count = 0 a l'initial", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dirty-count")).toBeTruthy();
+    });
+    expect(screen.getByTestId("dirty-count").textContent).toMatch(
+      /Aucune modification/,
+    );
+  });
+
+  it("incremente dirty count quand un champ change", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("input-motto")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-motto"), {
+      target: { value: "New motto" },
+    });
+
+    expect(screen.getByTestId("dirty-count").textContent).toMatch(
+      /1 champ modifie/,
+    );
+  });
+
+  it("PATCH n'envoie que les champs modifies", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ team: teamFixture }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: { ...teamFixture, motto: "Updated", primaryColor: "#FF0000" },
+      }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("input-motto")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-motto"), {
+      target: { value: "Updated" },
+    });
+    fireEvent.change(screen.getByTestId("input-primary"), {
+      target: { value: "#FF0000" },
+    });
+
+    fireEvent.click(screen.getByTestId("btn-save"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("form-success")).toBeTruthy();
+    });
+
+    const patchCall = fetchMock.mock.calls[1];
+    expect(patchCall[1].method).toBe("PATCH");
+    const body = JSON.parse(patchCall[1].body as string);
+    expect(body).toEqual({ motto: "Updated", primaryColor: "#FF0000" });
+  });
+
+  it("vide motto envoie null pour effacer", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ team: teamFixture }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ team: { ...teamFixture, motto: null } }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("input-motto")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-motto"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByTestId("btn-save"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("form-success")).toBeTruthy();
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    expect(body).toEqual({ motto: null });
+  });
+
+  it("affiche erreur format invalide pour couleur", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("input-primary")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-primary"), {
+      target: { value: "red" },
+    });
+
+    expect(screen.getByText(/#RRGGBB/)).toBeTruthy();
+    const saveBtn = screen.getByTestId("btn-save") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  it("bouton save desactive quand pas dirty", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-save")).toBeTruthy();
+    });
+
+    const saveBtn = screen.getByTestId("btn-save") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  it("reset restaure les valeurs serveur", async () => {
+    global.fetch = mockGetTeam() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("input-motto")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-motto"), {
+      target: { value: "Changed" },
+    });
+    expect(
+      (screen.getByTestId("input-motto") as HTMLInputElement).value,
+    ).toBe("Changed");
+
+    fireEvent.click(screen.getByTestId("btn-reset"));
+
+    expect(
+      (screen.getByTestId("input-motto") as HTMLInputElement).value,
+    ).toBe("Smash hour");
+  });
+
+  it("affiche erreur PATCH si serveur rejette", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ team: teamFixture }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Forbidden" }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamEditPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("input-motto")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByTestId("input-motto"), {
+      target: { value: "X" },
+    });
+    fireEvent.click(screen.getByTestId("btn-save"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("form-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("form-error").textContent).toMatch(/Forbidden/);
+  });
+});

--- a/apps/web/app/admin/pro-league/teams/[id]/page.tsx
+++ b/apps/web/app/admin/pro-league/teams/[id]/page.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+/**
+ * Admin Pro League — edition branding d'une team.
+ *
+ * Form controle avec preview live des couleurs. PATCH partiel : seuls
+ * les champs modifies sont envoyes au server. Reset bouton restaure les
+ * valeurs serveur. Audit log strict cote API.
+ */
+
+import { useEffect, useState, useMemo, useCallback } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { API_BASE } from "../../../../auth-client";
+
+interface ProTeamDetail {
+  readonly id: string;
+  readonly leagueId: string;
+  readonly slug: string;
+  readonly city: string;
+  readonly name: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly motto: string | null;
+  readonly headline: string | null;
+  readonly baseTv: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+interface FormState {
+  city: string;
+  name: string;
+  nflFlavor: string;
+  primaryColor: string;
+  secondaryColor: string;
+  motto: string;
+  headline: string;
+}
+
+const HEX_REGEX = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_PRIMARY = "#1f2937";
+const DEFAULT_SECONDARY = "#9ca3af";
+
+async function fetchJSON(path: string, options?: RequestInit) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: token ? `Bearer ${token}` : "",
+      "Content-Type": "application/json",
+    },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(json?.error || `Erreur ${res.status}`);
+  }
+  return json;
+}
+
+function teamToForm(team: ProTeamDetail): FormState {
+  return {
+    city: team.city,
+    name: team.name,
+    nflFlavor: team.nflFlavor ?? "",
+    primaryColor: team.primaryColor ?? "",
+    secondaryColor: team.secondaryColor ?? "",
+    motto: team.motto ?? "",
+    headline: team.headline ?? "",
+  };
+}
+
+/** Construit le diff form vs team. Renvoie les champs touches uniquement.
+ *  Pour les optionnels (nflFlavor, primaryColor, ...), une chaine vide
+ *  envoie `null` pour effacer. Pour city/name (required), chaine vide
+ *  est ignoree (validation cote API). */
+function buildPatch(
+  form: FormState,
+  team: ProTeamDetail,
+): Record<string, string | null> {
+  const patch: Record<string, string | null> = {};
+
+  if (form.city.trim() && form.city !== team.city) {
+    patch.city = form.city.trim();
+  }
+  if (form.name.trim() && form.name !== team.name) {
+    patch.name = form.name.trim();
+  }
+
+  const nullableFields: Array<{
+    key: keyof FormState;
+    apiKey: string;
+    serverValue: string | null;
+  }> = [
+    { key: "nflFlavor", apiKey: "nflFlavor", serverValue: team.nflFlavor },
+    {
+      key: "primaryColor",
+      apiKey: "primaryColor",
+      serverValue: team.primaryColor,
+    },
+    {
+      key: "secondaryColor",
+      apiKey: "secondaryColor",
+      serverValue: team.secondaryColor,
+    },
+    { key: "motto", apiKey: "motto", serverValue: team.motto },
+    { key: "headline", apiKey: "headline", serverValue: team.headline },
+  ];
+
+  for (const f of nullableFields) {
+    const formVal = form[f.key].trim();
+    const serverVal = f.serverValue ?? "";
+    if (formVal === serverVal) continue;
+    patch[f.apiKey] = formVal === "" ? null : formVal;
+  }
+
+  return patch;
+}
+
+export default function AdminProLeagueTeamEditPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const teamId = params?.id;
+
+  const [team, setTeam] = useState<ProTeamDetail | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!teamId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchJSON(`/admin/pro-league/teams/${teamId}`);
+      setTeam(data.team);
+      setForm(teamToForm(data.team));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Erreur";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const patch = useMemo(
+    () => (team && form ? buildPatch(form, team) : {}),
+    [form, team],
+  );
+  const dirtyCount = Object.keys(patch).length;
+
+  const colorErrors = useMemo(() => {
+    const errs: { primary?: string; secondary?: string } = {};
+    if (form?.primaryColor && !HEX_REGEX.test(form.primaryColor)) {
+      errs.primary = "Format attendu : #RRGGBB";
+    }
+    if (form?.secondaryColor && !HEX_REGEX.test(form.secondaryColor)) {
+      errs.secondary = "Format attendu : #RRGGBB";
+    }
+    return errs;
+  }, [form?.primaryColor, form?.secondaryColor]);
+
+  const hasErrors = Boolean(colorErrors.primary || colorErrors.secondary);
+
+  const handleChange = (key: keyof FormState, value: string) => {
+    setSuccess(null);
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+  };
+
+  const handleReset = () => {
+    if (!team) return;
+    setForm(teamToForm(team));
+    setSuccess(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!team || !form || dirtyCount === 0 || hasErrors) return;
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const data = await fetchJSON(`/admin/pro-league/teams/${team.id}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      });
+      setTeam(data.team);
+      setForm(teamToForm(data.team));
+      setSuccess("Branding mis a jour.");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Erreur";
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="text-sm text-gray-500" data-testid="team-loading">
+        Chargement…
+      </div>
+    );
+  }
+
+  if (error && !team) {
+    return (
+      <div className="space-y-4">
+        <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-800">
+          {error}
+        </div>
+        <Link
+          href={"/admin/pro-league/teams" as any}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Retour
+        </Link>
+      </div>
+    );
+  }
+
+  if (!team || !form) return null;
+
+  const previewPrimary =
+    form.primaryColor && HEX_REGEX.test(form.primaryColor)
+      ? form.primaryColor
+      : DEFAULT_PRIMARY;
+  const previewSecondary =
+    form.secondaryColor && HEX_REGEX.test(form.secondaryColor)
+      ? form.secondaryColor
+      : DEFAULT_SECONDARY;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite">
+          🎨 {team.city} {team.name}
+        </h1>
+        <Link
+          href={"/admin/pro-league/teams" as any}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Liste teams
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 p-5 rounded-xl border bg-white border-gray-200"
+          data-testid="branding-form"
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <span className="text-xs font-semibold text-gray-700">
+                Ville
+              </span>
+              <input
+                type="text"
+                value={form.city}
+                onChange={(e) => handleChange("city", e.target.value)}
+                maxLength={80}
+                className="mt-1 w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                data-testid="input-city"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-semibold text-gray-700">
+                Nom
+              </span>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => handleChange("name", e.target.value)}
+                maxLength={120}
+                className="mt-1 w-full px-2 py-1 border border-gray-300 rounded text-sm"
+                data-testid="input-name"
+              />
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="text-xs font-semibold text-gray-700">
+              Flavor NFL
+            </span>
+            <input
+              type="text"
+              value={form.nflFlavor}
+              onChange={(e) => handleChange("nflFlavor", e.target.value)}
+              maxLength={120}
+              placeholder="Ex: Steelers, Cowboys…"
+              className="mt-1 w-full px-2 py-1 border border-gray-300 rounded text-sm"
+              data-testid="input-nflflavor"
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <span className="text-xs font-semibold text-gray-700">
+                Couleur primaire
+              </span>
+              <div className="mt-1 flex items-center gap-2">
+                <input
+                  type="color"
+                  value={
+                    HEX_REGEX.test(form.primaryColor)
+                      ? form.primaryColor
+                      : DEFAULT_PRIMARY
+                  }
+                  onChange={(e) =>
+                    handleChange("primaryColor", e.target.value.toUpperCase())
+                  }
+                  className="h-9 w-12 border border-gray-300 rounded cursor-pointer"
+                  data-testid="picker-primary"
+                  aria-label="Color picker primaire"
+                />
+                <input
+                  type="text"
+                  value={form.primaryColor}
+                  onChange={(e) =>
+                    handleChange("primaryColor", e.target.value)
+                  }
+                  placeholder="#RRGGBB"
+                  className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm font-mono"
+                  data-testid="input-primary"
+                />
+              </div>
+              {colorErrors.primary && (
+                <span className="text-xs text-red-600">
+                  {colorErrors.primary}
+                </span>
+              )}
+            </label>
+            <label className="block">
+              <span className="text-xs font-semibold text-gray-700">
+                Couleur secondaire
+              </span>
+              <div className="mt-1 flex items-center gap-2">
+                <input
+                  type="color"
+                  value={
+                    HEX_REGEX.test(form.secondaryColor)
+                      ? form.secondaryColor
+                      : DEFAULT_SECONDARY
+                  }
+                  onChange={(e) =>
+                    handleChange(
+                      "secondaryColor",
+                      e.target.value.toUpperCase(),
+                    )
+                  }
+                  className="h-9 w-12 border border-gray-300 rounded cursor-pointer"
+                  data-testid="picker-secondary"
+                  aria-label="Color picker secondaire"
+                />
+                <input
+                  type="text"
+                  value={form.secondaryColor}
+                  onChange={(e) =>
+                    handleChange("secondaryColor", e.target.value)
+                  }
+                  placeholder="#RRGGBB"
+                  className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm font-mono"
+                  data-testid="input-secondary"
+                />
+              </div>
+              {colorErrors.secondary && (
+                <span className="text-xs text-red-600">
+                  {colorErrors.secondary}
+                </span>
+              )}
+            </label>
+          </div>
+
+          <label className="block">
+            <span className="text-xs font-semibold text-gray-700">Motto</span>
+            <input
+              type="text"
+              value={form.motto}
+              onChange={(e) => handleChange("motto", e.target.value)}
+              maxLength={200}
+              placeholder="Ex: Block first, ask later."
+              className="mt-1 w-full px-2 py-1 border border-gray-300 rounded text-sm"
+              data-testid="input-motto"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-xs font-semibold text-gray-700">
+              Headline
+            </span>
+            <input
+              type="text"
+              value={form.headline}
+              onChange={(e) => handleChange("headline", e.target.value)}
+              maxLength={200}
+              placeholder="Phrase d'accroche broadcast"
+              className="mt-1 w-full px-2 py-1 border border-gray-300 rounded text-sm"
+              data-testid="input-headline"
+            />
+          </label>
+
+          {error && (
+            <div
+              className="p-2 rounded bg-red-50 border border-red-200 text-xs text-red-800"
+              data-testid="form-error"
+            >
+              {error}
+            </div>
+          )}
+
+          {success && (
+            <div
+              className="p-2 rounded bg-green-50 border border-green-200 text-xs text-green-800"
+              data-testid="form-success"
+            >
+              {success}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <span
+              className="text-xs text-gray-500"
+              data-testid="dirty-count"
+            >
+              {dirtyCount === 0
+                ? "Aucune modification"
+                : `${dirtyCount} champ${dirtyCount > 1 ? "s" : ""} modifie${dirtyCount > 1 ? "s" : ""}`}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleReset}
+                disabled={dirtyCount === 0 || saving}
+                className="px-3 py-1.5 rounded border border-gray-300 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                data-testid="btn-reset"
+              >
+                Reset
+              </button>
+              <button
+                type="submit"
+                disabled={dirtyCount === 0 || saving || hasErrors}
+                className="px-4 py-1.5 rounded bg-nuffle-gold text-white text-sm font-semibold hover:bg-yellow-600 disabled:opacity-50"
+                data-testid="btn-save"
+              >
+                {saving ? "Enregistrement…" : "Enregistrer"}
+              </button>
+            </div>
+          </div>
+        </form>
+
+        <div className="space-y-4">
+          <div
+            className="p-5 rounded-xl border bg-white border-gray-200"
+            data-testid="preview"
+          >
+            <div className="text-xs font-semibold text-gray-500 mb-2">
+              APERCU
+            </div>
+            <div
+              className="rounded-lg p-4 text-white"
+              style={{
+                background: `linear-gradient(135deg, ${previewPrimary} 0%, ${previewSecondary} 100%)`,
+              }}
+            >
+              <div className="text-sm opacity-80">
+                {form.nflFlavor || team.race}
+              </div>
+              <div className="text-xl font-bold leading-tight">
+                {form.city || team.city}
+              </div>
+              <div className="text-2xl font-heading leading-tight">
+                {form.name || team.name}
+              </div>
+              {form.motto && (
+                <div className="mt-2 text-xs italic opacity-90">
+                  « {form.motto} »
+                </div>
+              )}
+            </div>
+            {form.headline && (
+              <div className="mt-3 text-sm text-gray-700 italic">
+                {form.headline}
+              </div>
+            )}
+          </div>
+
+          <div className="p-4 rounded-xl border bg-gray-50 border-gray-200 text-xs text-gray-600">
+            <div>
+              <strong>Slug :</strong>{" "}
+              <code className="text-gray-800">{team.slug}</code> (immutable)
+            </div>
+            <div>
+              <strong>Race :</strong> {team.race} (immutable)
+            </div>
+            <div>
+              <strong>Base TV :</strong> {team.baseTv}
+            </div>
+            <div className="mt-1 text-gray-500">
+              Mis a jour : {new Date(team.updatedAt).toLocaleString()}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/pro-league/teams/page.test.tsx
+++ b/apps/web/app/admin/pro-league/teams/page.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests de la page admin/pro-league/teams (liste).
+ *
+ * Couvre : chargement liste, rendu cards, etat empty, erreur fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import AdminProLeagueTeamsPage from "./page";
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy-token",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+const teamFixture = {
+  id: "t1",
+  leagueId: "l1",
+  slug: "pit-smashers",
+  city: "Pittsburgh",
+  name: "Smashers",
+  race: "Orc",
+  nflFlavor: "Steelers",
+  primaryColor: "#000000",
+  secondaryColor: "#FFB612",
+  motto: "Smash hour",
+  headline: null,
+};
+
+describe("AdminProLeagueTeamsPage", () => {
+  it("affiche les cards teams apres chargement", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ teams: [teamFixture] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("team-card-pit-smashers")).toBeTruthy();
+    });
+    expect(screen.getByText(/Pittsburgh Smashers/)).toBeTruthy();
+    expect(screen.getByText(/Smash hour/)).toBeTruthy();
+  });
+
+  it("affiche message empty quand 0 team", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ teams: [] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Aucune team Pro League/)).toBeTruthy();
+    });
+  });
+
+  it("affiche erreur quand fetch echoue", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Forbidden" }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Forbidden/)).toBeTruthy();
+    });
+  });
+
+  it("applique la couleur primaire au swatch", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ teams: [teamFixture] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamsPage />);
+
+    await waitFor(() => {
+      const swatch = screen.getByTestId("primary-pit-smashers");
+      expect((swatch as HTMLElement).style.backgroundColor).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/admin/pro-league/teams/page.tsx
+++ b/apps/web/app/admin/pro-league/teams/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * Admin Pro League — liste des teams pour edition branding.
+ *
+ * Affiche toutes les teams (toutes ligues confondues) avec apercu
+ * couleur primaire/secondaire + ville/nom/race + lien vers la page
+ * d'edition.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { API_BASE } from "../../../auth-client";
+
+interface ProTeamSummary {
+  readonly id: string;
+  readonly leagueId: string;
+  readonly slug: string;
+  readonly city: string;
+  readonly name: string;
+  readonly race: string;
+  readonly nflFlavor: string | null;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+  readonly motto: string | null;
+  readonly headline: string | null;
+}
+
+async function fetchJSON(path: string) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      Authorization: token ? `Bearer ${token}` : "",
+      "Content-Type": "application/json",
+    },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(json?.error || `Erreur ${res.status}`);
+  }
+  return json;
+}
+
+export default function AdminProLeagueTeamsPage() {
+  const [teams, setTeams] = useState<ProTeamSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    fetchJSON("/admin/pro-league/teams")
+      .then((data) => {
+        if (alive) setTeams(data.teams ?? []);
+      })
+      .catch((e: Error) => {
+        if (alive) setError(e.message);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite">
+            🎨 Branding teams
+          </h1>
+          <Link
+            href={"/admin/pro-league" as any}
+            className="text-sm text-blue-700 hover:underline"
+          >
+            ← Retour hub
+          </Link>
+        </div>
+        <p className="text-sm text-gray-600">
+          Editer couleurs primaire/secondaire, motto, headline, ville/nom et
+          flavor NFL d&apos;une team. Toute modification est tracee dans
+          l&apos;audit log admin.
+        </p>
+      </div>
+
+      {error && (
+        <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {loading && (
+        <div className="text-sm text-gray-500" data-testid="teams-loading">
+          Chargement…
+        </div>
+      )}
+
+      {!loading && !error && teams.length === 0 && (
+        <div className="p-4 rounded-lg bg-yellow-50 border border-yellow-200 text-sm text-yellow-800">
+          Aucune team Pro League. Seedez la ligue depuis{" "}
+          <Link
+            href={"/admin/utilities" as any}
+            className="text-blue-700 hover:underline"
+          >
+            /admin/utilities
+          </Link>
+          .
+        </div>
+      )}
+
+      <div
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+        data-testid="teams-grid"
+      >
+        {teams.map((team) => (
+          <Link
+            key={team.id}
+            href={`/admin/pro-league/teams/${team.id}` as any}
+            data-testid={`team-card-${team.slug}`}
+            className="p-4 rounded-xl border bg-white border-gray-200 hover:border-nuffle-gold hover:shadow-md transition"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex flex-col gap-1">
+                <span
+                  className="block w-6 h-6 rounded border border-gray-300"
+                  style={{
+                    backgroundColor: team.primaryColor ?? "#e5e7eb",
+                  }}
+                  aria-label="Couleur primaire"
+                  data-testid={`primary-${team.slug}`}
+                />
+                <span
+                  className="block w-6 h-6 rounded border border-gray-300"
+                  style={{
+                    backgroundColor: team.secondaryColor ?? "#e5e7eb",
+                  }}
+                  aria-label="Couleur secondaire"
+                  data-testid={`secondary-${team.slug}`}
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="font-semibold text-nuffle-anthracite truncate">
+                  {team.city} {team.name}
+                </div>
+                <div className="text-xs text-gray-500 truncate">
+                  {team.race}
+                  {team.nflFlavor ? ` · ${team.nflFlavor}` : ""}
+                </div>
+                {team.motto && (
+                  <div className="text-xs italic text-gray-600 mt-1 truncate">
+                    « {team.motto} »
+                  </div>
+                )}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Ajoute la gestion admin du branding ProTeam (couleurs, motto, headline, ville/nom, flavor NFL).

- **API** : `GET /admin/pro-league/teams[/:id]` + `PATCH /admin/pro-league/teams/:id`
- **Schema Zod** : `adminProTeamBrandingSchema` avec validation hex `#RRGGBB`, tous les champs optionnels (PATCH partiel), au moins un requis
- **Service pur** : `pro-team-branding.ts` avec parser meta tolerant sqlite (string) + PG (objet) + merger non destructif (preserve fanbase, skills, etc.)
- **UI hub** : nouvelle card "Branding teams" dans `/admin/pro-league`
- **UI liste** : `/admin/pro-league/teams` avec swatches couleur primaire/secondaire + lien edit
- **UI edit** : `/admin/pro-league/teams/[id]` avec form contrôle, color picker + input hex, preview live (gradient + motto + headline), bouton Reset, dirty count, validation client
- **Audit log strict** : oldValue/newValue limites aux champs branding
- **Aucune migration** : tous les champs existent deja dans `ProTeam` (motto/headline dans `meta` JSON)

## Champs editables

| Champ | Type | Notes |
|---|---|---|
| city | string (1-80) | required |
| name | string (1-120) | required |
| nflFlavor | string (≤120) ou null | optionnel, null efface |
| primaryColor | hex `#RRGGBB` ou null | optionnel, null efface |
| secondaryColor | hex `#RRGGBB` ou null | optionnel, null efface |
| motto | string (≤200) ou null | merge dans meta, null efface |
| headline | string (≤200) ou null | merge dans meta, null efface |

`slug`, `race`, `baseTv` restent immutables (hors scope branding, exposes en lecture).

## Pattern : meta merge non destructif

`applyBrandingMeta()` preserve les autres entrees meta (`fanbase`, `skills`, etc.) en touchant uniquement `motto` et `headline`. Compatible PG (objet) et sqlite mirror (string serialisee).

## Test plan

- [x] Tests unitaires service (14 — parser meta, merge, edge cases)
- [x] Tests integration route (15 — GET liste/detail, PATCH succes/validation/404, audit, merge meta)
- [x] Tests UI page liste (4 — chargement, empty, erreur, swatches)
- [x] Tests UI page edit (9 — form, dirty/diff, save, validation, reset, erreur)
- [x] Build TS server + web : OK
- [x] Test suite complete : server 2348/2348 ✓, web 1042/1042 ✓
- [ ] Test manuel prod : creer une saison, modifier les couleurs d'une team, verifier le badge couleur dans `/pro-league/teams/[slug]`

## Captures (manuelles, post-merge)

- Liste teams avec swatches
- Page edit avec preview gradient live

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_