### PR TITLE
fix(game-engine/skills): star player rules once-per-match marquées comme utilisées (Crushing Blow)

### DIFF
--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -13,7 +13,7 @@ import {
   Player,
 } from '../core/types';
 import { isAdjacent, inBounds, isPositionOccupied } from './movement';
-import { checkGuard, checkBlockNegatesBothDown, checkDodgeNegatesStumble, getMightyBlowBonusFromRegistry, checkWrestleOnBothDown, getArmorSkillContext, getInjurySkillModifiers } from '../skills/skill-bridge';
+import { checkGuard, checkBlockNegatesBothDown, checkDodgeNegatesStumble, getMightyBlowBonusFromRegistry, checkWrestleOnBothDown, getArmorSkillContext, getInjurySkillModifiers, consumeOncePerMatchSkills } from '../skills/skill-bridge';
 import { hasSkill } from '../skills/skill-effects';
 import { collectModifiers } from '../skills/skill-registry';
 import { performArmorRoll, roll2D6 } from '../utils/dice';
@@ -197,6 +197,12 @@ function armorAndInjuryWithMightyBlow(
     const injuryDefenderMod = getInjurySkillModifiers(state, victim);
     state = performInjuryRoll(state, victim, rng, injuryBonus + injuryDefenderMod, attacker.id);
   }
+
+  // BUG fix : consommer les star player rules « once-per-match » qui ont
+  // contribué au jet d'armure côté attaquant (Crushing Blow notamment).
+  // Sans cet appel, Crushing Blow firait son +1 armure à chaque block,
+  // pas une seule fois par match.
+  state = consumeOncePerMatchSkills(state, attacker, 'on-armor', { state, opponent: victim });
 
   return state;
 }

--- a/packages/game-engine/src/skills/skill-bridge.ts
+++ b/packages/game-engine/src/skills/skill-bridge.ts
@@ -5,9 +5,31 @@
  */
 
 import type { Player, GameState, Position } from '../core/types';
-import type { SkillTrigger } from './skill-registry';
-import { collectModifiers, getSkillEffect } from './skill-registry';
+import type { SkillTrigger, SkillContext } from './skill-registry';
+import { collectModifiers, getSkillEffect, getOncePerMatchSlugsToConsume } from './skill-registry';
+import { markStarPlayerRuleUsed } from './star-player-rules';
 import { getAdjacentOpponents } from '../mechanics/movement';
+
+/**
+ * Marque les star player rules « once-per-match » consommés par un
+ * trigger. À appeler après que le caller a effectivement utilisé les
+ * modifiers retournés par `collectModifiers` (jet d'armure, esquive,
+ * etc.). Sans cet appel, les skills une-fois-par-match (Crushing Blow,
+ * Pirouette, Casse-Os) firent à chaque trigger → infinite uses.
+ */
+export function consumeOncePerMatchSkills(
+  state: GameState,
+  player: Player,
+  trigger: SkillTrigger,
+  ctx: Omit<SkillContext, 'player' | 'currentTrigger'> = { state },
+): GameState {
+  const slugs = getOncePerMatchSlugsToConsume(player, trigger, ctx);
+  let newState = state;
+  for (const slug of slugs) {
+    newState = markStarPlayerRuleUsed(newState, player.id, slug);
+  }
+  return newState;
+}
 
 /**
  * Calcule les modificateurs de compétences pour un jet d'esquive.

--- a/packages/game-engine/src/skills/skill-registry.ts
+++ b/packages/game-engine/src/skills/skill-registry.ts
@@ -91,6 +91,15 @@ export interface SkillEffect {
 
   /** Effet spécial non-standard */
   specialEffect?: (ctx: SkillContext) => Partial<GameState> | null;
+
+  /**
+   * Si défini, marque ce slug comme « utilisé pour ce match » via
+   * `markStarPlayerRuleUsed` après que le skill ait été consommé (ie.
+   * canApply==true ET son effet a été appliqué). Utilisé par les star
+   * player rules « once-per-match » (Crushing Blow, Pirouette,
+   * Casse-Os, etc.).
+   */
+  oncePerMatchSlug?: string;
 }
 
 // ─── Registre global des skills ──────────────────────────────────────────
@@ -141,6 +150,37 @@ export function collectModifiers(
   }
 
   return result;
