### PR TITLE
feat(i18n): Sprint R.A.1 — i18n routing + locale auto-detection

### DIFF
--- a/apps/web/app/contexts/LanguageContext.tsx
+++ b/apps/web/app/contexts/LanguageContext.tsx
@@ -16,10 +16,21 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const [language, setLanguageState] = useState<Language>("fr");
 
   useEffect(() => {
-    // Après le montage, charger la langue depuis localStorage
+    // Après le montage, charger la langue depuis localStorage en
+    // priorite (choix explicite user), sinon depuis le cookie
+    // `NEXT_LOCALE` (auto-detecte au middleware via Accept-Language —
+    // Sprint R lot R.A.1).
     const stored = localStorage.getItem("language") as Language | null;
     if (stored === "fr" || stored === "en") {
       setLanguageState(stored);
+      return;
+    }
+    if (typeof document !== "undefined") {
+      const match = /(?:^|; )NEXT_LOCALE=([^;]+)/.exec(document.cookie);
+      const cookie = match ? decodeURIComponent(match[1]) : null;
+      if (cookie === "fr" || cookie === "en") {
+        setLanguageState(cookie);
+      }
     }
   }, []);
 
@@ -33,8 +44,11 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const setLanguage = (lang: Language) => {
     setLanguageState(lang);
     localStorage.setItem("language", lang);
-    // Mettre à jour l'attribut lang du html
+    // Sprint R.A.1 — sync le cookie NEXT_LOCALE pour que le serveur
+    // SSR/middleware voie la meme langue au prochain reload.
     if (typeof document !== "undefined") {
+      const oneYear = 60 * 60 * 24 * 365;
+      document.cookie = `NEXT_LOCALE=${encodeURIComponent(lang)}; Max-Age=${oneYear}; Path=/; SameSite=Lax`;
       document.documentElement.lang = lang;
     }
   };

--- a/apps/web/app/lib/locale-detection.test.ts
+++ b/apps/web/app/lib/locale-detection.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Sprint R lot R.A.1 — tests du helper locale-detection.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_LOCALE,
+  detectLocaleFromHeader,
+  parseAcceptLanguageHeader,
+} from "./locale-detection";
+
+describe("parseAcceptLanguageHeader", () => {
+  it("parse une seule entree sans q", () => {
+    const out = parseAcceptLanguageHeader("en");
+    expect(out).toEqual([{ tag: "en", q: 1 }]);
+  });
+
+  it("parse plusieurs entrees triees par q desc", () => {
+    const out = parseAcceptLanguageHeader("fr;q=0.5,en;q=0.9,de;q=0.7");
+    expect(out.map((e) => e.tag)).toEqual(["en", "de", "fr"]);
+  });
+
+  it("default q=1 si absent", () => {
+    const out = parseAcceptLanguageHeader("en-US,fr;q=0.5");
+    expect(out[0]).toEqual({ tag: "en-us", q: 1 });
+  });
+
+  it("ignore les entrees vides ou '*'", () => {
+    const out = parseAcceptLanguageHeader("*,, ,en");
+    expect(out).toEqual([{ tag: "en", q: 1 }]);
+  });
+
+  it("lowercase les tags", () => {
+    const out = parseAcceptLanguageHeader("EN-US,FR");
+    expect(out.map((e) => e.tag)).toEqual(["en-us", "fr"]);
+  });
+
+  it("rejette les q-values invalides (defaut 1)", () => {
+    const out = parseAcceptLanguageHeader("en;q=2.0,fr;q=NaN");
+    // q=2.0 invalide (max 1), q=NaN invalide → default 1.
+    expect(out[0].q).toBe(1);
+  });
+});
+
+describe("detectLocaleFromHeader", () => {
+  it("retourne defaultLocale si header null/vide", () => {
+    expect(detectLocaleFromHeader(null)).toBe(DEFAULT_LOCALE);
+    expect(detectLocaleFromHeader("")).toBe(DEFAULT_LOCALE);
+    expect(detectLocaleFromHeader("   ")).toBe(DEFAULT_LOCALE);
+  });
+
+  it("match exact fr", () => {
+    expect(detectLocaleFromHeader("fr")).toBe("fr");
+  });
+
+  it("match exact en", () => {
+    expect(detectLocaleFromHeader("en")).toBe("en");
+  });
+
+  it("match prefix en-US → en", () => {
+    expect(detectLocaleFromHeader("en-US,en;q=0.9")).toBe("en");
+  });
+
+  it("respecte la q-value : en > fr", () => {
+    expect(detectLocaleFromHeader("fr;q=0.5,en;q=0.9")).toBe("en");
+  });
+
+  it("respecte la q-value : fr > en", () => {
+    expect(detectLocaleFromHeader("en;q=0.5,fr;q=0.9")).toBe("fr");
+  });
+
+  it("fallback default si aucun match (de non supporte)", () => {
+    expect(detectLocaleFromHeader("de-DE,de;q=0.9", "fr")).toBe("fr");
+  });
+
+  it("respecte custom defaultLocale", () => {
+    expect(detectLocaleFromHeader("de-DE", "en")).toBe("en");
+  });
+
+  it("preserve l'ordre de priorite quand q egal", () => {
+    // Avec q identique (1), trie stable → premier element gagne.
+    expect(detectLocaleFromHeader("en,fr")).toBe("en");
+    expect(detectLocaleFromHeader("fr,en")).toBe("fr");
+  });
+});

