### PR TITLE
Fix admin navigation and pro-league match URL routing

### DIFF
--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -30,6 +30,10 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
     if (path === "/admin/sim") {
       return pathname === "/admin/sim";
     }
+    // Idem pour /admin/pro-league vs /admin/pro-league/seasons (et /teams).
+    if (path === "/admin/pro-league") {
+      return pathname === "/admin/pro-league";
+    }
     return pathname?.startsWith(path);
   };
 

--- a/apps/web/app/admin/sim/test-match/page.tsx
+++ b/apps/web/app/admin/sim/test-match/page.tsx
@@ -218,7 +218,7 @@ export default function AdminTestMatchPage() {
           Match simulé : <code>{lastResult.matchId}</code> (engineVer{" "}
           {lastResult.engineVer}) ·{" "}
           <Link
-            href={`/pro-league/match/${lastResult.matchId}` as never}
+            href={`/pro-league/matches/${lastResult.matchId}` as never}
             className="underline text-green-700"
           >
             Voir le replay
@@ -264,7 +264,7 @@ export default function AdminTestMatchPage() {
                 </td>
                 <td className="p-2 text-right">
                   <Link
-                    href={`/pro-league/match/${m.id}` as never}
+                    href={`/pro-league/matches/${m.id}` as never}
                     className="text-blue-600 underline"
                   >
                     Replay


### PR DESCRIPTION
## Résumé

- [x] Correction de la navigation admin pour `/admin/pro-league`
- [x] Correction des URLs de redirection vers les replays de matchs

## Description

Cette PR corrige deux problèmes :

1. **Navigation admin** : Ajout d'une logique spéciale pour `/admin/pro-league` (similaire à `/admin/sim`) pour éviter que les sous-routes comme `/admin/pro-league/seasons` et `/admin/pro-league/teams` ne marquent le lien parent comme actif.

2. **URLs de matchs** : Correction des URLs de redirection depuis `/pro-league/match/{id}` vers `/pro-league/matches/{id}` (pluriel) pour correspondre au bon endpoint de visualisation des replays.

## Checklist

- [x] Lint / Types OK
- [x] Tests unitaires : N/A (changements de configuration et URLs)
- [x] Tests e2e : N/A
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01L65e4zkyWW5hR2QDUgN1Ki