### PR TITLE
fix(sim-engine/ai): 3 bugs tactique (momentum decay, blitz-train, fallback offense)

### DIFF
--- a/packages/sim-engine/src/ai/play.test.ts
+++ b/packages/sim-engine/src/ai/play.test.ts
@@ -125,6 +125,65 @@ describe('chooseStrategy — Pass 2', () => {
     const b = chooseStrategy(createRng(99), ctx, profile);
     expect(b).toBe(a);
   });
+
+  it('blitz-train est favorisée quand l\'adversaire avance (pastMidfield) en défense', () => {
+    // BUG fix : avant, le bonus pastMidfield de BLITZ_TRAIN était inversé
+    // (+0.15 quand NON-pastMidfield). Comparaison ratio (défense, profil
+    // bash uniforme) : pastMidfield doit choisir BLITZ_TRAIN plus souvent
+    // que sans (docstring : « ramener la cavalerie sur le porteur »).
+    const profile = parseTacticalProfile({
+      blitzPriority: 90,
+      bashIndex: 90,
+      screenAffinity: 0,
+      pressingDefense: 0,
+      foulFrequency: 0,
+      riskAppetite: 0,
+    });
+    // pastMidfield (ballYardline 18 > 13) en défense → blitz-train doit dominer.
+    const ctxPastMid = evaluateSituation(
+      baseSnap({ hasPossession: false, ballYardline: 18 })
+    );
+    let blitzPicks = 0;
+    for (let seed = 0; seed < 50; seed += 1) {
+      if (chooseStrategy(createRng(seed), ctxPastMid, profile) === 'blitz-train') {
+        blitzPicks += 1;
+      }
+    }
+    // Avec bonus +0.15 sur un profil neutre (somme ≈ 0.9 + 0.45 + 0.15 = 1.5),
+    // blitz-train doit dominer sur la majorité des seeds.
+    expect(blitzPicks).toBeGreaterThanOrEqual(30);
+  });
+
+  it('fallback en défense ne choisit JAMAIS une stratégie offensive (hard-gated)', () => {
+    // BUG fix : avant, quand toutes les stratégies scoraient 0 (e.g. profil
+    // neutre + défense), le fallback re-mettait toutes les stratégies à
+    // 0.01, y compris CAGE_BUILD/BREAKAWAY/STALL qui hard-gate sur
+    // hasPossession=true. L'AI pouvait alors exécuter des patterns
+    // offensifs en défense. Maintenant on filtre par contexte.
+    const offensiveOnly = new Set(['cage-build', 'breakaway', 'stall']);
+    // Profil "neutre" qui ne pousse aucune stratégie au-dessus de 0 côté défense.
+    const profile = parseTacticalProfile({
+      bashIndex: 0,
+      breakawayInstinct: 0,
+      passingFrequency: 0,
+      foulFrequency: 0,
+      screenAffinity: 0,
+      pressingDefense: 0,
+      blitzPriority: 0,
+      stallTendency: 0,
+      cageAffinity: 0,
+      patience: 0,
+      pace: 50,
+      gfiTolerance: 50,
+      riskAppetite: 0,
+    });
+    const ctxDef = evaluateSituation(baseSnap({ hasPossession: false }));
+    // Sur 20 seeds, aucune stratégie offensive ne doit sortir.
+    for (let seed = 0; seed < 20; seed += 1) {
+      const choice = chooseStrategy(createRng(seed), ctxDef, profile);
+      expect(offensiveOnly.has(choice)).toBe(false);
+    }
+  });
 });
 
 describe('aiPlay — full 3-pass orchestration', () => {

--- a/packages/sim-engine/src/ai/play.ts
+++ b/packages/sim-engine/src/ai/play.ts
@@ -50,6 +50,30 @@ export function evaluateSituation(snap: DriveSnapshot): DriveContext {
   };
 }
 
+/**
+ * Strategies whose score functions hard-gate on possession (return 0
+ * when the gate is off). Used pour filtrer le fallback du softmax
+ * quand toutes les stratégies scoreraient 0 — éviter de laisser un
+ * `CAGE_BUILD` (offensive) être choisi en défense.
+ */
+const STRATEGY_REQUIRES_POSSESSION: Readonly<Record<StrategyId, boolean>> = {
+  'cage-build': true,
+  'breakaway': true,
+  'stall': true,
+  // Les stratégies suivantes sont défensives ou agnostiques.
+  'defensive-screen': false,
+  'blitz-train': false,
+  'foul-fest': false,
+};
+
+function isStrategyEligibleForContext(
+  s: Strategy,
+  context: DriveContext
+): boolean {
+  if (STRATEGY_REQUIRES_POSSESSION[s.id] && !context.hasPossession) return false;
+  return true;
+}
+
 /** Pass 2 : softmax over the 6 strategies given context+profile. */
 export function chooseStrategy(
   rng: Pick<Rng, 'next'>,
@@ -62,9 +86,20 @@ export function chooseStrategy(
   }));
   // Filter out strategies with zero score so they are never sampled.
   const live = candidates.filter((c) => c.score > 0);
