### PR TITLE
feat(sim-engine): engine 0.17.0 — tune TDs (option F combo C+D)

### DIFF
--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,6 +1,6 @@
 {
-  "engineVer": "0.16.0",
-  "snapshotAt": "2026-05-07",
+  "engineVer": "0.17.0",
+  "snapshotAt": "2026-05-12",
   "tolerance": 0.05,
   "pairings": [
     {
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.365,
-        "tdStd": 0.8554384840536465,
-        "casualtyMean": 0.96,
+        "tdMean": 1.6,
+        "tdStd": 0.9591663046625445,
+        "casualtyMean": 0.97,
         "turnoverMean": 4.09,
-        "homeWinRate": 0.265,
-        "awayWinRate": 0.395,
-        "drawRate": 0.34
+        "homeWinRate": 0.285,
+        "awayWinRate": 0.435,
+        "drawRate": 0.28
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.33,
-        "tdStd": 0.8950418984606255,
-        "casualtyMean": 1.12,
-        "turnoverMean": 5.075,
-        "homeWinRate": 0.8,
-        "awayWinRate": 0.025,
-        "drawRate": 0.175
+        "tdMean": 1.52,
+        "tdStd": 1.0486181383134658,
+        "casualtyMean": 1.135,
+        "turnoverMean": 5.08,
+        "homeWinRate": 0.735,
+        "awayWinRate": 0.055,
+        "drawRate": 0.21
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.035,
-        "tdStd": 0.8624239096871101,
-        "casualtyMean": 0.95,
-        "turnoverMean": 4.255,
-        "homeWinRate": 0.3,
-        "awayWinRate": 0.26,
-        "drawRate": 0.44
+        "tdMean": 1.455,
+        "tdStd": 0.988926185314151,
+        "casualtyMean": 0.96,
+        "turnoverMean": 4.19,
+        "homeWinRate": 0.35,
+        "awayWinRate": 0.325,
+        "drawRate": 0.325
       }
     }
   ]

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -459,18 +459,27 @@ function rollYards(
   const dice = Math.floor(rng.next() * 6) + Math.floor(rng.next() * 6) + 2;
   const paceOffset = Math.round(profile.pace / 25) - 2;
   const bashCounter = -Math.round(defenseProfile.bashIndex / 28);
+  // Engine 0.17.0 tuning (matchs 0-0 fix) : cap defensiveDisruption a -2
+  // (previously -3). Combine avec bashCounter (-3 max), la penalite
+  // defense max etait -6 yds/turn — trop punitive vs Dwarf bash. Reduit
+  // a -5 max permet de re-equilibrer le TD/match mean (0.95 → ~1.4).
   const defensiveDisruption = -Math.min(
-    3,
+    2,
     Math.round((defenseProfile.stallTendency * defenseProfile.bashIndex) / 2000)
   );
   const tvBonus = Math.max(-3, Math.min(3, Math.round(tvDelta / 80)));
   const fatTail = rng.next();
   let breakthrough = 0;
-  if (fatTail < 0.18) {
+  // Engine 0.17.0 tuning : breakthrough probability 18% → 25% pour
+  // augmenter la frequence des "long plays" dramaturgiques sans toucher
+  // aux magnitudes (que le panel feedback avait critiquees a 30/35/40).
+  // Magnitudes 12/15/18 inchangees. Breakthrough negatif (-10) deplacé
+  // proportionellement (0.34 → 0.41).
+  if (fatTail < 0.25) {
     if (defenseProfile.bashIndex < 50) breakthrough = 18;
     else if (defenseProfile.bashIndex < 70) breakthrough = 15;
     else breakthrough = 12;
-  } else if (fatTail < 0.34) {
+  } else if (fatTail < 0.41) {
     breakthrough = -10;
   }
   const total = dice + paceOffset + bashCounter + defensiveDisruption + tvBonus + breakthrough;

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.16.0';
+export const ENGINE_VER = '0.17.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Summary

Suite a l'investigation PR #786 : applique **option F (combo C + D)** pour re-tuner `rollYards` du hybrid driver et augmenter le TD/match mean (0.95 → 1.22, +28%).

## Changements

| Param | Avant | Apres | Justif |
|---|---|---|---|
| `defensiveDisruption` max | -3 yds | -2 yds | Penalite defense max -6 → -5 |
| `breakthrough` probability | 18% | 25% | Plus de "long plays" sans toucher magnitudes |
| `breakthrough` negatif window | 0.34 | 0.41 | Translation proportionnelle |
| `ENGINE_VER` | 0.16.0 | 0.17.0 | Bump (changement comportement) |
| `bench-baseline.json` | snapshotted 2026-05-07 | snapshotted 2026-05-12 | Re-snapshot avec nouvelles valeurs |

**Magnitudes 12/15/18 inchangees** — le panel feedback original visait les magnitudes (30/35/40 → 12/15/18), pas la frequence. On a juste rendu les breakthrough events plus frequents.

## Resultats

### Bench matrix (120 pairings × 20 runs)

| | Avant 0.16.0 | Apres 0.17.0 | FUMBBL ref |
|---|---|---|---|
| TD/match mean | 0.95 | **1.22** | 1.5-2.2 |
| TD/match min | 0.10 | **0.35** | — |
| TD/match max | 2.70 | 2.75 | — |

### Pairing reproduit (Gold Rush vs Iron Bears, 50 runs)

| | Avant | Apres |
|---|---|---|
| TD mean | 1.04 | **1.46** |
| Outcomes (H/A/D) | 9/18/23 | 9/17/24 |
| Std dev TD | 0.85 | 0.92 |

Toujours sous FUMBBL ref (1.5-2.2) mais bien plus proche. Si encore juge trop bas, options residuelles (A starting yardline, E magnitudes, B base dice).

### Baseline officielle (Smashers vs Soaring Hawks 200 runs)

| | Avant | Apres |
|---|---|---|
| tdMean | 1.365 | **1.6** |
| tdStd | 0.855 | 0.959 |
| awayWinRate | 0.395 | 0.435 |
| drawRate | 0.34 | 0.28 |

## Verifications

- [x] 30/30 test files sim-engine pass (**382 tests**)
- [x] 203/204 test files server pass (3 fails `kofi.test.ts` **pre-existants** sur main, sqlite JSON serialisation, non lies)
- [x] `pnpm sim:bench:ci` PASS sur baseline 0.17.0
- [x] `pnpm lint` clean
- [x] `pnpm build` clean

## Test plan

- [x] Bench matrix mesure le gain (~+28% TDs)
- [x] Bench CI valide la nouvelle baseline
- [x] sim-engine tests passent
- [ ] Sandbox test match en prod produit des scores varies (a verifier post-merge avec script `pnpm tsx packages/sim-engine/scripts/debug-match.ts`)

## Suivi

Si le TD/match reste juge trop bas apres ce sprint :
- **Option A** (starting yardline 4 → 8) — +30% TDs, risque modere
- **Option E** (breakthrough magnitudes 12/15/18 → 16/20/24) — +30-40%, modere (re-introduit critique panel feedback)
- **Option B** (base dice 2d6+2 → 3d6+0) — +50-60%, risque eleve

Reference : `docs/engine-investigation-2026-05-12-low-tds.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_