### PR TITLE
fix(game-engine): Frenzy chain limitée + handleBlitz immutable (CRITICAL)

### DIFF
--- a/packages/game-engine/src/actions/blitz-handler-immutability.test.ts
+++ b/packages/game-engine/src/actions/blitz-handler-immutability.test.ts
@@ -1,0 +1,111 @@
+/**
+ * BUG fix : `handleBlitz` mutait directement `state.players[i].pos`,
+ * `.pm`, `.stunned`, `.hasBall` via index. Comme `handlePlayerSwitch`
+ * retourne `{...state, selectedPlayerId}`, `newState.players` est
+ * la MÊME référence que `state.players` — chaque mutation polluait le
+ * snapshot du caller (utilisé pour replay, history, undo).
+ *
+ * Ce test snapshote le state avant l'appel et vérifie que les
+ * propriétés clé restent inchangées dans le snapshot original après
+ * l'execution de handleBlitz, quel que soit le path traversé.
+ */
+import { describe, it, expect } from 'vitest';
+import type { GameState, Player, RNG } from '../core/types';
+import { handleBlitz } from './blitz-handler';
+
+const rng: RNG = () => 0.5;
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p',
+    team: 'A',
+    pos: { x: 5, y: 5 },
+    name: 'P',
+    number: 1,
+    position: 'Lineman',
+    ma: 6,
+    st: 3,
+    ag: 3,
+    pa: 4,
+    av: 8,
+    skills: [],
+    pm: 6,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    width: 26,
+    height: 15,
+    players: [],
+    currentPlayer: 'A',
+    turn: 1,
+    selectedPlayerId: null,
+    isTurnover: false,
+    apothecaryAvailable: { teamA: true, teamB: true },
+    dugouts: {
+      teamA: { reserves: [], ko: [], casualties: [] },
+      teamB: { reserves: [], ko: [], casualties: [] },
+    },
+    gamePhase: 'playing',
+    half: 1,
+    score: { teamA: 0, teamB: 0 },
+    teamNames: { teamA: 'A', teamB: 'B' },
+    teamRosters: { teamA: 'skaven', teamB: 'human' },
+    pm: 0,
+    gameLog: [],
+    playerActions: {},
+    teamBlitzCount: { A: 0, B: 0 },
+    teamFoulCount: { A: 0, B: 0 },
+    matchStats: {},
+    ...overrides,
+  } as unknown as GameState;
+}
+
+describe('handleBlitz — immutabilité du state d\'entree', () => {
+  it("ne mute pas state.players[i].pos lors d'un blitz reussi sans dodge", () => {
+    const attacker = makePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, pm: 6 });
+    const target = makePlayer({ id: 'B1', team: 'B', pos: { x: 7, y: 5 }, pm: 6 });
+    const state = makeState({ players: [attacker, target] });
+    const beforePos = { ...attacker.pos };
+    const beforePm = attacker.pm;
+
+    const next = handleBlitz(
+      state,
+      { type: 'BLITZ', playerId: 'A1', to: { x: 6, y: 5 }, targetId: 'B1' },
+      rng,
+    );
+
+    // Le state d'entree ne doit JAMAIS etre mute (immutabilite stricte).
+    expect(state.players[0].pos).toEqual(beforePos);
+    expect(state.players[0].pm).toBe(beforePm);
+    // Le state retourne doit refleter le mouvement (si le blitz a ete legal).
+    // Si le blitz est illegal, next === state apres handlePlayerSwitch — on
+    // verifie juste qu'on n'a pas casse le snapshot.
+    expect(next).toBeDefined();
+  });
+
+  it("ne mute pas state.players quand le blitz est legal et le mouvement applique", () => {
+    // Configuration ou le blitz est legal : attacker adjacent a target apres
+    // mouvement, attaquant peut se deplacer.
+    const attacker = makePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, pm: 6 });
+    const target = makePlayer({ id: 'B1', team: 'B', pos: { x: 7, y: 5 }, pm: 6 });
+    const state = makeState({
+      players: [attacker, target],
+      currentPlayer: 'A',
+      teamBlitzCount: { A: 0, B: 0 },
+    });
+    // Capture profonde des champs muables.
+    const snapshotPlayer = JSON.parse(JSON.stringify(state.players[0]));
+
+    handleBlitz(
+      state,
+      { type: 'BLITZ', playerId: 'A1', to: { x: 6, y: 5 }, targetId: 'B1' },
+      rng,
+    );
+
+    // Apres l'appel : le state d'entree doit etre intact.
+    expect(JSON.parse(JSON.stringify(state.players[0]))).toEqual(snapshotPlayer);
+  });
+});

