### PR TITLE
feat(supporter): Sprint R.B.3 — supporter status (ad-free + early access)

### DIFF
--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -2,8 +2,19 @@ import { Router } from "express";
 import { prisma } from "../prisma";
 import { authUser, AuthenticatedRequest } from "../middleware/authUser";
 import { parsePagination, buildApiMeta } from "../utils/pagination";
+import { getSupporterStatus } from "../services/supporter-status";
 
 const router = Router();
+
+// Sprint R lot R.B.3 — statut supporter (ad-free + early access).
+router.get(
+  "/supporter",
+  authUser,
+  async (req: AuthenticatedRequest, res) => {
+    const status = await getSupporterStatus(req.user!.id);
+    res.json(status);
+  },
+);
 
 router.get("/matches", authUser, async (req: AuthenticatedRequest, res) => {
   const { limit, offset } = parsePagination(req.query as Record<string, unknown>);

--- a/apps/server/src/services/supporter-status.test.ts
+++ b/apps/server/src/services/supporter-status.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Sprint R lot R.B.3 — tests du service supporter-status.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  SUPPORTER_BENEFITS,
+  getSupporterStatus,
+  isUserSupporter,
+} from "./supporter-status";
+
+const mockedUser = prisma as unknown as {
+  user: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSupporterStatus", () => {
+  it("retourne NO_STATUS si l'user n'existe pas", async () => {
+    mockedUser.user.findUnique.mockResolvedValue(null as never);
+    const status = await getSupporterStatus("missing");
+    expect(status.isSupporter).toBe(false);
+    expect(status.benefits).toHaveLength(0);
+  });
+
+  it("source=admin_override quand patreon=true", async () => {
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: true,
+      supporterTier: null,
+      supporterActiveUntil: null,
+    } as never);
+    const status = await getSupporterStatus("u_1");
+    expect(status.isSupporter).toBe(true);
+    expect(status.source).toBe("admin_override");
+    expect(status.benefits).toEqual(SUPPORTER_BENEFITS);
+  });
+
+  it("source=kofi quand abo actif (now < activeUntil)", async () => {
+    const futureDate = new Date(Date.now() + 30 * 24 * 3600 * 1000);
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: false,
+      supporterTier: "supporter",
+      supporterActiveUntil: futureDate,
+    } as never);
+    const status = await getSupporterStatus("u_1");
+    expect(status.isSupporter).toBe(true);
+    expect(status.source).toBe("kofi");
+    expect(status.tier).toBe("supporter");
+    expect(status.activeUntil).toBe(futureDate.toISOString());
+  });
+
+  it("NO_STATUS quand abo expire", async () => {
+    const pastDate = new Date(Date.now() - 24 * 3600 * 1000);
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: false,
+      supporterTier: "supporter",
+      supporterActiveUntil: pastDate,
+    } as never);
+    const status = await getSupporterStatus("u_1");
+    expect(status.isSupporter).toBe(false);
+    expect(status.source).toBeNull();
+  });
+
+  it("NO_STATUS si jamais paye et pas d'override admin", async () => {
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: false,
+      supporterTier: null,
+      supporterActiveUntil: null,
+    } as never);
+    const status = await getSupporterStatus("u_1");
+    expect(status.isSupporter).toBe(false);
+  });
+
+  it("benefits inclut ad_free + early_replay + profile_badge", async () => {
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: true,
+      supporterTier: null,
+      supporterActiveUntil: null,
+    } as never);
+    const status = await getSupporterStatus("u_1");
+    const ids = status.benefits.map((b) => b.id).sort();
+    expect(ids).toEqual(["ad_free", "early_replay", "profile_badge"]);
+  });
+});
+
+describe("isUserSupporter", () => {
+  it("retourne true si supporter actif", async () => {
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: true,
+      supporterTier: null,
+      supporterActiveUntil: null,
+    } as never);
+    expect(await isUserSupporter("u_1")).toBe(true);
+  });
+
+  it("retourne false si pas supporter", async () => {
+    mockedUser.user.findUnique.mockResolvedValue({
+      id: "u_1",
+      patreon: false,
+      supporterTier: null,
+      supporterActiveUntil: null,
+    } as never);
+    expect(await isUserSupporter("u_1")).toBe(false);
+  });
+});

