### PR TITLE
fix(game-engine): TZ + secret-weapon + disturbing-presence pour joueurs hors-terrain

### DIFF
--- a/packages/game-engine/src/mechanics/disturbing-presence.test.ts
+++ b/packages/game-engine/src/mechanics/disturbing-presence.test.ts
@@ -134,6 +134,24 @@ describe('getDisturbingPresenceModifier', () => {
     expect(getDisturbingPresenceModifier(state, { x: 5, y: 5 }, TEAM_A)).toBe(0);
   });
 
+  it("ne compte pas un adversaire en réserves (hors terrain, pos = -1)", () => {
+    // BUG fix : avant, le filtre `canExertDisturbingPresence` ne vérifiait
+    // pas `pos.x >= 0`. Un adversaire en réserves (state='active', pos=-1)
+    // passait — le `chebyshev` bloquait en pratique mais c'était un
+    // fallback fragile.
+    const state = makeState([
+      makePlayer({
+        id: 'B1',
+        team: TEAM_B,
+        pos: { x: -1, y: -1 },
+        skills: ['disturbing-presence'],
+        state: 'active',
+      }),
+    ]);
+    expect(getDisturbingPresenceModifier(state, { x: -1, y: -1 }, TEAM_A)).toBe(0);
+    expect(getDisturbingPresenceModifier(state, { x: 0, y: 0 }, TEAM_A)).toBe(0);
+  });
+
   it('ne compte pas un adversaire stunned', () => {
     const state = makeState([
       makePlayer({

--- a/packages/game-engine/src/mechanics/disturbing-presence.ts
+++ b/packages/game-engine/src/mechanics/disturbing-presence.ts
@@ -28,9 +28,16 @@ export function hasDisturbingPresence(player: Player): boolean {
  * Indique si ce joueur peut exercer sa presence perturbante :
  * il doit etre sur le terrain et actif (ni stunned, ni KO, ni casualty,
  * ni expulse, ni hypnotise).
+ *
+ * BUG fix : avant, on ne vérifiait pas `pos.x >= 0`. Un joueur en
+ * réserves (`state === 'active'` mais `pos = (-1, -1)`) passait le
+ * filtre. Le `chebyshev` bloque en pratique (distance énorme), mais
+ * c'est un fallback fragile. Maintenant on exclut explicitement les
+ * joueurs hors-terrain.
  */
 function canExertDisturbingPresence(state: GameState, player: Player): boolean {
   if (player.stunned) return false;
+  if (player.pos.x < 0 || player.pos.y < 0) return false;
   const s = player.state;
   if (s === 'knocked_out' || s === 'casualty' || s === 'sent_off') return false;
   const hypnotized = state.hypnotizedPlayers ?? [];

--- a/packages/game-engine/src/mechanics/movement.test.ts
+++ b/packages/game-engine/src/mechanics/movement.test.ts
@@ -450,6 +450,28 @@ describe('Jets de désquive', () => {
 
       expect(opponents).toHaveLength(0);
     });
+
+    it("ne devrait pas inclure les adversaires KO / blessés / expulsés (TZ filter)", () => {
+      // BUG fix : avant, `getAdjacentOpponents` ne filtrait que `!stunned`.
+      // Un joueur KO / casualty / sent_off dont la `pos` n'avait pas été
+      // zéroée comptait quand même comme TZ adjacente → biaisait dodge,
+      // pickup, pass modifiers. Cohérent avec `tackle-zones.ts:53`.
+      const playerA = state.players.find(p => p.team === 'A');
+      const playerB = state.players.find(p => p.team === 'B');
+      if (!playerA || !playerB) return;
+      const adjPos = { x: playerA.pos.x + 1, y: playerA.pos.y };
+
+      for (const blockedState of ['knocked_out', 'casualty', 'sent_off'] as const) {
+        const stateWithBlocked = {
+          ...state,
+          players: state.players.map(p =>
+            p.id === playerB.id ? { ...p, pos: adjPos, state: blockedState } : p
+          ),
+        };
+        const opponents = getAdjacentOpponents(stateWithBlocked, playerA.pos, 'A');
+        expect(opponents).toHaveLength(0);
+      }
+    });
   });
 
   describe('calculateDodgeModifiers', () => {

--- a/packages/game-engine/src/mechanics/movement.ts
+++ b/packages/game-engine/src/mechanics/movement.ts
@@ -77,6 +77,12 @@ export function getAdjacentOpponents(state: GameState, position: Position, team:
         && p.pos.y === checkPos.y
         && !p.stunned
         && !hypnotized.includes(p.id)
+        // BB rule : un joueur KO / blessé / expulsé n'exerce pas de zone
+        // de tacle (cf. tackle-zones.ts:53). Avant ce fix, seul `!stunned`
+        // était vérifié — un joueur KO dont la `pos` n'avait pas été
+        // zéroée comptait quand même comme TZ adjacente, biaisant dodge /
+        // pickup / pass modifiers.
+        && (!p.state || p.state === 'active')
         // O.1 batch 3g : un joueur Titchy n'exerce pas de zone de tacle.
         && !p.skills.includes('titchy')
     );

--- a/packages/game-engine/src/mechanics/secret-weapons.test.ts
+++ b/packages/game-engine/src/mechanics/secret-weapons.test.ts
@@ -98,6 +98,26 @@ describe('Regle: Secret Weapons — expulsion en fin de drive', () => {
       const result = getSecretWeaponPlayers(state, 'A');
       expect(result).toHaveLength(1);
     });
+
+    it("ne devrait PAS inclure un joueur secret-weapon resté en réserves (n'a pas participé)", () => {
+      // BUG fix : avant, un Goblin Fanatic resté en réserves toute la
+      // mi-temps était quand même expulsé. Un joueur en réserves a
+      // state='active' AND pos=-1 — distinct des KO (state='knocked_out',
+      // pos=-1) qui ont participé au drive. Maintenant on exclut
+      // explicitement le pattern actif-mais-hors-terrain.
+      const state = createTestState({
+        players: [
+          createTestPlayer({
+            id: 'A1',
+            skills: ['secret-weapon'],
+            state: 'active',
+            pos: { x: -1, y: -1 }, // jamais joué le drive
+          }),
+        ],
+      });
+      const result = getSecretWeaponPlayers(state, 'A');
+      expect(result).toHaveLength(0);
+    });
   });
 
   describe('expelSecretWeapons — sans bribe', () => {

--- a/packages/game-engine/src/mechanics/secret-weapons.ts
+++ b/packages/game-engine/src/mechanics/secret-weapons.ts
@@ -14,7 +14,17 @@ import { createLogEntry } from '../utils/logging';
 
 /**
  * Retourne les joueurs d'une équipe possédant secret-weapon et éligibles
- * à l'expulsion (non déjà casualty ou sent_off).
+ * à l'expulsion en fin de drive.
+ *
+ * BB rule : un joueur ayant **participé au drive** est expulsé.
+ *  - Joueur encore sur le terrain (`state === 'active'`, `pos.x >= 0`) → participe.
+ *  - Joueur KO durant le drive (`state === 'knocked_out'`, `pos === -1`) → participe.
+ *  - Joueur en réserves n'ayant jamais joué (`state === 'active'`, `pos === -1`)
+ *    → n'a PAS participé, ne doit pas être expulsé. Avant ce fix, un Goblin
+ *    Fanatic en réserves toute la mi-temps était quand même expulsé.
+ *
+ * Exclusions : déjà casualty / sent_off (déjà sorti pour autre raison) et
+ * réserves actifs hors-terrain (n'ont jamais joué le drive).
  */
 export function getSecretWeaponPlayers(state: GameState, teamId: TeamId): Player[] {
   return state.players.filter(
@@ -22,7 +32,10 @@ export function getSecretWeaponPlayers(state: GameState, teamId: TeamId): Player
       p.team === teamId &&
       hasSkill(p, 'secret-weapon') &&
       p.state !== 'casualty' &&
-      p.state !== 'sent_off'
+      p.state !== 'sent_off' &&
+      // Exclure le cas spécifique « actif en réserves, jamais joué » :
+      // state='active' AND pos.x<0 → n'a pas participé au drive.
+      !((p.state === 'active' || !p.state) && p.pos.x < 0)
   );
 }
 


### PR DESCRIPTION
## Résumé

3 bugs liés au filtrage des joueurs qui ne devraient PAS exercer d'influence sur le terrain (TZ, expulsion, présence perturbante).

| Fichier | Bug | Impact |
|---|---|---|
| `movement.ts` | `getAdjacentOpponents` ne filtrait que `!stunned` | KO/cas/sent_off comptaient comme TZ → dodge/pickup biaisés |
| `secret-weapons.ts` | Réserves non-joués expulsés en fin de drive | Goblin Fanatic resté au banc = quand même expulsé |
| `disturbing-presence.ts` | Pas de filtre `pos.x >= 0` | Réserves exerçaient présence (masqué par chebyshev) |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4956/4956** (+3 tests TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

### `getAdjacentOpponents` TZ filter
Avant : `p => !p.stunned && !hypnotized.includes(p.id) && !titchy`. Un joueur KO / casualty / sent_off dont la `pos` n'avait pas été zéroée comptait comme TZ adjacente, biaisant systématiquement dodge / pickup / pass / catch modifiers. Cohérent avec `tackle-zones.ts:53` qui exclut correctement `!active`. Fix : ajouter `(!p.state || p.state === 'active')`.

### Secret-weapons réserves
BB rule : seuls les joueurs **ayant participé au drive** sont expulsés.

Pattern distinctif :
- En réserves jamais joué : `state === 'active'` ET `pos.x < 0`
- KO/casualty/sent_off (a participé) : `state !== 'active'` (avec ou sans pos=-1)

Avant : tout `secret-weapon` non-casualty/sent_off était expulsé, incluant les réserves. Fix : `!((p.state === 'active' || !p.state) && p.pos.x < 0)` exclut le pattern réserves-jamais-joué tout en conservant l'expulsion des KO participants (test existant ligne 92-100 reste vert).

### Disturbing Presence reserves
`canExertDisturbingPresence` ne vérifiait pas `pos.x >= 0`. Un adversaire en réserves (`state='active'`, `pos=-1`) passait — le `chebyshev` bloquait en pratique mais c'était un fallback fragile. Fix : `if (player.pos.x < 0 || player.pos.y < 0) return false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_