### PR TITLE
fix(game-engine): bribes sur foul send-off + Officious Ref drive flag

### DIFF
--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -916,6 +916,9 @@ export function handlePostTouchdown(state: GameState, rng: RNG): GameState {
     teamFoulCount: {} as Record<string, number>,
     rerollUsedThisTurn: false,
     lastDiceResult: undefined,
+    // BB2020 : Officious Ref effect lasts only for the current drive.
+    // Reset at touchdown (= drive end).
+    officiousRefForDrive: false,
     gameLog: [...newState.gameLog, resetLog],
     preMatch: {
       ...extState.preMatch,

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -128,6 +128,10 @@ export interface GameState {
   pendingKickoffEvent?: PendingKickoffEvent;
   // Tour de blitz kickoff en cours (équipe qui botte joue un tour immédiat)
   kickoffBlitzTurn?: boolean;
+  // Officious Ref (kickoff event 11) : pour ce drive, tout foul declenche
+  // un check D6 supplementaire ; sur 1 = expulsion automatique (en plus
+  // du doublet armor/injury). BB2020 LRB. Reset au prochain kickoff/TD.
+  officiousRefForDrive?: boolean;
   // Zones de dugout pour chaque équipe
   dugouts: {
     teamA: TeamDugout;

--- a/packages/game-engine/src/mechanics/foul-bribes-officious.test.ts
+++ b/packages/game-engine/src/mechanics/foul-bribes-officious.test.ts
@@ -1,0 +1,123 @@
+/**
+ * BB2020 :
+ *  - Bribes peuvent etre consommes pour eviter une expulsion sur foul
+ *    send-off. Avant le fix, les bribes n'etaient jamais consultes sur
+ *    foul send-off → inducement Bribe achete specifiquement pour ce
+ *    cas etait silencieusement mort.
+ *  - Officious Ref (kickoff event 11) : pendant le drive, chaque foul
+ *    declenche un D6 ; sur 1 = expulsion automatique. Avant le fix,
+ *    seul le log etait emis, le flag n'etait pas pose et `executeFoul`
+ *    ne pouvait pas le tester.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from '../actions/actions';
+import type { GameState, Player, RNG, Move } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 0, y: 0 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+function makeFoulState(over: Partial<GameState> = {}): GameState {
+  const s = setup();
+  const players: Player[] = [
+    basePlayer({ id: 'A1', team: 'A', pos: { x: 10, y: 7 }, name: 'Fouler', av: 7 }),
+    basePlayer({ id: 'B1', team: 'B', pos: { x: 11, y: 7 }, name: 'Victim', av: 7, stunned: true, pm: 0 }),
+  ];
+  return {
+    ...s,
+    players,
+    currentPlayer: 'A',
+    playerActions: {},
+    teamFoulCount: {},
+    bribesRemaining: { teamA: 0, teamB: 0 },
+    ball: { x: 5, y: 5 },
+    ...over,
+  };
+}
+
+describe('Foul Bribes (BB2020)', () => {
+  it("Bribe utilisé évite l'expulsion sur doublet armor", () => {
+    // Armor doublet 4-4 (broken) → send-off attempt. Bribe D6=3 (2+ → save).
+    const state = makeFoulState({ bribesRemaining: { teamA: 1, teamB: 0 } });
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.4]); // armor 4-4, injury 4-4, bribe roll 3
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).not.toBe('sent_off');
+    expect(result.bribesRemaining.teamA).toBe(0); // bribe consume
+  });
+
+  it("Bribe rate (D6=1) consomme quand meme + expulsion", () => {
+    const state = makeFoulState({ bribesRemaining: { teamA: 1, teamB: 0 } });
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.0]); // bribe D6=1 -> fail
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+    expect(result.bribesRemaining.teamA).toBe(0); // consume
+  });
+
+  it("Pas de bribe disponible → expulsion sur doublet", () => {
+    const state = makeFoulState({ bribesRemaining: { teamA: 0, teamB: 0 } });
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+  });
+});
+
+describe('Officious Ref (kickoff event 11 — BB2020)', () => {
+  it("Officious Ref + D6=1 → expulsion meme sans doublet", () => {
+    // Armor 5+3=8 broken pas doublet. Injury 3+4=7 stunned pas doublet.
+    // Officious Ref D6=1 → expulsion.
+    const state = makeFoulState({ officiousRefForDrive: true });
+    const rng = makeRNG([0.83, 0.4, 0.4, 0.5, 0.0]);
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).toBe('sent_off');
+  });
+
+  it("Officious Ref + D6=4 → pas d'expulsion (sans doublet)", () => {
+    const state = makeFoulState({ officiousRefForDrive: true });
+    const rng = makeRNG([0.83, 0.4, 0.4, 0.5, 0.5]); // ref D6=4
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    const fouler = result.players.find(p => p.id === 'A1')!;
+    expect(fouler.state).not.toBe('sent_off');
+  });
+
+  it("Sans Officious Ref, pas de D6 supplementaire", () => {
+    const state = makeFoulState({ officiousRefForDrive: false });
+    const rng = makeRNG([0.83, 0.4, 0.4, 0.5]); // 4 dice for armor + injury
+
+    const move: Move = { type: 'FOUL', playerId: 'A1', targetId: 'B1' };
+    const result = applyMove(state, move, rng);
+
+    // Pas de log Officious Ref
+    const refLog = result.gameLog.find(l => l.message.includes('Officious Ref'));
+    expect(refLog).toBeUndefined();
+  });
+});

--- a/packages/game-engine/src/mechanics/foul.ts
+++ b/packages/game-engine/src/mechanics/foul.ts
@@ -141,18 +141,79 @@ export function executeFoul(
   const isDoubles = armorDoubles || injuryDoubles;
   // Expulsion si doublet, sauf si l'attaquant possede Sneaky Git
   const sneakyGit = isSneakyGitActive(newState, attacker);
-  if (isDoubles && !sneakyGit) {
+
+  // BB2020 Officious Ref (kickoff event 11) : ce drive, chaque foul
+  // declenche un D6 supplementaire ; sur 1, le fouleur est expulse
+  // (en plus du doublet armor/injury). Le check s'ajoute, ne remplace pas.
+  let officiousRefSendOff = false;
+  if (newState.officiousRefForDrive) {
+    const refRoll = rollD6(rng);
+    const refLog = createLogEntry(
+      'dice',
+      `Officious Ref D6: ${refRoll}${refRoll === 1 ? ' → expulsion automatique' : ''}`,
+      attacker.id,
+      attacker.team,
+      { refRoll, officiousRef: true }
+    );
+    newState.gameLog = [...newState.gameLog, refLog];
+    officiousRefSendOff = refRoll === 1;
+  }
+
+  const sendOffTriggered = (isDoubles && !sneakyGit) || officiousRefSendOff;
+
+  if (sendOffTriggered) {
     const attackerPlayer = newState.players.find(p => p.id === attacker.id);
     if (attackerPlayer) {
-      const doublesSource = armorDoubles ? 'armure' : 'blessure';
-      const expulsionLog = createLogEntry(
-        'action',
-        `Doublet ${doublesSource} ! ${attacker.name} est expulsé par l'arbitre !`,
-        attacker.id,
-        attacker.team
-      );
-      newState.gameLog = [...newState.gameLog, expulsionLog];
-      newState = handleSentOff(newState, attackerPlayer);
+      // BB2020 Bribe : un coach peut depenser un Pot-de-vin pour eviter
+      // l'expulsion sur foul (D6 2+). Avant le fix, les bribes n'etaient
+      // jamais consultes sur foul send-off — l'inducement Bribe acheté
+      // specifiquement pour cet usage primaire (cf. catalogue.description)
+      // etait silencieusement mort. Roll D6 sur 2+ = bribe consume + skip.
+      const teamKey = attacker.team === 'A' ? 'teamA' : 'teamB';
+      const bribesAvailable = (newState.bribesRemaining?.[teamKey] ?? 0) > 0;
+      let bribeUsed = false;
+      if (bribesAvailable) {
+        const bribeRoll = rollD6(rng);
+        // Consommer le bribe que le jet reussisse ou non (BB rule).
+        newState.bribesRemaining = {
+          ...newState.bribesRemaining!,
+          [teamKey]: newState.bribesRemaining![teamKey] - 1,
+        };
+        if (bribeRoll >= 2) {
+          bribeUsed = true;
+          const bribeLog = createLogEntry(
+            'action',
+            `Pot-de-vin utilisé (D6: ${bribeRoll}) — ${attacker.name} échappe à l'expulsion. Bribes restantes : ${newState.bribesRemaining[teamKey]}`,
+            attacker.id,
+            attacker.team,
+            { bribeRoll, bribesRemaining: newState.bribesRemaining[teamKey] }
+          );
+          newState.gameLog = [...newState.gameLog, bribeLog];
+        } else {
+          const bribeFailLog = createLogEntry(
+            'action',
+            `Pot-de-vin gaspillé (D6: ${bribeRoll}) — ${attacker.name} sera expulsé. Bribes restantes : ${newState.bribesRemaining[teamKey]}`,
+            attacker.id,
+            attacker.team,
+            { bribeRoll, bribesRemaining: newState.bribesRemaining[teamKey] }
+          );
+          newState.gameLog = [...newState.gameLog, bribeFailLog];
+        }
+      }
+
+      if (!bribeUsed) {
+        const source = officiousRefSendOff && !isDoubles
+          ? 'Officious Ref'
+          : (armorDoubles ? 'Doublet armure' : 'Doublet blessure');
+        const expulsionLog = createLogEntry(
+          'action',
+          `${source} ! ${attacker.name} est expulsé par l'arbitre !`,
+          attacker.id,
+          attacker.team
+        );
+        newState.gameLog = [...newState.gameLog, expulsionLog];
+        newState = handleSentOff(newState, attackerPlayer);
+      }
     }
   } else if (isDoubles && sneakyGit) {
     const sneakyLog = createLogEntry(

--- a/packages/game-engine/src/mechanics/kickoff-events.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.ts
@@ -225,7 +225,12 @@ export function applyKickoffEvent(
     }
 
     case 'officious-ref': {
-      const log = createLogEntry('action', 'Arbitre zélé : toute faute entraîne une expulsion automatique ce drive');
+      // BB2020 : « Each Coach rolls a D6 each time their Player commits a
+      // Foul this drive. If they roll a 1, the player is Sent Off. »
+      // Avant le fix, le log etait emis mais aucun flag n'etait pose sur
+      // state ; `executeFoul` ne pouvait pas declencher ce check.
+      newState.officiousRefForDrive = true;
+      const log = createLogEntry('action', 'Arbitre zélé : toute faute peut entraîner une expulsion (D6=1) ce drive');
       newState.gameLog = [...newState.gameLog, log];
       break;
     }


### PR DESCRIPTION
## Summary

Deux bugs ciblés de l'audit round 2 — la feature Bribe et Officious Ref étaient toutes deux **mortes** côté gameplay :

### 1. Bribes jamais consultés sur foul send-off

L'inducement Pot-de-vin (Bribe) est spécifiquement décrit dans le catalogue :

> *« May be used once per bribe to avoid a send-off after committing a foul. »*

Avant le fix, `executeFoul` ne testait **jamais** `state.bribesRemaining`. Les coachs achetaient des bribes spécifiquement pour cet usage (Goblin/Halfling notamment) et n'en obtenaient aucun effet.

**Fix** : avant `handleSentOff`, si bribes disponibles, roll D6 :
- 2+ → bribe consommé + send-off évité
- 1 → bribe consommé sans effet (BB rule : la tentative coûte le bribe)

### 2. Officious Ref (kickoff event 11) flag jamais posé

L'event était loggé mais aucun state ne marquait le drive comme "officious". `executeFoul` ne pouvait donc pas déclencher le check D6 supplémentaire.

**Fix** :
- Nouveau champ `officiousRefForDrive?: boolean` sur `GameState`.
- Set à `true` dans `applyKickoffEvent('officious-ref')`.
- Reset sur `handlePostTouchdown` (fin de drive).
- `executeFoul` roule un D6 si flag actif ; sur 1 → expulsion (bribe peut encore sauver).

## Test plan

- [x] `foul-bribes-officious.test.ts` (6 nouveaux tests)
  - [x] Bribe save sur doublet armor
  - [x] Bribe raté (D6=1) consume quand même + expulsion
  - [x] Pas de bribe → expulsion sur doublet
  - [x] Officious Ref + D6=1 → expulsion même sans doublet
  - [x] Officious Ref + D6=4 → pas d'expulsion
  - [x] Sans Officious Ref → pas de check D6 supplémentaire
- [x] 5018 game-engine tests passent
- [x] Typecheck OK sur les deux engines

🔧 PR 2 d'une série de 8 de l'audit round 2. Précédent #828 (déterminisme + Apothecary count) en CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_