### PR TITLE
fix(star-players): implement roster filter using engine data

### DIFF
--- a/apps/web/app/star-players/page.tsx
+++ b/apps/web/app/star-players/page.tsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import StarPlayerCard from '../components/StarPlayerCard';
 import CopyrightFooter from '../components/CopyrightFooter';
-import type { StarPlayerDefinition } from '@bb/game-engine';
+import {
+  TEAM_REGIONAL_RULES,
+  type StarPlayerDefinition,
+} from '@bb/game-engine';
 import { useLanguage } from '../contexts/LanguageContext';
 import { UMAMI_EVENTS, trackUmamiEvent } from '../lib/umami-events';
 
@@ -79,10 +82,21 @@ export default function StarPlayersPage() {
       );
     }
 
-    // Filtre par roster
+    // Filtre par roster.
+    //
+    // Un star player est recrutable par un roster si :
+    //   - `hirableBy.includes("all")` (mercenaire universel), OU
+    //   - intersection non-vide entre `hirableBy` (regles speciales
+    //     du player) et `regionalRules` du roster.
+    //
+    // `TEAM_REGIONAL_RULES` map les slugs de roster vers leur set de
+    // regional rules (donnees engine, source de verite).
     if (selectedRoster !== 'all') {
-      // TODO: Implémenter le filtrage par roster via l'API
-      // Pour l'instant, on garde tous les joueurs
+      const rosterRules = TEAM_REGIONAL_RULES[selectedRoster] ?? [];
+      filtered = filtered.filter((sp) => {
+        if (sp.hirableBy.includes('all')) return true;
+        return sp.hirableBy.some((rule) => rosterRules.includes(rule));
+      });
     }
 
     // Filtre par coût


### PR DESCRIPTION
## Summary

Cleanup d'un TODO actionable. Le filtre par roster sur `/star-players` etait un placeholder ("Pour l'instant on garde tous les joueurs"). La data necessaire existe deja cote engine.

## Pattern

Un star player est recrutable par un roster ssi :
- `hirableBy.includes("all")` (mercenaire universel), OU
- intersection non-vide entre `hirableBy` (regles speciales du player) et `regionalRules` du roster.

Meme logique que `getAvailableStarPlayers()` cote engine, mais pure cote client pour eviter un fetch supplementaire. Utilise `TEAM_REGIONAL_RULES` (deja exporte depuis `@bb/game-engine`).

## Verifications

- [x] `pnpm build` web clean
- [x] `pnpm lint` clean

## Test plan

- [ ] Visiter `/star-players` → tous les players affiches (filter "all")
- [ ] Selectionner "Skaven" → seulement les players avec `hirableBy.includes("all")` ou `"underworld_challenge"` (regional rule des Skaven)
- [ ] Selectionner "Wood Elf" → seulement ceux qui partagent une regional rule avec le roster wood_elf
- [ ] Combinaison filtre roster + skill + cout marche


---
_Generated by [Claude Code](https://claude.ai/code/session_018zoFWnLVELWx54eTQ6x4fs)_