### PR TITLE
fix(game-engine): Always Hungry eaten + Prayer 14 donnent leur chance à l'apothicaire

### DIFF
--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -15,6 +15,8 @@ import { movePlayerToDugoutZone } from './dugout';
 import { getPushDirections } from './blocking';
 import { checkBlockNegatesBothDown, checkDodgeNegatesStumble } from '../skills/skill-bridge';
 import { bounceBall } from './ball';
+import { isApothecaryAvailable } from './apothecary';
+import { hasRegeneration, tryRegeneration } from './regeneration';
 
 export interface ActivationCheckResult {
   passed: boolean;
@@ -814,7 +816,11 @@ export function checkAlwaysHungry(
   };
 
   if (eaten) {
-    // Teammate is removed from play as a casualty (no armor/injury roll)
+    // Teammate is removed from play as a casualty (Dead). BB rule :
+    // l'apothicaire peut tenter de sauver la victime, et Regeneration
+    // s'applique aussi en fallback. Avant ce fix, on force-positionnait
+    // `state='casualty'` et `casualtyResults='dead'` sans passer par le
+    // flow apothecary/regen — privant la victime de ses sauvegardes.
     newState = movePlayerToDugoutZone(newState, thrown.id, 'casualty', thrown.team);
     newState = {
       ...newState,
@@ -837,6 +843,25 @@ export function checkAlwaysHungry(
       ...newState,
       gameLog: [...newState.gameLog, eatenLog],
     };
+
+    // Donne sa chance à l'apothecaire / regen — pattern identique à
+    // `handleCasualty` (cf. injury.ts:262-269).
+    if (isApothecaryAvailable(newState, thrown.id)) {
+      newState = {
+        ...newState,
+        pendingApothecary: {
+          playerId: thrown.id,
+          team: thrown.team,
+          injuryType: 'casualty',
+          originalCasualtyOutcome: 'dead',
+          causedById: thrower.id,
+          fallbackToRegeneration: hasRegeneration(newState, thrown.id),
+        },
+      };
+    } else if (hasRegeneration(newState, thrown.id)) {
+      const regenResult = tryRegeneration(newState, thrown.id, rng, 'casualty');
+      if (regenResult) newState = regenResult;
+    }
 
     return { passed: false, eaten: true, escaped: false, newState };
   }

--- a/packages/game-engine/src/mechanics/prayers-to-nuffle.ts
+++ b/packages/game-engine/src/mechanics/prayers-to-nuffle.ts
@@ -7,6 +7,8 @@
 import { GameState, TeamId, Player, RNG } from '../core/types';
 import { createLogEntry } from '../utils/logging';
 import { rollD6, roll2D6 } from '../utils/dice';
+import { isApothecaryAvailable as isApothecaryAvailableFn } from './apothecary';
+import { hasRegeneration as hasRegenerationFn, tryRegeneration as tryRegenerationFn } from './regeneration';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -518,11 +520,40 @@ export function applyPrayerEffect(
           }));
           break;
         case 'casualty':
+          // BUG fix : avant, on forçait `state='casualty'` directement
+          // sans set `casualtyResults`, ni proposer apothecaire/regen.
+          // Maintenant on enregistre une casualty 'badly_hurt' (par
+          // défaut Prayer 14 — pas de D16 spécifié dans la règle) ET
+          // on offre les sauvegardes (apothecary/regen) comme tout
+          // jet de casualty normal.
           newState = updatePlayer(state, target.id, (p) => ({
             ...p,
             state: 'casualty',
             pos: { x: -1, y: -1 },
           }));
+          newState = {
+            ...newState,
+            casualtyResults: {
+              ...(newState.casualtyResults ?? {}),
+              [target.id]: 'badly_hurt',
+            },
+          };
+          // Apothecary check (cf. injury.ts:handleCasualty pattern).
+          if (isApothecaryAvailableFn(newState, target.id)) {
+            newState = {
+              ...newState,
+              pendingApothecary: {
+                playerId: target.id,
+                team: target.team,
+                injuryType: 'casualty',
+                originalCasualtyOutcome: 'badly_hurt',
+                fallbackToRegeneration: hasRegenerationFn(newState, target.id),
+              },
+            };
+          } else if (hasRegenerationFn(newState, target.id)) {
+            const regenResult = tryRegenerationFn(newState, target.id, rng, 'casualty');
+            if (regenResult) newState = regenResult;
+          }
           break;
       }
 


### PR DESCRIPTION
## Résumé

Deux bugs de mécaniques qui forçaient l'état `casualty` directement sans donner sa chance à l'apothicaire / régénération.

| Fichier | Bug | Impact |
|---|---|---|
| `negative-traits.ts:checkAlwaysHungry` | Eaten → casualty 'dead' direct, pas d'apoth/regen | Player avalé impossible à sauver |
| `prayers-to-nuffle.ts` Prayer 14 | Casualty forcée sans casualtyResults / apoth / regen | Victime sortait sans trace, sans save |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4975/4975**
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

### Always Hungry 'eaten' (`negative-traits.ts`)
BB rule : un joueur avalé subit une casualty 'dead'. Comme toute casualty, l'apothicaire peut la convertir en outcome moins sévère, et Regeneration peut tenter de ramener le joueur en réserves.

Avant : `state='casualty'` + `casualtyResults='dead'` setté directement, sans `pendingApothecary` ni `tryRegeneration`. La victime sortait définitivement, l'apothicaire restait inutilisé.

Fix : après le marquage casualty, check `isApothecaryAvailable` → set `pendingApothecary` avec `originalCasualtyOutcome='dead'`. Fallback `tryRegeneration` si pas d'apoth dispo mais skill Regeneration.

### Prayer 14 'Throw a Rock' (`prayers-to-nuffle.ts`)
Branche casualty oubliée trois choses :
1. **`casualtyResults`** non set → post-match SPP / healing ne savait pas que la victime avait subi une casualty.
2. **Apothicaire** non proposé.
3. **Regeneration** non tentée.

Fix : casualty par défaut `'badly_hurt'` (Prayer ne spécifie pas de D16) + apoth check + regen fallback, identique au pattern de `handleCasualty`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_