### PR TITLE
fix(sim-engine): full driver — ball carrier idx variable + ballYardline initial

### DIFF
--- a/packages/sim-engine/src/driver/full-driver-events.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.ts
@@ -375,6 +375,16 @@ function estimateBallYardline(state: GameState): number {
 }
 
 /**
+ * Variante exportee de `estimateBallYardline` — utilisee par
+ * `full-driver.ts` pour le TURN_START initial. Avant le fix, le
+ * yardline initial etait hardcode a 4, ce qui est faux si le roster
+ * place le ball carrier ailleurs (post-fix C3 ball idx variable).
+ */
+export function getInitialBallYardline(state: GameState): number {
+  return estimateBallYardline(state);
+}
+
+/**
  * Inférence best-effort de la cause d'un turnover à partir du Move
  * qui l'a déclenché. La taxonomie matche celle du hybrid driver
  * pour que les consommateurs (narrator, gazette) restent uniformes.

--- a/packages/sim-engine/src/driver/full-driver-roster-fixes.test.ts
+++ b/packages/sim-engine/src/driver/full-driver-roster-fixes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * BUG fixes audit round 3 :
+ *  - C3 : ball carrier idx=9 hardcode → undefined si roster < 10.
+ *  - H2 : ballYardline=4 magique au TURN_START initial.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildGameStateFromRosters } from './full-driver-roster';
+import { getInitialBallYardline } from './full-driver-events';
+import type { SimRosterPlayer } from '../types';
+
+function rosterPlayer(over: Partial<SimRosterPlayer> = {}): SimRosterPlayer {
+  return {
+    id: 'p',
+    name: 'P',
+    number: 1,
+    position: 'Lineman',
+    ma: 6, st: 3, ag: 3, pa: 4, av: 8, skills: [],
+    ...over,
+  };
+}
+
+describe('Ball carrier idx variable (C3)', () => {
+  it("roster complet (11 joueurs) : ball carrier = idx 9", () => {
+    const homeRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `H${i}`, name: `H${i}`, number: i + 1 }),
+    );
+    const awayRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `A${i}`, name: `A${i}`, number: i + 1 }),
+    );
+    const state = buildGameStateFromRosters({
+      homeRoster, awayRoster, receivingTeam: 'B',
+    });
+
+    const carrier = state.players.find((p) => p.hasBall);
+    expect(carrier).toBeDefined();
+    expect(carrier?.id).toBe('A9'); // idx 9 du roster away
+  });
+
+  it("roster court (7 joueurs) : ball carrier = dernier joueur (idx=6)", () => {
+    // Avant le fix, idx=9 → awayPlayers[9] undefined → personne n'a la balle
+    // → la team receveuse ne marque jamais. Resultat : tous les matches en
+    // 0-0 ou victoire kicker.
+    const homeRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `H${i}`, name: `H${i}`, number: i + 1 }),
+    );
+    const awayRoster = Array.from({ length: 7 }, (_, i) =>
+      rosterPlayer({ id: `A${i}`, name: `A${i}`, number: i + 1 }),
+    );
+    const state = buildGameStateFromRosters({
+      homeRoster, awayRoster, receivingTeam: 'B',
+    });
+
+    const carrier = state.players.find((p) => p.hasBall);
+    expect(carrier).toBeDefined();
+    expect(carrier?.id).toBe('A6'); // dernier joueur place
+  });
+});
+
+describe('getInitialBallYardline (H2)', () => {
+  it("retourne la position du carrier au lieu d'un hardcode 4", () => {
+    const homeRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `H${i}`, name: `H${i}`, number: i + 1 }),
+    );
+    const awayRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `A${i}`, name: `A${i}`, number: i + 1 }),
+    );
+    const state = buildGameStateFromRosters({
+      homeRoster, awayRoster, receivingTeam: 'B',
+    });
+
+    const yardline = getInitialBallYardline(state);
+    // Le carrier est place sur TEAM_B_FORMATION[9] — sa position x est
+    // utilisee comme yardline.
+    const carrier = state.players.find((p) => p.hasBall)!;
+    expect(yardline).toBe(carrier.pos.x);
+  });
+});

--- a/packages/sim-engine/src/driver/full-driver-roster.ts
+++ b/packages/sim-engine/src/driver/full-driver-roster.ts
@@ -128,25 +128,32 @@ export function buildGameStateFromRosters(input: {
   receivingTeam: TeamId;
 }): GameState {
   const baseline = setup();
+  // BUG fix C3 audit round 3 : avant, le ball carrier etait hardcode
+  // `idx === 9`. Si un roster a moins de 10 joueurs (KO antérieur,
+  // casualty pre-match, roster court < 11), `players[9]` est undefined
+  // → personne n'a la balle, l'equipe receveuse ne marque jamais.
+  // Maintenant on prend le dernier joueur place (ou idx=9 si dispo).
+  const homeBallIdx = Math.min(9, input.homeRoster.length - 1);
+  const awayBallIdx = Math.min(9, input.awayRoster.length - 1);
   const teamAPlayers = input.homeRoster
     .slice(0, MAX_PLAYERS_ON_FIELD)
     .map((roster, idx) => {
       const pos = TEAM_A_FORMATION[idx];
-      const hasBall = input.receivingTeam === 'A' && idx === 9;
+      const hasBall = input.receivingTeam === 'A' && idx === homeBallIdx;
       return rosterPlayerToGameEnginePlayer(roster, 'A', pos, hasBall);
     });
   const teamBPlayers = input.awayRoster
     .slice(0, MAX_PLAYERS_ON_FIELD)
     .map((roster, idx) => {
       const pos = TEAM_B_FORMATION[idx];
-      const hasBall = input.receivingTeam === 'B' && idx === 9;
+      const hasBall = input.receivingTeam === 'B' && idx === awayBallIdx;
       return rosterPlayerToGameEnginePlayer(roster, 'B', pos, hasBall);
     });
 
   const carrier =
     input.receivingTeam === 'A'
-      ? teamAPlayers[9]
-      : teamBPlayers[9];
+      ? teamAPlayers[homeBallIdx]
+      : teamBPlayers[awayBallIdx];
   const ball = carrier ? { x: carrier.pos.x, y: carrier.pos.y } : undefined;
 
   return {

--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -67,7 +67,11 @@ import {
 } from '../tactics/tactical-profile';
 import type { MatchEvent } from '@bb/shared-types';
 
-import { MS_PER_ACTION, diffStatesToEvents } from './full-driver-events';
+import {
+  MS_PER_ACTION,
+  diffStatesToEvents,
+  getInitialBallYardline,
+} from './full-driver-events';
 import { buildGameStateFromRosters } from './full-driver-roster';
 
 /**
@@ -290,7 +294,10 @@ export function runFullDriver(input: SimInput): SimResult {
         turn: state.turn,
         drivingTeam: state.currentPlayer === 'A' ? 'home' : 'away',
         score: { home: state.score.teamA, away: state.score.teamB },
-        ballYardline: 4,
+        // BUG fix H2 audit round 3 : avant, hardcode 4. Si le roster
+        // place le ball carrier ailleurs (post-fix C3 ball idx variable),
+        // le narrator affichait un placement initial incorrect.
+        ballYardline: getInitialBallYardline(state),
       },
     },
   ];


### PR DESCRIPTION
## Summary

Audit round 3 — Full driver C3 + H2.

### C3 — Ball carrier idx hardcode

`full-driver-roster.ts:135,142,148` hardcodait `idx === 9` pour déterminer le ball carrier. Si un roster a moins de 10 joueurs (KO antérieur, casualty pre-match, roster court), `players[9]` était `undefined` → personne n'a la balle → l'équipe receveuse ne marque jamais. Tous les matches en 0-0 ou victoire kicker.

**Fix** : `Math.min(9, roster.length - 1)` → dernier joueur placé si roster court, sinon idx 9. Aligne `carrier` lookup + `hasBall`.

### H2 — `ballYardline: 4` magique

TURN_START initial dans `full-driver.ts:294` hardcodait `ballYardline: 4`. Avec C3 fix (ball carrier idx variable), le placement initial peut varier. Le narrator/replay affichait un placement faux pour des rosters custom.

**Fix** : nouvelle export `getInitialBallYardline(state)` qui lit la position réelle du carrier (ou `state.ball`) — clamp 0..26.

## Test plan

- [x] `full-driver-roster-fixes.test.ts` (3 nouveaux tests)
  - [x] Ball carrier sur roster complet (idx=9)
  - [x] Roster court (7 joueurs) → ball carrier = idx 6 (dernier)
  - [x] `getInitialBallYardline` retourne la position du carrier
- [x] 416 sim-engine tests passent
- [x] `sim:bench:ci` PASS
- [x] Typecheck OK

🔧 PR 4 d'une série de 6 de l'audit round 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_