### PR TITLE
fix(game-engine): déterminisme push chain + Wandering Apothecary cumulatif (CRITICAL)

### DIFF
--- a/packages/game-engine/src/actions/actions.ts
+++ b/packages/game-engine/src/actions/actions.ts
@@ -250,7 +250,7 @@ export function applyMove(state: GameState, move: Move, rng: RNG): GameState {
     case 'BLOCK_CHOOSE':
       return resolveMultipleBlock(resolveFrenzyBlock(handleBlockChoose(activeState, move, rng), rng), rng);
     case 'PUSH_CHOOSE':
-      return resolveMultipleBlock(resolveFrenzyBlock(handlePushChoose(activeState, move), rng), rng);
+      return resolveMultipleBlock(resolveFrenzyBlock(handlePushChoose(activeState, move, rng), rng), rng);
     case 'FOLLOW_UP_CHOOSE':
       return resolveMultipleBlock(resolveFrenzyBlock(handleFollowUpChoose(activeState, move), rng), rng);
     case 'BLITZ':

--- a/packages/game-engine/src/actions/blitz-handler-immutability.test.ts
+++ b/packages/game-engine/src/actions/blitz-handler-immutability.test.ts
@@ -43,7 +43,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/blitz-handler.test.ts
+++ b/packages/game-engine/src/actions/blitz-handler.test.ts
@@ -47,7 +47,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/block-action.test.ts
+++ b/packages/game-engine/src/actions/block-action.test.ts
@@ -54,7 +54,7 @@ function makeState(players: Player[]): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/block-handler.test.ts
+++ b/packages/game-engine/src/actions/block-handler.test.ts
@@ -49,7 +49,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/choice-handlers.ts
+++ b/packages/game-engine/src/actions/choice-handlers.ts
@@ -140,6 +140,12 @@ export function handleBlockChoose(
 
 /**
  * Gere le choix de direction de poussee.
+ *
+ * BUG fix : avant, l'appel a `applyChainPush` utilisait
+ * `() => Math.random()` localement. Le chain push peut surfer un
+ * joueur dans la foule (jet d'injury crowd) : avec Math.random,
+ * le resultat etait non-deterministe et brisait la rejouabilite
+ * des replays (seed -> outcome). Passer le RNG seede du dispatcher.
  */
 export function handlePushChoose(
   state: GameState,
@@ -149,6 +155,7 @@ export function handlePushChoose(
     targetId: string;
     direction: Position;
   },
+  rng: RNG,
 ): GameState {
   const attacker = state.players.find((p) => p.id === move.playerId);
   const target = state.players.find((p) => p.id === move.targetId);
@@ -182,8 +189,9 @@ export function handlePushChoose(
   const fendActive = isFendActiveForFollowUp(newState, attacker, target);
 
   // Chain push : si la destination est occupee, pousser le joueur qui
-  // y est d'abord
-  const rng = () => Math.random(); // RNG pour les surfs en chaine
+  // y est d'abord. Utilise le RNG seede du dispatcher pour conserver
+  // la rejouabilite (surfs en chaine peuvent declencher des injury
+  // crowd rolls).
   newState = applyChainPush(newState, target.id, move.direction, rng);
 
   const frenzyActive = hasFrenzy(attacker) && !!newState.pendingFrenzyBlock;

--- a/packages/game-engine/src/actions/legal-moves.test.ts
+++ b/packages/game-engine/src/actions/legal-moves.test.ts
@@ -41,7 +41,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/move-leap-dodge-handlers.test.ts
+++ b/packages/game-engine/src/actions/move-leap-dodge-handlers.test.ts
@@ -47,7 +47,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/push-choose-determinism.test.ts
+++ b/packages/game-engine/src/actions/push-choose-determinism.test.ts
@@ -1,0 +1,79 @@
+/**
+ * BUG fixes :
+ *  1. `handlePushChoose` utilisait `Math.random()` localement pour
+ *     l'appel a `applyChainPush`. Les surfs en chaine (crowd injury
+ *     rolls) etaient donc non-deterministes — replay seed -> result
+ *     non rejouable. Fix : passer le RNG seede du dispatcher.
+ *
+ *  2. `apothecaryAvailable` etait boolean. Une equipe avec apothecary
+ *     natif (Human, Dwarf) qui achetait Wandering Apothecary inducement
+ *     ne pouvait pas en accumuler 2 — silent no-op. Fix : compteur.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from './actions';
+import type { GameState, Player, RNG, Move } from '../core/types';
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 5, y: 5 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+describe('Determinism — chain push surf utilise le RNG seede', () => {
+  it("deux runs avec meme seed produisent le meme state (surf chain push)", () => {
+    // Scenario : push chain au bord du terrain — surf B1 dans la foule,
+    // ce qui declenche un crowd injury roll. Avant le fix, ce roll
+    // utilisait Math.random() local → non-deterministe.
+    const base = setup();
+    const players: Player[] = [
+      basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } }),
+      basePlayer({ id: 'B1', team: 'B', pos: { x: 25, y: 5 } }), // au bord
+    ];
+    const state: GameState = {
+      ...base,
+      players,
+      currentPlayer: 'A',
+      pendingPushChoice: {
+        attackerId: 'A1', targetId: 'B1',
+        availableDirections: [{ x: 1, y: 0 }],
+        blockResult: 'PUSH_BACK',
+        offensiveAssists: 0, defensiveAssists: 0,
+        totalStrength: 3, targetStrength: 3,
+      },
+    };
+    const move: Move = {
+      type: 'PUSH_CHOOSE', playerId: 'A1', targetId: 'B1',
+      direction: { x: 1, y: 0 },
+    };
+
+    // Deux runs avec le meme RNG seede : doit produire le meme outcome.
+    const rng1 = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+    const rng2 = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+    const result1 = applyMove(state, move, rng1);
+    const result2 = applyMove(state, move, rng2);
+
+    const b1Result1 = result1.players.find(p => p.id === 'B1');
+    const b1Result2 = result2.players.find(p => p.id === 'B1');
+    // Meme state.players (apres surf : meme pos, meme state).
+    expect(b1Result1?.pos).toEqual(b1Result2?.pos);
+    expect(b1Result1?.state).toEqual(b1Result2?.state);
+  });
+});
+
+describe('Apothecary count — Wandering Apothecary cumule', () => {
+  it("apothecaryAvailable est un compteur (type number)", () => {
+    const state = setup();
+    expect(typeof state.apothecaryAvailable.teamA).toBe('number');
+    expect(state.apothecaryAvailable.teamA).toBe(0);
+    expect(state.apothecaryAvailable.teamB).toBe(0);
+  });
+});

--- a/packages/game-engine/src/actions/reroll-choose-handler.test.ts
+++ b/packages/game-engine/src/actions/reroll-choose-handler.test.ts
@@ -27,7 +27,7 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/actions/special-actions.test.ts
+++ b/packages/game-engine/src/actions/special-actions.test.ts
@@ -56,7 +56,7 @@ function makeState(players: Player[], current: "A" | "B" = "A"): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: { reserves: [], ko: [], casualties: [] },
       teamB: { reserves: [], ko: [], casualties: [] },

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -148,8 +148,8 @@ export function setupPreMatchWithTeams(
     },
     rerollUsedThisTurn: false,
     apothecaryAvailable: {
-      teamA: options?.teamAApothecary ?? false,
-      teamB: options?.teamBApothecary ?? false,
+      teamA: options?.teamAApothecary ? 1 : 0,
+      teamB: options?.teamBApothecary ? 1 : 0,
     },
     // Informations de match
     gamePhase: 'playing' as const,
@@ -306,7 +306,7 @@ export function setupPreMatch(): GameState {
     teamFoulCount: {} as Record<string, number>,
     teamRerolls: { teamA: 3, teamB: 3 },
     rerollUsedThisTurn: false,
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     // Informations de match
     gamePhase: 'playing' as const,
     half: 0, // Pas de mi-temps en phase pré-match
@@ -422,7 +422,7 @@ export function setup(): GameState {
     // Relances d'équipe (3 par défaut pour les matchs de démonstration)
     teamRerolls: { teamA: 3, teamB: 3 },
     rerollUsedThisTurn: false,
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     // Informations de match
     gamePhase: 'playing' as const,
     half: 1,

--- a/packages/game-engine/src/core/inducement-handler.test.ts
+++ b/packages/game-engine/src/core/inducement-handler.test.ts
@@ -24,7 +24,7 @@ function createMockState(overrides: Partial<ExtendedGameState> = {}): ExtendedGa
     teamNames: { teamA: "Skaven", teamB: "Lizardmen" },
     dugouts: { teamA: { reserves: [], ko: [], casualties: [], dead: [], expelled: [] }, teamB: { reserves: [], ko: [], casualties: [], dead: [], expelled: [] } },
     matchStats: {},
-    apothecaryAvailable: { teamA: true, teamB: false },
+    apothecaryAvailable: { teamA: 1, teamB: 0 },
     preMatch: {
       phase: "inducements",
       currentCoach: "A",

--- a/packages/game-engine/src/core/inducements.test.ts
+++ b/packages/game-engine/src/core/inducements.test.ts
@@ -294,7 +294,24 @@ describe('Règle: Effets des inducements', () => {
       { slug: 'wandering_apothecary', displayName: 'Wandering Apothecary', cost: 100_000, quantity: 1 },
     ]);
 
-    expect(newState.apothecaryAvailable.teamB).toBe(true);
+    expect(newState.apothecaryAvailable.teamB).toBe(1);
+  });
+
+  it('Wandering Apothecary cumule avec un apothecary natif (BB2020)', () => {
+    // BUG fix : avant, apothecaryAvailable etait boolean. Achat d'un
+    // Wandering Apothecary sur une equipe deja apothecary etait un
+    // silent no-op. Maintenant, le compteur cumule (1 natif + 1 = 2).
+    const state = makeState();
+    const stateWithNative = {
+      ...state,
+      apothecaryAvailable: { teamA: 1, teamB: 0 },
+    };
+
+    const newState = applyInducementEffects(stateWithNative, 'A', [
+      { slug: 'wandering_apothecary', displayName: 'Wandering Apothecary', cost: 100_000, quantity: 1 },
+    ]);
+
+    expect(newState.apothecaryAvailable.teamA).toBe(2);
   });
 
   it('devrait activer l\'apothicaire avec Igor pour une équipe sans apothicaire', () => {
@@ -302,14 +319,14 @@ describe('Règle: Effets des inducements', () => {
     // Simulate team without apothecary
     const stateNoApo = {
       ...state,
-      apothecaryAvailable: { teamA: false, teamB: false },
+      apothecaryAvailable: { teamA: 0, teamB: 0 },
     };
 
     const newState = applyInducementEffects(stateNoApo, 'A', [
       { slug: 'igor', displayName: 'Igor', cost: 100_000, quantity: 1 },
     ]);
 
-    expect(newState.apothecaryAvailable.teamA).toBe(true);
+    expect(newState.apothecaryAvailable.teamA).toBe(1);
   });
 
   it('ne devrait pas modifier l\'état pour les inducements in-match (bribe, wizard, etc.)', () => {

--- a/packages/game-engine/src/core/inducements.ts
+++ b/packages/game-engine/src/core/inducements.ts
@@ -372,13 +372,18 @@ export function applyInducementEffects(
 
       case 'wandering_apothecary':
       case 'igor': {
-        // Grant apothecary availability (or extra use for wandering apothecary)
+        // BB2020 : Wandering Apothecary = +1 use (cumulatif avec un
+        // apothecary natif). Igor = idem pour les equipes sans apothecary
+        // natif. Avant le fix, `apothecaryAvailable` etait boolean :
+        // l'achat sur une equipe deja apothecary etait un silent no-op.
+        // Maintenant on incremente le compteur par `quantity`.
         const apoKey = teamId === 'A' ? 'teamA' : 'teamB';
+        const current = newState.apothecaryAvailable[apoKey] ?? 0;
         newState = {
           ...newState,
           apothecaryAvailable: {
             ...newState.apothecaryAvailable,
-            [apoKey]: true,
+            [apoKey]: current + item.quantity,
           },
         };
         break;

--- a/packages/game-engine/src/core/replay.test.ts
+++ b/packages/game-engine/src/core/replay.test.ts
@@ -20,7 +20,7 @@ function makeGameState(overrides: Partial<GameState> = {}): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: {
         teamId: 'A',

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -122,7 +122,13 @@ export interface GameState {
   lastDiceResult?: DiceResult;
   isTurnover: boolean;
   // Apothecaire
-  apothecaryAvailable: { teamA: boolean; teamB: boolean };
+  // BB2020 : un apothecary peut etre utilise UNE fois par match. Une
+  // equipe avec apothecary natif (Human, Dwarf, etc.) demarre avec
+  // teamA/teamB = 1. L'inducement Wandering Apothecary INCREMENTE ce
+  // compteur (deuxieme usage), Igor pareil pour les equipes sans
+  // apothecary natif. Stocker en number permet de cumuler plusieurs
+  // achats. Avant le fix, c'etait un boolean -> 2e achat etait un no-op.
+  apothecaryAvailable: { teamA: number; teamB: number };
   pendingApothecary?: PendingApothecary;
   // Événement de kickoff en attente de résolution UI
   pendingKickoffEvent?: PendingKickoffEvent;

--- a/packages/game-engine/src/mechanics/apothecary-stunty-reroll.test.ts
+++ b/packages/game-engine/src/mechanics/apothecary-stunty-reroll.test.ts
@@ -35,7 +35,7 @@ function makeStateWithApothecary(player: Player): GameState {
       originalLastingInjury: undefined,
       fallbackToRegeneration: false,
     },
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
   };
 }
 

--- a/packages/game-engine/src/mechanics/apothecary.test.ts
+++ b/packages/game-engine/src/mechanics/apothecary.test.ts
@@ -45,7 +45,7 @@ function createTestState(overrides: Partial<GameState> = {}): GameState {
     casualtyResults: {},
     lastingInjuryDetails: {},
     gameLog: [],
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     ...overrides,
   };
 }
@@ -53,7 +53,7 @@ function createTestState(overrides: Partial<GameState> = {}): GameState {
 describe('Regle: Apothecaire', () => {
   describe('Eligibilite', () => {
     it('ne devrait PAS proposer l\'apothecaire pour un resultat Stunned', () => {
-      const state = createTestState({ apothecaryAvailable: { teamA: true, teamB: false } });
+      const state = createTestState({ apothecaryAvailable: { teamA: 1, teamB: 0 } });
       // RNG: low rolls → stunned (2-7)
       const rng = () => 0.01;
       const result = performInjuryRoll(state, state.players[0], rng);
@@ -64,7 +64,7 @@ describe('Regle: Apothecaire', () => {
     });
 
     it('devrait proposer l\'apothecaire pour un resultat KO quand disponible', () => {
-      const state = createTestState({ apothecaryAvailable: { teamA: true, teamB: false } });
+      const state = createTestState({ apothecaryAvailable: { teamA: 1, teamB: 0 } });
       // RNG: 0.5 per die → 4+4 = 8 (KO range)
       const rng = () => 0.5;
       const result = performInjuryRoll(state, state.players[0], rng);
@@ -76,7 +76,7 @@ describe('Regle: Apothecaire', () => {
     });
 
     it('devrait proposer l\'apothecaire pour un resultat Casualty quand disponible', () => {
-      const state = createTestState({ apothecaryAvailable: { teamA: true, teamB: false } });
+      const state = createTestState({ apothecaryAvailable: { teamA: 1, teamB: 0 } });
       let callCount = 0;
       const rng = () => {
         callCount++;
@@ -92,7 +92,7 @@ describe('Regle: Apothecaire', () => {
     });
 
     it('ne devrait PAS proposer l\'apothecaire si deja utilise', () => {
-      const state = createTestState({ apothecaryAvailable: { teamA: false, teamB: false } });
+      const state = createTestState({ apothecaryAvailable: { teamA: 0, teamB: 0 } });
       // KO roll
       const rng = () => 0.5;
       const result = performInjuryRoll(state, state.players[0], rng);
@@ -102,7 +102,7 @@ describe('Regle: Apothecaire', () => {
 
     it('ne devrait PAS proposer l\'apothecaire pour l\'equipe adverse', () => {
       // Team A player injured, only team B has apothecary
-      const state = createTestState({ apothecaryAvailable: { teamA: false, teamB: true } });
+      const state = createTestState({ apothecaryAvailable: { teamA: 0, teamB: 1 } });
       const rng = () => 0.5; // KO
       const result = performInjuryRoll(state, state.players[0], rng);
 
@@ -114,7 +114,7 @@ describe('Regle: Apothecaire', () => {
     it('devrait deplacer le joueur en Reserves quand apothecaire utilise sur KO', () => {
       // Setup: player already in KO zone with pendingApothecary
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -132,14 +132,14 @@ describe('Regle: Apothecaire', () => {
       expect(result.dugouts.teamA.zones.knockedOut.players).not.toContain('A1');
       expect(result.dugouts.teamA.zones.reserves.players).toContain('A1');
       // Apothecary consumed
-      expect(result.apothecaryAvailable.teamA).toBe(false);
+      expect(result.apothecaryAvailable.teamA).toBe(0);
       // Pending cleared
       expect(result.pendingApothecary).toBeUndefined();
     });
 
     it('devrait laisser le joueur KO quand apothecaire refuse', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -155,7 +155,7 @@ describe('Regle: Apothecaire', () => {
       // Player stays in KO
       expect(result.dugouts.teamA.zones.knockedOut.players).toContain('A1');
       // Apothecary NOT consumed
-      expect(result.apothecaryAvailable.teamA).toBe(true);
+      expect(result.apothecaryAvailable.teamA).toBe(1);
       // Pending cleared
       expect(result.pendingApothecary).toBeUndefined();
     });
@@ -164,7 +164,7 @@ describe('Regle: Apothecaire', () => {
   describe('Utilisation sur Casualty', () => {
     it('devrait re-lancer le D16 et garder le meilleur resultat', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -187,13 +187,13 @@ describe('Regle: Apothecaire', () => {
       // Better casualty result applied
       expect(result.casualtyResults['A1']).toBe('badly_hurt');
       // Apothecary consumed
-      expect(result.apothecaryAvailable.teamA).toBe(false);
+      expect(result.apothecaryAvailable.teamA).toBe(0);
       expect(result.pendingApothecary).toBeUndefined();
     });
 
     it('devrait garder le resultat original si le re-roll est pire', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -215,12 +215,12 @@ describe('Regle: Apothecaire', () => {
       // Keeps original better result
       expect(result.casualtyResults['A1']).toBe('badly_hurt');
       // Apothecary consumed
-      expect(result.apothecaryAvailable.teamA).toBe(false);
+      expect(result.apothecaryAvailable.teamA).toBe(0);
     });
 
     it('devrait laisser le joueur en Casualty quand apothecaire refuse', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -240,13 +240,13 @@ describe('Regle: Apothecaire', () => {
       expect(result.dugouts.teamA.zones.casualty.players).toContain('A1');
       expect(result.casualtyResults['A1']).toBe('seriously_hurt');
       // Apothecary NOT consumed
-      expect(result.apothecaryAvailable.teamA).toBe(true);
+      expect(result.apothecaryAvailable.teamA).toBe(1);
       expect(result.pendingApothecary).toBeUndefined();
     });
 
     it('devrait conserver les lasting injury details du meilleur resultat', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -284,7 +284,7 @@ describe('Regle: Apothecaire', () => {
       const playerB = createTestPlayer({ id: 'B1', team: 'B', name: 'Team B Player' });
       const state = createTestState({
         players: [playerB],
-        apothecaryAvailable: { teamA: false, teamB: true },
+        apothecaryAvailable: { teamA: 0, teamB: 1 },
       });
 
       // KO roll
@@ -299,7 +299,7 @@ describe('Regle: Apothecaire', () => {
   describe('Game log', () => {
     it('devrait ajouter une entree de log quand l\'apothecaire est utilise', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',
@@ -318,7 +318,7 @@ describe('Regle: Apothecaire', () => {
 
     it('devrait ajouter une entree de log quand l\'apothecaire est refuse', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
         pendingApothecary: {
           playerId: 'A1',
           team: 'A',

--- a/packages/game-engine/src/mechanics/apothecary.ts
+++ b/packages/game-engine/src/mechanics/apothecary.ts
@@ -34,7 +34,10 @@ export function isApothecaryAvailable(state: GameState, playerId: string): boole
 
   if (!state.apothecaryAvailable) return false;
   const teamKey = player.team === 'A' ? 'teamA' : 'teamB';
-  return state.apothecaryAvailable[teamKey] === true;
+  // BB2020 : apothecaryAvailable est un compteur (un apothecary natif
+  // ou achete via Wandering Apothecary/Igor inducement = +1 use). Le
+  // joueur peut soigner si compteur > 0.
+  return (state.apothecaryAvailable[teamKey] ?? 0) > 0;
 }
 
 /**
@@ -106,11 +109,12 @@ export function applyApothecaryChoice(
     return newState;
   }
 
-  // Consume apothecary
+  // Consume apothecary (decrement count, min 0)
   const teamKey = pending.team === 'A' ? 'teamA' : 'teamB';
+  const current = newState.apothecaryAvailable[teamKey] ?? 0;
   newState.apothecaryAvailable = {
     ...newState.apothecaryAvailable,
-    [teamKey]: false,
+    [teamKey]: Math.max(0, current - 1),
   };
 
   const playerName = getPlayerName(newState, pending.playerId);

--- a/packages/game-engine/src/mechanics/kick-skill.test.ts
+++ b/packages/game-engine/src/mechanics/kick-skill.test.ts
@@ -52,7 +52,7 @@ function makeState(players: Player[]): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     teamNames: { teamA: 'Team A', teamB: 'Team B' },
     gameLog: [],
     half: 1,

--- a/packages/game-engine/src/mechanics/regeneration.test.ts
+++ b/packages/game-engine/src/mechanics/regeneration.test.ts
@@ -45,7 +45,7 @@ function createTestState(overrides: Partial<GameState> = {}): GameState {
     casualtyResults: {},
     lastingInjuryDetails: {},
     gameLog: [],
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     ...overrides,
   };
 }
@@ -107,7 +107,7 @@ describe('Regle: Regeneration', () => {
       // BB Season 2/3 : apothecaire est toujours offert en premier si
       // disponible. La regen sert de fallback si le coach decline.
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
       });
       const rng = () => 0.5; // 4+4=8 (KO)
       const result = performInjuryRoll(state, state.players[0], rng);
@@ -122,7 +122,7 @@ describe('Regle: Regeneration', () => {
 
     it('Lot O.A.1 — refus apothecaire → regen tentee en fallback (succes, KO)', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
       });
       let callCount = 0;
       const rng = () => {
@@ -142,7 +142,7 @@ describe('Regle: Regeneration', () => {
 
     it('Lot O.A.1 — refus apothecaire → regen tentee en fallback (echec, KO)', () => {
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
       });
       let callCount = 0;
       const rng = () => {
@@ -202,7 +202,7 @@ describe('Regle: Regeneration', () => {
       // BB Season 2/3 : apothecaire offert en premier pour casualty
       // aussi. Permet au coach de re-roller le D16 (typique pour dead).
       const state = createTestState({
-        apothecaryAvailable: { teamA: true, teamB: false },
+        apothecaryAvailable: { teamA: 1, teamB: 0 },
       });
       let callCount = 0;
       const rng = () => {

--- a/packages/game-engine/src/mechanics/secret-weapons.test.ts
+++ b/packages/game-engine/src/mechanics/secret-weapons.test.ts
@@ -45,7 +45,7 @@ function createTestState(overrides: Partial<GameState> = {}): GameState {
     casualtyResults: {},
     lastingInjuryDetails: {},
     gameLog: [],
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     turnTimerSeconds: 0,
     usedStarPlayerRules: {},
     bribesRemaining: { teamA: 0, teamB: 0 },

--- a/packages/game-engine/src/mechanics/weather-drive-effects.test.ts
+++ b/packages/game-engine/src/mechanics/weather-drive-effects.test.ts
@@ -44,7 +44,7 @@ function createTestGameState(playersPerTeam: number = 6): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: false, teamB: false },
+    apothecaryAvailable: { teamA: 0, teamB: 0 },
     dugouts: {
       teamA: {
         teamId: 'A',

--- a/packages/game-engine/src/utils/logging.test.ts
+++ b/packages/game-engine/src/utils/logging.test.ts
@@ -27,7 +27,7 @@ function makeState(log: GameLogEntry[] = []): GameState {
     turn: 1,
     selectedPlayerId: null,
     isTurnover: false,
-    apothecaryAvailable: { teamA: true, teamB: true },
+    apothecaryAvailable: { teamA: 1, teamB: 1 },
     dugouts: {
       teamA: {
         teamId: 'A',


### PR DESCRIPTION
## Summary

Deux bugs **CRITIQUES** identifiés par l'audit (round 2) :

### 1. `actions/choice-handlers.ts:186` — `Math.random()` dans push chain

`handlePushChoose` créait un RNG local `() => Math.random()` pour passer à `applyChainPush`. Les surfs en chaîne (crowd injury rolls quand un joueur est poussé dans la foule) étaient donc **non-déterministes** : même seed → résultat différent. **Brisait la rejouabilité des replays.**

**Fix** : `handlePushChoose` accepte maintenant le `rng: RNG` paramètre du dispatcher.

### 2. `core/types.ts:125` — `apothecaryAvailable` boolean → no-op silent sur 2e achat

Une équipe avec apothecary natif (Human, Dwarf, Imperial) qui achetait Wandering Apothecary inducement obtenait... rien. Le boolean restait `true`, pas de compteur.

**BB2020** : Wandering Apothecary donne UN usage supplémentaire (cumulable). Une équipe peut donc avoir 2 utilisations dans le match.

**Fix** : conversion en compteur `number`. Increment par `item.quantity` à l'achat, decrement (clamp min 0) à la consommation.

## Test plan

- [x] `push-choose-determinism.test.ts` (2 nouveaux tests)
  - [x] Mêmes seeds → mêmes outcomes (surf dans la foule deterministe)
  - [x] `apothecaryAvailable.teamA` est de type `number`
- [x] `inducements.test.ts` +1 test : Wandering Apothecary cumule avec natif (1 + 1 = 2)
- [x] 13 test fixtures mises à jour pour le nouveau type `number`
- [x] 5015 game-engine tests passent
- [x] Typecheck OK sur les deux engines

🔧 PR 1 d'une nouvelle série de 8 fix issus de l'audit round 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_