### PR TITLE
feat(match): Sprint R.E.2 — UI async web (countdown + listing)

### DIFF
--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -7,11 +7,33 @@ const router = Router();
 
 router.get("/matches", authUser, async (req: AuthenticatedRequest, res) => {
   const { limit, offset } = parsePagination(req.query as Record<string, unknown>);
-  const where = { players: { some: { id: req.user!.id } } };
+  // Sprint R.E.2 — filtre optionnel `?mode=async` pour la page
+  // /me/matches/async qui liste les matches en attente d'un coup.
+  const modeFilter = typeof req.query.mode === "string" ? req.query.mode : null;
+  const where: {
+    players: { some: { id: string } };
+    mode?: string;
+    status?: string;
+  } = { players: { some: { id: req.user!.id } } };
+  if (modeFilter === "async" || modeFilter === "realtime") {
+    where.mode = modeFilter;
+  }
+  if (typeof req.query.status === "string" && req.query.status.length > 0) {
+    where.status = req.query.status;
+  }
   const [matches, total] = await Promise.all([
     prisma.match.findMany({
       where,
-      select: { id: true, status: true, seed: true, createdAt: true },
+      select: {
+        id: true,
+        status: true,
+        seed: true,
+        createdAt: true,
+        mode: true,
+        currentTurnUserId: true,
+        currentTurnDeadline: true,
+        turnDeadlineHours: true,
+      },
       orderBy: { createdAt: "desc" },
       take: limit,
       skip: offset,

--- a/apps/web/app/components/AsyncMatchCountdown.tsx
+++ b/apps/web/app/components/AsyncMatchCountdown.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Sprint R — Lot R.E.2 : composant countdown async match.
+ *
+ * Poll GET /match/:id/async-status toutes les 30s. Affiche :
+ *   - Badge "Ton tour" si isYourTurn (couleur emerald)
+ *   - Countdown "X h Y min restantes" si async + not your turn
+ *   - "Deadline depassee" si isDeadlineExpired (rouge)
+ *   - Rien (composant retourne null) si match realtime ou inexistant.
+ *
+ * Pas de WebSocket — on poll simplement. Pour les async matches,
+ * 30s est tres conservateur (deadline = heures, pas secondes).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { apiRequest } from "../lib/api-client";
+
+interface AsyncMatchStatus {
+  readonly matchId: string;
+  readonly mode: "realtime" | "async";
+  readonly status: string;
+  readonly currentTurnUserId: string | null;
+  readonly currentTurnDeadline: string | null;
+  readonly turnDeadlineHours: number;
+  readonly hoursRemaining: number | null;
+  readonly isYourTurn: boolean;
+  readonly isDeadlineExpired: boolean;
+}
+
+interface AsyncMatchCountdownProps {
+  readonly matchId: string;
+  /** Tick interval en ms. Default 30s. */
+  readonly pollIntervalMs?: number;
+  /** Affiche aussi en mode realtime (default false : composant retourne null). */
+  readonly showInRealtime?: boolean;
+}
+
+function formatRemaining(hoursRemaining: number): string {
+  if (hoursRemaining <= 0) return "0 min";
+  const totalMinutes = Math.round(hoursRemaining * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes} min`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes} min`;
+}
+
+export function AsyncMatchCountdown(
+  props: AsyncMatchCountdownProps,
+): JSX.Element | null {
+  const { matchId, pollIntervalMs = 30_000, showInRealtime = false } = props;
+  const [status, setStatus] = useState<AsyncMatchStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchStatus(): Promise<void> {
+      try {
+        const result = await apiRequest<{ data: AsyncMatchStatus } | AsyncMatchStatus>(
+          `/match/${encodeURIComponent(matchId)}/async-status`,
+        );
+        // sendSuccess wrapper retourne { data: ... } sometimes.
+        const view: AsyncMatchStatus =
+          (result as { data?: AsyncMatchStatus }).data ?? (result as AsyncMatchStatus);
+        if (!cancelled) setStatus(view);
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Erreur reseau");
+        }
+      }
+    }
+    void fetchStatus();
+    const id = setInterval(fetchStatus, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [matchId, pollIntervalMs]);
+
+  const remaining = useMemo(
+    () =>
+      status?.hoursRemaining !== null && status?.hoursRemaining !== undefined
+        ? formatRemaining(status.hoursRemaining)
+        : null,
+    [status?.hoursRemaining],
+  );
+
+  if (error) {
+    return (
+      <span
+        data-testid="async-countdown-error"
+        className="text-xs text-red-400"
+      >
+        {error}
+      </span>
+    );
+  }
+  if (!status) return null;
+  if (status.mode === "realtime" && !showInRealtime) return null;
+  if (status.status !== "active") return null;
+
+  if (status.isDeadlineExpired) {
+    return (
+      <span
+        data-testid="async-countdown-expired"
+        className="rounded bg-red-900/40 px-2 py-0.5 text-xs text-red-200"
+      >
+        Deadline depassee
+      </span>
+    );
+  }
+
+  if (status.isYourTurn) {
+    return (
+      <span
+        data-testid="async-countdown-your-turn"
+        className="rounded bg-emerald-900/40 px-2 py-0.5 text-xs text-emerald-200"
+      >
+        A toi de jouer ({remaining ?? "—"})
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-testid="async-countdown-waiting"
+      className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-300"
+    >
+      Tour adverse — {remaining ?? "—"} restantes
+    </span>
+  );
+}

--- a/apps/web/app/me/matches/async/page.tsx
+++ b/apps/web/app/me/matches/async/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+/**
+ * Sprint R — Lot R.E.2 : page liste matches async.
+ *
+ * Liste les matches en mode `async` de l'utilisateur courant, classes :
+ *   1. Ton tour en premier (isYourTurn=true)
+ *   2. En attente adverse ensuite
+ *   3. Termines/abandonnes a la fin
+ *
+ * Chaque ligne affiche le countdown via `<AsyncMatchCountdown>`.
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { AsyncMatchCountdown } from "../../../components/AsyncMatchCountdown";
+import { apiRequest } from "../../../lib/api-client";
+
+interface AsyncMatch {
+  readonly id: string;
+  readonly status: string;
+  readonly seed: string;
+  readonly createdAt: string;
+  readonly mode: "realtime" | "async";
+  readonly currentTurnUserId: string | null;
+  readonly currentTurnDeadline: string | null;
+  readonly turnDeadlineHours: number;
+}
+
+interface ListResponse {
+  readonly matches: readonly AsyncMatch[];
+}
+
+interface MeResponse {
+  readonly user?: { id: string };
+}
+
+export default function AsyncMatchesPage(): JSX.Element {
+  const [matches, setMatches] = useState<readonly AsyncMatch[] | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([
+      apiRequest<ListResponse>("/me/matches?mode=async&limit=50&status=active"),
+      apiRequest<MeResponse>("/auth/me").catch(() => ({ user: undefined }) as MeResponse),
+    ])
+      .then(([list, me]) => {
+        setMatches(list.matches);
+        setCurrentUserId(me.user?.id ?? null);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Erreur reseau"));
+  }, []);
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="mb-4 text-2xl font-bold">Matches async</h1>
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      </main>
+    );
+  }
+
+  if (matches === null) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="mb-4 text-2xl font-bold">Matches async</h1>
+        <p className="text-sm text-slate-400">Chargement…</p>
+      </main>
+    );
+  }
+
+  if (matches.length === 0) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="mb-2 text-2xl font-bold">Matches async</h1>
+        <p
+          data-testid="async-matches-empty"
+          className="text-sm text-slate-400"
+        >
+          Aucun match async actif. Cree un match en mode async depuis ta ligue
+          pour jouer un coup par jour.
+        </p>
+      </main>
+    );
+  }
+
+  // Tri : ton tour en premier, puis adversaire, puis le reste.
+  const sorted = [...matches].sort((a, b) => {
+    const aYour = a.currentTurnUserId === currentUserId ? 0 : 1;
+    const bYour = b.currentTurnUserId === currentUserId ? 0 : 1;
+    if (aYour !== bYour) return aYour - bYour;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-2 text-2xl font-bold">Matches async</h1>
+      <p className="mb-4 text-sm text-slate-400">
+        1 coup par jour. Si tu ne joues pas avant la deadline, le tour passe
+        automatiquement.
+      </p>
+      <ul className="space-y-2">
+        {sorted.map((m) => (
+          <li
+            key={m.id}
+            data-testid={`async-match-${m.id}`}
+            className="flex items-center justify-between rounded border border-slate-800 bg-slate-900 p-3"
+          >
+            <div>
+              <Link
+                href={`/play/${m.id}` as never as string}
+                className="font-mono text-sm text-slate-200 hover:underline"
+              >
+                #{m.id.slice(0, 8)}
+              </Link>
+              <p className="text-xs text-slate-500">
+                {m.turnDeadlineHours}h par tour
+              </p>
+            </div>
+            <AsyncMatchCountdown matchId={m.id} pollIntervalMs={60_000} />
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Suite R.E.1 (backend async). Ajoute UI web :
- **Composant** `<AsyncMatchCountdown>` reutilisable : poll 30s, badge "A toi de jouer (Xh Y min)" / "Tour adverse" / "Deadline depassee".
- **Page** `/me/matches/async` : liste les async matches actifs, tries (ton tour d'abord, puis adverse).
- **Backend mineur** : `GET /me/matches?mode=async&status=active` accepte filtre + expose `mode`/`currentTurnUserId`/`currentTurnDeadline`/`turnDeadlineHours`.

## Verifications

- [x] 26/26 tests async-match (backend, inchanges) pass
- [x] `pnpm lint` clean
- [x] `pnpm build` web clean
- [ ] `pnpm typecheck` : 1 nouvelle erreur `typedRoutes` (Next.js) dans `app/me/matches/async/page.tsx` (Link href string vs RouteImpl) — meme pattern que 5 erreurs **pre-existantes** sur main, non-bloquant.

## Test plan

- [ ] Visiter `/me/matches/async` non-auth → redirect login
- [ ] Visiter avec aucun async match → empty state
- [ ] Match async cree, c'est ton tour → badge "A toi de jouer (24h)" + tri en haut
- [ ] Match async cree, c'est ton adversaire → "Tour adverse - 24h restantes"
- [ ] Deadline depassee → badge rouge "Deadline depassee"
- [ ] Click sur le match → redirect `/play/:id`

## Suite R.E

- **R.E.3** : migration ligues v2 vers async (option `async league` au create).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_