### PR TITLE
feat(pro-league): rivalry narrative dans la Gazette (Sprint Q lot Q.A.4)

### DIFF
--- a/apps/server/src/services/pro-gazette-llm.test.ts
+++ b/apps/server/src/services/pro-gazette-llm.test.ts
@@ -94,6 +94,65 @@ describe("buildUserPrompt — sprint 1.E.1", () => {
     expect(prompt).toContain('"score": "4-0"');
     expect(prompt).toContain("MAIN");
   });
+
+  // Q.A.4 — Tests enrichissement rivalry_buildup
+  it("expose les refs de rivalry_buildup au LLM (Q.A.4)", () => {
+    const recapWithRivalry: DailyRecap = {
+      ...RECAP_FIXTURE,
+      storylines: [
+        ...RECAP_FIXTURE.storylines,
+        {
+          type: "rivalry_buildup",
+          weight: 90,
+          refs: {
+            matchId: "m1",
+            home: "buf-snow-ogres",
+            away: "kc-soaring-hawks",
+            priorCount: 3,
+            since: "2026-08-25",
+            suggestedPersona: "statistician",
+            winsHome: 2,
+            winsAway: 0,
+            drawsHistorical: 1,
+            streakKind: "win",
+            streakLength: 2,
+          },
+          summary:
+            "Buffalo et KC : 4e affrontement. Bilan : 2-1-0 pour Buffalo.",
+        },
+      ],
+    };
+    const prompt = buildUserPrompt({
+      recap: recapWithRivalry,
+      date: "2026-05-06",
+    });
+    // Le prompt doit contenir les refs (winsHome/winsAway/streakKind)
+    expect(prompt).toContain("rivalry_buildup");
+    expect(prompt).toContain('"winsHome": 2');
+    expect(prompt).toContain('"streakKind": "win"');
+    expect(prompt).toContain('"suggestedPersona": "statistician"');
+    // Et l'instruction supplementaire pour le statistician
+    expect(prompt).toContain("EDITO 'statistician'");
+  });
+
+  it("n'ajoute pas d'instruction statistician si pas de rivalry_buildup", () => {
+    const prompt = buildUserPrompt({
+      recap: RECAP_FIXTURE,
+      date: "2026-05-06",
+    });
+    expect(prompt).not.toContain("EDITO 'statistician'");
+  });
+
+  it("n'expose pas les refs pour les autres types de storyline", () => {
+    const prompt = buildUserPrompt({
+      recap: RECAP_FIXTURE,
+      date: "2026-05-06",
+    });
+    // RECAP_FIXTURE a un blowout avec refs.matchId mais on ne doit
+    // pas l'exposer (seul rivalry_buildup expose ses refs).
+    expect(prompt).toContain('"summary":');
+    expect(prompt).not.toContain('"matchId": "m1"');
+  });
 });
 
 function expectCode(fn: () => unknown, code: string): void {

--- a/apps/server/src/services/pro-gazette-llm.ts
+++ b/apps/server/src/services/pro-gazette-llm.ts
@@ -113,11 +113,20 @@ export function buildUserPrompt(opts: BuildPromptOptions): string {
   const standingsTop = recap.standings
     .slice(0, 5)
     .map((s) => `#${s.rank} ${s.teamName} (${s.wins}-${s.draws}-${s.losses}, ${s.points} pts)`);
-  const storylines = recap.storylines.map((s) => ({
-    type: s.type,
-    weight: s.weight,
-    summary: s.summary,
-  }));
+  // Q.A.4 — expose les refs complets pour rivalry_buildup afin que
+  // le LLM puisse citer le bilan W-D-L et le streak. Les autres types
+  // n'ont pas besoin des refs (le summary leur suffit).
+  const storylines = recap.storylines.map((s) => {
+    const base: Record<string, unknown> = {
+      type: s.type,
+      weight: s.weight,
+      summary: s.summary,
+    };
+    if (s.type === "rivalry_buildup") {
+      base.refs = s.refs;
+    }
+    return base;
+  });
   const payload = {
     date,
     matchesPlayed: recap.matchesPlayed,
@@ -125,6 +134,17 @@ export function buildUserPrompt(opts: BuildPromptOptions): string {
     standingsTop5: standingsTop,
     storylines,
   };
+
+  // Q.A.4 — instruction supplementaire si une rivalry_buildup est
+  // detectee : le LLM est invite a signer un EDITO statistician sur
+  // l'historique de la rivalite (W-D-L, streak).
+  const hasRivalry = recap.storylines.some(
+    (s) => s.type === "rivalry_buildup",
+  );
+  const rivalryInstruction = hasRivalry
+    ? "\nUne storyline 'rivalry_buildup' est detectee : SIGNE un EDITO 'statistician' sur cette rivalite (cite winsHome/winsAway/draws/streak depuis ses refs)."
+    : "";
+
   return [
     `Genere l'edition Nuffle Gazette pour le ${date}.`,
     "Donnees factuelles (recap aggregator) :",
@@ -132,7 +152,8 @@ export function buildUserPrompt(opts: BuildPromptOptions): string {
     JSON.stringify(payload, null, 2),
     "```",
     "",
-    "Cible : 1 MAIN (story principale, base sur la storyline la plus ponderee), 2 BREVE (storylines secondaires), 1 EDITO (signe par 1 persona).",
+    "Cible : 1 MAIN (story principale, base sur la storyline la plus ponderee), 2 BREVE (storylines secondaires), 1 EDITO (signe par 1 persona)." +
+      rivalryInstruction,
     "Reponds UNIQUEMENT en JSON strict.",
   ].join("\n");
 }

--- a/apps/server/src/services/pro-gazette-recap.test.ts
+++ b/apps/server/src/services/pro-gazette-recap.test.ts
@@ -152,13 +152,43 @@ describe("getDailyRecap — sprint 1.E.3", () => {
       },
     ]);
     mocked.proLeagueSeason.findFirst.mockResolvedValueOnce(null);
-    // Rivalry query : 3 matchs passés entre Buffalo & KC
+    // Rivalry query : 3 matchs passés entre Buffalo & KC (ordre desc).
+    // Q.A.4 : on inclut maintenant homeTeam/awayTeam/outcome.
     mocked.proLeagueMatch.findMany.mockResolvedValue([
-      { completedAt: new Date("2026-08-25T22:00:00Z") },
-      { completedAt: new Date("2026-09-05T22:00:00Z") },
-      { completedAt: new Date("2026-09-15T22:00:00Z") },
+      {
+        completedAt: new Date("2026-09-15T22:00:00Z"),
+        homeTeam: { slug: "buf" },
+        awayTeam: { slug: "kc" },
+        outcome: "home",
+      },
+      {
+        completedAt: new Date("2026-09-05T22:00:00Z"),
+        homeTeam: { slug: "kc" },
+        awayTeam: { slug: "buf" },
+        outcome: "home",
+      },
+      {
+        completedAt: new Date("2026-08-25T22:00:00Z"),
+        homeTeam: { slug: "buf" },
+        awayTeam: { slug: "kc" },
+        outcome: "draw",
+      },
     ]);
     const out = await getDailyRecap(new Date("2026-09-15T00:00:00Z"));
-    expect(out.storylines.some((s) => s.type === "rivalry_buildup")).toBe(true);
+    const rivalry = out.storylines.find(
+      (s) => s.type === "rivalry_buildup",
+    );
+    expect(rivalry).toBeTruthy();
+    // Q.A.4 — verifie les refs enrichis : bilan W-D-L + streak +
+    // suggestedPersona.
+    expect(rivalry?.refs.suggestedPersona).toBe("statistician");
+    // Buffalo (curHome) : m1 = home win (W), m2 = kc home win → buf loss (L),
+    // m3 = draw (D). Donc 1-1-1.
+    expect(rivalry?.refs.winsHome).toBe(1);
+    expect(rivalry?.refs.winsAway).toBe(1);
+    expect(rivalry?.refs.drawsHistorical).toBe(1);
+    // Streak depuis le plus recent : 1 win.
+    expect(rivalry?.refs.streakKind).toBe("win");
+    expect(rivalry?.refs.streakLength).toBe(1);
   });
 });

