### PR TITLE
fix(sim-engine): resolver corrections BB3 — sent_off + pa pour passes

### DIFF
--- a/packages/sim-engine/bench/bench-baseline.json
+++ b/packages/sim-engine/bench/bench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "engineVer": "0.23.0",
+  "engineVer": "0.24.0",
   "snapshotAt": "2026-05-18",
   "tolerance": 0.05,
   "pairings": [
@@ -9,13 +9,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.845,
-        "tdStd": 1.0396994758101965,
-        "casualtyMean": 0.95,
-        "turnoverMean": 4.2,
-        "homeWinRate": 0.275,
-        "awayWinRate": 0.45,
-        "drawRate": 0.275
+        "tdMean": 1.79,
+        "tdStd": 1.002945661539048,
+        "casualtyMean": 0.955,
+        "turnoverMean": 4.255,
+        "homeWinRate": 0.375,
+        "awayWinRate": 0.34,
+        "drawRate": 0.285
       }
     },
     {
@@ -24,13 +24,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.685,
-        "tdStd": 1.098077866091471,
-        "casualtyMean": 1.115,
-        "turnoverMean": 5.33,
-        "homeWinRate": 0.765,
-        "awayWinRate": 0.04,
-        "drawRate": 0.195
+        "tdMean": 1.995,
+        "tdStd": 1.0416213323468373,
+        "casualtyMean": 1.13,
+        "turnoverMean": 4.775,
+        "homeWinRate": 0.86,
+        "awayWinRate": 0.02,
+        "drawRate": 0.12
       }
     },
     {
@@ -39,13 +39,13 @@
       "runs": 200,
       "seedOffset": 0,
       "expected": {
-        "tdMean": 1.605,
-        "tdStd": 1.0143840495591403,
-        "casualtyMean": 0.955,
-        "turnoverMean": 4.43,
-        "homeWinRate": 0.37,
-        "awayWinRate": 0.355,
-        "drawRate": 0.275
+        "tdMean": 1.61,
+        "tdStd": 1.0039422294136238,
+        "casualtyMean": 0.96,
+        "turnoverMean": 4.415,
+        "homeWinRate": 0.44,
+        "awayWinRate": 0.21,
+        "drawRate": 0.35
       }
     }
   ]

--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -188,8 +188,10 @@ function deriveStats(state: GameState): DriverStats {
     home: state.score.teamA,
     away: state.score.teamB,
   };
