### PR TITLE
fix(game-engine): 4 bugs BB rules critiques (block dice, pass fumble, turn counter, GFI weather)

### DIFF
--- a/packages/game-engine/src/actions/move-handlers.ts
+++ b/packages/game-engine/src/actions/move-handlers.ts
@@ -41,6 +41,20 @@ import { isInOpponentEndzone, awardTouchdown } from '../mechanics/ball';
 import { getArmBarBonus } from '../mechanics/arm-bar';
 import { applyRollFailure } from './failure-helpers';
 import { handleBallPickup } from './ball-pickup';
+import { getWeatherModifiers } from '../mechanics/weather-effects';
+
+/**
+ * BB rule : GFI target = 2+ par défaut, 3+ en Blizzard / Neige forte.
+ * Avant ce fix, le code hardcodait `>= 2` sans consulter
+ * `state.weatherCondition`, donc les modificateurs météo (`gfiModifier`
+ * de `getWeatherModifiers`) n'étaient jamais appliqués au seuil GFI.
+ *
+ * Le modifier météo est négatif (-1 en Blizzard) → seuil = 2 - (-1) = 3.
+ */
+function gfiTargetFromWeather(state: GameState): number {
+  const mods = getWeatherModifiers(state.weatherCondition);
+  return 2 - mods.gfiModifier;
+}
 
 /**
  * Gere un jet d'esquive complet : modifiers, relance Dodge / Break
@@ -162,10 +176,12 @@ export function handleDodgeRoll(
   }
 
   if (finalDodgeSuccess) {
-    // Si c'est aussi un GFI, jet supplementaire de GFI (2+ sur D6)
+    // Si c'est aussi un GFI, jet supplementaire de GFI (2+ sur D6, 3+ en
+    // Blizzard / Neige forte via `gfiTargetFromWeather`).
     if (isDodgeGFI) {
+      const gfiTarget = gfiTargetFromWeather(state);
       let gfiRoll = Math.floor(rng() * 6) + 1;
-      let gfiSuccess = gfiRoll >= 2;
+      let gfiSuccess = gfiRoll >= gfiTarget;
 
       // Sure Feet auto-reroll (via skill registry)
       if (!gfiSuccess && canSkillReroll(player, 'on-gfi', state)) {
@@ -177,24 +193,24 @@ export function handleDodgeRoll(
         );
         next.gameLog = [...next.gameLog, sfLog];
         gfiRoll = Math.floor(rng() * 6) + 1;
-        gfiSuccess = gfiRoll >= 2;
+        gfiSuccess = gfiRoll >= gfiTarget;
       }
 
       const gfiLogEntry = createLogEntry(
         'dice',
-        `GFI (Going For It) après esquive: ${gfiRoll}/2 ${
+        `GFI (Going For It) après esquive: ${gfiRoll}/${gfiTarget} ${
           gfiSuccess ? '✓' : '✗'
         }`,
         player.id,
         player.team,
-        { diceRoll: gfiRoll, targetNumber: 2, success: gfiSuccess },
+        { diceRoll: gfiRoll, targetNumber: gfiTarget, success: gfiSuccess },
       );
       next.gameLog = [...next.gameLog, gfiLogEntry];
       next.lastDiceResult = {
         type: 'dodge' as never,
         playerId: player.id,
         diceRoll: gfiRoll,
-        targetNumber: 2,
+        targetNumber: gfiTarget,
         success: gfiSuccess,
         modifiers: 0,
         playerName: player.name,
@@ -207,7 +223,7 @@ export function handleDodgeRoll(
             rollType: 'gfi',
             playerId: player.id,
             team: player.team,
-            targetNumber: 2,
+            targetNumber: gfiTarget,
             modifiers: 0,
             playerIndex: idx,
             to,
@@ -275,9 +291,10 @@ export function handleNormalMove(
     // GFI : ne decremente pas pm, incremente gfiUsed
     next.players[idx].gfiUsed = (next.players[idx].gfiUsed ?? 0) + 1;
 
-    // Jet de GFI : 2+ sur D6
+    // Jet de GFI : 2+ par défaut, 3+ en Blizzard / Neige forte.
+    const gfiTarget = gfiTargetFromWeather(state);
     let gfiRoll = Math.floor(rng() * 6) + 1;
-    let gfiSuccess = gfiRoll >= 2;
+    let gfiSuccess = gfiRoll >= gfiTarget;
 
     // Sure Feet : relance automatique du GFI rate (via skill registry)
     if (!gfiSuccess && canSkillReroll(player, 'on-gfi', state)) {
@@ -289,22 +306,22 @@ export function handleNormalMove(
       );
       next.gameLog = [...next.gameLog, rerollLog];
       gfiRoll = Math.floor(rng() * 6) + 1;
-      gfiSuccess = gfiRoll >= 2;
+      gfiSuccess = gfiRoll >= gfiTarget;
     }
 
     const gfiLogEntry = createLogEntry(
       'dice',
-      `GFI (Going For It): ${gfiRoll}/2 ${gfiSuccess ? '✓' : '✗'}`,
+      `GFI (Going For It): ${gfiRoll}/${gfiTarget} ${gfiSuccess ? '✓' : '✗'}`,
       player.id,
       player.team,
-      { diceRoll: gfiRoll, targetNumber: 2, success: gfiSuccess },
+      { diceRoll: gfiRoll, targetNumber: gfiTarget, success: gfiSuccess },
     );
     next.gameLog = [...next.gameLog, gfiLogEntry];
     next.lastDiceResult = {
       type: 'dodge' as never,
       playerId: player.id,
       diceRoll: gfiRoll,
-      targetNumber: 2,
+      targetNumber: gfiTarget,
       success: gfiSuccess,
       modifiers: 0,
       playerName: player.name,
@@ -322,7 +339,7 @@ export function handleNormalMove(
           rollType: 'gfi',
           playerId: player.id,
           team: player.team,
-          targetNumber: 2,
+          targetNumber: gfiTarget,
           modifiers: 0,
           playerIndex: idx,
           to,

--- a/packages/game-engine/src/actions/turn-foul-actions.ts
+++ b/packages/game-engine/src/actions/turn-foul-actions.ts
@@ -14,7 +14,7 @@
  * Reduction de bruit dans `actions.ts` : ~134 lignes en moins.
  */
 
