### PR TITLE
fix(game-engine): Bloodweiser Kegs +1 KO recovery + getGfiCap honore rulesConfig

### DIFF
--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -778,14 +778,21 @@ function recoverKOPlayers(state: GameState, rng: RNG): GameState {
     const dugout = newState.dugouts[dugoutKey];
     const koZone = dugout.zones.knockedOut;
 
+    // BUG fix : appliquer le bonus Bloodweiser Kegs (+1 par keg acheté,
+    // max 2). Avant, le bonus était déclaré dans inducements mais jamais
+    // lu — le jet était `>= 4` hardcodé. Maintenant on lit
+    // `state.bloodweiserKegs[teamKey]` (initialisé depuis preMatch dans
+    // startMatchFromKickoff) et on relâche le seuil en conséquence.
+    const kegBonus = newState.bloodweiserKegs?.[dugoutKey] ?? 0;
+    const recoveryThreshold = Math.max(2, 4 - kegBonus);
+
     if (koZone.players.length > 0) {
       const recoveredIds: string[] = [];
       const stillKOIds: string[] = [];
 
       for (const playerId of koZone.players) {
-        // Simple 4+ check using seeded RNG
         const roll = Math.floor(rng() * 6) + 1;
-        if (roll >= 4) {
+        if (roll >= recoveryThreshold) {
           recoveredIds.push(playerId);
         } else {
           stillKOIds.push(playerId);
@@ -953,16 +960,27 @@ export function canPlayerAct(state: GameState, playerId: string): boolean {
 }
 
 /**
- * S27.7.2 — Cap de GFI pour un joueur, derive du registry des skills.
+ * S27.7.2 — Cap de GFI pour un joueur, derive du registry des skills
+ * et du rulesConfig actif.
  *
  * Defaut 2 (regle BB3). Sprint ajoute +1 (cap = 3) via le modifier
  * `gfiCapBonus` collecte sur le trigger `on-gfi`. Tout futur skill
  * qui modifie le cap (ex: Big Hand variant, Tarpit, etc.) n'aura
  * qu'a poser un `gfiCapBonus` sans toucher aux call-sites.
+ *
+ * BUG fix : avant, le rulesConfig (`maxGFI`, `enableGFI`) n'etait pas
+ * respecte. Le mode `simplified` declare `maxGFI: 0` et `enableGFI: false`,
+ * mais la GFI continuait a etre autorisee jusqu'a 2 cases par joueur.
+ * Maintenant on plafonne avec `min(skill-based, rulesConfig.maxGFI)`,
+ * et retourne 0 si `enableGFI === false`.
  */
 export function getGfiCap(state: GameState, player: Player): number {
+  const rules = getRulesConfigForState(state);
+  if (rules.enableGFI === false) return 0;
   const mods = collectModifiers(player, 'on-gfi', { state });
-  return 2 + (mods.gfiCapBonus ?? 0);
+  // Cap de base = rulesConfig.maxGFI (2 en full, 0 en simplified).
+  // Les skills (ex. Sprint) ajoutent leur bonus par-dessus le cap de base.
+  return rules.maxGFI + (mods.gfiCapBonus ?? 0);
 }
 
 /**
@@ -1551,6 +1569,9 @@ export function startMatchFromKickoff(state: ExtendedGameState, rng?: RNG): Game
     bribesRemaining: isInitialStart
       ? initializeBribesFromInducements(preMatch, state.prayerEffects)
       : state.bribesRemaining,
+    bloodweiserKegs: isInitialStart
+      ? initializeBloodweiserKegsFromInducements(preMatch)
+      : state.bloodweiserKegs,
     fanAttendance,
     dedicatedFans,
     weatherCondition,
@@ -1611,6 +1632,31 @@ function initializeBribesFromInducements(preMatch: PreMatchState, prayerEffects?
     }
   }
   return bribes;
+}
+
+/**
+ * Bloodweiser Kegs inducement (`bloodweiser_kegs`) — chaque keg donne +1
+ * aux jets de KO recovery de l'équipe propriétaire (max 2 kegs).
+ *
+ * BUG fix : avant, le bonus était déclaré dans `inducements.ts:107` mais
+ * jamais lu — `recoverKOPlayers` utilisait un `>= 4` hardcodé sans bonus.
+ * Désormais on persiste le count par équipe dans le state (similaire à
+ * `bribesRemaining`) et on l'applique dans `recoverKOPlayers`.
+ */
+function initializeBloodweiserKegsFromInducements(
+  preMatch: PreMatchState,
+): { teamA: number; teamB: number } {
+  const kegs = { teamA: 0, teamB: 0 };
+  if (preMatch.inducements) {
+    for (const teamKey of ['teamA', 'teamB'] as const) {
+      const items = preMatch.inducements[teamKey].items;
+      const kegItem = items.find(i => i.slug === 'bloodweiser_kegs');
+      if (kegItem) {
+        kegs[teamKey] = kegItem.quantity;
+      }
+    }
+  }
+  return kegs;
 }
 
 /**

--- a/packages/game-engine/src/core/halftime.test.ts
+++ b/packages/game-engine/src/core/halftime.test.ts
@@ -164,6 +164,50 @@ describe('Règle: Mi-temps complète (B1.7)', () => {
       expect(result.casualtyResults).toEqual({ A2: 'bh' });
     });
 
+    it('Bloodweiser Kegs (+1 KO recovery) augmente le taux de récupération', () => {
+      // BUG fix : avant, l'inducement Bloodweiser Kegs (+1 KO recovery)
+      // était déclaré dans inducements.ts mais jamais lu. Le jet était
+      // un `>= 4` hardcodé sans bonus. Maintenant `state.bloodweiserKegs`
+      // est lu et abaisse le seuil de recovery (e.g. 2 kegs → seuil 2+).
+      const base = setup();
+      const koPlayerIds = ['A1', 'A2'];
+      const stateWithKegs = createHalftimeState({
+        bloodweiserKegs: { teamA: 2, teamB: 0 }, // 2 kegs → seuil 2+ (presque tout récupère)
+        players: base.players.map(p =>
+          koPlayerIds.includes(p.id)
+            ? { ...p, state: 'knocked_out' as const, pos: { x: -1, y: -1 } }
+            : p
+        ),
+        dugouts: {
+          ...base.dugouts,
+          teamA: {
+            ...base.dugouts.teamA,
+            zones: {
+              ...base.dugouts.teamA.zones,
+              knockedOut: {
+                ...base.dugouts.teamA.zones.knockedOut,
+                players: koPlayerIds,
+              },
+            },
+          },
+        },
+      });
+
+      // Avec 2 kegs (seuil=2+), un jet à 2,3,4,5,6 = recovery (5/6 chance).
+      // En moyenne sur 100 seeds, on devrait avoir bcp plus de recoveries
+      // qu'avec le seuil 4+ baseline (3/6 chance).
+      let recoveriesWithKegs = 0;
+      for (let i = 0; i < 100; i++) {
+        const rng = makeRNG(`bloodweiser-${i}`);
+        const result = advanceHalfIfNeeded(stateWithKegs, rng);
+        const koZone = result.dugouts.teamA.zones.knockedOut;
+        recoveriesWithKegs += koPlayerIds.filter(id => !koZone.players.includes(id)).length;
+      }
+      // 200 attempts (2 players × 100 seeds), seuil 2+ = ~5/6 = ~167.
+      // Permet une variance large pour passer en CI.
+      expect(recoveriesWithKegs).toBeGreaterThan(140);
+    });
+
     it('devrait tenter de récupérer les joueurs KO', () => {
       const base = setup();
       const state = createHalftimeState({

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -267,6 +267,10 @@ export interface GameState {
   usedStarPlayerRules: Record<string, boolean>;
   // Nombre de bribes restantes par équipe (achetées via inducements ou prières)
   bribesRemaining: { teamA: number; teamB: number };
+  // Bloodweiser Kegs achetés (inducement) — chaque keg donne +1 aux jets de
+  // KO recovery de l'équipe (BB rule, max 2 kegs). Optional pour compat avec
+  // les états sérialisés pré-fix.
+  bloodweiserKegs?: { teamA: number; teamB: number };
   // Joueurs hypnotisés (perdent leur zone de tacle jusqu'à leur prochaine activation)
   hypnotizedPlayers?: string[];
   // IDs des joueurs qui ont déjà utilisé Running Pass ce tour (une fois par tour par joueur).

--- a/packages/game-engine/src/skills/sprint-gfi-cap.test.ts
+++ b/packages/game-engine/src/skills/sprint-gfi-cap.test.ts
@@ -103,4 +103,29 @@ describe("getGfiCap", () => {
     const player = makePlayer({ skills: ["sure-feet"] });
     expect(getGfiCap(FAKE_STATE, player)).toBe(2);
   });
+
+  it("respecte rulesConfig.enableGFI=false (mode simplified)", () => {
+    // BUG fix : avant, getGfiCap ignorait rulesConfig et retournait
+    // toujours 2 même en mode simplified (enableGFI=false, maxGFI=0).
+    const player = makePlayer({ skills: ["sprint"] });
+    const simplifiedState = {
+      rulesConfig: { enableGFI: false, maxGFI: 0 },
+    } as unknown as GameState;
+    expect(getGfiCap(simplifiedState, player)).toBe(0);
+  });
+
+  it("base cap suit rulesConfig.maxGFI (extensible par skill)", () => {
+    // maxGFI=2 (full) + Sprint=+1 → 3
+    const sprintPlayer = makePlayer({ skills: ["sprint"] });
+    const fullState = {
+      rulesConfig: { enableGFI: true, maxGFI: 2 },
+    } as unknown as GameState;
+    expect(getGfiCap(fullState, sprintPlayer)).toBe(3);
+
+    // Si jamais maxGFI=1 dans une rulesConfig custom, Sprint donne 2.
+    const reducedState = {
+      rulesConfig: { enableGFI: true, maxGFI: 1 },
+    } as unknown as GameState;
+    expect(getGfiCap(reducedState, sprintPlayer)).toBe(2);
+  });
 });


### PR DESCRIPTION
## Résumé

Deux bugs d'application incorrecte des règles inducement / rulesConfig.

| Fichier | Bug | Impact |
|---|---|---|
| `core/game-state.ts` | Bloodweiser Kegs jamais lu malgré déclaration | Inducement +1 KO recovery gâché (50k gp) |
| `core/game-state.ts:getGfiCap` | Ignore `rulesConfig.maxGFI` / `enableGFI` | Mode simplified autorisait quand même 2 GFI |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4975/4975** (+3 tests TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

### Bloodweiser Kegs +1 KO recovery
`inducements.ts:107` déclare l'item avec description « +1 to KO recovery rolls for each keg purchased », mais `recoverKOPlayers` utilisait un `>= 4` hardcodé. Les coachs ayant acheté l'inducement (50k gp, max 2) ne bénéficiaient jamais du bonus.

Fix :
1. Nouveau champ `bloodweiserKegs: { teamA: number; teamB: number }` sur `GameState` (similaire à `bribesRemaining`).
2. `initializeBloodweiserKegsFromInducements()` lit les quantités achetées dans `preMatch.inducements`.
3. `startMatchFromKickoff` initialise le champ pour les drives initiaux.
4. `recoverKOPlayers` lit `state.bloodweiserKegs[teamKey]` et abaisse le seuil de recovery : `Math.max(2, 4 - kegBonus)`.

### `getGfiCap` rulesConfig honoring
Avant : `return 2 + (mods.gfiCapBonus ?? 0)` hardcodait le cap de base à 2, indépendamment du `rulesConfig`. Le mode simplified (`enableGFI: false`, `maxGFI: 0`) autorisait quand même 2 GFI.

Fix : `if (rules.enableGFI === false) return 0`, puis cap = `rules.maxGFI + skillBonus`. Le mode full (maxGFI=2) garde le comportement Sprint (+1 → 3). Le mode simplified retourne 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_