### PR TITLE
fix(game-engine): corrections combat misc BB2020

### DIFF
--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -21,7 +21,7 @@ import { performArmorRollWithNotification } from '../utils/dice-notifications';
 import { createLogEntry } from '../utils/logging';
 import { canTeamBlitz } from '../core/game-state';
 import { performInjuryRoll, handleSentOff, handleInjuryByCrowd } from './injury';
-import { shouldConvertBothDownToPushBack } from './juggernaut';
+import { shouldConvertBothDownToPushBack, isJuggernautActiveForBlock } from './juggernaut';
 import { bounceBall } from './ball';
 import {
   isStandFirmActiveForBlock,
@@ -525,10 +525,15 @@ export function handlePushWithChoice(
   blockResult: string,
   rng: RNG
 ): GameState {
-  // Stand Firm : la cible peut refuser la poussee. Note : pour POW, la cible
-  // est deja marquee stunned=true AVANT cet appel, donc elle tombera bien sur
-  // sa case actuelle sans etre deplacee.
-  if (isStandFirmActiveForBlock(state, attacker, target)) {
+  // BUG fix : pour POW/STUMBLE le caller marque target.stunned=true AVANT
+  // d'appeler cette fonction, mais le parametre `target` capture l'objet
+  // pre-knockdown (immutabilite : map() cree un nouveau Player). Le check
+  // Stand Firm voyait donc target.stunned=false et autorisait Stand Firm
+  // alors que BB2020 dit Stand Firm requiert le joueur DEBOUT — un joueur
+  // tout juste tombe par POW/STUMBLE ne peut PAS utiliser Stand Firm.
+  // Re-fetch le target depuis le state actuel pour lire le bon stunned.
+  const currentTarget = state.players.find((p) => p.id === target.id) ?? target;
+  if (isStandFirmActiveForBlock(state, attacker, currentTarget)) {
     const standFirmLog = createLogEntry(
       'action',
       `${target.name} utilise Stand Firm : refuse d'etre pousse`,
@@ -805,8 +810,14 @@ function handleBothDown(state: GameState, attacker: Player, target: Player, rng:
     return handlePushBack(stateWithLog, attacker, target, rng);
   }
 
+  // BB2020 : Juggernaut sur Blitz annule Wrestle de la cible. Avant le fix,
+  // un attaquant Juggernaut+Block contre une cible Wrestle voyait Wrestle
+  // s'activer (les deux tombent), alors que Juggernaut anti-Wrestle
+  // devrait laisser l'attaquant debout (Block) et la cible au sol.
+  const juggernautNegatesTargetWrestle = isJuggernautActiveForBlock(state, attacker);
   const attackerHasWrestle = checkWrestleOnBothDown(attacker, state);
-  const targetHasWrestle = checkWrestleOnBothDown(target, state);
+  const targetHasWrestle =
+    !juggernautNegatesTargetWrestle && checkWrestleOnBothDown(target, state);
   const wrestleActive = attackerHasWrestle || targetHasWrestle;
 
   // Wrestle: les deux tombent, pas de jet d'armure, pas de turnover

--- a/packages/game-engine/src/mechanics/chainsaw.ts
+++ b/packages/game-engine/src/mechanics/chainsaw.ts
@@ -125,7 +125,13 @@ export function executeChainsaw(
     if (!selfArmor.success) {
       const currentAttacker = newState.players.find(p => p.id === attacker.id);
       if (currentAttacker) {
-        newState = performInjuryRoll(newState, currentAttacker, rng, 0, attacker.id);
+        // BUG fix : sur une auto-blessure (double 1), l'attaquant N'est PAS
+        // credite de la casualty — il se blesse lui-meme. Avant le fix,
+        // `causedById: attacker.id` faisait grimper le compteur de
+        // casualties de l'attaquant comme s'il l'avait infligee a un
+        // adversaire, faussant les SPP / stats. Cf. PR #814 bombardier
+        // pour le meme pattern. `undefined` = casualty non-creditee.
+        newState = performInjuryRoll(newState, currentAttacker, rng, 0, undefined);
       }
     }
 

--- a/packages/game-engine/src/mechanics/combat-misc-bb2020.test.ts
+++ b/packages/game-engine/src/mechanics/combat-misc-bb2020.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Combat misc corrections BB2020 :
+ *  1. Juggernaut sur Blitz annule Wrestle de la cible.
+ *  2. Stand Firm ne s'applique pas si la cible vient de tomber (POW/STUMBLE).
+ *  3. Projectile Vomit reussi : pm=0 (activation termine).
+ *  4. Chainsaw self-hit : casualty NON-creditee a l'attaquant.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { resolveBlockResult } from './blocking';
+import { executeProjectileVomit } from './projectile-vomit';
+import { executeChainsaw } from './chainsaw';
+import type { GameState, Player, RNG } from '../core/types';
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 5, y: 5 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  const s = setup();
+  return { ...s, players, currentPlayer: 'A', playerActions: {}, matchStats: {} };
+}
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function bothDownResult(attackerId: string, targetId: string) {
+  return {
+    type: 'block' as const,
+    playerId: attackerId,
+    targetId,
+    diceRoll: 2,
+    result: 'BOTH_DOWN' as const,
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+function powResult(attackerId: string, targetId: string) {
+  return {
+    type: 'block' as const,
+    playerId: attackerId,
+    targetId,
+    diceRoll: 5,
+    result: 'POW' as const,
+    offensiveAssists: 0,
+    defensiveAssists: 0,
+    totalStrength: 3,
+    targetStrength: 3,
+  };
+}
+
+describe('1. Juggernaut anti-Wrestle (BB2020)', () => {
+  it('Juggernaut+Block attaquant sur Blitz contre Wrestle defenseur : Wrestle annule', () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['juggernaut', 'block'] }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, skills: ['wrestle'] }),
+    ];
+    const state: GameState = {
+      ...makeState(players),
+      playerActions: { A1: 'BLITZ' },
+    };
+
+    const result = resolveBlockResult(state, bothDownResult('A1', 'B1'), makeRNG([0.5, 0.5, 0.5]));
+
+    // Avec Juggernaut+Block : attaquant Block negate fall + Juggernaut
+    // negate target Wrestle. Cible tombe (Block != Wrestle pour cette
+    // path), attaquant reste debout.
+    const attacker = result.players.find((p) => p.id === 'A1')!;
+    const target = result.players.find((p) => p.id === 'B1')!;
+    expect(attacker.stunned).toBeFalsy();
+    expect(target.stunned).toBe(true);
+  });
+
+  it('Pas de Juggernaut : Wrestle s\'applique normalement (les 2 tombent)', () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['block'] }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, skills: ['wrestle'] }),
+    ];
+    const state: GameState = {
+      ...makeState(players),
+      playerActions: { A1: 'BLOCK' },
+    };
+
+    const result = resolveBlockResult(state, bothDownResult('A1', 'B1'), makeRNG([0.5, 0.5]));
+
+    const attacker = result.players.find((p) => p.id === 'A1')!;
+    const target = result.players.find((p) => p.id === 'B1')!;
+    // Wrestle : les deux tombent
+    expect(attacker.stunned).toBe(true);
+    expect(target.stunned).toBe(true);
+  });
+});
+
+describe('2. Stand Firm sur POW (BB2020)', () => {
+  it("Stand Firm ne s'applique PAS sur POW (le joueur vient de tomber)", () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, skills: ['stand-firm'] }),
+    ];
+    const state = makeState(players);
+
+    const result = resolveBlockResult(state, powResult('A1', 'B1'), makeRNG([0.5, 0.5, 0.5, 0.5]));
+
+    // Apres POW + push : la cible est stunned ET deplacee (Stand Firm
+    // n'a pas pu s'appliquer car elle vient de tomber). Position != initiale.
+    const target = result.players.find((p) => p.id === 'B1')!;
+    expect(target.stunned).toBe(true);
+    // Le push a deplace la cible : x != 6 OU y != 5.
+    expect(target.pos.x === 6 && target.pos.y === 5).toBe(false);
+  });
+});
+
+describe('3. Projectile Vomit : pm=0 sur succes (BB2020)', () => {
+  it('PV reussi termine l\'activation (pm=0)', () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['projectile-vomit'], pm: 5 }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 } }),
+    ];
+    const state = makeState(players);
+
+    // RNG : 0.5 → die=4 → 2+ success. Puis armor 0.5/0.5 (tient).
+    const result = executeProjectileVomit(state, players[0], players[1], makeRNG([0.5, 0.5, 0.5, 0.5]));
+
+    const vomiter = result.players.find((p) => p.id === 'A1')!;
+    expect(vomiter.pm).toBe(0);
+  });
+
+  it('PV echoue termine aussi l\'activation (comportement preserve)', () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['projectile-vomit'], pm: 5 }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 } }),
+    ];
+    const state = makeState(players);
+
+    // RNG : 0.0 → die=1 → echec.
+    const result = executeProjectileVomit(state, players[0], players[1], makeRNG([0.0]));
+
+    const vomiter = result.players.find((p) => p.id === 'A1')!;
+    expect(vomiter.pm).toBe(0);
+  });
+});
+
+describe('4. Chainsaw self-hit non-credite (BB2020)', () => {
+  it("auto-blessure (double 1) ne credite PAS l'attaquant de la casualty", () => {
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['chainsaw'], pm: 5 }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, av: 9 }),
+    ];
+    const state = makeState(players);
+
+    // RNG initial : roll1=0.0 (die=1), roll2=0.0 (die=1) → double 1 self-hit.
+    // Puis selfDie1=0.99, selfDie2=0.99 (armor 5+5=10+3=13>av=7 perce).
+    // Puis injury die1=0.99, die2=0.99 (12+ ⇒ casualty).
+    const result = executeChainsaw(state, players[0], players[1], makeRNG([0.0, 0.0, 0.99, 0.99, 0.99, 0.99, 0.99, 0.99, 0.99]));
+
+    // Verifier : aucune casualty creditee a A1 (l'attaquant).
+    const a1Stats = result.matchStats?.['A1'];
+    expect(a1Stats?.casualties ?? 0).toBe(0);
+  });
+});

