### PR TITLE
fix(game-engine): skills/utils — Stunty apothecary reroll + team value clamp + Armored Skull prayer

### DIFF
--- a/packages/game-engine/src/mechanics/apothecary-stunty-reroll.test.ts
+++ b/packages/game-engine/src/mechanics/apothecary-stunty-reroll.test.ts
@@ -1,0 +1,73 @@
+/**
+ * BB2020 : Stunty players suffer +1 modifier to any Casualty roll made
+ * against them. Le modificateur s'applique aussi au re-roll apothecary.
+ * Avant le fix, le re-roll D16 ne tenait pas compte du Stunty.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyApothecaryChoice } from './apothecary';
+import type { GameState, Player, RNG } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'B', pos: { x: -1, y: -1 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 0, state: 'casualty', stunned: true,
+    ...over,
+  };
+}
+
+function makeStateWithApothecary(player: Player): GameState {
+  const s = setup();
+  return {
+    ...s,
+    players: [...s.players, player],
+    pendingApothecary: {
+      playerId: player.id,
+      team: player.team,
+      injuryType: 'casualty',
+      originalCasualtyOutcome: 'badly_hurt',
+      originalLastingInjury: undefined,
+      fallbackToRegeneration: false,
+    },
+    apothecaryAvailable: { teamA: true, teamB: true },
+  };
+}
+
+describe('Apothecary re-roll D16 — Stunty +1 (BB2020)', () => {
+  it("le log mentionne `+1 Stunty` quand le joueur a Stunty", () => {
+    const stunty = basePlayer({ id: 'V', skills: ['stunty'] });
+    const state = makeStateWithApothecary(stunty);
+    // 0.5 → floor(0.5*16)+1 = 9 → seriously_hurt sans Stunty,
+    // mais +1 → 10 → serious_injury.
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+
+    const result = applyApothecaryChoice(state, true, rng);
+
+    const rerollLog = result.gameLog.find(l =>
+      l.message.includes('re-lancer casualty')
+    );
+    expect(rerollLog).toBeDefined();
+    const details = rerollLog?.details as Record<string, unknown> | undefined;
+    expect(details?.stuntyMod).toBe(1);
+  });
+
+  it("aucun modificateur Stunty pour un joueur non-stunty", () => {
+    const regular = basePlayer({ id: 'V', skills: [] });
+    const state = makeStateWithApothecary(regular);
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+
+    const result = applyApothecaryChoice(state, true, rng);
+
+    const rerollLog = result.gameLog.find(l =>
+      l.message.includes('re-lancer casualty')
+    );
+    const details = rerollLog?.details as Record<string, unknown> | undefined;
+    expect(details?.stuntyMod).toBe(0);
+  });
+});

--- a/packages/game-engine/src/mechanics/apothecary.ts
+++ b/packages/game-engine/src/mechanics/apothecary.ts
@@ -9,11 +9,12 @@
  * - Ne peut PAS etre utilise sur Stunned
  */
 
-import { GameState, TeamId, RNG, CasualtyOutcome, PendingApothecary } from '../core/types';
+import { GameState, TeamId, RNG, CasualtyOutcome, PendingApothecary, Player } from '../core/types';
 import { movePlayerToDugoutZone } from './dugout';
 import { rollLastingInjuryType } from './injury';
 import { tryRegeneration } from './regeneration';
 import { createLogEntry } from '../utils/logging';
