### PR TITLE
docs(sim-engine): investigation matchs 0-0 + script debug-match

### DIFF
--- a/docs/engine-investigation-2026-05-12-low-tds.md
+++ b/docs/engine-investigation-2026-05-12-low-tds.md
@@ -1,0 +1,136 @@
+# Investigation moteur 0.16.0 — TD/match trop bas
+
+> **2026-05-12** — User rapporte 4 matchs sandbox consecutifs 0-0 sur
+> les pairings : Gold Rush vs Iron Bears (x2), Tomb Cardinals vs Gold
+> Rush, Smashers vs Vipers. EngineVer 0.16.0.
+>
+> Investigation : le tuning actuel produit **0.95 TD/match en moyenne**
+> sur 120 matchups (matrix bench), bien en-dessous de la baseline
+> FUMBBL (1.5-2.2 selon race).
+
+## Constat
+
+### Bench matrix (20 runs/pairing × 120 pairings)
+
+| Stat | Observe | Reference FUMBBL |
+|---|---|---|
+| TD/match mean | **0.95** | 1.5-2.2 selon race |
+| TD/match min | 0.10 | — |
+| TD/match max | 2.70 | — |
+| Draw rate (single pairing) | **50-80%** | ~25-30% |
+
+### Cas concret : Gold Rush (Skaven, fast) vs Iron Bears (Dwarf, slow)
+
+5 runs, seed=42 :
+- 4 draws, 1 away win
+- TD mean 0.20 (vs Skaven FUMBBL ref 2.2)
+
+50 runs, seed=1 :
+- 9H / 18A / 23D (46% draws)
+- TD mean 1.04, std 0.85
+
+### Cas concret : match debug seed=42
+
+- 16 turns total, 13 MOVE events
+- MOVE breakdown : 8 "positioning" (16 yds total), 4 "halt" (0 yds), 1 "sweep" (12 yds)
+- Total yards : home 18, away 10
+- Pour scorer (yardline 4 → 26 = 22 yds), il faudrait ~22 yards par drive
+- BLOCK success 0/3 (0%), DODGE 6/7, PASS 1/3
+
+## Hypotheses
+
+### Hypothese 1 : tuning `rollYards` trop conservateur (probable)
+
+Le commentaire dans `hybrid-driver.ts:443-458` explique le re-tuning suite a un "Bug #2 panel feedback" :
+
+> "breakthrough magnitudes 30/35/40 → 12/15/18. The original values
+> meant a single breakthrough roll could traverse the entire 26-yard
+> field, producing TDs from the kickoff line right after a single
+> block. The reduced magnitudes still create 'long play' drama but
+> multi-yard advances now require 2-3 turns to compose into a TD."
+
+> "Hard cap at MAX_TURN_YARDS = 16 yards/turn. Belt-and-suspenders :
+> even with the reduced magnitudes, dice + bonuses + breakthrough
+> could still reach ~30 yards in extreme stacks. Capping at 16
+> guarantees a drive needs at least 2 turns to score from the
+> receiving yardline (4 + 16 = 20 < 26 = FIELD_YARDS)."
+
+Math des yards/turn actuels (Skaven attack, Dwarf defense) :
+
+```
+dice = 2d6+2 (mean 7)
+paceOffset = round(90/25) - 2 = +2
+bashCounter = -round(90/28) = -3      // Dwarf bashIndex high
+defensiveDisruption = -3              // Dwarf stall*bash high
+tvBonus = round(-50/80) = -1
+breakthrough = 0.18 * ~15 + 0.16 * -10 = +1.1
+                                       ─────
+Total mean = 7 + 2 - 3 - 3 - 1 + 1.1 = 3.1 yds/turn
+```
+
+Pour scorer 22 yds, il faut ~7-8 turns parfaits sans turnover. Avec
+turnovers observes (~5/match), drives moyens font 2-3 turns avant
+turnover. Donc TD rare.
+
+### Hypothese 2 : starting yardline trop bas (4 / 26)
+
+BB officiel utilise un terrain 26 yards × 15 hexes. Le receiving team
+demarre vers son cote du terrain, pas a yardline 4. Selon BB rules, le
+ball est au centre apres kick (yardline 13) ou plus selon kick distance.
+
+Si on demarrait a yardline 8-10, on aurait besoin de 16-18 yds pour TD
+au lieu de 22. C'est une difference materielle (1-2 turns de moins).
+
+### Hypothese 3 : breakthrough trop rare (probable)
+
+Probability breakthrough positif = 18%. Magnitudes 12/15/18 selon
+defense bashIndex.
+
+Pour les pairings rapides vs slow defense :
+- Skaven (pace 90) vs Dwarf (bash 90) : breakthrough rarement positif
+  car defenseProfile.bashIndex 90 ≥ 70 → magnitude minimum 12
+- Le gain breakthrough est insufficient pour compenser le penalty
+  defensif (-6)
+
+## Recommendations possibles
+
+| Option | Difficulte | Impact estime | Risque |
+|---|---|---|---|
+| **A.** Starting yardline 4 → 8 | trivial | +30% TDs (1 turn de moins) | Modere, casse baseline |
+| **B.** Base dice 2d6+2 → 3d6+0 (mean 7 → 10.5) | facile | +50-60% TDs | Eleve, perte de granularite |
+| **C.** Reduire defensiveDisruption max -3 → -2 | facile | +15-20% TDs | Faible |
+| **D.** Augmenter breakthrough probability 18% → 25% | facile | +25-30% TDs | Modere |
+| **E.** Breakthrough magnitudes 12/15/18 → 16/20/24 | facile | +30-40% TDs | Modere (vs panel feedback original) |
+| **F.** Combo C + D | facile | +40-50% TDs | Modere |
+
+**Recommandation initiale (a discuter)** : combo C + D, conservateur,
+sans toucher aux magnitudes que le panel avait critiquees.
+
+## Outils ajoutes pour debug
+
+`packages/sim-engine/scripts/debug-match.ts` — nouvel utilitaire :
+
+```bash
+pnpm tsx scripts/debug-match.ts --teamA=sf-gold-rush --teamB=chi-iron-bears --seed=42
+```
+
+Affiche : event histogram, MOVE breakdown par kind, turnover reasons,
+key moments success rates. Permet d'isoler la cause d'un drive sans TD.
+
+Optionnel `--events` pour dump le stream complet d'events JSON.
+
+## Process pour fix
+
+1. Decide quelle option (A-F) tester en premier (input user)
+2. Modifier `hybrid-driver.ts`
+3. Re-run `pnpm sim:bench --matrix --runs=20 --seed=1` pour mesurer
+4. Comparer contre `fumbbl-reference.ts` (race tdAverage)
+5. Si OK : snapshot le nouveau baseline `pnpm tsx scripts/bench-baseline-snapshot.ts`
+6. Bump `ENGINE_VER` 0.16.0 → 0.17.0 (changement comportement)
+
+## Etat actuel
+
+- Pas de fix applique (en attente input user)
+- Script debug commit pour permettre investigation parallele
+- Baseline 0.16.0 reste en place
+- Tous les replays existants restent decodables

