### PR TITLE
feat(seo): Sprint R.A.4 — SEO multi-langue (hreflang + sitemap)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
+import { buildHreflangAlternates } from "./seo/hreflang";
 import { Cinzel_Decorative, Cinzel, Montserrat, Inter, Bebas_Neue } from "next/font/google";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
@@ -96,11 +97,10 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
   alternates: {
     canonical: baseUrl,
-    languages: {
-      "fr-FR": baseUrl,
-      en: baseUrl,
-      "x-default": baseUrl,
-    },
+    // Sprint R.A.4 — `buildHreflangAlternates` retourne le map BCP 47
+    // (fr-FR, en, x-default) pour le path racine. Quand R.A.2 introduira
+    // les segments /fr/* /en/*, ce helper prefixera automatiquement.
+    languages: buildHreflangAlternates("/"),
   },
   openGraph: {
     type: "website",

--- a/apps/web/app/lib/locale-detection.ts
+++ b/apps/web/app/lib/locale-detection.ts
@@ -1,0 +1,77 @@
+/**
+ * Sprint R — Lot R.A.1 : detection de locale depuis Accept-Language.
+ *
+ * Helper pur (testable sans Next.js runtime) qui parse un Accept-Language
+ * header et retourne la meilleure locale supportee par l'app.
+ *
+ * Strategie :
+ *   1. Parse les entrees `Accept-Language` avec leurs q-values.
+ *   2. Trie par q-value desc.
+ *   3. Pour chaque entree, match avec les SUPPORTED_LOCALES par prefixe
+ *      (ex: "en-US" matche "en"). Premier match gagne.
+ *   4. Sinon → defaultLocale.
+ *
+ * Exemple :
+ *   parseAcceptLanguage("en-US,en;q=0.9,fr;q=0.8") → "en"
+ *   parseAcceptLanguage("de-DE,de;q=0.9", default="fr") → "fr"
+ *     (de pas dans SUPPORTED → fallback)
+ */
+
+export type Locale = "fr" | "en";
+
+export const SUPPORTED_LOCALES: readonly Locale[] = ["fr", "en"] as const;
+export const DEFAULT_LOCALE: Locale = "fr";
+
+interface ParsedEntry {
+  readonly tag: string;
+  readonly q: number;
+}
+
+/**
+ * Parse un header Accept-Language en entrees `{ tag, q }` triees par
+ * q-value desc. Tolerant aux espaces et q-values invalides.
+ */
+export function parseAcceptLanguageHeader(header: string): ParsedEntry[] {
+  return header
+    .split(",")
+    .map((raw): ParsedEntry | null => {
+      const trimmed = raw.trim();
+      if (!trimmed) return null;
+      const [tag, ...params] = trimmed.split(";").map((p) => p.trim());
+      if (!tag || tag === "*") return null;
+      let q = 1;
+      for (const p of params) {
+        const match = /^q=([01](?:\.\d+)?)$/.exec(p);
+        if (match) {
+          const parsed = Number.parseFloat(match[1]);
+          if (Number.isFinite(parsed)) q = parsed;
+        }
+      }
+      return { tag: tag.toLowerCase(), q };
+    })
+    .filter((e): e is ParsedEntry => e !== null)
+    .sort((a, b) => b.q - a.q);
+}
+
+function isSupported(loc: string): loc is Locale {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(loc);
+}
+
+/**
+ * Determine la meilleure locale supportee depuis un Accept-Language
+ * header. Fallback `defaultLocale` (FR) si rien ne match.
+ */
+export function detectLocaleFromHeader(
+  header: string | null | undefined,
+  defaultLocale: Locale = DEFAULT_LOCALE,
+): Locale {
+  if (!header || header.trim().length === 0) return defaultLocale;
+  const entries = parseAcceptLanguageHeader(header);
+  for (const entry of entries) {
+    // Match exact (ex: "fr") ou prefix (ex: "fr-CA" → "fr").
+    if (isSupported(entry.tag)) return entry.tag;
+    const prefix = entry.tag.split("-")[0];
+    if (isSupported(prefix)) return prefix;
+  }
+  return defaultLocale;
+}

--- a/apps/web/app/seo/hreflang.test.ts
+++ b/apps/web/app/seo/hreflang.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Sprint R lot R.A.4 — tests du helper hreflang.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  buildHreflangAlternates,
+  sitemapEntryWithAlternates,
+} from "./hreflang";
+
+describe("buildHreflangAlternates", () => {
+  it("retourne fr-FR + en + x-default pour la racine", () => {
+    const alt = buildHreflangAlternates("/");
+    expect(Object.keys(alt).sort()).toEqual(
+      ["en", "fr-FR", "x-default"].sort(),
+    );
+  });
+
+  it("toutes les URLs pointent vers le meme endpoint (pre-R.A.2 segments)", () => {
+    const alt = buildHreflangAlternates("/teams");
+    const urls = Object.values(alt);
+    expect(new Set(urls).size).toBe(1);
+    expect(urls[0]).toMatch(/\/teams$/);
+  });
+
+  it("normalize les paths sans leading slash", () => {
+    const alt = buildHreflangAlternates("teams");
+    expect(alt["fr-FR"]).toMatch(/\/teams$/);
+  });
+
+  it("path '/' retourne juste BASE_URL (pas BASE_URL/)", () => {
+    const alt = buildHreflangAlternates("/");
+    for (const url of Object.values(alt)) {
+      expect(url).not.toMatch(/\/$/);
+    }
+  });
+
+  it("x-default pointe vers le default locale", () => {
+    const alt = buildHreflangAlternates("/teams");
+    expect(alt["x-default"]).toBe(alt["fr-FR"]);
+  });
+});
+
+describe("sitemapEntryWithAlternates", () => {
+  it("genere un entry sitemap complet avec alternates.languages", () => {
+    const entry = sitemapEntryWithAlternates("/teams", {
+      lastModified: new Date("2026-05-12"),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    });
+    expect(entry.url).toMatch(/\/teams$/);
+    expect(entry.priority).toBe(0.9);
+    expect(entry.changeFrequency).toBe("weekly");
+    expect(entry.alternates?.languages).toBeDefined();
+    expect(Object.keys(entry.alternates?.languages ?? {}).sort()).toEqual(
+      ["en", "fr-FR", "x-default"].sort(),
+    );
+  });
+});