--- a/apps/web/app/lib/locale-detection.ts
+++ b/apps/web/app/lib/locale-detection.ts
@@ -1,0 +1,77 @@
+/**
+ * Sprint R — Lot R.A.1 : detection de locale depuis Accept-Language.
+ *
+ * Helper pur (testable sans Next.js runtime) qui parse un Accept-Language
+ * header et retourne la meilleure locale supportee par l'app.
+ *
+ * Strategie :
+ *   1. Parse les entrees `Accept-Language` avec leurs q-values.
+ *   2. Trie par q-value desc.
+ *   3. Pour chaque entree, match avec les SUPPORTED_LOCALES par prefixe
+ *      (ex: "en-US" matche "en"). Premier match gagne.
+ *   4. Sinon → defaultLocale.
+ *
+ * Exemple :
+ *   parseAcceptLanguage("en-US,en;q=0.9,fr;q=0.8") → "en"
+ *   parseAcceptLanguage("de-DE,de;q=0.9", default="fr") → "fr"
+ *     (de pas dans SUPPORTED → fallback)
+ */
+
+export type Locale = "fr" | "en";
+
+export const SUPPORTED_LOCALES: readonly Locale[] = ["fr", "en"] as const;
+export const DEFAULT_LOCALE: Locale = "fr";
+
+interface ParsedEntry {
+  readonly tag: string;
+  readonly q: number;
+}
+
+/**
+ * Parse un header Accept-Language en entrees `{ tag, q }` triees par
+ * q-value desc. Tolerant aux espaces et q-values invalides.
+ */
+export function parseAcceptLanguageHeader(header: string): ParsedEntry[] {
+  return header
+    .split(",")
+    .map((raw): ParsedEntry | null => {
+      const trimmed = raw.trim();
+      if (!trimmed) return null;
+      const [tag, ...params] = trimmed.split(";").map((p) => p.trim());
+      if (!tag || tag === "*") return null;
+      let q = 1;
+      for (const p of params) {
+        const match = /^q=([01](?:\.\d+)?)$/.exec(p);
+        if (match) {
+          const parsed = Number.parseFloat(match[1]);
+          if (Number.isFinite(parsed)) q = parsed;
+        }
+      }
+      return { tag: tag.toLowerCase(), q };
+    })
+    .filter((e): e is ParsedEntry => e !== null)
+    .sort((a, b) => b.q - a.q);
+}
+
+function isSupported(loc: string): loc is Locale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(loc);
+}
+
+/**
+ * Determine la meilleure locale supportee depuis un Accept-Language
+ * header. Fallback `defaultLocale` (FR) si rien ne match.
+ */
+export function detectLocaleFromHeader(
+  header: string | null | undefined,
+  defaultLocale: Locale = DEFAULT_LOCALE,
+): Locale {
+  if (!header || header.trim().length === 0) return defaultLocale;
+  const entries = parseAcceptLanguageHeader(header);
+  for (const entry of entries) {
+    // Match exact (ex: "fr") ou prefix (ex: "fr-CA" → "fr").
+    if (isSupported(entry.tag)) return entry.tag;
+    const prefix = entry.tag.split("-")[0];
+    if (isSupported(prefix)) return prefix;
+  }
+  return defaultLocale;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,6 +1,46 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { decodeJWT, isAdminToken } from "./lib/jwt-utils";
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  detectLocaleFromHeader,
+  type Locale,
+} from "./app/lib/locale-detection";
+
+const LOCALE_COOKIE = "NEXT_LOCALE";
+const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 an
+
+/**
+ * Sprint R lot R.A.1 — detection de locale.
+ *
+ * Set un cookie `NEXT_LOCALE` au premier visit selon `Accept-Language`.
+ * Le LanguageContext lit ce cookie au mount cote client si rien n'est
+ * stocke en `localStorage`. Les locales SUPPORTED_LOCALES sont
+ * "fr" et "en" pour l'instant ; les extensions futures (de, pl)
+ * peuvent etre ajoutees en modifiant uniquement `locale-detection.ts`.
+ */
+function maybeSetLocaleCookie(
+  request: NextRequest,
+  response: NextResponse,
+): void {
+  const existing = request.cookies.get(LOCALE_COOKIE)?.value;
+  if (
+    existing &&
+    (SUPPORTED_LOCALES as readonly string[]).includes(existing)
+  ) {
+    return;
+  }
+  const detected: Locale = detectLocaleFromHeader(
+    request.headers.get("accept-language"),
+    DEFAULT_LOCALE,
+  );
+  response.cookies.set(LOCALE_COOKIE, detected, {
+    maxAge: LOCALE_COOKIE_MAX_AGE,
+    sameSite: "lax",
+    path: "/",
+  });
+}
 
 function verifyAdminAccess(request: NextRequest): boolean {
   // Récupère le token depuis les cookies ou les headers
@@ -31,6 +71,11 @@ export async function middleware(request: NextRequest) {
   if (pathname.startsWith("/api/")) {
     return NextResponse.next();
   }
+
+  // Sprint R lot R.A.1 — set NEXT_LOCALE cookie au 1er visit. Pas de
+  // matcher specifique : on l'ajoute a chaque response, idempotent.
+  const localeResponse = NextResponse.next();
+  maybeSetLocaleCookie(request, localeResponse);
 
   // Protège toutes les routes commençant par /admin
   if (pathname.startsWith("/admin")) {
@@ -80,10 +125,15 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  return localeResponse;
 }
 
+// Matcher elargi pour le cookie locale : toutes les pages sauf
+// `/api/*`, `/_next/*` (statics), `/favicon.*`, etc. Les routes
+// `/admin/*` et `/me/*` continuent de beneficier des verifs auth.
 export const config = {
-  matcher: ["/admin/:path*", "/me/:path*"],
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon|images|fonts|icons|.*\\.).*)",
+  ],
 };
 