--- a/packages/sim-engine/scripts/debug-match.ts
+++ b/packages/sim-engine/scripts/debug-match.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env tsx
+/**
+ * `pnpm tsx scripts/debug-match.ts --teamA=sf-gold-rush --teamB=chi-iron-bears`
+ *
+ * Dump les events d'un match unique pour debug. Affiche le breakdown
+ * des events par type + scores + raisons des non-TDs.
+ */
+
+import { parseArgs } from "node:util";
+
+import { PRO_LEAGUE_TEAM_BY_ID } from "../src/tactics/race-profiles";
+import { simulateMatch } from "../src/simulate-match";
+
+const { values: opts } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    teamA: { type: "string" },
+    teamB: { type: "string" },
+    seed: { type: "string", default: "42" },
+    full: { type: "boolean", default: false },
+    events: { type: "boolean", default: false },
+  },
+});
+
+const teamA = PRO_LEAGUE_TEAM_BY_ID[opts.teamA ?? ""];
+const teamB = PRO_LEAGUE_TEAM_BY_ID[opts.teamB ?? ""];
+if (!teamA || !teamB) {
+  console.error("Missing or invalid --teamA / --teamB");
+  process.exit(1);
+}
+
+const seed = Number.parseInt(opts.seed ?? "42", 10);
+const driverKind = opts.full ? "full" : "hybrid";
+
+const result = simulateMatch(
+  {
+    seed,
+    home: { id: teamA.id, name: teamA.name, side: "home", tactics: teamA.tactics, tv: teamA.tv },
+    away: { id: teamB.id, name: teamB.name, side: "away", tactics: teamB.tactics, tv: teamB.tv },
+  },
+  { driverKind },
+);
+
+console.log(`Match : ${teamA.name} (home) vs ${teamB.name} (away)`);
+console.log(`Seed: ${seed} · Driver: ${driverKind} · EngineVer: ${result.engineVer}`);
+console.log(
+  `Score: ${result.summary.score.home}-${result.summary.score.away} · Outcome: ${result.summary.outcome}`,
+);
+console.log(`TDs: ${result.summary.touchdownCount} · Cas: ${result.casualties.length} · Turnovers: ${result.summary.turnoverCount}`);
+
+// Event histogram by type
+const byType = new Map<string, number>();
+for (const ev of result.events) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const t = (ev as any).type as string;
+  byType.set(t, (byType.get(t) ?? 0) + 1);
+}
+console.log("\nEvent histogram:");
+const sorted = Array.from(byType.entries()).sort((a, b) => b[1] - a[1]);
+for (const [type, count] of sorted) {
+  console.log(`  ${type.padEnd(20)} ${count}`);
+}
+
+// MOVE breakdown by kind
+const moveKinds = new Map<string, { count: number; sumYards: number }>();
+let totalMoveYards = { home: 0, away: 0 };
+for (const ev of result.events) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  if (e.type !== "MOVE") continue;
+  const k = String(e.meta?.kind ?? "?");
+  const yards = Number(e.meta?.yards ?? 0);
+  const team = String(e.meta?.team ?? "?");
+  const existing = moveKinds.get(k) ?? { count: 0, sumYards: 0 };
+  existing.count += 1;
+  existing.sumYards += yards;
+  moveKinds.set(k, existing);
+  if (team === "home") totalMoveYards.home += yards;
+  else if (team === "away") totalMoveYards.away += yards;
+}
+if (moveKinds.size > 0) {
+  console.log("\nMOVE breakdown (kind / count / total yards):");
+  for (const [k, v] of moveKinds) {
+    console.log(`  ${k.padEnd(15)} ${String(v.count).padStart(3)}  ${v.sumYards} yds`);
+  }
+  console.log(
+    `  total home yards : ${totalMoveYards.home} · total away yards : ${totalMoveYards.away}`,
+  );
+}
+
+// Drive endings / turnover sources
+const turnoverReasons = new Map<string, number>();
+for (const ev of result.events) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  if (e.type !== "TURNOVER") continue;
+  const reason = String(e.meta?.reason ?? "?");
+  turnoverReasons.set(reason, (turnoverReasons.get(reason) ?? 0) + 1);
+}
+if (turnoverReasons.size > 0) {
+  console.log("\nTurnover reasons:");
+  for (const [r, n] of turnoverReasons) {
+    console.log(`  ${r.padEnd(20)} ${n}`);
+  }
+}
+
+// Key moments (BLOCK / PASS / DODGE / GFI / etc)
+const moments = new Map<string, { attempts: number; success: number }>();
+for (const ev of result.events) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const e = ev as any;
+  if (!["BLOCK", "PASS", "DODGE", "GFI", "PICKUP", "FOUL"].includes(e.type)) continue;
+  const success = e.meta?.success === true;
+  const existing = moments.get(e.type) ?? { attempts: 0, success: 0 };
+  existing.attempts += 1;
+  if (success) existing.success += 1;
+  moments.set(e.type, existing);
+}
+if (moments.size > 0) {
+  console.log("\nKey moments (success / attempts):");
+  for (const [type, v] of moments) {
+    const pct = v.attempts > 0 ? ((100 * v.success) / v.attempts).toFixed(0) : "0";
+    console.log(`  ${type.padEnd(10)} ${v.success}/${v.attempts} (${pct}%)`);
+  }
+}
+
+if (opts.events) {
+  console.log("\nFull event stream:");
+  for (const ev of result.events) {
+    console.log("  " + JSON.stringify(ev));
+  }
+}

