### PR TITLE
fix(game-engine): once-per-match consumption élargi + Diving Tackle Prone (BB3 S3)

### DIFF
--- a/packages/game-engine/src/actions/block-handler.ts
+++ b/packages/game-engine/src/actions/block-handler.ts
@@ -43,6 +43,7 @@ import { canDumpOff, getDumpOffReceivers } from '../mechanics/dump-off';
 import { checkFoulAppearance } from '../mechanics/negative-traits';
 import { checkDauntless } from '../mechanics/dauntless';
 import { collectModifiers } from '../skills/skill-registry';
+import { consumeOncePerMatchSkills } from '../skills/skill-bridge';
 import { blockResultFromRoll } from '../utils/dice';
 import { rollBlockDiceManyWithNotification } from '../utils/dice-notifications';
 import { createLogEntry } from '../utils/logging';
@@ -152,6 +153,19 @@ export function handleBlock(
     isBlitz: isBlitzDuringMove,
   });
   const attackerSkillStBonus = attackerSkillStMods.strengthModifier ?? 0;
+  // BUG fix : consommer les star player rules « once-per-match » qui
+  // contribuent au calcul de force du blocage (Casse-Os = Mighty Zug).
+  // Avant le fix, `consumeOncePerMatchSkills` n'etait appele que sur
+  // l'armor roll (mechanics/blocking.ts:205). Casse-Os donnait donc
+  // un +1 ST a chaque blocage du match, contre la regle « une seule
+  // fois ». Le bonus est consume meme si le bloc echoue (rule BB3 S3).
+  const stateAfterCasseOs = attackerSkillStBonus !== 0
+    ? consumeOncePerMatchSkills(stateAfterFA, attacker, 'on-block-attacker', {
+        state: stateAfterFA,
+        opponent: target,
+        isBlitz: isBlitzDuringMove,
+      })
+    : stateAfterFA;
 
   // Forces de base avant Dauntless (penalite Multiple Block et bonus
   // Horns inclus via `attackerSkillStBonus`).
