### PR TITLE
feat(sim-engine): engine 0.18.0 — starting yardline 4→6 (option A)

### DIFF
--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.17.0",
+  "engineVer": "0.18.0",
   "snapshotAt": "2026-05-12",
   "tolerance": 0.05,
   "pairings": [
@@ -9,12 +9,12 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.6,
-        "tdStd": 0.9591663046625445,
-        "casualtyMean": 0.97,
-        "turnoverMean": 4.09,
-        "homeWinRate": 0.285,
-        "awayWinRate": 0.435,
+        "tdMean": 1.865,
+        "tdStd": 1.0376776956261513,
+        "casualtyMean": 0.945,
+        "turnoverMean": 4.165,
+        "homeWinRate": 0.28,
+        "awayWinRate": 0.44,
         "drawRate": 0.28
       }
     },
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.52,
-        "tdStd": 1.0486181383134658,
-        "casualtyMean": 1.135,
-        "turnoverMean": 5.08,
-        "homeWinRate": 0.735,
-        "awayWinRate": 0.055,
-        "drawRate": 0.21
+        "tdMean": 1.625,
+        "tdStd": 1.1110243021644486,
+        "casualtyMean": 1.12,
+        "turnoverMean": 5.22,
+        "homeWinRate": 0.745,
+        "awayWinRate": 0.05,
+        "drawRate": 0.205
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.455,
-        "tdStd": 0.988926185314151,
-        "casualtyMean": 0.96,
-        "turnoverMean": 4.19,
-        "homeWinRate": 0.35,
-        "awayWinRate": 0.325,
-        "drawRate": 0.325
+        "tdMean": 1.68,
+        "tdStd": 1.038075141788878,
+        "casualtyMean": 0.955,
+        "turnoverMean": 4.31,
+        "homeWinRate": 0.325,
+        "awayWinRate": 0.385,
+        "drawRate": 0.29
       }
     }
   ]

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -486,10 +486,17 @@ function rollYards(
   return Math.max(0, Math.min(MAX_TURN_YARDS, total));
 }
 
+// Engine 0.18.0 — starting yardline 4 → 6 (option A modeste). Le ball
+// BB atterrit cote receiver typiquement vers yard 6 (pas yard 4 qui
+// supposait 22 yds a traverser). Ramene le drive a 20 yds = ~3 turns
+// avec mean 6-7 yds/turn (vs ~4 turns avant). Cible : TD/match mean
+// 1.22 → ~1.5 (FUMBBL Dwarf ref).
+const STARTING_YARDLINE = 6;
+
 function nextDrive(prev: DriveState): DriveState {
   return {
     drivingTeam: otherSide(prev.drivingTeam),
-    ballYardline: 4,
+    ballYardline: STARTING_YARDLINE,
   };
 }
 
@@ -837,7 +844,7 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
       turn: 1,
       scoreHome: 0,
       scoreAway: 0,
-      drive: { drivingTeam: initialReceiver, ballYardline: 4 },
+      drive: { drivingTeam: initialReceiver, ballYardline: STARTING_YARDLINE },
       clockMs: kickoffAtMs,
     },
     events: [
@@ -885,7 +892,7 @@ export function runHybridDriver(input: SimInput, options: DriverOptions = {}): S
     half: 2,
     turn: 1,
     clockMs: m.state.clockMs + MS_HALFTIME,
-    drive: { drivingTeam: otherSide(initialReceiver), ballYardline: 4 },
+    drive: { drivingTeam: otherSide(initialReceiver), ballYardline: STARTING_YARDLINE },
   };
 
   // Second half.

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.17.0';
+export const ENGINE_VER = '0.18.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Summary

Suite a l'engine 0.17.0 (#787, +28% TDs), applique **option A** : starting yardline 4 → 6 pour rapprocher davantage FUMBBL (cible mean ~1.7).

## Rationale BB

En BB officiel, apres un kickoff, le ball atterrit cote receiver typiquement vers yard 6-8 sur terrain 26 yds. **Yard 4 etait trop pessimiste** (22 yds a traverser pour scorer). Yard 6 → 20 yds = ~1 turn de moins en moyenne.

## Changements

| Param | Avant 0.17.0 | Apres 0.18.0 |
|---|---|---|
| `STARTING_YARDLINE` | 4 (litteral disperse) | 6 (constant module) |
| Drive distance | 22 yds | 20 yds |
| `ENGINE_VER` | 0.17.0 | 0.18.0 |
| `bench-baseline.json` | 0.17.0 / 2026-05-12 | 0.18.0 / 2026-05-12 |

Code propre : extrait `STARTING_YARDLINE = 6` en constant module pour eviter les 3 litteraux disperses dans le code.

## Resultats — progression cumulee 3 PRs

### Matrix 120 pairings × 20 runs

| | 0.16.0 | 0.17.0 (#787) | **0.18.0 (this PR)** |
|---|---|---|---|
| TD/match mean | 0.95 | 1.22 | **1.43** |
| TD/match min | 0.10 | 0.35 | **0.50** |
| TD/match max | 2.70 | 2.75 | **3.00** |

### Pairings 50 runs (rapproches FUMBBL 1.5-2.2)

| Pairing | 0.16.0 | 0.17.0 | **0.18.0** |
|---|---|---|---|
| Gold Rush (Skaven) vs Iron Bears (Dwarf) | 1.04 | 1.46 | **1.80** |
| Smashers (Orc) vs Soaring Hawks (Wood Elf) | 1.38 | 1.46 | **1.78** |
| Gold Rush vs Cold Tacticians | — | — | **1.94** |
| Cheese Halflings vs Snow Ogres | — | — | **1.76** |

FUMBBL ref : Skaven 2.2, Orc 1.7, Dwarf 1.5. **On est dans la cible** pour Orc/Dwarf, encore sous Skaven (2.2) mais bien plus proche que 0.16.0 (1.04 vs 1.80).

### Baseline officielle (Smashers vs Soaring Hawks 200 runs)

| | 0.16.0 | 0.17.0 | **0.18.0** |
|---|---|---|---|
| tdMean | 1.365 | 1.6 | **1.865** |
| awayWinRate | 0.395 | 0.435 | 0.44 |
| drawRate | 0.34 | 0.28 | 0.28 |
| casualtyMean | 0.96 | 0.97 | 0.945 |

Cas/turnovers/win-rates restent stables — on a juste facilite le scoring, pas casse l'equilibrage defense.

## Verifications

- [x] 30/30 test files sim-engine pass (**382 tests**)
- [x] `pnpm sim:bench:ci` PASS sur baseline 0.18.0
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] `pnpm sim:bench --matrix` mesure le gain

## Test plan

- [x] Bench matrix mesure +17% TDs vs 0.17.0
- [x] Pairings specifiques montrent rapprochement FUMBBL (1.76-1.94 vs ref 1.5-2.2)
- [x] Bench CI valide nouvelle baseline
- [ ] Sandbox test match en prod (a verifier post-merge avec `/admin/sim/test-match`)

## Suite possible (si encore juge trop bas)

| Option | Impact estime | Risque |
|---|---|---|
| Yardline 6 → 8 | +15-20% TDs | Modere — sort du range BB realiste |
| Option B (2d6+2 → 3d6+0) | +50% | Eleve — change variance distribution |
| Layer C/D plus aggressive | variable | Modere |

Reference : `docs/engine-investigation-2026-05-12-low-tds.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_