--- a/packages/sim-engine/scripts/debug-match.ts
+++ b/packages/sim-engine/scripts/debug-match.ts
@@ -63,7 +63,7 @@ for (const [type, count] of sorted) {
 
 // MOVE breakdown by kind
 const moveKinds = new Map<string, { count: number; sumYards: number }>();
-let totalMoveYards = { home: 0, away: 0 };
+const totalMoveYards = { home: 0, away: 0 };
 for (const ev of result.events) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const e = ev as any;


### PR DESCRIPTION
## Summary

Investigation des 4 matchs test sandbox 0-0 rapportes par l'user. Le moteur 0.16.0 produit **0.95 TD/match en moyenne** (120 pairings, 20 runs chacun) vs **FUMBBL reference 1.5-2.2** selon race. **30-50% trop bas en scoring**.

## Investigation

### Bench matrix observe
- TD/match mean : **0.95** (vs FUMBBL 1.5-2.2)
- TD/match range : 0.10 - 2.70
- Draw rate single pairing : **50-80%** (vs ~25-30% attendu)

### Cas reproduit (Gold Rush vs Iron Bears, seed=42)
- 16 turns, 13 MOVE events
- Total yards : home 18, away 10
- MOVE breakdown : 8 "positioning" (16 yds), 4 "halt" (0 yds), 1 "sweep" (12 yds)
- Pour scorer (yardline 4 → 26 = 22 yds), il faudrait ~22 yards/drive

### Cause probable

Le commentaire dans `hybrid-driver.ts:443-458` explique le re-tuning "Bug #2 panel feedback" :
- breakthrough magnitudes 30/35/40 → 12/15/18 (divises par 2.5x)
- Hard cap MAX_TURN_YARDS = 16 ajoute

Math des yards/turn (Skaven attack, Dwarf defense) :
```
dice 2d6+2 (mean 7) + paceOffset +2 + bashCounter -3 +
defensiveDisruption -3 + tvBonus -1 + breakthrough +1.1 = 3.1 yds/turn
```

Pour scorer 22 yds, il faut ~7-8 turns parfaits sans turnover. Avec ~5 turnovers/match, drives moyens font 2-3 turns. Donc TD rare.

## Livrables

1. **`docs/engine-investigation-2026-05-12-low-tds.md`** — rapport complet :
   - Constat chiffre (bench matrix + cas concret)
   - 3 hypotheses cause
   - 6 options de fix (A-F) avec estimation impact + risque
   - Process pour fix (re-bench + snapshot + bump engineVer)

2. **`packages/sim-engine/scripts/debug-match.ts`** — utilitaire CLI :
   ```bash
   pnpm tsx scripts/debug-match.ts --teamA=sf-gold-rush --teamB=chi-iron-bears
   # → event histogram, MOVE breakdown, turnover reasons, key moments
   ```
   Optionnel `--events` pour dump le stream complet.

## Options de fix proposees

| Option | Difficulte | Impact estime | Risque |
|---|---|---|---|
| A. Starting yardline 4 → 8 | trivial | +30% TDs | Modere |
| B. Base dice 2d6+2 → 3d6+0 | facile | +50-60% TDs | Eleve |
| C. defensiveDisruption max -3 → -2 | facile | +15-20% TDs | Faible |
| D. Breakthrough probability 18% → 25% | facile | +25-30% TDs | Modere |
| E. Breakthrough magnitudes 12/15/18 → 16/20/24 | facile | +30-40% TDs | Modere |
| **F. Combo C + D** | facile | **+40-50% TDs** | Modere |

**Recommendation initiale** : option F (combo C + D), conservatrice et qui ne touche pas aux magnitudes critiquees par le panel.

## Etat

- Pas de fix applique
- Script debug commit pour permettre investigation parallele (user a demande "j'attends le debug des replay")
- Baseline 0.16.0 reste en place
- Tous les replays existants restent decodables

## Test plan

- [x] Bench matrix run pour confirmer le constat (120 pairings, 20 runs)
- [x] Script debug fonctionnel sur Gold Rush vs Iron Bears (seed 42)
- [ ] Decide quelle option tester (input user)
- [ ] Re-bench apres fix
- [ ] Snapshot nouveau baseline si OK
- [ ] Bump ENGINE_VER 0.16.0 → 0.17.0

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_