--- a/apps/web/app/seo/hreflang.ts
+++ b/apps/web/app/seo/hreflang.ts
@@ -1,0 +1,81 @@
+/**
+ * Sprint R — Lot R.A.4 : helpers SEO multi-langue.
+ *
+ * Genere les `alternates.languages` (hreflang) pour une URL donnee.
+ * Pour l'instant, toutes les locales pointent vers la **meme** URL
+ * (FR par defaut) — Google accepte ce mode tant que le content
+ * Server detecte la langue dynamiquement. Quand R.A.2 introduira
+ * les segments `/fr/*`, `/en/*`, il suffira d'etendre `localeToHref`
+ * pour faire prefixer le path.
+ *
+ * Convention BCP 47 :
+ *   - "fr-FR" / "en" / "x-default"
+ *   - Demain : "de-DE", "pl-PL" via SUPPORTED_LOCALES_SEO.
+ *
+ * x-default = page neutre (FR par defaut ici puisque c'est l'origin).
+ */
+
+import type { MetadataRoute } from "next";
+
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  type Locale,
+} from "../lib/locale-detection";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+/**
+ * Mappe une locale `Locale` (fr|en) vers son hreflang BCP 47 complet
+ * (fr-FR, en, …). Permet d'evoluer si on ajoute des variantes
+ * regionales (en-GB vs en-US par ex).
+ */
+const LOCALE_TO_HREFLANG: Record<Locale, string> = {
+  fr: "fr-FR",
+  en: "en",
+};
+
+/**
+ * Construit l'URL complete pour une locale donnee. Aujourd'hui, toutes
+ * les locales pointent vers la meme URL (pas de segments). Quand R.A.2
+ * introduira `/fr/*` / `/en/*`, retourner ici `${BASE_URL}/${locale}${path}`.
+ */
+function localeToHref(locale: Locale, path: string): string {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  // Pre-R.A.2 : pas de prefix locale. Toutes les locales = meme URL.
+  void locale;
+  return `${BASE_URL}${normalized === "/" ? "" : normalized}`;
+}
+
+/**
+ * Genere le bloc `alternates.languages` pour un path donne, utilisable
+ * dans :
+ *   - `MetadataRoute.Sitemap` entries : `{ alternates: { languages: {...} } }`
+ *   - `Metadata.alternates.languages` : page-level metadata
+ *
+ * Inclut systematiquement `x-default` pointant vers la locale par defaut.
+ */
+export function buildHreflangAlternates(path: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const locale of SUPPORTED_LOCALES) {
+    map[LOCALE_TO_HREFLANG[locale]] = localeToHref(locale, path);
+  }
+  map["x-default"] = localeToHref(DEFAULT_LOCALE, path);
+  return map;
+}
+
+/**
+ * Helper pour generer une entree sitemap avec `alternates.languages`
+ * pre-rempli a partir d'un path relatif.
+ */
+export function sitemapEntryWithAlternates(
+  path: string,
+  rest: Omit<MetadataRoute.Sitemap[number], "url" | "alternates">,
+): MetadataRoute.Sitemap[number] {
+  return {
+    url: localeToHref(DEFAULT_LOCALE, path),
+    alternates: { languages: buildHreflangAlternates(path) },
+    ...rest,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,128 +1,112 @@
 import { MetadataRoute } from 'next';
 
+import { sitemapEntryWithAlternates } from './seo/hreflang';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8201';
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://nufflearena.fr';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
 
-  // Pages statiques publiques
+  // Sprint R.A.4 — chaque entree sitemap inclut `alternates.languages`
+  // hreflang (FR + EN + x-default) via `sitemapEntryWithAlternates`.
+  // Pages statiques publiques.
   const staticPages: MetadataRoute.Sitemap = [
-    {
-      url: BASE_URL,
+    sitemapEntryWithAlternates('/', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 1,
-    },
-    {
-      url: `${BASE_URL}/teams`,
+    }),
+    sitemapEntryWithAlternates('/teams', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/star-players`,
+    }),
+    sitemapEntryWithAlternates('/star-players', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/skills`,
+    }),
+    sitemapEntryWithAlternates('/skills', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/tutoriel`,
+    }),
+    sitemapEntryWithAlternates('/tutoriel', {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/tutoriel/mon-premier-match`,
+    }),
+    sitemapEntryWithAlternates('/tutoriel/mon-premier-match', {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.6,
-    },
-    {
-      url: `${BASE_URL}/support`,
+    }),
+    sitemapEntryWithAlternates('/support', {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.5,
-    },
-    {
-      url: `${BASE_URL}/a-propos`,
+    }),
+    sitemapEntryWithAlternates('/a-propos', {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.6,
-    },
-    {
-      url: `${BASE_URL}/changelog`,
+    }),
+    sitemapEntryWithAlternates('/changelog', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.5,
-    },
-    {
-      url: `${BASE_URL}/legal/mentions-legales`,
+    }),
+    sitemapEntryWithAlternates('/legal/mentions-legales', {
       lastModified: now,
       changeFrequency: 'yearly',
       priority: 0.3,
-    },
-    {
-      url: `${BASE_URL}/legal/conditions-utilisation`,
+    }),
+    sitemapEntryWithAlternates('/legal/conditions-utilisation', {
       lastModified: now,
       changeFrequency: 'yearly',
       priority: 0.3,
-    },
-    {
-      url: `${BASE_URL}/legal/politique-de-confidentialite`,
+    }),
+    sitemapEntryWithAlternates('/legal/politique-de-confidentialite', {
       lastModified: now,
       changeFrequency: 'yearly',
       priority: 0.3,
-    },
-    {
-      url: `${BASE_URL}/legal/politique-de-cookies`,
+    }),
+    sitemapEntryWithAlternates('/legal/politique-de-cookies', {
       lastModified: now,
       changeFrequency: 'yearly',
       priority: 0.3,
-    },
-    // Pro League — sprint 1.F.3
-    {
-      url: `${BASE_URL}/pro-league`,
+    }),
+    sitemapEntryWithAlternates('/pro-league', {
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/pro-league/about`,
+    }),
+    sitemapEntryWithAlternates('/pro-league/about', {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/pro-league/standings`,
+    }),
+    sitemapEntryWithAlternates('/pro-league/standings', {
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/pro-league/leaderboard`,
+    }),
+    sitemapEntryWithAlternates('/pro-league/leaderboard', {
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.6,
-    },
-    {
-      url: `${BASE_URL}/pro-league/gazette`,
+    }),
+    sitemapEntryWithAlternates('/pro-league/gazette', {
       lastModified: now,
       changeFrequency: 'daily',
       priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/pro-league/hall-of-fame`,
+    }),
+    sitemapEntryWithAlternates('/pro-league/hall-of-fame', {
       lastModified: now,
       changeFrequency: 'weekly',
       priority: 0.6,
-    },
+    }),
   ];
 
   // Pages dynamiques - Teams