--- a/packages/game-engine/src/mechanics/projectile-vomit.ts
+++ b/packages/game-engine/src/mechanics/projectile-vomit.ts
@@ -133,6 +133,18 @@ export function executeProjectileVomit(
     if (!armorResult.success) {
       newState = performInjuryRoll(newState, newState.players[targetIdx], rng, 0, vomiter.id);
     }
+
+    // BB2020 rule : « After Projectile Vomit has been used, the activated
+    // player's activation ends. » L'activation termine APRES un succes
+    // comme apres un echec. Avant le fix, pm n'etait set a 0 que sur
+    // echec — un PV reussi laissait le joueur continuer son tour, contre
+    // la regle officielle.
+    newState = {
+      ...newState,
+      players: newState.players.map((p) =>
+        p.id === vomiter.id ? { ...p, pm: 0 } : p,
+      ),
+    };
   } else {
     // Échec : l'activation du joueur prend fin (pm = 0), PAS de turnover
     newState.players = newState.players.map(p =>


### PR DESCRIPTION
## Summary

Quatre bugs dans la mécanique de combat (BB2020) :

### 1. Juggernaut anti-Wrestle dans `handleBothDown`

Un attaquant Juggernaut+Block sur Blitz contre une cible Wrestle voyait Wrestle s'activer (les deux tombent). BB2020 : Juggernaut sur Blitz *« cancels the Fend, Stand Firm and Wrestle skills of the target »*. Fix : pré-check `isJuggernautActiveForBlock` dans `handleBothDown` et clear `targetHasWrestle`.

### 2. Stand Firm sur POW

La cible vient de tomber AVANT le check Stand Firm, mais le paramètre `target` référençait l'objet pré-knockdown (immutabilité : `map()` crée un nouveau Player). `isStandFirmActiveForBlock` voyait `stunned=false` et autorisait Stand Firm. **BB2020** : Stand Firm ne s'applique que sur joueur DEBOUT, refusé après POW/STUMBLE. Fix : re-fetch `target` depuis `state.players` dans `handlePushWithChoice`.

### 3. Projectile Vomit réussi → `pm=0`

**BB2020** : *« After Projectile Vomit has been used, the activated player's activation ends. »* La règle s'applique en succès comme en échec. Avant le fix, seul l'échec setait `pm=0` ; un PV réussi laissait le joueur continuer.

### 4. Chainsaw self-hit ne crédite plus l'attaquant

Avant, `performInjuryRoll(... causedById: attacker.id)` sur l'auto-blessure (double 1) incrémentait les casualties de l'attaquant. Pattern déjà appliqué pour Bombardier (PR #814). Fix : `causedById = undefined` sur le code path self-hit.

## Test plan

- [x] `combat-misc-bb2020.test.ts` (6 nouveaux tests)
  - [x] Juggernaut+Block annule Wrestle de la cible
  - [x] Sans Juggernaut, Wrestle s'applique normalement
  - [x] Stand Firm ne s'applique pas sur POW (target déplacé)
  - [x] PV réussi termine l'activation (`pm=0`)
  - [x] PV échoué termine l'activation (préservé)
  - [x] Chainsaw self-hit ne crédite pas la casualty à l'attaquant
- [x] 4996 game-engine + 416 sim-engine tests passent
- [x] Typecheck OK

🔧 PR 4 d'une série de 6 fix l'audit. Précédents #822 (merged), #823 (in CI), #824 (in CI). Suivants : kickoff/inducements, skills/utils.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_