### PR TITLE
feat(pro-league): team head-to-head card + page detail (Sprint Q lot Q.A.3)

### DIFF
--- a/apps/server/src/routes/pro-league-rivalry.test.ts
+++ b/apps/server/src/routes/pro-league-rivalry.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests integration des endpoints rivalry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({ prisma: {} }));
+
+vi.mock("../services/pro-league-rivalry", () => {
+  class TeamNotFoundError extends Error {
+    constructor(slug: string) {
+      super(`ProTeam '${slug}' introuvable`);
+      this.name = "TeamNotFoundError";
+    }
+  }
+  return {
+    TeamNotFoundError,
+    getHeadToHead: vi.fn(),
+    getTopRivals: vi.fn(),
+  };
+});
+
+import express from "express";
+import http from "http";
+import {
+  handleGetTeamRivalries,
+  handleGetHeadToHead,
+} from "./pro-league";
+import {
+  getTopRivals,
+  getHeadToHead,
+  TeamNotFoundError,
+} from "../services/pro-league-rivalry";
+
+const mockedTopRivals = vi.mocked(getTopRivals);
+const mockedHeadToHead = vi.mocked(getHeadToHead);
+
+async function request(
+  method: "GET",
+  path: string,
+): Promise<{ status: number; body: any }> {
+  const app = express();
+  app.use(express.json());
+  app.get("/api/pro-league/teams/:slug/rivalries", handleGetTeamRivalries);
+  app.get(
+    "/api/pro-league/teams/:slug/head-to-head/:opponentSlug",
+    handleGetHeadToHead,
+  );
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("listen failed"));
+        return;
+      }
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path,
+          method,
+          headers: { "Content-Type": "application/json" },
+        },
+        (res) => {
+          let buf = "";
+          res.on("data", (c) => (buf += c));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({
+                status: res.statusCode ?? 0,
+                body: buf ? JSON.parse(buf) : {},
+              });
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+      req.on("error", (e) => {
+        server.close();
+        reject(e);
+      });
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("GET /pro-league/teams/:slug/rivalries", () => {
+  it("retourne la liste des rivaux", async () => {
+    mockedTopRivals.mockResolvedValueOnce([
+      {
+        team: {
+          id: "tB",
+          slug: "team-b",
+          city: "City B",
+          name: "Beasts",
+          race: "Orc",
+          primaryColor: null,
+          secondaryColor: null,
+        },
+        totalMatches: 5,
+        winsFor: 3,
+        winsAgainst: 1,
+        draws: 1,
+        lastMatch: null,
+      },
+    ]);
+
+    const res = await request(
+      "GET",
+      "/api/pro-league/teams/team-a/rivalries",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.rivals).toHaveLength(1);
+    expect(res.body.rivals[0].team.slug).toBe("team-b");
+    expect(res.body.rivals[0].totalMatches).toBe(5);
+    expect(mockedTopRivals).toHaveBeenCalledWith("team-a", 3);
+  });
+
+  it("respecte le query param limit", async () => {
+    mockedTopRivals.mockResolvedValueOnce([]);
+    await request("GET", "/api/pro-league/teams/team-a/rivalries?limit=5");
+    expect(mockedTopRivals).toHaveBeenCalledWith("team-a", 5);
+  });
+
+  it("cap limit a 10", async () => {
+    mockedTopRivals.mockResolvedValueOnce([]);
+    await request("GET", "/api/pro-league/teams/team-a/rivalries?limit=99");
+    expect(mockedTopRivals).toHaveBeenCalledWith("team-a", 10);
+  });
+
+  it("404 si team introuvable", async () => {
+    mockedTopRivals.mockRejectedValueOnce(
+      new TeamNotFoundError("ghost") as any,
+    );
+    const res = await request(
+      "GET",
+      "/api/pro-league/teams/ghost/rivalries",
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /pro-league/teams/:slug/head-to-head/:opponentSlug", () => {
+  it("retourne le summary", async () => {
+    mockedHeadToHead.mockResolvedValueOnce({
+      teamA: {
+        id: "tA",
+        slug: "team-a",
+        city: "X",
+        name: "Y",
+        race: "Z",
+        primaryColor: null,
+        secondaryColor: null,
+      },
+      teamB: {
+        id: "tB",
+        slug: "team-b",
+        city: "X",
+        name: "Y",
+        race: "Z",
+        primaryColor: null,
+        secondaryColor: null,
+      },
+      record: {
+        totalMatches: 3,
+        winsA: 1,
+        winsB: 1,
+        draws: 1,
+        totalTdA: 5,
+        totalTdB: 4,
+      },
+      lastMatch: null,
+      streakA: { kind: "win", length: 1 },
+      recentMatches: [],
+    });
+
+    const res = await request(
+      "GET",
+      "/api/pro-league/teams/team-a/head-to-head/team-b",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary.record.winsA).toBe(1);
+    expect(mockedHeadToHead).toHaveBeenCalledWith("team-a", "team-b");
+  });
+
+  it("400 si meme slug", async () => {
+    const res = await request(
+      "GET",
+      "/api/pro-league/teams/team-a/head-to-head/team-a",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("same-team");
+    expect(mockedHeadToHead).not.toHaveBeenCalled();
+  });
+
+  it("404 si une team introuvable", async () => {
+    mockedHeadToHead.mockRejectedValueOnce(
+      new TeamNotFoundError("ghost") as any,
+    );
+    const res = await request(
+      "GET",
+      "/api/pro-league/teams/team-a/head-to-head/ghost",
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -102,6 +102,11 @@ import {
   getProTeamDetail,
 } from "../services/pro-league-team";
 import {
+  TeamNotFoundError as RivalryTeamNotFoundError,
+  getHeadToHead,
+  getTopRivals,
+} from "../services/pro-league-rivalry";
+import {
   ProPlayerNotFoundError,
   getProPlayerDetail,
 } from "../services/pro-player-detail";
@@ -322,6 +327,71 @@ export async function handleGetTeamDetail(
     }
     const msg = err instanceof Error ? err.message : "unknown";
     serverLog.error(`[pro-league/teams/${slug}] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint Q lot Q.A.3 — Top rivaux d'une team (par totalMatches desc).
+ * Limit par defaut = 3, max = 10.
+ */
+export async function handleGetTeamRivalries(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const slug = req.params.slug;
+  if (!slug || typeof slug !== "string") {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  const limitRaw = req.query.limit;
+  let limit = 3;
+  if (typeof limitRaw === "string" && /^\d+$/.test(limitRaw)) {
+    limit = Math.min(10, Math.max(1, Number.parseInt(limitRaw, 10)));
+  }
+  try {
+    const rivals = await getTopRivals(slug, limit);
+    res.json({ rivals });
+  } catch (err: unknown) {
+    if (err instanceof RivalryTeamNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(`[pro-league/teams/${slug}/rivalries] failed: ${msg}`);
+    res.status(500).json({ error: "internal-error" });
+  }
+}
+
+/**
+ * Sprint Q lot Q.A.3 — Detail head-to-head entre 2 teams.
+ */
+export async function handleGetHeadToHead(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const slug = req.params.slug;
+  const opponentSlug = req.params.opponentSlug;
+  if (!slug || !opponentSlug) {
+    res.status(400).json({ error: "missing-slug" });
+    return;
+  }
+  if (slug === opponentSlug) {
+    res.status(400).json({ error: "same-team" });
+    return;
+  }
+  try {
+    const summary = await getHeadToHead(slug, opponentSlug);
+    res.json({ summary });
+  } catch (err: unknown) {
+    if (err instanceof RivalryTeamNotFoundError) {
+      res.status(404).json({ error: err.message });
+      return;
+    }
+    const msg = err instanceof Error ? err.message : "unknown";
+    serverLog.error(
+      `[pro-league/teams/${slug}/head-to-head/${opponentSlug}] failed: ${msg}`,
+    );
     res.status(500).json({ error: "internal-error" });
   }
 }
@@ -1018,6 +1088,8 @@ const router = Router();
 router.get("/seasons/current", handleGetCurrentSeasonHub);
 router.get("/seasons/current/standings", handleGetCurrentSeasonStandings);
 router.get("/teams/:slug", handleGetTeamDetail);
+router.get("/teams/:slug/rivalries", handleGetTeamRivalries);
+router.get("/teams/:slug/head-to-head/:opponentSlug", handleGetHeadToHead);
 router.get("/players/:id", handleGetPlayerDetail);
 router.get("/players/:id/history", handleGetPlayerHistory);
 router.get("/players/:id/career", handleGetPlayerCareer);

--- a/apps/server/src/services/pro-league-rivalry.test.ts
+++ b/apps/server/src/services/pro-league-rivalry.test.ts
@@ -1,0 +1,570 @@
+/**
+ * Tests unitaires du service pro-league-rivalry.
+ *
+ * Couvre :
+ *  - Helpers purs (computeRecord, computeRivalryStreak)
+ *  - getHeadToHead avec mock prisma (avec/sans matchs, 404 team)
+ *  - getTopRivals avec mock prisma (tri par totalMatches desc)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    proTeam: { findUnique: vi.fn(), findMany: vi.fn() },
+    proLeagueMatch: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  TeamNotFoundError,
+  computeRecord,
+  computeRivalryStreak,
+  getHeadToHead,
+  getTopRivals,
+  HEAD_TO_HEAD_RECENT_CAP,
+} from "./pro-league-rivalry";
+
+const mockedPrisma = prisma as unknown as {
+  proTeam: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  proLeagueMatch: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const teamABrief = {
+  id: "tA",
+  slug: "team-a",
+  city: "City A",
+  name: "Athletics",
+  race: "Orc",
+  primaryColor: "#000",
+  secondaryColor: "#fff",
+};
+const teamBBrief = {
+  id: "tB",
+  slug: "team-b",
+  city: "City B",
+  name: "Beasts",
+  race: "Wood Elf",
+  primaryColor: "#0f0",
+  secondaryColor: "#00f",
+};
+
+function fakeMatch(
+  partial: Partial<{
+    matchId: string;
+    homeTeamId: string;
+    awayTeamId: string;
+    scoreHome: number | null;
+    scoreAway: number | null;
+    outcome: "home" | "away" | "draw" | null;
+    seasonYear: number | null;
+    scheduledAt: string | null;
+  }>,
+) {
+  return {
+    matchId: partial.matchId ?? "m1",
+    homeTeamId: partial.homeTeamId ?? "tA",
+    awayTeamId: partial.awayTeamId ?? "tB",
+    scoreHome: partial.scoreHome ?? 0,
+    scoreAway: partial.scoreAway ?? 0,
+    outcome: partial.outcome ?? null,
+    seasonYear: partial.seasonYear ?? null,
+    scheduledAt: partial.scheduledAt ?? null,
+  };
+}
+
+describe("computeRecord", () => {
+  it("retourne 0 pour aucun match", () => {
+    expect(computeRecord("tA", [])).toEqual({
+      totalMatches: 0,
+      winsA: 0,
+      winsB: 0,
+      draws: 0,
+      totalTdA: 0,
+      totalTdB: 0,
+    });
+  });
+
+  it("compte teamA home win + total TD", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+      }),
+    ];
+    const record = computeRecord("tA", matches);
+    expect(record).toEqual({
+      totalMatches: 1,
+      winsA: 1,
+      winsB: 0,
+      draws: 0,
+      totalTdA: 3,
+      totalTdB: 1,
+    });
+  });
+
+  it("compte teamA away win", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tB",
+        awayTeamId: "tA",
+        scoreHome: 0,
+        scoreAway: 2,
+        outcome: "away",
+      }),
+    ];
+    expect(computeRecord("tA", matches)).toMatchObject({
+      winsA: 1,
+      winsB: 0,
+      totalTdA: 2,
+      totalTdB: 0,
+    });
+  });
+
+  it("compte loss home pour teamA", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 1,
+        scoreAway: 3,
+        outcome: "away",
+      }),
+    ];
+    expect(computeRecord("tA", matches)).toMatchObject({
+      winsA: 0,
+      winsB: 1,
+      totalTdA: 1,
+      totalTdB: 3,
+    });
+  });
+
+  it("compte draws", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+      }),
+    ];
+    expect(computeRecord("tA", matches)).toMatchObject({
+      winsA: 0,
+      winsB: 0,
+      draws: 1,
+    });
+  });
+
+  it("ignore les matches sans outcome", () => {
+    const matches = [
+      fakeMatch({ outcome: null, scoreHome: 5, scoreAway: 5 }),
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 1,
+        scoreAway: 0,
+        outcome: "home",
+      }),
+    ];
+    const r = computeRecord("tA", matches);
+    expect(r.totalMatches).toBe(1);
+    expect(r.totalTdA).toBe(1);
+  });
+
+  it("agrege plusieurs matches", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+      }),
+      fakeMatch({
+        homeTeamId: "tB",
+        awayTeamId: "tA",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+      }),
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 2,
+        scoreAway: 2,
+        outcome: "draw",
+      }),
+    ];
+    const r = computeRecord("tA", matches);
+    expect(r).toEqual({
+      totalMatches: 3,
+      winsA: 1,
+      winsB: 1,
+      draws: 1,
+      totalTdA: 2 + 1 + 2,
+      totalTdB: 1 + 3 + 2,
+    });
+  });
+});
+
+describe("computeRivalryStreak", () => {
+  it("none/0 si vide", () => {
+    expect(computeRivalryStreak("tA", [])).toEqual({
+      kind: "none",
+      length: 0,
+    });
+  });
+
+  it("none si tous matches null outcome", () => {
+    expect(
+      computeRivalryStreak("tA", [
+        fakeMatch({ outcome: null }),
+        fakeMatch({ outcome: null }),
+      ]),
+    ).toEqual({ kind: "none", length: 0 });
+  });
+
+  it("compte le streak de wins consecutifs depuis le plus recent", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+      }),
+      fakeMatch({
+        homeTeamId: "tB",
+        awayTeamId: "tA",
+        scoreHome: 0,
+        scoreAway: 2,
+        outcome: "away",
+      }),
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 1,
+        scoreAway: 2,
+        outcome: "away",
+      }),
+    ];
+    expect(computeRivalryStreak("tA", matches)).toEqual({
+      kind: "win",
+      length: 2,
+    });
+  });
+
+  it("stop au premier changement", () => {
+    const matches = [
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 1,
+        scoreAway: 2,
+        outcome: "away",
+      }),
+      fakeMatch({
+        homeTeamId: "tA",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+      }),
+    ];
+    expect(computeRivalryStreak("tA", matches)).toEqual({
+      kind: "loss",
+      length: 1,
+    });
+  });
+});
+
+describe("getHeadToHead", () => {
+  it("404 si teamA introuvable", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(teamBBrief);
+    await expect(getHeadToHead("ghost", "team-b")).rejects.toBeInstanceOf(
+      TeamNotFoundError,
+    );
+  });
+
+  it("404 si teamB introuvable", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce(teamABrief)
+      .mockResolvedValueOnce(null);
+    await expect(getHeadToHead("team-a", "ghost")).rejects.toBeInstanceOf(
+      TeamNotFoundError,
+    );
+  });
+
+  it("retourne summary vide quand 0 match", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce(teamABrief)
+      .mockResolvedValueOnce(teamBBrief);
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+
+    const summary = await getHeadToHead("team-a", "team-b");
+
+    expect(summary.record.totalMatches).toBe(0);
+    expect(summary.lastMatch).toBeNull();
+    expect(summary.recentMatches).toEqual([]);
+    expect(summary.streakA.kind).toBe("none");
+  });
+
+  it("agrege correctement 3 matches", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce(teamABrief)
+      .mockResolvedValueOnce(teamBBrief);
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m-recent",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-05-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 3,
+        scoreAway: 1,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m-older",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-04-01"),
+        homeTeamId: "tB",
+        awayTeamId: "tA",
+        scoreHome: 2,
+        scoreAway: 0,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m-oldest",
+        seasonId: "s0",
+        scheduledAt: new Date("2025-12-01"),
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+        season: { year: 2025 },
+      },
+    ]);
+
+    const summary = await getHeadToHead("team-a", "team-b");
+
+    expect(summary.teamA.slug).toBe("team-a");
+    expect(summary.teamB.slug).toBe("team-b");
+    expect(summary.record).toEqual({
+      totalMatches: 3,
+      winsA: 1,
+      winsB: 1,
+      draws: 1,
+      totalTdA: 3 + 0 + 1,
+      totalTdB: 1 + 2 + 1,
+    });
+    expect(summary.lastMatch?.matchId).toBe("m-recent");
+    expect(summary.streakA.kind).toBe("win"); // m-recent etait une victoire
+    expect(summary.streakA.length).toBe(1); // m-older = loss
+  });
+
+  it("cap recentMatches a HEAD_TO_HEAD_RECENT_CAP", async () => {
+    mockedPrisma.proTeam.findUnique
+      .mockResolvedValueOnce(teamABrief)
+      .mockResolvedValueOnce(teamBBrief);
+    const manyMatches = Array.from({ length: 30 }, (_, i) => ({
+      id: `m${i}`,
+      seasonId: "s1",
+      scheduledAt: new Date(`2026-01-${String(i + 1).padStart(2, "0")}`),
+      homeTeamId: "tA",
+      awayTeamId: "tB",
+      scoreHome: 1,
+      scoreAway: 0,
+      outcome: "home",
+      season: { year: 2026 },
+    }));
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce(manyMatches);
+
+    const summary = await getHeadToHead("team-a", "team-b");
+
+    expect(summary.record.totalMatches).toBe(30);
+    expect(summary.recentMatches).toHaveLength(HEAD_TO_HEAD_RECENT_CAP);
+  });
+});
+
+describe("getTopRivals", () => {
+  it("retourne [] si limit < 1", async () => {
+    expect(await getTopRivals("team-a", 0)).toEqual([]);
+  });
+
+  it("404 si team introuvable", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(null);
+    await expect(getTopRivals("ghost", 3)).rejects.toBeInstanceOf(
+      TeamNotFoundError,
+    );
+  });
+
+  it("retourne [] si pas de matchs", async () => {
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamABrief);
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([]);
+    expect(await getTopRivals("team-a", 3)).toEqual([]);
+  });
+
+  it("regroupe par opponent et trie par totalMatches desc", async () => {
+    const tC = {
+      id: "tC",
+      slug: "team-c",
+      city: "City C",
+      name: "Crushers",
+      race: "Dwarf",
+      primaryColor: null,
+      secondaryColor: null,
+    };
+    const tD = {
+      id: "tD",
+      slug: "team-d",
+      city: "City D",
+      name: "Devils",
+      race: "Chaos",
+      primaryColor: null,
+      secondaryColor: null,
+    };
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamABrief);
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([
+      // vs tB : 3 matches (la rival #1)
+      {
+        id: "m1",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-05-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 2,
+        scoreAway: 1,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m2",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-04-10"),
+        homeTeamId: "tB",
+        awayTeamId: "tA",
+        scoreHome: 1,
+        scoreAway: 0,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m3",
+        seasonId: "s0",
+        scheduledAt: new Date("2025-12-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 1,
+        scoreAway: 1,
+        outcome: "draw",
+        season: { year: 2025 },
+      },
+      // vs tC : 2 matches
+      {
+        id: "m4",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-03-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tC",
+        scoreHome: 3,
+        scoreAway: 2,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m5",
+        seasonId: "s0",
+        scheduledAt: new Date("2025-11-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tC",
+        scoreHome: 0,
+        scoreAway: 1,
+        outcome: "away",
+        season: { year: 2025 },
+      },
+      // vs tD : 1 match
+      {
+        id: "m6",
+        seasonId: "s0",
+        scheduledAt: new Date("2025-10-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tD",
+        scoreHome: 1,
+        scoreAway: 0,
+        outcome: "home",
+        season: { year: 2025 },
+      },
+    ]);
+    mockedPrisma.proTeam.findMany.mockResolvedValueOnce([
+      teamBBrief,
+      tC,
+      tD,
+    ]);
+
+    const rivals = await getTopRivals("team-a", 2);
+
+    expect(rivals).toHaveLength(2);
+    expect(rivals[0].team.slug).toBe("team-b");
+    expect(rivals[0].totalMatches).toBe(3);
+    expect(rivals[0].winsFor).toBe(1);
+    expect(rivals[0].winsAgainst).toBe(1);
+    expect(rivals[0].draws).toBe(1);
+    expect(rivals[1].team.slug).toBe("team-c");
+    expect(rivals[1].totalMatches).toBe(2);
+  });
+
+  it("tie-break par slug asc quand egalite totalMatches", async () => {
+    const tC = {
+      id: "tC",
+      slug: "alpha-team",
+      city: "X",
+      name: "Y",
+      race: "Z",
+      primaryColor: null,
+      secondaryColor: null,
+    };
+    mockedPrisma.proTeam.findUnique.mockResolvedValueOnce(teamABrief);
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValueOnce([
+      {
+        id: "m1",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-05-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tB",
+        scoreHome: 1,
+        scoreAway: 0,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+      {
+        id: "m2",
+        seasonId: "s1",
+        scheduledAt: new Date("2026-04-10"),
+        homeTeamId: "tA",
+        awayTeamId: "tC",
+        scoreHome: 1,
+        scoreAway: 0,
+        outcome: "home",
+        season: { year: 2026 },
+      },
+    ]);
+    mockedPrisma.proTeam.findMany.mockResolvedValueOnce([teamBBrief, tC]);
+
+    const rivals = await getTopRivals("team-a", 3);
+
+    // egalite 1 match chacun → tri par slug asc → "alpha-team" devant "team-b"
+    expect(rivals[0].team.slug).toBe("alpha-team");
+    expect(rivals[1].team.slug).toBe("team-b");
+  });
+});

--- a/apps/server/src/services/pro-league-rivalry.ts
+++ b/apps/server/src/services/pro-league-rivalry.ts
@@ -1,0 +1,364 @@
+/**
+ * Sprint Q lot Q.A.3 — Service rivalry head-to-head pour Pro League.
+ *
+ * Calcule les statistiques de rivalite entre 2 teams (W-D-L bilan,
+ * total TDs, dernier match) et les top rivaux d'une team (les N teams
+ * les plus affrontees en matches completed, avec leur bilan).
+ *
+ * Logique 100% derived de `ProLeagueMatch` : aucune table dediee, on
+ * agrege les matchs `completed` avec `outcome != null`.
+ */
+
+import { prisma } from "../prisma";
+
+export class TeamNotFoundError extends Error {
+  constructor(teamRef: string) {
+    super(`ProTeam '${teamRef}' introuvable`);
+    this.name = "TeamNotFoundError";
+  }
+}
+
+export interface TeamBrief {
+  readonly id: string;
+  readonly slug: string;
+  readonly city: string;
+  readonly name: string;
+  readonly race: string;
+  readonly primaryColor: string | null;
+  readonly secondaryColor: string | null;
+}
+
+export interface RivalryRecord {
+  /** Nb total de matches completed entre les deux teams. */
+  readonly totalMatches: number;
+  /** Victoires de teamA. */
+  readonly winsA: number;
+  /** Victoires de teamB. */
+  readonly winsB: number;
+  /** Nuls. */
+  readonly draws: number;
+  /** Total TDs marques par teamA (au cumul des head-to-head). */
+  readonly totalTdA: number;
+  /** Total TDs marques par teamB. */
+  readonly totalTdB: number;
+}
+
+export interface MatchBrief {
+  readonly matchId: string;
+  readonly seasonYear: number | null;
+  readonly scheduledAt: string | null;
+  readonly homeTeamId: string;
+  readonly awayTeamId: string;
+  readonly scoreHome: number | null;
+  readonly scoreAway: number | null;
+  readonly outcome: "home" | "away" | "draw" | null;
+}
+
+export interface RivalrySummary {
+  readonly teamA: TeamBrief;
+  readonly teamB: TeamBrief;
+  readonly record: RivalryRecord;
+  /** Match le plus recent (ordonne par scheduledAt desc). */
+  readonly lastMatch: MatchBrief | null;
+  /** Streak de teamA en cours (depuis le match le plus recent). */
+  readonly streakA: {
+    readonly kind: "win" | "loss" | "draw" | "none";
+    readonly length: number;
+  };
+  /** Liste des matchs head-to-head (newest first, cap 20). */
+  readonly recentMatches: readonly MatchBrief[];
+}
+
+export interface TopRivalEntry {
+  readonly team: TeamBrief;
+  readonly totalMatches: number;
+  readonly winsFor: number;
+  readonly winsAgainst: number;
+  readonly draws: number;
+  readonly lastMatch: MatchBrief | null;
+}
+
+const HEAD_TO_HEAD_LIMIT = 20;
+
+interface MatchRow {
+  id: string;
+  seasonId: string;
+  scheduledAt: Date | null;
+  homeTeamId: string;
+  awayTeamId: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: string | null;
+  season: { year: number } | null;
+}
+
+function toMatchBrief(m: MatchRow): MatchBrief {
+  const outcomeRaw = m.outcome;
+  const outcome: "home" | "away" | "draw" | null =
+    outcomeRaw === "home" || outcomeRaw === "away" || outcomeRaw === "draw"
+      ? outcomeRaw
+      : null;
+  return {
+    matchId: m.id,
+    seasonYear: m.season?.year ?? null,
+    scheduledAt:
+      m.scheduledAt instanceof Date
+        ? m.scheduledAt.toISOString()
+        : null,
+    homeTeamId: m.homeTeamId,
+    awayTeamId: m.awayTeamId,
+    scoreHome: m.scoreHome,
+    scoreAway: m.scoreAway,
+    outcome,
+  };
+}
+
+/** Compte W-D-L pour teamA sur une liste de matchs head-to-head. */
+export function computeRecord(
+  teamAId: string,
+  matches: ReadonlyArray<MatchBrief>,
+): RivalryRecord {
+  let winsA = 0;
+  let winsB = 0;
+  let draws = 0;
+  let totalTdA = 0;
+  let totalTdB = 0;
+  for (const m of matches) {
+    if (m.outcome === null) continue;
+    const aIsHome = m.homeTeamId === teamAId;
+    if (m.outcome === "draw") draws += 1;
+    else if (m.outcome === "home") {
+      if (aIsHome) winsA += 1;
+      else winsB += 1;
+    } else {
+      // outcome === "away"
+      if (aIsHome) winsB += 1;
+      else winsA += 1;
+    }
+    const scoreHome = m.scoreHome ?? 0;
+    const scoreAway = m.scoreAway ?? 0;
+    if (aIsHome) {
+      totalTdA += scoreHome;
+      totalTdB += scoreAway;
+    } else {
+      totalTdA += scoreAway;
+      totalTdB += scoreHome;
+    }
+  }
+  return {
+    totalMatches: matches.filter((m) => m.outcome !== null).length,
+    winsA,
+    winsB,
+    draws,
+    totalTdA,
+    totalTdB,
+  };
+}
+
+/** Calcule le streak en cours de teamA depuis les matches ordonnes
+ *  newest first. Voir aussi `computeCurrentStreak` dans pro-player-career-stats. */
+export function computeRivalryStreak(
+  teamAId: string,
+  matchesNewestFirst: ReadonlyArray<MatchBrief>,
+): { kind: "win" | "loss" | "draw" | "none"; length: number } {
+  const settled = matchesNewestFirst.filter((m) => m.outcome !== null);
+  if (settled.length === 0) return { kind: "none", length: 0 };
+
+  function teamAOutcome(m: MatchBrief): "win" | "loss" | "draw" {
+    if (m.outcome === "draw") return "draw";
+    const aIsHome = m.homeTeamId === teamAId;
+    if (m.outcome === "home") return aIsHome ? "win" : "loss";
+    return aIsHome ? "loss" : "win";
+  }
+
+  const first = teamAOutcome(settled[0]);
+  let length = 1;
+  for (let i = 1; i < settled.length; i += 1) {
+    if (teamAOutcome(settled[i]) !== first) break;
+    length += 1;
+  }
+  return { kind: first, length };
+}
+
+async function loadTeamBriefById(teamId: string): Promise<TeamBrief> {
+  const team = (await prisma.proTeam.findUnique({
+    where: { id: teamId },
+    select: {
+      id: true,
+      slug: true,
+      city: true,
+      name: true,
+      race: true,
+      primaryColor: true,
+      secondaryColor: true,
+    },
+  })) as TeamBrief | null;
+  if (!team) {
+    throw new TeamNotFoundError(teamId);
+  }
+  return team;
+}
+
+async function loadTeamBriefBySlug(slug: string): Promise<TeamBrief> {
+  const team = (await prisma.proTeam.findUnique({
+    where: { slug },
+    select: {
+      id: true,
+      slug: true,
+      city: true,
+      name: true,
+      race: true,
+      primaryColor: true,
+      secondaryColor: true,
+    },
+  })) as TeamBrief | null;
+  if (!team) {
+    throw new TeamNotFoundError(slug);
+  }
+  return team;
+}
+
+/**
+ * Charge l'historique complet head-to-head entre deux teams.
+ *
+ * Retourne tous les matchs `completed` ordonnes newest first. Le cap
+ * HEAD_TO_HEAD_LIMIT cap les "recentMatches" exposes en sortie ; le
+ * bilan W-D-L est calcule sur l'ensemble.
+ */
+export async function getHeadToHead(
+  teamASlug: string,
+  teamBSlug: string,
+): Promise<RivalrySummary> {
+  const [teamA, teamB] = await Promise.all([
+    loadTeamBriefBySlug(teamASlug),
+    loadTeamBriefBySlug(teamBSlug),
+  ]);
+
+  const matchesRaw = (await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "completed",
+      OR: [
+        { homeTeamId: teamA.id, awayTeamId: teamB.id },
+        { homeTeamId: teamB.id, awayTeamId: teamA.id },
+      ],
+    },
+    orderBy: { scheduledAt: "desc" },
+    select: {
+      id: true,
+      seasonId: true,
+      scheduledAt: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      season: { select: { year: true } },
+    },
+  })) as MatchRow[];
+
+  const matchesBrief = matchesRaw.map(toMatchBrief);
+  const record = computeRecord(teamA.id, matchesBrief);
+  const streakA = computeRivalryStreak(teamA.id, matchesBrief);
+  const lastMatch = matchesBrief.find((m) => m.outcome !== null) ?? null;
+
+  return {
+    teamA,
+    teamB,
+    record,
+    lastMatch,
+    streakA,
+    recentMatches: matchesBrief.slice(0, HEAD_TO_HEAD_LIMIT),
+  };
+}
+
+/**
+ * Top N teams les plus affrontees par `teamSlug` en matches completed.
+ * Pour chaque rival : bilan W-D-L + lastMatch.
+ *
+ * Ordre : par totalMatches desc, puis par slug asc (tie-break).
+ */
+export async function getTopRivals(
+  teamSlug: string,
+  limit: number = 3,
+): Promise<readonly TopRivalEntry[]> {
+  if (limit < 1) return [];
+  const team = await loadTeamBriefBySlug(teamSlug);
+
+  const matchesRaw = (await prisma.proLeagueMatch.findMany({
+    where: {
+      status: "completed",
+      OR: [{ homeTeamId: team.id }, { awayTeamId: team.id }],
+    },
+    orderBy: { scheduledAt: "desc" },
+    select: {
+      id: true,
+      seasonId: true,
+      scheduledAt: true,
+      homeTeamId: true,
+      awayTeamId: true,
+      scoreHome: true,
+      scoreAway: true,
+      outcome: true,
+      season: { select: { year: true } },
+    },
+  })) as MatchRow[];
+
+  // Regroupe par opponent teamId.
+  const byOpponent = new Map<string, MatchBrief[]>();
+  for (const m of matchesRaw) {
+    if (m.outcome === null) continue;
+    const opponentId =
+      m.homeTeamId === team.id ? m.awayTeamId : m.homeTeamId;
+    if (!byOpponent.has(opponentId)) byOpponent.set(opponentId, []);
+    byOpponent.get(opponentId)!.push(toMatchBrief(m));
+  }
+
+  if (byOpponent.size === 0) return [];
+
+  // Charge les briefs des opponents.
+  const opponentIds = Array.from(byOpponent.keys());
+  const opponentTeams = (await prisma.proTeam.findMany({
+    where: { id: { in: opponentIds } },
+    select: {
+      id: true,
+      slug: true,
+      city: true,
+      name: true,
+      race: true,
+      primaryColor: true,
+      secondaryColor: true,
+    },
+  })) as TeamBrief[];
+  const opponentBriefById = new Map<string, TeamBrief>();
+  for (const o of opponentTeams) {
+    opponentBriefById.set(o.id, o);
+  }
+
+  const entries: TopRivalEntry[] = [];
+  for (const [opponentId, matches] of byOpponent) {
+    const opp = opponentBriefById.get(opponentId);
+    if (!opp) continue; // safety, deleted team
+    const record = computeRecord(team.id, matches);
+    entries.push({
+      team: opp,
+      totalMatches: record.totalMatches,
+      winsFor: record.winsA,
+      winsAgainst: record.winsB,
+      draws: record.draws,
+      lastMatch: matches[0] ?? null,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (b.totalMatches !== a.totalMatches) {
+      return b.totalMatches - a.totalMatches;
+    }
+    return a.team.slug.localeCompare(b.team.slug);
+  });
+
+  return entries.slice(0, limit);
+}
+
+// Marqueur exporte pour les tests / consumers qui veulent expliciter
+// le cap d'expose recentMatches.
+export const HEAD_TO_HEAD_RECENT_CAP = HEAD_TO_HEAD_LIMIT;

--- a/apps/web/app/pro-league/teams/[slug]/_components/TeamRivalriesSection.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/_components/TeamRivalriesSection.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests pour TeamRivalriesSection.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { TeamRivalriesSection } from "./TeamRivalriesSection";
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy-token",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+const rivalFixture = {
+  team: {
+    id: "tB",
+    slug: "team-b",
+    city: "City B",
+    name: "Beasts",
+    race: "Orc",
+    primaryColor: "#0f0",
+    secondaryColor: null,
+  },
+  totalMatches: 3,
+  winsFor: 2,
+  winsAgainst: 1,
+  draws: 0,
+  lastMatch: null,
+};
+
+describe("TeamRivalriesSection", () => {
+  it("loading state initial", () => {
+    global.fetch = vi.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+    render(<TeamRivalriesSection teamSlug="team-a" />);
+    expect(screen.getByTestId("rivalries-loading")).toBeTruthy();
+  });
+
+  it("affiche les rival cards quand non vide", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rivals: [rivalFixture] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<TeamRivalriesSection teamSlug="team-a" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rivalries-section")).toBeTruthy();
+    });
+    expect(screen.getByTestId("rival-card-team-b")).toBeTruthy();
+    expect(screen.getByTestId("rival-record-team-b").textContent).toMatch(
+      /2W/,
+    );
+    expect(screen.getByTestId("rival-record-team-b").textContent).toMatch(
+      /1L/,
+    );
+  });
+
+  it("affiche message empty quand 0 rival", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rivals: [] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<TeamRivalriesSection teamSlug="team-a" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rivalries-empty")).toBeTruthy();
+    });
+  });
+
+  it("affiche erreur si fetch echoue", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Not found" }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<TeamRivalriesSection teamSlug="ghost" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rivalries-error")).toBeTruthy();
+    });
+  });
+
+  it("link vers la page head-to-head", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rivals: [rivalFixture] }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(<TeamRivalriesSection teamSlug="team-a" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rival-link-team-b")).toBeTruthy();
+    });
+    expect(
+      screen.getByTestId("rival-link-team-b").getAttribute("href"),
+    ).toBe("/pro-league/teams/team-a/vs/team-b");
+  });
+});

--- a/apps/web/app/pro-league/teams/[slug]/_components/TeamRivalriesSection.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/_components/TeamRivalriesSection.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * Sprint Q lot Q.A.3 — Section "Rivalries" sur la page team.
+ *
+ * Fetch les top N rivaux d'une team (par defaut 3) et affiche un bilan
+ * compact W-D-L par rival, avec un bouton "Voir l'historique" vers
+ * la page vs.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../../../lib/api-client";
+
+interface TeamBrief {
+  id: string;
+  slug: string;
+  city: string;
+  name: string;
+  race: string;
+  primaryColor: string | null;
+  secondaryColor: string | null;
+}
+
+interface MatchBrief {
+  matchId: string;
+  seasonYear: number | null;
+  scheduledAt: string | null;
+  scoreHome: number | null;
+  scoreAway: number | null;
+}
+
+interface TopRivalEntry {
+  team: TeamBrief;
+  totalMatches: number;
+  winsFor: number;
+  winsAgainst: number;
+  draws: number;
+  lastMatch: MatchBrief | null;
+}
+
+interface RivalriesResponse {
+  rivals: TopRivalEntry[];
+}
+
+interface TeamRivalriesSectionProps {
+  readonly teamSlug: string;
+}
+
+export function TeamRivalriesSection({
+  teamSlug,
+}: TeamRivalriesSectionProps): JSX.Element {
+  const [rivals, setRivals] = useState<TopRivalEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiRequest<RivalriesResponse>(
+      `/pro-league/teams/${encodeURIComponent(teamSlug)}/rivalries`,
+    )
+      .then((d) => {
+        if (!cancelled) setRivals(Array.isArray(d?.rivals) ? d.rivals : []);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "fetch error");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [teamSlug]);
+
+  if (error) {
+    return (
+      <section className="mb-6" data-testid="rivalries-error">
+        <h2 className="mb-2 text-lg font-semibold text-slate-100">
+          Rivalries
+        </h2>
+        <p className="text-sm text-rose-400">{error}</p>
+      </section>
+    );
+  }
+
+  if (rivals === null) {
+    return (
+      <section className="mb-6" data-testid="rivalries-loading">
+        <h2 className="mb-2 text-lg font-semibold text-slate-100">
+          Rivalries
+        </h2>
+        <p className="text-sm text-slate-500">Chargement…</p>
+      </section>
+    );
+  }
+
+  if (rivals.length === 0) {
+    return (
+      <section className="mb-6" data-testid="rivalries-empty">
+        <h2 className="mb-2 text-lg font-semibold text-slate-100">
+          Rivalries
+        </h2>
+        <p className="text-sm text-slate-500">
+          Pas encore de rival — il faut au moins 1 match completed contre
+          une autre equipe.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-6" data-testid="rivalries-section">
+      <h2 className="mb-2 text-lg font-semibold text-slate-100">
+        Rivalries
+      </h2>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {rivals.map((r) => (
+          <RivalCard key={r.team.id} teamSlug={teamSlug} entry={r} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RivalCard({
+  teamSlug,
+  entry,
+}: {
+  teamSlug: string;
+  entry: TopRivalEntry;
+}): JSX.Element {
+  const { team, totalMatches, winsFor, winsAgainst, draws } = entry;
+  return (
+    <article
+      className="rounded-lg border border-slate-800 bg-slate-900 p-3"
+      data-testid={`rival-card-${team.slug}`}
+      style={{
+        borderLeftWidth: "4px",
+        borderLeftColor: team.primaryColor ?? undefined,
+      }}
+    >
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-slate-100">
+            {team.city} {team.name}
+          </div>
+          <div className="text-xs text-slate-500">{team.race}</div>
+        </div>
+        <span className="font-mono text-xs text-slate-400">
+          {totalMatches} match{totalMatches > 1 ? "es" : ""}
+        </span>
+      </div>
+      <div
+        className="my-2 flex items-center gap-2 text-xs"
+        data-testid={`rival-record-${team.slug}`}
+      >
+        <span className="rounded bg-emerald-900/50 px-1.5 py-0.5 font-mono text-emerald-300">
+          {winsFor}W
+        </span>
+        <span className="rounded bg-slate-800 px-1.5 py-0.5 font-mono text-slate-300">
+          {draws}D
+        </span>
+        <span className="rounded bg-rose-900/50 px-1.5 py-0.5 font-mono text-rose-300">
+          {winsAgainst}L
+        </span>
+      </div>
+      <Link
+        href={`/pro-league/teams/${teamSlug}/vs/${team.slug}` as never}
+        className="block text-xs text-amber-300 hover:underline"
+        data-testid={`rival-link-${team.slug}`}
+      >
+        Voir l&apos;historique →
+      </Link>
+    </article>
+  );
+}

--- a/apps/web/app/pro-league/teams/[slug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiRequest } from "../../../lib/api-client";
+import { TeamRivalriesSection } from "./_components/TeamRivalriesSection";
 
 /**
  * Page détail d'une équipe Pro League — sprint Pro League lot 1.C.2.
@@ -902,7 +903,7 @@ export default function ProLeagueTeamPage({
               )}
             </section>
 
-            <section>
+            <section className="mb-6">
               <h2 className="mb-2 text-lg font-semibold text-slate-100">
                 Derniers matchs
               </h2>
@@ -918,6 +919,8 @@ export default function ProLeagueTeamPage({
                 </div>
               )}
             </section>
+
+            <TeamRivalriesSection teamSlug={params.slug} />
           </div>
         </>
       )}

--- a/apps/web/app/pro-league/teams/[slug]/vs/[opponentSlug]/page.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/vs/[opponentSlug]/page.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests pour la page head-to-head.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import HeadToHeadPage from "./page";
+
+const originalFetch = global.fetch;
+
+const teamA = {
+  id: "tA",
+  slug: "team-a",
+  city: "City A",
+  name: "Athletics",
+  race: "Orc",
+  primaryColor: "#000",
+  secondaryColor: null,
+};
+
+const teamB = {
+  id: "tB",
+  slug: "team-b",
+  city: "City B",
+  name: "Beasts",
+  race: "Wood Elf",
+  primaryColor: "#0f0",
+  secondaryColor: null,
+};
+
+const summaryFixture = {
+  teamA,
+  teamB,
+  record: {
+    totalMatches: 4,
+    winsA: 2,
+    winsB: 1,
+    draws: 1,
+    totalTdA: 8,
+    totalTdB: 5,
+  },
+  lastMatch: null,
+  streakA: { kind: "win" as const, length: 2 },
+  recentMatches: [
+    {
+      matchId: "m1",
+      seasonYear: 2026,
+      scheduledAt: null,
+      homeTeamId: "tA",
+      awayTeamId: "tB",
+      scoreHome: 3,
+      scoreAway: 1,
+      outcome: "home" as const,
+    },
+    {
+      matchId: "m2",
+      seasonYear: 2026,
+      scheduledAt: null,
+      homeTeamId: "tB",
+      awayTeamId: "tA",
+      scoreHome: 0,
+      scoreAway: 2,
+      outcome: "away" as const,
+    },
+    {
+      matchId: "m3",
+      seasonYear: 2025,
+      scheduledAt: null,
+      homeTeamId: "tA",
+      awayTeamId: "tB",
+      scoreHome: 1,
+      scoreAway: 1,
+      outcome: "draw" as const,
+    },
+    {
+      matchId: "m4",
+      seasonYear: 2025,
+      scheduledAt: null,
+      homeTeamId: "tA",
+      awayTeamId: "tB",
+      scoreHome: 0,
+      scoreAway: 2,
+      outcome: "away" as const,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => "dummy-token",
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("HeadToHeadPage", () => {
+  it("affiche le header avec record W-D-L", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ summary: summaryFixture }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(
+      <HeadToHeadPage
+        params={{ slug: "team-a", opponentSlug: "team-b" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("h2h-header")).toBeTruthy();
+    });
+    expect(screen.getByTestId("h2h-header").textContent).toMatch(
+      /2 - 1 - 1/,
+    );
+    expect(screen.getByTestId("h2h-team-team-a")).toBeTruthy();
+    expect(screen.getByTestId("h2h-team-team-b")).toBeTruthy();
+  });
+
+  it("affiche TDs cumules et streak", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ summary: summaryFixture }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(
+      <HeadToHeadPage
+        params={{ slug: "team-a", opponentSlug: "team-b" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("h2h-tds")).toBeTruthy();
+    });
+    expect(screen.getByTestId("h2h-tds").textContent).toMatch(/8 - 5/);
+    expect(screen.getByTestId("h2h-streak").textContent).toMatch(/2 wins/);
+  });
+
+  it("affiche la liste des matchs avec badges W/D/L", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ summary: summaryFixture }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(
+      <HeadToHeadPage
+        params={{ slug: "team-a", opponentSlug: "team-b" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("h2h-matches")).toBeTruthy();
+    });
+    // m1 : teamA home, outcome home → W badge
+    const m1 = screen.getByTestId("h2h-match-m1");
+    expect(m1.textContent).toMatch(/W/);
+    // m4 : teamA home, outcome away → L badge
+    const m4 = screen.getByTestId("h2h-match-m4");
+    expect(m4.textContent).toMatch(/L/);
+    // m3 : draw → D badge
+    const m3 = screen.getByTestId("h2h-match-m3");
+    expect(m3.textContent).toMatch(/D/);
+  });
+
+  it("affiche message empty si recentMatches vide", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        summary: {
+          ...summaryFixture,
+          record: {
+            totalMatches: 0,
+            winsA: 0,
+            winsB: 0,
+            draws: 0,
+            totalTdA: 0,
+            totalTdB: 0,
+          },
+          streakA: { kind: "none" as const, length: 0 },
+          recentMatches: [],
+        },
+      }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(
+      <HeadToHeadPage
+        params={{ slug: "team-a", opponentSlug: "team-b" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Aucun match joue/)).toBeTruthy();
+    });
+  });
+
+  it("error state quand fetch echoue", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Team not found" }),
+    } as unknown as Response) as unknown as typeof fetch;
+
+    render(
+      <HeadToHeadPage
+        params={{ slug: "ghost-a", opponentSlug: "team-b" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("h2h-error")).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/app/pro-league/teams/[slug]/vs/[opponentSlug]/page.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/vs/[opponentSlug]/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+/**
+ * Sprint Q lot Q.A.3 — Page detail head-to-head entre 2 teams.
+ *
+ * Affiche :
+ *  - Header avec les 2 teams + W-D-L bilan
+ *  - Streak actuel (perspective teamA)
+ *  - Liste des matchs head-to-head recents (20 max)
+ */
+
+import Link from "next/link";
+import { JSX, useEffect, useState } from "react";
+
+import { apiRequest } from "../../../../../lib/api-client";
+
+interface TeamBrief {
+  id: string;
+  slug: string;
+  city: string;
+  name: string;
+  race: string;
+  primaryColor: string | null;
+  secondaryColor: string | null;
+}
+
+interface MatchBrief {
+  matchId: string;
+  seasonYear: number | null;
+  scheduledAt: string | null;
+  homeTeamId: string;
+  awayTeamId: string;
+  scoreHome: number | null;
+  scoreAway: number | null;
+  outcome: "home" | "away" | "draw" | null;
+}
+
+interface RivalryRecord {
+  totalMatches: number;
+  winsA: number;
+  winsB: number;
+  draws: number;
+  totalTdA: number;
+  totalTdB: number;
+}
+
+interface RivalrySummary {
+  teamA: TeamBrief;
+  teamB: TeamBrief;
+  record: RivalryRecord;
+  lastMatch: MatchBrief | null;
+  streakA: { kind: "win" | "loss" | "draw" | "none"; length: number };
+  recentMatches: MatchBrief[];
+}
+
+interface PageProps {
+  params: { slug: string; opponentSlug: string };
+}
+
+export default function HeadToHeadPage({ params }: PageProps): JSX.Element {
+  const [summary, setSummary] = useState<RivalrySummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    apiRequest<{ summary: RivalrySummary }>(
+      `/pro-league/teams/${encodeURIComponent(params.slug)}/head-to-head/${encodeURIComponent(params.opponentSlug)}`,
+    )
+      .then((d) => {
+        if (!cancelled) setSummary(d.summary);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "fetch error");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.slug, params.opponentSlug]);
+
+  if (loading) {
+    return (
+      <main className="mx-auto min-h-screen max-w-4xl bg-slate-950 p-6 text-slate-100">
+        <BackLink slug={params.slug} />
+        <p className="mt-4 text-sm text-slate-400" data-testid="h2h-loading">
+          Chargement…
+        </p>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="mx-auto min-h-screen max-w-4xl bg-slate-950 p-6 text-slate-100">
+        <BackLink slug={params.slug} />
+        <p
+          className="mt-4 rounded border border-rose-700 bg-rose-950 px-3 py-2 text-sm text-rose-200"
+          data-testid="h2h-error"
+        >
+          {error}
+        </p>
+      </main>
+    );
+  }
+
+  if (!summary) return <></>;
+
+  return (
+    <main className="mx-auto min-h-screen max-w-4xl bg-slate-950 p-6 text-slate-100 space-y-6">
+      <BackLink slug={params.slug} />
+
+      <header
+        className="rounded-xl border border-slate-800 bg-slate-900 p-5"
+        data-testid="h2h-header"
+      >
+        <div className="grid grid-cols-3 items-center gap-3">
+          <TeamHero team={summary.teamA} align="left" />
+          <div className="text-center">
+            <div className="font-mono text-3xl text-amber-300">
+              {summary.record.winsA} - {summary.record.draws} - {summary.record.winsB}
+            </div>
+            <div className="text-xs uppercase text-slate-500">
+              W - D - L
+            </div>
+            <div className="mt-2 text-xs text-slate-400">
+              {summary.record.totalMatches} match
+              {summary.record.totalMatches > 1 ? "es" : ""}
+            </div>
+          </div>
+          <TeamHero team={summary.teamB} align="right" />
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+          <div data-testid="h2h-tds">
+            <span className="text-xs uppercase text-slate-500">
+              TD cumules
+            </span>
+            <div className="font-mono">
+              {summary.record.totalTdA} - {summary.record.totalTdB}
+            </div>
+          </div>
+          <div data-testid="h2h-streak">
+            <span className="text-xs uppercase text-slate-500">
+              Streak {summary.teamA.slug}
+            </span>
+            <div
+              className={`font-mono ${summary.streakA.kind === "win" ? "text-emerald-400" : summary.streakA.kind === "loss" ? "text-rose-400" : "text-slate-300"}`}
+            >
+              {summary.streakA.kind === "none"
+                ? "—"
+                : `${summary.streakA.length} ${summary.streakA.kind}${summary.streakA.length > 1 ? "s" : ""}`}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section
+        className="rounded-lg border border-slate-800 bg-slate-900 p-4"
+        data-testid="h2h-matches"
+      >
+        <h2 className="mb-3 text-sm font-medium uppercase text-slate-400">
+          Derniers matchs ({summary.recentMatches.length})
+        </h2>
+        {summary.recentMatches.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            Aucun match joue entre ces 2 equipes.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {summary.recentMatches.map((m) => (
+              <MatchRow
+                key={m.matchId}
+                match={m}
+                teamAId={summary.teamA.id}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function BackLink({ slug }: { slug: string }): JSX.Element {
+  return (
+    <Link
+      href={`/pro-league/teams/${slug}` as never}
+      className="text-sm text-slate-500 hover:text-slate-300"
+    >
+      ← retour equipe
+    </Link>
+  );
+}
+
+function TeamHero({
+  team,
+  align,
+}: {
+  team: TeamBrief;
+  align: "left" | "right";
+}): JSX.Element {
+  return (
+    <div
+      className={align === "left" ? "text-left" : "text-right"}
+      data-testid={`h2h-team-${team.slug}`}
+    >
+      <div className="text-xs text-slate-500">{team.city}</div>
+      <div className="text-lg font-bold text-slate-100">{team.name}</div>
+      <div className="text-xs text-slate-500">{team.race}</div>
+    </div>
+  );
+}
+
+function MatchRow({
+  match,
+  teamAId,
+}: {
+  match: MatchBrief;
+  teamAId: string;
+}): JSX.Element {
+  const aIsHome = match.homeTeamId === teamAId;
+  const aScore = aIsHome ? match.scoreHome : match.scoreAway;
+  const bScore = aIsHome ? match.scoreAway : match.scoreHome;
+
+  let resultBadge: { label: string; color: string };
+  if (match.outcome === "draw") {
+    resultBadge = { label: "D", color: "bg-slate-700 text-slate-300" };
+  } else if (
+    (match.outcome === "home" && aIsHome) ||
+    (match.outcome === "away" && !aIsHome)
+  ) {
+    resultBadge = {
+      label: "W",
+      color: "bg-emerald-900/60 text-emerald-300",
+    };
+  } else {
+    resultBadge = { label: "L", color: "bg-rose-900/60 text-rose-300" };
+  }
+
+  return (
+    <li
+      className="flex items-center justify-between rounded border border-slate-800 px-2 py-1"
+      data-testid={`h2h-match-${match.matchId}`}
+    >
+      <Link
+        href={`/pro-league/matches/${match.matchId}` as never}
+        className="flex items-center gap-3 text-sm hover:text-amber-300"
+      >
+        <span
+          className={`rounded px-1.5 py-0.5 font-mono text-xs ${resultBadge.color}`}
+        >
+          {resultBadge.label}
+        </span>
+        <span className="font-mono text-slate-200">
+          {aScore ?? "?"} - {bScore ?? "?"}
+        </span>
+        <span className="text-xs text-slate-500">
+          {aIsHome ? "(home)" : "(away)"}
+        </span>
+      </Link>
+      <span className="text-xs text-slate-500">
+        {match.seasonYear ?? "—"}
+      </span>
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary

Q.A.3 — Rivalries inter-teams. Bilan W-D-L historique entre 2 teams + top 3 rivaux d'une team avec lien vers la page detail.

## Service `pro-league-rivalry`

- `getTopRivals(teamSlug, limit=3)` — groupe les matchs `completed` par opponent, tri par `totalMatches` desc, tie-break par slug asc
- `getHeadToHead(teamASlug, teamBSlug)` — bilan complet + streak + 20 derniers matchs
- Helpers purs : `computeRecord` (W-D-L + total TDs cumules), `computeRivalryStreak` (depuis le plus recent)
- `TeamNotFoundError` typee

## Endpoints

| Method | Path | Description |
|---|---|---|
| GET | `/pro-league/teams/:slug/rivalries?limit=N` | Top N rivaux (default 3, cap 10) |
| GET | `/pro-league/teams/:slug/head-to-head/:opponentSlug` | Detail head-to-head |

Mapping 404 si team introuvable, 400 si `slug === opponentSlug`.

## UI

### Section "Rivalries" sur la page team

Composant `TeamRivalriesSection` (auto-fetch sur mount) :
- Grid de 3 cards (limit=3 par defaut)
- Chaque card : ville/nom + race + bilan `W D L` colore (emerald/slate/rose)
- Bouton "Voir l'historique →" vers la page detail vs

### Page `/pro-league/teams/[slug]/vs/[opponentSlug]`

- Header 3 colonnes : teamA · record W-D-L · teamB
- TD cumules + streak teamA colore (win=emerald / loss=rose / draw=slate)
- Liste matchs avec badge **W/D/L** (perspective teamA) + score + season year + lien match

## Test plan

- [x] Tests unit service (21 — helpers purs computeRecord / computeRivalryStreak / getHeadToHead / getTopRivals avec multi-matches, ties, edge cases)
- [x] Tests integration route (7 — happy path, query param limit, 404, 400 same team)
- [x] Tests UI section (5 — loading, empty, error, cards, link)
- [x] Tests UI page detail (5 — header, TDs/streak, match rows W/D/L badges, empty, error)
- [x] Type-check server + web : OK
- [x] Test suite complete : server 2543/2543 ✓ (+28), web 1091/1091 ✓ (+10)

## Hors scope (lots subsequents)

- **Top scorers head-to-head** : necessite scan des replays par player pour extraire les rewards individuels. A reserver a un nouveau lot si pertinent.
- **Casualties causes vs received** entre 2 teams : meme remarque (scan replays).
- **Filter par seasonYear** : pour limiter l'historique aux dernieres N saisons.

## Sprint Q progress

- [x] Q.D.1 — Mini-leagues prediction (#775)
- [x] Q.D.2 — Survivor Pick'em (#776)
- [x] Q.A.1 — Career stats persistees (#777)
- [x] Q.A.2 — Page career dediee (#778)
- [x] Q.A.3 — Team head-to-head card (ce PR)
- [ ] Q.A.4 — Rivalry narrative Gazette
- [ ] Q.B — Vote MVP + commentaires + predictions
- [ ] Q.C — Clips highlights MP4

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_