### PR TITLE
fix(sim-engine/driver): emit events for appliedMove, stale-detect on fallback

### DIFF
--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -318,8 +318,12 @@ export function runFullDriver(input: SimInput): SimResult {
     // on considère que le moteur est coincé et on force end. Note : en BB
     // un END_TURN sur deux fait alterner currentPlayer sans incrémenter
     // turn (cycle A turn N → B turn N → A turn N+1) — c'est NORMAL ;
-    // seuls les END_TURN qui ne font *rien* avancer sont stale.
-    if (move.type === 'END_TURN') {
+    // seuls les END_TURN qui ne font *rien* avancer sont stale. On teste
+    // `appliedMove` (le coup réellement passé à `applyMove`) plutôt que
+    // `move` : si l'IA retourne un coup illégal et qu'on retombe sur
+    // END_TURN via le catch, c'est ce END_TURN qui peut stagner — pas
+    // le coup IA initial.
+    if (appliedMove.type === 'END_TURN') {
       const advanced =
         next.turn !== prev.turn ||
         next.half !== prev.half ||
@@ -335,10 +339,17 @@ export function runFullDriver(input: SimInput): SimResult {
     // Lot 3.A.2.b — diff prev → next pour émettre les events
     // narratifs (BLOCK/PASS/DODGE/TD/CASUALTY/KO/TURNOVER/HALFTIME/
     // END/TURN_START). Timestamps incrémentaux 1s/action.
+    //
+    // On passe `appliedMove` (le coup effectivement appliqué) au lieu de
+    // `move` (le coup retourné par l'IA). Sans cette correction, lorsqu'un
+    // coup IA était illégal et qu'on retombait sur END_TURN, on émettait
+    // faussement les events Move-specific (BLITZ_DECLARED, BLOCK, PASS,
+    // DODGE, FOUL) correspondant au coup initial qui n'a jamais été
+    // appliqué — corruption sémantique du timeline narratif.
     const displayAtMs = (actionsApplied + 1) * MS_PER_ACTION;
     const newEvents = diffStatesToEvents(prev, next, {
       displayAtMs,
-      move,
+      move: appliedMove,
     });
     events.push(...newEvents);
 


### PR DESCRIPTION
## Résumé

Deux bugs jumeaux dans la boucle `runFullDriver` quand l'IA retourne un coup illégal et que le driver retombe sur END_TURN via `catch`.

### 1. [CRITICAL] `diffStatesToEvents` recevait le mauvais `move`

`full-driver.ts:339-342` passait `move` (le coup illégal initial retourné par l'IA) au lieu de `appliedMove` (END_TURN effectivement appliqué via le `catch`). Conséquence : émission de faux events Move-specific (BLITZ_DECLARED, BLOCK, PASS, DODGE, FOUL kind) correspondant à un coup qui n'a jamais été exécuté — corruption sémantique du timeline narratif.

### 2. [HIGH] Stale-detection contournée sur fallback

`full-driver.ts:322` testait `move.type === 'END_TURN'` au lieu de `appliedMove.type`. Si l'IA produit en boucle des coups illégaux, chaque fallback END_TURN n'incrémente jamais `staleEndTurns` (car `move.type` reste sur le coup illégal). La garde « stop après 5 stale » est contournée — le driver peut itérer jusqu'à `MAX_ACTIONS_PER_MATCH = 1500`.

## Fix

Utiliser `appliedMove` aux deux endroits. Patch minimal (3 lignes de logique).

## Test plan

- [x] `pnpm exec vitest run` (sim-engine) : 408/408 OK
- [x] `pnpm exec turbo run typecheck` : OK
- [x] `pnpm sim:bench:ci` : PASS, tolérance 5%
- [ ] Pas de nouveau test : exercer le `catch` requerrait de mocker `applyMove` pour throw, hors scope de ce fix minimal

## Note

Le 3ᵉ bug identifié dans l'audit (`candidate === baselineMove` toujours faux dans la boucle opening book) est cosmétique selon ma relecture — le seuil `+10` est un trade-off design délibéré pour la « couleur raciale » du opening book (Wood Elves passent, Orcs bashent). Skip pour ce PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_