### PR TITLE
fix(game-engine): joueurs KO récupérés deviennent state='active' à la mi-temps

### DIFF
--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -761,9 +761,17 @@ function calculateMatchResult(state: GameState, rng: RNG): {
 
 /**
  * Récupération des joueurs KO (4+ sur D6)
+ *
+ * Bug halftime-substitution : sans la mise à jour de `player.state`, les
+ * joueurs récupérés du KO restaient flagés `state='knocked_out'` côté objet
+ * Player. `autoSetupAITeam` (filtre `state === 'active' || !state`) et
+ * `placePlayerInSetup` (rejet `state !== 'active'`) les excluaient alors du
+ * re-setup, et ils ne pouvaient plus revenir sur le terrain en 2e mi-temps
+ * ou au drive post-touchdown.
  */
 function recoverKOPlayers(state: GameState, rng: RNG): GameState {
   const newState = { ...state };
+  const allRecoveredIds = new Set<string>();
 
   for (const teamId of ['A', 'B'] as TeamId[]) {
     const dugoutKey = teamId === 'A' ? 'teamA' : 'teamB';
@@ -799,6 +807,8 @@ function recoverKOPlayers(state: GameState, rng: RNG): GameState {
           },
         };
 
+        for (const id of recoveredIds) allRecoveredIds.add(id);
+
         const recoveryLog = createLogEntry(
           'info',
           `${recoveredIds.length} joueur(s) de l'équipe ${teamId} récupèrent du KO`,
@@ -808,6 +818,16 @@ function recoverKOPlayers(state: GameState, rng: RNG): GameState {
         newState.gameLog = [...newState.gameLog, recoveryLog];
       }
     }
+  }
+
+  // Sync player.state pour les joueurs récupérés : passage 'knocked_out' →
+  // 'active' afin que le re-setup les considère éligibles. On clear aussi
+  // le flag `stunned` carry-over éventuel — un joueur de retour des réserves
+  // est frais.
+  if (allRecoveredIds.size > 0) {
+    newState.players = newState.players.map(p =>
+      allRecoveredIds.has(p.id) ? { ...p, state: 'active', stunned: false } : p
+    );
   }
 
   return newState;

--- a/packages/game-engine/src/core/halftime.test.ts
+++ b/packages/game-engine/src/core/halftime.test.ts
@@ -201,6 +201,92 @@ describe('Règle: Mi-temps complète (B1.7)', () => {
       }
       expect(recoveredAtLeastOnce).toBe(true);
     });