+}
+
+/**
+ * Retourne les slugs `oncePerMatchSlug` des skills `getModifiers` du
+ * joueur qui SE SERAIENT déclenchés pour ce trigger (canApply==true).
+ *
+ * Le caller doit appeler `markStarPlayerRuleUsed` pour chacun après
+ * avoir effectivement consommé l'effet (i.e. après le jet d'armure,
+ * d'esquive, etc.).
+ *
+ * BUG fix : avant, `markStarPlayerRuleUsed` n'était jamais invoqué
+ * depuis la production code. Les star player rules « once-per-match »
+ * (Crushing Blow, Pirouette, Casse-Os) firaient à chaque trigger →
+ * infinite uses. Cette fonction expose le set de slugs à consommer.
+ */
+export function getOncePerMatchSlugsToConsume(
+  player: Player,
+  trigger: SkillTrigger,
+  ctx: Omit<SkillContext, 'player' | 'currentTrigger'>
+): string[] {
+  const fullCtx: SkillContext = { ...ctx, player, currentTrigger: trigger };
+  const slugs: string[] = [];
+  for (const skill of player.skills) {
+    const effect = getSkillEffect(skill);
+    if (!effect) continue;
+    if (!effect.oncePerMatchSlug) continue;
+    if (!effect.triggers.includes(trigger)) continue;
+    if (!effect.canApply(fullCtx)) continue;
+    slugs.push(effect.oncePerMatchSlug);
+  }
+  return slugs;
 }
 
 // ─── Enregistrement des compétences de base ──────────────────────────────

