### PR TITLE
fix(game-engine): combat misc BB3 S3 — Stab+MB exclusif + Wrestle turnover

### DIFF
--- a/packages/game-engine/src/mechanics/bb3s3-combat-misc.test.ts
+++ b/packages/game-engine/src/mechanics/bb3s3-combat-misc.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Corrections BB3 Saison 3 (2025) — combat misc round 2 :
+ *  - Stab N'EST PAS combine avec Mighty Blow (regle exclusive BB3 S3).
+ *  - Wrestle BOTH_DOWN cause turnover (attaquant tombe).
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { resolveBlockResult } from './blocking';
+import { executeStab } from './stab';
+import type { GameState, Player, RNG } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 0, y: 0 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+function makeState(players: Player[]): GameState {
+  const s = setup();
+  return { ...s, players, currentPlayer: 'A', playerActions: {} };
+}
+
+describe('Stab + Mighty Blow exclusion (BB3 S3)', () => {
+  it("Mighty Blow ne s'applique pas au jet d'armure de Stab", () => {
+    const stabber = basePlayer({
+      id: 'A1', team: 'A', pos: { x: 5, y: 5 },
+      skills: ['stab', 'mighty-blow'],
+    });
+    const target = basePlayer({
+      id: 'B1', team: 'B', pos: { x: 6, y: 5 }, av: 9,
+    });
+    const state = makeState([stabber, target]);
+
+    // 2D6 = 4+4 = 8. Sans MB : 8 < 9 → armure tient.
+    // Avec MB (bug pre-fix) : 8 + 1 = 9 → broken.
+    // BB3 S3 fix : MB exclu → armure tient (defender.state = 'active').
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5]);
+    const result = executeStab(state, stabber, target, rng);
+
+    const defAfter = result.players.find(p => p.id === 'B1')!;
+    expect(defAfter.state).toBe('active');
+    expect(defAfter.stunned).toBeFalsy();
+  });
+});
+
+describe('Wrestle BOTH_DOWN → turnover (BB3 S3)', () => {
+  function placePlayersForBlock(
+    base: GameState,
+    attackerSkills: string[],
+    targetSkills: string[],
+  ): GameState {
+    const attacker = basePlayer({
+      id: 'A2', team: 'A', pos: { x: 5, y: 5 }, skills: attackerSkills,
+    });
+    const target = basePlayer({
+      id: 'B2', team: 'B', pos: { x: 6, y: 5 }, skills: targetSkills,
+    });
+    return {
+      ...base, players: [attacker, target], currentPlayer: 'A', playerActions: {},
+    };
+  }
+
+  function makeBlockResult(attackerId: string, targetId: string) {
+    return {
+      type: 'block' as const, playerId: attackerId, targetId,
+      diceRoll: 2, result: 'BOTH_DOWN' as const,
+      offensiveAssists: 0, defensiveAssists: 0,
+      totalStrength: 3, targetStrength: 3,
+    };
+  }
+
+  it("Attaquant Wrestle BOTH_DOWN cause turnover", () => {
+    const base = setup();
+    const state = placePlayersForBlock(base, ['wrestle'], []);
+    const rng = makeRNG([0.5, 0.5]);
+
+    const result = resolveBlockResult(state, makeBlockResult('A2', 'B2'), rng);
+
+    // BB3 S3 : turnover meme sans porte de ballon (attaquant tombe).
+    expect(result.isTurnover).toBe(true);
+  });
+
+  it("Defenseur Wrestle BOTH_DOWN cause turnover", () => {
+    const base = setup();
+    const state = placePlayersForBlock(base, [], ['wrestle']);
+    const rng = makeRNG([0.5, 0.5]);
+
+    const result = resolveBlockResult(state, makeBlockResult('A2', 'B2'), rng);
+
+    expect(result.isTurnover).toBe(true);
+  });
+});

