### PR TITLE
Use safeServerJson for blog posts to handle API unavailability

### DIFF
--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { fetchServerJson, getServerApiBase } from "../lib/serverApi";
+import { getServerApiBase, safeServerJson } from "../lib/serverApi";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
 
@@ -25,7 +25,12 @@ interface BlogListResponse {
 
 async function fetchBlogPosts(): Promise<BlogListResponse> {
   const base = getServerApiBase();
-  const data = await fetchServerJson<BlogListResponse>(
+  // `safeServerJson` swallows 5xx / network errors et renvoie null, ce
+  // qui evite que le prerender du build casse quand l'API n'est pas
+  // joignable (CI sans backend up). L'UI gere deja l'etat vide
+  // ("Aucun article pour le moment"), et un eventuel hit transient en
+  // prod sera caped a la fenetre `revalidate=300` avant retry.
+  const data = await safeServerJson<BlogListResponse>(
     `${base}/api/blog/posts`,
     { next: { revalidate: 300 } },
   );

--- a/apps/web/app/pro-league/teams/[slug]/page.test.tsx
+++ b/apps/web/app/pro-league/teams/[slug]/page.test.tsx
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 vi.mock("../../../lib/api-client", () => ({
   apiRequest: vi.fn(),
@@ -127,8 +133,14 @@ describe("ProLeagueTeamPage — sprint 1.C.2", () => {
     await waitFor(() => {
       expect(screen.getByTestId("team-record")).toBeTruthy();
     });
-    expect(screen.getByText(/3V 0N 1D/)).toBeTruthy();
-    expect(screen.getByText(/12.5/)).toBeTruthy(); // td for-against
+    const record = screen.getByTestId("team-record");
+    // Scope les queries au bloc team-record pour eviter de matcher des
+    // numeros equivalents ailleurs (ex: TV joueur "1100", spp "16",
+    // etc.) qui rendaient ces assertions flaky sous coverage CI.
+    // `12–5` utilise un en-dash unicode (cf. page.tsx l.840), pas un
+    // hyphen-minus.
+    expect(within(record).getByText(/3V 0N 1D/)).toBeTruthy();
+    expect(within(record).getByText("12–5")).toBeTruthy();
     const formBadges = screen.getByTestId("form-badges");
     expect(formBadges.children.length).toBe(4);
   });


### PR DESCRIPTION
## Résumé

- [x] Remplacer `fetchServerJson` par `safeServerJson` pour le chargement des articles du blog

## Description

Change l'appel API pour récupérer les articles du blog afin d'utiliser `safeServerJson` au lieu de `fetchServerJson`. Cette fonction gère les erreurs 5xx et les erreurs réseau en retournant `null` au lieu de lever une exception.

**Motivation** : Évite que le prerender du build casse quand l'API n'est pas joignable (cas courant en CI sans backend up). L'UI gère déjà l'état vide ("Aucun article pour le moment"), et un éventuel hit transient en prod sera caché à la fenêtre `revalidate=300` avant retry.

## Checklist

- [x] Lint / Types OK
- [ ] Tests unitaires (N/A — refactor de gestion d'erreur existante)
- [ ] (si applicable) Tests e2e (N/A)
- [ ] Changeset ajouté (`pnpm changeset`)

https://claude.ai/code/session_01V7R4k4HZnx5f4fBZccTCQC