--- a/packages/game-engine/src/actions/blitz-handler.ts
+++ b/packages/game-engine/src/actions/blitz-handler.ts
@@ -117,20 +117,33 @@ export function handleBlitz(
     );
     newState.gameLog = [...newState.gameLog, dodgeLogEntry];
 
-    // Le joueur se déplace toujours, que le jet d'esquive réussisse ou échoue
-    const attackerIdx = newState.players.findIndex(p => p.id === attacker.id);
-    newState.players[attackerIdx].pos = { ...to };
-
     // BB rule : le coût en PM d'un déplacement est la distance Chebyshev
     // (king-move) — 1 PM par case adjacente, diagonales incluses. Avant ce
     // fix, on utilisait la distance Manhattan (|dx| + |dy|) qui comptait
     // un déplacement diagonal comme 2 PM au lieu d'1. `getLegalMoves` énumère
     // pourtant les 8 directions comme BLITZ steps single-PM.
     const distance = Math.max(Math.abs(from.x - to.x), Math.abs(from.y - to.y));
-    newState.players[attackerIdx].pm = Math.max(0, newState.players[attackerIdx].pm - distance);
+    // BUG fix : `handlePlayerSwitch` retourne `{...state, selectedPlayerId}`
+    // donc `newState.players` est la MÊME référence que `state.players`.
+    // Toute mutation via `newState.players[i].x = ...` casse l'invariant
+    // d'immutabilite et corrompt le state du caller (les autres joueurs
+    // gardent un alias vers le snapshot d'avant). On remplace par un
+    // `map` qui produit une nouvelle copie du joueur deplacé.
+    newState = {
+      ...newState,
+      players: newState.players.map((p) =>
+        p.id === attacker.id
+          ? { ...p, pos: { ...to }, pm: Math.max(0, p.pm - distance) }
+          : p,
+      ),
+    };
 
     // Shadowing : tentative de suivi après le mouvement (BB3).
     newState = resolveShadowingAfterDodge(newState, attacker, from, rng);
+
+    // Re-resolve l'attaquant apres shadowing (pos peut avoir change).
+    const attackerAfterMove = newState.players.find((p) => p.id === attacker.id);
+    if (!attackerAfterMove) return newState;
 
     // Break Tackle (BB3): +1/+2 une fois par activation sur un Dodge raté
     // pendant un Blitz.
