### PR TITLE
docs(session): Sprint Q 9/13 livre + patterns recurrents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,151 @@ la regle BB officielle. Pattern fix :
    `applyApothecaryChoice`.
 3. Pas d'apothecary disponible → regen directe en fallback path.
 
+### Snapshot lazy compute avec staleness window (Q.A.1+Q.A.2)
+Pour un compute couteux (scan replays + attributeSpp), persister un
+modele `Snapshot` 1-1 (`@unique playerId`) avec un timestamp
+`recomputedAt`. Au read, si `Date.now() - recomputedAt >= STALE_WINDOW_MS`
+(ou snapshot inexistant), declenche le recompute synchrone et upsert.
+Pas de cron — l'utilisateur "paye" le recompute en ouvrant la page.
+
+```ts
+const STALE_WINDOW_MS = 60 * 60 * 1000;
+export async function getCareerSnapshot(playerId: string) {
+  const existing = await prisma.proPlayerCareerSnapshot.findUnique({
+    where: { playerId },
+  });
+  const isStale = !existing ||
+    Date.now() - existing.recomputedAt.getTime() >= STALE_WINDOW_MS;
+  if (isStale) return recomputeCareerSnapshot(playerId);
+  return mapToView(existing);
+}
+```
+
+### Hook post-settlement encapsule (Q.D.1, Q.D.2, Q.B.3)
+Quand `settleMarketsForMatch` doit aussi settle d'autres entites
+(picks, survivor entries, fan predictions), chaque call est dans un
+`try/catch` isole pour ne pas faire echouer le bet settlement principal :
+
+```ts
+try {
+  await settlePicksForMatch({ matchId, result: match.outcome as PickSelection });
+} catch (e) {
+  serverLog.error(`[pro-prediction-leagues] settle failed for match ${matchId}`, e);
+}
+```
+
+Le service externe doit etre idempotent (skip si deja settled).
+
+### Blocklist regex auto-flag pour user-generated text (Q.B.2)
+Pour moderer les inputs texte sans Perspective API, un array de regex
+case-insensitive verifie a la creation. Si match, `flaggedAt` +
+`flagReason='blocklist:<pattern>'` set automatiquement. `listComments`
+filtre alors selon perspective (auteur+admin voient flagged, autres non).
+
+```ts
+const BLOCKLIST_PATTERNS: ReadonlyArray<{ name: string; regex: RegExp }> = [
+  { name: "slur-1", regex: /\bn[\W_]*i[\W_]*g[\W_]*g[\W_]*(?:e[\W_]*r|a)\b/i },
+];
+export function detectBlocklist(body: string): string | null {
+  for (const { name, regex } of BLOCKLIST_PATTERNS) {
+    if (regex.test(body)) return name;
+  }
+  return null;
+}
+```
+
+### Heuristique scoring pure pour user-generated text (Q.B.3)
+Pour scorer une prediction texte fan vs resultat reel : regex parsing
+du score "X-Y" + substring case-insensitive du slug/nom equipe.
+Accepte les 2 ordres (home-away ET away-home). `"perfect"` si team +
+score, `"winner"` si team seul, `"wrong"` sinon. 100% pur, testable
+en unit sans Prisma.
+
+### Window post-action avec auto-close cote service (Q.B.1)
+Pour les actions valides N heures apres un event (vote MVP 24h),
+check `Date.now() - completedAt.getTime() > WINDOW_MS` au submit.
+Cote UI, calculer `windowClosesAt` et disable les boutons. Pas
+besoin de cron pour close si on accepte "silent close" — l'API
+rejette, l'UI affiche fermee.
+
+### Settle progressif multi-match round (Q.D.2)
+Pour le Survivor : chaque entry reference un round (pas un match
+specifique). Au fil des matches completed d'un round, on appelle
+`settleSurvivorRound(roundId)` qui :
+1. Charge entries pending du round
+2. Pour chaque entry, cherche le match ou la team piquee a joue
+3. Si `match.outcome` existe → settle (alive/eliminated)
+4. Sinon → skip, l'entry reste pending pour le prochain call
+
+Evite un trigger explicite "round completed", marche par accumulation.
+
+### Parser tolerant PG + sqlite pour JSON fields (Q.A.2)
+Pour les champs `Json?` qui peuvent etre array natif (PG), string
+JSON serialisee (sqlite mirror), null ou undefined :
+
+```ts
+export function parseStringArrayJson(raw: unknown): readonly string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? parsed.filter((s): s is string => typeof s === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+```
+
+### Composant section autonome avec `/auth/me` fetch interne (Q.B.2/Q.B.3)
+Pour un composant de section (thread comments, predictions, etc.) qui
+doit savoir si l'utilisateur est connecte sans propager `currentUserId`
+depuis le parent :
+
+```ts
+useEffect(() => {
+  apiRequest<MeResponse>("/auth/me")
+    .then((m) => setCurrentUserId(m.user?.id ?? null))
+    .catch(() => setCurrentUserId(null));
+}, []);
+```
+
+Permet d'integrer le composant n'importe ou sans refactor parent.
+
+### `vi.resetAllMocks` au lieu de `vi.clearAllMocks` (Q.D.1)
+`clearAllMocks` clear seulement les calls/instances/results, **pas** la
+queue `mockResolvedValueOnce`. Si les tests utilisent cette queue,
+utiliser `resetAllMocks` qui vide aussi la queue. Sinon les valeurs
+queue persistent entre tests et contaminent les fixtures suivantes.
+
+```ts
+beforeEach(() => {
+  vi.resetAllMocks(); // vide aussi mockResolvedValueOnce queue
+});
+```
+
+### `vi.mock` factory pour service avec class d'erreur typee (Q.D.1/Q.B.1)
+Quand on mock un service qui exporte une class d'erreur (`MvpError`,
+`SeasonFactoryError`, etc.), la class doit etre **dans la factory**
+`vi.mock` — sinon "Cannot access X before initialization" :
+
+```ts
+vi.mock("../services/pro-mvp-vote", () => {
+  class MvpError extends Error {
+    constructor(public readonly code: string, message: string) {
+      super(message);
+      this.name = "MvpError";
+    }
+  }
+  return { MvpError, submitVote: vi.fn() };
+});
+```
+
 ## Pieges connus
 
 ### `nextLevelSpp(spp)` est **strictement** > spp (K)