+  // BUG fix : exclure les `sent_off` (expulsion sur foul) du compteur
+  // casualty — c'est un etat joueur distinct, pas une blessure.
   const casualties = state.players.filter(
-    (p) => p.state === 'casualty' || p.state === 'sent_off'
+    (p) => p.state === 'casualty'
   ).length;
   return {
     score,
@@ -200,13 +202,18 @@ function deriveStats(state: GameState): DriverStats {
 }
 
 function buildCasualties(state: GameState): Casualty[] {
+  // BUG fix : avant, les joueurs `sent_off` (expulsion sur foul) etaient
+  // inclus dans les casualties avec `outcome: 'badly_hurt'` — ce qui
+  // polluait les stats de victimes et faussait les SPP/casualty count
+  // post-match. Un fouleur expulse n'est PAS une casualty. PR #823
+  // (sim-engine `resolveFoul`) avait fixe le state cote resolver, mais
+  // ce builder ici re-mergait `sent_off` comme `badly_hurt`. Maintenant
+  // on n'inclut QUE les `state === 'casualty'` (vraies blessures).
   // Casualty.outcome n'a pas de variante 'sent_off' (c'est un état joueur,
-  // pas une issue casualty). Pour le MVP on rapporte les sorties de jeu
-  // comme `badly_hurt` ; Lot 3.C.1 affinera la classification (lasting
-  // injuries, dead, etc.) en lisant les events qui auront leur place
-  // dans les MatchEvent[] de Lot 3.A.2.b.
+  // pas une issue casualty). Lot 3.C.1 affinera la classification
+  // (lasting injuries, dead, etc.) en lisant les events.
   return state.players
-    .filter((p) => p.state === 'casualty' || p.state === 'sent_off')
+    .filter((p) => p.state === 'casualty')
     .map<Casualty>((p) => ({
       playerId: p.id,
       team: p.team as TeamId,

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -231,19 +231,23 @@ function otherSide(s: Side): Side {
 function deriveLosStats(profile: TacticalProfile): {
   st: number;
   ag: number;
+  pa: number;
   ma: number;
   av: number;
   skills: string[];
 } {
   const st = Math.max(2, Math.min(6, 2 + Math.round(profile.bashIndex / 25)));
   const ag = Math.max(1, Math.min(4, 1 + Math.round(profile.breakawayInstinct / 33)));
+  // BB3 PA : derive du passingFrequency (proxy synthetique LOS).
+  // Plus passingFrequency est haut, meilleur le PA (1 = elite, 6 = nul).
+  const pa = Math.max(1, Math.min(6, 5 - Math.round(profile.passingFrequency / 25)));
   const ma = Math.max(4, Math.min(8, 4 + Math.round(profile.pace / 25)));
   const skills: string[] = [];
   if (profile.bashIndex >= 80) skills.push('block');
   if (profile.breakawayInstinct >= 75) skills.push('dodge');
   if (profile.passingFrequency >= 75) skills.push('pass');
   if (profile.foulFrequency >= 75) skills.push('dirty_player');
-  return { st, ag, ma, av: 9, skills };
+  return { st, ag, pa, ma, av: 9, skills };
 }
 
 function buildKeyMomentState(

--- a/packages/sim-engine/src/resolvers/pass.ts
+++ b/packages/sim-engine/src/resolvers/pass.ts
@@ -99,11 +99,12 @@ export function resolvePass(
 
   const totalModifier = rangeMod + tzMod + accurateMod + strongArmMod;
 
-  // BB target : raw d6 >= 7 - pa - modifier, clamped to [2, 6].
-  const rawTarget = 7 - passer.ag - totalModifier;
-  // Note: in BB3 PA replaces AG for passing — sim-engine's `ResolverPlayer`
-  // uses `ag` as the generic skill stat ; the driver maps PA→ag for the
-  // passer when calling this resolver.
+  // BB3 target : raw d6 >= 7 - pa - modifier, clamped to [2, 6].
+  // BUG fix : utilise PA (Passing Ability) au lieu d'AG. Avant le fix,
+  // `passer.ag` etait utilise (workaround « le driver mappe PA→ag »).
+  // ResolverPlayer expose maintenant `pa` directement → utilise. Cf.
+  // BB3 LRB : PA remplace AG pour les passes.
+  const rawTarget = 7 - passer.pa - totalModifier;
   const target = Math.max(2, Math.min(6, rawTarget));
 
   const firstRoll = rollD6(rng as Parameters<typeof rollD6>[0]);

--- a/packages/sim-engine/src/resolvers/resolvers.test.ts
+++ b/packages/sim-engine/src/resolvers/resolvers.test.ts
@@ -17,6 +17,7 @@ function player(p: Partial<ResolverPlayer> & Pick<ResolverPlayer, 'id' | 'team' 
   return {
     st: 3,
     ag: 3,
+    pa: 4,
     ma: 6,
     av: 9,
     skills: [],
@@ -271,15 +272,16 @@ describe('Pass resolver — sprint 0.A.5', () => {
   });
 
   it('reroll fumble drop la balle (state coherent avec event)', () => {
-    // Cherche un seed : premier roll fail non-fumble (>=2, <target), reroll = 1 (fumble).
-    // Avec ag=3 target=4 (quick range), firstRoll=2 fail puis secondRoll=1 fumble.
+    // BB3 fix : resolvePass utilise maintenant `passer.pa` (BB3) au lieu de
+    // `passer.ag`. Avec pa=3 target=4 (quick range), firstRoll=2 fail puis
+    // secondRoll=1 fumble.
     for (let seed = 0; seed < 5000; seed += 1) {
       const probe = createRng(seed);
       const first = Math.floor(probe.next() * 6) + 1;
       const second = Math.floor(probe.next() * 6) + 1;
       if (first === 2 && second === 1) {
         const state = baseState({
-          players: [{ ...passer, ag: 3, skills: ['pass'] }],
+          players: [{ ...passer, pa: 3, skills: ['pass'] }],
         });
         const out = resolvePass(
           state,

--- a/packages/sim-engine/src/resolvers/types.ts
+++ b/packages/sim-engine/src/resolvers/types.ts
@@ -46,10 +46,12 @@ export interface ResolverPosition {
 export interface ResolverPlayer {
   id: string;
   team: ResolverSide;
-  /** Strength stat (BB2020 / BB3 — typically 2..6+). */
+  /** Strength stat (BB3 — typically 2..6+). */
   st: number;
   /** Agility stat — used as `7 - ag` target on a d6 (BB3 stat scale). */
   ag: number;
+  /** Passing stat (BB3) — used as `7 - pa` target on a d6 for passes. */
+  pa: number;
   /** Movement Allowance — used by GFI (no roll under MA), passing range. */
   ma: number;
   /** Armour Value — used by armour rolls on foul / KD. */

--- a/packages/sim-engine/src/types.ts
+++ b/packages/sim-engine/src/types.ts
@@ -15,7 +15,7 @@ import type { TacticalProfile } from './tactics/tactical-profile';
 
 /** Identifies the package version that produced a SimResult. Used for replay
  *  freezing and bench regression baselines (cf. lots 0.D / 1.A.5). */
-export const ENGINE_VER = '0.23.0';
+export const ENGINE_VER = '0.24.0';
 export type EngineVersion = string;
 
 /** Match outcome at score level. */


### PR DESCRIPTION
## Summary

Trois corrections sur les resolvers sim-engine (BB3 Saison 3 — **PR 8 finale** de l'audit round 2) :

### 1. `driver/full-driver.ts:buildCasualties` — annule fix PR #823

Avant, les joueurs `state === 'sent_off'` (expulsion sur foul) étaient inclus dans les casualties avec `outcome: 'badly_hurt'`. **PR #823** avait fixé le state côté `resolveFoul`, mais ce builder en aval re-mergeait `sent_off` comme casualty — polluant stats victimes et SPP downstream.

**Fix** : filtre uniquement `state === 'casualty'` (vraies blessures). Idem pour `deriveStats.casualtyCount`.

### 2. `resolvers/types.ts:ResolverPlayer` — ajout champ `pa`

Le commentaire `« in BB3 PA replaces AG for passing — sim-engine's ResolverPlayer uses ag as the generic skill stat ; the driver maps PA→ag for the passer »` reconnaissait une dette technique. Maintenant `pa: number` est explicite.

### 3. `resolvers/pass.ts:resolvePass` — utilise `passer.pa`

Avant : `7 - passer.ag - totalModifier`. **BB3** : `7 - passer.pa - totalModifier`. Update `hybrid-driver.deriveLosStats` pour dériver `pa` depuis `profile.passingFrequency`.

### Bump ENGINE_VER 0.23.0 → 0.24.0

Re-snapshot `bench/bench-baseline.json` pour prendre en compte les changements sim-engine + game-engine en aval (PRs #824–#834).

## Test plan

- [x] `resolvers.test.ts` : update `player()` factory (`pa: 4` default) et test fumble (use `pa: 3` au lieu de `ag: 3`)
- [x] 416 sim-engine + 5024 game-engine tests passent
- [x] Typecheck OK
- [x] `sim:bench:ci` PASS avec nouveau baseline 0.24.0

🎯 **PR 8/8 — fin de la série de l'audit round 2.** Précédents PRs : #828–#834.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_