@@ -163,7 +177,7 @@ export function handleBlock(
   // Si l'attaquant a Dauntless et est en desavantage, il tente
   // d'egaliser la force.
   const dauntlessResult = checkDauntless(
-    stateAfterFA,
+    stateAfterCasseOs,
     attacker,
     target,
     baseAttackerStrength,

--- a/packages/game-engine/src/actions/move-handlers.ts
+++ b/packages/game-engine/src/actions/move-handlers.ts
@@ -34,6 +34,8 @@ import { createLogEntry } from '../utils/logging';
 import {
   getDodgeSkillModifiers,
   canSkillReroll,
+  consumeOncePerMatchSkills,
+  applyDivingTacklePronePostDodge,
 } from '../skills/skill-bridge';
 import { resolveShadowingAfterDodge } from '../mechanics/shadowing';
 import { checkBreakTackle } from '../mechanics/break-tackle';
@@ -75,6 +77,14 @@ export function handleDodgeRoll(
   const skillDodgeModifiers = getDodgeSkillModifiers(state, player, from);
   const dodgeModifiers = baseDodgeModifiers + skillDodgeModifiers;
 
+  // BUG fix : consommer les star player rules « once-per-match » qui
+  // contribuent au jet d'esquive (Pirouette = Roxanna Darknail). Avant
+  // le fix, `consumeOncePerMatchSkills` n'etait pas appele dans le path
+  // dodge — Pirouette donnait +1 esquive a chaque dodge du match.
+  const stateAfterPirouette = consumeOncePerMatchSkills(
+    state, player, 'on-dodge', { state }
+  );
+
   // Effectuer le jet d'esquive avec les modificateurs
   const dodgeResult = performDodgeRollWithNotification(
     player,
@@ -82,7 +92,16 @@ export function handleDodgeRoll(
     dodgeModifiers,
   );
 
-  let next = structuredClone(state) as GameState;
+  // BB3 S3 : Diving Tackle place le tackleur Prone apres une tentative
+  // d'esquive ou il a contribue le -2. Avant le fix, le -2 etait applique
+  // gratuitement (tackleur restait debout).
+  const stateAfterDivingTackle = applyDivingTacklePronePostDodge(
+    stateAfterPirouette,
+    player.team,
+    from,
+  );
+
+  let next = structuredClone(stateAfterDivingTackle) as GameState;
   next.lastDiceResult = dodgeResult;
 
   // Log du jet d'esquive

--- a/packages/game-engine/src/skills/once-per-match-consumption.test.ts
+++ b/packages/game-engine/src/skills/once-per-match-consumption.test.ts
@@ -1,0 +1,106 @@
+/**
+ * BUG fix : `consumeOncePerMatchSkills` n'etait appele que sur
+ * `'on-armor'` (`mechanics/blocking.ts:205`). Les skills star player
+ * « once-per-match » sur d'autres triggers (Pirouette `on-dodge`,
+ * Casse-Os `on-block-attacker`) firaient indefiniment.
+ *
+ * Verifie que les modifiers contributifs marquent le skill comme
+ * utilise via `markStarPlayerRuleUsed`.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from '../actions/actions';
+import { isStarPlayerRuleUsed } from './star-player-rules';
+import type { GameState, Player, RNG, Move } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 0, y: 0 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+describe("Star player rules once-per-match — consume sur block/dodge", () => {
+  it("Casse-Os (on-block-attacker) marque le skill comme utilise apres un blocage", () => {
+    const base = setup();
+    const attacker = basePlayer({
+      id: 'A1', team: 'A', pos: { x: 5, y: 5 }, skills: ['casse-os'], st: 3,
+    });
+    const target = basePlayer({
+      id: 'B1', team: 'B', pos: { x: 6, y: 5 }, st: 3,
+    });
+    const state: GameState = {
+      ...base, players: [attacker, target], currentPlayer: 'A',
+    };
+
+    // Avant le bloc : Casse-Os pas encore utilise.
+    expect(isStarPlayerRuleUsed(state, 'A1', 'casse-os')).toBe(false);
+
+    const move: Move = { type: 'BLOCK', playerId: 'A1', targetId: 'B1' };
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]);
+    const result = applyMove(state, move, rng);
+
+    // Apres le bloc : Casse-Os marque comme consume.
+    expect(isStarPlayerRuleUsed(result, 'A1', 'casse-os')).toBe(true);
+  });
+
+  it("Pirouette (on-dodge) marque le skill comme utilise apres un dodge", () => {
+    const base = setup();
+    const dodger = basePlayer({
+      id: 'A1', team: 'A', pos: { x: 5, y: 5 },
+      skills: ['pirouette'], pm: 5,
+    });
+    // Un adversaire en TZ pour forcer un dodge.
+    const opp = basePlayer({
+      id: 'B1', team: 'B', pos: { x: 5, y: 6 },
+    });
+    const state: GameState = {
+      ...base, players: [dodger, opp], currentPlayer: 'A',
+    };
+
+    expect(isStarPlayerRuleUsed(state, 'A1', 'pirouette')).toBe(false);
+
+    // MOVE de (5,5) vers (6,5) — esquive necessaire car B1 est adjacent a (5,5).
+    const move: Move = { type: 'MOVE', playerId: 'A1', to: { x: 6, y: 5 } };
+    const rng = makeRNG([0.99, 0.5, 0.5, 0.5]);
+    const result = applyMove(state, move, rng);
+
+    expect(isStarPlayerRuleUsed(result, 'A1', 'pirouette')).toBe(true);
+  });
+});
+
+describe('Diving Tackle Prone post-dodge (BB3 S3)', () => {
+  it("Le tackleur se place Prone (stunned) apres avoir contribue au -2", () => {
+    const base = setup();
+    const dodger = basePlayer({
+      id: 'A1', team: 'A', pos: { x: 5, y: 5 }, pm: 5,
+    });
+    const tackler = basePlayer({
+      id: 'B1', team: 'B', pos: { x: 5, y: 6 },
+      skills: ['diving-tackle'],
+    });
+    const state: GameState = {
+      ...base, players: [dodger, tackler], currentPlayer: 'A',
+    };
+
+    expect(tackler.stunned).toBeFalsy();
+
+    const move: Move = { type: 'MOVE', playerId: 'A1', to: { x: 6, y: 5 } };
+    const rng = makeRNG([0.99, 0.5, 0.5, 0.5]);
+    const result = applyMove(state, move, rng);
+
+    const tacklerAfter = result.players.find(p => p.id === 'B1')!;
+    expect(tacklerAfter.stunned).toBe(true);
+
+    // Log doit mentionner Diving Tackle Prone.
+    const dtLog = result.gameLog.find(l => l.message.includes('Diving Tackle'));
+    expect(dtLog).toBeDefined();
+  });
+});

--- a/packages/game-engine/src/skills/skill-bridge.ts
+++ b/packages/game-engine/src/skills/skill-bridge.ts
@@ -4,11 +4,12 @@
  * de compétences lors des jets de dés (dodge, pickup, etc.).
  */
 
-import type { Player, GameState, Position } from '../core/types';
+import type { Player, GameState, Position, TeamId } from '../core/types';
 import type { SkillTrigger, SkillContext } from './skill-registry';
 import { collectModifiers, getSkillEffect, getOncePerMatchSlugsToConsume } from './skill-registry';
 import { markStarPlayerRuleUsed } from './star-player-rules';
 import { getAdjacentOpponents } from '../mechanics/movement';
+import { hasSkill } from './skill-effects';
 
 /**
  * Marque les star player rules « once-per-match » consommés par un
@@ -54,6 +55,55 @@ export function getDodgeSkillModifiers(
   }
 
   return playerBonus + opponentPenalty;
+}
+
+/**
+ * BB3 S3 Diving Tackle : « Place this player Prone, and the dodge roll
+ * suffers -2 ». Le coût « Prone » manquait — Diving Tackle donnait le
+ * -2 sans poser le tackleur au sol. Maintenant, les tackleurs adjacents
+ * qui ont contribue au -2 sont mis Prone (stunned=true). Le caller
+ * decide a quel moment appliquer (typiquement apres la resolution
+ * dodge — meme si le dodger reussit/echoue, le tackleur tombe).
+ *
+ * NOTE : la regle officielle est opt-in cote defenseur. Le moteur
+ * applique auto (le -2 est toujours avantageux contre la perte du
+ * Prone qui dure 1 tour). Future amelioration : passer par une UI
+ * prompt « may declare Diving Tackle ».
+ */
+export function applyDivingTacklePronePostDodge(
+  state: GameState,
+  dodgerTeam: TeamId,
+  from: Position,
+): GameState {
+  const opponents = getAdjacentOpponents(state, from, dodgerTeam);
+  const tacklers = opponents.filter(
+    (opp) =>
+      hasSkill(opp, 'diving-tackle') || hasSkill(opp, 'diving_tackle'),
+  );
+  if (tacklers.length === 0) return state;
+
+  let newState = state;
+  for (const tackler of tacklers) {
+    newState = {
+      ...newState,
+      players: newState.players.map((p) =>
+        p.id === tackler.id ? { ...p, stunned: true } : p,
+      ),
+      gameLog: [
+        ...newState.gameLog,
+        {
+          id: `log-${Date.now()}-dt-${tackler.id}`,
+          timestamp: Date.now(),
+          type: 'action' as const,
+          message: `${tackler.name} se place au sol pour Diving Tackle.`,
+          playerId: tackler.id,
+          team: tackler.team,
+          details: { skill: 'diving-tackle' },
+        },
+      ],
+    };
+  }
+  return newState;
 }
 
 /**


### PR DESCRIPTION
## Summary

Deux corrections sur les skills star player (BB3 S3) :

### 1. Once-per-match consumption broader

Avant le fix, `consumeOncePerMatchSkills` n'était appelé que sur le path `'on-armor'` (`mechanics/blocking.ts:205`). Les skills star player avec `oncePerMatchSlug` sur d'autres triggers leakaient :

- **Casse-Os** (Mighty Zug, `on-block-attacker`) : donnait +1 ST à CHAQUE blocage du match → rerolls infinis du bonus.
- **Pirouette** (Roxanna Darknail, `on-dodge`) : donnait +1 esquive à chaque dodge du match.

**Fix** :
- `block-handler.ts` : consume après collect du `strengthModifier`.
- `move-handlers.ts:handleDodgeRoll` : consume après calcul des modifiers dodge.

### 2. Diving Tackle Prone post-dodge (BB3 S3)

**BB3 S3 LRB Diving Tackle** : *« Place this player Prone, and the dodge roll suffers -2. »*

Avant le fix, le -2 était appliqué sans le coût Prone — Diving Tackle restait debout. **Fix** : nouvelle fonction `applyDivingTacklePronePostDodge` qui pose les tackleurs adjacents au sol (`stunned=true`) après le jet d'esquive.

Auto-appliqué (le -2 vaut toujours le coût Prone). Future amélioration : prompt UI opt-in.

## Test plan

- [x] `once-per-match-consumption.test.ts` (3 nouveaux tests)
  - [x] Casse-Os marqué consommé après BLOCK
  - [x] Pirouette marqué consommé après MOVE+dodge
  - [x] Diving Tackle Prone après dodge
- [x] 5024 game-engine tests passent
- [x] Typecheck OK

🔧 PR 5 d'une série de 8 de l'audit round 2. Précédents tous merged ou en CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_