--- a/apps/server/src/services/pro-gazette-recap.ts
+++ b/apps/server/src/services/pro-gazette-recap.ts
@@ -170,11 +170,20 @@ export async function getDailyRecap(
   }
 
   // Compte les matchups passés sur les 30 derniers jours pour les
-  // pairings de la journée.
+  // pairings de la journée. Q.A.4 — enrichit avec W-D-L + streak
+  // (perspective home du match courant).
   const rivalryFromAt = new Date(at.getTime() - RIVALRY_WINDOW_DAYS * DAY_MS);
   const priorMatchups = new Map<
     string,
-    { count: number; firstAt: string }
+    {
+      count: number;
+      firstAt: string;
+      winsHome: number;
+      winsAway: number;
+      draws: number;
+      streakKind: "win" | "loss" | "draw" | "none";
+      streakLength: number;
+    }
   >();
   for (const m of matches) {
     const key = matchupKey(m.homeTeamSlug, m.awayTeamSlug);
@@ -195,13 +204,64 @@ export async function getDailyRecap(
           },
         ],
       },
-      orderBy: { completedAt: "asc" },
-      select: { completedAt: true },
-    })) as { completedAt: Date | null }[];
+      orderBy: { completedAt: "desc" },
+      select: {
+        completedAt: true,
+        homeTeam: { select: { slug: true } },
+        awayTeam: { select: { slug: true } },
+        outcome: true,
+      },
+    })) as Array<{
+      completedAt: Date | null;
+      homeTeam: { slug: string };
+      awayTeam: { slug: string };
+      outcome: string | null;
+    }>;
     if (past.length > 0) {
+      // Compte W-D-L perspective home du match courant.
+      let winsHome = 0;
+      let winsAway = 0;
+      let draws = 0;
+      function pastResultForCurrentHome(
+        rec: typeof past[number],
+      ): "win" | "loss" | "draw" | null {
+        if (rec.outcome === null) return null;
+        const curHomeWasHome = rec.homeTeam.slug === m.homeTeamSlug;
+        if (rec.outcome === "draw") return "draw";
+        if (rec.outcome === "home") return curHomeWasHome ? "win" : "loss";
+        return curHomeWasHome ? "loss" : "win";
+      }
+      for (const rec of past) {
+        const r = pastResultForCurrentHome(rec);
+        if (r === "win") winsHome += 1;
+        else if (r === "loss") winsAway += 1;
+        else if (r === "draw") draws += 1;
+      }
+      // Streak depuis le plus recent.
+      let streakKind: "win" | "loss" | "draw" | "none" = "none";
+      let streakLength = 0;
+      for (const rec of past) {
+        const r = pastResultForCurrentHome(rec);
+        if (r === null) continue;
+        if (streakLength === 0) {
+          streakKind = r;
+          streakLength = 1;
+        } else if (r === streakKind) {
+          streakLength += 1;
+        } else {
+          break;
+        }
+      }
+      // `past` est order desc → firstAt = dernier element.
+      const firstAt = past[past.length - 1].completedAt as Date;
       priorMatchups.set(key, {
         count: past.length,
-        firstAt: (past[0].completedAt as Date).toISOString(),
+        firstAt: firstAt.toISOString(),
+        winsHome,
+        winsAway,
+        draws,
+        streakKind,
+        streakLength,
       });
     }
   }

