### PR TITLE
feat(admin): gestion rosters Pro League (replenish/regenerate/retire)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,6 +17,7 @@ import adminWalletRoutes from "./routes/admin-wallet";
 import adminUtilitiesRoutes from "./routes/admin-utilities";
 import adminProSeasonRoutes from "./routes/admin-pro-season";
 import adminProTeamRoutes from "./routes/admin-pro-team";
+import adminProRosterRoutes from "./routes/admin-pro-roster";
 import userRoutes from "./routes/user";
 import teamRoutes from "./routes/team";
 import teamAdvancementRoutes from "./routes/team-advancement";
@@ -236,6 +237,8 @@ app.use("/admin/utilities", adminUtilitiesRoutes);
 app.use("/admin/pro-league", adminProSeasonRoutes);
 // Branding teams Pro League (couleurs / motto / headline).
 app.use("/admin/pro-league", adminProTeamRoutes);
+// Gestion rosters Pro League (regen, replenish, retire joueur).
+app.use("/admin/pro-league", adminProRosterRoutes);
 // Feedback public : pas d'auth, captcha + rate limiter dedies dans le router.
 app.use("/feedback", feedbackPublicRouter);
 app.use("/pro-league", proLeagueRoutes);

--- a/apps/server/src/routes/admin-pro-roster.test.ts
+++ b/apps/server/src/routes/admin-pro-roster.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests integration des endpoints admin-pro-roster.
+ *
+ * Couvre : GET roster, POST replenish, POST regenerate (success +
+ * erreurs), POST retire, audit log, mapping RosterAdminError → HTTP.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn() },
+    proTeamRoster: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("../middleware/authUser", () => ({
+  authUser: (req: any, _res: any, next: any) => {
+    req.user = { id: "admin-1", role: "admin", roles: ["admin"] };
+    return next();
+  },
+}));
+
+vi.mock("../middleware/adminOnly", () => ({
+  adminOnly: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../services/audit-log", () => ({
+  safeRecordAdminActionFromRequest: vi.fn(async () => {}),
+}));
+
+vi.mock("../services/pro-roster-generator", () => ({
+  replenishTeamRoster: vi.fn(),
+}));
+
+vi.mock("../services/pro-roster-admin", () => {
+  class RosterAdminError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "RosterAdminError";
+    }
+  }
+  return {
+    regenerateRoster: vi.fn(),
+    retirePlayer: vi.fn(),
+    RosterAdminError,
+  };
+});
+
+import express from "express";
+import http from "http";
+import rosterRouter from "./admin-pro-roster";
+import { prisma } from "../prisma";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+import { replenishTeamRoster as replenishMock } from "../services/pro-roster-generator";
+import {
+  regenerateRoster as regenerateMock,
+  retirePlayer as retireMock,
+  RosterAdminError,
+} from "../services/pro-roster-admin";
+
+const mockedAudit = vi.mocked(safeRecordAdminActionFromRequest);
+const replenish = vi.mocked(replenishMock);
+const regenerate = vi.mocked(regenerateMock);
+const retire = vi.mocked(retireMock);
+
+const mockedPrisma = prisma as unknown as {
+  proTeam: { findUnique: ReturnType<typeof vi.fn> };
+  proTeamRoster: { findMany: ReturnType<typeof vi.fn> };
+};
+
+async function request(
+  method: "GET" | "POST",
+  path: string,
+  body: Record<string, unknown> | null = null,
+): Promise<{ status: number; body: any }> {
+  const app = express();
+  app.use(express.json());
+  app.use("/admin/pro-league", rosterRouter);
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("listen failed"));
+        return;
+      }
+      const data = body !== null ? JSON.stringify(body) : "";
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: `/admin/pro-league${path}`,
+          method,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(data).toString(),
+            Authorization: "Bearer dummy",
+          },
+        },
+        (res) => {
+          let buf = "";
+          res.on("data", (c) => (buf += c));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({
+                status: res.statusCode ?? 0,
+                body: buf ? JSON.parse(buf) : {},
+              });
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+      req.on("error", (e) => {
+        server.close();
+        reject(e);
+      });
+      if (data) req.write(data);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const teamFixture = {
+  id: "t1",
+  slug: "pit-smashers",
+  city: "Pittsburgh",
+  name: "Smashers",
+  race: "Orc",
+};
+
+const playerFixture = {
+  id: "p1",
+  teamId: "t1",
+  name: "Grott Steelfist",
+  position: "Lineman",
+  ma: 5,
+  st: 3,
+  ag: 3,
+  pa: 4,
+  av: 10,
+  skills: ["block"],
+  niggling: 0,
+  maReduction: 0,
+  stReduction: 0,
+  agReduction: 0,
+  avReduction: 0,
+  status: "active",
+  form: 60,
+  spp: 12,
+  level: 2,
+  tvCached: 70000,
+  tdCount: 3,
+  casCount: 2,
+  compCount: 1,
+  mvpCount: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("GET /admin/pro-league/teams/:id/roster", () => {
+  it("retourne le roster complet avec counters", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeamRoster.findMany.mockResolvedValueOnce([
+      playerFixture,
+      { ...playerFixture, id: "p2", status: "injured" },
+      { ...playerFixture, id: "p3", status: "dead" },
+    ]);
+
+    const res = await request("GET", "/teams/t1/roster");
+
+    expect(res.status).toBe(200);
+    expect(res.body.team).toMatchObject({ id: "t1", slug: "pit-smashers" });
+    expect(res.body.counts).toEqual({
+      total: 3,
+      active: 1,
+      injured: 1,
+      dead: 1,
+      retired: 0,
+    });
+    expect(res.body.players).toHaveLength(3);
+    expect(res.body.players[0]).toMatchObject({
+      id: "p1",
+      name: "Grott Steelfist",
+      level: 2,
+      spp: 12,
+    });
+  });
+
+  it("404 si team introuvable", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(null);
+    const res = await request("GET", "/teams/missing/roster");
+    expect(res.status).toBe(404);
+  });
+
+  it("parse skills depuis string sqlite", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeamRoster.findMany.mockResolvedValueOnce([
+      { ...playerFixture, skills: JSON.stringify(["block", "tackle"]) },
+    ]);
+    const res = await request("GET", "/teams/t1/roster");
+    expect(res.body.players[0].skills).toEqual(["block", "tackle"]);
+  });
+
+  it("skills array vide si format invalide", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamFixture);
+    mockedPrisma.proTeamRoster.findMany.mockResolvedValueOnce([
+      { ...playerFixture, skills: "{notjson" },
+    ]);
+    const res = await request("GET", "/teams/t1/roster");
+    expect(res.body.players[0].skills).toEqual([]);
+  });
+});
+
+describe("POST /admin/pro-league/teams/:id/roster/replenish", () => {
+  it("replenit jusqu'a target et trace audit", async () => {
+    replenish.mockResolvedValueOnce({
+      teamId: "t1",
+      activeBefore: 8,
+      created: 4,
+      targetSize: 12,
+    });
+
+    const res = await request("POST", "/teams/t1/roster/replenish", {
+      targetSize: 12,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ created: 4, targetSize: 12 });
+    expect(replenish).toHaveBeenCalledWith("t1", 12);
+    expect(mockedAudit).toHaveBeenCalledTimes(1);
+    const auditArg = mockedAudit.mock.calls[0][2];
+    expect(auditArg.action).toBe("pro-roster.replenish");
+  });
+
+  it("targetSize optionnel utilise default service", async () => {
+    replenish.mockResolvedValueOnce({
+      teamId: "t1",
+      activeBefore: 12,
+      created: 0,
+      targetSize: 12,
+    });
+
+    await request("POST", "/teams/t1/roster/replenish", {});
+
+    expect(replenish).toHaveBeenCalledWith("t1", undefined);
+  });
+
+  it("rejette targetSize > 30 (validation)", async () => {
+    const res = await request("POST", "/teams/t1/roster/replenish", {
+      targetSize: 50,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404 si team introuvable (service throws)", async () => {
+    replenish.mockRejectedValueOnce(new Error("ProTeam 'x' introuvable"));
+    const res = await request("POST", "/teams/x/roster/replenish", {});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /admin/pro-league/teams/:id/roster/regenerate", () => {
+  it("regenere avec count + trace audit destructif", async () => {
+    regenerate.mockResolvedValueOnce({
+      teamId: "t1",
+      deleted: 12,
+      created: 12,
+    });
+
+    const res = await request("POST", "/teams/t1/roster/regenerate", {
+      count: 12,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ deleted: 12, created: 12 });
+    expect(regenerate).toHaveBeenCalledWith({ teamId: "t1", count: 12 });
+    const auditArg = mockedAudit.mock.calls[0][2];
+    expect(auditArg.action).toBe("pro-roster.regenerate");
+    expect(auditArg.oldValue).toEqual({ deleted: 12 });
+  });
+
+  it("count default = 12 si non fourni", async () => {
+    regenerate.mockResolvedValueOnce({
+      teamId: "t1",
+      deleted: 0,
+      created: 12,
+    });
+    await request("POST", "/teams/t1/roster/regenerate", {});
+    expect(regenerate).toHaveBeenCalledWith({ teamId: "t1", count: 12 });
+  });
+
+  it("404 quand TEAM_NOT_FOUND", async () => {
+    regenerate.mockRejectedValueOnce(
+      new RosterAdminError("TEAM_NOT_FOUND", "introuvable") as any,
+    );
+    const res = await request("POST", "/teams/x/roster/regenerate", {
+      count: 12,
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("400 quand INVALID_INPUT", async () => {
+    regenerate.mockRejectedValueOnce(
+      new RosterAdminError("INVALID_INPUT", "invalide") as any,
+    );
+    const res = await request("POST", "/teams/t1/roster/regenerate", {
+      count: 5,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejette count > 30 a la validation", async () => {
+    const res = await request("POST", "/teams/t1/roster/regenerate", {
+      count: 99,
+    });
+    expect(res.status).toBe(400);
+    expect(regenerate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /admin/pro-league/rosters/:id/retire", () => {
+  it("retire un joueur active + trace audit", async () => {
+    retire.mockResolvedValueOnce({ playerId: "p1", previousStatus: "active" });
+
+    const res = await request("POST", "/rosters/p1/retire");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ playerId: "p1", previousStatus: "active" });
+    const auditArg = mockedAudit.mock.calls[0][2];
+    expect(auditArg).toMatchObject({
+      action: "pro-roster.retire",
+      entity: "ProTeamRoster",
+      entityId: "p1",
+      oldValue: { status: "active" },
+      newValue: { status: "retired" },
+    });
+  });
+
+  it("404 si joueur introuvable", async () => {
+    retire.mockRejectedValueOnce(
+      new RosterAdminError("ROSTER_NOT_FOUND", "introuvable") as any,
+    );
+    const res = await request("POST", "/rosters/missing/retire");
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/server/src/routes/admin-pro-roster.ts
+++ b/apps/server/src/routes/admin-pro-roster.ts
@@ -1,0 +1,282 @@
+/**
+ * Admin Pro League — gestion rosters.
+ *
+ * Endpoints :
+ *  - GET  /admin/pro-league/teams/:id/roster                — liste joueurs
+ *  - POST /admin/pro-league/teams/:id/roster/replenish      — combler manques
+ *  - POST /admin/pro-league/teams/:id/roster/regenerate     — DESTRUCTIF
+ *  - POST /admin/pro-league/rosters/:playerId/retire        — set retired
+ *
+ * Toute mutation est tracee dans l'audit log strict.
+ */
+
+import { Router } from "express";
+import { prisma } from "../prisma";
+import { authUser } from "../middleware/authUser";
+import { adminOnly } from "../middleware/adminOnly";
+import { validate } from "../middleware/validate";
+import {
+  adminRosterReplenishSchema,
+  adminRosterRegenerateSchema,
+} from "../schemas/admin.schemas";
+import { serverLog } from "../utils/server-log";
+import { safeRecordAdminActionFromRequest } from "../services/audit-log";
+import type { AuthenticatedRequest } from "../middleware/authUser";
+import { replenishTeamRoster } from "../services/pro-roster-generator";
+import {
+  regenerateRoster,
+  retirePlayer,
+  RosterAdminError,
+} from "../services/pro-roster-admin";
+
+const router = Router();
+
+router.use(authUser, adminOnly);
+
+function errorStatus(code: RosterAdminError["code"]): number {
+  switch (code) {
+    case "TEAM_NOT_FOUND":
+    case "ROSTER_NOT_FOUND":
+      return 404;
+    case "INVALID_INPUT":
+      return 400;
+    case "ROSTER_HAS_HISTORY":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+interface RosterRow {
+  id: string;
+  teamId: string;
+  name: string;
+  position: string;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  skills: unknown;
+  niggling: number;
+  maReduction: number;
+  stReduction: number;
+  agReduction: number;
+  avReduction: number;
+  status: string;
+  form: number;
+  spp: number;
+  level: number;
+  tvCached: number;
+  tdCount: number;
+  casCount: number;
+  compCount: number;
+  mvpCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function parseSkills(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? parsed.filter((s): s is string => typeof s === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function serializePlayer(p: RosterRow): {
+  id: string;
+  name: string;
+  position: string;
+  ma: number;
+  st: number;
+  ag: number;
+  pa: number | null;
+  av: number;
+  skills: string[];
+  status: string;
+  form: number;
+  spp: number;
+  level: number;
+  tvCached: number;
+  niggling: number;
+  tdCount: number;
+  casCount: number;
+  compCount: number;
+  mvpCount: number;
+} {
+  return {
+    id: p.id,
+    name: p.name,
+    position: p.position,
+    ma: p.ma,
+    st: p.st,
+    ag: p.ag,
+    pa: p.pa,
+    av: p.av,
+    skills: parseSkills(p.skills),
+    status: p.status,
+    form: p.form,
+    spp: p.spp,
+    level: p.level,
+    tvCached: p.tvCached,
+    niggling: p.niggling,
+    tdCount: p.tdCount,
+    casCount: p.casCount,
+    compCount: p.compCount,
+    mvpCount: p.mvpCount,
+  };
+}
+
+/** GET /admin/pro-league/teams/:id/roster — liste des joueurs (tous statuts). */
+router.get("/teams/:id/roster", async (req, res) => {
+  try {
+    const team = await prisma.proTeam.findUnique({
+      where: { id: req.params.id },
+      select: { id: true, slug: true, city: true, name: true, race: true },
+    });
+    if (!team) {
+      return res.status(404).json({ error: "Team introuvable" });
+    }
+
+    const players = (await prisma.proTeamRoster.findMany({
+      where: { teamId: req.params.id },
+      orderBy: [{ status: "asc" }, { level: "desc" }, { spp: "desc" }],
+    })) as RosterRow[];
+
+    const counts = {
+      total: players.length,
+      active: players.filter((p) => p.status === "active").length,
+      injured: players.filter((p) => p.status === "injured").length,
+      dead: players.filter((p) => p.status === "dead").length,
+      retired: players.filter((p) => p.status === "retired").length,
+    };
+
+    res.json({
+      team,
+      counts,
+      players: players.map(serializePlayer),
+    });
+  } catch (e) {
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors de la lecture du roster" });
+  }
+});
+
+/**
+ * POST /admin/pro-league/teams/:id/roster/replenish — combler les manques.
+ *
+ * Non destructif : ajoute uniquement le nombre necessaire pour
+ * atteindre `targetSize` joueurs `active` (defaut 12).
+ */
+router.post(
+  "/teams/:id/roster/replenish",
+  validate(adminRosterReplenishSchema),
+  async (req, res) => {
+    try {
+      const targetSize = (req.body as { targetSize?: number }).targetSize;
+      const result = await replenishTeamRoster(req.params.id, targetSize);
+
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-roster.replenish",
+          entity: "ProTeam",
+          entityId: req.params.id,
+          newValue: {
+            targetSize: result.targetSize,
+            activeBefore: result.activeBefore,
+            created: result.created,
+          },
+        },
+      );
+
+      res.json(result);
+    } catch (e) {
+      serverLog.error(e);
+      const message = e instanceof Error ? e.message : "Erreur";
+      const status = message.includes("introuvable") ? 404 : 500;
+      res.status(status).json({ error: message });
+    }
+  },
+);
+
+/**
+ * POST /admin/pro-league/teams/:id/roster/regenerate — DESTRUCTIF.
+ *
+ * Wipe complet du roster + re-seed `count` rookies. A utiliser pour
+ * reset une team en debut de saison ou apres un bug majeur. Audit
+ * log avec count + deleted.
+ */
+router.post(
+  "/teams/:id/roster/regenerate",
+  validate(adminRosterRegenerateSchema),
+  async (req, res) => {
+    try {
+      const { count } = req.body as { count: number };
+      const result = await regenerateRoster({
+        teamId: req.params.id,
+        count,
+      });
+
+      await safeRecordAdminActionFromRequest(
+        prisma,
+        req as AuthenticatedRequest,
+        {
+          action: "pro-roster.regenerate",
+          entity: "ProTeam",
+          entityId: req.params.id,
+          oldValue: { deleted: result.deleted },
+          newValue: { created: result.created, count },
+        },
+      );
+
+      res.json(result);
+    } catch (e) {
+      if (e instanceof RosterAdminError) {
+        return res.status(errorStatus(e.code)).json({ error: e.message });
+      }
+      serverLog.error(e);
+      res.status(500).json({ error: "Erreur lors de la regeneration" });
+    }
+  },
+);
+
+/** POST /admin/pro-league/rosters/:playerId/retire — set status=retired. */
+router.post("/rosters/:playerId/retire", async (req, res) => {
+  try {
+    const result = await retirePlayer(req.params.playerId);
+
+    await safeRecordAdminActionFromRequest(
+      prisma,
+      req as AuthenticatedRequest,
+      {
+        action: "pro-roster.retire",
+        entity: "ProTeamRoster",
+        entityId: req.params.playerId,
+        oldValue: { status: result.previousStatus },
+        newValue: { status: "retired" },
+      },
+    );
+
+    res.json(result);
+  } catch (e) {
+    if (e instanceof RosterAdminError) {
+      return res.status(errorStatus(e.code)).json({ error: e.message });
+    }
+    serverLog.error(e);
+    res.status(500).json({ error: "Erreur lors du retire" });
+  }
+});
+
+export default router;

--- a/apps/server/src/schemas/admin.schemas.ts
+++ b/apps/server/src/schemas/admin.schemas.ts
@@ -166,6 +166,19 @@ export const adminForceForfeitSchema = z.object({
   }),
 });
 
+/** Replenish d'un roster Pro League : remplit jusqu'a `targetSize`
+ *  (defaut 12) avec des rookies. Action non destructive — n'efface
+ *  rien. */
+export const adminRosterReplenishSchema = z.object({
+  targetSize: z.number().int().min(1).max(30).optional(),
+});
+
+/** Regenerate complet d'un roster (DESTRUCTIF). Wipe puis re-seed
+ *  `count` rookies. */
+export const adminRosterRegenerateSchema = z.object({
+  count: z.number().int().min(1).max(30).default(12),
+});
+
 /** Branding admin d'une ProTeam : couleurs, motto, headline, nflFlavor.
  *  Tous les champs sont optionnels — l'endpoint applique seulement ceux
  *  fournis, ne touche pas aux autres. `null` explicite = effacer le champ. */

--- a/apps/server/src/services/pro-roster-admin.test.ts
+++ b/apps/server/src/services/pro-roster-admin.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn() },
+    proTeamRoster: {
+      deleteMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  regenerateRoster,
+  retirePlayer,
+  RosterAdminError,
+} from "./pro-roster-admin";
+
+const mockedPrisma = prisma as unknown as {
+  proTeam: { findUnique: ReturnType<typeof vi.fn> };
+  proTeamRoster: {
+    deleteMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("regenerateRoster", () => {
+  it("rejette count < 1", async () => {
+    await expect(
+      regenerateRoster({ teamId: "t1", count: 0 }),
+    ).rejects.toThrow(RosterAdminError);
+  });
+
+  it("rejette count > 30", async () => {
+    await expect(
+      regenerateRoster({ teamId: "t1", count: 31 }),
+    ).rejects.toThrow(RosterAdminError);
+  });
+
+  it("rejette si team introuvable", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      regenerateRoster({ teamId: "missing", count: 12 }),
+    ).rejects.toMatchObject({
+      code: "TEAM_NOT_FOUND",
+    });
+  });
+
+  it("wipe + re-seed avec le count fourni", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce({ id: "t1" })
+      .mockResolvedValueOnce({ id: "t1", race: "Orc", slug: "pit-smashers" });
+    mockedPrisma.proTeamRoster.deleteMany.mockResolvedValueOnce({ count: 12 });
+    mockedPrisma.proTeamRoster.count.mockResolvedValueOnce(0);
+    mockedPrisma.proTeamRoster.create.mockResolvedValue({});
+
+    const result = await regenerateRoster({ teamId: "t1", count: 12 });
+
+    expect(result).toEqual({ teamId: "t1", deleted: 12, created: 12 });
+    expect(mockedPrisma.proTeamRoster.deleteMany).toHaveBeenCalledWith({
+      where: { teamId: "t1" },
+    });
+    expect(mockedPrisma.proTeamRoster.create).toHaveBeenCalledTimes(12);
+  });
+
+  it("supporte count personnalise", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce({ id: "t1" })
+      .mockResolvedValueOnce({ id: "t1", race: "Orc", slug: "x" });
+    mockedPrisma.proTeamRoster.deleteMany.mockResolvedValueOnce({ count: 5 });
+    mockedPrisma.proTeamRoster.count.mockResolvedValueOnce(0);
+    mockedPrisma.proTeamRoster.create.mockResolvedValue({});
+
+    const result = await regenerateRoster({ teamId: "t1", count: 16 });
+
+    expect(result.created).toBe(16);
+    expect(mockedPrisma.proTeamRoster.create).toHaveBeenCalledTimes(16);
+  });
+});
+
+describe("retirePlayer", () => {
+  it("rejette si joueur introuvable", async () => {
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValueOnce(null);
+    await expect(retirePlayer("missing")).rejects.toMatchObject({
+      code: "ROSTER_NOT_FOUND",
+    });
+  });
+
+  it("met le status a retired et retourne previousStatus", async () => {
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p1",
+      status: "active",
+    });
+    mockedPrisma.proTeamRoster.update.mockResolvedValueOnce({});
+
+    const result = await retirePlayer("p1");
+
+    expect(result).toEqual({ playerId: "p1", previousStatus: "active" });
+    expect(mockedPrisma.proTeamRoster.update).toHaveBeenCalledWith({
+      where: { id: "p1" },
+      data: { status: "retired" },
+    });
+  });
+
+  it("idempotent si deja retired (no-op)", async () => {
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p1",
+      status: "retired",
+    });
+
+    const result = await retirePlayer("p1");
+
+    expect(result).toEqual({ playerId: "p1", previousStatus: "retired" });
+    expect(mockedPrisma.proTeamRoster.update).not.toHaveBeenCalled();
+  });
+
+  it("fonctionne pour un joueur injured", async () => {
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValueOnce({
+      id: "p1",
+      status: "injured",
+    });
+    mockedPrisma.proTeamRoster.update.mockResolvedValueOnce({});
+
+    const result = await retirePlayer("p1");
+
+    expect(result.previousStatus).toBe("injured");
+  });
+});

--- a/apps/server/src/services/pro-roster-admin.ts
+++ b/apps/server/src/services/pro-roster-admin.ts
@@ -1,0 +1,123 @@
+/**
+ * Admin Pro League — actions destructives sur rosters.
+ *
+ * Ce module est explicitement separe de `pro-roster-generator.ts` car
+ * il contient des actions destructives (wipe + re-seed) qui ne doivent
+ * etre invoquees que depuis l'admin (jamais depuis un cron ou un
+ * service applicatif).
+ *
+ * Toute mutation est tracee via l'audit log au niveau de la route.
+ */
+
+import { prisma } from "../prisma";
+import { seedTeamRoster } from "./pro-roster-generator";
+
+export type RosterAdminErrorCode =
+  | "TEAM_NOT_FOUND"
+  | "ROSTER_NOT_FOUND"
+  | "INVALID_INPUT"
+  | "ROSTER_HAS_HISTORY";
+
+export class RosterAdminError extends Error {
+  constructor(
+    public readonly code: RosterAdminErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RosterAdminError";
+  }
+}
+
+export interface RegenerateRosterInput {
+  readonly teamId: string;
+  readonly count: number;
+}
+
+export interface RegenerateRosterResult {
+  readonly teamId: string;
+  readonly deleted: number;
+  readonly created: number;
+}
+
+/**
+ * Wipe complet du roster de l'equipe puis re-seed `count` rookies.
+ *
+ * Action destructive : tous les joueurs sont supprimes (peu importe
+ * leur status). Les match events historiques referencant ces joueurs
+ * conservent l'id mais le joueur n'existera plus en DB.
+ *
+ * Refuse si `count` < 1 ou > 30 (pour eviter les erreurs).
+ */
+export async function regenerateRoster(
+  input: RegenerateRosterInput,
+): Promise<RegenerateRosterResult> {
+  if (input.count < 1 || input.count > 30) {
+    throw new RosterAdminError(
+      "INVALID_INPUT",
+      "count doit etre entre 1 et 30",
+    );
+  }
+
+  const team = await prisma.proTeam.findUnique({
+    where: { id: input.teamId },
+    select: { id: true },
+  });
+  if (!team) {
+    throw new RosterAdminError(
+      "TEAM_NOT_FOUND",
+      `ProTeam '${input.teamId}' introuvable`,
+    );
+  }
+
+  const deleteResult = await prisma.proTeamRoster.deleteMany({
+    where: { teamId: input.teamId },
+  });
+
+  // seedTeamRoster est idempotent et no-op si des joueurs existent ;
+  // apres le deleteMany on est garanti a 0, donc le seed va se faire.
+  const seedResult = await seedTeamRoster(input.teamId, input.count);
+
+  return {
+    teamId: input.teamId,
+    deleted: deleteResult.count,
+    created: seedResult.created,
+  };
+}
+
+export interface RetirePlayerResult {
+  readonly playerId: string;
+  readonly previousStatus: string;
+}
+
+/**
+ * Set le status d'un joueur a "retired". Action non destructive (le
+ * joueur reste en DB pour conserver l'historique career stats), mais
+ * le joueur sera exclu des prochains matches.
+ *
+ * Idempotent : retirer un joueur deja retired no-op.
+ */
+export async function retirePlayer(
+  playerId: string,
+): Promise<RetirePlayerResult> {
+  const player = await prisma.proTeamRoster.findUnique({
+    where: { id: playerId },
+    select: { id: true, status: true },
+  });
+  if (!player) {
+    throw new RosterAdminError(
+      "ROSTER_NOT_FOUND",
+      `ProTeamRoster '${playerId}' introuvable`,
+    );
+  }
+
+  if (player.status === "retired") {
+    return { playerId, previousStatus: "retired" };
+  }
+
+  await prisma.proTeamRoster.update({
+    where: { id: playerId },
+    data: { status: "retired" },
+  });
+
+  return { playerId, previousStatus: player.status as string };
+}

--- a/apps/web/app/admin/pro-league/page.tsx
+++ b/apps/web/app/admin/pro-league/page.tsx
@@ -130,9 +130,9 @@ export default function AdminProLeagueHubPage() {
 
       <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-800">
         <strong>Roadmap admin Pro League</strong> : a venir dans les
-        prochains sprints : gestion fine des rosters (re-generer joueurs,
-        editer skills), re-simulation d&apos;un match avec nouveau seed,
-        gestion des bet markets.
+        prochains sprints : edition individuelle skills/stats joueurs,
+        re-simulation d&apos;un match avec nouveau seed, gestion des bet
+        markets.
       </div>
     </div>
   );

--- a/apps/web/app/admin/pro-league/teams/[id]/page.tsx
+++ b/apps/web/app/admin/pro-league/teams/[id]/page.tsx
@@ -246,12 +246,21 @@ export default function AdminProLeagueTeamEditPage() {
         <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite">
           🎨 {team.city} {team.name}
         </h1>
-        <Link
-          href={"/admin/pro-league/teams" as any}
-          className="text-sm text-blue-700 hover:underline"
-        >
-          ← Liste teams
-        </Link>
+        <div className="flex gap-3 text-sm">
+          <Link
+            href={`/admin/pro-league/teams/${team.id}/roster` as any}
+            className="text-blue-700 hover:underline"
+            data-testid="link-roster"
+          >
+            👥 Roster
+          </Link>
+          <Link
+            href={"/admin/pro-league/teams" as any}
+            className="text-blue-700 hover:underline"
+          >
+            ← Liste teams
+          </Link>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/apps/web/app/admin/pro-league/teams/[id]/roster/page.test.tsx
+++ b/apps/web/app/admin/pro-league/teams/[id]/roster/page.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * Tests de la page admin roster team.
+ *
+ * Couvre : chargement, affichage joueurs/counters, actions (replenish,
+ * regenerate, retire), erreurs API.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "t1" }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import AdminProLeagueTeamRosterPage from "./page";
+
+const originalFetch = global.fetch;
+const originalConfirm = global.confirm;
+
+const teamFixture = {
+  id: "t1",
+  slug: "pit-smashers",
+  city: "Pittsburgh",
+  name: "Smashers",
+  race: "Orc",
+};
+
+const playerActive = {
+  id: "p1",
+  name: "Grott Steelfist",
+  position: "Lineman",
+  ma: 5,
+  st: 3,
+  ag: 3,
+  pa: 4,
+  av: 10,
+  skills: ["block"],
+  status: "active",
+  form: 60,
+  spp: 12,
+  level: 2,
+  tvCached: 70000,
+  niggling: 0,
+  tdCount: 3,
+  casCount: 2,
+  compCount: 1,
+  mvpCount: 0,
+};
+
+const playerDead = { ...playerActive, id: "p2", name: "Old Dead", status: "dead" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy-token",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+  global.confirm = vi.fn(() => true);
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  global.confirm = originalConfirm;
+});
+
+function mockGetRoster(
+  players = [playerActive, playerDead],
+  counts = { total: 2, active: 1, injured: 0, dead: 1, retired: 0 },
+) {
+  return vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ team: teamFixture, counts, players }),
+  } as unknown as Response);
+}
+
+describe("AdminProLeagueTeamRosterPage", () => {
+  it("affiche la liste des joueurs et les counters", async () => {
+    global.fetch = mockGetRoster() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Grott Steelfist")).toBeTruthy();
+    expect(screen.getByText("Old Dead")).toBeTruthy();
+    expect(screen.getByTestId("roster-counts").textContent).toMatch(/Active/);
+  });
+
+  it("masque le bouton retire pour un joueur dead", async () => {
+    global.fetch = mockGetRoster() as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("roster-row-p1")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("btn-retire-p1")).toBeTruthy();
+    expect(screen.queryByTestId("btn-retire-p2")).toBeNull();
+  });
+
+  it("replenish appelle l'endpoint et rafraichit", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 1, active: 1, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        teamId: "t1",
+        activeBefore: 1,
+        created: 11,
+        targetSize: 12,
+      }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 12, active: 12, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-replenish")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("btn-replenish"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-message")).toBeTruthy();
+    });
+    expect(screen.getByTestId("action-message").textContent).toMatch(
+      /11 rookie/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const call2 = fetchMock.mock.calls[1];
+    expect(call2[0]).toMatch(/\/roster\/replenish/);
+    expect(call2[1].method).toBe("POST");
+  });
+
+  it("regenerate appelle l'endpoint destructif et affiche message", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 5, active: 5, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ teamId: "t1", deleted: 5, created: 12 }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 12, active: 12, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-regenerate")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("btn-regenerate"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-message")).toBeTruthy();
+    });
+    expect(screen.getByTestId("action-message").textContent).toMatch(
+      /5.*supprime.*12.*cree/,
+    );
+    const regenerateCall = fetchMock.mock.calls[1];
+    expect(regenerateCall[0]).toMatch(/\/roster\/regenerate/);
+    expect(JSON.parse(regenerateCall[1].body as string)).toEqual({ count: 12 });
+  });
+
+  it("regenerate annule si confirm refuse", async () => {
+    global.confirm = vi.fn(() => false);
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 1, active: 1, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-regenerate")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("btn-regenerate"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retire un joueur appelle l'endpoint", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 1, active: 1, injured: 0, dead: 0, retired: 0 },
+        players: [playerActive],
+      }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ playerId: "p1", previousStatus: "active" }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 1, active: 0, injured: 0, dead: 0, retired: 1 },
+        players: [{ ...playerActive, status: "retired" }],
+      }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-retire-p1")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("btn-retire-p1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-message")).toBeTruthy();
+    });
+    const retireCall = fetchMock.mock.calls[1];
+    expect(retireCall[0]).toMatch(/\/rosters\/p1\/retire/);
+  });
+
+  it("affiche erreur si fetch initial echoue", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Forbidden" }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Forbidden/)).toBeTruthy();
+    });
+  });
+
+  it("affiche erreur action si replenish echoue", async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 0, active: 0, injured: 0, dead: 0, retired: 0 },
+        players: [],
+      }),
+    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Replenish failed" }),
+    } as unknown as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("btn-replenish")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId("btn-replenish"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("action-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("action-error").textContent).toMatch(
+      /Replenish failed/,
+    );
+  });
+
+  it("affiche message empty quand 0 joueurs", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        team: teamFixture,
+        counts: { total: 0, active: 0, injured: 0, dead: 0, retired: 0 },
+        players: [],
+      }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<AdminProLeagueTeamRosterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Aucun joueur dans le roster/)).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/admin/pro-league/teams/[id]/roster/page.tsx
+++ b/apps/web/app/admin/pro-league/teams/[id]/roster/page.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+/**
+ * Admin Pro League — gestion roster d'une team.
+ *
+ * Liste tous les joueurs (active / injured / dead / retired) avec
+ * stats + boutons d'action :
+ *  - Replenish (combler les manques jusqu'a 12 actives)
+ *  - Regenerate (DESTRUCTIF — wipe + re-seed)
+ *  - Retire (par joueur)
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { API_BASE } from "../../../../../auth-client";
+
+interface RosterPlayer {
+  readonly id: string;
+  readonly name: string;
+  readonly position: string;
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number | null;
+  readonly av: number;
+  readonly skills: readonly string[];
+  readonly status: string;
+  readonly form: number;
+  readonly spp: number;
+  readonly level: number;
+  readonly tvCached: number;
+  readonly niggling: number;
+  readonly tdCount: number;
+  readonly casCount: number;
+  readonly compCount: number;
+  readonly mvpCount: number;
+}
+
+interface RosterResponse {
+  readonly team: {
+    readonly id: string;
+    readonly slug: string;
+    readonly city: string;
+    readonly name: string;
+    readonly race: string;
+  };
+  readonly counts: {
+    readonly total: number;
+    readonly active: number;
+    readonly injured: number;
+    readonly dead: number;
+    readonly retired: number;
+  };
+  readonly players: readonly RosterPlayer[];
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  active: "bg-green-100 text-green-800",
+  injured: "bg-yellow-100 text-yellow-800",
+  dead: "bg-red-100 text-red-800",
+  retired: "bg-gray-100 text-gray-700",
+};
+
+async function fetchJSON(path: string, options?: RequestInit) {
+  const token = localStorage.getItem("auth_token");
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Authorization: token ? `Bearer ${token}` : "",
+      "Content-Type": "application/json",
+    },
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(json?.error || `Erreur ${res.status}`);
+  }
+  return json;
+}
+
+export default function AdminProLeagueTeamRosterPage() {
+  const params = useParams<{ id: string }>();
+  const teamId = params?.id;
+
+  const [data, setData] = useState<RosterResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!teamId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = (await fetchJSON(
+        `/admin/pro-league/teams/${teamId}/roster`,
+      )) as RosterResponse;
+      setData(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleReplenish = async () => {
+    if (!teamId) return;
+    if (!confirm("Combler les manques jusqu'a 12 joueurs actifs ?")) return;
+    setActionLoading("replenish");
+    setActionMessage(null);
+    setError(null);
+    try {
+      const res = await fetchJSON(
+        `/admin/pro-league/teams/${teamId}/roster/replenish`,
+        { method: "POST", body: JSON.stringify({ targetSize: 12 }) },
+      );
+      setActionMessage(
+        `Replenish OK : ${res.created} rookie(s) ajoute(s) (${res.activeBefore} → ${res.targetSize}).`,
+      );
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleRegenerate = async () => {
+    if (!teamId) return;
+    if (
+      !confirm(
+        "DESTRUCTIF : wipe complet du roster + re-seed 12 rookies. Confirmer ?",
+      )
+    ) {
+      return;
+    }
+    setActionLoading("regenerate");
+    setActionMessage(null);
+    setError(null);
+    try {
+      const res = await fetchJSON(
+        `/admin/pro-league/teams/${teamId}/roster/regenerate`,
+        { method: "POST", body: JSON.stringify({ count: 12 }) },
+      );
+      setActionMessage(
+        `Roster regenere : ${res.deleted} joueur(s) supprime(s), ${res.created} cree(s).`,
+      );
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleRetire = async (playerId: string, playerName: string) => {
+    if (!confirm(`Retirer ${playerName} (status → retired) ?`)) return;
+    setActionLoading(`retire:${playerId}`);
+    setActionMessage(null);
+    setError(null);
+    try {
+      await fetchJSON(`/admin/pro-league/rosters/${playerId}/retire`, {
+        method: "POST",
+      });
+      setActionMessage(`${playerName} retire.`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="text-sm text-gray-500" data-testid="roster-loading">
+        Chargement…
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="space-y-4">
+        <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-800">
+          {error}
+        </div>
+        <Link
+          href={"/admin/pro-league/teams" as any}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Liste teams
+        </Link>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { team, counts, players } = data;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite">
+          👥 Roster — {team.city} {team.name}
+        </h1>
+        <div className="flex gap-3 text-sm">
+          <Link
+            href={`/admin/pro-league/teams/${team.id}` as any}
+            className="text-blue-700 hover:underline"
+          >
+            Branding
+          </Link>
+          <Link
+            href={"/admin/pro-league/teams" as any}
+            className="text-blue-700 hover:underline"
+          >
+            ← Liste teams
+          </Link>
+        </div>
+      </div>
+
+      <div
+        className="grid grid-cols-2 md:grid-cols-5 gap-3"
+        data-testid="roster-counts"
+      >
+        <div className="p-3 rounded-lg bg-white border border-gray-200">
+          <div className="text-xs text-gray-500">Total</div>
+          <div className="text-2xl font-bold">{counts.total}</div>
+        </div>
+        <div className="p-3 rounded-lg bg-green-50 border border-green-200">
+          <div className="text-xs text-green-700">Active</div>
+          <div className="text-2xl font-bold text-green-800">
+            {counts.active}
+          </div>
+        </div>
+        <div className="p-3 rounded-lg bg-yellow-50 border border-yellow-200">
+          <div className="text-xs text-yellow-700">Injured</div>
+          <div className="text-2xl font-bold text-yellow-800">
+            {counts.injured}
+          </div>
+        </div>
+        <div className="p-3 rounded-lg bg-red-50 border border-red-200">
+          <div className="text-xs text-red-700">Dead</div>
+          <div className="text-2xl font-bold text-red-800">{counts.dead}</div>
+        </div>
+        <div className="p-3 rounded-lg bg-gray-50 border border-gray-200">
+          <div className="text-xs text-gray-600">Retired</div>
+          <div className="text-2xl font-bold text-gray-700">
+            {counts.retired}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleReplenish}
+          disabled={actionLoading !== null}
+          className="px-4 py-2 rounded bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 disabled:opacity-50"
+          data-testid="btn-replenish"
+        >
+          {actionLoading === "replenish"
+            ? "Replenish…"
+            : "Replenish (combler manques)"}
+        </button>
+        <button
+          type="button"
+          onClick={handleRegenerate}
+          disabled={actionLoading !== null}
+          className="px-4 py-2 rounded bg-red-600 text-white text-sm font-semibold hover:bg-red-700 disabled:opacity-50"
+          data-testid="btn-regenerate"
+        >
+          {actionLoading === "regenerate"
+            ? "Regeneration…"
+            : "⚠️ Regenerate (DESTRUCTIF)"}
+        </button>
+      </div>
+
+      {actionMessage && (
+        <div
+          className="p-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-800"
+          data-testid="action-message"
+        >
+          {actionMessage}
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-800"
+          data-testid="action-error"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border bg-white border-gray-200">
+        <table
+          className="min-w-full text-sm"
+          data-testid="roster-table"
+        >
+          <thead className="bg-gray-50 text-xs uppercase text-gray-600">
+            <tr>
+              <th className="px-3 py-2 text-left">Nom</th>
+              <th className="px-3 py-2 text-left">Position</th>
+              <th className="px-3 py-2 text-left">Status</th>
+              <th className="px-3 py-2 text-right">MA/ST/AG/PA/AV</th>
+              <th className="px-3 py-2 text-right">Lvl</th>
+              <th className="px-3 py-2 text-right">SPP</th>
+              <th className="px-3 py-2 text-right">TV</th>
+              <th className="px-3 py-2 text-right">TD/CAS/MVP</th>
+              <th className="px-3 py-2 text-left">Skills</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((p) => (
+              <tr
+                key={p.id}
+                className="border-t border-gray-100 hover:bg-gray-50"
+                data-testid={`roster-row-${p.id}`}
+              >
+                <td className="px-3 py-2 font-medium">{p.name}</td>
+                <td className="px-3 py-2">{p.position}</td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`text-[10px] font-semibold px-2 py-0.5 rounded-full ${STATUS_BADGE[p.status] ?? "bg-gray-100 text-gray-700"}`}
+                  >
+                    {p.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs">
+                  {p.ma}/{p.st}/{p.ag}/{p.pa ?? "-"}/{p.av}
+                </td>
+                <td className="px-3 py-2 text-right">{p.level}</td>
+                <td className="px-3 py-2 text-right">{p.spp}</td>
+                <td className="px-3 py-2 text-right">
+                  {(p.tvCached / 1000).toFixed(0)}k
+                </td>
+                <td className="px-3 py-2 text-right text-xs text-gray-600">
+                  {p.tdCount}/{p.casCount}/{p.mvpCount}
+                </td>
+                <td className="px-3 py-2 text-xs text-gray-600">
+                  {p.skills.length ? p.skills.join(", ") : "—"}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {p.status !== "retired" && p.status !== "dead" && (
+                    <button
+                      type="button"
+                      onClick={() => handleRetire(p.id, p.name)}
+                      disabled={actionLoading !== null}
+                      className="text-xs text-red-600 hover:underline disabled:opacity-50"
+                      data-testid={`btn-retire-${p.id}`}
+                    >
+                      Retire
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {players.length === 0 && (
+              <tr>
+                <td
+                  colSpan={10}
+                  className="px-3 py-6 text-center text-sm text-gray-500"
+                >
+                  Aucun joueur dans le roster.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Ajoute la gestion admin des rosters `ProTeamRoster` :
- **API** : 4 endpoints (liste, replenish non destructif, regenerate destructif, retire joueur)
- **Service** `pro-roster-admin` : `regenerateRoster()` (wipe + re-seed) et `retirePlayer()` (idempotent), avec `RosterAdminError` typee
- **UI** `/admin/pro-league/teams/[id]/roster` : counters + boutons actions + table joueurs

## Endpoints

| Method | Path | Description | Audit |
|---|---|---|---|
| GET | `/admin/pro-league/teams/:id/roster` | Liste joueurs (tous statuts) + counters | — |
| POST | `/admin/pro-league/teams/:id/roster/replenish` | Combler manques jusqu'a 12 actives | `pro-roster.replenish` |
| POST | `/admin/pro-league/teams/:id/roster/regenerate` | DESTRUCTIF : wipe + re-seed N | `pro-roster.regenerate` |
| POST | `/admin/pro-league/rosters/:playerId/retire` | Set status=retired | `pro-roster.retire` |

## UX (page roster)

- Counters par status (active / injured / dead / retired)
- Bouton **Replenish** (bleu) — ajoute des rookies pour atteindre 12 actives
- Bouton **Regenerate** (rouge) — DESTRUCTIF, confirm dialog explicite
- Table joueurs : nom, position, status badge, stats `MA/ST/AG/PA/AV`, level, SPP, TV, TD/CAS/MVP, skills, action retire
- Bouton retire cache si joueur deja `dead` ou `retired`
- Lien navigation depuis la page edit branding

## Pattern : reuse vs nouveaux services

`replenishTeamRoster` (existant, idempotent) est reuse tel quel. `regenerateRoster` (nouveau) wrappe `seedTeamRoster` apres un `deleteMany`. La separation `pro-roster-generator` (logique partagee) vs `pro-roster-admin` (actions destructives admin-only) reflete le pattern intent : seules les routes admin doivent appeler le module destructif.

## Test plan

- [x] Tests unit service (9 — regenerate validation, wipe+seed, retire idempotent)
- [x] Tests integration route (15 — GET roster, POST replenish/regenerate/retire, audit, validation, mapping erreurs)
- [x] Tests UI page (9 — affichage, actions, confirm, erreurs, empty)
- [x] Type-check server + web : OK
- [x] Test suite complete : server 2372/2372 ✓, web 1051/1051 ✓ (+33 nouveaux)
- [ ] Test manuel prod : creer une saison, regenerer un roster, verifier que les standings ne sont pas casses

## Note

L'edition individuelle stats/skills d'un joueur n'est pas dans ce lot — c'est un scope plus large (cf. roadmap admin Pro League dans le hub).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_