### PR TITLE
fix(game-engine/blitz): coût PM diagonal = 1 (Chebyshev) au lieu de 2 (Manhattan)

### DIFF
--- a/packages/game-engine/src/actions/blitz-handler.test.ts
+++ b/packages/game-engine/src/actions/blitz-handler.test.ts
@@ -118,4 +118,43 @@ describe('S27.8.13 — handleBlitz', () => {
     );
     expect(JSON.stringify(state)).toBe(snapshot);
   });
+
+  it("un déplacement diagonal coûte 1 PM (Chebyshev), pas 2 (BB rule)", () => {
+    // BUG fix : avant, le coût en PM était calculé en Manhattan
+    // (|dx| + |dy|), donc une diagonale coûtait 2 PM au lieu d'1. BB
+    // utilise Chebyshev (king-move) : 1 PM par case adjacente, diagonales
+    // incluses. `getLegalMoves` énumère pourtant les 8 directions comme
+    // single-PM BLITZ steps — incohérence corrigée ici.
+    //
+    // Setup : attaquant (4,5), cible (6,7). Le blitz consiste à se
+    // déplacer en (5,6) (diagonale, distance Chebyshev=1 / Manhattan=2)
+    // puis bloquer la cible adjacente.
+    const attacker = makePlayer({
+      id: 'A',
+      team: 'A',
+      pos: { x: 4, y: 5 },
+      ma: 6,
+      pm: 6,
+      skills: [],
+    });
+    const target = makePlayer({
+      id: 'T',
+      team: 'B',
+      pos: { x: 6, y: 7 },
+      ma: 6,
+      pm: 6,
+    });
+    const state = makeState({
+      players: [attacker, target],
+      currentPlayer: 'A',
+    });
+    const next = handleBlitz(
+      state,
+      { type: 'BLITZ', playerId: 'A', to: { x: 5, y: 6 }, targetId: 'T' },
+      rng,
+    );
+    // L'attaquant a maintenant pm = 6 - 1 = 5 (Chebyshev), pas 6 - 2 = 4 (Manhattan).
+    const movedAttacker = next.players.find(p => p.id === 'A');
+    expect(movedAttacker?.pm).toBe(5);
+  });
 });

--- a/packages/game-engine/src/actions/blitz-handler.ts
+++ b/packages/game-engine/src/actions/blitz-handler.ts
@@ -121,8 +121,12 @@ export function handleBlitz(
     const attackerIdx = newState.players.findIndex(p => p.id === attacker.id);
     newState.players[attackerIdx].pos = { ...to };
 
-    // Calculer le coût en PM : distance seulement (le blocage coûtera 1 PM supplémentaire)
-    const distance = Math.abs(from.x - to.x) + Math.abs(from.y - to.y);
+    // BB rule : le coût en PM d'un déplacement est la distance Chebyshev
+    // (king-move) — 1 PM par case adjacente, diagonales incluses. Avant ce
+    // fix, on utilisait la distance Manhattan (|dx| + |dy|) qui comptait
+    // un déplacement diagonal comme 2 PM au lieu d'1. `getLegalMoves` énumère
+    // pourtant les 8 directions comme BLITZ steps single-PM.
+    const distance = Math.max(Math.abs(from.x - to.x), Math.abs(from.y - to.y));
     newState.players[attackerIdx].pm = Math.max(0, newState.players[attackerIdx].pm - distance);
 
     // Shadowing : tentative de suivi après le mouvement (BB3).
@@ -213,8 +217,9 @@ export function handleBlitz(
     const attackerIdx = newState.players.findIndex(p => p.id === attacker.id);
     newState.players[attackerIdx].pos = { ...to };
 
-    // Calculer le coût en PM : distance seulement (le blocage coûtera 1 PM supplémentaire)
-    const distance = Math.abs(from.x - to.x) + Math.abs(from.y - to.y);
+    // BB rule : distance Chebyshev (king-move) — 1 PM par case adjacente.
+    // Cf. commentaire au-dessus pour le bug fix Manhattan → Chebyshev.
+    const distance = Math.max(Math.abs(from.x - to.x), Math.abs(from.y - to.y));
     newState.players[attackerIdx].pm = Math.max(0, newState.players[attackerIdx].pm - distance);
 
     // Si le joueur porte la balle et atteint l'en-but adverse -> touchdown


### PR DESCRIPTION
## Résumé

`handleBlitz` calculait le coût en PM d'un déplacement via la distance Manhattan (`|dx| + |dy|`) au lieu de Chebyshev (`max(|dx|, |dy|)`).

| Mouvement | Manhattan (bug) | Chebyshev (fix) |
|---|---|---|
| (4,5) → (5,5) | 1 PM | 1 PM |
| (4,5) → (5,6) diagonale | **2 PM** | **1 PM** |
| (4,5) → (6,7) | **4 PM** | **2 PM** |

`getLegalMoves` énumère les 8 directions comme single-PM BLITZ steps — l'incohérence faisait que le moteur acceptait le coup en `getLegalMoves` mais consommait 2 PM au lieu de 1, pénalisant systématiquement le blitz diagonal.

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4958/4958** (+1 test TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

Fix appliqué aux deux branches de `handleBlitz` (with-dodge ligne 125, without-dodge ligne 217) :

```diff
-const distance = Math.abs(from.x - to.x) + Math.abs(from.y - to.y);
+const distance = Math.max(Math.abs(from.x - to.x), Math.abs(from.y - to.y));
```

Aligne le coût PM avec BB rule king-move (1 PM par case adjacente, diagonales comprises).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_