--- a/apps/server/src/services/pro-storyline-detector.test.ts
+++ b/apps/server/src/services/pro-storyline-detector.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   type DetectStorylinesInput,
   type MatchSnapshot,
+  type PriorMatchupCounts,
   type StandingEntry,
   detectStorylines,
   matchupKey,
@@ -235,5 +236,144 @@ describe("detectStorylines — sprint 1.E.3", () => {
     );
     expect(out.some((s) => s.type === "blowout")).toBe(true);
     expect(out.some((s) => s.type === "bloodbath")).toBe(true);
+  });
+});
+
+// Q.A.4 — Tests enrichissement rivalry_buildup
+describe("rivalry_buildup enrichi — Q.A.4", () => {
+  it("inclut suggestedPersona statistician dans les refs", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [matchupKey("buf", "kc"), { count: 3, firstAt: "2026-08-25" }],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [
+          match({ homeTeamSlug: "buf", awayTeamSlug: "kc" }),
+        ],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r).toBeTruthy();
+    expect(r?.refs.suggestedPersona).toBe("statistician");
+  });
+
+  it("inclut bilan W-D-L quand fourni", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [
+        matchupKey("buf", "kc"),
+        {
+          count: 3,
+          firstAt: "2026-08-25",
+          winsHome: 2,
+          winsAway: 0,
+          draws: 1,
+        },
+      ],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [
+          match({
+            homeTeamSlug: "buf",
+            homeTeamName: "Buffalo",
+            awayTeamSlug: "kc",
+            awayTeamName: "KC",
+          }),
+        ],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r?.refs.winsHome).toBe(2);
+    expect(r?.refs.winsAway).toBe(0);
+    expect(r?.refs.drawsHistorical).toBe(1);
+    expect(r?.summary).toMatch(/2-1-0/);
+    expect(r?.summary).toMatch(/Buffalo/);
+  });
+
+  it("weight=90 quand streak >= 2 (rivalry qui chauffe)", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [
+        matchupKey("buf", "kc"),
+        {
+          count: 3,
+          firstAt: "2026-08-25",
+          streakKind: "win",
+          streakLength: 2,
+        },
+      ],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ homeTeamSlug: "buf", awayTeamSlug: "kc" })],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r?.weight).toBe(90);
+  });
+
+  it("weight=85 quand streak < 2 (rivalry standard)", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [
+        matchupKey("buf", "kc"),
+        {
+          count: 3,
+          firstAt: "2026-08-25",
+          streakKind: "win",
+          streakLength: 1,
+        },
+      ],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ homeTeamSlug: "buf", awayTeamSlug: "kc" })],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r?.weight).toBe(85);
+  });
+
+  it("inclut streak dans les refs", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [
+        matchupKey("buf", "kc"),
+        {
+          count: 3,
+          firstAt: "2026-08-25",
+          streakKind: "loss",
+          streakLength: 2,
+        },
+      ],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ homeTeamSlug: "buf", awayTeamSlug: "kc" })],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r?.refs.streakKind).toBe("loss");
+    expect(r?.refs.streakLength).toBe(2);
+  });
+
+  it("retro-compat : marche sans W-D-L ni streak (signature pre-Q.A.4)", () => {
+    const matchups = new Map<string, PriorMatchupCounts>([
+      [matchupKey("buf", "kc"), { count: 3, firstAt: "2026-08-25" }],
+    ]);
+    const out = detectStorylines(
+      emptyInput({
+        matches: [match({ homeTeamSlug: "buf", awayTeamSlug: "kc" })],
+        priorMatchups: matchups,
+      }),
+    );
+    const r = out.find((s) => s.type === "rivalry_buildup");
+    expect(r).toBeTruthy();
+    // Pas de winsHome / streakKind si pas fourni
+    expect(r?.refs.winsHome).toBeUndefined();
+    expect(r?.refs.streakKind).toBeUndefined();
+    expect(r?.weight).toBe(85);
   });
 });