@@ -330,3 +475,9 @@ vi.mock("./pro-roster-spp", () => ({
   → fixes regen/apothecary BB order, onboarding modal, daily bonus,
   badge toast, OG image, share buttons, match report banner. Voir
   [`docs/roadmap/sessions/2026-05-11-sprint-O.md`](./docs/roadmap/sessions/2026-05-11-sprint-O.md).
+- **2026-05-12** : Sprint Q (Differenciation fan), 12 PRs (#772-#784).
+  Q.A complete (career page + rivalries + Gazette narrative),
+  Q.B complete (vote MVP + commentaires + fan predictions), Q.D
+  complete (mini-leagues prediction + Survivor). Q.C (clips MP4)
+  differe. 8 nouveaux modeles Prisma. Voir
+  [`docs/roadmap/sessions/2026-05-12-sprint-Q.md`](./docs/roadmap/sessions/2026-05-12-sprint-Q.md).

--- a/docs/roadmap/sessions/2026-05-12-sprint-Q.md
+++ b/docs/roadmap/sessions/2026-05-12-sprint-Q.md
@@ -1,0 +1,313 @@
+# Session Sprint Q (+ utilities admin) — Differenciation fan / engagement narratif
+
+> **2026-05-12** — 12 PRs livrees et mergees (PRs #772-#784). Sprint Q
+> termine a 9/13 sous-taches (lots Q.A, Q.B et Q.D complets ; lot Q.C
+> Clips highlights MP4 differe a un sprint dedie video infra).
+>
+> Demarrage : Node 24 opt-in workflows (#772), serie admin Pro League
+> (branding teams + rosters #773/#774), puis Sprint Q (10 PRs
+> consecutives #775-#784).
+
+## Recap des 12 lots livres
+
+| # | Lot | Titre | PR | Surface | Impact business |
+|---|-----|-------|----|---------|-----------------|
+| 1 | Infra | Node 24 opt-in 11 workflows GHA | #772 | ci/cd | Warning deprecation Node 20 silenced |
+| 2 | Admin | Branding teams Pro League | #773 | server + web admin | Editer couleurs/motto/headline d'une team |
+| 3 | Admin | Rosters Pro League (regen / replenish / retire) | #774 | server + web admin | Reset roster d'une team |
+| 4 | **Q.D.1** | Mini-leagues prediction privees | #775 | server + web | Engagement fan long-terme (group competition) |
+| 5 | **Q.D.2** | Survivor Pick'em hebdo | #776 | server + web | Boucle retention hebdo |
+| 6 | **Q.A.1** | Career stats persistees joueur | #777 | server + web | Foundation narrative career |
+| 7 | **Q.A.2** | Page career joueur dediee | #778 | server + web | Experience narrative riche (top matches, rivalries, casualties) |
+| 8 | **Q.A.3** | Team head-to-head card | #779 | server + web | Rivalries inter-teams visibles |
+| 9 | **Q.A.4** | Rivalry narrative Gazette | #781 | server | LLM signe EDITO statistician sur rivalry_buildup |
+| 10 | **Q.B.1** | Player-of-the-week vote | #782 | server + web | Vote communautaire + tally + leaderboard |
+| 11 | **Q.B.2** | Commentaires Gazette + moderation | #783 | server + web | Engagement social Gazette (blocklist auto + admin) |
+| 12 | **Q.B.3** | Fan predictions thread | #784 | server + web | Predictions publiques pre-match + badges Seer |
+
+## Modeles Prisma ajoutes (8)
+
+| Modele | Lot | Migration | Description |
+|--------|-----|-----------|-------------|
+| `ProPredictionLeague` | Q.D.1 | `20260515000000` | Ligue de pronostics privee (joinCode unique 8 chars) |
+| `ProPredictionLeagueMember` | Q.D.1 | id. | Appartenance (unique leagueId+userId) |
+| `ProPredictionPick` | Q.D.1 | id. | Pick winner home/draw/away par match dans ligue |
+| `ProSurvivorEntry` | Q.D.2 | `20260516000000` | Pick survivor (unique seasonId+userId+roundId, unique seasonId+userId+pickedTeamId) |
+| `ProPlayerCareerSnapshot` | Q.A.1+Q.A.2 | `20260517000000` + `20260518000000` | Snapshot career joueur (lazy compute, topMatches/rivalries/casualties en JSON) |
+| `ProPlayerOfMatchVote` | Q.B.1 | `20260519000000` | Vote MVP (unique userId+matchId, window 24h) |
+| `ProGazetteComment` | Q.B.2 | `20260520000000` | Commentaires Gazette (soft delete + flag) |
+| `ProMatchPrediction` | Q.B.3 | `20260521000000` | Prediction publique fan pre-match (scoring perfect/winner/wrong) |
+
+## Surfaces backend touchees
+
+### Nouveaux services (10)
+- `pro-team-branding.ts` (#773) — parser meta tolerant sqlite + PG, applyBrandingMeta non destructif.
+- `pro-roster-admin.ts` (#774) — regenerateRoster (wipe + reseed) + retirePlayer (idempotent).
+- `pro-prediction-leagues.ts` (#775) — createLeague (joinCode safe alphabet), joinLeagueByCode, submitPick, getLeagueLeaderboard, settlePicksForMatch.
+- `pro-survivor.ts` (#776) — submitSurvivorPick (multi validations), computeTeamResult, settleSurvivorRound, getSurvivorStandings.
+- `pro-player-career-stats.ts` (#777+#778) — recomputeCareerSnapshot (lazy compute, STALE_WINDOW_MS=1h, STATS_MATCH_CAP=50), aggregateContributions, topOpponents, topMatchesBySpp, parseStringArrayJson, parseTopMatchesJson.
+- `pro-league-rivalry.ts` (#779) — getHeadToHead (W-D-L + streak + 20 matches), getTopRivals.
+- `pro-mvp-vote.ts` (#782) — getMvpCandidates (top 5 SPP via attributeSpp + replay), submitVote (window 24h + candidates), getVoteTally, getWeeklyMvpLeaderboard.
+- `pro-gazette-comments.ts` (#783) — createComment (blocklist regex auto-flag), listComments (filtre perspective), flag/unflag/restore/softDelete, adminListComments.
+- `pro-match-predictions.ts` (#784) — createOrUpdatePrediction (upsert tant que scheduled), parseScoreFromBody, scorePrediction (perfect/winner/wrong), settlePredictions, getSeerLeaderboard.
+- Extensions sur `pro-bet-settlement.ts` : hooks settlePicksForMatch (Q.D.1), settleSurvivorRound (Q.D.2), settlePredictions (Q.B.3) tous encapsules dans try/catch isole.
+- Extensions sur `pro-storyline-detector.ts` (Q.A.4) : PriorMatchupCounts enrichi avec winsHome/winsAway/draws/streak ; rivalry_buildup expose suggestedPersona='statistician'.
+- Extensions sur `pro-gazette-recap.ts` (Q.A.4) : calcul W-D-L + streak rivalry from past matches.
+- Extensions sur `pro-gazette-llm.ts` (Q.A.4) : refs rivalry exposes au LLM + instruction EDITO statistician.
+
+### Nouveaux routers (8)
+- `admin-pro-team.ts` (#773) — GET teams + PATCH branding.
+- `admin-pro-roster.ts` (#774) — GET roster + POST replenish/regenerate, POST retire.
+- `pro-prediction-leagues.ts` (#775) — 7 endpoints user-facing.
+- `pro-survivor.ts` (#776) — 4 endpoints (2 public + 2 auth).
+- `pro-gazette-comments.ts` (#783) — 4 endpoints user + 4 admin.
+- Extensions sur `pro-league.ts` : `GET players/:id/career` (#777), `GET teams/:slug/rivalries` + `GET teams/:slug/head-to-head/:opp` (#779), 4 endpoints MVP vote (#782), 4 endpoints fan predictions (#784).
+
+## Surfaces frontend touchees
+
+### Nouvelles pages
+- `/admin/pro-league/teams` + `/admin/pro-league/teams/[id]` (#773) — liste + edit branding avec form diff/patch + preview live.
+- `/admin/pro-league/teams/[id]/roster` (#774) — gestion roster avec counters + replenish/regenerate/retire.
+- `/pro-league/leagues` + `/pro-league/leagues/[id]` (#775) — mes ligues prediction + detail leaderboard.
+- `/pro-league/survivor` (#776) — overview + form pick + standings + my picks.
+- `/pro-league/teams/[slug]/players/[playerId]/career` (#778) — page career joueur dediee.
+- `/pro-league/teams/[slug]/vs/[opponentSlug]` (#779) — page head-to-head detail.
+- `/admin/gazette/comments` (#783) — moderation comments avec filter flagged/deleted/all.
+
+### Composants ajoutes
+- `TeamRivalriesSection` (#779) sur la page team.
+- `GazetteCommentsThread` (#783) integre dans `ArticleCard`.
+- `MvpVoteSection` (#782) sur la page match (status=completed).
+- `FanPredictionsThread` (#784) sur la page match (status=scheduled OU completed).
+- Section "Career" enrichie sur la fiche joueur principale (#777+#778) avec lien vers career page complete.
+
+## Metriques
+
+| | Avant session | Apres session | Delta |
+|---|---|---|---|
+| Tests serveur | 2425 | **2675** | **+250** |
+| Tests web | 1058 | **1121** | **+63** |
+| Test files serveur | 188 | **204** | +16 |
+| Test files web | 116 | **125** | +9 |
+| Modeles Prisma | 25 | **33** | +8 |
+| Migrations Prisma | 25 | **31** | +6 (Q.A.1/Q.A.2 fusionnees en 2 migrations) |
+| PRs mergees ce sprint | 0/13 | **9/13** (69%) | — |
+
+## Patterns recurrents (a integrer dans CLAUDE.md)
+
+### Snapshot lazy compute avec staleness window (Q.A.1+Q.A.2)
+Pour un compute couteux (lit replays + attributeSpp), persister un
+`Snapshot` model 1-1 avec une `recomputedAt` timestamp. Au read,
+si `Date.now() - recomputedAt >= STALE_WINDOW_MS` (ou snapshot
+inexistant), declenche le recompute synchrone et upsert. Pas de cron.
+
+```ts
+const STALE_WINDOW_MS = 60 * 60 * 1000; // 1h
+
+export async function getCareerSnapshot(playerId: string) {
+  const existing = await prisma.proPlayerCareerSnapshot.findUnique({
+    where: { playerId },
+  });
+  const isStale =
+    existing === null ||
+    Date.now() - existing.recomputedAt.getTime() >= STALE_WINDOW_MS;
+  if (isStale) return recomputeCareerSnapshot(playerId);
+  return mapToView(existing);
+}
+```
+
+### Hook post-settlement encapsule (Q.D.1, Q.D.2, Q.B.3)
+Quand `settleMarketsForMatch` doit aussi settle d'autres entites
+(picks, survivor entries, fan predictions), chaque call est dans un
+`try/catch` isole pour ne pas faire echouer le bet settlement principal :
+
+```ts
+try {
+  await settlePicksForMatch({ matchId, result: match.outcome as PickSelection });
+} catch (e) {
+  serverLog.error(`[pro-prediction-leagues] settle failed for match ${matchId}`, e);
+}
+try {
+  await settleSurvivorRound({ roundId: match.roundId });
+} catch (e) {
+  serverLog.error(`[pro-survivor] settle failed for round ${match.roundId}`, e);
+}
+```
+
+### Blocklist regex auto-flag (Q.B.2)
+Pour modere les input texte user-generated sans Perspective API, un
+array de regex case-insensitive verifie a la creation. Si match,
+`flaggedAt` + `flagReason='blocklist:<pattern-name>'` sont set
+automatiquement.
+
+```ts
+const BLOCKLIST_PATTERNS: ReadonlyArray<{ name: string; regex: RegExp }> = [
+  { name: "slur-1", regex: /\bn[\W_]*i[\W_]*g[\W_]*g[\W_]*(?:e[\W_]*r|a)\b/i },
+];
+
+export function detectBlocklist(body: string): string | null {
+  for (const { name, regex } of BLOCKLIST_PATTERNS) {
+    if (regex.test(body)) return name;
+  }
+  return null;
+}
+```
+
+`listComments` masque les flagged pour les autres users mais les expose a l'auteur + admin (filtrage cote service).
+
+### Heuristique scoring pure pour user-generated text (Q.B.3)
+Pour scorer une prediction texte fan vs resultat reel, on fait une
+heuristique pure 100% testable :
+- regex parsing du score "X-Y" / "X to Y" / "X vs Y" / "X tds Y"
+- substring case-insensitive du slug ou nom de l'equipe gagnante
+- accepte les 2 ordres (home-away ET away-home)
+- "perfect" si team + score, "winner" si team seul, "wrong" sinon
+
+```ts
+export function scorePrediction(body: string, ctx: PredictionContext): PredictionScore {
+  const winnerMatched = winnerTerms !== null
+    ? bodyMentions(body, winnerTerms)
+    : bodyMentions(body, ["draw", "nul", "egalite"]);
+  const parsed = parseScoreFromBody(body);
+  const scoreMatched =
+    parsed !== null &&
+    ((parsed.first === ctx.scoreHome && parsed.second === ctx.scoreAway) ||
+     (parsed.first === ctx.scoreAway && parsed.second === ctx.scoreHome));
+  if (winnerMatched && scoreMatched) return "perfect";
+  if (winnerMatched) return "winner";
+  return "wrong";
+}
+```
+
+### Window post-match avec auto-cancel (Q.B.1)
+Pour les actions qui ne sont valides que pendant N heures apres un event
+(MVP vote 24h), check `Date.now() - completedAt.getTime() > WINDOW_MS`
+au submit. Cote UI, calculer `windowClosesAt` et disable les boutons
+quand la window est fermee. Pas besoin de cron pour close si on accepte
+"silent close" (l'API rejette, l'UI affiche fermee).
+
+### Settle "progressif" multi-match round (Q.D.2)
+Pour le Survivor : chaque entry referencee un round (pas un match
+specifique). Au fil des matches completed d'un round, on appelle
+`settleSurvivorRound(roundId)` qui :
+- Charge toutes les entries pending du round
+- Pour chaque entry, cherche le match ou la team piquee a joue
+- Si match.outcome existe → settle (alive/eliminated)
+- Si pas encore d'outcome → skip (l'entry reste pending pour le prochain call)
+
+Cette approche evite un trigger explicite "round completed" et marche
+naturellement par accumulation.
+
+### Validation Zod via z.object + z.refine (Q.A/Q.D)
+Patterns recurrents pour les inputs HTTP :
+- Hex color avec regex : `z.string().regex(/^#[0-9a-fA-F]{6}$/)`
+- joinCode : `z.string().trim().min(1).max(20)` puis normalize uppercase
+  cote service
+- refine sur l'objet complet pour exiger au moins un champ touche :
+  `.refine((data) => Object.keys(data).length > 0, { message: "..." })`
+
+### JSON fields parser tolerant PG + sqlite (Q.A.2)
+Pour les champs `Json?` qui peuvent etre :
+- Array natif (Postgres)
+- String JSON serialisee (sqlite mirror)
+- null / undefined
+
+```ts
+export function parseStringArrayJson(raw: unknown): readonly string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? parsed.filter((s): s is string => typeof s === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+```
+
+### vi.resetAllMocks au lieu de vi.clearAllMocks (Q.D.1)
+`clearAllMocks` clear seulement les calls/instances/results, **PAS** la
+queue `mockResolvedValueOnce`. Si les tests utilisent `mockResolvedValueOnce`
+queue pour les mocks Prisma, utiliser `resetAllMocks` qui vide aussi la
+queue. Sinon les valeurs queue persistent entre tests et contaminent
+les fixtures d'apres.
+
+```ts
+beforeEach(() => {
+  vi.resetAllMocks(); // vide aussi mockResolvedValueOnce queue
+});
+```
+
+### vi.mock factory pour services + class qui throw (Q.D.1/Q.D.2/Q.B.1)
+Quand on mock un service qui exporte une class d'erreur typee
+(`SeasonFactoryError`, `MvpError`, `PredictionError`, etc.), la class
+doit etre **dans la factory** vi.mock — sinon erreur "Cannot access X before initialization" :
+
+```ts
+vi.mock("../services/pro-mvp-vote", () => {
+  class MvpError extends Error {
+    constructor(public readonly code: string, message: string) {
+      super(message);
+      this.name = "MvpError";
+    }
+  }
+  return {
+    MvpError,
+    submitVote: vi.fn(),
+    // ...
+  };
+});
+```
+
+### Composant section autonome avec /auth/me fetch interne (Q.B.2/Q.B.3)
+Pour un composant de section (thread comments, predictions, etc.) qui
+doit savoir si l'utilisateur courant est connecte sans propager
+`currentUserId` depuis le parent :
+
+```ts
+useEffect(() => {
+  apiRequest<MeResponse>("/auth/me")
+    .then((m) => setCurrentUserId(m.user?.id ?? null))
+    .catch(() => setCurrentUserId(null));
+}, []);
+```
+
+Permet d'integrer le composant n'importe ou sans refactor parent.
+
+## Sprint Q : status final
+
+- [x] **Q.D.1** Mini-leagues prediction
+- [x] **Q.D.2** Survivor Pick'em
+- [x] **Q.A.1** Career stats persistees
+- [x] **Q.A.2** Page career dediee
+- [x] **Q.A.3** Team head-to-head card
+- [x] **Q.A.4** Rivalry narrative Gazette ✓ **Lot Q.A complete**
+- [x] **Q.B.1** Vote MVP
+- [x] **Q.B.2** Commentaires Gazette + moderation
+- [x] **Q.B.3** Fan predictions thread ✓ **Lot Q.B complete**
+- [ ] **Q.C.1** Pixi headless renderer (differe)
+- [ ] **Q.C.2** ffmpeg encoder MP4 vertical (differe)
+- [ ] **Q.C.3** Auto-detect top 3 moments (differe)
+- [ ] **Q.C.4** Share highlights UI (differe)
+
+Lot **Q.C** (Clips highlights MP4) differe : risque technique eleve
+(node-canvas + Pixi headless reportes par la spec elle-meme),
+infrastructure ffmpeg + S3 a setup, ~12j d'effort vs MVP simplifie
+livrable en 1-2 lots si on accepte clips text-overlay seuls (sans
+re-render des events). A reprendre dans un sprint dedie "video infra".
+
+## Reward / badges differres (a brancher)
+
+Plusieurs lots ont laisse les rewards Crowns + badges hors scope :
+- **Q.B.1** : reward 25 Crowns au winner MVP + badge `carried_my_team`
+- **Q.D.2** : reward 5000 Crowns au last survivor + tie-breaker
+
+Necessite cron close + tx wallet (audit log ADMIN_REWARD) + badge
+persistence. A reunir dans un futur lot "Sprint Q rewards" si volume
+metier justifie.

--- a/docs/roadmap/sprints/SPRINT-Q-fan-differentiation.md
+++ b/docs/roadmap/sprints/SPRINT-Q-fan-differentiation.md
@@ -1,7 +1,11 @@
 # SPRINT Q — Differenciation fan / engagement narratif Pro League
 
-> **Statut** : PLANIFIE — demarre apres Sprint P.
-> **Duree estimee** : 6-8 semaines.
+> **Statut** : 9/13 LIVRES (Q.A, Q.B, Q.D complets) — session 2026-05-12.
+> Q.C (clips highlights MP4) differe a un sprint video dedie.
+> Voir [`docs/roadmap/sessions/2026-05-12-sprint-Q.md`](../sessions/2026-05-12-sprint-Q.md).
+>
+> **Duree estimee** : 6-8 semaines (Q.A+Q.B+Q.D livres en 1 session
+> 2026-05-12, Q.C reporte).
 > **Pre-requis** : Sprint O (acquisition) + Sprint P (ops + sinks
 > Crowns).
 
@@ -42,10 +46,10 @@ communaute.
 
 | # | Tache | Cat | Effort | Statut | Detail |
 |---|-------|-----|--------|--------|--------|
-| Q.A.1 | Career stats persistees joueur | DB + Backend | M | [ ] | Nouvelle table `ProPlayerCareerSnapshot` qui agrege par joueur : `matchesPlayed`, `tdTotal`, `casTotal`, `mvpTotal`, `bestMatchId`, `worstMatchId`, `topNemesisTeamId`, `topVictoryTeamId`, `currentStreak`. Cron post-match recompute (incremental). Read-only API `GET /api/pro-league/players/:id/career`. |
-| Q.A.2 | Page `/pro-league/players/[id]/career` | Frontend | M | [ ] | Nouvelle sub-page de la fiche joueur : graphique SPP/TV sur saison, table top 5 matches (les plus marquants), section "Rivalries" (top 3 teams qui ont battu/blesse le joueur), liste casualties recues + infligees. Cards visuelles, partageable. |
-| Q.A.3 | Team head-to-head card | Frontend + Backend | M | [ ] | Service `pro-league-rivalry.ts` : pour 2 teams, calcule W-D-L historique sur N saisons, top scorers head-to-head, casualties causes. UI sur `/pro-league/teams/[slug]` : section "Rivalries" liste top 3 rivaux + boutton "Voir l'historique vs X". |
-| Q.A.4 | Rivalry narrative dans Gazette | Backend | M | [ ] | Extend `pro-storyline-detector.ts` : detecte "rivalry_buildup" (>= 3 matchs en 30j entre 2 teams) → trigger article Gazette specifique "Storyline of the Rivalry". Persona "statistician" raconte l'historique. Test : 3 matchs Buffalo vs GB en 30j → article auto-publie. |
+| Q.A.1 | Career stats persistees joueur | DB + Backend | M | [x] #777 | Nouvelle table `ProPlayerCareerSnapshot` qui agrege par joueur : `matchesPlayed`, `tdTotal`, `casTotal`, `mvpTotal`, `bestMatchId`, `worstMatchId`, `topNemesisTeamId`, `topVictoryTeamId`, `currentStreak`. Cron post-match recompute (incremental). Read-only API `GET /api/pro-league/players/:id/career`. |
+| Q.A.2 | Page `/pro-league/players/[id]/career` | Frontend | M | [x] #778 | Nouvelle sub-page de la fiche joueur : graphique SPP/TV sur saison, table top 5 matches (les plus marquants), section "Rivalries" (top 3 teams qui ont battu/blesse le joueur), liste casualties recues + infligees. Cards visuelles, partageable. |
+| Q.A.3 | Team head-to-head card | Frontend + Backend | M | [x] #779 | Service `pro-league-rivalry.ts` : pour 2 teams, calcule W-D-L historique sur N saisons, top scorers head-to-head, casualties causes. UI sur `/pro-league/teams/[slug]` : section "Rivalries" liste top 3 rivaux + boutton "Voir l'historique vs X". |
+| Q.A.4 | Rivalry narrative dans Gazette | Backend | M | [x] #781 | Extend `pro-storyline-detector.ts` : detecte "rivalry_buildup" (>= 3 matchs en 30j entre 2 teams) → trigger article Gazette specifique "Storyline of the Rivalry". Persona "statistician" raconte l'historique. Test : 3 matchs Buffalo vs GB en 30j → article auto-publie. |
 
 **DoD lot Q.A** : un joueur fictif a une page career complete avec
 trajectoire visible, on peut raconter son histoire. Une equipe a des
@@ -55,9 +59,9 @@ rivaux nommes avec un historique W-D-L.
 
 | # | Tache | Cat | Effort | Statut | Detail |
 |---|-------|-----|--------|--------|--------|
-| Q.B.1 | Player-of-the-week vote | Backend + Frontend | M | [ ] | Modele Prisma `ProPlayerOfMatchVote {userId, matchId, votedRosterId, createdAt}`. Window 24h post-match. UI : sur `/pro-league/matches/[id]` apres `completed`, montre cards des MVPs potentiels (top SPP gagne du match) avec bouton "Voter". Tally final : top voted recoit badge `carried_my_team` + bonus 25 Crowns. Weekly leaderboard "Player of the Week". |
-| Q.B.2 | Commentaires Gazette | Backend + Frontend | L | [ ] | Modele `ProGazetteComment {id, articleId, userId, body, createdAt, deletedAt}`. Max 500 chars. UI thread sous chaque article Gazette. Moderation : `flagComment` + auto-flag Perspective API si configure (sinon manual flagging). Page admin `/admin/gazette/comments` pour bulk moderate. Test : commentaire avec slur → flag auto + masque pour autres users. |
-| Q.B.3 | Fan predictions thread | Backend + Frontend | M | [ ] | Pre-match, fans peuvent poster prediction publique (max 200 chars, ex: "Orcs gagnent 3-1"). Modele `ProMatchPrediction {userId, matchId, body, createdAt}`. Post-match, badge `seer` si la prediction "match" le resultat (heuristique simple : contient mention de l'equipe gagnante + diff TD coherent). UI thread integre sur fiche match. |
+| Q.B.1 | Player-of-the-week vote | Backend + Frontend | M | [x] #782 | Modele Prisma `ProPlayerOfMatchVote {userId, matchId, votedRosterId, createdAt}`. Window 24h post-match. UI : sur `/pro-league/matches/[id]` apres `completed`, montre cards des MVPs potentiels (top SPP gagne du match) avec bouton "Voter". Tally final : top voted recoit badge `carried_my_team` + bonus 25 Crowns. Weekly leaderboard "Player of the Week". |
+| Q.B.2 | Commentaires Gazette | Backend + Frontend | L | [x] #783 | Modele `ProGazetteComment {id, articleId, userId, body, createdAt, deletedAt}`. Max 500 chars. UI thread sous chaque article Gazette. Moderation : `flagComment` + auto-flag Perspective API si configure (sinon manual flagging). Page admin `/admin/gazette/comments` pour bulk moderate. Test : commentaire avec slur → flag auto + masque pour autres users. |
+| Q.B.3 | Fan predictions thread | Backend + Frontend | M | [x] #784 | Pre-match, fans peuvent poster prediction publique (max 200 chars, ex: "Orcs gagnent 3-1"). Modele `ProMatchPrediction {userId, matchId, body, createdAt}`. Post-match, badge `seer` si la prediction "match" le resultat (heuristique simple : contient mention de l'equipe gagnante + diff TD coherent). UI thread integre sur fiche match. |
 
 **DoD lot Q.B** : un fan peut voter MVP, commenter un article, poster
 une prediction. Au moins 100 commentaires generes en 1 semaine
@@ -80,8 +84,8 @@ publication 1er clip viral.
 
 | # | Tache | Cat | Effort | Statut | Detail |
 |---|-------|-----|--------|--------|--------|
-| Q.D.1 | Prediction mini-leagues | Backend + Frontend | L | [ ] | Modeles `ProPredictionLeague {id, name, ownerId, isPrivate, joinCode, createdAt}`, `ProPredictionLeagueMember {leagueId, userId, joinedAt}`, `ProPredictionPick {leagueId, userId, matchId, selection, createdAt}`. Endpoints : create, join via code, list members, pick. UI `apps/web/app/pro-league/leagues/page.tsx` (mes ligues) + `[id]/page.tsx` (leaderboard custom). Score = correct picks dans la ligue. |
-| Q.D.2 | Survivor Pick'em hebdo | Backend + Frontend | M | [ ] | 1 match selectionne / semaine. User pique 1 equipe → si elle gagne, il survive a la semaine, sinon eliminate. Modele `ProSurvivorEntry {userId, seasonId, weekN, pickedTeamId, status enum(alive/eliminated)}`. UI countdown "Survivor cette semaine : Round 5 - mardi 21h". Last survivor recoit 5000 Crowns. |
+| Q.D.1 | Prediction mini-leagues | Backend + Frontend | L | [x] #775 | Modeles `ProPredictionLeague {id, name, ownerId, isPrivate, joinCode, createdAt}`, `ProPredictionLeagueMember {leagueId, userId, joinedAt}`, `ProPredictionPick {leagueId, userId, matchId, selection, createdAt}`. Endpoints : create, join via code, list members, pick. UI `apps/web/app/pro-league/leagues/page.tsx` (mes ligues) + `[id]/page.tsx` (leaderboard custom). Score = correct picks dans la ligue. |
+| Q.D.2 | Survivor Pick'em hebdo | Backend + Frontend | M | [x] #776 | 1 match selectionne / semaine. User pique 1 equipe → si elle gagne, il survive a la semaine, sinon eliminate. Modele `ProSurvivorEntry {userId, seasonId, weekN, pickedTeamId, status enum(alive/eliminated)}`. UI countdown "Survivor cette semaine : Round 5 - mardi 21h". Last survivor recoit 5000 Crowns. |
 
 **DoD lot Q.D** : 50+ ligues prediction crees, Survivor pick'em a 200+
 entries la 1ere semaine.


### PR DESCRIPTION
## Summary

Capture la session 2026-05-12 (12 PRs #772-#784) — Sprint Q a 9/13 livre (Q.A, Q.B, Q.D complets ; Q.C clips MP4 differe).

- `docs/roadmap/sessions/2026-05-12-sprint-Q.md` (nouveau) : recap complet (modeles Prisma ajoutes, services, routes, UI, metriques tests, patterns recurrents)
- `docs/roadmap/sprints/SPRINT-Q-fan-differentiation.md` : statuts par lot mis a jour avec ref PR
- `CLAUDE.md` : 9 nouveaux patterns capitalises du sprint

## Patterns nouveaux dans CLAUDE.md

1. **Snapshot lazy compute** avec staleness window (Q.A.1/Q.A.2)
2. **Hook post-settlement encapsule** try/catch isole (Q.D.1/Q.D.2/Q.B.3)
3. **Blocklist regex auto-flag** pour user-generated text (Q.B.2)
4. **Heuristique scoring pure** texte vs resultat (Q.B.3)
5. **Window post-action auto-close** cote service (Q.B.1)
6. **Settle progressif multi-match round** (Q.D.2)
7. **Parser tolerant PG + sqlite** pour JSON fields (Q.A.2)
8. **Composant section autonome** avec `/auth/me` fetch interne (Q.B.2/Q.B.3)
9. **`vi.resetAllMocks` vs `clearAllMocks`** + factory class d'erreur dans `vi.mock`

## Test plan

- [x] Markdown valide
- [ ] N/A — pas de code

## Status final Sprint Q

- 9/13 sous-taches livrees (Q.A complet, Q.B complet, Q.D complet)
- Q.C (clips MP4) differe a sprint video dedie

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_