### PR DESCRIPTION
## Summary

Premier lot du **Sprint R.A** (internationalisation). Pose les fondations pour 4 locales (FR/EN + DE/PL futures) **sans** refactor des pages.

**Approche pragmatique** : plutot que de migrer toutes les pages vers `/fr/*`, `/en/*` segments (XL refactor), on attaque par la detection : middleware Next.js qui set le cookie `NEXT_LOCALE` au premier visit selon Accept-Language.

## Pattern

- **Helper pur** `app/lib/locale-detection.ts` : `parseAcceptLanguageHeader` + `detectLocaleFromHeader`. Testable sans Next.js runtime.
- **Middleware Next.js** : set `NEXT_LOCALE` cookie (1 an, SameSite=Lax, Path=/) si pas deja present. Matcher elargi pour s'appliquer a toutes les pages (sauf API et statics).
- **`LanguageContext`** (client) :
  - Lit localStorage en priorite (choix explicite user).
  - Fallback sur cookie NEXT_LOCALE (auto-detecte).
  - Au `setLanguage`, sync le cookie pour coherence serveur.

## Q-value parsing

Parse les entrees `Accept-Language` avec q-values, trie desc, match exact ou par prefixe (`en-US` → `en`). Tolerant aux entrees invalides (`*`, vides, q=NaN). Si rien ne match, fallback `DEFAULT_LOCALE` (fr).

## Extension future

Pour ajouter DE/PL, il suffira d'etendre `SUPPORTED_LOCALES` dans `locale-detection.ts` (+ ajouter les bundles translations). Le middleware n'a pas besoin de modif.

## Tests

`locale-detection.test.ts` : **15 tests** unit
- `parseAcceptLanguageHeader` : single, multi-q, default q=1, ignore `*`/vides, lowercase, q invalide
- `detectLocaleFromHeader` : null/empty, exact match, prefix match, custom default, ordre quand q egal

## Verifications

- [x] 15/15 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [ ] `pnpm typecheck` : memes 5 erreurs `typedRoutes` **pre-existantes** sur main (non-bloquant car build passe).

## Test plan

- [ ] Visiter site avec Accept-Language=`en-US` → cookie `NEXT_LOCALE=en` set
- [ ] Visiter site avec Accept-Language=`de-DE` (non supporte) → cookie `NEXT_LOCALE=fr` (default)
- [ ] User clique switch language → cookie + localStorage updated en sync
- [ ] Reload → langue preservee depuis localStorage > cookie

## Sprint R progression

| Lot | Statut |
|---|---|
| R.E.1 backend async | ✅ #792 mergee |
| R.E.2 UI async | ✅ #793 en revue |
| R.E.3 ligues async | ✅ #794 en revue |
| **R.A.1 i18n routing** | **this PR** |
| R.A.4 SEO multi-langue | next |
| R.B.3 Ad-free supporter | next |
| R.D.3 NAF API | next |


---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_