--- a/apps/server/src/services/pro-storyline-detector.ts
+++ b/apps/server/src/services/pro-storyline-detector.ts
@@ -71,6 +71,17 @@ export interface PriorMatchupCounts {
   readonly count: number;
   /** Date du plus ancien match du compte, pour aider le LLM. */
   readonly firstAt: string;
+  /** Q.A.4 — Bilan W-D-L de l'historique (perspective home du match
+   *  courant). Optionnel — si absent la storyline n'expose pas le
+   *  bilan dans ses refs. */
+  readonly winsHome?: number;
+  readonly winsAway?: number;
+  readonly draws?: number;
+  /** Q.A.4 — Streak en cours (perspective home du match courant) :
+   *  "win" / "loss" / "draw" / "none". */
+  readonly streakKind?: "win" | "loss" | "draw" | "none";
+  /** Q.A.4 — Longueur du streak (>= 0). */
+  readonly streakLength?: number;
 }
 
 export interface DetectStorylinesInput {
@@ -252,22 +263,55 @@ export function detectStorylines(
       });
     }
 
-    // rivalry_buildup
+    // rivalry_buildup (Q.A.4 enrichi avec W-D-L + streak)
     if (input.priorMatchups) {
       const key = matchupKey(m.homeTeamSlug, m.awayTeamSlug);
       const matchup = input.priorMatchups.get(key);
       if (matchup && matchup.count >= 3) {
+        const refs: Record<string, string | number> = {
+          matchId: m.id,
+          home: m.homeTeamSlug,
+          away: m.awayTeamSlug,
+          homeName: m.homeTeamName,
+          awayName: m.awayTeamName,
+          priorCount: matchup.count,
+          since: matchup.firstAt,
+          // Q.A.4 — la rivalry storyline preconise une persona
+          // "statistician" : le LLM est invite a signer cet article
+          // dans un EDITO chiffre.
+          suggestedPersona: "statistician",
+        };
+        // Optionnels : ajoute uniquement si fourni cote caller.
+        if (
+          matchup.winsHome !== undefined &&
+          matchup.winsAway !== undefined &&
+          matchup.draws !== undefined
+        ) {
+          refs.winsHome = matchup.winsHome;
+          refs.winsAway = matchup.winsAway;
+          refs.drawsHistorical = matchup.draws;
+        }
+        if (matchup.streakKind && matchup.streakLength !== undefined) {
+          refs.streakKind = matchup.streakKind;
+          refs.streakLength = matchup.streakLength;
+        }
+
+        const balance =
+          matchup.winsHome !== undefined &&
+          matchup.winsAway !== undefined &&
+          matchup.draws !== undefined
+            ? ` Bilan : ${matchup.winsHome}-${matchup.draws}-${matchup.winsAway} pour ${m.homeTeamName}.`
+            : "";
+
         out.push({
           type: "rivalry_buildup",
-          weight: 85,
-          refs: {
-            matchId: m.id,
-            home: m.homeTeamSlug,
-            away: m.awayTeamSlug,
-            priorCount: matchup.count,
-            since: matchup.firstAt,
-          },
-          summary: `${m.homeTeamName} et ${m.awayTeamName} : ${matchup.count}e affrontement, la rivalité s'enracine.`,
+          // Weight +5 si on a un streak >= 2 (rivalry "qui chauffe")
+          weight:
+            matchup.streakLength !== undefined && matchup.streakLength >= 2
+              ? 90
+              : 85,
+          refs,
+          summary: `${m.homeTeamName} et ${m.awayTeamName} : ${matchup.count}e affrontement, la rivalité s'enracine.${balance}`,
         });
       }
     }


