### PR TITLE
fix(game-engine,sim-engine): corrections BB2020 sur les fouls

### DIFF
--- a/packages/game-engine/src/mechanics/foul-bb2020-rules.test.ts
+++ b/packages/game-engine/src/mechanics/foul-bb2020-rules.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Foul BB2020 / BB3 — corrections de règles :
+ *  1. Defensive assists adjacent au FOULEUR (pas à la victime).
+ *  2. Send-off déclenché aussi par doublet sur le jet de blessure
+ *     (pas seulement sur l'armor roll).
+ */
+import { describe, it, expect } from 'vitest';
+import { setup, applyMove } from '../index';
+import { calculateFoulAssists } from './foul';
+import type { GameState, RNG, Move, Player } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 0, y: 0 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, hasBall: false, state: 'active',
+    ...over,
+  };
+}
+
+function makeFoulState(players: Player[]): GameState {
+  const s = setup();
+  return {
+    ...s,
+    players,
+    ball: { x: 5, y: 5 },
+    currentPlayer: 'A',
+    playerActions: {},
+    teamFoulCount: {},
+  };
+}
+
+describe('calculateFoulAssists — defensive adjacents au FOULEUR (BB2020)', () => {
+  it("defensive assists comptent les adverses adjacents au fouleur (et non à la victime)", () => {
+    // A1 fouler (10,7), A2 helper (10,6) adjacent victim et fouler.
+    // B1 victim (11,7) stunned. B2 defender (9,8) adjacent FOULEUR seulement.
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Fouler' }),
+      basePlayer({ id: 'A2', team: 'A', pos: { x: 10, y: 6 }, name: 'Helper' }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Victim', stunned: true, pm: 0 }),
+      basePlayer({ id: 'B2', team: 'B', pos: { x: 9, y: 8 }, name: 'Defender' }),
+    ];
+    const state = makeFoulState(players);
+
+    // Offensifs : A2 adjacent à B1(victim) → +1
+    // Defensifs (BB2020) : B2 adjacent à A1(fouler) → -1
+    // Total : 0
+    const assists = calculateFoulAssists(state, players[0], players[2]);
+    expect(assists).toBe(0);
+  });
+
+  it("defensive assists n'incluent PAS un adverse adjacent à la victime mais loin du fouleur", () => {
+    // B2 defender (12,7) adjacent VICTIME seulement (pas au fouleur (10,7)).
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Fouler' }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Victim', stunned: true, pm: 0 }),
+      basePlayer({ id: 'B2', team: 'B', pos: { x: 12, y: 7 }, name: 'Defender' }),
+    ];
+    const state = makeFoulState(players);
+
+    // B2 n'est PAS adjacent au fouleur (distance Chebyshev=2). Pas de defensive assist.
+    const assists = calculateFoulAssists(state, players[0], players[1]);
+    expect(assists).toBe(0);
+  });
+
+  it("offensive assists comptent les amis adjacents à la VICTIME (et non au fouleur)", () => {
+    // A2 helper (12,6) adjacent VICTIME (11,7) seulement.
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Fouler' }),
+      basePlayer({ id: 'A2', team: 'A', pos: { x: 12, y: 6 }, name: 'Helper' }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Victim', stunned: true, pm: 0 }),
+    ];
+    const state = makeFoulState(players);
+
+    // A2 adjacent à victim → +1, pas de defenders → 0
+    const assists = calculateFoulAssists(state, players[0], players[2]);
+    expect(assists).toBe(1);
+  });
+});
+
+describe('Foul send-off — doublet sur ARMOR ou INJURY (BB2020)', () => {
+  function makeStateForSendOff(): GameState {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Fouler', av: 7 }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Victim', av: 7, stunned: true, pm: 0 }),
+    ];
+    return makeFoulState(players);
+  }
+
+  it("send-off si doublet sur INJURY (armor pas doublet)", () => {
+    // floor(rng*6)+1 : 0.83→5, 0.5→4, 0.4→3, 0.16→1
+    // Armor : die1=5 (0.83), die2=4 (0.5). 5+4=9 ≥ 7 broken. Pas doublet.
+    // Injury : die1=3 (0.4), die2=3 (0.4). 3+3=6 stunned. Doublet → expulsion.
+    const state = makeStateForSendOff();
+    const rng = makeRNG([0.83, 0.5, 0.4, 0.4, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find((p) => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+  });
+
+  it("PAS de send-off si ni armor ni injury en doublet (armure brisée)", () => {
+    // Armor : die1=5 (0.83), die2=4 (0.5). 9 broken, pas doublet.
+    // Injury : die1=3 (0.4), die2=4 (0.5). 7 stunned, pas doublet.
+    const state = makeStateForSendOff();
+    const rng = makeRNG([0.83, 0.5, 0.4, 0.5, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find((p) => p.id === 'A1')!;
+    expect(fouler.state).not.toBe('sent_off');
+  });
+
+  it("send-off si doublet sur ARMOR (comportement préservé)", () => {
+    // Armor : die1=4 (0.5), die2=4 (0.5). Doublet 4-4 = 8 ≥ 7 broken.
+    const state = makeStateForSendOff();
+    const rng = makeRNG([0.5, 0.5, 0.4, 0.5, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find((p) => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+  });
+});

--- a/packages/game-engine/src/mechanics/foul.ts
+++ b/packages/game-engine/src/mechanics/foul.ts
@@ -33,12 +33,21 @@ export function canFoul(state: GameState, attacker: Player, target: Player): boo
 }
 
 /**
- * Calcule les assists de foul (joueurs amis adjacents à la cible - joueurs adverses adjacents à la cible)
+ * Calcule les assists de foul (BB2020 / BB3) :
+ *  - Offensifs : joueurs amis (hors fouleur) adjacents à la VICTIME → +1 chacun.
+ *  - Défensifs : joueurs adverses (hors victime) adjacents au FOULEUR → -1 chacun.
+ *
+ * BUG fix : avant, les défensifs étaient comptés adjacents à la VICTIME
+ * (la même position que les offensifs). Sous-estimation des modificateurs
+ * négatifs quand un défenseur entoure le fouleur sans entourer la victime.
+ * Source : BB2020 LRB "Fouls" §p.65 — "each team-mate of the fouler
+ * adjacent to the player being fouled adds +1 ; each team-mate of the
+ * victim adjacent to the fouler subtracts -1."
  */
 export function calculateFoulAssists(state: GameState, attacker: Player, target: Player): number {
   let assists = 0;
 
-  // Joueurs amis adjacents à la cible (hors attaquant)
+  // Offensifs : amis adjacents à la VICTIME (hors fouleur)
   for (const player of state.players) {
     if (player.id === attacker.id) continue;
     if (player.team !== attacker.team) continue;
@@ -48,12 +57,12 @@ export function calculateFoulAssists(state: GameState, attacker: Player, target:
     }
   }
 
-  // Joueurs adverses adjacents à la cible (défenseurs, hors la cible elle-même)
+  // Défensifs : adverses adjacents au FOULEUR (hors victime)
   for (const player of state.players) {
     if (player.id === target.id) continue;
     if (player.team !== target.team) continue;
     if (player.stunned || player.state === 'knocked_out' || player.state === 'casualty') continue;
-    if (isAdjacent(player.pos, target.pos)) {
+    if (isAdjacent(player.pos, attacker.pos)) {
       assists -= 1;
     }
   }
@@ -105,23 +114,40 @@ export function executeFoul(
   );
   newState.gameLog = [...newState.gameLog, armorLog];
 
-  // Vérifier l'expulsion AVANT d'appliquer la blessure (doublet sur les dés bruts)
-  const isDoubles = die1 === die2;
+  // Doublet armor (sur les dés bruts) — check pour expulsion.
+  const armorDoubles = die1 === die2;
 
+  // BB2020 : si l'armure casse, jet de blessure. Roule les dés ICI pour
+  // pouvoir tester le doublet sur le jet d'injury et déclencher
+  // l'expulsion (BB rule : doubles sur armor OR injury → fouleur expulsé).
+  // Avant ce fix, seul le doublet armor déclenchait l'expulsion ; les
+  // doublets injury (3-3, 4-4 etc.) étaient ignorés.
+  let injuryDoubles = false;
   if (armorBroken) {
-    // Jet de blessure (l'attaquant est crédité pour la casualty)
+    const injuryDie1 = rollD6(rng);
+    const injuryDie2 = rollD6(rng);
+    injuryDoubles = injuryDie1 === injuryDie2;
     const targetPlayer = newState.players.find(p => p.id === target.id)!;
-    newState = performInjuryRoll(newState, targetPlayer, rng, 0, attacker.id);
+    newState = performInjuryRoll(
+      newState,
+      targetPlayer,
+      rng,
+      0,
+      attacker.id,
+      [injuryDie1, injuryDie2],
+    );
   }
 
+  const isDoubles = armorDoubles || injuryDoubles;
   // Expulsion si doublet, sauf si l'attaquant possede Sneaky Git
   const sneakyGit = isSneakyGitActive(newState, attacker);
   if (isDoubles && !sneakyGit) {
     const attackerPlayer = newState.players.find(p => p.id === attacker.id);
     if (attackerPlayer) {
+      const doublesSource = armorDoubles ? 'armure' : 'blessure';
       const expulsionLog = createLogEntry(
         'action',
-        `Doublet (${die1}-${die2}) ! ${attacker.name} est expulsé par l'arbitre !`,
+        `Doublet ${doublesSource} ! ${attacker.name} est expulsé par l'arbitre !`,
         attacker.id,
         attacker.team
       );
@@ -131,7 +157,7 @@ export function executeFoul(
   } else if (isDoubles && sneakyGit) {
     const sneakyLog = createLogEntry(
       'action',
-      `Doublet (${die1}-${die2}) ! ${attacker.name} evite l'expulsion grâce à Sneaky Git.`,
+      `Doublet ! ${attacker.name} evite l'expulsion grâce à Sneaky Git.`,
       attacker.id,
       attacker.team
     );

--- a/packages/game-engine/src/mechanics/injury.ts
+++ b/packages/game-engine/src/mechanics/injury.ts
@@ -25,14 +25,29 @@ function armoredSkullModifier(player: Player): number {
  * @param state - État du jeu
  * @param player - Joueur blessé
  * @param rng - Générateur de nombres aléatoires
+ * @param bonus - Bonus de jet (Mighty Blow, etc.)
+ * @param causedById - ID du joueur causant la blessure
+ * @param preRolledDice - Dés pre-rollés (utilisé par foul pour check doubles)
  * @returns Nouvel état du jeu après le jet de blessure
  */
-export function performInjuryRoll(state: GameState, player: Player, rng: RNG, bonus: number = 0, causedById?: string): GameState {
+export function performInjuryRoll(
+  state: GameState,
+  player: Player,
+  rng: RNG,
+  bonus: number = 0,
+  causedById?: string,
+  preRolledDice?: [number, number],
+): GameState {
   const newState = structuredClone(state) as GameState;
 
   // Jet de 2D6 pour la blessure (+ bonus de Mighty Blow éventuel, - Armored Skull si applicable)
+  // BUG fix : foul send-off check requires access to the raw injury dice
+  // (doubles sur ARMOR or INJURY → expulsion BB2020). Pre-rolled dice
+  // peuvent etre fournies par `executeFoul` pour conserver les valeurs.
+  const die1 = preRolledDice ? preRolledDice[0] : Math.floor(rng() * 6) + 1;
+  const die2 = preRolledDice ? preRolledDice[1] : Math.floor(rng() * 6) + 1;
   const armoredSkullMod = armoredSkullModifier(player);
-  const injuryRoll = Math.floor(rng() * 6) + 1 + Math.floor(rng() * 6) + 1 + bonus + armoredSkullMod;
+  const injuryRoll = die1 + die2 + bonus + armoredSkullMod;
 
   // Log du jet de blessure
   const injuryLog = createLogEntry(
@@ -40,7 +55,7 @@ export function performInjuryRoll(state: GameState, player: Player, rng: RNG, bo
     `Jet de blessure: ${injuryRoll}`,
     player.id,
     player.team,
-    { injuryRoll }
+    { injuryRoll, die1, die2 }
   );
   newState.gameLog = [...newState.gameLog, injuryLog];
 

--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,6 +1,6 @@
 {
-  "engineVer": "0.22.0",
-  "snapshotAt": "2026-05-17",
+  "engineVer": "0.23.0",
+  "snapshotAt": "2026-05-18",
   "tolerance": 0.05,
   "pairings": [
     {
@@ -24,12 +24,12 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.65,
-        "tdStd": 1.1034038245356965,
-        "casualtyMean": 1.13,
-        "turnoverMean": 5.255,
-        "homeWinRate": 0.76,
-        "awayWinRate": 0.045,
+        "tdMean": 1.685,
+        "tdStd": 1.098077866091471,
+        "casualtyMean": 1.115,
+        "turnoverMean": 5.33,
+        "homeWinRate": 0.765,
+        "awayWinRate": 0.04,
         "drawRate": 0.195
       }
     },
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.665,
-        "tdStd": 1.0405647505081077,
-        "casualtyMean": 0.96,
-        "turnoverMean": 4.33,
-        "homeWinRate": 0.32,
-        "awayWinRate": 0.375,
-        "drawRate": 0.305
+        "tdMean": 1.605,
+        "tdStd": 1.0143840495591403,
+        "casualtyMean": 0.955,
+        "turnoverMean": 4.43,
+        "homeWinRate": 0.37,
+        "awayWinRate": 0.355,
+        "drawRate": 0.275
       }
     }
   ]

--- a/packages/sim-engine/src/resolvers/foul.ts
+++ b/packages/sim-engine/src/resolvers/foul.ts
@@ -141,7 +141,12 @@ export function resolveFoul(
   const sentOff = armorDoubles || injuryDoubles;
 
   if (sentOff) {
-    newState = updatePlayer(newState, fouler.id, { state: 'casualty' });
+    // BUG fix : utiliser `sent_off` (BB2020 expulsion) au lieu de
+    // `casualty`. Le joueur expulsé n'est PAS blessé — il sort
+    // définitivement pour la mi-temps en cours sans jet apothecary.
+    // Avant le fix, le `casualty` faussait les stats de victimes et
+    // ouvrait la voie à un apothecary erroné côté driver.
+    newState = updatePlayer(newState, fouler.id, { state: 'sent_off' });
   }
 
   events.unshift({

--- a/packages/sim-engine/src/resolvers/types.ts
+++ b/packages/sim-engine/src/resolvers/types.ts
@@ -24,8 +24,12 @@ import type { Rng } from '../rng/seeded';
 export type ResolverSide = 'home' | 'away';
 
 /** Minimal set of player states the resolvers care about. The driver
- *  expands this when needed (e.g. `ko` / `casualty` for benching). */
-export type ResolverPlayerState = 'standing' | 'prone' | 'stunned' | 'ko' | 'casualty';
+ *  expands this when needed (e.g. `ko` / `casualty` for benching).
+ *  `sent_off` : foul expulsion par l'arbitre (BB2020 doubles on armor or
+ *  injury). Distinct de `casualty` car le joueur n'est PAS blessé et
+ *  ne peut pas être ramené par un apothecary — il sort définitivement
+ *  pour la mi-temps en cours. */
+export type ResolverPlayerState = 'standing' | 'prone' | 'stunned' | 'ko' | 'casualty' | 'sent_off';
 
 export type ResolverWeather =
   | 'nice'

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.22.0';
+export const ENGINE_VER = '0.23.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Summary

Trois bugs sur la mécanique de faute (foul) :

### 1. `game-engine/mechanics/foul.ts:calculateFoulAssists`

Les défensifs étaient comptés adjacents à la **VICTIME** au lieu du **FOULEUR**. Sous-estimation des modificateurs négatifs quand un défenseur entoure le fouleur sans entourer la victime.

**BB2020 LRB "Fouls" §p.65** : "each team-mate of the fouler adjacent to the player being fouled adds +1 ; each team-mate of the victim adjacent to the fouler subtracts -1."

### 2. `game-engine/mechanics/foul.ts:executeFoul`

L'expulsion ne se déclenchait que sur un doublet ARMOR. BB2020 dit "doubles on the Armour Roll OR the Injury Roll" envoie au vestiaire.

**Refactor** : `performInjuryRoll` accepte des dés pré-rollés via paramètre optionnel `preRolledDice`. `executeFoul` roule les dés d'injury lui-même pour pouvoir tester le doublet avant de déclencher le send-off.

### 3. `sim-engine/resolvers/foul.ts`

Le fouleur expulsé était marqué `state: 'casualty'` au lieu de `'sent_off'`. Le `casualty` faussait les stats de victimes et ouvrait la voie à un apothecary erroné côté driver. Ajout de `'sent_off'` au type `ResolverPlayerState`.

## Test plan

- [x] `foul-bb2020-rules.test.ts` (6 nouveaux tests)
  - [x] Defensive assists adjacent au fouleur (pas à la victime)
  - [x] Defensive n'incluent pas un adverse loin du fouleur
  - [x] Offensive assists adjacent à la victime (pas au fouleur)
  - [x] Send-off déclenché par doublet ARMOR (préservé)
  - [x] Send-off déclenché par doublet INJURY (nouveau)
  - [x] PAS de send-off si ni armor ni injury en doublet
- [x] Tous les tests existants passent : 4990 game-engine + 416 sim-engine
- [x] Typecheck OK sur les deux engines

🔧 PR 2 d'une série de 6 fix l'audit. Précédent #822 (Frenzy chain + Blitz immutable) merged. Suivants : TZ filter remaining sites, combat misc, kickoff/inducements, skills/utils.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_