### PR TITLE
fix(game-engine): turnover gate softlock + referee ordre + armor target min clamp

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -162,9 +162,28 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
     return state;
   }
 
-  // Si c'est un turnover, on ne peut que finir le tour
-  // Exception : PUSH_CHOOSE, FOLLOW_UP_CHOOSE et REROLL_CHOOSE font partie de la résolution
-  if (state.isTurnover && move.type !== 'END_TURN' && move.type !== 'PUSH_CHOOSE' && move.type !== 'FOLLOW_UP_CHOOSE' && move.type !== 'REROLL_CHOOSE' && move.type !== 'APOTHECARY_CHOOSE' && move.type !== 'ON_THE_BALL_MOVE' && move.type !== 'ON_THE_BALL_DECLINE') {
+  // Si c'est un turnover, on ne peut que finir le tour OU compléter la
+  // résolution d'un coup en cours (push/follow-up choice, reroll,
+  // apothecary, on-the-ball, block-choice multi-dés, dump-off receiver).
+  //
+  // BUG fix : avant, BLOCK_CHOOSE et DUMP_OFF_CHOOSE étaient absents de
+  // cette whitelist. Si un turnover était set après le jet de dés d'un
+  // BLOCK multi-dés mais AVANT que le coach ne choisisse le résultat
+  // (e.g. cascade Frenzy / chained Push), le dispatcher rejetait le
+  // BLOCK_CHOOSE → seul END_TURN restait → **softlock** car le choix
+  // de dé n'était jamais résolu.
+  if (
+    state.isTurnover &&
+    move.type !== 'END_TURN' &&
+    move.type !== 'PUSH_CHOOSE' &&
+    move.type !== 'FOLLOW_UP_CHOOSE' &&
+    move.type !== 'REROLL_CHOOSE' &&
+    move.type !== 'APOTHECARY_CHOOSE' &&
+    move.type !== 'ON_THE_BALL_MOVE' &&
+    move.type !== 'ON_THE_BALL_DECLINE' &&
+    move.type !== 'BLOCK_CHOOSE' &&
+    move.type !== 'DUMP_OFF_CHOOSE'
+  ) {
     return state;
   }
 

--- a/packages/game-engine/src/utils/dice.test.ts
+++ b/packages/game-engine/src/utils/dice.test.ts
@@ -260,10 +260,11 @@ describe('calculateArmorTarget', () => {
     expect(calculateArmorTarget(player, 5)).toBe(12);
   });
 
-  it('does not clamp the minimum (can go below 2)', () => {
-    // av=2, modifiers=-5 → -3 (no minimum clamp in this function)
+  it('clamp le minimum à 2 (le D6 minimal sur 2D6)', () => {
+    // BUG fix : avant, pas de min clamp → av=2, modifiers=-5 → -3.
+    // Maintenant : clamp à 2 (cible minimale atteignable par 2D6).
     const player = mockPlayer({ av: 2 });
-    expect(calculateArmorTarget(player, -5)).toBe(-3);
+    expect(calculateArmorTarget(player, -5)).toBe(2);
   });
 
   it('returns 12 when av is already 12 with zero modifier', () => {

--- a/packages/game-engine/src/utils/dice.ts
+++ b/packages/game-engine/src/utils/dice.ts
@@ -70,8 +70,15 @@ export function calculateArmorTarget(player: Player, modifiers: number = 0): num
   // La valeur de base est l'armure du joueur (av), et on ajoute les modificateurs positifs
   // Stunty : la valeur d'armure est réduite de 1 (plus fragile), ce qui rend la
   // cassure plus facile. S'applique toujours, cumulatif avec tout autre modificateur.
+  //
+  // BUG fix : avant, seul `Math.min(12, ...)` était appliqué (pas de min
+  // clamp). Si le total descendait à 0 ou négatif (debuffs cumulés),
+  // l'armure « tient » seulement si roll >= target, et 2D6 ≥ 2 toujours
+  // vrai → l'armure cassait dans 100% des cas mais avec une cible
+  // illisible. Clamper à `2` (le minimum atteignable par 2D6) garde
+  // le contrat « 2D6 >= target » cohérent.
   const stuntyAdjust = hasSkill(player, 'stunty') ? -1 : 0;
-  return Math.min(12, player.av + modifiers + stuntyAdjust);
+  return Math.max(2, Math.min(12, player.av + modifiers + stuntyAdjust));
 }
 
 /**

--- a/packages/game-engine/src/utils/referee.ts
+++ b/packages/game-engine/src/utils/referee.ts
@@ -37,7 +37,28 @@ export function validateMove(state: GameState, move: Move): ValidationResult {
     return { valid: false, errors, warnings };
   }
 
-  // END_TURN est toujours valide
+  // Vérifier les états pending AVANT le shortcut END_TURN.
+  //
+  // BUG fix : avant, le early-return `if (move.type === 'END_TURN')` arrivait
+  // ligne 41, AVANT les checks pending* (lignes 53-62). Le validator
+  // retournait donc `valid: true` pour un END_TURN soumis pendant qu'un
+  // pendingBlock/Push/FollowUp était ouvert, alors que le dispatcher
+  // principal rejette (avec raison). Désordre validator ↔ dispatcher :
+  // le caller croyait son END_TURN accepté puis voyait l'état inchangé.
+  if (state.pendingBlock && move.type !== 'BLOCK_CHOOSE') {
+    errors.push({ code: 'PENDING_BLOCK', message: 'Un choix de blocage est en attente' });
+  }
+  if (state.pendingPushChoice && move.type !== 'PUSH_CHOOSE') {
+    errors.push({ code: 'PENDING_PUSH', message: 'Un choix de poussée est en attente' });
+  }
+  if (state.pendingFollowUpChoice && move.type !== 'FOLLOW_UP_CHOOSE') {
+    errors.push({ code: 'PENDING_FOLLOWUP', message: 'Un choix de follow-up est en attente' });
+  }
+  if (errors.length > 0) {
+    return { valid: false, errors, warnings };
+  }
+
+  // END_TURN est toujours valide (en l'absence de pendings checked ci-dessus).
   if (move.type === 'END_TURN') {
     return { valid: true, errors, warnings };
   }
@@ -48,17 +69,6 @@ export function validateMove(state: GameState, move: Move): ValidationResult {
       errors.push({ code: 'NO_PENDING_REROLL', message: 'Aucune relance en attente' });
     }
     return { valid: errors.length === 0, errors, warnings };
-  }
-
-  // Vérifier les états pending
-  if (state.pendingBlock && move.type !== 'BLOCK_CHOOSE') {
-    errors.push({ code: 'PENDING_BLOCK', message: 'Un choix de blocage est en attente' });
-  }
-  if (state.pendingPushChoice && move.type !== 'PUSH_CHOOSE') {
-    errors.push({ code: 'PENDING_PUSH', message: 'Un choix de poussée est en attente' });
-  }
-  if (state.pendingFollowUpChoice && move.type !== 'FOLLOW_UP_CHOOSE') {
-    errors.push({ code: 'PENDING_FOLLOWUP', message: 'Un choix de follow-up est en attente' });
   }
 
   // Vérifier que le move est dans la liste des moves légaux


### PR DESCRIPTION
## Résumé

Trois bugs MEDIUM de robustesse / cohérence du flow.

| Fichier | Bug | Impact |
|---|---|---|
| `actions.ts` | Turnover gate rejetait BLOCK_CHOOSE / DUMP_OFF_CHOOSE | Softlock cascade Frenzy/Push |
| `utils/referee.ts` | END_TURN bypass pending checks (ordre incorrect) | Désordre validator ↔ dispatcher |
| `utils/dice.ts` | `calculateArmorTarget` sans min clamp | Cible illisible si debuffs cumulés |

## Test plan

- [x] `pnpm exec vitest run` (game-engine) : **4978/4978**
- [x] `pnpm exec turbo run typecheck` : OK
- 1 test existant ajusté (calculateArmorTarget min clamp comportement)

## Détails

### Turnover gate softlock (`actions.ts:167`)
Si un turnover était set après le jet de dés d'un BLOCK multi-dés mais AVANT que le coach choisisse (cascade Frenzy / chained Push), le dispatcher rejetait `BLOCK_CHOOSE` → seul `END_TURN` restait → **softlock** car le choix n'était jamais résolu.

Fix : `BLOCK_CHOOSE` et `DUMP_OFF_CHOOSE` ajoutés à la whitelist d'exceptions du turnover gate.

### `validateMove` order (`referee.ts:41-62`)
Avant : `if (move.type === 'END_TURN') return {valid: true}` arrivait **avant** les checks pendingBlock/Push/FollowUp. Le validator retournait `valid: true` pour un END_TURN soumis pendant qu'un pending était ouvert → désordre validator ↔ dispatcher (qui rejette le END_TURN).

Fix : pending checks d'abord, END_TURN shortcut ensuite.

### `calculateArmorTarget` min clamp (`dice.ts:73-74`)
Avant : `Math.min(12, av + modifiers + stuntyAdjust)` sans `Math.max`. Si les debuffs s'accumulaient (e.g. av=2, modifiers=-5 → -3), 2D6 ≥ target toujours vrai → armure cassait dans 100% des cas mais avec cible illisible (négative).

Fix : `Math.max(2, Math.min(12, ...))` — clamp aux extrêmes atteignables par 2D6.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_