### PR DESCRIPTION
## Summary

Q.A.4 — Le storyline `rivalry_buildup` (deja detecte par `pro-storyline-detector`) est enrichi pour generer un article Gazette specifique signe par la persona `statistician`.

Final lot du Sprint Q lot **Q.A** (career page + rivalries) — clot la foundation narrative.

## Extensions

### `PriorMatchupCounts`

| Field | Type | Description |
|---|---|---|
| `winsHome` | int? | Wins de la team home (perspective match courant) |
| `winsAway` | int? | Wins de la team away |
| `draws` | int? | Nuls historiques |
| `streakKind` | "win" \| "loss" \| "draw" \| "none"? | Streak en cours perspective home |
| `streakLength` | int? | Longueur du streak |

Tous optionnels → back-compat avec signature pre-Q.A.4.

### Storyline `rivalry_buildup` enrichi

- `refs.suggestedPersona = "statistician"`
- `refs.winsHome`, `winsAway`, `drawsHistorical`, `streakKind`, `streakLength` (si fournis)
- `refs.homeName`, `awayName` (pour le LLM)
- Summary mentionne le bilan : `"Bilan : X-Y-Z pour Buffalo."`
- Weight `85 → 90` si streak >= 2 (rivalry qui chauffe)

### `pro-gazette-recap.ts`

Calcule W-D-L + streak en parsant `homeTeam`/`awayTeam`/`outcome` des matchs passes (perspective home du match courant). Query past matches enrichie avec ces champs.

### `pro-gazette-llm.buildUserPrompt`

- Expose les refs uniquement pour `rivalry_buildup` (autres types : summary suffit)
- Si une `rivalry_buildup` est detectee → instruction explicite ajoutee au prompt :
  > "Une storyline 'rivalry_buildup' est detectee : SIGNE un EDITO 'statistician' sur cette rivalite (cite winsHome/winsAway/draws/streak depuis ses refs)."

## Acceptance criterion (spec Sprint Q)

> "3 matchs Buffalo vs GB en 30j → article auto-publie"

La pipeline existante (`pro-gazette-recap` → `detectStorylines` → LLM) traite ce cas. Avec Q.A.4, le LLM recoit en plus :
1. Bilan W-D-L complet
2. Streak en cours
3. Instruction explicite de signer un EDITO statistician

## Test plan

- [x] Tests unit detector (6 nouveaux — suggestedPersona, W-D-L exposes, weight 90/85 selon streak, retro-compat sans extras)
- [x] Tests unit recap (1 enrichi — bilan W-D-L + streak verifies dans le snapshot)
- [x] Tests unit LLM prompt (3 nouveaux — refs exposes pour rivalry, instruction statistician, autres types pas de refs)
- [x] Type-check server : OK
- [x] Test suite complete : server 2552/2552 ✓ (+9)

## Hors scope (lots subsequents)

- **Top scorers head-to-head** pour enrichir encore plus l'article (necessite scan replays par player)
- **Casualties causees** entre 2 teams a inclure dans la storyline

## Sprint Q progress — Lot Q.A complete

- [x] Q.D.1 — Mini-leagues prediction (#775)
- [x] Q.D.2 — Survivor Pick'em (#776)
- [x] Q.A.1 — Career stats persistees (#777)
- [x] Q.A.2 — Page career dediee (#778)
- [x] Q.A.3 — Team head-to-head card (#779)
- [x] Q.A.4 — Rivalry narrative Gazette (ce PR) ✓ **lot Q.A complete**
- [ ] Q.B — Vote MVP + commentaires + predictions
- [ ] Q.C — Clips highlights MP4

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_