### PR TITLE
feat(admin): responsive layout pour mobile

### DIFF
--- a/apps/web/app/admin/analytics/page.tsx
+++ b/apps/web/app/admin/analytics/page.tsx
@@ -131,11 +131,11 @@ export default function AdminAnalyticsPage(): JSX.Element {
   }, [refreshTick]);
 
   return (
-    <main className="mx-auto max-w-5xl p-6">
-      <header className="mb-6 flex items-center justify-between">
+    <main className="mx-auto max-w-5xl">
+      <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">
-            Analytics — Tableau de bord
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">
+            📈 Analytics
           </h1>
           {data && (
             <p className="mt-1 text-xs text-gray-500">

--- a/apps/web/app/admin/audit-log/page.tsx
+++ b/apps/web/app/admin/audit-log/page.tsx
@@ -101,7 +101,7 @@ export default function AdminAuditLogPage() {
   return (
     <div className="max-w-6xl">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-nuffle-anthracite flex items-center gap-2">
+        <h1 className="text-2xl sm:text-3xl font-bold text-nuffle-anthracite flex items-center gap-2">
           <span>📜</span> Journal d&apos;audit admin
         </h1>
         <p className="text-sm text-gray-600 mt-1">
@@ -112,7 +112,7 @@ export default function AdminAuditLogPage() {
 
       <form
         onSubmit={applyFilters}
-        className="mb-4 grid grid-cols-1 md:grid-cols-4 gap-3 bg-white rounded-lg shadow-sm p-4 border border-gray-200"
+        className="mb-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 bg-white rounded-lg shadow-sm p-3 sm:p-4 border border-gray-200"
       >
         <label className="flex flex-col text-sm">
           <span className="text-gray-700 font-medium mb-1">Action</span>
@@ -183,31 +183,33 @@ export default function AdminAuditLogPage() {
             {data.total} entree{data.total > 1 ? "s" : ""} (page {data.page} /{" "}
             {totalPages})
           </div>
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
-              <tr>
-                <th className="px-3 py-2">Date</th>
-                <th className="px-3 py-2">Admin</th>
-                <th className="px-3 py-2">Action</th>
-                <th className="px-3 py-2">Entite</th>
-                <th className="px-3 py-2">Cible</th>
-                <th className="px-3 py-2">IP</th>
-                <th className="px-3 py-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.entries.map((e) => (
-                <AuditLogRow
-                  key={e.id}
-                  entry={e}
-                  expanded={expandedId === e.id}
-                  onToggle={() =>
-                    setExpandedId(expandedId === e.id ? null : e.id)
-                  }
-                />
-              ))}
-            </tbody>
-          </table>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
+                <tr>
+                  <th className="px-3 py-2 whitespace-nowrap">Date</th>
+                  <th className="px-3 py-2 whitespace-nowrap">Admin</th>
+                  <th className="px-3 py-2 whitespace-nowrap">Action</th>
+                  <th className="px-3 py-2 whitespace-nowrap">Entite</th>
+                  <th className="px-3 py-2 whitespace-nowrap">Cible</th>
+                  <th className="px-3 py-2 whitespace-nowrap">IP</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.entries.map((e) => (
+                  <AuditLogRow
+                    key={e.id}
+                    entry={e}
+                    expanded={expandedId === e.id}
+                    onToggle={() =>
+                      setExpandedId(expandedId === e.id ? null : e.id)
+                    }
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 

--- a/apps/web/app/admin/cups/page.tsx
+++ b/apps/web/app/admin/cups/page.tsx
@@ -147,16 +147,16 @@ export default function AdminCupsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
         <div>
-          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
             🏆 Coupes
           </h1>
           <p className="text-sm text-gray-600">
             Gérez toutes les coupes du système
           </p>
         </div>
-        <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200">
+        <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200 self-start sm:self-auto">
           {filteredCups.length} coupe{filteredCups.length !== 1 ? "s" : ""}
         </div>
       </div>
@@ -170,12 +170,12 @@ export default function AdminCupsPage() {
       )}
 
       {/* Filters */}
-      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-4">
-        <div className="flex gap-4">
+      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-3 sm:p-4">
+        <div className="flex gap-3 sm:gap-4 flex-col sm:flex-row">
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="border border-gray-300 rounded-lg px-4 py-2.5 focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
+            className="w-full sm:w-auto border border-gray-300 rounded-lg px-4 py-2.5 focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
           >
             <option value="">Tous les statuts</option>
             <option value="open">Ouvertes</option>
@@ -186,7 +186,7 @@ export default function AdminCupsPage() {
             placeholder="Rechercher (nom, créateur)..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="border border-gray-300 rounded-lg px-4 py-2.5 flex-1 focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all"
+            className="border border-gray-300 rounded-lg px-4 py-2.5 flex-1 min-w-0 focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all"
           />
         </div>
         {(statusFilter || search) && (

--- a/apps/web/app/admin/feature-flags/page.tsx
+++ b/apps/web/app/admin/feature-flags/page.tsx
@@ -83,9 +83,9 @@ export default function AdminFeatureFlagsPage() {
 
   return (
     <div className="max-w-5xl">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <div>
-          <h1 className="text-3xl font-bold text-nuffle-anthracite flex items-center gap-2">
+          <h1 className="text-2xl sm:text-3xl font-bold text-nuffle-anthracite flex items-center gap-2">
             <span>🚩</span> Feature Flags
           </h1>
           <p className="text-sm text-gray-600 mt-1">
@@ -96,7 +96,7 @@ export default function AdminFeatureFlagsPage() {
         <button
           type="button"
           onClick={() => setCreateOpen((prev) => !prev)}
-          className="px-4 py-2 rounded-lg bg-nuffle-gold text-white hover:bg-nuffle-bronze transition"
+          className="self-start sm:self-auto px-4 py-2 rounded-lg bg-nuffle-gold text-white hover:bg-nuffle-bronze transition"
         >
           {createOpen ? "Annuler" : "+ Nouveau flag"}
         </button>
@@ -166,14 +166,15 @@ export default function AdminFeatureFlagsPage() {
         </div>
       ) : (
         <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
             <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
               <tr>
-                <th className="px-4 py-3">Clé</th>
-                <th className="px-4 py-3">Description</th>
-                <th className="px-4 py-3">Global</th>
-                <th className="px-4 py-3">Utilisateurs</th>
-                <th className="px-4 py-3 text-right">Actions</th>
+                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Clé</th>
+                <th className="px-3 sm:px-4 py-3">Description</th>
+                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Global</th>
+                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Utilisateurs</th>
+                <th className="px-3 sm:px-4 py-3 text-right whitespace-nowrap">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
@@ -222,6 +223,7 @@ export default function AdminFeatureFlagsPage() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/app/admin/feedback/page.tsx
+++ b/apps/web/app/admin/feedback/page.tsx
@@ -116,8 +116,8 @@ export default function AdminFeedbackPage() {
   return (
     <div>
       <header className="mb-6">
-        <h1 className="text-2xl font-heading font-bold text-nuffle-anthracite mb-1">
-          Feedback
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          💬 Feedback
         </h1>
         <p className="text-sm text-gray-600">
           Retours envoyes via la page publique <code>/feedback</code>. Total :{" "}
@@ -125,9 +125,9 @@ export default function AdminFeedbackPage() {
         </p>
       </header>
 
-      <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 mb-6">
-        <div className="flex flex-wrap items-end gap-4">
-          <div>
+      <section className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4 mb-6">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap items-stretch sm:items-end gap-3 sm:gap-4">
+          <div className="w-full sm:w-auto">
             <label
               htmlFor="filter-status"
               className="block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1"
@@ -141,7 +141,7 @@ export default function AdminFeedbackPage() {
                 setStatusFilter(e.target.value as FeedbackStatus | "");
                 setPage(1);
               }}
-              className="px-3 py-2 rounded-lg border border-gray-300"
+              className="w-full sm:w-auto px-3 py-2 rounded-lg border border-gray-300"
             >
               <option value="">Tous</option>
               {STATUS_OPTIONS.map((o) => (
@@ -152,7 +152,7 @@ export default function AdminFeedbackPage() {
             </select>
           </div>
 
-          <div>
+          <div className="w-full sm:w-auto">
             <label
               htmlFor="filter-type"
               className="block text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1"
@@ -166,7 +166,7 @@ export default function AdminFeedbackPage() {
                 setTypeFilter(e.target.value as FeedbackType | "");
                 setPage(1);
               }}
-              className="px-3 py-2 rounded-lg border border-gray-300"
+              className="w-full sm:w-auto px-3 py-2 rounded-lg border border-gray-300"
             >
               <option value="">Tous</option>
               {TYPE_OPTIONS.map((o) => (
@@ -177,7 +177,7 @@ export default function AdminFeedbackPage() {
             </select>
           </div>
 
-          <form onSubmit={onSearchSubmit} className="flex items-end gap-2 flex-1 min-w-[200px]">
+          <form onSubmit={onSearchSubmit} className="flex items-end gap-2 flex-1 w-full sm:min-w-[200px]">
             <div className="flex-1">
               <label
                 htmlFor="filter-search"

--- a/apps/web/app/admin/gazette/comments/page.tsx
+++ b/apps/web/app/admin/gazette/comments/page.tsx
@@ -76,14 +76,14 @@ export default function AdminGazetteCommentsPage(): JSX.Element {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-slate-100">
-          Gazette · Moderation commentaires
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h1 className="text-2xl sm:text-3xl font-bold text-slate-100">
+          💬 Gazette · Moderation
         </h1>
       </div>
 
       <div
-        className="flex gap-2 text-sm"
+        className="flex gap-2 text-sm flex-wrap"
         data-testid="admin-comments-filters"
       >
         {(["flagged", "deleted", "all"] as const).map((f) => (
@@ -136,8 +136,8 @@ export default function AdminGazetteCommentsPage(): JSX.Element {
               className={`rounded border p-3 ${c.deleted ? "border-rose-800 bg-rose-950/30" : c.flagged ? "border-amber-700 bg-amber-950/30" : "border-slate-800 bg-slate-900"}`}
               data-testid={`admin-comment-${c.id}`}
             >
-              <div className="mb-1 flex items-center gap-2 text-xs text-slate-400">
-                <span className="font-mono text-slate-200">
+              <div className="mb-1 flex items-center gap-2 text-xs text-slate-400 flex-wrap">
+                <span className="font-mono text-slate-200 break-all">
                   {c.userName ?? c.userEmail}
                 </span>
                 <span className="text-slate-600">

--- a/apps/web/app/admin/layout.tsx
+++ b/apps/web/app/admin/layout.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { syncAuthCookie } from "../lib/auth-cookie";
 import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { LEAGUES_V2_UI_FLAG } from "../lib/featureFlagKeys";
@@ -10,6 +10,7 @@ import { LEAGUES_V2_UI_FLAG } from "../lib/featureFlagKeys";
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const leaguesEnabled = useFeatureFlag(LEAGUES_V2_UI_FLAG);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   // Synchronise le cookie httpOnly auth_token (S24.1). La route est
   // idempotente et le cookie n'est plus visible cote JS, on tente
@@ -20,6 +21,23 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
       void syncAuthCookie(token);
     }
   }, []);
+
+  // Ferme le drawer mobile a chaque navigation
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
+
+  // Lock body scroll quand le drawer mobile est ouvert
+  useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileOpen]);
 
   const isActive = (path: string) => {
     if (path === "/admin") {
@@ -51,62 +69,118 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
     </Link>
   );
 
+  const navContent = (
+    <nav className="p-4 space-y-1">
+      <div className="mb-4">
+        <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+          Administration
+        </div>
+        {navItem("/admin", "Aperçu", "📊")}
+        {navItem("/admin/progress", "Avancement", "🗺️")}
+        {navItem("/admin/users", "Utilisateurs", "👥")}
+        {navItem("/admin/teams", "Équipes", "⚽")}
+        {navItem("/admin/matches", "Parties", "🎮")}
+        {navItem("/admin/local-matches", "Matchs Locaux", "🎯")}
+        {leaguesEnabled && navItem("/admin/leagues", "Ligues", "🏅")}
+        {navItem("/admin/cups", "Coupes", "🏆")}
+        {navItem("/admin/feature-flags", "Feature Flags", "🚩")}
+        {navItem("/admin/sim", "Sim Pro League", "🎲")}
+        {navItem("/admin/sim/replays", "Replays Panel", "📜")}
+        {navItem("/admin/sim/health", "Sim Health", "❤️")}
+        {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
+        {navItem("/admin/sim/test-match", "Test Match", "🧪")}
+        {navItem("/admin/pro-league", "Hub Pro League", "🏈")}
+        {navItem("/admin/pro-league/seasons", "Saisons Pro League", "🏆")}
+        {navItem("/admin/feedback", "Feedback", "💬")}
+        {navItem("/admin/audit-log", "Journal d'audit", "📜")}
+        {navItem("/admin/routes", "Routes", "📋")}
+        {navItem("/admin/utilities", "Utilitaires", "🛠️")}
+      </div>
+
+      <div className="pt-4 border-t border-gray-200">
+        <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+          Données du jeu
+        </div>
+        {navItem("/admin/data/skills", "Compétences", "📚")}
+        {navItem("/admin/data/rosters", "Rosters", "⚽")}
+        {navItem("/admin/data/positions", "Positions", "🎯")}
+        {navItem("/admin/data/star-players", "Star Players", "⭐")}
+      </div>
+    </nav>
+  );
+
+  const sidebarHeader = (
+    <div className="p-6 border-b border-gray-200 bg-gradient-to-r from-nuffle-gold/10 to-transparent flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-heading font-bold text-nuffle-anthracite flex items-center gap-2">
+          <span className="text-3xl">🔧</span>
+          Admin
+        </h1>
+        <p className="text-xs text-gray-500 mt-1 font-subtitle">
+          Panneau de contrôle
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => setMobileOpen(false)}
+        className="lg:hidden text-gray-500 hover:text-gray-700 text-2xl leading-none p-2 -mr-2"
+        aria-label="Fermer le menu"
+      >
+        ✕
+      </button>
+    </div>
+  );
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-nuffle-ivory via-white to-nuffle-ivory/50 w-screen relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw]">
-      <div className="flex w-full">
-        {/* Sidebar */}
-        <aside className="w-64 min-h-screen bg-white border-r border-gray-200 shadow-sm sticky top-0 flex-shrink-0">
-          <div className="p-6 border-b border-gray-200 bg-gradient-to-r from-nuffle-gold/10 to-transparent">
-            <h1 className="text-2xl font-heading font-bold text-nuffle-anthracite flex items-center gap-2">
-              <span className="text-3xl">🔧</span>
-              Admin
-            </h1>
-            <p className="text-xs text-gray-500 mt-1 font-subtitle">
-              Panneau de contrôle
-            </p>
-          </div>
-          
-          <nav className="p-4 space-y-1">
-            <div className="mb-4">
-              <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                Administration
-              </div>
-              {navItem("/admin", "Aperçu", "📊")}
-              {navItem("/admin/progress", "Avancement", "🗺️")}
-              {navItem("/admin/users", "Utilisateurs", "👥")}
-              {navItem("/admin/teams", "Équipes", "⚽")}
-              {navItem("/admin/matches", "Parties", "🎮")}
-              {navItem("/admin/local-matches", "Matchs Locaux", "🎯")}
-              {leaguesEnabled && navItem("/admin/leagues", "Ligues", "🏅")}
-              {navItem("/admin/cups", "Coupes", "🏆")}
-              {navItem("/admin/feature-flags", "Feature Flags", "🚩")}
-              {navItem("/admin/sim", "Sim Pro League", "🎲")}
-              {navItem("/admin/sim/replays", "Replays Panel", "📜")}
-              {navItem("/admin/sim/health", "Sim Health", "❤️")}
-              {navItem("/admin/sim/broadcaster", "Broadcaster", "📡")}
-              {navItem("/admin/sim/test-match", "Test Match", "🧪")}
-              {navItem("/admin/pro-league", "Hub Pro League", "🏈")}
-              {navItem("/admin/pro-league/seasons", "Saisons Pro League", "🏆")}
-              {navItem("/admin/feedback", "Feedback", "💬")}
-              {navItem("/admin/audit-log", "Journal d'audit", "📜")}
-              {navItem("/admin/routes", "Routes", "📋")}
-              {navItem("/admin/utilities", "Utilitaires", "🛠️")}
-            </div>
+      {/* Topbar mobile */}
+      <div className="lg:hidden sticky top-0 z-30 bg-white border-b border-gray-200 shadow-sm flex items-center justify-between px-4 py-3">
+        <button
+          type="button"
+          onClick={() => setMobileOpen(true)}
+          className="flex items-center gap-2 px-3 py-2 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors"
+          aria-label="Ouvrir le menu admin"
+          data-testid="admin-mobile-menu-button"
+        >
+          <span className="text-xl">☰</span>
+          <span className="text-sm font-medium">Menu</span>
+        </button>
+        <h1 className="text-lg font-heading font-bold text-nuffle-anthracite flex items-center gap-1.5">
+          <span>🔧</span>
+          <span>Admin</span>
+        </h1>
+        <div className="w-[72px]" aria-hidden="true" />
+      </div>
 
-            <div className="pt-4 border-t border-gray-200">
-              <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-                Données du jeu
-              </div>
-              {navItem("/admin/data/skills", "Compétences", "📚")}
-              {navItem("/admin/data/rosters", "Rosters", "⚽")}
-              {navItem("/admin/data/positions", "Positions", "🎯")}
-              {navItem("/admin/data/star-players", "Star Players", "⭐")}
-            </div>
-          </nav>
+      <div className="flex w-full">
+        {/* Sidebar desktop */}
+        <aside className="hidden lg:block w-64 min-h-screen bg-white border-r border-gray-200 shadow-sm sticky top-0 flex-shrink-0">
+          {sidebarHeader}
+          {navContent}
+        </aside>
+
+        {/* Drawer mobile */}
+        {mobileOpen && (
+          <div
+            className="lg:hidden fixed inset-0 z-40 bg-black/50"
+            onClick={() => setMobileOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+        <aside
+          className={`lg:hidden fixed top-0 left-0 z-50 w-72 max-w-[85vw] h-full bg-white border-r border-gray-200 shadow-xl transform transition-transform duration-200 overflow-y-auto ${
+            mobileOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
+          data-testid="admin-mobile-drawer"
+        >
+          {sidebarHeader}
+          {navContent}
         </aside>
 
         {/* Main Content */}
-        <main className="flex-1 min-w-0 w-full p-6 lg:p-8">{children}</main>
+        <main className="flex-1 min-w-0 w-full px-3 py-4 sm:px-4 sm:py-6 lg:p-8">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/apps/web/app/admin/local-matches/page.tsx
+++ b/apps/web/app/admin/local-matches/page.tsx
@@ -220,21 +220,19 @@ export default function AdminLocalMatchesPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-nuffle-ivory via-white to-nuffle-ivory/50 p-6">
-        <div className="text-center py-12">
-          <p className="text-gray-600">Chargement...</p>
-        </div>
+      <div className="text-center py-12">
+        <p className="text-gray-600">Chargement...</p>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-nuffle-ivory via-white to-nuffle-ivory/50">
+    <div>
       <div className="mb-6">
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-2">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-2">
           🎯 Gestion des Matchs Locaux
         </h1>
-        <p className="text-gray-600">
+        <p className="text-sm sm:text-base text-gray-600">
           Administration de toutes les parties offline (Match Local)
         </p>
       </div>
@@ -246,8 +244,8 @@ export default function AdminLocalMatchesPage() {
       )}
 
       {/* Filtres */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 mb-6">
-        <div className="grid md:grid-cols-2 gap-4">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4 mb-6">
+        <div className="grid sm:grid-cols-2 gap-3 sm:gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
               Rechercher
@@ -280,30 +278,30 @@ export default function AdminLocalMatchesPage() {
       </div>
 
       {/* Statistiques */}
-      <div className="grid md:grid-cols-4 gap-4 mb-6">
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-nuffle-anthracite">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 sm:gap-4 mb-6">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-nuffle-anthracite">
             {localMatches.length}
           </div>
-          <div className="text-sm text-gray-600">Total</div>
+          <div className="text-xs sm:text-sm text-gray-600">Total</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-yellow-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-yellow-600">
             {localMatches.filter((m) => m.status === "pending").length}
           </div>
-          <div className="text-sm text-gray-600">En attente</div>
+          <div className="text-xs sm:text-sm text-gray-600">En attente</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-blue-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-blue-600">
             {localMatches.filter((m) => m.status === "in_progress").length}
           </div>
-          <div className="text-sm text-gray-600">En cours</div>
+          <div className="text-xs sm:text-sm text-gray-600">En cours</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-green-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-green-600">
             {localMatches.filter((m) => m.status === "completed").length}
           </div>
-          <div className="text-sm text-gray-600">Terminées</div>
+          <div className="text-xs sm:text-sm text-gray-600">Terminées</div>
         </div>
       </div>
 

--- a/apps/web/app/admin/matches/page.tsx
+++ b/apps/web/app/admin/matches/page.tsx
@@ -303,7 +303,7 @@ export default function AdminMatchesPage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           Gestion des Parties
         </h1>
         <p className="text-sm text-gray-600">
@@ -326,50 +326,50 @@ export default function AdminMatchesPage() {
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-nuffle-anthracite">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-4">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-nuffle-anthracite">
             {totalMatches}
           </div>
-          <div className="text-sm text-gray-600">Total</div>
+          <div className="text-xs sm:text-sm text-gray-600">Total</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-yellow-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-yellow-600">
             {statusCounts?.pending ?? 0}
           </div>
-          <div className="text-sm text-gray-600">En attente</div>
+          <div className="text-xs sm:text-sm text-gray-600">En attente</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-orange-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-orange-600">
             {(statusCounts?.prematch ?? 0) +
               (statusCounts?.["prematch-setup"] ?? 0)}
           </div>
-          <div className="text-sm text-gray-600">Pré-match</div>
+          <div className="text-xs sm:text-sm text-gray-600">Pré-match</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-blue-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-blue-600">
             {statusCounts?.active ?? 0}
           </div>
-          <div className="text-sm text-gray-600">En cours</div>
+          <div className="text-xs sm:text-sm text-gray-600">En cours</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-green-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-green-600">
             {statusCounts?.ended ?? 0}
           </div>
-          <div className="text-sm text-gray-600">Terminées</div>
+          <div className="text-xs sm:text-sm text-gray-600">Terminées</div>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-          <div className="text-2xl font-bold text-red-600">
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+          <div className="text-xl sm:text-2xl font-bold text-red-600">
             {statusCounts?.cancelled ?? 0}
           </div>
-          <div className="text-sm text-gray-600">Annulées</div>
+          <div className="text-xs sm:text-sm text-gray-600">Annulées</div>
         </div>
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
-        <div className="grid md:grid-cols-3 gap-4">
-          <div>
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-3 sm:p-4">
+        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
+          <div className="md:col-span-1 sm:col-span-2">
             <label className="block text-sm font-medium text-gray-700 mb-2">
               Rechercher
             </label>
@@ -380,11 +380,11 @@ export default function AdminMatchesPage() {
                 onChange={(e) => setSearch(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSearch()}
                 placeholder="ID, seed, coach, equipe..."
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-transparent"
+                className="flex-1 min-w-0 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-transparent"
               />
               <button
                 onClick={handleSearch}
-                className="px-4 py-2 bg-nuffle-gold text-white rounded-lg hover:bg-nuffle-bronze transition-colors"
+                className="px-4 py-2 bg-nuffle-gold text-white rounded-lg hover:bg-nuffle-bronze transition-colors whitespace-nowrap"
               >
                 Chercher
               </button>
@@ -411,7 +411,7 @@ export default function AdminMatchesPage() {
           <div className="flex items-end">
             <button
               onClick={loadMatches}
-              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
+              className="w-full sm:w-auto px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
             >
               Rafraichir
             </button>

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -111,10 +111,10 @@ export default function AdminPage() {
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6 sm:space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           📊 Aperçu
         </h1>
         <p className="text-sm text-gray-600">
@@ -132,15 +132,15 @@ export default function AdminPage() {
 
       {/* Stats Cards */}
       <section id="overview">
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6">
           {/* Utilisateurs */}
-          <div className="rounded-xl p-6 bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
+          <div className="rounded-xl p-4 sm:p-6 bg-gradient-to-br from-blue-50 to-blue-100 border border-blue-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
                onClick={() => router.push("/admin/users")}>
             <div className="flex items-center justify-between mb-3">
               <div className="text-sm font-medium text-blue-700">Utilisateurs</div>
               <span className="text-3xl">👥</span>
             </div>
-            <div className="text-4xl font-bold text-blue-900 mb-2">
+            <div className="text-3xl sm:text-4xl font-bold text-blue-900 mb-2">
               {stats?.users.total ?? "—"}
             </div>
             <div className="flex gap-4 text-xs text-blue-600">
@@ -153,13 +153,13 @@ export default function AdminPage() {
           </div>
 
           {/* Parties */}
-          <div className="rounded-xl p-6 bg-gradient-to-br from-green-50 to-green-100 border border-green-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
+          <div className="rounded-xl p-4 sm:p-6 bg-gradient-to-br from-green-50 to-green-100 border border-green-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
                onClick={() => router.push("/admin/matches")}>
             <div className="flex items-center justify-between mb-3">
               <div className="text-sm font-medium text-green-700">Parties</div>
               <span className="text-3xl">🎮</span>
             </div>
-            <div className="text-4xl font-bold text-green-900">
+            <div className="text-3xl sm:text-4xl font-bold text-green-900">
               {stats?.matches.total ?? "—"}
             </div>
           </div>
@@ -173,7 +173,7 @@ export default function AdminPage() {
               <div className="text-sm font-medium text-pink-700">Matchs locaux</div>
               <span className="text-3xl">🎯</span>
             </div>
-            <div className="text-4xl font-bold text-pink-900 mb-2">
+            <div className="text-3xl sm:text-4xl font-bold text-pink-900 mb-2">
               {stats?.localMatches?.total ?? "—"}
             </div>
             <div className="flex flex-wrap gap-2 text-xs text-pink-700">
@@ -184,25 +184,25 @@ export default function AdminPage() {
           </div>
 
           {/* Équipes */}
-          <div className="rounded-xl p-6 bg-gradient-to-br from-purple-50 to-purple-100 border border-purple-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
+          <div className="rounded-xl p-4 sm:p-6 bg-gradient-to-br from-purple-50 to-purple-100 border border-purple-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
                onClick={() => router.push("/admin/users")}>
             <div className="flex items-center justify-between mb-3">
               <div className="text-sm font-medium text-purple-700">Équipes</div>
               <span className="text-3xl">⚽</span>
             </div>
-            <div className="text-4xl font-bold text-purple-900">
+            <div className="text-3xl sm:text-4xl font-bold text-purple-900">
               {stats?.teams.total ?? "—"}
             </div>
           </div>
 
           {/* Coupes */}
-          <div className="rounded-xl p-6 bg-gradient-to-br from-yellow-50 to-yellow-100 border border-yellow-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
+          <div className="rounded-xl p-4 sm:p-6 bg-gradient-to-br from-yellow-50 to-yellow-100 border border-yellow-200 shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer"
                onClick={() => router.push("/admin/cups")}>
             <div className="flex items-center justify-between mb-3">
               <div className="text-sm font-medium text-yellow-700">Coupes</div>
               <span className="text-3xl">🏆</span>
             </div>
-            <div className="text-4xl font-bold text-yellow-900 mb-2">
+            <div className="text-3xl sm:text-4xl font-bold text-yellow-900 mb-2">
               {stats?.cups.total ?? "—"}
             </div>
             <div className="flex gap-2 text-xs text-yellow-600">
@@ -219,7 +219,7 @@ export default function AdminPage() {
         <h2 className="text-xl font-heading font-semibold text-nuffle-anthracite mb-4">
           🚀 Actions rapides
         </h2>
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
           <button
             onClick={() => router.push("/admin/users")}
             className="p-4 bg-white rounded-xl border border-gray-200 shadow-md hover:shadow-lg transition-all text-left hover:bg-blue-50"
@@ -265,9 +265,9 @@ export default function AdminPage() {
 
       {/* Recent Activity */}
       <section>
-        <div className="grid md:grid-cols-2 gap-6">
+        <div className="grid md:grid-cols-2 gap-4 sm:gap-6">
           {/* Recent Users */}
-          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-4 sm:p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-heading font-semibold text-nuffle-anthracite">
                 👥 Utilisateurs récents
@@ -305,7 +305,7 @@ export default function AdminPage() {
           </div>
 
           {/* Recent Matches */}
-          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+          <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-4 sm:p-6">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-heading font-semibold text-nuffle-anthracite">
                 🎮 Parties récentes
@@ -366,16 +366,16 @@ export default function AdminPage() {
             <table className="min-w-full">
               <thead className="bg-gradient-to-r from-nuffle-gold/10 to-nuffle-gold/5">
                 <tr>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Email
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Nom
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Rôle
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Créé le
                   </th>
                 </tr>
@@ -437,16 +437,16 @@ export default function AdminPage() {
             <table className="min-w-full">
               <thead className="bg-gradient-to-r from-nuffle-gold/10 to-nuffle-gold/5">
                 <tr>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     ID
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Statut
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Seed
                   </th>
-                  <th className="text-left px-6 py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
+                  <th className="text-left px-3 sm:px-6 py-3 sm:py-4 text-sm font-semibold text-nuffle-anthracite uppercase tracking-wider">
                     Créée le
                   </th>
                 </tr>

--- a/apps/web/app/admin/pro-league/page.tsx
+++ b/apps/web/app/admin/pro-league/page.tsx
@@ -87,7 +87,7 @@ export default function AdminProLeagueHubPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           🏈 Admin Pro League
         </h1>
         <p className="text-sm text-gray-600">

--- a/apps/web/app/admin/pro-league/seasons/page.tsx
+++ b/apps/web/app/admin/pro-league/seasons/page.tsx
@@ -164,9 +164,9 @@ export default function AdminProLeagueSeasonsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between flex-wrap gap-3">
+      <div className="flex items-start justify-between flex-wrap gap-3">
         <div>
-          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
             🏆 Saisons Pro League
           </h1>
           <p className="text-sm text-gray-600">
@@ -190,17 +190,18 @@ export default function AdminProLeagueSeasonsPage() {
       )}
 
       <div className="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
+        <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="bg-gray-50">
             <tr>
-              <th className="text-left p-3">Annee</th>
-              <th className="text-left p-3">Statut</th>
-              <th className="text-left p-3">Driver</th>
-              <th className="text-left p-3">Engine</th>
-              <th className="text-right p-3">Rounds</th>
-              <th className="text-right p-3">Matches</th>
-              <th className="text-right p-3">Joues</th>
-              <th className="text-left p-3">Actions</th>
+              <th className="text-left p-3 whitespace-nowrap">Annee</th>
+              <th className="text-left p-3 whitespace-nowrap">Statut</th>
+              <th className="text-left p-3 whitespace-nowrap">Driver</th>
+              <th className="text-left p-3 whitespace-nowrap">Engine</th>
+              <th className="text-right p-3 whitespace-nowrap">Rounds</th>
+              <th className="text-right p-3 whitespace-nowrap">Matches</th>
+              <th className="text-right p-3 whitespace-nowrap">Joues</th>
+              <th className="text-left p-3 whitespace-nowrap">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -321,6 +322,7 @@ export default function AdminProLeagueSeasonsPage() {
             )}
           </tbody>
         </table>
+        </div>
       </div>
 
       <CreateSeasonModal

--- a/apps/web/app/admin/progress/page.tsx
+++ b/apps/web/app/admin/progress/page.tsx
@@ -245,9 +245,9 @@ export default function AdminProgressPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between gap-4 flex-wrap">
+      <div className="flex items-start justify-between gap-3 sm:gap-4 flex-wrap">
         <div>
-          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
             🗺️ Avancement
           </h1>
           <p className="text-sm text-gray-600">

--- a/apps/web/app/admin/routes/page.tsx
+++ b/apps/web/app/admin/routes/page.tsx
@@ -201,7 +201,7 @@ export default function AdminRoutesPage() {
     <div className="space-y-8">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           📋 Routes disponibles
         </h1>
         <p className="text-sm text-gray-600">
@@ -224,12 +224,12 @@ export default function AdminRoutesPage() {
         </h2>
         {apiRoutes.map((category) => (
           <div key={category.category} className="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
-            <div className="bg-gradient-to-r from-nuffle-gold/10 to-nuffle-gold/5 px-6 py-3 border-b border-gray-200">
+            <div className="bg-gradient-to-r from-nuffle-gold/10 to-nuffle-gold/5 px-4 sm:px-6 py-3 border-b border-gray-200">
               <h3 className="text-lg font-semibold text-nuffle-anthracite">
                 {category.category}
               </h3>
             </div>
-            <div className="p-6">
+            <div className="p-4 sm:p-6">
               <div className="space-y-2">
                 {category.routes.map((route, index) => (
                   <div

--- a/apps/web/app/admin/sim/page.tsx
+++ b/apps/web/app/admin/sim/page.tsx
@@ -122,7 +122,7 @@ export default function AdminSimPage() {
   return (
     <div className="space-y-6 max-w-5xl">
       <header>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           🎲 Simulateur Pro League
         </h1>
         <p className="text-sm text-gray-600">
@@ -138,7 +138,7 @@ export default function AdminSimPage() {
         </div>
       )}
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+      <section className="rounded-xl border border-gray-200 bg-white p-4 sm:p-6 shadow-sm">
         <h2 className="text-lg font-semibold mb-4">Parametres</h2>
         {loading ? (
           <p className="text-gray-500">Chargement des equipes…</p>
@@ -223,9 +223,9 @@ export default function AdminSimPage() {
       </section>
 
       {result && (
-        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
-          <header className="flex items-baseline justify-between">
-            <h2 className="text-lg font-semibold">
+        <section className="rounded-xl border border-gray-200 bg-white p-4 sm:p-6 shadow-sm space-y-4">
+          <header className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1">
+            <h2 className="text-lg font-semibold break-words">
               {result.pairing.home.name} vs {result.pairing.away.name}
             </h2>
             <span className="text-xs text-gray-500">

--- a/apps/web/app/admin/teams/page.tsx
+++ b/apps/web/app/admin/teams/page.tsx
@@ -180,9 +180,9 @@ export default function AdminTeamsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
         <div>
-          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
             ⚽ Gestion des Équipes
           </h1>
           <p className="text-sm text-gray-600">
@@ -190,16 +190,16 @@ export default function AdminTeamsPage() {
           </p>
         </div>
         {pagination && (
-          <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200">
+          <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200 self-start sm:self-auto">
             {pagination.total} équipe{pagination.total !== 1 ? "s" : ""}
           </div>
         )}
       </div>
 
       {/* Filtres et recherche */}
-      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-4">
-        <div className="flex gap-4 items-center flex-wrap">
-          <div className="flex-1 min-w-[200px]">
+      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-3 sm:p-4">
+        <div className="flex gap-3 sm:gap-4 items-stretch sm:items-center flex-col sm:flex-row sm:flex-wrap">
+          <div className="flex-1 sm:min-w-[200px]">
             <input
               type="text"
               placeholder="Rechercher (nom d'équipe)..."
@@ -216,7 +216,7 @@ export default function AdminTeamsPage() {
               setOwnerFilter(e.target.value);
               setCurrentPage(1);
             }}
-            className="px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white min-w-[150px]"
+            className="w-full sm:w-auto px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white sm:min-w-[150px]"
           />
           <select
             value={rosterFilter}
@@ -224,7 +224,7 @@ export default function AdminTeamsPage() {
               setRosterFilter(e.target.value);
               setCurrentPage(1);
             }}
-            className="px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
+            className="w-full sm:w-auto px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
           >
             <option value="">Tous les rosters</option>
             <option value="skaven">Skavens</option>
@@ -264,7 +264,7 @@ export default function AdminTeamsPage() {
               setRulesetFilter(e.target.value);
               setCurrentPage(1);
             }}
-            className="px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
+            className="w-full sm:w-auto px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
           >
             <option value="">Tous les rulesets</option>
             <option value="season_2">Saison 2</option>
@@ -438,14 +438,14 @@ export default function AdminTeamsPage() {
       {/* Modal de détails */}
       {selectedTeam && teamDetails && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50"
           onClick={() => {
             setSelectedTeam(null);
             setTeamDetails(null);
           }}
         >
           <div
-            className="bg-white rounded-xl shadow-2xl p-6 max-w-4xl max-h-[90vh] overflow-y-auto w-full mx-4"
+            className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl p-4 sm:p-6 max-w-4xl max-h-[95vh] sm:max-h-[90vh] overflow-y-auto w-full sm:mx-4"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex justify-between items-center mb-6">
@@ -466,7 +466,7 @@ export default function AdminTeamsPage() {
             <div className="space-y-4">
               <div>
                 <h3 className="font-semibold mb-2">Informations générales</h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 text-sm">
                   <div>
                     <span className="text-gray-600">Nom:</span>{" "}
                     <span className="font-medium">{teamDetails.name}</span>
@@ -508,7 +508,7 @@ export default function AdminTeamsPage() {
 
               <div>
                 <h3 className="font-semibold mb-2">Équipement</h3>
-                <div className="grid grid-cols-4 gap-4 text-sm">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 text-sm">
                   <div className="bg-blue-50 p-3 rounded">
                     <div className="text-gray-600">Relances</div>
                     <div className="text-2xl font-bold">{teamDetails.rerolls}</div>

--- a/apps/web/app/admin/users/page.tsx
+++ b/apps/web/app/admin/users/page.tsx
@@ -414,9 +414,9 @@ export default function AdminUsersPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
         <div>
-          <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+          <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
             👥 Gestion des Utilisateurs
           </h1>
           <p className="text-sm text-gray-600">
@@ -424,16 +424,16 @@ export default function AdminUsersPage() {
           </p>
         </div>
         {pagination && (
-          <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200">
+          <div className="text-sm text-gray-600 bg-white px-4 py-2 rounded-lg border border-gray-200 self-start sm:self-auto">
             {pagination.total} utilisateur{pagination.total !== 1 ? "s" : ""}
           </div>
         )}
       </div>
 
       {/* Filtres et recherche */}
-      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-4">
-        <div className="flex gap-4 items-center flex-wrap">
-          <div className="flex-1 min-w-[200px]">
+      <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-3 sm:p-4">
+        <div className="flex gap-3 sm:gap-4 items-stretch sm:items-center flex-col sm:flex-row sm:flex-wrap">
+          <div className="flex-1 sm:min-w-[200px]">
             <input
               type="text"
               placeholder="Rechercher (email, nom)..."
@@ -448,7 +448,7 @@ export default function AdminUsersPage() {
               setRoleFilter(e.target.value);
               setCurrentPage(1);
             }}
-            className="px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
+            className="w-full sm:w-auto px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-nuffle-gold focus:border-nuffle-gold outline-none transition-all bg-white"
           >
             <option value="">Tous les rôles</option>
             <option value="user">User</option>
@@ -715,14 +715,14 @@ export default function AdminUsersPage() {
       {/* Modal de détails */}
       {selectedUser && userDetails && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50"
           onClick={() => {
             setSelectedUser(null);
             setUserDetails(null);
           }}
         >
           <div
-            className="bg-white rounded-xl shadow-2xl p-6 max-w-3xl max-h-[90vh] overflow-y-auto w-full mx-4"
+            className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl p-4 sm:p-6 max-w-3xl max-h-[95vh] sm:max-h-[90vh] overflow-y-auto w-full sm:mx-4"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex justify-between items-center mb-6">
@@ -743,7 +743,7 @@ export default function AdminUsersPage() {
             <div className="space-y-4">
               <div>
                 <h3 className="font-semibold mb-2">Informations</h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 text-sm">
                   <div>
                     <span className="text-gray-600">Email:</span>{" "}
                     <span className="font-mono">{userDetails.email}</span>
@@ -1049,7 +1049,7 @@ export default function AdminUsersPage() {
 
               <div>
                 <h3 className="font-semibold mb-2">Statistiques</h3>
-                <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3 sm:gap-4 text-sm">
                   <div className="bg-blue-50 p-3 rounded">
                     <div className="text-gray-600">Équipes</div>
                     <div className="text-2xl font-bold">{userDetails._count.teams}</div>
@@ -1162,14 +1162,14 @@ export default function AdminUsersPage() {
       {/* Modal de détails d'équipe */}
       {selectedTeam && teamDetails && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50"
           onClick={() => {
             setSelectedTeam(null);
             setTeamDetails(null);
           }}
         >
           <div
-            className="bg-white rounded-xl shadow-2xl p-6 max-w-4xl max-h-[90vh] overflow-y-auto w-full mx-4"
+            className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl p-4 sm:p-6 max-w-4xl max-h-[95vh] sm:max-h-[90vh] overflow-y-auto w-full sm:mx-4"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex justify-between items-center mb-6">
@@ -1190,7 +1190,7 @@ export default function AdminUsersPage() {
             <div className="space-y-4">
               <div>
                 <h3 className="font-semibold mb-2">Informations générales</h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 text-sm">
                   <div>
                     <span className="text-gray-600">Nom:</span>{" "}
                     <span className="font-medium">{teamDetails.name}</span>
@@ -1232,7 +1232,7 @@ export default function AdminUsersPage() {
 
               <div>
                 <h3 className="font-semibold mb-2">Équipement</h3>
-                <div className="grid grid-cols-4 gap-4 text-sm">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 text-sm">
                   <div className="bg-blue-50 p-3 rounded">
                     <div className="text-gray-600">Relances</div>
                     <div className="text-2xl font-bold">{teamDetails.rerolls || 0}</div>

--- a/apps/web/app/admin/utilities/page.tsx
+++ b/apps/web/app/admin/utilities/page.tsx
@@ -113,7 +113,7 @@ export default function AdminUtilitiesPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
+        <h1 className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite mb-1">
           🛠️ Utilitaires
         </h1>
         <p className="text-sm text-gray-600">

--- a/apps/web/app/admin/wallets/[userId]/page.tsx
+++ b/apps/web/app/admin/wallets/[userId]/page.tsx
@@ -173,30 +173,30 @@ export default function AdminWalletDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
+      <div className="flex items-start justify-between flex-wrap gap-3">
+        <div className="min-w-0">
           <h1
             data-testid="admin-wallet-title"
-            className="text-3xl font-heading font-bold text-nuffle-anthracite"
+            className="text-2xl sm:text-3xl font-heading font-bold text-nuffle-anthracite break-words"
           >
             Wallet de {data.user.coachName}
           </h1>
-          <p className="text-sm text-gray-600">{data.user.email}</p>
+          <p className="text-sm text-gray-600 break-all">{data.user.email}</p>
         </div>
         <Link
           href="/admin/users"
-          className="text-sm text-blue-600 hover:underline"
+          className="text-sm text-blue-600 hover:underline whitespace-nowrap"
         >
-          ← Retour aux utilisateurs
+          ← Retour
         </Link>
       </div>
 
-      <div className="bg-white rounded-xl shadow border border-gray-200 p-6 flex items-center justify-between gap-4 flex-wrap">
+      <div className="bg-white rounded-xl shadow border border-gray-200 p-4 sm:p-6 flex items-center justify-between gap-3 sm:gap-4 flex-wrap">
         <div>
           <div className="text-sm text-gray-600">Solde courant</div>
           <div
             data-testid="wallet-balance"
-            className="text-4xl font-bold text-nuffle-anthracite"
+            className="text-3xl sm:text-4xl font-bold text-nuffle-anthracite"
           >
             {data.wallet.crowns.toLocaleString("fr-FR")}{" "}
             <span className="text-base font-normal text-gray-500">Crowns</span>
@@ -205,7 +205,7 @@ export default function AdminWalletDetailPage() {
         <button
           onClick={() => setAdjustOpen(true)}
           data-testid="btn-adjust-balance"
-          className="px-4 py-2 text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 rounded-lg"
+          className="px-4 py-2 text-sm font-medium text-white bg-pink-600 hover:bg-pink-700 rounded-lg whitespace-nowrap"
         >
           Ajuster le solde
         </button>
@@ -218,6 +218,7 @@ export default function AdminWalletDetailPage() {
         {data.pendingBets.length === 0 ? (
           <p className="text-sm text-gray-500 italic">Aucun pari en attente.</p>
         ) : (
+          <div className="overflow-x-auto -mx-4 sm:mx-0 px-4 sm:px-0">
           <table className="min-w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
@@ -252,11 +253,12 @@ export default function AdminWalletDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
 
       <div className="bg-white rounded-xl shadow border border-gray-200 p-4">
-        <div className="flex justify-between items-center mb-3">
+        <div className="flex justify-between items-center mb-3 flex-wrap gap-2">
           <h2 className="text-lg font-semibold">
             Transactions ({data.pagination.total})
           </h2>
@@ -267,6 +269,7 @@ export default function AdminWalletDetailPage() {
         {data.transactions.length === 0 ? (
           <p className="text-sm text-gray-500 italic">Aucune transaction.</p>
         ) : (
+          <div className="overflow-x-auto -mx-4 sm:mx-0 px-4 sm:px-0">
           <table className="min-w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
@@ -308,6 +311,7 @@ export default function AdminWalletDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
         {data.pagination.totalPages > 1 && (
           <div className="flex justify-center gap-2 mt-4">


### PR DESCRIPTION
Refonte responsive globale des interfaces admin pour faciliter la gestion
depuis un telephone :

- Layout : sidebar desktop preservee, drawer mobile avec overlay et
  topbar a hamburger. Body scroll lock quand le drawer est ouvert,
  fermeture auto a chaque navigation.
- Headers : conversion des "flex justify-between items-center" en
  flex-col sm:flex-row + tailles de titre adaptatives
  (text-2xl sm:text-3xl).
- Filtres : inputs et selects passent en full-width sur mobile,
  retour a la rangee horizontale a partir de sm.
- Stats cards : grids passent a 2 col sur mobile (au lieu de stack),
  padding et tailles de texte reduites.
- Modals (users, teams, wallets) : sliding bottom-sheet sur mobile
  (items-end + rounded-t-2xl + max-h-95vh), full-width sans marges
  laterales, padding p-4 sur mobile.
- Grilles internes (infos, equipement, statistiques) : grid-cols-1/2
  sur mobile au lieu de grid-cols-4/5.
- Tables (audit-log, feature-flags, pro-league/seasons, wallets) :
  ajout d'un wrapper overflow-x-auto pour permettre le scroll
  horizontal, whitespace-nowrap sur les en-tetes.
- Suppression du wrapper min-h-screen + gradient redondant sur
  local-matches (deja fourni par le layout parent).

Aucune regression : 1124 tests passent, typecheck OK.