### PR TITLE
fix(sim-engine/rng): fork re-forks distincts + seedToState gère seed > 2^32

### DIFF
--- a/packages/sim-engine/src/rng/seeded.test.ts
+++ b/packages/sim-engine/src/rng/seeded.test.ts
@@ -66,6 +66,50 @@ describe('createRng — xoroshiro PRNG (sprint Pro League 0.A.4)', () => {
     expect(seqOther).not.toEqual(seq1);
   });
 
+  it('rng.fork avec le MÊME label appelé plusieurs fois produit des flux DISTINCTS', () => {
+    // BUG fix : avant, deux appels successifs `parent.fork('foo')`
+    // produisaient exactement le même flux enfant (seul `parentSeed`
+    // était utilisé, indépendamment du nombre de re-forks). Un caller
+    // qui aurait fork le même label pour deux phases distinctes (e.g.
+    // drive 1 puis drive 2) cassait la pseudo-indépendance.
+    const parent = createRng(42);
+    const childA = parent.fork('phase');
+    const childB = parent.fork('phase');
+    const childC = parent.fork('phase');
+    const seqA = Array.from({ length: 8 }, () => childA.next());
+    const seqB = Array.from({ length: 8 }, () => childB.next());
+    const seqC = Array.from({ length: 8 }, () => childC.next());
+    expect(seqB).not.toEqual(seqA);
+    expect(seqC).not.toEqual(seqA);
+    expect(seqC).not.toEqual(seqB);
+  });
+
+  it('rng.fork préserve le comportement legacy pour la première occurrence (backward-compat)', () => {
+    // La première fork(label) doit produire la même séquence qu'avant le
+    // fix — sinon les bench baselines et replays existants cassent.
+    const parent = createRng(100);
+    const child = parent.fork('block-resolver');
+    const seq = Array.from({ length: 4 }, () => child.next());
+    // Si quelqu'un re-fork plus tard, la première occurrence doit rester
+    // identique à un fork "frais" depuis un nouveau parent.
+    const parentFresh = createRng(100);
+    const childFresh = parentFresh.fork('block-resolver');
+    const seqFresh = Array.from({ length: 4 }, () => childFresh.next());
+    expect(seq).toEqual(seqFresh);
+  });
+
+  it('seedToState dérive `hi` des bits hauts (pas de collision pour seed > 2^32)', () => {
+    // BUG fix : avant, tous les seeds positifs avaient hi=0 dans
+    // seedToState. Donc createRng(2^32) collidait avec createRng(0)
+    // (qui tombait sur le fallback dead_beef après hi=0,lo=0).
+    // Maintenant on calcule hi depuis Math.floor(seed / 2^32).
+    const rngLow = createRng(5);
+    const rngHigh = createRng(5 + 2 ** 32);
+    const seqLow = Array.from({ length: 8 }, () => rngLow.next());
+    const seqHigh = Array.from({ length: 8 }, () => rngHigh.next());
+    expect(seqHigh).not.toEqual(seqLow);
+  });
+
   it('rng.fork does not consume the parent stream (children are derived hashes)', () => {
     const parent = createRng(50);
     const beforeFork = parent.next();

--- a/packages/sim-engine/src/rng/seeded.ts
+++ b/packages/sim-engine/src/rng/seeded.ts
@@ -144,8 +144,15 @@ function seedToState(seed: number): XoroState {
     throw new Error('createRng: seed must be a finite number');
   }
   const normalized = Math.trunc(seed);
+  // BUG fix : avant, `hi` était toujours 0 pour les seeds positifs
+  // (seule la branche `< 0` calculait `Math.floor / 2^32`). Donc
+  // `createRng(2^32)`, `createRng(2^33)`, etc. collidaient avec
+  // `createRng(0)` après le fallback dead_beef. On dérive maintenant
+  // `hi` des bits hauts pour TOUT seed. Comportement identique pour
+  // les seeds < 2^32 (positifs ou négatifs) — pas de régression sur
+  // les replays/bench existants.
   let sm: U64 = u64(
-    normalized < 0 ? Math.floor(normalized / TWO_POW_32) >>> 0 : 0,
+    Math.floor(normalized / TWO_POW_32) >>> 0,
     normalized >>> 0
   );
   if (sm.hi === 0 && sm.lo === 0) {
@@ -194,6 +201,18 @@ function hashLabel(label: string): U64 {
 class XoroRng implements Rng {
   private state: XoroState;
   private readonly parentSeed: number;
+  /**
+   * BUG fix : avant, `fork(label)` réutilisait uniquement `parentSeed`
+   * (immuable) XOR hash(label). Conséquence : deux appels successifs
+   * `parent.fork('foo')` produisaient **exactement le même flux enfant**.
+   * Un consommateur qui fork le même label pour deux phases distinctes
+   * (ex: drive 1 puis drive 2) cassait la pseudo-indépendance des
+   * sub-streams. On compte maintenant les occurrences par label pour
+   * mixer un offset unique sur les re-forks. La PREMIÈRE occurrence
+   * d'un label conserve le comportement legacy (préserve la déterminisme
+   * des replays / bench existants où chaque label n'est forké qu'une fois).
+   */
+  private readonly forkedLabels = new Map<string, number>();
 
   constructor(seed: number) {
     this.parentSeed = seed;
@@ -209,7 +228,14 @@ class XoroRng implements Rng {
       throw new Error('rng.fork: label must be a non-empty string');
     }
     const labelHash = hashLabel(label);
-    const blended = (this.parentSeed >>> 0) ^ labelHash.lo ^ labelHash.hi;
+    const occurrence = this.forkedLabels.get(label) ?? 0;
+    this.forkedLabels.set(label, occurrence + 1);
+    // First occurrence : pre-fix behavior. Re-forks of the same label
+    // mix in an occurrence-specific hash to produce distinct streams.
+    const occurrenceMix =
+      occurrence > 0 ? hashLabel(`${label}:${occurrence}`).lo : 0;
+    const blended =
+      (this.parentSeed >>> 0) ^ labelHash.lo ^ labelHash.hi ^ occurrenceMix;
     return new XoroRng(blended >>> 0);
   }
 


### PR DESCRIPTION
## Résumé

Audit du sim-engine → 2 bugs RNG dans `seeded.ts` (xoroshiro128+ PRNG seedé), corrigés avec tests TDD et **sans casser la déterminisme** des replays/bench existants.

| Bug | Avant | Après |
|---|---|---|
| `fork(label)` ignore l'état du parent | 2 forks successifs même label → MÊME flux | Re-forks → flux distincts (1ʳᵉ occurrence backward-compat) |
| `seedToState` perd les bits hauts | `createRng(2^32)` ≡ `createRng(0)` | `hi` dérivé de `Math.floor(seed / 2^32)` |

## Test plan

- [x] `pnpm exec vitest run` (sim-engine) : **411/411** (+3 tests TDD : re-forks distincts, 1ʳᵉ occurrence backward-compat, seed > 2^32)
- [x] `pnpm exec turbo run typecheck` : OK
- [x] `pnpm sim:bench:ci` : **PASS** (backward-compat préservée — usage actuel = 1 fork par label au startup)

## Détails

### `fork(label)` ignore l'état courant

Avant :
```ts
fork(label: string): Rng {
  const labelHash = hashLabel(label);
  const blended = (this.parentSeed >>> 0) ^ labelHash.lo ^ labelHash.hi;
  return new XoroRng(blended >>> 0);
}
```

Le blend n'utilise que `parentSeed` (immuable) → deux `parent.fork('foo')` successifs produisent exactement le même flux enfant. Footgun si un caller fork le même label pour deux phases.

Fix : tracking d'occurrences par-label dans `forkedLabels: Map<string, number>`. Première occurrence = comportement legacy (préserve déterminisme bench/replays existants — usage = 10 forks distincts au startup, jamais re-fork). Re-forks mélangent `hash(${label}:${occurrence})` pour produire des flux indépendants.

### `seedToState` perd les bits hauts (positifs)

Avant : `hi = normalized < 0 ? ... : 0` — `hi` toujours 0 pour seeds positifs. Donc `createRng(2^32)`, `createRng(2^33)`, etc. tombent sur le fallback `dead_beef` après `hi=0 ∧ lo=0`.

Fix : `hi = Math.floor(normalized / TWO_POW_32) >>> 0` pour tout seed. Pour les seeds <= 2^32-1 (positifs ou négatifs), comportement identique → pas de régression sur les seeds existants (FNV1a 32-bit côté server, ints courts en bench/tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_