### PR TITLE
fix(sim-engine/resolvers): 6 bugs BB rules (wrestle, GFI, foul, pass)

### DIFF
--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,6 +1,6 @@
 {
-  "engineVer": "0.18.0",
-  "snapshotAt": "2026-05-12",
+  "engineVer": "0.22.0",
+  "snapshotAt": "2026-05-17",
   "tolerance": 0.05,
   "pairings": [
     {
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.865,
-        "tdStd": 1.0376776956261513,
-        "casualtyMean": 0.945,
-        "turnoverMean": 4.165,
-        "homeWinRate": 0.28,
-        "awayWinRate": 0.44,
-        "drawRate": 0.28
+        "tdMean": 1.845,
+        "tdStd": 1.0396994758101965,
+        "casualtyMean": 0.95,
+        "turnoverMean": 4.2,
+        "homeWinRate": 0.275,
+        "awayWinRate": 0.45,
+        "drawRate": 0.275
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.625,
-        "tdStd": 1.1110243021644486,
-        "casualtyMean": 1.12,
-        "turnoverMean": 5.22,
-        "homeWinRate": 0.745,
-        "awayWinRate": 0.05,
-        "drawRate": 0.205
+        "tdMean": 1.65,
+        "tdStd": 1.1034038245356965,
+        "casualtyMean": 1.13,
+        "turnoverMean": 5.255,
+        "homeWinRate": 0.76,
+        "awayWinRate": 0.045,
+        "drawRate": 0.195
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.68,
-        "tdStd": 1.038075141788878,
-        "casualtyMean": 0.955,
-        "turnoverMean": 4.31,
-        "homeWinRate": 0.325,
-        "awayWinRate": 0.385,
-        "drawRate": 0.29
+        "tdMean": 1.665,
+        "tdStd": 1.0405647505081077,
+        "casualtyMean": 0.96,
+        "turnoverMean": 4.33,
+        "homeWinRate": 0.32,
+        "awayWinRate": 0.375,
+        "drawRate": 0.305
       }
     }
   ]

--- a/packages/sim-engine/src/resolvers/block.ts
+++ b/packages/sim-engine/src/resolvers/block.ts
@@ -208,15 +208,19 @@ export function resolveBlock(
     }
   }
 
+  // BB2020/BB3 Wrestle : sur BOTH_DOWN, les deux joueurs sont *Placed Prone*
+  // (pas de Knock-Down) — donc PAS d'armor/injury roll et PAS de turnover.
+  // La balle est lâchée si l'attaquant ou le défenseur en avait possession.
+  const isWrestle = resolution === 'wrestle';
   if (attackerDown) {
     newState = updatePlayer(newState, attacker.id, { state: 'prone' });
     if (attacker.hasBall) newState = updatePlayer(newState, attacker.id, { hasBall: false });
-    rollArmorAndInjury(attacker, defender.id);
+    if (!isWrestle) rollArmorAndInjury(attacker, defender.id);
   }
   if (defenderDown) {
     newState = updatePlayer(newState, defender.id, { state: 'prone' });
     if (defender.hasBall) newState = updatePlayer(newState, defender.id, { hasBall: false });
-    rollArmorAndInjury(defender, attacker.id);
+    if (!isWrestle) rollArmorAndInjury(defender, attacker.id);
   }
 
   events.unshift({
@@ -234,7 +238,10 @@ export function resolveBlock(
       useWrestle: input.useWrestle === true,
     },
   });