@@ -134,12 +118,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     if (teamsResponse.ok) {
       const teamsData = await teamsResponse.json();
-      teamPages = (teamsData.rosters || []).map((team: { slug: string }) => ({
-        url: `${BASE_URL}/teams/${team.slug}`,
-        lastModified: now,
-        changeFrequency: 'monthly' as const,
-        priority: 0.7,
-      }));
+      teamPages = (teamsData.rosters || []).map((team: { slug: string }) =>
+        sitemapEntryWithAlternates(`/teams/${team.slug}`, {
+          lastModified: now,
+          changeFrequency: 'monthly' as const,
+          priority: 0.7,
+        }),
+      );
     }
   } catch (error) {
     console.error('Erreur lors de la récupération des équipes pour le sitemap:', error);
@@ -155,12 +140,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     if (starPlayersResponse.ok) {
       const starPlayersData = await starPlayersResponse.json();
       if (starPlayersData.success && starPlayersData.data) {
-        starPlayerPages = starPlayersData.data.map((player: { slug: string }) => ({
-          url: `${BASE_URL}/star-players/${player.slug}`,
-          lastModified: now,
-          changeFrequency: 'monthly' as const,
-          priority: 0.6,
-        }));
+        starPlayerPages = starPlayersData.data.map((player: { slug: string }) =>
+          sitemapEntryWithAlternates(`/star-players/${player.slug}`, {
+            lastModified: now,
+            changeFrequency: 'monthly' as const,
+            priority: 0.6,
+          }),
+        );
       }
     }
   } catch (error) {
@@ -184,12 +170,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           )
         : [];
       if (body?.success && slugs.length > 0) {
-        coachPages = slugs.map((slug) => ({
-          url: `${BASE_URL}/coach/${slug}`,
-          lastModified: now,
-          changeFrequency: 'weekly' as const,
-          priority: 0.5,
-        }));
+        coachPages = slugs.map((slug) =>
+          sitemapEntryWithAlternates(`/coach/${slug}`, {
+            lastModified: now,
+            changeFrequency: 'weekly' as const,
+            priority: 0.5,
+          }),
+        );
       }
     }
   } catch (error) {
@@ -218,12 +205,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     'buf-snow-ogres',
   ] as const;
   const proLeagueTeamPages: MetadataRoute.Sitemap = PRO_LEAGUE_TEAM_SLUGS.map(
-    (slug) => ({
-      url: `${BASE_URL}/pro-league/teams/${slug}`,
-      lastModified: now,
-      changeFrequency: 'weekly' as const,
-      priority: 0.7,
-    }),
+    (slug) =>
+      sitemapEntryWithAlternates(`/pro-league/teams/${slug}`, {
+        lastModified: now,
+        changeFrequency: 'weekly' as const,
+        priority: 0.7,
+      }),
   );
 
   return [


### PR DESCRIPTION
## Summary

Suite R.A.1 (i18n routing). Pose la base SEO multi-langue : hreflang auto-genere sur sitemap + layout root, prepare la migration future vers segments `/fr/*` `/en/*` (R.A.2).

## Helper `app/seo/hreflang.ts`

- `buildHreflangAlternates(path)` → `{ "fr-FR": "...", "en": "...", "x-default": "..." }` (BCP 47).
- `sitemapEntryWithAlternates(path, opts)` → entry sitemap avec `alternates.languages` pre-rempli.
- Pre-R.A.2 : toutes les locales pointent vers le meme URL (mode detection serveur-side via cookie `NEXT_LOCALE` de R.A.1). Quand segments introduits, modifier `localeToHref` uniquement.

## Sitemap

Migration de **toutes** les entries statiques (16 pages) + dynamiques (teams, star-players, coaches, pro-league teams) vers `sitemapEntryWithAlternates`. Chaque entry inclut maintenant `alternates.languages` (Google utilise pour servir la bonne version selon Accept-Language du user).

## Layout root

`metadata.alternates.languages` utilise `buildHreflangAlternates("/")` au lieu de hardcoder le map. Single source of truth.

## Tests

`seo/hreflang.test.ts` : **6 tests** unit (racine, URLs identiques pre-R.A.2, normalize paths, trailing slash, x-default, structure entry).

## Note merge order

Inclut `locale-detection.ts` (deja sur la branche R.A.1 #795 mais pas encore mergee a main). Quand #795 mergee, ce fichier sera identique → **merge trivial**.

## Verifications

- [x] 6/6 tests hreflang pass
- [x] `pnpm lint` clean
- [x] `pnpm build` clean

## Test plan

- [ ] Build prod → consulter `sitemap.xml` → chaque entry a `<xhtml:link rel="alternate" hreflang="fr-FR" href="..."/>` + `en` + `x-default`
- [ ] Inspecter `<head>` page d'accueil → balises `<link rel="alternate" hreflang>` presentes

## Sprint R progression

| Lot | Statut |
|---|---|
| R.E.1 backend async | ✅ #792 mergee |
| R.E.2 UI async | ✅ #793 mergee |
| R.E.3 ligues async | ✅ #794 en revue |
| R.A.1 i18n routing | ✅ #795 en revue |
| **R.A.4 SEO multi-langue** | **this PR** |
| R.B.3 Ad-free supporter | next |
| R.D.3 NAF API | next |


---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_