-  // Fallback : if every strategy scored 0 (e.g. no possession + bash team),
-  // use the full list with a tiny epsilon so the softmax still works.
-  const finalCandidates = live.length > 0 ? live : candidates.map((c) => ({ ...c, score: 0.01 }));
+  // BUG fix : avant, le fallback re-mettait TOUTES les stratégies (y
+  // compris CAGE_BUILD/BREAKAWAY/STALL qui hard-gate sur `hasPossession`)
+  // à 0.01 → l'AI pouvait exécuter des patterns offensifs en défense.
+  // Maintenant on garde uniquement les stratégies eligibles pour le
+  // contexte (e.g. en défense : defensive-screen, blitz-train, foul-fest).
+  const finalCandidates =
+    live.length > 0
+      ? live
+      : candidates
+          .filter((c) => {
+            const s = STRATEGY_BY_ID[c.value];
+            return isStrategyEligibleForContext(s, context);
+          })
+          .map((c) => ({ ...c, score: 0.01 }));
   return softmaxSample(rng, finalCandidates, riskAppetiteToTemperature(profile.riskAppetite));
 }
 

--- a/packages/sim-engine/src/ai/strategy/strategies.ts
+++ b/packages/sim-engine/src/ai/strategy/strategies.ts
@@ -58,7 +58,11 @@ const BLITZ_TRAIN: Strategy = {
   patterns: ['wedge'],
   score: (ctx, p) => {
     if (ctx.hasPossession) return 0.05; // useable at low base when in possession
-    return p.blitzPriority / 100 + p.bashIndex / 200 + (ctx.pastMidfield ? 0 : 0.15);
+    // BUG fix : signe inversé du bonus pastMidfield. La défense doit
+    // blitzer DAVANTAGE quand l'adversaire a avancé (pastMidfield),
+    // pas moins. Comparer `CAGE_BUILD` (l.24) qui donne +0.2 quand
+    // pastMidfield (signe normal).
+    return p.blitzPriority / 100 + p.bashIndex / 200 + (ctx.pastMidfield ? 0.15 : 0);
   },
 };
 

--- a/packages/sim-engine/src/tactics/momentum.test.ts
+++ b/packages/sim-engine/src/tactics/momentum.test.ts
@@ -157,6 +157,32 @@ describe('applyDecay — cross-match decay (consumed by lot 0.C.4 PlayerForm)', 
     applyDecay(t);
     expect(t.get('p1').state).toBe<MomentumState>('normal');
   });