-  if (attackerDown) {
+  // Wrestle ne déclenche pas de turnover (BB rule). Pour les autres
+  // attacker_down (PLAYER_DOWN, BOTH_DOWN sans Block), turnover normal.
+  const turnover = attackerDown && !isWrestle;
+  if (turnover) {
     events.push({
       type: 'TURNOVER',
       displayAtMs: input.displayAtMs,
@@ -244,8 +251,8 @@ export function resolveBlock(
   }
 
   return {
-    success: !attackerDown,
-    turnover: attackerDown,
+    success: !turnover,
+    turnover,
     newState,
     events,
     trace: {

--- a/packages/sim-engine/src/resolvers/foul.ts
+++ b/packages/sim-engine/src/resolvers/foul.ts
@@ -96,18 +96,20 @@ export function resolveFoul(
   const armorTotal = armorRoll[0] + armorRoll[1] + assistDelta + dirtyPlayerBonus;
   const armorTarget = victim.av + 1;
   const armorBroken = armorTotal >= armorTarget;
-  const sentOff = armorRoll[0] === armorRoll[1]; // doubles → ref spots foul
+  const armorDoubles = armorRoll[0] === armorRoll[1];
 
   const events: MatchEvent[] = [];
   let newState: ResolverState = state;
   let injuryRoll: [number, number] | undefined;
   let injuryOutcome: FoulInjuryOutcome | undefined;
+  let injuryDoubles = false;
 
   if (armorBroken) {
     injuryRoll = [
       rollD6(rng as Parameters<typeof rollD6>[0]),
       rollD6(rng as Parameters<typeof rollD6>[0]),
     ];
+    injuryDoubles = injuryRoll[0] === injuryRoll[1];
     const injuryTotal = injuryRoll[0] + injuryRoll[1] + dirtyPlayerBonus;
     if (injuryTotal >= 10) injuryOutcome = 'casualty';
     else if (injuryTotal >= 8) injuryOutcome = 'ko';
@@ -130,6 +132,13 @@ export function resolveFoul(
       });
     }
   }
+
+  // BB2020/BB3 : doubles sur Armour OR Injury roll → fouleur expulsé. Avant
+  // ce fix, seul le double armor déclenchait — sous-estimation des
+  // expulsions sur foul. Skill `sneaky_git` permettrait d'ignorer le double
+  // armor si l'armure ne casse pas, mais on garde le simplification BB2020
+  // base : tout double sur l'un des deux rolls envoie au vestiaire.
+  const sentOff = armorDoubles || injuryDoubles;
 
   if (sentOff) {
     newState = updatePlayer(newState, fouler.id, { state: 'casualty' });

--- a/packages/sim-engine/src/resolvers/gfi.ts
+++ b/packages/sim-engine/src/resolvers/gfi.ts
@@ -48,7 +48,9 @@ export interface GfiResult extends ResolverResult {
 }
 
 export function gfiTargetForWeather(weather: ResolverState['weather']): number {
-  return weather === 'blizzard' || weather === 'pouring_rain' ? 3 : 2;
+  // BB2020/BB3 : seul Blizzard impose GFI 3+. Pouring Rain affecte uniquement
+  // les pickup/catch/handoff/passing — pas la GFI.
+  return weather === 'blizzard' ? 3 : 2;
 }
 
 export function resolveGfi(
@@ -81,6 +83,39 @@ export function resolveGfi(
   const events: MatchEvent[] = [];
   if (!success) {
     newState = updatePlayer(newState, player.id, { state: 'prone' });
+    if (player.hasBall) newState = updatePlayer(newState, player.id, { hasBall: false });
+    // BB rule (cf. docstring ligne 9-10) : sur fail GFI, le joueur tombe →
+    // armour roll → injury roll. Sans ce chain, le sim sous-estime fortement
+    // les casualties induites par les GFI manquées (mirrors le block resolver
+    // sprint 0.E.1 iter #2).
+    const a1 = rollD6(rng as Parameters<typeof rollD6>[0]);
+    const a2 = rollD6(rng as Parameters<typeof rollD6>[0]);
+    const armorTotal = a1 + a2;
+    if (armorTotal >= player.av + 1) {
+      const i1 = rollD6(rng as Parameters<typeof rollD6>[0]);
+      const i2 = rollD6(rng as Parameters<typeof rollD6>[0]);
+      const injury = i1 + i2;
+      let outcome: 'stunned' | 'ko' | 'casualty';
+      if (injury >= 10) outcome = 'casualty';
+      else if (injury >= 8) outcome = 'ko';
+      else outcome = 'stunned';
+      newState = updatePlayer(newState, player.id, { state: outcome });
+      if (outcome === 'ko') {
+        events.push({
+          type: 'KO',
+          displayAtMs: input.displayAtMs,
+          engineVer: state.engineVer,
+          meta: { playerId: player.id, via: 'gfi', armor: armorTotal, injury },
+        });
+      } else if (outcome === 'casualty') {
+        events.push({
+          type: 'CASUALTY',
+          displayAtMs: input.displayAtMs,
+          engineVer: state.engineVer,
+          meta: { playerId: player.id, via: 'gfi', armor: armorTotal, injury },
+        });
+      }
+    }
     events.push({
       type: 'TURNOVER',
       displayAtMs: input.displayAtMs,

--- a/packages/sim-engine/src/resolvers/pass.ts
+++ b/packages/sim-engine/src/resolvers/pass.ts
@@ -90,7 +90,12 @@ export function resolvePass(
   const tzMod = -tzCount;
   // Skills
   const accurateMod = hasSkill(passer, 'accurate') && (range === 'quick' || range === 'short') ? 1 : 0;
-  const strongArmMod = hasSkill(passer, 'strong_arm') && (range === 'long' || range === 'bomb') ? 1 : 0;
+  // BB2020 Strong Arm : « Add 1 to any Short, Long or Long Bomb passes. »
+  // L'ancien code excluait Short, ce qui sous-évaluait les Throwers.
+  const strongArmMod =
+    hasSkill(passer, 'strong_arm') && (range === 'short' || range === 'long' || range === 'bomb')
+      ? 1
+      : 0;
 
   const totalModifier = rangeMod + tzMod + accurateMod + strongArmMod;
 
@@ -120,15 +125,16 @@ export function resolvePass(
     newState = updatePlayer(newState, passer.id, { rerollAvailable: false });
   }
 
+  // Un fumble peut survenir au premier ou au reroll. Dans les deux cas, la
+  // balle tombe aux pieds du passer (BB rule) — le scatter est driver-side.
+  // Avant ce fix, un reroll-fumble laissait `hasBall` sur le passer alors
+  // que `meta.fumble` était `true`, créant un state incohérent.
+  const fumbleOccurred = isFumble || (usedReroll && secondRoll === 1);
   if (success) {
     newState = updatePlayer(newState, passer.id, { hasBall: false });
     newState = { ...newState, ballAt: { ...input.to } };
-  } else {
-    // On fumble, ball drops at passer's feet ; on inaccurate pass scatter
-    // is driver-side. We just clear `hasBall` on the passer.
-    if (isFumble) {
-      newState = updatePlayer(newState, passer.id, { hasBall: false });
-    }
+  } else if (fumbleOccurred) {
+    newState = updatePlayer(newState, passer.id, { hasBall: false });
   }
 
   const events: MatchEvent[] = [
@@ -146,7 +152,7 @@ export function resolvePass(
         roll: firstRoll,
         rerollRoll: secondRoll,
         usedReroll,
-        fumble: isFumble || (usedReroll && secondRoll === 1),
+        fumble: fumbleOccurred,
         success,
       },
     },
@@ -157,7 +163,7 @@ export function resolvePass(
       displayAtMs: input.displayAtMs,
       engineVer: state.engineVer,
       meta: {
-        cause: isFumble ? 'pass_fumble' : 'pass_failed',
+        cause: fumbleOccurred ? 'pass_fumble' : 'pass_failed',
         passerId: passer.id,
       },
     });
@@ -173,7 +179,7 @@ export function resolvePass(
       target,
       modifier: totalModifier,
       roll: firstRoll,
-      fumble: isFumble,
+      fumble: fumbleOccurred,
       rerollRoll: secondRoll,
       usedReroll,
     },

--- a/packages/sim-engine/src/resolvers/resolvers.test.ts
+++ b/packages/sim-engine/src/resolvers/resolvers.test.ts
@@ -39,10 +39,39 @@ function baseState(overrides: Partial<ResolverState> = {}): ResolverState {
 }
 
 describe('GFI resolver — sprint 0.A.5', () => {
-  it('targets 2+ in nice weather and 3+ in blizzard / pouring rain', () => {
+  it('targets 2+ in nice weather and 3+ in blizzard only (pouring rain n\'affecte pas la GFI)', () => {
+    // BB2020/BB3 : seul Blizzard impose GFI 3+. Pouring Rain affecte
+    // uniquement pickup/catch/handoff/passing — pas la GFI.
     expect(gfiTargetForWeather('nice')).toBe(2);
     expect(gfiTargetForWeather('blizzard')).toBe(3);
-    expect(gfiTargetForWeather('pouring_rain')).toBe(3);
+    expect(gfiTargetForWeather('pouring_rain')).toBe(2);
+    expect(gfiTargetForWeather('sweltering')).toBe(2);
+    expect(gfiTargetForWeather('very_sunny')).toBe(2);
+  });
+
+  it('declenche armor + injury roll sur fail (chain documenté ligne 9-10)', () => {
+    // Cherche un seed où firstRoll fail puis armor casse → on doit
+    // observer un state final différent de "prone" (stunned/ko/casualty)
+    // ET potentiellement un event KO/CASUALTY.
+    let foundInjury = false;
+    for (let seed = 0; seed < 5000 && !foundInjury; seed += 1) {
+      const probe = createRng(seed);
+      const gfi = Math.floor(probe.next() * 6) + 1;
+      const a1 = Math.floor(probe.next() * 6) + 1;
+      const a2 = Math.floor(probe.next() * 6) + 1;
+      // GFI fail (=1, target 2+ nice) + armor casse vs AV 7 (target 8)
+      if (gfi === 1 && a1 + a2 >= 8) {
+        const state = baseState({
+          players: [player({ id: 'p1', team: 'home', position: { x: 5, y: 5 }, av: 7 })],
+        });
+        const out = resolveGfi(state, { playerId: 'p1', displayAtMs: 0 }, createRng(seed));
+        expect(out.success).toBe(false);
+        const finalState = out.newState.players[0].state;
+        expect(['stunned', 'ko', 'casualty']).toContain(finalState);
+        foundInjury = true;
+      }
+    }
+    expect(foundInjury).toBe(true);
   });
 
   it('all events emitted pass the shared isMatchEvent guard', () => {
@@ -51,7 +80,7 @@ describe('GFI resolver — sprint 0.A.5', () => {
     for (const e of out.events) expect(isMatchEvent(e)).toBe(true);
   });
 
-  it('marks the player prone and emits TURNOVER on a forced-fail seed', () => {
+  it('marks the player down and emits TURNOVER on a forced-fail seed', () => {
     // Find a seed whose first d6 roll equals 1 → guaranteed fail at target 2+.
     let seed = 0;
     while (seed < 1000) {
@@ -64,7 +93,9 @@ describe('GFI resolver — sprint 0.A.5', () => {
     expect(out.success).toBe(false);
     expect(out.turnover).toBe(true);
     expect(out.events.find((e) => e.type === 'TURNOVER')).toBeDefined();
-    expect(out.newState.players[0].state).toBe('prone');
+    // Avec la chain armor+injury post-fix, le joueur tombe `prone` (armor a tenu)
+    // ou évolue vers `stunned`/`ko`/`casualty` (armor cassée).
+    expect(['prone', 'stunned', 'ko', 'casualty']).toContain(out.newState.players[0].state);
   });
 
   it('sure_feet consumes the reroll on fail', () => {
@@ -214,6 +245,57 @@ describe('Pass resolver — sprint 0.A.5', () => {
     expect(out.success).toBe(false);
     expect(out.trace.fumble).toBe(true);
   });
+
+  it('strong_arm s\'applique aussi aux passes courtes (BB2020 : Short, Long, Long Bomb)', () => {
+    // Comparaison directe : un passer avec strong_arm doit avoir un modifier
+    // strictement supérieur sur un short pass vs sans skill. (5,5) → (10,5)
+    // = distance 5 → short range.
+    const baseShort = baseState({ players: [{ ...passer, ag: 3 }] });
+    const withStrongArm = baseState({
+      players: [{ ...passer, ag: 3, skills: ['strong_arm'] }],
+    });
+    const outBase = resolvePass(
+      baseShort,
+      { passerId: 'p1', to: { x: 10, y: 5 }, displayAtMs: 0 },
+      createRng(42)
+    );
+    const outStrong = resolvePass(
+      withStrongArm,
+      { passerId: 'p1', to: { x: 10, y: 5 }, displayAtMs: 0 },
+      createRng(42)
+    );
+    expect(outBase.trace.range).toBe('short');
+    expect(outStrong.trace.range).toBe('short');
+    // Strong Arm doit donner +1 → cible plus facile (modifier supérieur).
+    expect(outStrong.trace.modifier - outBase.trace.modifier).toBe(1);
+  });
+
+  it('reroll fumble drop la balle (state coherent avec event)', () => {
+    // Cherche un seed : premier roll fail non-fumble (>=2, <target), reroll = 1 (fumble).
+    // Avec ag=3 target=4 (quick range), firstRoll=2 fail puis secondRoll=1 fumble.
+    for (let seed = 0; seed < 5000; seed += 1) {
+      const probe = createRng(seed);
+      const first = Math.floor(probe.next() * 6) + 1;
+      const second = Math.floor(probe.next() * 6) + 1;
+      if (first === 2 && second === 1) {
+        const state = baseState({
+          players: [{ ...passer, ag: 3, skills: ['pass'] }],
+        });
+        const out = resolvePass(
+          state,
+          { passerId: 'p1', to: { x: 6, y: 5 }, displayAtMs: 0 },
+          createRng(seed)
+        );
+        expect(out.success).toBe(false);
+        expect(out.trace.usedReroll).toBe(true);
+        expect(out.trace.fumble).toBe(true);
+        // BUG fixé : state doit refléter le fumble → ballon lâché.
+        expect(out.newState.players[0].hasBall).toBeFalsy();
+        return;
+      }
+    }
+    throw new Error('Could not find seed with first=2 second=1 within 5k tries');
+  });
 });
 
 describe('Foul resolver — sprint 0.A.5', () => {
@@ -291,6 +373,28 @@ describe('Foul resolver — sprint 0.A.5', () => {
     }
     throw new Error('Could not find seed inducing a casualty within 20k tries');
   });
+
+  it('expulse le fouleur sur doubles de injury roll (BB2020 rule)', () => {
+    // BB2020 : « If the result of the Armour roll or the Injury roll is a
+    // double, the fouler is Sent Off. » Avant le fix, seul le double armor
+    // déclenchait — les doubles d'injury étaient ignorés.
+    // On cherche un seed : armor non-double + casse, injury double.
+    for (let seed = 0; seed < 30_000; seed += 1) {
+      const r = createRng(seed);
+      const a = Math.floor(r.next() * 6) + 1;
+      const b = Math.floor(r.next() * 6) + 1;
+      const i1 = Math.floor(r.next() * 6) + 1;
+      const i2 = Math.floor(r.next() * 6) + 1;
+      if (a !== b && a + b >= victim.av + 1 && i1 === i2) {
+        const state = baseState({ players: [fouler, victim] });
+        const out = resolveFoul(state, { foulerId: 'f1', victimId: 'v1', displayAtMs: 0 }, createRng(seed));
+        expect(out.trace.sentOff).toBe(true);
+        expect(out.turnover).toBe(true);
+        return;
+      }
+    }
+    throw new Error('Could not find seed with non-double armor + injury doubles within 30k tries');
+  });
 });
 
 describe('Block resolver — sprint 0.A.5', () => {
@@ -339,6 +443,41 @@ describe('Block resolver — sprint 0.A.5', () => {
         // (sprint 0.E.1 iter #2 enables this chain on every block KD).
         const defState = out.newState.players.find((p) => p.id === 'd1')?.state;
         expect(['prone', 'stunned', 'ko', 'casualty']).toContain(defState);
+        return;
+      }
+    }
+    throw new Error('Could not find BOTH_DOWN seed within 10k tries');
+  });
+
+  it('wrestle: BOTH_DOWN convertit sans armor roll, sans turnover (BB rule)', () => {
+    // BB2020/BB3 Wrestle : sur BOTH_DOWN les deux joueurs sont *Placed
+    // Prone* sans Knock-Down. Donc PAS d'armor/injury roll, PAS de
+    // turnover. Avant le fix, le code lançait armor rolls + déclenchait
+    // un TURNOVER. On force BOTH_DOWN (face=2 sur le die index, 1d block).
+    for (let seed = 0; seed < 10_000; seed += 1) {
+      const r = createRng(seed);
+      const face = Math.floor(r.next() * 6) + 1;
+      if (face === 2) {
+        const state = baseState({
+          players: [
+            { ...attacker, skills: ['wrestle'] },
+            { ...defender, skills: [] },
+          ],
+        });
+        const out = resolveBlock(
+          state,
+          { attackerId: 'a1', defenderId: 'd1', displayAtMs: 0, useWrestle: true },
+          createRng(seed)
+        );
+        expect(out.trace.chosen).toBe('BOTH_DOWN');
+        expect(out.trace.resolution).toBe('wrestle');
+        // Pas de turnover sur wrestle.
+        expect(out.turnover).toBe(false);
+        expect(out.events.find((e) => e.type === 'TURNOVER')).toBeUndefined();
+        // Les deux joueurs sont prone (pas stunned/ko/casualty — pas
+        // d'armor roll).
+        expect(out.newState.players.find((p) => p.id === 'a1')?.state).toBe('prone');
+        expect(out.newState.players.find((p) => p.id === 'd1')?.state).toBe('prone');
         return;
       }
     }

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.21.0';
+export const ENGINE_VER = '0.22.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Résumé

Audit du sim-engine → 6 bugs de règles BB2020/BB3 dans les resolvers, corrigés avec tests TDD.

| Fichier | Bug | Impact |
|---|---|---|
| `block.ts` | Wrestle déclenchait armor roll + turnover | Critiques + turnovers fantômes |
| `gfi.ts` | Pouring Rain → GFI 3+ (devrait rester 2+) | 33% fail vs 17% attendu sous pluie |
| `gfi.ts` | Fail GFI → pas d'armor/injury chain (promis docstring) | Sous-estimation casualties |
| `foul.ts` | Send-off seulement sur doubles d'armure | Doubles d'injury jamais expulsés |
| `pass.ts` | Strong Arm n'incluait pas Short Pass | Throwers sous-évalués |
| `pass.ts` | Reroll fumble : ball restait au passer | State corrompu vs event |

## Test plan

- [x] `pnpm exec vitest run` (sim-engine) : 408/408 (était 403/403, +5 tests TDD)
- [x] `pnpm exec turbo run typecheck` (sim-engine + game-engine) : OK
- [x] 1 test existant ajusté : GFI Pouring Rain (2+ au lieu de 3+) + GFI prone state qui peut maintenant être stunned/ko/casualty si armor casse

## Détails des fixes

### Wrestle (`block.ts`)
BB2020/BB3 Wrestle sur BOTH_DOWN : les deux joueurs sont **Placed Prone** (pas Knock-Down). Donc pas d'armor/injury roll, pas de turnover (sauf perte de balle). Avant : un wrestle pouvait crit/KO et compter comme turnover.

### GFI sous Pouring Rain (`gfi.ts`)
Seul Blizzard impose 3+ en BB2020. Pouring Rain affecte pickup/catch/handoff/passing — pas la GFI.

### GFI fail (`gfi.ts`)
Docstring promet « KD → armour roll → injury roll » mais code ne faisait que `state: 'prone'`. Aligné sur block resolver.

### Foul send-off (`foul.ts`)
BB2020 : « If the **Armour roll OR the Injury roll** is a double, the fouler is Sent Off. » Avant : seul armor doubles déclenchait.

### Strong Arm Short Pass (`pass.ts`)
BB2020 : « Add 1 to any **Short**, Long or Long Bomb passes. »

### Reroll fumble (`pass.ts`)
Reroll = 1 → `meta.fumble: true` mais `hasBall` restait sur le passer. Maintenant la balle tombe systématiquement sur fumble (premier roll ou reroll).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_