### PR TITLE
fix(pro-league-replay): vue terrain par défaut + résolution playerIds en noms

### DIFF
--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.test.tsx
@@ -10,9 +10,20 @@ import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import type { MatchEvent } from "@bb/shared-types";
 
-vi.mock("../../../../lib/api-client", () => ({
-  apiRequest: vi.fn(),
-}));
+vi.mock("../../../../lib/api-client", () => {
+  class ApiClientError extends Error {
+    readonly status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.name = "ApiClientError";
+      this.status = status;
+    }
+  }
+  return {
+    apiRequest: vi.fn(),
+    ApiClientError,
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: vi.fn() }),
@@ -327,5 +338,189 @@ describe("<MatchReplayPlayer> — sprint 1.G.2", () => {
       await Promise.resolve();
     });
     expect(screen.queryByTestId("scrub-markers")).toBeNull();
+  });
+});
+
+describe("<MatchReplayPlayer> — vue terrain par défaut + résolution noms", () => {
+  const PID_ATTACKER = "cmp3w1e2a045dqpfv74lkun5b";
+  const PID_DEFENDER = "cmp3w1egr04apqpfv5so0ex47";
+
+  const BLOCK_FIXTURE_EVENTS: MatchEvent[] = [
+    {
+      type: "KICKOFF",
+      displayAtMs: 0,
+      engineVer: "0.13.0",
+      meta: { home: "home", away: "away", weather: "nice" },
+    },
+    {
+      type: "BLOCK",
+      displayAtMs: 30_000,
+      engineVer: "0.13.0",
+      meta: { attackerId: PID_ATTACKER, defenderId: PID_DEFENDER },
+    },
+    {
+      type: "END",
+      displayAtMs: 600_000,
+      engineVer: "0.13.0",
+      meta: { score: { home: 0, away: 0 } },
+    },
+  ];
+
+  const REPLAY_FIXTURE = {
+    matchId: "m1",
+    status: "completed",
+    durationMs: 600_000,
+    eventCount: BLOCK_FIXTURE_EVENTS.length,
+    events: BLOCK_FIXTURE_EVENTS,
+  };
+
+  const FULL_REPLAY_FIXTURE = {
+    matchId: "m1",
+    status: "completed",
+    durationMs: 600_000,
+    initialState: {
+      players: [
+        {
+          id: PID_ATTACKER,
+          team: "A",
+          pos: { x: 5, y: 7 },
+          name: "Tartar Steve",
+          number: 5,
+          position: "Blitzer",
+          ma: 7,
+          st: 3,
+          ag: 3,
+          pa: 4,
+          av: 9,
+          skills: ["block"],
+          pm: 7,
+        },
+        {
+          id: PID_DEFENDER,
+          team: "B",
+          pos: { x: 20, y: 7 },
+          name: "Slick Bob",
+          number: 12,
+          position: "Lineman",
+          ma: 6,
+          st: 3,
+          ag: 3,
+          pa: 4,
+          av: 8,
+          skills: [],
+          pm: 6,
+        },
+      ],
+    },
+  };
+
+  function mockBothEndpoints(opts: {
+    replay?: unknown;
+    fullReplay?: unknown;
+    fullReplayError?: unknown;
+  }): void {
+    mockedRequest.mockImplementation((path: string) => {
+      if (path.includes("/full-replay")) {
+        if (opts.fullReplayError) return Promise.reject(opts.fullReplayError);
+        return Promise.resolve(opts.fullReplay ?? FULL_REPLAY_FIXTURE);
+      }
+      return Promise.resolve(opts.replay ?? REPLAY_FIXTURE);
+    });
+  }
+
+  it("résout les playerIds en 'Nom (#N Position)' dans le feed des events", async () => {
+    mockBothEndpoints({});
+    renderPlayer("m1");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Avance jusqu'au BLOCK event pour le faire apparaître.
+    const scrub = screen.getByTestId("replay-scrub") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(scrub, { target: { value: "60000" } });
+    });
+    const feed = screen.getByTestId("replay-event-feed");
+    expect(feed.textContent).toContain("Tartar Steve (#5 Blitzer)");
+    expect(feed.textContent).toContain("Slick Bob (#12 Lineman)");
+    // Les IDs bruts ne doivent plus apparaître à l'écran.
+    expect(feed.textContent).not.toContain(PID_ATTACKER);
+    expect(feed.textContent).not.toContain(PID_DEFENDER);
+  });
+
+  it("retombe sur l'ID brut si le playerId n'est pas dans le roster", async () => {
+    mockBothEndpoints({
+      fullReplay: {
+        ...FULL_REPLAY_FIXTURE,
+        initialState: { players: [] },
+      },
+    });
+    renderPlayer("m1");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const scrub = screen.getByTestId("replay-scrub") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(scrub, { target: { value: "60000" } });
+    });
+    const feed = screen.getByTestId("replay-event-feed");
+    expect(feed.textContent).toContain(PID_ATTACKER);
+  });
+
+  it("par défaut, rend la vue terrain (replay-field-wrapper-full)", async () => {
+    mockBothEndpoints({});
+    renderPlayer("m1");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId("replay-field-wrapper-full")).not.toBeNull();
+    expect(screen.queryByTestId("replay-field-wrapper")).toBeNull();
+    expect(
+      screen
+        .getByTestId("replay-view-field")
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+  });
+
+  it("bascule sur la vue classique si le full-replay est 404", async () => {
+    mockBothEndpoints({
+      fullReplayError: new Error("FULL_REPLAY_NOT_AVAILABLE"),
+    });
+    renderPlayer("m1");
+    // Le .catch() interne sur le full-replay introduit une micro-tâche
+    // supplémentaire avant que Promise.all ne résolve. On flush deux ticks
+    // pour s'assurer que setState propage avant l'assertion.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId("replay-field-wrapper-full")).toBeNull();
+    expect(screen.queryByTestId("replay-field-wrapper")).not.toBeNull();
+    expect(
+      screen
+        .getByTestId("replay-view-classic")
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    // L'onglet Terrain doit être désactivé.
+    expect(
+      screen.getByTestId("replay-view-field").getAttribute("disabled"),
+    ).not.toBeNull();
+  });
+
+  it("l'onglet Terrain reste cliquable si le full-replay est disponible", async () => {
+    mockBothEndpoints({});
+    renderPlayer("m1");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("replay-view-classic"));
+    });
+    expect(screen.queryByTestId("replay-field-wrapper")).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("replay-view-field"));
+    });
+    expect(screen.queryByTestId("replay-field-wrapper-full")).not.toBeNull();
   });
 });