+import { hasSkill } from '../skills/skill-effects';
 
 /** Severity ranking for casualty outcomes (lower = less severe) */
 const CASUALTY_SEVERITY: Record<CasualtyOutcome, number> = {
@@ -38,15 +39,27 @@ export function isApothecaryAvailable(state: GameState, playerId: string): boole
 
 /**
  * Rolls a D16 casualty outcome (same logic as in injury.ts handleCasualty)
+ *
+ * BB2020 rule : « Stunty players suffer +1 modifier to any Casualty roll
+ * made against them. » Le modificateur s'applique aussi au re-roll
+ * apothecary. Avant le fix, le re-roll D16 ne tenait pas compte du
+ * Stunty → la mecanique cherchait a soigner un Goblin/Halfling avec un
+ * D16 base alors que la regle veut +1 (rendant les blessures graves
+ * plus probables, donc le re-roll moins "sain" qu'il devrait).
  */
-function rollCasualtyOutcome(rng: RNG): { roll: number; outcome: CasualtyOutcome } {
-  const roll = Math.floor(rng() * 16) + 1;
+function rollCasualtyOutcome(
+  rng: RNG,
+  player?: Player,
+): { roll: number; outcome: CasualtyOutcome; stuntyMod: number } {
+  const stuntyMod = player && hasSkill(player, 'stunty') ? 1 : 0;
+  const rawRoll = Math.floor(rng() * 16) + 1;
+  const roll = Math.min(16, rawRoll + stuntyMod);
 
-  if (roll <= 6) return { roll, outcome: 'badly_hurt' };
-  if (roll <= 9) return { roll, outcome: 'seriously_hurt' };
-  if (roll <= 12) return { roll, outcome: 'serious_injury' };
-  if (roll <= 14) return { roll, outcome: 'lasting_injury' };
-  return { roll, outcome: 'dead' };
+  if (roll <= 6) return { roll, outcome: 'badly_hurt', stuntyMod };
+  if (roll <= 9) return { roll, outcome: 'seriously_hurt', stuntyMod };
+  if (roll <= 12) return { roll, outcome: 'serious_injury', stuntyMod };
+  if (roll <= 14) return { roll, outcome: 'lasting_injury', stuntyMod };
+  return { roll, outcome: 'dead', stuntyMod };
 }
 
 /**
@@ -145,15 +158,16 @@ function applyApothecaryOnCasualty(
   rng: RNG
 ): GameState {
   // Re-roll casualty
-  const newCasualty = rollCasualtyOutcome(rng);
   const player = state.players.find(p => p.id === pending.playerId);
+  const newCasualty = rollCasualtyOutcome(rng, player);
 
+  const stuntySuffix = newCasualty.stuntyMod > 0 ? ` (+${newCasualty.stuntyMod} Stunty)` : '';
   const rerollLog = createLogEntry(
     'dice',
-    `Apothecaire - re-lancer casualty: ${newCasualty.roll} (${newCasualty.outcome})`,
+    `Apothecaire - re-lancer casualty: ${newCasualty.roll} (${newCasualty.outcome})${stuntySuffix}`,
     pending.playerId,
     pending.team,
-    { casualtyRoll: newCasualty.roll, outcome: newCasualty.outcome }
+    { casualtyRoll: newCasualty.roll, outcome: newCasualty.outcome, stuntyMod: newCasualty.stuntyMod }
   );
   state.gameLog = [...state.gameLog, rerollLog];
 

--- a/packages/game-engine/src/mechanics/prayers-to-nuffle.ts
+++ b/packages/game-engine/src/mechanics/prayers-to-nuffle.ts
@@ -7,6 +7,7 @@
 import { GameState, TeamId, Player, RNG } from '../core/types';
 import { createLogEntry } from '../utils/logging';
 import { rollD6, roll2D6 } from '../utils/dice';
+import { hasSkill } from '../skills/skill-effects';
 import { isApothecaryAvailable as isApothecaryAvailableFn } from './apothecary';
 import { hasRegeneration as hasRegenerationFn, tryRegeneration as tryRegenerationFn } from './regeneration';
 
@@ -187,8 +188,21 @@ function getOpponentTeam(team: TeamId): TeamId {
 // Injury roll helper (simplified for pre-match prayer context)
 // ---------------------------------------------------------------------------
 
-function performPrayerInjuryRoll(rng: RNG): 'stunned' | 'knocked_out' | 'casualty' {
-  const injuryRoll = roll2D6(rng);
+function performPrayerInjuryRoll(
+  rng: RNG,
+  target?: Player,
+): 'stunned' | 'knocked_out' | 'casualty' {
+  // BUG fix : aligner le jet de Prayer 14 (Throw a Rock!) avec
+  // `performInjuryRoll` :
+  //  - Stunty cible : -1 a l'injury (le caillou les fait moins de
+  //    degats par rapport a la table de blessure standard) — non,
+  //    Stunty s'applique au jet de CASUALTY, pas au jet de blessure.
+  //  - Armored Skull : -1 a tout injury roll (BB3 S2/S3).
+  // Avant le fix, le jet de Prayer 14 etait nu (pas de modificateurs
+  // de skill defensifs), ce qui surevaluait les KOs / casualties sur
+  // les cibles armored.
+  const armoredSkullMod = target && hasSkill(target, 'armored-skull') ? -1 : 0;
+  const injuryRoll = roll2D6(rng) + armoredSkullMod;
   if (injuryRoll <= 7) return 'stunned';
   if (injuryRoll <= 9) return 'knocked_out';
   return 'casualty';
@@ -502,7 +516,7 @@ export function applyPrayerEffect(
         return { state, description: `${prayer.nameFr} — Aucun joueur adverse disponible.` };
       }
 
-      const injuryOutcome = performPrayerInjuryRoll(rng);
+      const injuryOutcome = performPrayerInjuryRoll(rng, target);
       let newState: GameState;
 
       switch (injuryOutcome) {

--- a/packages/game-engine/src/utils/team-value-calculator.ts
+++ b/packages/game-engine/src/utils/team-value-calculator.ts
@@ -146,7 +146,9 @@ function calculateStaffCost(data: TeamValueData): number {
   }
   
   // Fans Dévoués: 10k po chacun au-dessus du premier (gratuit)
-  cost += (data.dedicatedFans - 1) * 10000;
+  // BUG fix : si `dedicatedFans` = 0 (equipe nouvelle pas encore loggee),
+  // (0 - 1) * 10000 = -10000 → cout total negatif. Clamp via Math.max(0).
+  cost += Math.max(0, data.dedicatedFans - 1) * 10000;
   
   return cost;
 }


### PR DESCRIPTION
## Summary

Trois bugs « skills & utils » (PR 6/6 de l'audit) :

### 1. `mechanics/apothecary.ts:rollCasualtyOutcome` — Stunty +1 sur D16 reroll

**BB2020** : *« Stunty players suffer +1 modifier to any Casualty roll made against them. »* Le modificateur s'applique aussi au re-roll apothecary. Avant le fix, le re-roll D16 ignorait Stunty → la mécanique faussait les chances de guérison pour Goblin/Halfling/Skink/Snotling.

### 2. `utils/team-value-calculator.ts:149` — Clamp coût négatif

```ts
cost += (data.dedicatedFans - 1) * 10000;
```

Si `dedicatedFans = 0` (équipe nouvelle pas encore loggée), `(0-1)*10000 = -10000` → coût total négatif. Fix : `Math.max(0, ...)`.

### 3. `mechanics/prayers-to-nuffle.ts:performPrayerInjuryRoll` — Armored Skull -1

Ajout du modificateur Armored Skull (-1) sur le jet de blessure de Prayer 14 (Throw a Rock!). Avant, le jet était nu, surévaluant les KOs/casualties sur les cibles Armored Skull (Dwarf Deathroller etc).

## Test plan

- [x] `apothecary-stunty-reroll.test.ts` (2 nouveaux tests)
  - [x] Log mentionne `+1 Stunty` pour joueur Stunty
  - [x] Aucun modificateur Stunty pour joueur non-stunty
- [x] 5004 game-engine tests passent (existants + nouveaux)
- [x] Typecheck OK

🎯 **PR 6/6 — fin de la série de bugs de l'audit.** Précédents : #822 (CRITICAL frenzy+blitz, merged), #823 (foul corrections, merged), #825 (combat misc, merged), #824 (TZ filter, en CI), #826 (kickoff/inducement, en CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_