@@ -138,7 +151,7 @@ export function handleBlitz(
     if (!blitzDodgeSuccess) {
       const breakTackleCheck = checkBreakTackle(
         newState,
-        newState.players[attackerIdx],
+        attackerAfterMove,
         dodgeResult.diceRoll,
         dodgeResult.targetNumber,
         dodgeResult.success
@@ -151,48 +164,63 @@ export function handleBlitz(
 
     if (blitzDodgeSuccess) {
       // Si le joueur porte la balle et atteint l'en-but adverse -> touchdown
-      const mover = newState.players[attackerIdx];
-      if (mover.hasBall && isInOpponentEndzone(newState, mover)) {
+      const mover = newState.players.find((p) => p.id === attacker.id);
+      if (mover && mover.hasBall && isInOpponentEndzone(newState, mover)) {
         return awardTouchdown(newState, mover.team, mover);
       }
     } else {
       // Jet d'esquive échoué : le joueur chute et doit faire un jet d'armure
-      newState.isTurnover = true;
-
       // Vérifier si le joueur avait le ballon AVANT de le mettre à terre
-      const hadBall = newState.players[attackerIdx].hasBall;
+      const beforeFall = newState.players.find((p) => p.id === attacker.id);
+      if (!beforeFall) return newState;
+      const hadBall = beforeFall.hasBall;
 
-      // Le joueur chute (est mis à terre)
-      newState.players[attackerIdx].stunned = true;
+      // Le joueur chute (est mis à terre) — immutable update.
+      newState = {
+        ...newState,
+        isTurnover: true,
+        players: newState.players.map((p) =>
+          p.id === attacker.id ? { ...p, stunned: true } : p,
+        ),
+      };
+
+      const downed = newState.players.find((p) => p.id === attacker.id);
+      if (!downed) return newState;
 
       // Effectuer le jet d'armure
-      const armorResult = performArmorRollWithNotification(newState.players[attackerIdx], rng);
-      newState.lastDiceResult = armorResult;
+      const armorResult = performArmorRollWithNotification(downed, rng);
+      newState = { ...newState, lastDiceResult: armorResult };
 
       // Log du jet d'armure
       const armorLogEntry = createLogEntry(
         'dice',
         `Jet d'armure (Blitz échoué): ${armorResult.diceRoll}/${armorResult.targetNumber} ${armorResult.success ? '✓' : '✗'}`,
-        newState.players[attackerIdx].id,
-        newState.players[attackerIdx].team,
+        downed.id,
+        downed.team,
         {
           diceRoll: armorResult.diceRoll,
           targetNumber: armorResult.targetNumber,
           success: armorResult.success,
         }
       );
-      newState.gameLog = [...newState.gameLog, armorLogEntry];
+      newState = { ...newState, gameLog: [...newState.gameLog, armorLogEntry] };
 
       // Si l'armure est percée (success = false), faire un jet de blessure
       if (!armorResult.success) {
-        newState = performInjuryRoll(newState, newState.players[attackerIdx], rng);
+        newState = performInjuryRoll(newState, downed, rng);
       }
 
       // Si le joueur avait le ballon, il le perd et le ballon rebondit
       // (même si l'armure n'est pas percée, le joueur chute et perd le ballon)
       if (hadBall) {
-        newState.players[attackerIdx].hasBall = false;
-        newState.ball = { ...newState.players[attackerIdx].pos };
+        const ballPos = { ...downed.pos };
+        newState = {
+          ...newState,
+          ball: ballPos,
+          players: newState.players.map((p) =>
+            p.id === attacker.id ? { ...p, hasBall: false } : p,
+          ),
+        };
 
         // Log de la perte de ballon
         const ballLossLogEntry = createLogEntry(
@@ -201,7 +229,7 @@ export function handleBlitz(
           attacker.id,
           attacker.team
         );
-        newState.gameLog = [...newState.gameLog, ballLossLogEntry];
+        newState = { ...newState, gameLog: [...newState.gameLog, ballLossLogEntry] };
 
         // Faire rebondir le ballon depuis la position du joueur
         return bounceBall(newState, rng);
@@ -213,18 +241,21 @@ export function handleBlitz(
       return newState;
     }
   } else {
-    // Pas de jet d'esquive nécessaire, déplacer directement
-    const attackerIdx = newState.players.findIndex(p => p.id === attacker.id);
-    newState.players[attackerIdx].pos = { ...to };
-
+    // Pas de jet d'esquive nécessaire, déplacer directement (immutable).
     // BB rule : distance Chebyshev (king-move) — 1 PM par case adjacente.
-    // Cf. commentaire au-dessus pour le bug fix Manhattan → Chebyshev.
     const distance = Math.max(Math.abs(from.x - to.x), Math.abs(from.y - to.y));
-    newState.players[attackerIdx].pm = Math.max(0, newState.players[attackerIdx].pm - distance);
+    newState = {
+      ...newState,
+      players: newState.players.map((p) =>
+        p.id === attacker.id
+          ? { ...p, pos: { ...to }, pm: Math.max(0, p.pm - distance) }
+          : p,
+      ),
+    };
 
     // Si le joueur porte la balle et atteint l'en-but adverse -> touchdown
-    const mover = newState.players[attackerIdx];
-    if (mover.hasBall && isInOpponentEndzone(newState, mover)) {
+    const mover = newState.players.find((p) => p.id === attacker.id);
+    if (mover && mover.hasBall && isInOpponentEndzone(newState, mover)) {
       return awardTouchdown(newState, mover.team, mover);
     }
   }

--- a/packages/game-engine/src/actions/block-action.ts
+++ b/packages/game-engine/src/actions/block-action.ts
@@ -51,8 +51,17 @@ export function resolveFrenzyBlock(state: GameState, rng: RNG): GameState {
   const attacker = state.players.find((p) => p.id === attackerId);
   const target = state.players.find((p) => p.id === targetId);
 
-  // Consommer le pending
-  const next: GameState = { ...state, pendingFrenzyBlock: undefined };
+  // BB2020 : marquer l'attaquant comme ayant deja consomme son second bloc
+  // Frenzy. handlePushBack lira ce flag et N'ARMERA PAS pendingFrenzyBlock
+  // pour un troisieme bloc en cas de second PUSH_BACK.
+  const alreadyTriggered = state.frenzySecondBlockTriggered ?? [];
+  const next: GameState = {
+    ...state,
+    pendingFrenzyBlock: undefined,
+    frenzySecondBlockTriggered: alreadyTriggered.includes(attackerId)
+      ? alreadyTriggered
+      : [...alreadyTriggered, attackerId],
+  };
 
   // Conditions pour le second bloc : attaquant et cible debout et adjacents
   if (!attacker || !target) return next;

--- a/packages/game-engine/src/actions/turn-foul-actions.ts
+++ b/packages/game-engine/src/actions/turn-foul-actions.ts
@@ -147,6 +147,7 @@ export function handleEndTurn(state: GameState, rng: RNG): GameState {
     pendingDumpOff: undefined,
     pendingMultipleBlock: undefined,
     pendingFrenzyBlock: undefined,
+    frenzySecondBlockTriggered: [],
     pendingOnTheBall: undefined,
     pendingKickoffEvent: undefined,
   };

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -298,6 +298,12 @@ export interface GameState {
     attackerId: string;
     targetId: string;
   };
+  // BB2020 : Frenzy donne EXACTEMENT un second bloc par action Block,
+  // jamais un troisième. Cette liste contient les attackerIds qui ont
+  // déjà déclenché leur second bloc Frenzy dans la séquence en cours.
+  // Reset au changement de tour (END_TURN). Avant ce flag, une suite
+  // de PUSH_BACK déclenchait un 3e, 4e, … bloc en chaîne infinie.
+  frenzySecondBlockTriggered?: string[];
   // On the Ball en attente : un joueur adverse peut réagir avant la passe.
   pendingOnTheBall?: {
     passerTeam: TeamId;

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -1054,7 +1054,12 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
 
     // Fend : verifier avant la poussee (la cible doit etre debout)
     const fendActive = isFendActiveForFollowUp(state, attacker, target);
-    const frenzyActive = hasFrenzy(attacker);
+    // BB2020 : Frenzy donne EXACTEMENT un second bloc par action Block.
+    // Si l'attaquant a deja consomme ce bonus dans la sequence en cours,
+    // ne pas armer un nouveau pendingFrenzyBlock (sinon chaine infinie).
+    const frenzyAlreadyConsumed =
+      state.frenzySecondBlockTriggered?.includes(attacker.id) ?? false;
+    const frenzyActive = hasFrenzy(attacker) && !frenzyAlreadyConsumed;
 
     state = applyChainPush(state, target.id, pushDirection, rng);
 
@@ -1114,8 +1119,11 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
       targetStrength: 2,
     };
     // Frenzy : marquer le second bloc en attente pour après le choix de
-    // direction + follow-up automatique
-    if (hasFrenzy(attacker)) {
+    // direction + follow-up automatique. BB2020 : pas de troisième bloc
+    // si le second a déjà été consommé dans la séquence en cours.
+    const frenzyAlreadyConsumedMulti =
+      state.frenzySecondBlockTriggered?.includes(attacker.id) ?? false;
+    if (hasFrenzy(attacker) && !frenzyAlreadyConsumedMulti) {
       state.pendingFrenzyBlock = {
         attackerId: attacker.id,
         targetId: target.id,

--- a/packages/game-engine/src/mechanics/frenzy-no-third-block.test.ts
+++ b/packages/game-engine/src/mechanics/frenzy-no-third-block.test.ts
@@ -1,0 +1,126 @@
+/**
+ * BB2020 : Frenzy donne EXACTEMENT un second bloc par action Block,
+ * jamais un troisième même si le second produit aussi un PUSH_BACK.
+ *
+ * Avant le fix, `handlePushBack` armait `pendingFrenzyBlock` à chaque
+ * fois que `hasFrenzy(attacker)` était vrai. Une suite de PUSH_BACK
+ * (premier bloc → second bloc → troisième bloc → …) déclenchait donc
+ * une chaîne infinie de blocs.
+ *
+ * Fix : la séquence trace les attackerIds qui ont déjà consommé leur
+ * second bloc Frenzy dans le tour courant via
+ * `state.frenzySecondBlockTriggered`. handlePushBack ne réarme plus
+ * pendingFrenzyBlock pour ces attackers.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { resolveBlockResult } from './blocking';
+import { resolveFrenzyBlock } from '../actions/block-action';
+import type { GameState, RNG } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+function placeAttackerWithFrenzy(base: GameState): GameState {
+  return {
+    ...base,
+    players: base.players.map((p) => {
+      if (p.id === 'A2')
+        return { ...p, pos: { x: 10, y: 7 }, stunned: false, pm: 6, skills: ['frenzy'] };
+      if (p.id === 'B2')
+        return { ...p, pos: { x: 11, y: 7 }, stunned: false, pm: 6, skills: [] };
+      return { ...p, pos: { x: 1, y: p.team === 'A' ? 1 : 14 }, stunned: false, pm: 6 };
+    }),
+    currentPlayer: 'A',
+  };
+}
+
+function makeBlockResult(result: 'PUSH_BACK') {
+  return {
+    type: 'block' as const,
+    playerId: 'A2',
+    targetId: 'B2',
+    diceRoll: 3,
+    result,
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+describe('Frenzy — pas de troisième bloc', () => {
+  it("apres un premier PUSH_BACK, pendingFrenzyBlock est marque puis consomme par resolveFrenzyBlock", () => {
+    const base = setup();
+    const state = placeAttackerWithFrenzy(base);
+
+    const result = resolveBlockResult(state, makeBlockResult('PUSH_BACK'), makeRNG([0.5]));
+
+    expect(result.pendingFrenzyBlock).toBeDefined();
+    expect(result.pendingFrenzyBlock?.attackerId).toBe('A2');
+    // Le flag n'est pas encore set tant que resolveFrenzyBlock n'a pas tourne.
+    expect(result.frenzySecondBlockTriggered).toBeFalsy();
+  });
+
+  it("apres resolveFrenzyBlock, l'attaquant est dans frenzySecondBlockTriggered", () => {
+    const base = setup();
+    // RNG queue : 0.5 pour la resolution du bloc unique (1 die seul, force 3v3 → 1 die).
+    // floor(0.5*6)+1 = 4 → PUSH_BACK.
+    // Mais en pratique resolveFrenzyBlock execute handleBlock qui peut roller plusieurs des.
+    // On verifie juste que la liste contient A2 apres l'appel.
+    const state: GameState = {
+      ...placeAttackerWithFrenzy(base),
+      pendingFrenzyBlock: { attackerId: 'A2', targetId: 'B2' },
+    };
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+
+    const result = resolveFrenzyBlock(state, rng);
+
+    expect(result.frenzySecondBlockTriggered).toBeDefined();
+    expect(result.frenzySecondBlockTriggered).toContain('A2');
+  });
+
+  it("si le second bloc produit aussi PUSH_BACK, pendingFrenzyBlock n'est PAS rearme (single direction)", () => {
+    const base = setup();
+    const state: GameState = {
+      ...placeAttackerWithFrenzy(base),
+      // Simule l'etat apres execution du 2nd bloc Frenzy : flag deja set
+      frenzySecondBlockTriggered: ['A2'],
+    };
+
+    // resolveBlockResult(PUSH_BACK) avec A2 deja dans la liste : ne doit
+    // pas reset pendingFrenzyBlock.
+    const result = resolveBlockResult(state, makeBlockResult('PUSH_BACK'), makeRNG([0.5]));
+
+    expect(result.pendingFrenzyBlock).toBeUndefined();
+  });
+
+  it("idem en multi-direction push : pas de pendingFrenzyBlock si deja consomme", () => {
+    const base = setup();
+    // Bord (x=0,y=0) avec attacker en (1,1) target en (0,0) → seulement
+    // quelques directions valides. On cree une scene simple avec
+    // adjacents bloquees pour forcer le multi-direction.
+    const state: GameState = {
+      ...base,
+      players: base.players.map((p) => {
+        if (p.id === 'A2') return { ...p, pos: { x: 5, y: 5 }, stunned: false, skills: ['frenzy'] };
+        if (p.id === 'B2') return { ...p, pos: { x: 6, y: 5 }, stunned: false, skills: [] };
+        return { ...p, pos: { x: 1, y: p.team === 'A' ? 1 : 14 }, stunned: false };
+      }),
+      currentPlayer: 'A',
+      frenzySecondBlockTriggered: ['A2'],
+    };
+
+    const result = resolveBlockResult(state, makeBlockResult('PUSH_BACK'), makeRNG([0.5]));
+
+    // Quelle que soit la branche (single ou multi direction), pendingFrenzyBlock
+    // ne doit pas etre reset apres une consommation deja en cours.
+    expect(result.pendingFrenzyBlock).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Deux bugs **CRITIQUES** détectés par l'audit complet :

### 1. Frenzy infinite chain (`mechanics/blocking.ts:handlePushBack`)

`handlePushBack` armait `pendingFrenzyBlock` à chaque PUSH_BACK tant que `hasFrenzy(attacker)` était vrai. Une suite de PUSH_BACK (premier bloc → second bloc → troisième bloc → …) déclenchait donc une chaîne infinie de blocs.

**BB2020 rule** : Frenzy donne EXACTEMENT un second bloc par action Block, jamais un troisième même si le second produit aussi un PUSH_BACK. Le commentaire `frenzy.test.ts:16` documentait cette invariante mais n'était pas enforced.

**Fix** :
- Nouveau champ `GameState.frenzySecondBlockTriggered?: string[]` (liste des attackerIds ayant déjà consommé leur second bloc).
- `resolveFrenzyBlock` ajoute l'attaquant à la liste avant de déclencher le 2e bloc.
- `handlePushBack` ne réarme PAS `pendingFrenzyBlock` si l'attaquant est dans la liste (single et multi direction).
- Reset au changement de tour (`handleEndTurn`).

### 2. handleBlitz mutations sur state partagé (`actions/blitz-handler.ts`)

`handlePlayerSwitch` retourne `{...state, selectedPlayerId}` donc `newState.players` est la MÊME référence que `state.players`. Toutes les mutations via :
- `newState.players[idx].pos = ...` (lignes 122, 218)
- `newState.players[idx].pm = ...` (lignes 130, 223)
- `newState.players[idx].stunned = ...` (ligne 166)
- `newState.players[idx].hasBall = ...` (ligne 194)

… corrompaient directement le snapshot du caller (replay, history, undo) et violaient l'invariant d'immutabilité documenté dans CLAUDE.md.

**Fix** : remplace chaque mutation par `players.map(...)` immutable, et chaque réaffectation de champ root par un spread sur `newState`.

## Test plan

- [x] **Frenzy** : `mechanics/frenzy-no-third-block.test.ts` (4 tests)
  - [x] Premier PUSH_BACK arme `pendingFrenzyBlock`, flag pas encore set
  - [x] Après `resolveFrenzyBlock`, attacker dans `frenzySecondBlockTriggered`
  - [x] Si flag déjà set, deuxième PUSH_BACK ne réarme pas `pendingFrenzyBlock` (single direction)
  - [x] Idem multi-direction
- [x] **Blitz immutabilité** : `actions/blitz-handler-immutability.test.ts` (2 tests)
  - [x] State d'entrée intact après un blitz sans dodge
  - [x] Snapshot JSON deep equality verifié pour fields muables
- [x] Tous les tests existants passent : 4990 tests game-engine + 416 sim-engine
- [x] Typecheck OK sur les deux engines

🔧 Premier PR d'une série de 6 visant les ~58 bugs identifiés dans l'audit récent. Suivants : foul corrections, TZ filter remaining sites, combat misc, kickoff/inducements, skills/utils.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_