-import type { GameState, RNG, ActionType } from '../core/types';
+import type { GameState, RNG, ActionType, TeamId } from '../core/types';
 import {
   hasPlayerActed,
   setPlayerAction,
@@ -98,11 +98,27 @@ export function handleEndTurn(state: GameState, rng: RNG): GameState {
     };
   }
 
-  // Changement de tour - le porteur de ballon garde le ballon
+  // Changement de tour - le porteur de ballon garde le ballon.
+  //
+  // BB rule : un "round" = équipe receveuse joue puis équipe kickeuse joue.
+  // Le compteur `turn` représente le numéro de round (1..8 par half). On
+  // l'incrémente après l'END_TURN de l'équipe **kickeuse** (la 2e à
+  // jouer dans le round), pas après la 1ère.
+  //
+  // BUG fix : avant, l'incrément était hardcodé à `currentPlayer === 'B'`,
+  // ce qui supposait que A joue toujours en premier (A = receveur). Quand
+  // A kicke en half 1 (donc B reçoit et joue en premier), l'incrément
+  // bumpait après B = receveur → après 8 END_TURN de B, turn=9 → halftime
+  // alors que A n'avait joué que 7 activations. Inéquité 8 vs 7. Fix : on
+  // bump quand l'équipe qui finit son tour est `kickingTeam`. Fallback sur
+  // 'B' (= comportement legacy) quand `kickingTeam` est undefined, pour
+  // préserver la compat des tests qui ne définissent pas explicitement
+  // l'équipe kickeuse.
+  const bumpingTeam: TeamId = state.kickingTeam ?? 'B';
   const newState: GameState = {
     ...state,
     currentPlayer: state.currentPlayer === 'A' ? 'B' : 'A',
-    turn: state.currentPlayer === 'B' ? state.turn + 1 : state.turn,
+    turn: state.currentPlayer === bumpingTeam ? state.turn + 1 : state.turn,
     selectedPlayerId: null,
     players: state.players.map((p) => ({ ...p, pm: p.ma, gfiUsed: 0 })),
     isTurnover: false,

--- a/packages/game-engine/src/core/halftime.test.ts
+++ b/packages/game-engine/src/core/halftime.test.ts
@@ -311,8 +311,33 @@ describe('Règle: Mi-temps complète (B1.7)', () => {
   });
 
   describe('END_TURN trigger halftime', () => {
-    it('devrait déclencher la mi-temps via END_TURN quand turn passe à 9', () => {
-      // Set up state at turn 8, player B's turn (B's END_TURN increments turn 8→9)
+    it('devrait déclencher la mi-temps via END_TURN du kicker au tour 8', () => {
+      // Setup : kickingTeam='B', A reçoit (joue en premier). Round 8 : A puis B.
+      // Après l'END_TURN du kicker B → bump turn → 9 → halftime triggers.
+      const base = setup();
+      const state: GameState = {
+        ...base,
+        gamePhase: 'playing' as const,
+        half: 1,
+        turn: 8,
+        currentPlayer: 'B' as TeamId, // kicker B finit son round 8
+        kickingTeam: 'B' as TeamId,
+      };
+      const rng = makeRNG('end-turn-halftime');
+      const result = applyMove(state, { type: 'END_TURN' }, rng) as ExtendedGameState;
+
+      expect(result.half).toBe(2);
+      expect(result.turn).toBe(1);
+      expect(result.gamePhase).toBe('halftime');
+      expect(result.preMatch?.phase).toBe('setup');
+    });
+
+    it("l'END_TURN du receveur n'incrémente PAS le tour (équité 8 vs 8 activations)", () => {
+      // BUG fix : avant, le bump était hardcodé à `currentPlayer === 'B'`.
+      // Quand A kickait et B recevait, B (receveur, joue en premier) bumpait
+      // → 8 END_TURN de B suffisaient à atteindre turn=9, mais A n'avait
+      // joué que 7 activations. Maintenant le bump suit `kickingTeam`,
+      // donc B END_TURN ne bump pas si A est kicker. A doit encore jouer.
       const base = setup();
       const state: GameState = {
         ...base,
@@ -322,13 +347,13 @@ describe('Règle: Mi-temps complète (B1.7)', () => {
         currentPlayer: 'B' as TeamId,
         kickingTeam: 'A' as TeamId,
       };
-      const rng = makeRNG('end-turn-halftime');
-      const result = applyMove(state, { type: 'END_TURN' }, rng) as ExtendedGameState;
+      const rng = makeRNG('end-turn-no-halftime-on-receiver');
+      const result = applyMove(state, { type: 'END_TURN' }, rng);
 
-      expect(result.half).toBe(2);
-      expect(result.turn).toBe(1);
-      expect(result.gamePhase).toBe('halftime');
-      expect(result.preMatch?.phase).toBe('setup');
+      expect(result.half).toBe(1);
+      expect(result.turn).toBe(8);
+      expect(result.gamePhase).toBe('playing');
+      expect(result.currentPlayer).toBe('A');
     });
   });
 

--- a/packages/game-engine/src/mechanics/blocking-dice-test.test.ts
+++ b/packages/game-engine/src/mechanics/blocking-dice-test.test.ts
@@ -122,6 +122,24 @@ describe('Tests des dés de blocage - Vérification complète', () => {
       expect(calculateBlockDiceCount(1, 3)).toBe(3);
     });
 
+    it("3 dés sur ratio EXACTEMENT 2× (BB rule: ≥ 2× = 3 dés)", () => {
+      // BUG fix : avant, la condition côté défenseur `attacker < target / 2`
+      // était strictement `<`, donc attacker=1 / target=2 (ratio 2×) → 2 dés
+      // au lieu de 3. Asymétrie avec l'autre direction (2 vs 1 → 3 dés).
+      // Maintenant symétrique : ratio 2× exact = 3 dés dans les deux sens.
+      expect(calculateBlockDiceCount(1, 2)).toBe(3); // défenseur 2× → 3 dés (défenseur choisit)
+      expect(calculateBlockDiceCount(2, 4)).toBe(3); // défenseur 2× → 3 dés
+      expect(calculateBlockDiceCount(2, 1)).toBe(3); // attacker 2× → 3 dés (attaquant choisit)
+      expect(calculateBlockDiceCount(4, 2)).toBe(3); // attacker 2× → 3 dés
+    });
+
+    it('2 dés pour différence sans ratio 2×', () => {
+      // Différence sans atteindre 2× → 2 dés.
+      expect(calculateBlockDiceCount(2, 3)).toBe(2); // 2 vs 3 (target 1.5× attacker)
+      expect(calculateBlockDiceCount(3, 5)).toBe(2); // 3 vs 5 (target 1.67×)
+      expect(calculateBlockDiceCount(4, 5)).toBe(2); // 4 vs 5 (target 1.25×)
+    });
+
     it('devrait déterminer correctement qui choisit le résultat', () => {
       // Force égale : 1 dé (pas de choix)
       expect(getBlockDiceChooser(3, 3)).toBe('attacker');

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -401,22 +401,30 @@ function getAdjacentOpponents(state: GameState, position: Position, team: TeamId
 }
 
 /**
- * Calcule le nombre de dés de blocage à lancer
- * @param attackerStrength - Force totale de l'attaquant
- * @param targetStrength - Force totale de la cible
- * @returns Nombre de dés à lancer
+ * Calcule le nombre de dés de blocage à lancer.
+ *
+ * BB2020 rule : 3 dés (camp avantagé choisit) lorsque la force d'un camp
+ * est **exactement le double ou plus** de l'autre. 2 dés lorsque
+ * différence sans 2×. 1 dé sur égalité.
+ *
+ * BUG fix : avant, la condition côté défenseur `attackerStrength <
+ * targetStrength / 2` était strictement `<`, donc attacker=1, target=2
+ * (ratio 2×) retournait 2 dés au lieu de 3. Asymétrie avec la branche
+ * attaquant `attackerStrength < targetStrength * 2` qui mettait 1 vs 2
+ * ratio défavorable / 2 vs 1 ratio favorable dans des cases différentes.
+ * Maintenant symétrique via `attackerStrength * 2 <= targetStrength`.
  */
 export function calculateBlockDiceCount(attackerStrength: number, targetStrength: number): number {
-  if (attackerStrength < targetStrength / 2) {
-    return 3; // 3 dés, le défenseur choisit
+  if (attackerStrength * 2 <= targetStrength) {
+    return 3; // 3 dés, le défenseur choisit (target ≥ 2× attacker)
   } else if (attackerStrength < targetStrength) {
     return 2; // 2 dés, le défenseur choisit
   } else if (attackerStrength === targetStrength) {
     return 1; // 1 dé
-  } else if (attackerStrength < targetStrength * 2) {
-    return 2; // 2 dés, l'attaquant choisit
+  } else if (targetStrength * 2 <= attackerStrength) {
+    return 3; // 3 dés, l'attaquant choisit (attacker ≥ 2× target)
   } else {
-    return 3; // 3 dés, l'attaquant choisit
+    return 2; // 2 dés, l'attaquant choisit
   }
 }
 

--- a/packages/game-engine/src/mechanics/passing.test.ts
+++ b/packages/game-engine/src/mechanics/passing.test.ts
@@ -118,6 +118,42 @@ describe('Pass Action', () => {
     // L'état ne devrait pas changer
     expect(result).toEqual(state);
   });
+
+  it('fumble (naturel 1) lâche le ballon aux pieds du PASSEUR (pas de la cible)', () => {
+    // BUG fix : avant, tout échec de passe faisait rebondir le ballon
+    // depuis la case CIBLE — même un fumble (naturel 1) qui devrait laisser
+    // tomber le ballon aux pieds du passeur. Sur un long-bomb fumble,
+    // cela donnait un énorme avantage indu (ballon au bout du terrain).
+    const state = createPassTestState();
+    // RNG: pass roll = 1 (fumble), puis bounces (utilisent les valeurs suivantes)
+    const rng = makeTestRNG([0.01, 0.5, 0.5, 0.5, 0.5]);
+
+    const passerPos = { ...state.players[0].pos };
+    const targetPos = { ...state.players[1].pos };
+
+    const move: Move = { type: 'PASS', playerId: 'A1', targetId: 'A2' };
+    const result = applyMove(state, move, rng);
+
+    expect(result.isTurnover).toBe(true);
+    // Le passeur n'a plus la balle (fumble = drop).
+    expect(result.players.find(p => p.id === 'A1')?.hasBall).toBeFalsy();
+    // Le ballon est aux pieds du passeur (initial pos), pas chez la cible.
+    // Note : après bounce, il a peut-être dérivé d'1 case ; on vérifie
+    // que la distance initiale du ballon au passeur << distance au target.
+    expect(result.ball).toBeDefined();
+    if (result.ball) {
+      const distToPasser = Math.max(
+        Math.abs(result.ball.x - passerPos.x),
+        Math.abs(result.ball.y - passerPos.y),
+      );
+      const distToTarget = Math.max(
+        Math.abs(result.ball.x - targetPos.x),
+        Math.abs(result.ball.y - targetPos.y),
+      );
+      expect(distToPasser).toBeLessThanOrEqual(1); // ≤ 1 case du passeur (bounce inclus)
+      expect(distToTarget).toBeGreaterThan(1); // loin de la cible
+    }
+  });
 });
 
 describe('Interception', () => {

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -430,16 +430,29 @@ export function executePass(
       return newState;
     }
 
-    // Passe ratée : le ballon dévie depuis la cible
+    // BB2020 rule : un fumble (jet naturel de 1) lâche le ballon aux pieds
+    // du passeur ; une passe inaccurée (autre échec) part de la case cible
+    // et rebondit. Avant ce fix, tout échec faisait rebondir depuis la
+    // cible — perte de la distinction fumble/inaccurate, qui donnait un
+    // énorme avantage indu sur les long-bomb fumbles (le ballon partait
+    // au bout du terrain au lieu de rester aux pieds du passeur).
+    const isFumble = passResult.diceRoll === 1;
     const failLog = createLogEntry(
       'turnover',
-      `Passe ratée - Turnover !`,
+      isFumble
+        ? `Passe ratée (fumble) — ballon aux pieds de ${passer.name}. Turnover !`
+        : `Passe ratée (inaccurate) — Turnover !`,
       passer.id,
-      passer.team
+      passer.team,
+      { fumble: isFumble },
     );
     newState.gameLog = [...newState.gameLog, failLog];
     newState.isTurnover = true;
-    newState.ball = { ...target.pos };
+    // Le passeur perd la balle dans les deux cas.
+    newState.players = newState.players.map(p =>
+      p.id === passer.id ? { ...p, hasBall: false } : p
+    );
+    newState.ball = isFumble ? { ...passer.pos } : { ...target.pos };
     return bounceBall(newState, rng);
   }
 


### PR DESCRIPTION
## Résumé

Audit du game-engine → 4 bugs critiques de règles BB2020/BB3 corrigés avec tests TDD.

| Fichier | Bug | Impact |
|---|---|---|
| `blocking.ts` | `calculateBlockDiceCount` asymétrie sur ratio 2× exact | Block dice incorrect pour ST 1 vs 2 (et symétriques) |
| `passing.ts` | Fumble (nat 1) drop ball à la CIBLE au lieu du PASSEUR | Long-bomb fumble = avantage indu massif |
| `turn-foul-actions.ts` | Compteur tour hardcodé sur `currentPlayer === 'B'` | Inéquité 8 vs 7 activations/half si A kicke |
| `move-handlers.ts` | GFI hardcodé `>= 2` ignore Blizzard `gfiModifier: -1` | 33% fail vs 17% en Blizzard, mais non appliqué |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4957/4957** (était 4953/4953, +4 tests TDD)
- [x] `pnpm exec turbo run typecheck` (game-engine + sim-engine) : OK
- [x] 1 test halftime ajusté pour refléter la logique correcte du turn counter

## Détails

### `calculateBlockDiceCount` ratio 2× exact (BB rule)
BB2020 : « when one player has ≥2× strength of the other → 3 dice, stronger chooses ». Avant : `attackerStrength < targetStrength / 2` (strict `<`) côté défenseur, donc 1 vs 2 → 2 dés (faux, devrait être 3). Branche attaquant utilisait `< target * 2` (aussi strict). Asymétrie réelle :
- 1 vs 2 (defender 2×) → 2 dés ❌ (devrait être 3)
- 2 vs 1 (attacker 2×) → 3 dés ✓

Fix : `* 2 <= ` (inclusif) des deux côtés → comportement symétrique correct.

### Pass fumble drops ball at passer position
BB2020 distingue :
- **Fumble** (naturel 1) : ballon aux pieds du passeur → potential interception/pickup au feet
- **Inaccurate** (autre échec) : ballon depuis la case cible → scatter

Avant : `newState.ball = target.pos` sur tout échec. Sur un long-bomb fumble (PA 3 thrower attempting bomb, nat 1 fail), le ballon partait au bout du terrain au lieu de rester aux pieds — gros déséquilibre game-flow.

Fix : `isFumble = diceRoll === 1` → ball @ passer.pos. Ball.hasBall = false sur passer.

### Turn counter follows kicker (BB round structure)
BB round : receiver joue puis kicker. Le compteur `turn` représente le numéro de round (1..8). On bump après l'END_TURN du **kicker** (2ᵉ à jouer).

Avant : `currentPlayer === 'B' ? +1 : 0` (hardcodé). Quand A kicke en half 1 → B reçoit et joue en premier. Bumper sur B = bumper sur le receveur = atteindre turn=9 après seulement 8 END_TURN de B, mais A n'a joué que 7 activations.

Fix : `currentPlayer === state.kickingTeam ? +1 : 0`. Fallback sur 'B' si `kickingTeam` undefined (compat tests qui ne le définissent pas).

### GFI Blizzard 3+ modifier
`weather-effects.ts` définit `gfiModifier: -1` pour Blizzard/Neige forte (BB2020 : GFI 3+ au lieu de 2+). `move-handlers.ts` hardcodait `gfiSuccess = gfiRoll >= 2` sans consulter la météo. Fix : helper `gfiTargetFromWeather(state)` qui retourne `2 - mods.gfiModifier`. Le `pendingReroll.targetNumber` est aussi mis à jour pour la cohérence des relances d'équipe.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_