+
+  it('reset les compteurs per-match à 0 (docstring contract)', () => {
+    // BUG fix : avant, `applyDecay` ne faisait que `-1` sur les compteurs.
+    // Conséquence : un joueur sortant d'un match avec touchdowns=2 (hot)
+    // avait après decay touchdowns=1 → au match suivant, 1 seul TD
+    // suffisait à le repasser hot. Inflation systématique des états hot.
+    const t = createMomentumTracker();
+    recordTouchdown(t, 'p1');
+    recordTouchdown(t, 'p1');
+    recordTouchdown(t, 'p1');
+    recordBlock(t, 'p1', { success: true });
+    recordBlock(t, 'p1', { success: true });
+    expect(t.get('p1').touchdowns).toBe(3);
+    expect(t.get('p1').successfulBlocks).toBe(2);
+
+    applyDecay(t);
+    expect(t.get('p1').touchdowns).toBe(0);
+    expect(t.get('p1').successfulBlocks).toBe(0);
+    expect(t.get('p1').failureStreak).toBe(0);
+    expect(t.get('p1').state).toBe<MomentumState>('normal');
+
+    // Vérif : 1 TD ne doit PAS suffire à repasser hot (compteurs vraiment
+    // remis à 0, pas juste -1 → 2 → ≥ HOT_TD_THRESHOLD).
+    recordTouchdown(t, 'p1');
+    expect(t.get('p1').state).toBe<MomentumState>('normal');
+  });
 });
 
 describe('snapshot — public read API for Gazette / odds', () => {

--- a/packages/sim-engine/src/tactics/momentum.ts
+++ b/packages/sim-engine/src/tactics/momentum.ts
@@ -162,25 +162,28 @@ export function confidenceBoostFor(state: MomentumState): -1 | 0 | 1 {
 }
 
 /**
- * Cross-match decay — moves every tracked player one notch toward
- * `normal`. The sprint specifies "decay sur 3 matchs" (lot 0.C.4) ; the
- * server-side cross-match orchestrator is expected to call this once
- * per match boundary on the persisted `PlayerForm` snapshot.
+ * End-of-match cleanup — reset les compteurs per-match et ramène l'état
+ * qualitatif à `normal`. Conforme au docstring de `PlayerMomentum`
+ * (« touchdowns: Touchdowns scored this match (resets on applyDecay) »).
  *
- * Counters are NOT reset (they represent the within-match cumulative
- * activity) — only the qualitative state moves toward normal.
+ * Le multi-match decay « sur 3 matchs » (sprint 0.C.4) est géré par
+ * `player-form.ts` au niveau persistant ; cette fonction n'est qu'une
+ * cleanup de boundary de match côté tracker en-mémoire.
+ *
+ * BUG fix : avant, les compteurs ne faisaient que `-1` au lieu de reset
+ * à 0. Conséquence : un joueur sortant d'un match avec `touchdowns=2`
+ * (hot) avait après decay `touchdowns=1` ; au match suivant, 1 seul TD
+ * suffisait pour repasser hot (touchdowns=2 ≥ HOT_TD_THRESHOLD).
+ * Inflation systématique des états hot entre matchs.
  */
 export function applyDecay(tracker: MomentumTracker): void {
   for (const [, e] of tracker._entries()) {
-    if (e.state === 'hot') {
-      e.state = 'normal';
-    } else if (e.state === 'cold') {
+    if (e.state === 'hot' || e.state === 'cold') {
       e.state = 'normal';
     }
-    // Drop counters by 1 on each decay tick so the in-match thresholds
-    // are not "sticky" forever.
-    e.touchdowns = Math.max(0, e.touchdowns - 1);
-    e.successfulBlocks = Math.max(0, e.successfulBlocks - 1);
-    e.failureStreak = Math.max(0, e.failureStreak - 1);
+    // Reset à 0 (conforme au docstring), pas un decrement -1.
+    e.touchdowns = 0;
+    e.successfulBlocks = 0;
+    e.failureStreak = 0;
   }
 }


### PR DESCRIPTION
## Résumé

Audit du sim-engine → 3 bugs côté IA tactique, corrigés avec tests TDD.

| Fichier | Bug | Impact |
|---|---|---|
| `tactics/momentum.ts` | `applyDecay` reset les compteurs par `-1` au lieu de 0 | Inflation systématique des états hot inter-match |
| `ai/strategy/strategies.ts` | BLITZ_TRAIN signe `pastMidfield` inversé | Défense blitze quand adversaire est ARRIÈRE, pas quand il avance |
| `ai/play.ts` | Fallback `chooseStrategy` choisit stratégies offensives en défense | Patterns offensifs (cage, pass) exécutés sans possession |

## Test plan

- [x] `pnpm exec vitest run` (sim-engine) : **411/411** (était 408/408, +3 tests TDD)
- [x] `pnpm exec turbo run typecheck` : OK
- [x] `pnpm sim:bench:ci` : PASS

## Détails

### `applyDecay` reset à 0 (`momentum.ts`)
Docstring : « touchdowns: Touchdowns scored this match (**resets on applyDecay**) ». Code faisait `Math.max(0, e.touchdowns - 1)`. Conséquence : joueur sort d'un match avec `touchdowns=2` (hot) → après decay `touchdowns=1` → match suivant, 1 TD suffit pour repasser hot. Inflation systématique. Le multi-match decay « sur 3 matchs » reste géré par `player-form.ts` au niveau persistant.

### BLITZ_TRAIN sign inverted (`strategies.ts:61`)
Avant : `(ctx.pastMidfield ? 0 : 0.15)`. Docstring « ramener la cavalerie sur le porteur » → défense doit blitzer davantage quand l'adversaire avance (pastMidfield), pas moins. Comparer `CAGE_BUILD` qui donne `+0.2` quand pastMidfield (signe normal).

### Fallback offensive en défense (`ai/play.ts:67`)
Quand toutes les stratégies scorent 0 (profil neutre + défense), le fallback remettait les 6 stratégies à 0.01 égales — dont `cage-build` / `breakaway` / `stall` qui hard-gate sur `hasPossession=true`. L'AI sélectionnait alors une stratégie offensive en défense, puis exécutait des patterns/moments incohérents (pickup sans ballon, pass sans porteur). Fix : table `STRATEGY_REQUIRES_POSSESSION` qui filtre le fallback par contexte.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_