+
+    it('devrait remettre player.state à "active" sur les joueurs KO récupérés', () => {
+      // Bug halftime-substitution : `recoverKOPlayers` ne mettait à jour que
+      // les zones de dugout sans toucher `player.state`. Conséquence : les
+      // joueurs récupérés du KO restaient flagés `state='knocked_out'` et
+      // étaient rejetés par `autoSetupAITeam` / `placePlayerInSetup`, donc
+      // jamais re-placés sur le terrain en 2e mi-temps.
+      const base = setup();
+      const state = createHalftimeState({
+        players: base.players.map(p =>
+          p.id === 'A2'
+            ? { ...p, state: 'knocked_out' as const, stunned: true, pos: { x: -1, y: -1 } }
+            : p
+        ),
+        dugouts: {
+          ...base.dugouts,
+          teamA: {
+            ...base.dugouts.teamA,
+            zones: {
+              ...base.dugouts.teamA.zones,
+              knockedOut: {
+                ...base.dugouts.teamA.zones.knockedOut,
+                players: ['A2'],
+              },
+            },
+          },
+        },
+      });
+
+      let recoveredAtLeastOnce = false;
+      for (let i = 0; i < 20; i++) {
+        const rng = makeRNG(`halftime-ko-state-${i}`);
+        const result = advanceHalfIfNeeded(state, rng);
+        const koZone = result.dugouts.teamA.zones.knockedOut;
+        if (!koZone.players.includes('A2')) {
+          recoveredAtLeastOnce = true;
+          const recovered = result.players.find(p => p.id === 'A2');
+          expect(recovered).toBeDefined();
+          expect(recovered?.state).toBe('active');
+          expect(recovered?.stunned).toBe(false);
+          break;
+        }
+      }
+      expect(recoveredAtLeastOnce).toBe(true);
+    });
+
+    it('ne devrait pas modifier player.state des joueurs qui restent KO', () => {
+      // Avec un seed où le D6 sort < 4, le joueur reste KO. Il doit garder
+      // `state='knocked_out'` pour rester en boîte KO côté UI et exclu du
+      // re-setup. On vérifie qu'aucun side-effect ne tape sur les non-récupérés.
+      const base = setup();
+      const state = createHalftimeState({
+        players: base.players.map(p =>
+          p.id === 'A2'
+            ? { ...p, state: 'knocked_out' as const, pos: { x: -1, y: -1 } }
+            : p
+        ),
+        dugouts: {
+          ...base.dugouts,
+          teamA: {
+            ...base.dugouts.teamA,
+            zones: {
+              ...base.dugouts.teamA.zones,
+              knockedOut: {
+                ...base.dugouts.teamA.zones.knockedOut,
+                players: ['A2'],
+              },
+            },
+          },
+        },
+      });
+
+      let foundStillKO = false;
+      for (let i = 0; i < 20; i++) {
+        const rng = makeRNG(`halftime-ko-still-${i}`);
+        const result = advanceHalfIfNeeded(state, rng);
+        const koZone = result.dugouts.teamA.zones.knockedOut;
+        if (koZone.players.includes('A2')) {
+          foundStillKO = true;
+          const stillKO = result.players.find(p => p.id === 'A2');
+          expect(stillKO?.state).toBe('knocked_out');
+          break;
+        }
+      }
+      expect(foundStillKO).toBe(true);
+    });
   });
 
   describe('advanceHalfIfNeeded — half 2 → end', () => {

--- a/packages/game-engine/src/core/post-touchdown.test.ts
+++ b/packages/game-engine/src/core/post-touchdown.test.ts
@@ -208,5 +208,48 @@ describe('Règle: Post-touchdown re-kickoff', () => {
       }
       expect(recoveredAtLeastOnce).toBe(true);
     });
+
+    it('devrait remettre player.state à "active" sur les joueurs KO récupérés', () => {
+      // Même bug que halftime : sans cette mise à jour, les joueurs récupérés
+      // du KO restent `state='knocked_out'` et `placePlayerInSetup` les rejette,
+      // bloquant le re-setup du drive post-TD.
+      const base = setup();
+      const state = createPostTdState({
+        players: base.players.map(p =>
+          p.id === 'A2'
+            ? { ...p, state: 'knocked_out' as const, stunned: true, hasBall: false, pos: { x: -1, y: -1 } }
+            : { ...p, hasBall: false }
+        ),
+        dugouts: {
+          ...base.dugouts,
+          teamA: {
+            ...base.dugouts.teamA,
+            zones: {
+              ...base.dugouts.teamA.zones,
+              knockedOut: {
+                ...base.dugouts.teamA.zones.knockedOut,
+                players: ['A2'],
+              },
+            },
+          },
+        },
+      });
+
+      let recoveredAtLeastOnce = false;
+      for (let i = 0; i < 20; i++) {
+        const rng = makeRNG(`ko-recovery-state-${i}`);
+        const result = handlePostTouchdown(state, rng);
+        const koZone = result.dugouts.teamA.zones.knockedOut;
+        if (!koZone.players.includes('A2')) {
+          recoveredAtLeastOnce = true;
+          const recovered = result.players.find(p => p.id === 'A2');
+          expect(recovered).toBeDefined();
+          expect(recovered?.state).toBe('active');
+          expect(recovered?.stunned).toBe(false);
+          break;
+        }
+      }
+      expect(recoveredAtLeastOnce).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
`recoverKOPlayers` ne synchronisait que les zones de dugout (knockedOut →
reserves) sans toucher `player.state`. Les joueurs récupérés du KO
restaient flagés `state='knocked_out'` côté objet Player, donc :

- `autoSetupAITeam` (filtre `state === 'active' || !state`) les excluait
  du re-setup IA
- `placePlayerInSetup` (rejet explicite `state !== 'active'`) bloquait
  toute tentative de placement manuel

Conséquence visible : les joueurs KO d'une équipe qui réussissaient leur
jet 4+ à la mi-temps (ou au re-kickoff post-TD) ne revenaient jamais sur
le terrain en 2e mi-temps — bug "remplacement après la mi-temps".

Fix : collecter les IDs récupérés sur l'ensemble des équipes, puis mapper
`state.players` en une passe pour passer `state` à 'active' et clear le
flag `stunned` carry-over.

Tests : 2 nouveaux tests TDD (halftime + post-touchdown) qui vérifient
`player.state === 'active'` après recovery, et un guard test que les
joueurs qui restent KO conservent bien `state === 'knocked_out'`.