### PR TITLE
fix(game-engine): règles core BB3 S3 — Dauntless, Frenzy/Fend, Hypnotic Gaze, Bloodlust

### DIFF
--- a/packages/game-engine/src/actions/choice-handlers.ts
+++ b/packages/game-engine/src/actions/choice-handlers.ts
@@ -188,7 +188,23 @@ export function handlePushChoose(
 
   const frenzyActive = hasFrenzy(attacker) && !!newState.pendingFrenzyBlock;
 
-  if (fendActive) {
+  // BB2020 LRB Fend : « This skill has no effect against the Frenzy skill. »
+  // → Frenzy bypass Fend. Avant le fix, Fend bloquait le follow-up Frenzy
+  // ET annulait pendingFrenzyBlock, ce qui inverse la regle officielle.
+  if (frenzyActive) {
+    // Frenzy : follow-up obligatoire (priorite sur Fend)
+    newState.players = newState.players.map((p) =>
+      p.id === attacker.id ? { ...p, pos: target.pos } : p,
+    );
+    const frenzyFollowLog = createLogEntry(
+      'action',
+      `${attacker.name} suit ${target.name} (Frenzy — obligatoire, ignore Fend)`,
+      attacker.id,
+      attacker.team,
+      { skill: 'frenzy' },
+    );
+    newState.gameLog = [...newState.gameLog, frenzyFollowLog];
+  } else if (fendActive) {
     const fendLog = createLogEntry(
       'action',
       `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
@@ -197,21 +213,6 @@ export function handlePushChoose(
       { skill: 'fend' },
     );
     newState.gameLog = [...newState.gameLog, fendLog];
-    // Fend annule le suivi -> pas de second bloc frenzy
-    newState.pendingFrenzyBlock = undefined;
-  } else if (frenzyActive) {
-    // Frenzy : follow-up obligatoire
-    newState.players = newState.players.map((p) =>
-      p.id === attacker.id ? { ...p, pos: target.pos } : p,
-    );
-    const frenzyFollowLog = createLogEntry(
-      'action',
-      `${attacker.name} suit ${target.name} (Frenzy — obligatoire)`,
-      attacker.id,
-      attacker.team,
-      { skill: 'frenzy' },
-    );
-    newState.gameLog = [...newState.gameLog, frenzyFollowLog];
   } else {
     // Demander confirmation pour le follow-up
     newState.pendingFollowUpChoice = {

--- a/packages/game-engine/src/mechanics/bb2020-rules-core.test.ts
+++ b/packages/game-engine/src/mechanics/bb2020-rules-core.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Corrections BB2020 / BB3 :
+ *  - Dauntless compare au ST de base de la cible (pas total avec assists).
+ *  - Hypnotic Gaze : seuil fixe 3+ modifie par TZ (pas base sur AG).
+ *  - Frenzy bypass Fend (rule explicite).
+ *  - Bloodlust : pas de modificateur Block/Blitz (modificateur invente).
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { checkDauntless } from './dauntless';
+import { executeHypnoticGaze } from './hypnotic-gaze';
+import { resolveBlockResult } from './blocking';
+import type { GameState, Player, RNG } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 0, y: 0 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+describe('Dauntless — compare au ST de base, pas total avec assists (BB2020)', () => {
+  it('Attaquant ST 2 vs cible ST 4 + 2 assists : Dauntless cible seulement 4 (base)', () => {
+    const attacker = basePlayer({ id: 'A1', team: 'A', st: 2, skills: ['dauntless'] });
+    const defender = basePlayer({ id: 'B1', team: 'B', st: 4 });
+    const state = setup();
+
+    // Total cible = 4+2=6. Avant fix : D6 + 2 >= 6 → D6 >= 4.
+    // BB2020 fix : D6 + 2 >= 4 (base) → D6 >= 2. Donc D6=2 suffit.
+    const rng = makeRNG([0.25]); // D6=2
+    const result = checkDauntless(state, attacker, defender, 2, 6, rng);
+
+    expect(result.triggered).toBe(true);
+    expect(result.success).toBe(true);
+    expect(result.diceRoll).toBe(2);
+    expect(result.newAttackerStrength).toBe(4); // defender.st base + 0 assists
+  });
+});
+
+describe('Hypnotic Gaze — flat 3+ sans malus marquage (BB3 S3)', () => {
+  it('gazer AG 4+ devrait avoir target 3 (pas 2 base sur AG)', () => {
+    const base = setup();
+    const gazer = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, ag: 4, skills: ['hypnotic-gaze'] });
+    const target = basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, ag: 3 });
+    const state: GameState = { ...base, players: [gazer, target], currentPlayer: 'A' };
+
+    // BB3 S3 : seuil flat 3+. Roll=2 doit echouer (avant fix : seuil 2 base sur AG, success).
+    const rng = makeRNG([0.17]); // roll=2
+    const result = executeHypnoticGaze(state, gazer, target, rng);
+    expect(result.hypnotizedPlayers ?? []).not.toContain('B1');
+
+    // Roll=3 reussit.
+    const rng2 = makeRNG([0.4]); // roll=3
+    const result2 = executeHypnoticGaze(state, gazer, target, rng2);
+    expect(result2.hypnotizedPlayers ?? []).toContain('B1');
+  });
+
+  it("BB3 S3 : pas de malus marquage (seuil reste 3+ meme avec adversaires adjacents)", () => {
+    const base = setup();
+    const gazer = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, ag: 3, skills: ['hypnotic-gaze'] });
+    const target = basePlayer({ id: 'B1', team: 'B', pos: { x: 6, y: 5 }, ag: 3 });
+    // Plusieurs adversaires en TZ du gazer.
+    const opp1 = basePlayer({ id: 'B2', team: 'B', pos: { x: 4, y: 4 } });
+    const opp2 = basePlayer({ id: 'B3', team: 'B', pos: { x: 5, y: 4 } });
+    const state: GameState = {
+      ...base, players: [gazer, target, opp1, opp2], currentPlayer: 'A',
+    };
+
+    // Avant fix : 2 TZ → target 3+ - 2 = clamped 2+, roll=2 reussit.
+    // BB3 S3 : flat 3+, roll=3 requis. Roll=2 echoue.
+    const rng = makeRNG([0.17]); // roll=2
+    const result = executeHypnoticGaze(state, gazer, target, rng);
+    expect(result.hypnotizedPlayers ?? []).not.toContain('B1');
+  });
+});
+
+describe('Frenzy bypass Fend (BB2020)', () => {
+  it("Frenzy attaquant impose follow-up meme si cible a Fend", () => {
+    const base = setup();
+    const attacker = basePlayer({
+      id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['frenzy'], stunned: false,
+    });
+    const target = basePlayer({
+      id: 'B1', team: 'B', pos: { x: 6, y: 5 }, skills: ['fend'], stunned: false,
+    });
+    const state: GameState = {
+      ...base,
+      players: [attacker, target],
+      currentPlayer: 'A',
+    };
+
+    // resolveBlockResult PUSH_BACK → handlePushBack.
+    const blockResult = {
+      type: 'block' as const,
+      playerId: 'A1',
+      targetId: 'B1',
+      diceRoll: 3,
+      result: 'PUSH_BACK' as const,
+      offensiveAssists: 0, defensiveAssists: 0,
+      totalStrength: 3, targetStrength: 3,
+    };
+    const rng = makeRNG([0.5, 0.5, 0.5]);
+    const result = resolveBlockResult(state, blockResult, rng);
+
+    // BB2020 : Frenzy bypass Fend. Avant le fix, Fend annulait
+    // pendingFrenzyBlock. Maintenant, malgre Fend cote cible, le
+    // pendingFrenzyBlock reste arme.
+    expect(result.pendingFrenzyBlock).toBeDefined();
+    expect(result.pendingFrenzyBlock?.attackerId).toBe('A1');
+  });
+});

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -1086,23 +1086,18 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
 
     state = applyChainPush(state, target.id, pushDirection, rng);
 
-    if (fendActive) {
-      const fendLog = createLogEntry(
-        'action',
-        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
-        target.id,
-        target.team,
-        { skill: 'fend' },
-      );
-      state.gameLog = [...state.gameLog, fendLog];
-    } else if (frenzyActive) {
-      // Frenzy : follow-up obligatoire + second bloc
+    // BB2020 LRB Fend : « This skill has no effect against the Frenzy skill. »
+    // → Frenzy bypass Fend. Avant le fix, Fend bloquait Frenzy (l'inverse
+    // de la regle officielle). Maintenant Frenzy a la priorite ; Fend
+    // s'applique uniquement si l'attaquant n'a pas Frenzy active.
+    if (frenzyActive) {
+      // Frenzy : follow-up obligatoire + second bloc (priorite sur Fend)
       state.players = state.players.map(p =>
         p.id === attacker.id ? { ...p, pos: target.pos } : p
       );
       const frenzyFollowLog = createLogEntry(
         'action',
-        `${attacker.name} suit ${target.name} (Frenzy — obligatoire)`,
+        `${attacker.name} suit ${target.name} (Frenzy — obligatoire, ignore Fend)`,
         attacker.id,
         attacker.team,
         { skill: 'frenzy' },
@@ -1112,6 +1107,15 @@ function handlePushBack(state: GameState, attacker: Player, target: Player, rng:
         attackerId: attacker.id,
         targetId: target.id,
       };
+    } else if (fendActive) {
+      const fendLog = createLogEntry(
+        'action',
+        `${target.name} utilise Fend : ${attacker.name} ne peut pas suivre`,
+        target.id,
+        target.team,
+        { skill: 'fend' },
+      );
+      state.gameLog = [...state.gameLog, fendLog];
     } else {
       // Follow-up is optional on PUSH_BACK — let the attacker choose
       state.pendingFollowUpChoice = {

--- a/packages/game-engine/src/mechanics/dauntless.test.ts
+++ b/packages/game-engine/src/mechanics/dauntless.test.ts
@@ -111,36 +111,37 @@ describe('Regle: Dauntless — activation', () => {
     expect(result.diceRoll).toBe(1);
   });
 
-  it('le calcul utilise uniquement la ST de base (pas les assists)', () => {
+  it('le calcul utilise uniquement la ST de base (pas les assists) — BB2020', () => {
     const attacker = makePlayer({ skills: ['dauntless'], st: 3 });
     const defender = makePlayer({ id: 'd1', team: 'B', st: 4 });
     const state = setup();
 
-    // Attaquant a 3 ST + 0 assist = 3 ; cible = 4 ST + 2 assists = 6 total
-    // Dauntless roll : ST(3) + D6 doit etre >= 6 → D6 >= 3
-    // D6 = 3 (rng 0.4 → 3). 3 + 3 = 6 >= 6 → succes → force = 6
-    const rng = makeTestRNG([0.4]);
+    // BB2020 : compare au ST de base (defender.st=4), PAS au total avec assists.
+    // Attaquant.st=3, D6=1 → 3+1=4 >= 4 → SUCCES.
+    // newAttackerStrength = defender.st (4) + offensiveAssists (0) = 4.
+    const rng = makeTestRNG([0.0]); // D6=1
     const result = checkDauntless(state, attacker, defender, 3, 6, rng);
 
     expect(result.triggered).toBe(true);
     expect(result.success).toBe(true);
-    expect(result.diceRoll).toBe(3);
-    expect(result.newAttackerStrength).toBe(6);
+    expect(result.diceRoll).toBe(1);
+    expect(result.newAttackerStrength).toBe(4); // defender.st base, pas 6
   });
 
-  it('le calcul utilise uniquement la ST de base (echec marginal)', () => {
-    const attacker = makePlayer({ skills: ['dauntless'], st: 3 });
+  it("le calcul utilise uniquement la ST de base (echec si D6 trop bas)", () => {
+    const attacker = makePlayer({ skills: ['dauntless'], st: 2 });
     const defender = makePlayer({ id: 'd1', team: 'B', st: 4 });
     const state = setup();
 
-    // Cible totale = 6. D6 = 2 → 3 + 2 = 5 < 6 → echec
-    const rng = makeTestRNG([0.25]);
-    const result = checkDauntless(state, attacker, defender, 3, 6, rng);
+    // attacker.st=2, defender.st=4 (base). D6 doit etre >= 2 pour reussir.
+    // D6=1 (rng=0.0 → floor(0*6)+1=1) → 2+1=3 < 4 → echec.
+    const rng = makeTestRNG([0.0]);
+    const result = checkDauntless(state, attacker, defender, 2, 6, rng);
 
     expect(result.triggered).toBe(true);
     expect(result.success).toBe(false);
-    expect(result.diceRoll).toBe(2);
-    expect(result.newAttackerStrength).toBe(3);
+    expect(result.diceRoll).toBe(1);
+    expect(result.newAttackerStrength).toBe(2);
   });
 
   it('ajoute une entree de log au GameState', () => {

--- a/packages/game-engine/src/mechanics/dauntless.ts
+++ b/packages/game-engine/src/mechanics/dauntless.ts
@@ -47,6 +47,12 @@ export function checkDauntless(
   defenderStrength: number,
   rng: RNG
 ): DauntlessCheckResult {
+  // BB2020 LRB Dauntless : « Roll a D6 and add the ST value of this player
+  // (on his Card). If the result is equal to or greater than the ST value
+  // of the Target (on his Card)... » → la cible **base ST** est testee,
+  // pas le total ST+assists. Avant le fix, on comparait au total avec
+  // assists defensives, ce qui rendait Dauntless plus difficile face a
+  // une cible avec assists et donc moins effectif que prevu BB2020.
   // Skill absent or attacker is not underdog → no Dauntless roll.
   if (!hasSkill(attacker, 'dauntless') || attackerStrength >= defenderStrength) {
     return {
@@ -57,19 +63,21 @@ export function checkDauntless(
   }
 
   const diceRoll = Math.floor(rng() * 6) + 1;
-  const success = attacker.st + diceRoll >= defenderStrength;
+  // BB2020 : compare au ST de base de la cible, pas au total avec assists.
+  const success = attacker.st + diceRoll >= defender.st;
 
   const rollLog = createLogEntry(
     'dice',
     `Intrépide (${attacker.name}): D6=${diceRoll}+ST${attacker.st}=${
       attacker.st + diceRoll
-    } vs ${defenderStrength} ${success ? '✓' : '✗'}`,
+    } vs ST cible ${defender.st} ${success ? '✓' : '✗'}`,
     attacker.id,
     attacker.team,
     {
       diceRoll,
-      targetNumber: defenderStrength - attacker.st,
+      targetNumber: defender.st - attacker.st,
       attackerSt: attacker.st,
+      defenderBaseSt: defender.st,
       defenderStrength,
       success,
       skill: 'dauntless',
@@ -85,7 +93,13 @@ export function checkDauntless(
     triggered: true,
     success,
     diceRoll,
-    newAttackerStrength: success ? defenderStrength : attackerStrength,
+    // BB2020 : si Dauntless reussit, l'attaquant est considere ST = target's
+    // base ST pour ce bloc. Les assists offensives s'ajoutent ensuite. Donc
+    // newAttackerStrength = defender.st + (attackerStrength - attacker.st) =
+    // defender.st + offensiveAssists.
+    newAttackerStrength: success
+      ? defender.st + (attackerStrength - attacker.st)
+      : attackerStrength,
     newState,
   };
 }

--- a/packages/game-engine/src/mechanics/hypnotic-gaze.test.ts
+++ b/packages/game-engine/src/mechanics/hypnotic-gaze.test.ts
@@ -167,9 +167,11 @@ describe('Regle: Hypnotic Gaze', () => {
       const state = createGazeTestState();
       const gazer = state.players.find(p => p.id === 'A1')!;
       const target = state.players.find(p => p.id === 'B1')!;
-      // AG 2+ → target number 2, roll 2 → success
-      // RNG value (0..1): for roll of 2 on d6, need value in [1/6, 2/6) → 0.17
-      const rng = makeTestRNG([0.17]);
+      // BB2020 : target number fixe a 3+ (modifie par TZ adverses).
+      // Avant le fix, target etait base sur gazer.ag, ce qui donnait 2+ pour
+      // un gazer AG3+ — c'etait incorrect. Maintenant 3+ avec roll=3 -> success.
+      // RNG value for roll=3: [2/6, 3/6) → 0.4.
+      const rng = makeTestRNG([0.4]);
       const result = executeHypnoticGaze(state, gazer, target, rng);
       expect(result.hypnotizedPlayers).toContain('B1');
     });

--- a/packages/game-engine/src/mechanics/hypnotic-gaze.ts
+++ b/packages/game-engine/src/mechanics/hypnotic-gaze.ts
@@ -73,10 +73,18 @@ export function executeHypnoticGaze(
   );
   newState.gameLog = [...newState.gameLog, actionLog];
 
-  // Calcul des modificateurs et jet de dé
+  // BB3 Season 3 Hypnotic Gaze : « Il faut un 3+ pour reussir tout le
+  // temps. Plus de malus pour marquage. » (cf. skill description
+  // index.ts:650 — BB3 simplification du BB2020 LRB). Le seuil est
+  // FLAT 3+ sans malus de marquage. Avant le fix, le seuil etait base
+  // sur l'AG du gazer (max(2, min(6, gazer.ag - modifiers))) — un
+  // gazer AG3+ obtenait 3+ par accident, mais un AG4+ obtenait un seuil
+  // 2+ injuste, ET les TZ adverses penalisaient le jet contre la regle BB3.
   const modifiers = calculateGazeModifiers(newState, gazer, target);
   const diceRoll = rollD6(rng);
-  const targetNumber = Math.max(2, Math.min(6, gazer.ag - modifiers));
+  // BB3 S3 : flat 3+, ignore marking modifier. `modifiers` n'est plus
+  // applique au seuil (log conserve pour traçabilite).
+  const targetNumber = 3;
   const success = diceRoll >= targetNumber && diceRoll !== 1;
 
   const diceResult: DiceResult = {

--- a/packages/game-engine/src/mechanics/negative-traits.test.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.test.ts
@@ -322,20 +322,22 @@ describe('Regle: Bloodlust (Soif de Sang)', () => {
       expect(result.passed).toBe(true);
     });
 
-    it('should pass on roll=3 for BLOCK action (3+1=4 >= 4)', () => {
+    it('BLOCK/BLITZ ne donnent PLUS de +1 BB2020 — roll=3 sur cible 4+ echoue', () => {
+      // BB2020 : aucun modificateur Block/Blitz n'existe pour Bloodlust.
+      // Avant le fix, le code ajoutait +1 si BLOCK/BLITZ (modificateur invente).
       let state = setup();
       state = withSkill(state, 'A1', 'bloodlust');
       const player = getPlayer(state, 'A1');
-      const result = checkBloodlust(state, player, fixedRNG(0.4), 'BLOCK');
-      expect(result.passed).toBe(true);
-    });
+      // bloodlust cible 4+, roll=3 (rng 0.4) → 3 < 4 echec, meme sur BLOCK.
+      const blockResult = checkBloodlust(state, player, fixedRNG(0.4), 'BLOCK');
+      expect(blockResult.passed).toBe(false);
 
-    it('should pass on roll=3 for BLITZ action (3+1=4 >= 4)', () => {
-      let state = setup();
-      state = withSkill(state, 'A1', 'bloodlust');
-      const player = getPlayer(state, 'A1');
-      const result = checkBloodlust(state, player, fixedRNG(0.4), 'BLITZ');
-      expect(result.passed).toBe(true);
+      // idem pour BLITZ
+      let state2 = setup();
+      state2 = withSkill(state2, 'A1', 'bloodlust');
+      const player2 = getPlayer(state2, 'A1');
+      const blitzResult = checkBloodlust(state2, player2, fixedRNG(0.4), 'BLITZ');
+      expect(blitzResult.passed).toBe(false);
     });
 
     it('should fail on natural 1 even with BLOCK modifier', () => {
@@ -421,12 +423,14 @@ describe('Regle: Bloodlust (Soif de Sang)', () => {
       expect(result.passed).toBe(true);
     });
 
-    it('should pass on roll=2 for BLOCK action (2+1=3 >= 3)', () => {
+    it('BB2020 : aucun bonus +1 sur BLOCK pour bloodlust-3 (roll=2 sur 3+ echoue)', () => {
+      // BB2020 supprime le modificateur Block/Blitz invente.
       let state = setup();
       state = withSkill(state, 'A1', 'bloodlust-3');
       const player = getPlayer(state, 'A1');
+      // bloodlust-3, roll=2 (rng 0.2 → 2) < 3 → echec.
       const result = checkBloodlust(state, player, fixedRNG(0.2), 'BLOCK');
-      expect(result.passed).toBe(true);
+      expect(result.passed).toBe(false);
     });
 
     it('should fail on natural 1 even with BLITZ modifier', () => {

--- a/packages/game-engine/src/mechanics/negative-traits.ts
+++ b/packages/game-engine/src/mechanics/negative-traits.ts
@@ -589,21 +589,20 @@ export function checkBloodlust(
     return { passed: true, newState: state };
   }
 
-  // Roll D6
+  // BB2020 Bloodlust : jet D6 fixe contre `targetNumber` (variant
+  // 2+/3+/4+). Aucun modificateur Block/Blitz n'existe dans la regle.
+  // Avant le fix, on ajoutait +1 si BLOCK/BLITZ — modificateur invente
+  // qui rendait Bloodlust trop facile pour les Vampires qui blitzent.
   const roll = Math.floor(rng() * 6) + 1;
-  const isBlockOrBlitz = moveType === 'BLOCK' || moveType === 'BLITZ';
-  const modifier = isBlockOrBlitz ? 1 : 0;
-  const total = roll + modifier;
-  // Natural 1 always fails, regardless of modifier
-  const success = roll !== 1 && total >= targetNumber;
+  // Natural 1 always fails (BB2020 standard).
+  const success = roll !== 1 && roll >= targetNumber;
 
-  const modifierText = modifier > 0 ? ` (+${modifier})` : '';
   const rollLog = createLogEntry(
     'dice',
-    `Soif de Sang: ${roll}${modifierText}/${targetNumber} ${success ? '✓' : '✗'}`,
+    `Soif de Sang: ${roll}/${targetNumber} ${success ? '✓' : '✗'}`,
     player.id,
     player.team,
-    { diceRoll: roll, targetNumber, success, skill: 'bloodlust', modifier }
+    { diceRoll: roll, targetNumber, success, skill: 'bloodlust' }
   );
 
   let newState: GameState = {

--- a/packages/game-engine/src/mechanics/sprint13-dauntless-juggernaut-integration.test.ts
+++ b/packages/game-engine/src/mechanics/sprint13-dauntless-juggernaut-integration.test.ts
@@ -270,20 +270,21 @@ describe('Integration: Dauntless dans le flow de blocage complet', () => {
 // ── Dauntless: checkDauntless unit integration with roster players ───────
 
 describe('Integration: Dauntless — checkDauntless avec joueurs roster', () => {
-  it('Troll Slayer vs Kroxigor : utilise ST de base (3) pas les assists', () => {
+  it('Troll Slayer vs Kroxigor : utilise ST de base (5) pas les assists', () => {
     const slayer = makeTrollSlayer();
     const krox = makeKroxigor();
     const state = makeState([slayer, krox]);
 
-    // Attaquant total=3, defenseur total=6 (ST5+1 assist)
-    // Dauntless: D6=3 (rng 0.4). 3+3=6 >= 6 → succes
-    const rng = makeTestRNG([0.4]);
+    // BB2020 : Dauntless compare au ST de base de la cible (krox.st=5),
+    // pas au total avec assists. attacker.st=3, D6=2 → 3+2=5 >= 5 → succes.
+    // newAttackerStrength = krox.st(5) + offensiveAssists(0) = 5.
+    const rng = makeTestRNG([0.25]); // D6=2
     const result = checkDauntless(state, slayer, krox, 3, 6, rng);
 
     expect(result.triggered).toBe(true);
     expect(result.success).toBe(true);
-    expect(result.diceRoll).toBe(3);
-    expect(result.newAttackerStrength).toBe(6);
+    expect(result.diceRoll).toBe(2);
+    expect(result.newAttackerStrength).toBe(5);
   });
 
   it('Dwarf Blocker SANS dauntless vs Saurus : ne declenche pas', () => {


### PR DESCRIPTION
## Summary

Quatre corrections sur les règles **core BB3 Saison 3 (2025)** identifiées par l'audit round 2.

### 1. `mechanics/dauntless.ts` — Compare au ST de base, pas total avec assists

**BB3 S3 LRB Dauntless** : *« Roll a D6 and add the ST value of this player (on his Card). If the result is equal to or greater than the ST value of the Target (on his Card)... »*

Avant le fix, on comparait à `defenderStrength` (ST + assists), ce qui rendait Dauntless plus difficile que prévu BB. Maintenant comparé à `defender.st` (base).

### 2. `mechanics/blocking.ts` + `actions/choice-handlers.ts` — Frenzy bypass Fend

**BB3 S3 LRB Fend** : *« This skill has no effect against the Frenzy skill. »*

Avant le fix, Fend bloquait Frenzy (règle inversée). Frenzy a maintenant priorité sur Fend.

### 3. `mechanics/hypnotic-gaze.ts` — Seuil flat 3+ sans malus marquage

**BB3 S3** simplification documentée dans `skills/index.ts:650` : *« Il faut un 3+ pour réussir tout le temps. Plus de malus pour marquage. »*

Avant le fix, le seuil était `gazer.ag - modifiers` — un AG4+ gazer obtenait 2+ injuste, et les TZ adverses pénalisaient contre la règle BB3.

### 4. `mechanics/negative-traits.ts` — Bloodlust sans modificateur Block/Blitz

**BB3 S3** : jet D6 contre cible 2+/3+/4+ sans modificateur. Natural 1 échec.

Avant le fix, le code ajoutait `+1 si BLOCK/BLITZ` — modificateur inventé qui rendait Bloodlust trop facile pour les Vampires qui blitzent.

## Test plan

- [x] `bb2020-rules-core.test.ts` (4 nouveaux tests)
  - [x] Dauntless base ST (pas total avec assists)
  - [x] Hypnotic Gaze flat 3+
  - [x] Hypnotic Gaze ignore marking
  - [x] Frenzy bypass Fend
- [x] Tests existants ajustés pour les nouvelles règles : `dauntless.test`, `hypnotic-gaze.test`, `negative-traits.test`, `sprint13-dauntless-juggernaut-integration.test`
- [x] 5015 game-engine tests passent
- [x] Typecheck OK

🔧 PR 3 d'une série de 8 de l'audit round 2. Précédents #828 (déterminisme), #829 (bribes/officious-ref).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_