### PR TITLE
fix(game-engine): Get the Ref! → +1 Bribe + dedup Star Player

### DIFF
--- a/packages/game-engine/src/core/inducements-star-player-dedup.test.ts
+++ b/packages/game-engine/src/core/inducements-star-player-dedup.test.ts
@@ -1,0 +1,72 @@
+/**
+ * BB2020 : un meme Star Player ne peut pas etre embauche en double par
+ * une meme equipe. Avant le fix, `validateInducementSelection` ne
+ * verifiait que la quantite globale de l'inducement 'star_player' (max 2)
+ * mais autorisait `{quantity: 2}` sur le meme starPlayerSlug, ou deux
+ * items separes avec le meme starPlayerSlug.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateInducementSelection } from './inducements';
+
+function makeCtx() {
+  return {
+    teamCode: 'human' as const,
+    teamTV: 1_000_000,
+    opponentTV: 1_000_000,
+    isUnderdog: false,
+    homeOrAway: 'home' as const,
+  };
+}
+
+describe('Star Player dedup (BB2020)', () => {
+  it('refuse 2x le meme Star Player via quantity > 1', () => {
+    const result = validateInducementSelection(
+      {
+        items: [
+          { slug: 'star_player', quantity: 2, starPlayerSlug: 'morg-n-thorg' },
+        ],
+      },
+      makeCtx(),
+      1_000_000,
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.toLowerCase().includes('star player'))).toBe(true);
+  });
+
+  it('refuse 2 items separes avec le meme starPlayerSlug', () => {
+    const result = validateInducementSelection(
+      {
+        items: [
+          { slug: 'star_player', quantity: 1, starPlayerSlug: 'morg-n-thorg' },
+          { slug: 'star_player', quantity: 1, starPlayerSlug: 'morg-n-thorg' },
+        ],
+      },
+      makeCtx(),
+      1_000_000,
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.toLowerCase().includes('deja embauche'))).toBe(true);
+  });
+
+  it('accepte 2 Star Players DIFFERENTS', () => {
+    const result = validateInducementSelection(
+      {
+        items: [
+          { slug: 'star_player', quantity: 1, starPlayerSlug: 'morg-n-thorg' },
+          { slug: 'star_player', quantity: 1, starPlayerSlug: 'griff-oberwald' },
+        ],
+      },
+      makeCtx(),
+      1_000_000,
+    );
+
+    // Pas d'erreur de dedup. (Le test ne valide pas le budget, juste l'absence
+    // d'erreur de dedup star-player.)
+    const dedupError = result.errors.find((e) =>
+      e.toLowerCase().includes('deja embauche') || e.includes('embauche qu\'une seule fois'),
+    );
+    expect(dedupError).toBeUndefined();
+  });
+});

--- a/packages/game-engine/src/core/inducements.ts
+++ b/packages/game-engine/src/core/inducements.ts
@@ -256,6 +256,9 @@ export function validateInducementSelection(
 
   // Track quantities per slug to enforce maxQuantity
   const quantityMap = new Map<InducementSlug, number>();
+  // BB2020 : un meme Star Player ne peut pas etre embauche en double par
+  // une meme equipe. Track les starPlayerSlug deja utilises.
+  const usedStarPlayerSlugs = new Set<string>();
 
   for (const item of selection.items) {
     const def = CATALOGUE_MAP.get(item.slug);
@@ -274,6 +277,24 @@ export function validateInducementSelection(
     if (def.canPurchase && !def.canPurchase(ctx)) {
       errors.push(`${def.displayName} n'est pas disponible pour cette équipe.`);
       continue;
+    }
+
+    // BB2020 : dedup star players. Un meme Star Player ne peut pas etre
+    // embauche en double (quantity > 1) ni via deux items separes.
+    if (item.slug === 'star_player' && item.starPlayerSlug) {
+      if (item.quantity > 1) {
+        errors.push(
+          `Un Star Player ne peut etre embauche qu'une seule fois (${item.starPlayerSlug}, demandé ${item.quantity}).`,
+        );
+        continue;
+      }
+      if (usedStarPlayerSlugs.has(item.starPlayerSlug)) {
+        errors.push(
+          `Star Player ${item.starPlayerSlug} deja embauche (un meme Star Player ne peut pas etre pris en double).`,
+        );
+        continue;
+      }
+      usedStarPlayerSlugs.add(item.starPlayerSlug);
     }
 
     // Accumulate quantities

--- a/packages/game-engine/src/mechanics/kickoff-events.test.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.test.ts
@@ -33,13 +33,19 @@ describe('Kickoff Events', () => {
   });
 
   describe('applyKickoffEvent', () => {
-    it('applies Get the Ref (+1 reroll each team)', () => {
+    it('applies Get the Ref (+1 Bribe each team — BB2020)', () => {
+      // BB2020 LRB : "Get the Ref! — Each team receives one additional
+      // Bribe to use during the game." Avant le fix, l'event donnait
+      // +1 relance (test legacy) au lieu de +1 Bribe.
       const state = setup();
       const event = KICKOFF_EVENTS[2]; // Get the Ref
       const rng = makeRNG('test');
       const result = applyKickoffEvent(state, event, rng, 'A');
-      expect(result.teamRerolls.teamA).toBe(state.teamRerolls.teamA + 1);
-      expect(result.teamRerolls.teamB).toBe(state.teamRerolls.teamB + 1);
+      expect(result.bribesRemaining.teamA).toBe(state.bribesRemaining.teamA + 1);
+      expect(result.bribesRemaining.teamB).toBe(state.bribesRemaining.teamB + 1);
+      // Rerolls inchangees
+      expect(result.teamRerolls.teamA).toBe(state.teamRerolls.teamA);
+      expect(result.teamRerolls.teamB).toBe(state.teamRerolls.teamB);
     });
 
     it('applies Riot (turn counter change)', () => {

--- a/packages/game-engine/src/mechanics/kickoff-events.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.ts
@@ -22,7 +22,7 @@ export const KICKOFF_EVENTS: Record<number, KickoffEvent> = {
     id: 'get-the-ref',
     name: 'Get the Ref!',
     nameFr: 'Corrompre l\'arbitre !',
-    description: 'Chaque équipe reçoit 1 relance d\'équipe supplémentaire gratuite pour ce drive. Elle est perdue si elle n\'est pas utilisée avant la fin du drive.',
+    description: 'Chaque équipe reçoit 1 Pot-de-vin (Bribe) supplémentaire pour le reste du match.',
   },
   3: {
     id: 'riot',
@@ -118,12 +118,17 @@ export function applyKickoffEvent(
 
   switch (event.id) {
     case 'get-the-ref': {
-      // +1 relance gratuite pour chaque équipe
-      newState.teamRerolls = {
-        teamA: (newState.teamRerolls?.teamA ?? 0) + 1,
-        teamB: (newState.teamRerolls?.teamB ?? 0) + 1,
+      // BUG fix : BB2020 dit « Each team receives one additional Bribe to
+      // use during the game », pas +1 relance. Avant le fix, l'event Get
+      // the Ref! donnait des relances comme Brilliant Coaching ou Cheering
+      // Fans — c'etait redondant avec ces 2 events et ignorait la mecanique
+      // Bribe (qui annule l'expulsion sur fouls, eject sur secret weapons).
+      const bribes = newState.bribesRemaining ?? { teamA: 0, teamB: 0 };
+      newState.bribesRemaining = {
+        teamA: bribes.teamA + 1,
+        teamB: bribes.teamB + 1,
       };
-      const log = createLogEntry('action', 'Chaque équipe reçoit 1 relance supplémentaire');
+      const log = createLogEntry('action', 'Chaque équipe reçoit 1 Pot-de-vin (Bribe) supplémentaire');
       newState.gameLog = [...newState.gameLog, log];
       break;
     }

--- a/packages/game-engine/src/mechanics/kickoff-get-the-ref.test.ts
+++ b/packages/game-engine/src/mechanics/kickoff-get-the-ref.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Get the Ref! (kickoff event 2) — BB2020 rule :
+ * « Each team receives one additional Bribe to use during the game. »
+ *
+ * Avant le fix, l'event donnait +1 relance par equipe au lieu d'un
+ * Pot-de-vin (Bribe). Conflit avec Brilliant Coaching et Cheering Fans
+ * qui donnent deja des relances, et mecanique Bribe ignoree (annulation
+ * d'expulsion sur fouls, eject sur secret weapons).
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyKickoffEvent, KICKOFF_EVENTS } from './kickoff-events';
+import type { GameState, RNG } from '../core/types';
+
+function makeRNG(): RNG {
+  return () => 0.5;
+}
+
+describe('Kickoff event 2 — Get the Ref! (BB2020)', () => {
+  it('donne +1 Bribe a chaque equipe (pas +1 relance)', () => {
+    const base = setup();
+    const state: GameState = {
+      ...base,
+      bribesRemaining: { teamA: 0, teamB: 0 },
+      teamRerolls: { teamA: 2, teamB: 2 },
+    };
+
+    const event = KICKOFF_EVENTS[2];
+    const result = applyKickoffEvent(state, event, makeRNG(), 'A');
+
+    // Bribes : +1 chaque equipe
+    expect(result.bribesRemaining.teamA).toBe(1);
+    expect(result.bribesRemaining.teamB).toBe(1);
+    // Rerolls : inchangees
+    expect(result.teamRerolls?.teamA).toBe(2);
+    expect(result.teamRerolls?.teamB).toBe(2);
+  });
+
+  it('cumule avec les bribes existantes', () => {
+    const base = setup();
+    const state: GameState = {
+      ...base,
+      bribesRemaining: { teamA: 1, teamB: 2 },
+    };
+
+    const event = KICKOFF_EVENTS[2];
+    const result = applyKickoffEvent(state, event, makeRNG(), 'A');
+
+    expect(result.bribesRemaining.teamA).toBe(2);
+    expect(result.bribesRemaining.teamB).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Deux bugs sur la mécanique pré-match / kickoff (BB2020) :

### 1. `mechanics/kickoff-events.ts` — Get the Ref! (event 2)

**BB2020 LRB** : *« Get the Ref! — Each team receives one additional Bribe to use during the game. »*

Avant le fix, l'event donnait **+1 relance** par équipe au lieu d'un Pot-de-vin (Bribe). Conflit avec :
- Brilliant Coaching (event 7) — déjà des relances
- Cheering Fans (event 6) — déjà des relances
- Mécanique Bribe ignorée (annulation expulsion sur fouls, eject sur secret weapons)

Update du test legacy pour refléter la règle correcte.

### 2. `core/inducements.ts:validateInducementSelection` — Star Player dedup

`validateInducementSelection` ne vérifiait que la quantité globale de l'inducement `'star_player'` (max 2), mais autorisait :
- `{ slug: 'star_player', quantity: 2, starPlayerSlug: 'morg-n-thorg' }` — 2x le même Star
- Deux items séparés avec le même `starPlayerSlug`

**BB2020** : un même Star Player ne peut pas être embauché deux fois par la même équipe. Ajout d'une `Set<string>` pour dédupliquer par `starPlayerSlug`.

## Test plan

- [x] `kickoff-get-the-ref.test.ts` (2 nouveaux tests)
  - [x] +1 bribe chaque équipe, rerolls inchangées
  - [x] Cumul avec bribes existantes
- [x] `kickoff-events.test.ts` — test legacy mis à jour pour BB2020
- [x] `inducements-star-player-dedup.test.ts` (3 nouveaux tests)
  - [x] Refus `quantity > 1` même Star Player
  - [x] Refus 2 items séparés même `starPlayerSlug`
  - [x] Accept 2 Star Players différents
- [x] 4995 game-engine tests passent
- [x] Typecheck OK

🔧 PR 5 d'une série de 6 fix l'audit. Précédents #822 (merged), #823 (merged), #825 (merged), #824 (en CI). Suivant : skills/utils.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_