### PR TITLE
fix(game-engine): lasting injury stat reduction immédiate (BB3 S3)

### DIFF
--- a/packages/game-engine/src/mechanics/injury.ts
+++ b/packages/game-engine/src/mechanics/injury.ts
@@ -245,12 +245,28 @@ function handleCasualty(state: GameState, player: Player, rng: RNG, causedById?:
       injuryType,
       missNextMatch: true,
     };
+    // BB3 S3 : la lasting injury reduit immediatement la stat du joueur
+    // sur le terrain. Avant le fix, le type etait stocke dans
+    // `lastingInjuryDetails` mais `player.ma/av/ag/pa/st` n'etait jamais
+    // decrement. La casualty etait purement cosmetique. Maintenant on
+    // applique la reduction immediatement (clamp min 1 pour eviter 0).
+    newState.players = newState.players.map(p => {
+      if (p.id !== player.id) return p;
+      switch (injuryType) {
+        case '-1ma': return { ...p, ma: Math.max(1, p.ma - 1) };
+        case '-1av': return { ...p, av: Math.max(1, p.av - 1) };
+        case '-1ag': return { ...p, ag: Math.max(1, p.ag - 1) };
+        case '-1pa': return { ...p, pa: Math.max(0, p.pa - 1) };
+        case '-1st': return { ...p, st: Math.max(1, p.st - 1) };
+        default: return p;
+      }
+    });
     const lastingInjuryLog = createLogEntry(
       'action',
       `${player.name} a une blessure permanente - ${LASTING_INJURY_LABELS[injuryType]} + manquera le prochain match`,
       player.id,
       player.team,
-      { injuryType }
+      { injuryType, statReduced: true }
     );
     newState.gameLog = [...newState.gameLog, lastingInjuryLog];
   } else {

--- a/packages/game-engine/src/mechanics/lasting-injury-stat-reduction.test.ts
+++ b/packages/game-engine/src/mechanics/lasting-injury-stat-reduction.test.ts
@@ -1,0 +1,67 @@
+/**
+ * BB3 S3 lasting injury : un joueur ayant subi une lasting_injury
+ * (casualty roll 13-14) voit sa stat correspondante reduite de 1
+ * immediatement. Avant le fix, le `lastingInjuryDetails[playerId]`
+ * etait stocke mais `player.ma/av/ag/pa/st` n'etait jamais decrement.
+ * La casualty etait purement cosmetique.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { performInjuryRoll } from './injury';
+import type { GameState, Player, RNG } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'V', team: 'B', pos: { x: -1, y: -1 }, name: 'Victim', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+function makeState(victim: Player): GameState {
+  const s = setup();
+  return { ...s, players: [...s.players, victim], currentPlayer: 'A' };
+}
+
+describe('Lasting injury stat reduction (BB3 S3)', () => {
+  it("lasting_injury type '-1ma' reduit MA du joueur de 1", () => {
+    const victim = basePlayer({ id: 'V', ma: 6 });
+    const state = makeState(victim);
+    // RNG : injury 2D6=12 (casualty), then casualtyRoll D16 = 13
+    // (rng = 12/16 = 0.75 → floor(0.75*16)+1 = 13).
+    // Then rollLastingInjuryType : rng=0 → roll=1 → '-1ma'.
+    const rng = makeRNG([0.99, 0.99, 0.75, 0.0, 0.5, 0.5]);
+    const result = performInjuryRoll(state, victim, rng, 0);
+
+    const victimAfter = result.players.find(p => p.id === 'V')!;
+    expect(victimAfter.ma).toBe(5); // 6 - 1
+  });
+
+  it("lasting_injury type '-1st' reduit ST du joueur de 1", () => {
+    const victim = basePlayer({ id: 'V', st: 4 });
+    const state = makeState(victim);
+    // RNG : injury 12, casualty D16=13, rollLasting rng=0.99 → roll=6 → '-1st'.
+    const rng = makeRNG([0.99, 0.99, 0.75, 0.99, 0.5, 0.5]);
+    const result = performInjuryRoll(state, victim, rng, 0);
+
+    const victimAfter = result.players.find(p => p.id === 'V')!;
+    expect(victimAfter.st).toBe(3); // 4 - 1
+  });
+
+  it("stats sont clamp a 1 minimum (pas de 0)", () => {
+    const victim = basePlayer({ id: 'V', ma: 1, st: 1, ag: 1, av: 1 });
+    const state = makeState(victim);
+    // Lasting injury -1ma → 1 - 1 = 0, clamp to 1.
+    const rng = makeRNG([0.99, 0.99, 0.75, 0.0, 0.5, 0.5]);
+    const result = performInjuryRoll(state, victim, rng, 0);
+
+    const victimAfter = result.players.find(p => p.id === 'V')!;
+    expect(victimAfter.ma).toBe(1); // clamped
+  });
+});


### PR DESCRIPTION
## Summary

**BB3 S3 lasting injury** : un joueur ayant subi une `lasting_injury` (casualty roll 13-14) voit sa stat correspondante (MA / AV / AG / PA / ST) **réduite de 1 immédiatement**.

Avant le fix, `state.lastingInjuryDetails[playerId]` était stocké avec le type (`'-1ma'`, `'-1st'`, etc.) mais `player.ma`/`av`/`ag`/`pa`/`st` n'était jamais décrémenté. La casualty était **purement cosmétique** en match — un joueur Snapped In Half restait à 7 AV alors qu'il aurait dû passer à 6.

## Fix

Dans `mechanics/injury.ts:handleCasualty`, branche `casualtyRoll <= 14` :
- Applique immédiatement la réduction selon `injuryType`.
- Clamp min :
  - MA / AV / AG / ST → min 1
  - PA → min 0 (autorise les Big Guys sans passing)

```ts
case '-1ma': return { ...p, ma: Math.max(1, p.ma - 1) };
case '-1av': return { ...p, av: Math.max(1, p.av - 1) };
// ...
```

## Test plan

- [x] `lasting-injury-stat-reduction.test.ts` (3 nouveaux tests)
  - [x] `-1ma` réduit MA du joueur de 1
  - [x] `-1st` réduit ST du joueur de 1
  - [x] Stats clamp à 1 minimum
- [x] 5027 game-engine tests passent
- [x] Typecheck OK

🔧 PR 7 d'une série de 8 de l'audit round 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_