--- a/apps/server/src/services/supporter-status.ts
+++ b/apps/server/src/services/supporter-status.ts
@@ -1,0 +1,125 @@
+/**
+ * Sprint R — Lot R.B.3 : statut supporter (ad-free + early access).
+ *
+ * Wraps le helper `isSupporter` (cf. kofi.ts) pour exposer un statut
+ * structure consommable par l'UI :
+ *   - isSupporter : boolean (override admin OR active Kofi/Patreon)
+ *   - tier : "supporter" | "patron" | "founder" | null
+ *   - activeUntil : ISO string ou null
+ *   - source : "admin_override" | "kofi" | "patreon" | null
+ *   - benefits : liste des benefices actuellement actives
+ *
+ * Architecture sink + payoff : le wallet payoff (Crowns daily, paris
+ * gagnes) est equilibre par les sinks (HoF dedicate, tournois entry,
+ * cosmetics futurs). Le supporter tier (3€/mois) debloque :
+ *   - ad-free (pas de bannieres Google AdSense si ajoutees plus tard)
+ *   - early replay access (-7j avant les free users) — a brancher
+ *     dans le service replay quand pertinent
+ *   - badge profil + flair Gazette commentaires
+ *
+ * `getSupporterStatus` est lu par l'endpoint `GET /me/supporter` et
+ * par les middlewares qui filtrent les contenus premium.
+ */
+
+import { prisma } from "../prisma";
+import { isSupporter } from "./kofi";
+
+export type SupporterSource = "admin_override" | "kofi" | "patreon";
+
+export interface SupporterBenefit {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+}
+
+export interface SupporterStatus {
+  readonly isSupporter: boolean;
+  readonly tier: string | null;
+  readonly activeUntil: string | null;
+  readonly source: SupporterSource | null;
+  readonly benefits: readonly SupporterBenefit[];
+}
+
+export const SUPPORTER_BENEFITS: readonly SupporterBenefit[] = [
+  {
+    id: "ad_free",
+    label: "Ad-free",
+    description:
+      "Aucune banniere publicitaire. Le site reste vierge de pub pour les supporters.",
+  },
+  {
+    id: "early_replay",
+    label: "Acces replays anticipe",
+    description:
+      "Replays archives accessibles jusqu'a 7 jours avant les free users.",
+  },
+  {
+    id: "profile_badge",
+    label: "Badge supporter",
+    description: "Flair distinctif sur ton profil coach + dans la Gazette.",
+  },
+] as const;
+
+const NO_STATUS: SupporterStatus = {
+  isSupporter: false,
+  tier: null,
+  activeUntil: null,
+  source: null,
+  benefits: [],
+};
+
+/**
+ * Determine le statut supporter d'un user. Retourne `NO_STATUS` si
+ * pas d'actif ni d'override. Source detection :
+ *   - `patreon=true` → "admin_override" (compte gift / dev / test)
+ *   - sinon, supporterActiveUntil > now → "kofi" (seul payment provider
+ *     pour l'instant ; "patreon" reserve a R.B.1)
+ */
+export async function getSupporterStatus(
+  userId: string,
+  now: Date = new Date(),
+): Promise<SupporterStatus> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      patreon: true,
+      supporterTier: true,
+      supporterActiveUntil: true,
+    },
+  });
+  if (!user) return NO_STATUS;
+
+  const active = isSupporter(
+    {
+      patreon: user.patreon as boolean,
+      supporterActiveUntil: (user.supporterActiveUntil as Date | null) ?? null,
+    },
+    now,
+  );
+  if (!active) return NO_STATUS;
+
+  const source: SupporterSource = (user.patreon as boolean)
+    ? "admin_override"
+    : "kofi";
+  return {
+    isSupporter: true,
+    tier: (user.supporterTier as string | null) ?? null,
+    activeUntil: user.supporterActiveUntil
+      ? (user.supporterActiveUntil as Date).toISOString()
+      : null,
+    source,
+    benefits: SUPPORTER_BENEFITS,
+  };
+}
+
+/**
+ * Helper concis pour les routes qui ne veulent que le boolean.
+ */
+export async function isUserSupporter(
+  userId: string,
+  now: Date = new Date(),
+): Promise<boolean> {
+  const status = await getSupporterStatus(userId, now);
+  return status.isSupporter;
+}

