### PR TITLE
fix(game-engine/skills): hasSkill normalise séparateurs (cohérent avec getSkillEffect)

### DIFF
--- a/packages/game-engine/src/skills/skill-effects.ts
+++ b/packages/game-engine/src/skills/skill-effects.ts
@@ -5,11 +5,29 @@
 
 import type { Player } from '../core/types';
 
-/** Vérifie si un joueur possède une compétence donnée (par slug) */
+/**
+ * Normalise un slug de skill : lowercase + remplace `_` et espaces par `-`.
+ * Cohérent avec `getSkillEffect` dans skill-registry.ts.
+ */
+function normalizeSkillSlug(slug: string): string {
+  return slug.toLowerCase().replace(/[_ ]/g, '-');
+}
+
+/**
+ * Vérifie si un joueur possède une compétence donnée (par slug).
+ *
+ * BUG fix : avant, seul `toLowerCase()` était appliqué. `hasSkill` était
+ * donc inconsistant avec `getSkillEffect` (skill-registry.ts:104-107)
+ * qui normalise aussi les séparateurs `_` / espace → `-`. Conséquence :
+ * `getSkillEffect('crushing_blow')` trouvait le slug `'crushing-blow'`,
+ * mais le `canApply` de l'effet appelait `hasSkill(player, 'crushing-blow')`
+ * qui ne matchait pas un skill `'crushing_blow'` dans `player.skills`.
+ * Les variantes snake_case dans les rosters/tests étaient silencieusement
+ * ignorées.
+ */
 export function hasSkill(player: Player, skillSlug: string): boolean {
-  return player.skills.some(
-    s => s.toLowerCase() === skillSlug.toLowerCase()
-  );
+  const target = normalizeSkillSlug(skillSlug);
+  return player.skills.some((s) => normalizeSkillSlug(s) === target);
 }
 
 // ─── BLOCK ────────────────────────────────────────────────────

--- a/packages/game-engine/src/skills/skill-registry.test.ts
+++ b/packages/game-engine/src/skills/skill-registry.test.ts
@@ -5,6 +5,7 @@ import {
   getSkillsForTrigger,
   collectModifiers,
 } from './skill-registry';
+import { hasSkill } from './skill-effects';
 import type { Player, GameState } from '../core/types';
 import { setup } from '../core/game-state';
 
@@ -72,6 +73,39 @@ describe('Skill Registry', () => {
       const effect = getSkillEffect('sidestep');
       expect(effect).toBeDefined();
       expect(effect!.canApply({ player, state: setup() })).toBe(true);
+    });
+  });
+
+  describe('hasSkill — normalisation cohérente avec getSkillEffect', () => {
+    // BUG fix : avant, `hasSkill` ne normalisait que la casse, alors que
+    // `getSkillEffect` normalise aussi `_` / espace → `-`. Conséquence :
+    // un skill stocké en snake_case dans player.skills (ex. `'crushing_blow'`)
+    // n'était PAS détecté par `hasSkill(player, 'crushing-blow')` côté
+    // canApply, même si `getSkillEffect('crushing_blow')` trouvait bien
+    // le slug `'crushing-blow'`. Maintenant les deux fonctions normalisent
+    // pareil.
+    it("match les variantes snake_case (player.skills = ['crushing_blow'])", () => {
+      const player = makePlayer({ skills: ['crushing_blow'] });
+      expect(hasSkill(player, 'crushing-blow')).toBe(true);
+      expect(hasSkill(player, 'crushing_blow')).toBe(true);
+      expect(hasSkill(player, 'Crushing-Blow')).toBe(true);
+      expect(hasSkill(player, 'Crushing Blow')).toBe(true);
+    });
+
+    it("match les variantes kebab-case (player.skills = ['crushing-blow'])", () => {
+      const player = makePlayer({ skills: ['crushing-blow'] });
+      expect(hasSkill(player, 'crushing-blow')).toBe(true);
+      expect(hasSkill(player, 'crushing_blow')).toBe(true);
+    });
+
+    it("retourne false pour un skill absent", () => {
+      const player = makePlayer({ skills: ['block', 'dodge'] });
+      expect(hasSkill(player, 'crushing-blow')).toBe(false);
+    });
+
+    it("space-separated 'big hand' matche 'big-hand'", () => {
+      const player = makePlayer({ skills: ['big hand'] });
+      expect(hasSkill(player, 'big-hand')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Résumé

Bug d'incohérence entre `hasSkill` (skill-effects.ts) et `getSkillEffect` (skill-registry.ts) sur la normalisation des slugs.

| Avant | Après |
|---|---|
| `hasSkill` normalise seulement la casse | `hasSkill` normalise casse + `_`/espace → `-` |
| `getSkillEffect` normalise `_`/espace → `-` | inchangé |

Conséquence du bug : `getSkillEffect('crushing_blow')` trouvait `'crushing-blow'`, mais `canApply` appelait `hasSkill(player, 'crushing-blow')` qui ne matchait pas un `player.skills = ['crushing_blow']` (snake_case). Les variantes snake_case dans les rosters/tests étaient silencieusement ignorées.

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4957/4957** (+4 tests TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

Extract helper `normalizeSkillSlug(slug)` qui applique `toLowerCase()` + `.replace(/[_ ]/g, '-')`, utilisé dans `hasSkill` ET cohérent avec la logique de `skill-registry.ts:getSkillEffect`.

Couvre les 4 cas :
- `'crushing_blow'` (snake) match `'crushing-blow'` (kebab) ✓
- `'crushing-blow'` (kebab) match `'crushing_blow'` (snake) ✓
- `'big hand'` (space) match `'big-hand'` ✓
- Casse mixte `'Crushing-Blow'` match ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_