### PR TITLE
fix(match-summary): extract real score from last gameState

### DIFF
--- a/apps/server/src/routes/match-summary-handler.ts
+++ b/apps/server/src/routes/match-summary-handler.ts
@@ -87,6 +87,35 @@ export async function handleGetMatchSummary(
     const half = turnsCount < 16 ? 1 : 2; // approximation
     const turn = (turnsCount % 16) + 1; // approximation
 
+    // Cleanup TODO : extrait le score du dernier gameState persiste
+    // (meme pattern que match-readonly-handlers.ts). Si pas de turn
+    // ou pas de gameState valide → fallback {teamA: 0, teamB: 0}.
+    const lastTurn = await prisma.turn.findFirst({
+      where: { matchId },
+      orderBy: { number: 'desc' },
+      select: { payload: true },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lastPayload = (lastTurn as any)?.payload ?? {};
+    const rawGameState = lastPayload.gameState;
+    let parsedGameState: { score?: { teamA?: number; teamB?: number } } | null =
+      null;
+    if (typeof rawGameState === 'string') {
+      try {
+        parsedGameState = JSON.parse(rawGameState);
+      } catch {
+        parsedGameState = null;
+      }
+    } else if (rawGameState && typeof rawGameState === 'object') {
+      parsedGameState = rawGameState as {
+        score?: { teamA?: number; teamB?: number };
+      };
+    }
+    const score = {
+      teamA: parsedGameState?.score?.teamA ?? 0,
+      teamB: parsedGameState?.score?.teamB ?? 0,
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pickName = (sel: any) =>
       sel?.teamRef?.name || sel?.teamRef?.roster || sel?.team || '';
@@ -130,7 +159,7 @@ export async function handleGetMatchSummary(
           eloRating: pickElo(visitor),
         },
       },
-      score: { teamA: 0, teamB: 0 }, // TODO: remplacer par score reel quand disponible
+      score,
       half,
       turn,
       acceptances: { local: localAccepted, visitor: visitorAccepted },

--- a/apps/server/src/routes/match.test.ts
+++ b/apps/server/src/routes/match.test.ts
@@ -1189,6 +1189,9 @@ describe("Route: GET /match/:id/summary (S25.5k)", () => {
       { payload: { type: "init" } },
     ]);
     mockPrisma.turn.count.mockResolvedValue(3);
+    // Cleanup TODO match-summary score : extract from last gameState
+    // turn. Aucun gameState ici → fallback 0-0.
+    mockPrisma.turn.findFirst.mockResolvedValue(null);
 
     const req = createReq({ params: { id: "m1" } });
     const res = createRes();
@@ -1207,6 +1210,50 @@ describe("Route: GET /match/:id/summary (S25.5k)", () => {
         half: 1,
         turn: 4,
         acceptances: { local: true, visitor: false },
+      },
+    });
+  });
+
+  it("returns real score from last turn gameState when available", async () => {
+    mockPrisma.match.findUnique.mockResolvedValue({
+      id: "m2",
+      status: "active",
+      seed: "seed-2",
+      creatorId: "user-1",
+      createdAt: new Date("2026-04-28T09:00:00Z"),
+    });
+    mockPrisma.teamSelection.findMany.mockResolvedValue([
+      {
+        userId: "user-1",
+        user: { id: "user-1", name: "Alice", email: "a@x", eloRating: 1200 },
+        teamRef: { id: "t1", name: "Reds", roster: "skaven" },
+      },
+      {
+        userId: "user-2",
+        user: { id: "user-2", name: "Bob", email: "b@x", eloRating: 1100 },
+        teamRef: { id: "t2", name: "Blues", roster: "lizardmen" },
+      },
+    ]);
+    mockPrisma.turn.findMany.mockResolvedValue([
+      { payload: { type: "accept", userId: "user-1" } },
+      { payload: { type: "accept", userId: "user-2" } },
+    ]);
+    mockPrisma.turn.count.mockResolvedValue(8);
+    mockPrisma.turn.findFirst.mockResolvedValue({
+      payload: {
+        gameState: { score: { teamA: 3, teamB: 1 } },
+      },
+    });
+
+    const req = createReq({ params: { id: "m2" } });
+    const res = createRes();
+    await handleGetMatchSummary(req, res);
+
+    expect(res.payload).toMatchObject({
+      success: true,
+      data: {
+        score: { teamA: 3, teamB: 1 },
+        acceptances: { local: true, visitor: true },
       },
     });
   });


### PR DESCRIPTION
## Summary

Cleanup d'un TODO B0.1 residuel. `GET /match/:id/summary` retournait un placeholder `{ teamA: 0, teamB: 0 }`. Le pattern est deja implemente dans `match-readonly-handlers.ts` — applique le meme ici.

## Pattern

- Load last turn via `prisma.turn.findFirst({orderBy:{number:'desc'}})`.
- Parse `gameState.score` (string JSON ou objet natif, tolerant sqlite vs PG).
- Fallback `{teamA:0, teamB:0}` si pas de turn ou pas de gameState.

## Tests

- Test existant adapte : mock `turn.findFirst` → null → score 0-0 (`vi.clearAllMocks()` ne reset pas la queue `mockResolvedValueOnce` — cf. pattern CLAUDE.md). Ajout d'un mock null explicite.
- **Nouveau test** : score 3-1 extrait quand le last turn a un gameState avec score persiste.

## Verifications

- [x] 64/64 tests `match.test.ts` pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_