--- a/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
+++ b/apps/web/app/pro-league/matches/[id]/replay/MatchReplayPlayer.tsx
@@ -3,10 +3,11 @@
 import dynamic from "next/dynamic";
 import { useEffect, useMemo, useState } from "react";
 
+import type { GameState, Player } from "@bb/game-engine";
 import type { MatchEvent } from "@bb/shared-types";
 
 import { useLanguage } from "../../../../contexts/LanguageContext";
-import { apiRequest } from "../../../../lib/api-client";
+import { ApiClientError, apiRequest } from "../../../../lib/api-client";
 import { deriveProLeagueFieldState } from "../../../../lib/pro-league-field-state";
 import {
   type ScrubMarker,
@@ -72,8 +73,57 @@ interface ReplayDump {
   readonly events: readonly MatchEvent[];
 }
 
+/**
+ * Sous-ensemble du dump `/full-replay` utilisé par `MatchReplayPlayer` :
+ * - `initialState.players` permet de résoudre les playerIds bruts (cuids)
+ *   en "Nom (#N Position)" dans le feed d'évents.
+ * - La simple présence du dump signale que la vue terrain BB est dispo
+ *   (donc on l'active par défaut).
+ */
+interface FullReplayDumpLite {
+  readonly initialState: GameState;
+  readonly states?: readonly GameState[];
+}
+
 interface PlayerProps {
   readonly matchId: string;
+}
+
+/**
+ * Construit un index `playerId → "Nom (#N Position)"` à partir des players
+ * du `initialState` (les 22 starters) plus des `states` ultérieurs (qui
+ * peuvent contenir des reserves ramenées sur le terrain en cours de match).
+ * Fallback gracieux : si l'ID n'est pas dans la map, on retourne l'ID brut.
+ */
+function buildPlayerNameIndex(
+  dump: FullReplayDumpLite | null,
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  if (!dump) return map;
+  const addPlayers = (players: readonly Player[] | undefined): void => {
+    if (!players) return;
+    for (const p of players) {
+      if (!p?.id || map.has(p.id)) continue;
+      const name = typeof p.name === "string" && p.name ? p.name : p.id;
+      const num = typeof p.number === "number" ? `#${p.number}` : "";
+      const pos = typeof p.position === "string" ? p.position : "";
+      const suffix = [num, pos].filter(Boolean).join(" ");
+      map.set(p.id, suffix ? `${name} (${suffix})` : name);
+    }
+  };
+  addPlayers(dump.initialState?.players);
+  if (dump.states) {
+    for (const s of dump.states) addPlayers(s.players);
+  }
+  return map;
+}
+
+function resolvePlayer(
+  rawId: unknown,
+  names: ReadonlyMap<string, string>,
+): string {
+  if (typeof rawId !== "string" || !rawId) return "?";
+  return names.get(rawId) ?? rawId;
 }
 
 const EVENT_BADGE_STYLES: Record<string, string> = {
@@ -117,7 +167,11 @@ interface EventsT {
   turnover: string;
 }
 
-function summarizeMeta(ev: MatchEvent, e: EventsT): string {
+function summarizeMeta(
+  ev: MatchEvent,
+  e: EventsT,
+  playerNames: ReadonlyMap<string, string>,
+): string {
   const meta = (ev.meta ?? {}) as Record<string, unknown>;
   switch (ev.type) {
     case "KICKOFF": {
@@ -136,25 +190,28 @@ function summarizeMeta(ev: MatchEvent, e: EventsT): string {
         .replace("{team}", drivingTeam);
     }
     case "BLITZ_DECLARED": {
-      const attacker = String(meta.attackerId ?? "?");
-      const defender = String(meta.defenderId ?? "?");
+      const attacker = resolvePlayer(meta.attackerId, playerNames);
+      const defender = resolvePlayer(meta.defenderId, playerNames);
       return e.blitzDeclared
         .replace("{attacker}", attacker)
         .replace("{defender}", defender);
     }
     case "BLOCK": {
-      const attacker = String(meta.attackerId ?? "");
-      const defender = String(meta.defenderId ?? "");
-      if (attacker && defender) {
+      const hasAttacker = typeof meta.attackerId === "string" && meta.attackerId;
+      const hasDefender = typeof meta.defenderId === "string" && meta.defenderId;
+      if (hasAttacker && hasDefender) {
         return e.blockBetween
-          .replace("{attacker}", attacker)
-          .replace("{defender}", defender);
+          .replace("{attacker}", resolvePlayer(meta.attackerId, playerNames))
+          .replace("{defender}", resolvePlayer(meta.defenderId, playerNames));
       }
       return e.block;
     }
     case "KNOCKDOWN": {
-      const player = String(meta.playerId ?? "?");
-      const cause = meta.causedBy ? String(meta.causedBy) : "";
+      const player = resolvePlayer(meta.playerId, playerNames);
+      const cause =
+        typeof meta.causedBy === "string" && meta.causedBy
+          ? resolvePlayer(meta.causedBy, playerNames)
+          : "";
       if (cause) {
         return e.knockdownWithCause
           .replace("{player}", player)
@@ -163,11 +220,11 @@ function summarizeMeta(ev: MatchEvent, e: EventsT): string {
       return e.knockdown.replace("{player}", player);
     }
     case "DODGE": {
-      const player = String(meta.playerId ?? "?");
+      const player = resolvePlayer(meta.playerId, playerNames);
       return e.dodge.replace("{player}", player);
     }
     case "PASS": {
-      const passer = String(meta.passerId ?? "?");
+      const passer = resolvePlayer(meta.passerId, playerNames);
       return e.pass.replace("{passer}", passer);
     }
     case "TD": {
@@ -175,7 +232,7 @@ function summarizeMeta(ev: MatchEvent, e: EventsT): string {
       return e.touchdownTeam.replace("{team}", team);
     }
     case "KO": {
-      const player = String(meta.playerId ?? "?");
+      const player = resolvePlayer(meta.playerId, playerNames);
       return e.ko.replace("{player}", player);
     }
     case "CASUALTY": {
@@ -354,22 +411,53 @@ export default function MatchReplayPlayer({
   const redirect = useMatchModeRedirect(matchId, "replay");
   const [dump, setDump] = useState<ReplayDump | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // Lot 3.D.4 — bascule entre vue classique (events + ProLeagueField
-  // abstrait) et vue terrain BB (GameBoardWithDugouts + states[]).
-  // Vue classique par défaut : disponible pour tous les replays.
-  const [viewMode, setViewMode] = useState<ReplayViewMode>("classic");
-  const [fieldUnavailable, setFieldUnavailable] = useState<string | null>(null);
+  // Vue terrain BB (GameBoardWithDugouts + states[]) par défaut quand le
+  // dump full-replay est disponible — c'est ce que l'utilisateur voit en
+  // direct sur `/play` ou `/live`. Bascule sur la vue classique (terrain
+  // abstrait + ball trail) si le full driver n'est pas disponible (replays
+  // legacy / driver hybrid).
+  const [viewMode, setViewMode] = useState<ReplayViewMode>("field");
+  // Lot replay-fix — dump léger du full-replay pour résoudre les playerIds
+  // bruts en "Nom (#N Position)" dans le feed, et savoir si la vue terrain
+  // est dispo. Fetch en parallèle du `/replay` ; null si 404 (legacy).
+  const [fullDump, setFullDump] = useState<FullReplayDumpLite | null>(null);
+  const [fullDumpUnavailable, setFullDumpUnavailable] =
+    useState<string | null>(null);
 
   useEffect(() => {
     if (redirect.redirecting) return;
     if (redirect.status !== null && redirect.status !== "completed") return;
     let cancelled = false;
-    apiRequest<ReplayDump>(
-      `/pro-league/matches/${encodeURIComponent(matchId)}/replay`,
-    )
-      .then((d) => {
+    // Pattern `Promise.all([detail, optional])` (cf. CLAUDE.md) : le
+    // dump events est obligatoire, le full-replay est optionnel et n'a
+    // pas le droit de bloquer l'affichage si 404 (replay legacy).
+    Promise.all([
+      apiRequest<ReplayDump>(
+        `/pro-league/matches/${encodeURIComponent(matchId)}/replay`,
+      ),
+      apiRequest<FullReplayDumpLite>(
+        `/pro-league/matches/${encodeURIComponent(matchId)}/full-replay`,
+      ).catch((e: unknown) => {
+        // 404 / FULL_REPLAY_NOT_AVAILABLE → on basculera en vue classique.
+        if (e instanceof ApiClientError) {
+          return { __unavailable: e.message } as const;
+        }
+        return {
+          __unavailable: e instanceof Error ? e.message : "fetch error",
+        } as const;
+      }),
+    ])
+      .then(([d, f]) => {
         if (cancelled) return;
         setDump(d);
+        if ("__unavailable" in f) {
+          setFullDump(null);
+          setFullDumpUnavailable(f.__unavailable);
+          setViewMode("classic");
+        } else {
+          setFullDump(f);
+          setFullDumpUnavailable(null);
+        }
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -403,6 +491,10 @@ export default function MatchReplayPlayer({
     [visibleEvents],
   );
   const score = useMemo(() => deriveScore(visibleEvents), [visibleEvents]);
+  const playerNames = useMemo(
+    () => buildPlayerNameIndex(fullDump),
+    [fullDump],
+  );
   const markers = useMemo(() => {
     if (!dump) return [];
     return buildScrubMarkers({
@@ -502,12 +594,24 @@ export default function MatchReplayPlayer({
             type="button"
             role="tab"
             aria-selected={viewMode === "field"}
+            aria-disabled={fullDumpUnavailable !== null}
+            disabled={fullDumpUnavailable !== null}
             data-testid="replay-view-field"
-            onClick={() => setViewMode("field")}
+            onClick={() => {
+              if (fullDumpUnavailable !== null) return;
+              setViewMode("field");
+            }}
+            title={
+              fullDumpUnavailable
+                ? `Vue terrain indisponible (${fullDumpUnavailable})`
+                : undefined
+            }
             className={`rounded px-3 py-1 font-mono ${
               viewMode === "field"
                 ? "bg-emerald-700 text-emerald-50"
-                : "text-slate-300 hover:bg-slate-800"
+                : fullDumpUnavailable !== null
+                  ? "cursor-not-allowed text-slate-600"
+                  : "text-slate-300 hover:bg-slate-800"
             }`}
           >
             Terrain
@@ -515,13 +619,13 @@ export default function MatchReplayPlayer({
         </div>
       </div>
 
-      {viewMode === "field" && fieldUnavailable && (
+      {viewMode === "field" && fullDumpUnavailable !== null && (
         <div
           role="alert"
           data-testid="replay-field-unavailable"
           className="mx-4 mt-2 rounded border border-amber-700 bg-amber-950 px-3 py-2 text-xs text-amber-200"
         >
-          Vue terrain indisponible ({fieldUnavailable}). Revenir en{" "}
+          Vue terrain indisponible ({fullDumpUnavailable}). Revenir en{" "}
           <button
             type="button"
             onClick={() => setViewMode("classic")}
@@ -541,7 +645,10 @@ export default function MatchReplayPlayer({
         <div className="px-4 pt-4" data-testid="replay-field-wrapper-full">
           <FullReplayField
             matchId={matchId}
-            onFallback={({ message }) => setFieldUnavailable(message)}
+            onFallback={({ message }) => {
+              setFullDumpUnavailable(message);
+              setViewMode("classic");
+            }}
           />
         </div>
       )}
@@ -617,7 +724,7 @@ export default function MatchReplayPlayer({
                   {ev.type}
                 </span>
                 <span className="flex-1 text-slate-200">
-                  {summarizeMeta(ev, t.proLeague.events)}
+                  {summarizeMeta(ev, t.proLeague.events, playerNames)}
                 </span>
               </li>
             ))


### PR DESCRIPTION
Deux problèmes signalés sur la page replay Pro League :

1. La vue "Classique" (terrain abstrait avec juste la balle) s'affichait
   par défaut au lieu de la vue "Terrain" (BB field complet avec les 22
   joueurs) — alors que la page `/play` ou `/live` montre toujours le
   terrain complet.

2. Le feed d'évènements affichait les playerIds bruts (cuids type
   `cmp3w1e2a045dqpfv74lkun5b`) au lieu de "Nom (#N Position)". Difficile
   de suivre l'action quand on voit `cmp... bloque cmp...`.

Fix :
- `MatchReplayPlayer` fetche `/replay` et `/full-replay` en parallèle
  (pattern `Promise.all([detail, optional])` de CLAUDE.md). Le
  `/full-replay` est optionnel : 404 = replay legacy / hybrid driver, on
  retombe gracieusement sur la vue classique.
- Vue "Terrain" activée par défaut quand le full-replay est dispo.
  Auto-fallback sur "Classique" si 404. L'onglet "Terrain" est désactivé
  (cursor + aria-disabled) dans ce cas.
- Index `playerId → "Nom (#N Position)"` construit à partir de
  `initialState.players` + `states[].players` (pour catcher les reserves
  ramenées en cours de match). `summarizeMeta` utilise cet index pour
  résoudre `attackerId/defenderId/playerId/passerId/causedBy`. Fallback
  sur l'ID brut si pas dans la map.

Tests : 5 nouveaux cas couvrent la résolution des noms, le fallback ID
brut, la vue terrain par défaut, le fallback sur 404 et le switch
manuel entre les deux vues.