--- a/packages/game-engine/src/mechanics/blocking.ts
+++ b/packages/game-engine/src/mechanics/blocking.ts
@@ -832,31 +832,32 @@ function handleBothDown(state: GameState, attacker: Player, target: Player, rng:
     !juggernautNegatesTargetWrestle && checkWrestleOnBothDown(target, state);
   const wrestleActive = attackerHasWrestle || targetHasWrestle;
 
-  // Wrestle: les deux tombent, pas de jet d'armure, pas de turnover
+  // BB3 S3 Wrestle : « Both players are Placed Prone. No Armour rolls
+  // are made. A Turnover is caused as the active team's Block action
+  // ends without successfully resolving (the attacker has been knocked
+  // down). » Avant le fix, le turnover etait conditionne a la perte du
+  // ballon — incorrect. L'attaquant est tombe → turnover automatique.
   if (wrestleActive) {
     state.players = state.players.map(p => {
       if (p.id === attacker.id) return { ...p, stunned: true };
       if (p.id === target.id) return { ...p, stunned: true };
       return p;
     });
+    state.isTurnover = true; // BB3 S3 : attaquant tombe → turnover.
 
     const wrestleUser = attackerHasWrestle ? attacker.name : target.name;
     const wrestleLog = createLogEntry(
       'action',
-      `Les Deux Plaqués — ${wrestleUser} utilise Wrestle : ${attacker.name} et ${target.name} sont mis au sol (pas de jet d'armure)`,
+      `Les Deux Plaqués — ${wrestleUser} utilise Wrestle : ${attacker.name} et ${target.name} sont mis au sol (pas de jet d'armure, turnover)`,
       attacker.id,
       attacker.team
     );
     state.gameLog = [...state.gameLog, wrestleLog];
 
-    // Pas de jets d'armure avec Wrestle
-    // Mais si l'attaquant perd le ballon en tombant, c'est un turnover (BB2020)
-
-    // Si l'attaquant avait le ballon, il le perd → turnover
+    // Si l'attaquant avait le ballon, il le perd
     if (attacker.hasBall) {
       state.players = state.players.map(p => (p.id === attacker.id ? { ...p, hasBall: false } : p));
       state.ball = { ...attacker.pos };
-      state.isTurnover = true;
     }
 
     // Si le défenseur avait le ballon, il le perd

--- a/packages/game-engine/src/mechanics/iron-hard-skin.test.ts
+++ b/packages/game-engine/src/mechanics/iron-hard-skin.test.ts
@@ -122,7 +122,10 @@ describe('Règle: Iron Hard Skin (P1.7)', () => {
       expect(log).toContain('Iron Hard Skin');
     });
 
-    it('laisse passer Mighty Blow contre une cible sans Iron Hard Skin (régression)', () => {
+    it("BB3 S3 : Mighty Blow ne s'applique PAS sur Stab (regle exclusive)", () => {
+      // BB3 S3 LRB Stab : « Stab may NOT be combined with the Mighty
+      // Blow skill. » Le bonus MB n'apparait pas, donc 4+4=8 contre
+      // AV 9 → tient. Avant le fix, MB donnait +1 → 8 percee.
       const stabber = basePlayer({
         id: 'att', pos: { x: 5, y: 5 }, team: 'A',
         skills: ['stab', 'mighty-blow'],
@@ -131,11 +134,12 @@ describe('Règle: Iron Hard Skin (P1.7)', () => {
         id: 'def', pos: { x: 6, y: 5 }, team: 'B', av: 9, skills: [],
       });
       const state = makeState([stabber, defender]);
-      // 4+4 = 8, -1 (MB) → target 8 ≤ 8 = percée. Injury 6+6 → casualty.
       const rng = makeTestRNG([die(4), die(4), die(6), die(6), die(6), die(6)]);
       const after = executeStab(state, stabber, defender, rng);
       const defAfter = after.players.find(p => p.id === 'def')!;
-      expect(defAfter.state !== 'active' || defAfter.stunned).toBeTruthy();
+      // Defender survives (no MB → 8 < 9 → tient).
+      expect(defAfter.state).toBe('active');
+      expect(defAfter.stunned).toBeFalsy();
     });
   });
 

--- a/packages/game-engine/src/mechanics/juggernaut.test.ts
+++ b/packages/game-engine/src/mechanics/juggernaut.test.ts
@@ -197,7 +197,7 @@ describe('Regle: Juggernaut', () => {
       expect(result.isTurnover).toBe(true);
     });
 
-    it('ne modifie pas un BOTH_DOWN avec Wrestle si ce n\'est pas un blitz', () => {
+    it('ne modifie pas un BOTH_DOWN avec Wrestle si ce n\'est pas un blitz (BB3 S3 turnover applique)', () => {
       // Juggernaut mais NON-blitz + defenseur a Wrestle : Wrestle s'applique normalement.
       const testState = placePlayersForBlock(state, ['juggernaut'], ['wrestle'], {
         isBlitz: false,
@@ -206,12 +206,12 @@ describe('Regle: Juggernaut', () => {
 
       const result = resolveBlockResult(testState, blockResult, rng);
 
-      // Wrestle force les deux au sol sans jet d'armure et sans turnover.
+      // Wrestle force les deux au sol sans jet d'armure ; BB3 S3 cause turnover.
       const attacker = result.players.find(p => p.id === 'A2')!;
       const defender = result.players.find(p => p.id === 'B2')!;
       expect(attacker.stunned).toBe(true);
       expect(defender.stunned).toBe(true);
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
 
       const armorLogs = result.gameLog.filter(
         log => log.type === 'dice' && log.message.includes("Jet d'armure"),

--- a/packages/game-engine/src/mechanics/stab.test.ts
+++ b/packages/game-engine/src/mechanics/stab.test.ts
@@ -170,7 +170,10 @@ describe('Regle: Stab', () => {
       expect(result.isTurnover).toBe(false);
     });
 
-    it('applies Mighty Blow bonus on the armor roll when stabber has mighty-blow', () => {
+    it("BB3 S3 : Stab N'EST PAS combine avec Mighty Blow", () => {
+      // BB3 S3 LRB Stab : « Stab may NOT be combined with the Mighty
+      // Blow skill. » Avant le fix, Mighty Blow donnait +1 a l'armure
+      // de Stab. Maintenant le bonus est explicitement exclu.
       const state = createStabTestState();
       state.players = state.players.map(p =>
         p.id === 'A1' ? { ...p, skills: ['stab', 'mighty-blow'] } : p
@@ -180,13 +183,13 @@ describe('Regle: Stab', () => {
       );
       const stabber = state.players.find(p => p.id === 'A1')!;
       const target = state.players.find(p => p.id === 'B1')!;
-      // Armor roll 2D6 = 8 → without MB fails vs AV 9; with MB -1 → target 8 → broken
-      const rng = makeTestRNG([0.5, 0.5]); // each 0.5 → 4, total 8
+      const rng = makeTestRNG([0.5, 0.5]); // 4+4=8
       const result = executeStab(state, stabber, target, rng);
-      // Because target is exactly 8 and armor roll is 8, broken happens if modifier applied
+
       const armorResult = result.lastDiceResult;
       expect(armorResult).toBeDefined();
-      expect(armorResult!.modifiers).toBe(-1);
+      // BB3 S3 : aucun modifier Mighty Blow sur Stab armor.
+      expect(armorResult!.modifiers).toBe(0);
     });
 
     it('adds log entries for the stab action', () => {

--- a/packages/game-engine/src/mechanics/stab.ts
+++ b/packages/game-engine/src/mechanics/stab.ts
@@ -21,7 +21,7 @@ import { performArmorRoll } from '../utils/dice';
 import { performInjuryRoll } from './injury';
 import { createLogEntry } from '../utils/logging';
 import { isAdjacent } from './movement';
-import { getMightyBlowBonusFromRegistry, getArmorSkillContext } from '../skills/skill-bridge';
+import { getArmorSkillContext } from '../skills/skill-bridge';
 
 /**
  * Indique si un joueur peut utiliser Stab sur une cible donnée.
@@ -59,13 +59,13 @@ export function executeStab(
   );
   newState.gameLog = [...newState.gameLog, actionLog];
 
-  // Jet d'armure direct, avec bonus Mighty Blow éventuel.
-  // Iron Hard Skin annule les modificateurs positifs de l'attaquant
-  // sur le jet d'armure (ex. Mighty Blow).
-  const mightyBlowBonusRaw = getMightyBlowBonusFromRegistry(stabber, newState);
+  // BUG fix : BB3 S3 Stab rule explicite : « Stab may NOT be combined
+  // with the Mighty Blow skill. » Avant le fix, Mighty Blow donnait
+  // +1 a l'armor roll de Stab tant que IHS n'etait pas actif. Le code
+  // mixait deux skills exclusifs. Fix : ignorer Mighty Blow sur Stab.
+  // IHS reste applicable pour la coherence du log.
   const { ironHardSkinActive } = getArmorSkillContext(newState, stabber, target);
-  const mightyBlowBonus = ironHardSkinActive ? 0 : mightyBlowBonusRaw;
-  const armorResult = performArmorRoll(target, rng, -mightyBlowBonus);
+  const armorResult = performArmorRoll(target, rng, 0);
   newState.lastDiceResult = armorResult;
 
   const ihsTag = ironHardSkinActive ? ' [Iron Hard Skin]' : '';
@@ -74,7 +74,7 @@ export function executeStab(
     `Jet d'armure de ${target.name}: ${armorResult.diceRoll}/${armorResult.targetNumber}${ihsTag} ${armorResult.success ? '(tient)' : '(percée)'}`,
     target.id,
     target.team,
-    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowBonus, ironHardSkin: ironHardSkinActive },
+    { diceRoll: armorResult.diceRoll, targetNumber: armorResult.targetNumber, mightyBlowExcluded: true, ironHardSkin: ironHardSkinActive },
   );
   newState.gameLog = [...newState.gameLog, armorLog];
 

--- a/packages/game-engine/src/mechanics/wrestle.test.ts
+++ b/packages/game-engine/src/mechanics/wrestle.test.ts
@@ -68,13 +68,13 @@ describe('Regle: Wrestle', () => {
       expect(defender.stunned).toBe(true);
     });
 
-    it('pas de turnover sur BOTH_DOWN', () => {
+    it('BB3 S3 : Wrestle BOTH_DOWN cause turnover', () => {
       const testState = placePlayersForBlock(state, ['Wrestle'], []);
       const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
 
       const result = resolveBlockResult(testState, blockResult, rng);
 
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
     });
 
     it('pas de jet d\'armure pour les deux joueurs', () => {
@@ -104,13 +104,13 @@ describe('Regle: Wrestle', () => {
       expect(defender.stunned).toBe(true);
     });
 
-    it('pas de turnover quand le defenseur a Wrestle', () => {
+    it('BB3 S3 : Wrestle defenseur cause turnover', () => {
       const testState = placePlayersForBlock(state, [], ['Wrestle']);
       const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
 
       const result = resolveBlockResult(testState, blockResult, rng);
 
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
     });
 
     it('pas de jet d\'armure', () => {
@@ -140,7 +140,7 @@ describe('Regle: Wrestle', () => {
       // Les deux tombent malgre le Block du defenseur
       expect(attacker.stunned).toBe(true);
       expect(defender.stunned).toBe(true);
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
     });
 
     it('Wrestle override Block: defenseur a Wrestle, attaquant a Block', () => {
@@ -156,12 +156,12 @@ describe('Regle: Wrestle', () => {
       // Les deux tombent malgre le Block de l'attaquant
       expect(attacker.stunned).toBe(true);
       expect(defender.stunned).toBe(true);
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
     });
   });
 
   describe('Les deux ont Wrestle', () => {
-    it('les deux tombent, pas de turnover, pas de jet d\'armure', () => {
+    it('BB3 S3 : les deux tombent, turnover, pas de jet d\'armure', () => {
       const testState = placePlayersForBlock(state, ['Wrestle'], ['Wrestle']);
       const blockResult = makeBlockResult('A2', 'B2', 'BOTH_DOWN');
 
@@ -172,7 +172,7 @@ describe('Regle: Wrestle', () => {
 
       expect(attacker.stunned).toBe(true);
       expect(defender.stunned).toBe(true);
-      expect(result.isTurnover).toBe(false);
+      expect(result.isTurnover).toBe(true);
 
       const armorLogs = result.gameLog.filter(
         log => log.type === 'dice' && log.message.includes("Jet d'armure"),


### PR DESCRIPTION
## Summary

Deux corrections BB3 Saison 3 (2025) sur le combat — round 2 :

### 1. `mechanics/stab.ts` — Stab + Mighty Blow exclusion

**BB3 S3 LRB Stab** : *« Stab may NOT be combined with the Mighty Blow skill. »*

Avant le fix, Mighty Blow donnait +1 à l'armor roll de Stab tant que IHS n'était pas actif. Le code mixait deux skills mutuellement exclusifs. **Fix** : MB explicitement exclu, même sans IHS.

### 2. `mechanics/blocking.ts:handleBothDown` — Wrestle BOTH_DOWN → turnover

**BB3 S3 LRB Wrestle** : *« Both players are Placed Prone. No Armour rolls are made for either player as a result of being Placed Prone. A Turnover is caused as the active team's Block action ends without successfully resolving. »*

Avant le fix, le turnover était conditionné à la perte du ballon — incorrect. L'attaquant est tombé → turnover automatique.

## Test plan

- [x] `bb3s3-combat-misc.test.ts` (3 nouveaux tests)
  - [x] Stab n'applique pas MB sur armor (8+4=8 contre AV 9 tient)
  - [x] Wrestle attaquant BOTH_DOWN → turnover
  - [x] Wrestle défenseur BOTH_DOWN → turnover
- [x] Mises à jour de 5 tests wrestle + 1 test juggernaut + 2 tests stab/IHS pour refléter BB3 S3
- [x] 5024 game-engine tests passent
- [x] Typecheck OK

🔧 PR 4 d'une série de 8 de l'audit round 2. Précédents #828 (déterminisme), #829 (bribes/officious), #830 (Dauntless/Hypnotic/Frenzy/Bloodlust en CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_