### PR TITLE
fix(game-engine): immutabilité ball-pickup + failure-helpers (CRITICAL)

### DIFF
--- a/packages/game-engine/src/actions/ball-pickup.ts
+++ b/packages/game-engine/src/actions/ball-pickup.ts
@@ -36,6 +36,16 @@ import { canUseTeamReroll } from '../core/game-state';
  *  - echec -> propose relance d'equipe si dispo, sinon turnover +
  *    rebond.
  */
+/**
+ * BUG fix immutabilite : avant, `handleBallPickup` mutait directement
+ * le parametre `state` (state.gameLog = ..., state.players[idx].hasBall
+ * = true, state.ball = undefined, state.pendingReroll = ...). Certains
+ * callers (`reroll-choose-handler.ts:215`) passent un shallow clone
+ * `{...state, pendingReroll: undefined}`, donc `state.players` est la
+ * MEME reference que celle du caller original — la mutation
+ * `state.players[idx].hasBall = true` corrompait le state d'origine.
+ * Maintenant chaque mutation passe par un spread immutable.
+ */
 export function handleBallPickup(
   state: GameState,
   player: Player,
@@ -82,6 +92,9 @@ export function handleBallPickup(
     pickupModifiers,
   );
 
+  // Tracker les logs et state via accumulateur immutable.
+  let newState: GameState = state;
+
   // Sure Hands : relance automatique du pickup rate (via skill registry)
   if (!pickupResult.success && canSkillReroll(player, 'on-pickup', state)) {
     const rerollLog = createLogEntry(
@@ -90,16 +103,13 @@ export function handleBallPickup(
       player.id,
       player.team,
     );
-    state.gameLog = [...state.gameLog, rerollLog];
+    newState = { ...newState, gameLog: [...newState.gameLog, rerollLog] };
     pickupResult = performPickupRollWithNotification(
       player,
       rng,
       pickupModifiers,
     );
   }
-
-  // Stocker le resultat pour l'affichage
-  state.lastDiceResult = pickupResult;
 
   // Log du jet de pickup
   const pickupLogEntry = createLogEntry(
@@ -116,55 +126,65 @@ export function handleBallPickup(
       modifiers: pickupModifiers,
     },
   );
-  state.gameLog = [...state.gameLog, pickupLogEntry];
+  newState = {
+    ...newState,
+    lastDiceResult: pickupResult,
+    gameLog: [...newState.gameLog, pickupLogEntry],
+  };
 
   if (pickupResult.success) {
-    // Ramassage reussi : attacher la balle au joueur
-    state.ball = undefined;
-    state.players[idx].hasBall = true;
-
-    // Log du ramassage reussi
+    // Ramassage reussi : attacher la balle au joueur (immutable update).
     const successLogEntry = createLogEntry(
       'action',
       `Ballon ramassé avec succès`,
       player.id,
       player.team,
     );
-    state.gameLog = [...state.gameLog, successLogEntry];
+    newState = {
+      ...newState,
+      ball: undefined,
+      players: newState.players.map((p) =>
+        p.id === player.id ? { ...p, hasBall: true } : p,
+      ),
+      gameLog: [...newState.gameLog, successLogEntry],
+    };
 
     // Si pickup dans l'en-but adverse, touchdown immediat
-    const picker = state.players[idx];
-    if (isInOpponentEndzone(state, picker)) {
-      return awardTouchdown(state, picker.team, picker);
+    const picker = newState.players.find((p) => p.id === player.id);
+    if (picker && isInOpponentEndzone(newState, picker)) {
+      return awardTouchdown(newState, picker.team, picker);
     }
-  } else {
-    // Echec de pickup : offrir relance d'equipe si disponible
-    if (canUseTeamReroll(state, player.team)) {
-      state.pendingReroll = {
+    return newState;
+  }
+
+  // Echec de pickup : offrir relance d'equipe si disponible
+  if (canUseTeamReroll(newState, player.team)) {
+    return {
+      ...newState,
+      pendingReroll: {
         rollType: 'pickup',
         playerId: player.id,
         team: player.team,
         targetNumber: pickupResult.targetNumber,
         modifiers: pickupModifiers,
         playerIndex: idx,
-      };
-      return state;
-    }
-    // Pas de relance : la balle rebondit et turnover
-    state.isTurnover = true;
-
-    // Log du ramassage echoue
-    const failLogEntry = createLogEntry(
-      'turnover',
-      `Échec du ramassage - Turnover`,
-      player.id,
-      player.team,
-    );
-    state.gameLog = [...state.gameLog, failLogEntry];
-
-    // Faire rebondir la balle
-    return bounceBall(state, rng);
+      },
+    };
   }
 
-  return state;
+  // Pas de relance : la balle rebondit et turnover
+  const failLogEntry = createLogEntry(
+    'turnover',
+    `Échec du ramassage - Turnover`,
+    player.id,
+    player.team,
+  );
+  newState = {
+    ...newState,
+    isTurnover: true,
+    gameLog: [...newState.gameLog, failLogEntry],
+  };
+
+  // Faire rebondir la balle
+  return bounceBall(newState, rng);
 }

--- a/packages/game-engine/src/actions/failure-helpers.ts
+++ b/packages/game-engine/src/actions/failure-helpers.ts
@@ -28,6 +28,13 @@ import { createLogEntry } from '../utils/logging';
  * Applique les consequences d'un echec de jet (chute, turnover,
  * armure, perte de balle).
  *
+ * BUG fix immutabilite : avant, le code mutait directement
+ * `state.players[playerIndex] = ...` (ecriture sur l'array partage avec
+ * le caller). `reroll-choose-handler.ts:87` passe un shallow clone
+ * `{...state, pendingReroll: undefined}` → `newState.players` est la
+ * MEME ref que `state.players` du dispatcher → corruption cross-state.
+ * Maintenant chaque mutation passe par un spread immutable.
+ *
  * @param armorBonus Bonus optionnel applique au jet d'armure (ex:
  *   +1 d'Arm Bar quand une esquive a echoue dans la zone de tacle
  *   d'un adversaire avec ce skill).
@@ -39,20 +46,22 @@ export function applyRollFailure(
   armorBonus = 0,
 ): GameState {
   const player = state.players[playerIndex];
-  state.isTurnover = true;
-  state.players[playerIndex] = { ...player, stunned: true };
 
-  // Jet d'armure (avec bonus eventuel d'Arm Bar). `armorBonus` est
-  // exprime comme bonus a l'attaquant (i.e. +1 facilite la cassure
-  // d'armure). Il est negativise ici car
-  // `performArmorRollWithNotification` attend un modificateur a
-  // appliquer au TARGET (positif = armure plus difficile a percer).
+  // Immutable : marque le joueur comme tombe + turnover.
+  let newState: GameState = {
+    ...state,
+    isTurnover: true,
+    players: state.players.map((p, i) =>
+      i === playerIndex ? { ...p, stunned: true } : p,
+    ),
+  };
+
+  // Jet d'armure (avec bonus eventuel d'Arm Bar).
   const armorResult = performArmorRollWithNotification(
-    state.players[playerIndex],
+    newState.players[playerIndex],
     rng,
     -armorBonus,
   );
-  state.lastDiceResult = armorResult;
   const armorLog = createLogEntry(
     'dice',
     `Jet d'armure: ${armorResult.diceRoll}/${armorResult.targetNumber} ${
@@ -67,42 +76,54 @@ export function applyRollFailure(
       armBar: armorBonus > 0,
     },
   );
-  state.gameLog = [...state.gameLog, armorLog];
+  newState = {
+    ...newState,
+    lastDiceResult: armorResult,
+    gameLog: [...newState.gameLog, armorLog],
+  };
 
-  // Si l'armure est percee (success = false), faire un jet de
-  // blessure
+  // Si l'armure est percee, faire un jet de blessure.
   if (!armorResult.success) {
-    state = performInjuryRoll(state, state.players[playerIndex], rng);
+    newState = performInjuryRoll(newState, newState.players[playerIndex], rng);
   }
 
-  // Perte de balle si le joueur la portait
+  // Perte de balle si le joueur la portait.
   if (player.hasBall) {
-    state.players[playerIndex] = {
-      ...state.players[playerIndex],
-      hasBall: false,
+    const fallenPlayer = newState.players[playerIndex];
+    newState = {
+      ...newState,
+      ball: { ...fallenPlayer.pos },
+      players: newState.players.map((p, i) =>
+        i === playerIndex ? { ...p, hasBall: false } : p,
+      ),
     };
-    state.ball = { ...state.players[playerIndex].pos };
-    return bounceBall(state, rng);
+    return bounceBall(newState, rng);
   }
 
-  return state;
+  return newState;
 }
 
 /**
  * Applique les consequences d'un echec de pickup (rebond + turnover).
+ *
+ * BUG fix immutabilite : avant, `state.isTurnover = true` et
+ * `state.gameLog = [...]` mutaient le parametre. Maintenant spread.
  */
 export function applyPickupFailure(
   state: GameState,
   playerIndex: number,
   rng: RNG,
 ): GameState {
-  state.isTurnover = true;
   const failLog = createLogEntry(
     'turnover',
     `Échec du ramassage - Turnover`,
     state.players[playerIndex].id,
     state.players[playerIndex].team,
   );
-  state.gameLog = [...state.gameLog, failLog];
-  return bounceBall(state, rng);
+  const newState: GameState = {
+    ...state,
+    isTurnover: true,
+    gameLog: [...state.gameLog, failLog],
+  };
+  return bounceBall(newState, rng);
 }

--- a/packages/game-engine/src/actions/mutations-immutability.test.ts
+++ b/packages/game-engine/src/actions/mutations-immutability.test.ts
@@ -1,0 +1,139 @@
+/**
+ * BUG fix audit round 3 — Mutations CRITICAL :
+ *  - `ball-pickup.ts` mutait `state.players[idx].hasBall = true`.
+ *  - `failure-helpers.ts` mutait `state.players[playerIndex] = ...`.
+ *  - `reroll-choose-handler.ts:87` shallow clone propagait la mutation.
+ *
+ * Vecteur d'attaque : tout reroll de dodge/pickup/gfi en live corrompait
+ * le state serveur (replays + WebSocket multi-client).
+ *
+ * Ces tests verifient l'invariant : passer un state en parametre ne le
+ * mute JAMAIS. Snapshot JSON deep equality avant/apres.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from './actions';
+import { handleBallPickup } from './ball-pickup';
+import { applyRollFailure, applyPickupFailure } from './failure-helpers';
+import type { GameState, Player, RNG, Move } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 5, y: 5 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+describe('ball-pickup — immutabilite', () => {
+  it("handleBallPickup ne mute pas le state d'entree (pickup reussi)", () => {
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const state: GameState = {
+      ...base,
+      players: [player],
+      ball: { x: 5, y: 5 },
+      currentPlayer: 'A',
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    const idx = 0;
+    const rng = makeRNG([0.99, 0.99]);
+
+    handleBallPickup(state, player, rng, idx);
+
+    expect(JSON.parse(JSON.stringify(state))).toEqual(snapshot);
+  });
+
+  it("handleBallPickup ne mute pas state.players[idx].hasBall", () => {
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const state: GameState = {
+      ...base,
+      players: [player],
+      ball: { x: 5, y: 5 },
+      currentPlayer: 'A',
+    };
+    const rng = makeRNG([0.99, 0.99]);
+
+    const result = handleBallPickup(state, player, rng, 0);
+
+    // result.players[0].hasBall = true, mais state.players[0].hasBall reste falsy.
+    expect(state.players[0].hasBall).toBeFalsy();
+    expect(result.players[0].hasBall).toBe(true);
+    // Reference distincte garantie.
+    expect(state.players).not.toBe(result.players);
+  });
+});
+
+describe('failure-helpers — immutabilite', () => {
+  it("applyRollFailure ne mute pas state.players[i]", () => {
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 }, hasBall: false });
+    const state: GameState = {
+      ...base,
+      players: [player],
+      currentPlayer: 'A',
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5]);
+
+    applyRollFailure(state, 0, rng, 0);
+
+    expect(JSON.parse(JSON.stringify(state))).toEqual(snapshot);
+  });
+
+  it("applyPickupFailure ne mute pas state.isTurnover ni state.gameLog", () => {
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const state: GameState = {
+      ...base,
+      players: [player],
+      ball: { x: 5, y: 5 },
+      currentPlayer: 'A',
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    const rng = makeRNG([0.5, 0.5]);
+
+    applyPickupFailure(state, 0, rng);
+
+    expect(JSON.parse(JSON.stringify(state))).toEqual(snapshot);
+  });
+});
+
+describe('reroll-choose-handler — pas de cross-state corruption', () => {
+  it("REROLL_CHOOSE refuse ne corrompt pas le state caller", () => {
+    // Scenario : un pickup raté en attente de reroll. Le coach refuse
+    // la relance via REROLL_CHOOSE. Avant le fix, applyPickupFailure
+    // ecrivait dans state.players[idx] qui etait partage avec le caller.
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const state: GameState = {
+      ...base,
+      players: [player],
+      ball: { x: 5, y: 5 },
+      currentPlayer: 'A',
+      pendingReroll: {
+        rollType: 'pickup',
+        playerId: 'A1',
+        team: 'A',
+        targetNumber: 4,
+        modifiers: 0,
+        playerIndex: 0,
+      },
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    const move: Move = { type: 'REROLL_CHOOSE', useReroll: false };
+    const rng = makeRNG([0.5, 0.5, 0.5, 0.5]);
+
+    applyMove(state, move, rng);
+
+    // Le state d'origine doit etre intact.
+    expect(JSON.parse(JSON.stringify(state))).toEqual(snapshot);
+  });
+});

--- a/packages/game-engine/src/actions/reroll-choose-handler.ts
+++ b/packages/game-engine/src/actions/reroll-choose-handler.ts
@@ -84,7 +84,14 @@ export function handleRerollChoose(
     from,
     to,
   } = state.pendingReroll;
-  let newState: GameState = { ...state, pendingReroll: undefined };
+  // BUG fix immutabilite : shallow clone `{...state}` ne suffit pas car
+  // les helpers `applyRollFailure` / `applyPickupFailure` / `handleBallPickup`
+  // ont historiquement mute `state.players[idx]` directement. Avec un
+  // shallow clone, `newState.players` est la MEME ref que `state.players`
+  // du caller → corruption cross-state. Apres le fix immutabilite de ces
+  // helpers (cette PR), le shallow clone est SUFFISANT. On garde le
+  // structuredClone par defense-in-depth contre une regression future.
+  let newState: GameState = structuredClone({ ...state, pendingReroll: undefined }) as GameState;
 
   if (!move.useReroll) {
     // Relance refusee : appliquer les consequences de l'echec


### PR DESCRIPTION
## Summary

**CRITICAL** : 3 mutations cross-state identifiées par l'audit round 3 corrompaient le state serveur sur tout reroll de dodge/pickup/gfi. Vecteur d'attaque vivait depuis longtemps malgré le fix partiel PR #816 (blitz-handler) qui n'avait traité que le symptôme, pas la racine dans les helpers partagés.

### 1. `actions/ball-pickup.ts:handleBallPickup`

Mutait `state.players[idx].hasBall = true`, `state.ball = undefined`, `state.isTurnover = true`, `state.gameLog = [...]`. Le caller `reroll-choose-handler.ts:215` passe un **shallow clone** — donc `state.players` est la **même référence** que celle du caller original.

**Fix** : refactor complet en immutable. Chaque mutation passe par un spread, `players.map(...)` pour les updates de player.

### 2. `actions/failure-helpers.ts:applyRollFailure`

Mutait `state.isTurnover`, `state.players[playerIndex] = ...` (écrasement de case dans l'array partagée), `state.gameLog`, `state.lastDiceResult`.

**Fix** : `let newState: GameState = { ...state, ... }` puis chaque step utilise un spread.

### 3. `actions/failure-helpers.ts:applyPickupFailure`

Mutait `state.isTurnover` et `state.gameLog`. Idem refactor.

### 4. `actions/reroll-choose-handler.ts:87` — defense-in-depth

Shallow clone remplacé par `structuredClone({ ...state, pendingReroll: undefined })`. Après le fix des 3 helpers ci-dessus, le shallow clone suffirait, mais le structuredClone protège contre une régression future.

## Test plan

- [x] `mutations-immutability.test.ts` (5 nouveaux tests)
  - [x] `handleBallPickup` ne mute pas state d'entrée (pickup réussi)
  - [x] `handleBallPickup` ne mute pas `state.players[idx].hasBall`
  - [x] `applyRollFailure` ne mute pas state.players[i]
  - [x] `applyPickupFailure` ne mute pas state.isTurnover / gameLog
  - [x] REROLL_CHOOSE refusé ne corrompt pas le state caller
- [x] 5037 game-engine tests passent
- [x] Typecheck OK

🔧 PR 2 d'une série de 6 de l'audit round 3. Précédent #836 (halftime softlock) en CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_