### PR TITLE
fix(game-engine/mechanics): Mighty Blow exclus de Projectile Vomit + bombardier self-credit

### DIFF
--- a/packages/game-engine/src/mechanics/bombardier.test.ts
+++ b/packages/game-engine/src/mechanics/bombardier.test.ts
@@ -229,6 +229,31 @@ describe('Regle: Bombardier', () => {
       // Activation terminee
       expect(result.players.find(p => p.id === 'A2')!.pm).toBe(0);
     });
+
+    it("sur fumble auto-explosion, le bombardier ne se credite PAS sa propre casualty (SPP)", () => {
+      // BUG fix : en cas de fumble (bombe explose sur le lanceur),
+      // `applyBombImpact` appelait `performInjuryRoll(... attackerId)`
+      // qui créditait la casualty au bombardier lui-même → SPP indu.
+      // Maintenant, on passe `undefined` comme causedById si victim === attacker.
+      let s = patchPlayer(state, 'A2', {
+        skills: ['bombardier'],
+        pos: { x: 5, y: 5 },
+        pa: 3,
+        pm: 6,
+        av: 7, // av faible pour casser facilement
+      });
+      s = patchPlayer(s, 'A1', { pos: { x: 0, y: 0 } });
+      s = patchPlayer(s, 'B1', { pos: { x: 25, y: 14 } });
+      s = patchPlayer(s, 'B2', { pos: { x: 25, y: 0 } });
+
+      // rng : pass D6=1 (fumble), armor 6+6=12 (casse), injury 6+6=12 (casualty)
+      const rng = scriptedRng([0.01, 0.99, 0.99, 0.99, 0.99, 0.5, 0.5, 0.5]);
+      const result = executeBombThrow(s, 'A2', { x: 8, y: 5 }, rng);
+
+      // Le bombardier A2 ne doit PAS avoir +1 casualty dans matchStats.
+      const a2Stats = result.matchStats?.['A2'];
+      expect(a2Stats?.casualties ?? 0).toBe(0);
+    });
   });
 
   describe('executeBombThrow - invariants', () => {

--- a/packages/game-engine/src/mechanics/bombardier.ts
+++ b/packages/game-engine/src/mechanics/bombardier.ts
@@ -112,7 +112,13 @@ function applyBombImpact(
   if (!armorResult.success) {
     const currentVictim = newState.players.find(p => p.id === victim.id);
     if (currentVictim) {
-      newState = performInjuryRoll(newState, currentVictim, rng, 0, attackerId);
+      // BUG fix : en cas de fumble, la bombe explose sur le bombardier
+      // lui-même (`victim.id === attackerId`). Avant, le `causedById` était
+      // toujours `attackerId` → le bombardier se créditait sa propre
+      // casualty (SPP indu). On ne credit que si la victime est différente
+      // de l'attaquant.
+      const causedById = victim.id === attackerId ? undefined : attackerId;
+      newState = performInjuryRoll(newState, currentVictim, rng, 0, causedById);
     }
   }
 

--- a/packages/game-engine/src/mechanics/projectile-vomit.test.ts
+++ b/packages/game-engine/src/mechanics/projectile-vomit.test.ts
@@ -209,6 +209,37 @@ describe('Regle: Projectile Vomit', () => {
       expect(injuryLogs.length).toBeGreaterThan(0);
     });
 
+    it("Mighty Blow ne s'applique PAS au jet d'armure de Projectile Vomit (BB rule)", () => {
+      // BUG fix : avant, Mighty Blow donnait +1 à l'armor roll de PV.
+      // BB2020 stipule explicitement que Mighty Blow ne s'applique pas
+      // aux jets d'armure / blessure issus de Projectile Vomit, Stab,
+      // Chainsaw, etc. Cf. line break dans le test "armor roll: need 2D6
+      // >= 7 (AV with mighty blow -1 = 6)" qui assumait MB appliqué.
+      const state = createVomitTestState();
+      // Target AV 7, vomiter a 'mighty-blow'. Avec MB appliqué (bug),
+      // l'armure target serait 7+1 = 8 (puis -MB = 7). Sans MB (fix),
+      // l'armure target reste 8 (AV+1).
+      state.players = state.players.map(p =>
+        p.id === 'B1' ? { ...p, av: 7 } : p
+      );
+      const vomiter = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      // Roll 6 vomit success, puis dés d'armure 3+4 = 7. Avec MB → 8 (casse).
+      // Sans MB (fix correct) → 7 < 8 → armure tient.
+      const rng = makeTestRNG([0.84, 0.4, 0.55]); // ~ vomit 6, armor [3, 4]
+      const result = executeProjectileVomit(state, vomiter, target, rng);
+
+      // Avec le fix, armure tient (sans MB). On vérifie qu'il n'y a pas
+      // de log mentionnant Mighty Blow sur l'armor.
+      const armorLog = result.gameLog.find(l =>
+        l.message.includes("armure de") && l.message.includes(target.name)
+      );
+      expect(armorLog).toBeDefined();
+      // Pas de mention "+Mighty Blow" sur l'armure de PV.
+      expect(armorLog?.message ?? '').not.toContain('Mighty Blow');
+      expect((armorLog?.details as Record<string, unknown>)?.mightyBlowBonus).toBeUndefined();
+    });
+
     it('bounces ball if knocked down target had the ball', () => {
       const state = createVomitTestState();
       // Give ball to B1

--- a/packages/game-engine/src/mechanics/projectile-vomit.ts
+++ b/packages/game-engine/src/mechanics/projectile-vomit.ts
@@ -18,7 +18,6 @@ import { performArmorRoll } from '../utils/dice';
 import { performInjuryRoll } from './injury';
 import { createLogEntry } from '../utils/logging';
 import { isAdjacent } from './movement';
-import { getMightyBlowBonusFromRegistry, getArmorSkillContext } from '../skills/skill-bridge';
 import { bounceBall } from './ball';
 
 /**
@@ -113,30 +112,24 @@ export function executeProjectileVomit(
       newState = bounceBall(newState, rng);
     }
 
-    // Jet d'armure avec bonus Mighty Blow éventuel.
-    // Iron Hard Skin annule les modificateurs positifs de l'attaquant
-    // sur le jet d'armure (ex. Mighty Blow).
-    const mightyBlowBonusRaw = getMightyBlowBonusFromRegistry(vomiter, newState);
-    const { ironHardSkinActive } = getArmorSkillContext(
-      newState,
-      vomiter,
-      newState.players[targetIdx],
-    );
-    const mightyBlowBonus = ironHardSkinActive ? 0 : mightyBlowBonusRaw;
-    const armorResult = performArmorRoll(newState.players[targetIdx], rng, -mightyBlowBonus);
+    // BB2020 rule : Mighty Blow ne s'applique PAS aux jets d'armure ni
+    // de blessure issus de Projectile Vomit. C'est une exclusion explicite
+    // dans le texte de Projectile Vomit. Avant ce fix, Mighty Blow donnait
+    // +1 à l'armure de PV, ce qui sur-évaluait les profils Mighty Blow +
+    // Projectile Vomit (rare mais existant via inducements / skill access).
+    const armorResult = performArmorRoll(newState.players[targetIdx], rng, 0);
     newState.lastDiceResult = armorResult;
 
-    const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
     const armorLog = createLogEntry(
       'dice',
-      `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber}${ihsTag} ${armorResult.success ? '(tient)' : '(percée)'}`,
+      `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '(tient)' : '(percée)'}`,
       target.id,
       target.team,
-      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus, ironHardSkin: ironHardSkinActive },
+      { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber },
     );
     newState.gameLog = [...newState.gameLog, armorLog];
 
-    // Si l'armure est percée (success = false), jet de blessure
+    // Si l'armure est percée, jet de blessure (sans bonus Mighty Blow non plus).
     if (!armorResult.success) {
       newState = performInjuryRoll(newState, newState.players[targetIdx], rng, 0, vomiter.id);
     }

--- a/packages/game-engine/src/mechanics/regeneration.ts
+++ b/packages/game-engine/src/mechanics/regeneration.ts
@@ -28,7 +28,15 @@ export function hasRegeneration(state: GameState, playerId: string): boolean {
  * Returns a new GameState if regeneration succeeds, or null if it fails.
  *
  * On success: moves the player to Reserves, clears casualty data, logs the result.
- * On failure: logs the failed roll, returns null (caller continues with normal flow).
+ * On failure: logs the failed roll to `state.gameLog` (in-place append) and
+ * returns null. Le caller doit travailler avec son state existant (qui contient
+ * désormais le log d'échec ajouté).
+ *
+ * Note immutability : la mutation in-place du `gameLog` sur l'échec est
+ * volontaire pour préserver l'API legacy `GameState | null`. Le caller
+ * passe toujours un state déjà cloné (via `structuredClone` au niveau de
+ * `injury.ts:performInjuryRoll`), donc la mutation reste « safe » du point
+ * de vue de l'appelant externe.
  */
 export function tryRegeneration(
   state: GameState,
@@ -47,7 +55,6 @@ export function tryRegeneration(
   if (success) {
     // Move player from current zone to reserves
     const team = player.team;
-    const fromZone = injuryType === 'ko' ? 'knockedOut' : 'casualty';
     const newState = movePlayerToDugoutZone(state, playerId, 'reserves', team);
 
     // Clear casualty data if applicable


### PR DESCRIPTION
## Résumé

Deux bugs dans les mécaniques d'armes spéciales BB2020/BB3.

| Fichier | Bug | Impact |
|---|---|---|
| `projectile-vomit.ts` | Mighty Blow appliqué au jet d'armure | Rotspawn + MB sur-évalué |
| `bombardier.ts` | Casualty self-créditée sur fumble auto-explosion | SPP indu +2 par self-cas |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4955/4955** (+2 tests TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

### Projectile Vomit + Mighty Blow
BB2020 rule explicite : « Mighty Blow does NOT apply to Armour or Injury rolls from Projectile Vomit, Stab, Chainsaw, etc. » Avant, le code appliquait `getMightyBlowBonusFromRegistry(vomiter)` puis `-mightyBlowBonus` comme modifier au `performArmorRoll`. Fix : `performArmorRoll(target, rng, 0)`, suppression des imports MB/IronHardSkin.

### Bombardier self-credit casualty
Sur fumble (D6=1), la bombe explose sur le lanceur. `applyBombImpact(state, attackerId, impactPos, rng)` passait `attackerId` comme `causedById` à `performInjuryRoll`, créditant la casualty au bombardier lui-même. Fix : si `victim.id === attackerId`, `causedById = undefined` (pas de SPP attribué).

### Doc clarification (regeneration.ts)
Le pattern `state.gameLog = [...state.gameLog, failLog]` (mutation in-place) avant `return null` est documenté explicitement dans le docstring — pas un fix de comportement, juste explicitation du contrat pour les futurs lecteurs.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_