--- a/apps/web/app/me/supporter/page.tsx
+++ b/apps/web/app/me/supporter/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+/**
+ * Sprint R — Lot R.B.3 : page supporter (ad-free + early access).
+ *
+ * Affiche le statut supporter du user (tier, activeUntil, source) et
+ * la liste des benefits. Si pas supporter, affiche un message CTA
+ * vers la page de don Kofi (env `NEXT_PUBLIC_KOFI_URL`).
+ */
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { apiRequest } from "../../lib/api-client";
+
+interface SupporterBenefit {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+}
+
+interface SupporterStatus {
+  readonly isSupporter: boolean;
+  readonly tier: string | null;
+  readonly activeUntil: string | null;
+  readonly source: "admin_override" | "kofi" | "patreon" | null;
+  readonly benefits: readonly SupporterBenefit[];
+}
+
+const KOFI_URL =
+  process.env.NEXT_PUBLIC_KOFI_URL ?? "https://ko-fi.com/nufflearena";
+
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default function SupporterPage(): JSX.Element {
+  const [status, setStatus] = useState<SupporterStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiRequest<SupporterStatus>("/me/supporter")
+      .then(setStatus)
+      .catch((e) => setError(e instanceof Error ? e.message : "Erreur reseau"));
+  }, []);
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-4 text-2xl font-bold">Supporter</h1>
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      </main>
+    );
+  }
+
+  if (status === null) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-4 text-2xl font-bold">Supporter</h1>
+        <p className="text-sm text-slate-400">Chargement…</p>
+      </main>
+    );
+  }
+
+  if (!status.isSupporter) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-2 text-2xl font-bold">Devenir supporter</h1>
+        <p className="mb-4 text-sm text-slate-300">
+          Soutiens le projet et debloque des avantages exclusifs.
+        </p>
+        <section
+          data-testid="supporter-benefits-list"
+          className="mb-6 space-y-3"
+        >
+          {[
+            {
+              id: "ad_free",
+              label: "Ad-free",
+              description:
+                "Aucune banniere publicitaire. Le site reste vierge de pub pour les supporters.",
+            },
+            {
+              id: "early_replay",
+              label: "Acces replays anticipe",
+              description:
+                "Replays archives accessibles jusqu'a 7 jours avant les free users.",
+            },
+            {
+              id: "profile_badge",
+              label: "Badge supporter",
+              description:
+                "Flair distinctif sur ton profil coach + dans la Gazette.",
+            },
+          ].map((b) => (
+            <article
+              key={b.id}
+              className="rounded border border-slate-800 bg-slate-900 p-3"
+            >
+              <h3 className="text-base font-semibold text-slate-100">
+                {b.label}
+              </h3>
+              <p className="mt-1 text-sm text-slate-400">{b.description}</p>
+            </article>
+          ))}
+        </section>
+        <a
+          href={KOFI_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="supporter-cta-kofi"
+          className="inline-flex rounded bg-emerald-700 px-4 py-2 text-sm text-emerald-50 hover:bg-emerald-600"
+        >
+          Soutenir sur Ko-fi
+        </a>
+        <p className="mt-4 text-xs text-slate-500">
+          <Link href="/support" className="underline">
+            En savoir plus sur le projet
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  const activeUntilFr = formatDate(status.activeUntil);
+  const isAdminGift = status.source === "admin_override";
+
+  return (
+    <main className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-2 text-2xl font-bold">Tu es supporter</h1>
+      <div
+        data-testid="supporter-active-badge"
+        className="mb-4 rounded border border-emerald-700 bg-emerald-900/30 p-3 text-sm"
+      >
+        <p className="font-semibold text-emerald-200">
+          Statut actif{status.tier ? ` — ${status.tier}` : ""}
+        </p>
+        {isAdminGift ? (
+          <p className="mt-1 text-emerald-300">
+            Cadeau de l'equipe Nuffle Arena.
+          </p>
+        ) : activeUntilFr ? (
+          <p className="mt-1 text-emerald-300">
+            Actif jusqu'au {activeUntilFr}.
+          </p>
+        ) : null}
+      </div>
+
+      <h2 className="mb-2 text-lg font-semibold text-slate-100">Tes avantages</h2>
+      <ul data-testid="supporter-benefits-list" className="space-y-2">
+        {status.benefits.map((b) => (
+          <li
+            key={b.id}
+            data-testid={`supporter-benefit-${b.id}`}
+            className="rounded border border-slate-800 bg-slate-900 p-3"
+          >
+            <h3 className="text-base font-semibold text-slate-100">{b.label}</h3>
+            <p className="mt-1 text-sm text-slate-400">{b.description}</p>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-6 text-xs text-slate-500">
+        <Link href="/support" className="underline">
+          Page de don Ko-fi
+        </Link>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Premier lot du Sprint R.B (monetisation). Expose le statut supporter aux clients (UI + futurs middlewares). Sert de base pour :
- Cacher les bannieres pub (ad-free) quand AdSense sera integre.
- Filtrer l'acces aux replays archived (early access -7j).
- Afficher un badge supporter sur le profil + flair Gazette.

> R.B.1 (Patreon API) + R.B.2 (Season Pass Stripe) **out-of-scope** — ils requierent des dev accounts externes hors session code-only.

## Backend

- **`services/supporter-status.ts`** :
  - `getSupporterStatus(userId, now)` → `SupporterStatus` complet (source, tier, activeUntil, benefits).
  - `isUserSupporter(userId)` helper boolean.
  - Source detection : `patreon=true` → `"admin_override"` ; `supporterActiveUntil > now` → `"kofi"`.
  - `SUPPORTER_BENEFITS` constante (3 ids : `ad_free`, `early_replay`, `profile_badge`).
- **Endpoint** `GET /me/supporter` (auth).

## Frontend

`/me/supporter/page.tsx` :
- **Non-supporter** : presentation des benefits + CTA Ko-fi (`NEXT_PUBLIC_KOFI_URL`).
- **Supporter actif** : badge avec tier + activeUntil, liste benefits debloques, message different si admin gift vs Ko-fi.

## Tests

`supporter-status.test.ts` : **8 tests** unit
- user inconnu / patreon admin / kofi actif / kofi expire / jamais paye
- benefits inclut les 3 ids
- isUserSupporter boolean

## Verifications

- [x] 8/8 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` web clean

## Test plan

- [ ] User non-supporter visite `/me/supporter` → page CTA Ko-fi
- [ ] User patreon=true → page "Tu es supporter" avec "Cadeau de l'equipe"
- [ ] User kofi actif → page avec tier + date d'expiration
- [ ] User kofi expire la veille → page CTA (NO_STATUS)
- [ ] `GET /me/supporter` non-auth → 401

## Sprint R progression

| Lot | Statut |
|---|---|
| R.E.1 backend async | ✅ #792 mergee |
| R.E.2 UI async | ✅ #793 mergee |
| R.E.3 ligues async | ✅ #794 en revue |
| R.A.1 i18n routing | ✅ #795 en revue |
| R.A.4 SEO multi-langue | ✅ #796 en revue |
| **R.B.3 supporter status** | **this PR** |
| R.D.3 NAF API | next |
| R.B.1 Patreon API | out-of-scope (dev account requis) |
| R.B.2 Season Pass Stripe | out-of-scope (Stripe account requis) |
| R.C.* Mobile | out-of-scope (App Store accounts requis) |
| R.D.1 Discord bot | out-of-scope (Discord server requis) |
| R.D.2 ambassadeurs | out-of-scope (content marketing) |


---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_