--- a/packages/game-engine/src/skills/star-player-once-per-match.test.ts
+++ b/packages/game-engine/src/skills/star-player-once-per-match.test.ts
@@ -1,0 +1,82 @@
+/**
+ * BUG fix : Star Player rules « once-per-match » (Crushing Blow,
+ * Pirouette, Casse-Os) gating sur `!isStarPlayerRuleUsed(...)` mais
+ * `markStarPlayerRuleUsed` n'était jamais appelé. Conséquence : ces
+ * skills firaient à chaque trigger → infinite uses.
+ *
+ * Fix : ajout de `oncePerMatchSlug` aux registrations + helper
+ * `consumeOncePerMatchSkills` appelé après le jet d'armure.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from '../actions/actions';
+import { makeRNG } from '../utils/rng';
+import { isStarPlayerRuleUsed } from './star-player-rules';
+import { getOncePerMatchSlugsToConsume } from './skill-registry';
+import { consumeOncePerMatchSkills } from './skill-bridge';
+import type { GameState, Player } from '../core/types';
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p', team: 'A', pos: { x: 5, y: 5 }, name: 'P', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 8,
+    skills: [], pm: 6, state: 'active', ...overrides,
+  };
+}
+
+describe('Star player rules — once-per-match (markUsed)', () => {
+  it("getOncePerMatchSlugsToConsume retourne 'crushing-blow' pour un joueur avec ce skill au trigger on-armor", () => {
+    const player = makePlayer({ skills: ['crushing-blow'] });
+    const state = { ...setup(), usedStarPlayerRules: {} };
+    const opponent = makePlayer({ id: 'v', team: 'B' });
+
+    const slugs = getOncePerMatchSlugsToConsume(player, 'on-armor', { state, opponent });
+    expect(slugs).toContain('crushing-blow');
+  });
+
+  it('après consumeOncePerMatchSkills, isStarPlayerRuleUsed retourne true', () => {
+    const player = makePlayer({ skills: ['crushing-blow'] });
+    let state: GameState = { ...setup(), usedStarPlayerRules: {} };
+    const opponent = makePlayer({ id: 'v', team: 'B' });
+
+    expect(isStarPlayerRuleUsed(state, player.id, 'crushing-blow')).toBe(false);
+    state = consumeOncePerMatchSkills(state, player, 'on-armor', { state, opponent });
+    expect(isStarPlayerRuleUsed(state, player.id, 'crushing-blow')).toBe(true);
+  });
+
+  it("getOncePerMatchSlugsToConsume retourne vide si déjà utilisé (canApply gate)", () => {
+    const player = makePlayer({ skills: ['crushing-blow'] });
+    const state: GameState = {
+      ...setup(),
+      usedStarPlayerRules: { [`${player.id}:crushing-blow`]: true },
+    };
+    const opponent = makePlayer({ id: 'v', team: 'B' });
+
+    const slugs = getOncePerMatchSlugsToConsume(player, 'on-armor', { state, opponent });
+    expect(slugs).not.toContain('crushing-blow');
+  });
+
+  it('Pirouette est aussi tracké (on-dodge)', () => {
+    const player = makePlayer({ skills: ['pirouette'] });
+    const state = { ...setup(), usedStarPlayerRules: {} };
+
+    const slugs = getOncePerMatchSlugsToConsume(player, 'on-dodge', { state });
+    expect(slugs).toContain('pirouette');
+  });
+
+  it("Casse-Os est aussi tracké (on-block-attacker)", () => {
+    const player = makePlayer({ skills: ['casse-os'] });
+    const state = { ...setup(), usedStarPlayerRules: {} };
+
+    const slugs = getOncePerMatchSlugsToConsume(player, 'on-block-attacker', { state });
+    expect(slugs).toContain('casse-os');
+  });
+
+  it("un joueur sans skill once-per-match ne consomme rien", () => {
+    const player = makePlayer({ skills: ['block', 'dodge'] });
+    const state = { ...setup(), usedStarPlayerRules: {} };
+
+    const slugs = getOncePerMatchSlugsToConsume(player, 'on-armor', { state });
+    expect(slugs).toHaveLength(0);
+  });
+});

--- a/packages/game-engine/src/skills/star-player-rules.ts
+++ b/packages/game-engine/src/skills/star-player-rules.ts
@@ -177,6 +177,7 @@ registerSkill({
     hasSkill(ctx.player, 'crushing-blow') &&
     !isStarPlayerRuleUsed(ctx.state, ctx.player.id, 'crushing-blow'),
   getModifiers: () => ({ armorModifier: 1 }),
+  oncePerMatchSlug: 'crushing-blow',
 });
 
 // ─── 7. LORD OF CHAOS (Lord Borak The Despoiler) ───────────────────────
@@ -211,6 +212,7 @@ registerSkill({
     hasSkill(ctx.player, 'pirouette') &&
     !isStarPlayerRuleUsed(ctx.state, ctx.player.id, 'pirouette'),
   getModifiers: () => ({ dodgeModifier: 1 }),
+  oncePerMatchSlug: 'pirouette',
 });
 
 // ─── 9. CASSE-OS (Mighty Zug) ──────────────────────────────────────────
@@ -224,6 +226,7 @@ registerSkill({
     hasSkill(ctx.player, 'casse-os') &&
     !isStarPlayerRuleUsed(ctx.state, ctx.player.id, 'casse-os'),
   getModifiers: () => ({ strengthModifier: 1 }),
+  oncePerMatchSlug: 'casse-os',
 });
 
 // ─── 10. RELIABLE (Deeproot Strongbranch) ───────────────────────────────


### PR DESCRIPTION
## Résumé

Bug HIGH : les star player rules « once-per-match » (Crushing Blow, Pirouette, Casse-Os) firent à chaque trigger car `markStarPlayerRuleUsed` n'était jamais invoqué.

| Skill | Effet (par trigger) | Avant fix | Après fix |
|---|---|---|---|
| Crushing Blow | +1 armure | À chaque block | 1× par match |
| Pirouette | +1 esquive | À chaque dodge | annoté (wire à venir) |
| Casse-Os | +1 force | À chaque block | annoté (wire à venir) |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4981/4981** (+6 TDD)
- [x] `pnpm exec turbo run typecheck` : OK

## Détails

### Architecture
1. `SkillEffect.oncePerMatchSlug?: string` — déclaratif sur les registrations qui requièrent le tracking.
2. `getOncePerMatchSlugsToConsume(player, trigger, ctx)` — scan registry, retourne les slugs à marquer used pour un trigger donné (gating par `canApply`).
3. `consumeOncePerMatchSkills(state, player, trigger, ctx)` — helper qui appelle `markStarPlayerRuleUsed` pour chaque slug.
4. Wire dans `blocking.ts:armorAndInjuryWithMightyBlow` après le jet d'armure → consomme Crushing Blow.

### Scope de ce PR
- ✅ Crushing Blow (le plus impactant) wired
- Annoté pour Pirouette et Casse-Os (oncePerMatchSlug ajouté) — wire des call-sites dans un PR séparé pour limiter le blast radius
- Les 3 « canReroll » rules (`coup-sauvage`, `la-baliste`, `consummate-professional`) ne sont pas couvertes — pattern de consommation différent (au moment de la relance), nécessite un autre wire

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_