### PR TITLE
fix(game-engine): immutabilité move handlers (HIGH anti-pattern)

### DIFF
--- a/packages/game-engine/src/actions/move-handlers-immutability.test.ts
+++ b/packages/game-engine/src/actions/move-handlers-immutability.test.ts
@@ -1,0 +1,65 @@
+/**
+ * BUG fix audit round 3 HIGH : `move-leap-dodge-handlers.ts` et
+ * `move-handlers.ts` mutaient les players in-place dans le clone
+ * (`next.players[idx].pos = ...`, `next.players[idx].pm = ...`).
+ *
+ * Local au clone donc safe pour le caller direct, mais anti-pattern :
+ * toute reassignation future de `next` casserait la chaine. Maintenant
+ * via spread immutable + `players.map()`.
+ *
+ * Ces tests verifient que le state d'entree reste intact (snapshot
+ * JSON deep equality avant/apres). Garde-fou contre regression.
+ */
+import { describe, it, expect } from 'vitest';
+import { setup } from '../core/game-state';
+import { applyMove } from './actions';
+import type { GameState, Player, RNG, Move } from '../core/types';
+
+function makeRNG(values: number[]): RNG {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function basePlayer(over: Partial<Player>): Player {
+  return {
+    id: 'X', team: 'A', pos: { x: 5, y: 5 }, name: 'X', number: 1,
+    position: 'Lineman', ma: 6, st: 3, ag: 3, pa: 4, av: 7,
+    skills: [], pm: 6, state: 'active',
+    ...over,
+  };
+}
+
+describe('MOVE handlers — immutabilite stricte', () => {
+  it("MOVE simple ne mute pas state.players[i]", () => {
+    const base = setup();
+    const player = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const state: GameState = {
+      ...base, players: [player], currentPlayer: 'A',
+    };
+    const snapshot = JSON.parse(JSON.stringify(state));
+    const move: Move = { type: 'MOVE', playerId: 'A1', to: { x: 6, y: 5 } };
+    const rng = makeRNG([0.5, 0.5]);
+
+    applyMove(state, move, rng);
+
+    expect(JSON.parse(JSON.stringify(state))).toEqual(snapshot);
+  });
+
+  it("MOVE avec dodge ne mute pas state.players[i].pm/pos", () => {
+    const base = setup();
+    const a1 = basePlayer({ id: 'A1', team: 'A', pos: { x: 5, y: 5 } });
+    const opp = basePlayer({ id: 'B1', team: 'B', pos: { x: 5, y: 6 } });
+    const state: GameState = {
+      ...base, players: [a1, opp], currentPlayer: 'A',
+    };
+    const beforePm = state.players[0].pm;
+    const beforePos = { ...state.players[0].pos };
+
+    const move: Move = { type: 'MOVE', playerId: 'A1', to: { x: 6, y: 5 } };
+    const rng = makeRNG([0.99, 0.5, 0.5]);
+    applyMove(state, move, rng);
+
+    expect(state.players[0].pm).toBe(beforePm);
+    expect(state.players[0].pos).toEqual(beforePos);
+  });
+});

--- a/packages/game-engine/src/actions/move-handlers.ts
+++ b/packages/game-engine/src/actions/move-handlers.ts
@@ -122,14 +122,23 @@ export function handleDodgeRoll(
   next.gameLog = [...next.gameLog, logEntry];
 
   // Le joueur se deplace toujours, que le jet d'esquive reussisse ou
-  // echoue
+  // echoue. Immutable spread (avant : mutation directe `next.players[idx]
+  // .pos = ...` etc. — safe sur clone mais anti-pattern fragile).
   const isDodgeGFI = next.players[idx].pm <= 0;
-  next.players[idx].pos = { ...to };
-  if (isDodgeGFI) {
-    next.players[idx].gfiUsed = (next.players[idx].gfiUsed ?? 0) + 1;
-  } else {
-    next.players[idx].pm = Math.max(0, next.players[idx].pm - 1);
-  }
+  next = {
+    ...next,
+    players: next.players.map((p, i) =>
+      i === idx
+        ? {
+            ...p,
+            pos: { ...to },
+            ...(isDodgeGFI
+              ? { gfiUsed: (p.gfiUsed ?? 0) + 1 }
+              : { pm: Math.max(0, p.pm - 1) }),
+          }
+        : p,
+    ),
+  };
 
   // Enregistrer l'action de mouvement seulement si c'est le premier
   // mouvement
@@ -303,12 +312,22 @@ export function handleNormalMove(
   let next = structuredClone(state) as GameState;
   const isGFI = next.players[idx].pm <= 0;
 
-  // Deplacer le joueur
-  next.players[idx].pos = { ...to };
+  // Deplacer le joueur (immutable). Avant : `next.players[idx].pos = ...`
+  // mutait l'objet player du clone (safe local, mais anti-pattern).
+  next = {
+    ...next,
+    players: next.players.map((p, i) =>
+      i === idx
+        ? {
+            ...p,
+            pos: { ...to },
+            ...(isGFI ? { gfiUsed: (p.gfiUsed ?? 0) + 1 } : {}),
+          }
+        : p,
+    ),
+  };
 
   if (isGFI) {
-    // GFI : ne decremente pas pm, incremente gfiUsed
-    next.players[idx].gfiUsed = (next.players[idx].gfiUsed ?? 0) + 1;
 
     // Jet de GFI : 2+ par défaut, 3+ en Blizzard / Neige forte.
     const gfiTarget = gfiTargetFromWeather(state);
@@ -386,8 +405,13 @@ export function handleNormalMove(
     return next;
   }
 
-  // Mouvement normal (a des PM)
-  next.players[idx].pm = Math.max(0, next.players[idx].pm - 1);
+  // Mouvement normal (a des PM) — immutable update.
+  next = {
+    ...next,
+    players: next.players.map((p, i) =>
+      i === idx ? { ...p, pm: Math.max(0, p.pm - 1) } : p,
+    ),
+  };
 
   // Enregistrer l'action de mouvement seulement si c'est le premier
   // mouvement

--- a/packages/game-engine/src/actions/move-leap-dodge-handlers.ts
+++ b/packages/game-engine/src/actions/move-leap-dodge-handlers.ts
@@ -99,9 +99,19 @@ export function handleLeap(
   );
   next.gameLog = [...next.gameLog, leapLogEntry];
 
-  // Déplacer le joueur vers la case d'arrivée et consommer 2 PM
-  next.players[idx].pos = { ...move.to };
-  next.players[idx].pm = Math.max(0, next.players[idx].pm - 2);
+  // Déplacer le joueur vers la case d'arrivée et consommer 2 PM (immutable).
+  // BUG fix : avant, `next.players[idx].pos = ...` / `.pm = ...` mutaient
+  // l'objet player dans le clone. Le clone est `structuredClone` donc safe
+  // localement, mais cette convention est dangereuse — toute reassignation
+  // future de `next` casserait la chaine. Maintenant via `players.map`.
+  next = {
+    ...next,
+    players: next.players.map((p, i) =>
+      i === idx
+        ? { ...p, pos: { ...move.to }, pm: Math.max(0, p.pm - 2) }
+        : p,
+    ),
+  };
 
   // Enregistrer l'action de mouvement si c'est le premier mouvement
   if (!hasPlayerActed(next, player.id)) {
@@ -210,9 +220,17 @@ export function handleDodge(
   );
   next.gameLog = [...next.gameLog, dodgeLogEntry];
 
-  // Le joueur se déplace toujours, que le jet d'esquive réussisse ou échoue
-  next.players[idx].pos = { ...move.to };
-  next.players[idx].pm = Math.max(0, next.players[idx].pm - 1);
+  // Le joueur se déplace toujours, que le jet d'esquive réussisse ou échoue.
+  // BUG fix immutabilite : avant, `next.players[idx].pos = ...` / `.pm = ...`
+  // mutaient l'objet player dans le clone. Maintenant via spread immutable.
+  next = {
+    ...next,
+    players: next.players.map((p, i) =>
+      i === idx
+        ? { ...p, pos: { ...move.to }, pm: Math.max(0, p.pm - 1) }
+        : p,
+    ),
+  };
 
   // Shadowing : résolu après le mouvement, indépendamment du résultat (BB3).
   next = resolveShadowingAfterDodge(next, player, from, rng);


### PR DESCRIPTION
## Summary

Audit round 3 — Mutations HIGH dans move handlers (anti-pattern).

Pattern dangereux : `let next = structuredClone(state)` puis `next.players[idx].pos = ...` / `.pm = ...`. Le clone est safe localement, mais toute réassignation future de `next` (via `setPlayerAction`, `checkPlayerTurnEnd`, etc.) casserait la chaîne immutable et propagerait des mutations.

## Refactor

Trois hot spots :

1. **`actions/move-leap-dodge-handlers.ts:103-104`** — `handleLeap` : pos + pm via spread immutable.
2. **`actions/move-leap-dodge-handlers.ts:224-225`** — `handleDodge` : pos + pm via spread immutable.
3. **`actions/move-handlers.ts:127-131,316-320,399`** — `handleDodgeRoll` + `handleNormalMove` : pos + pm + gfiUsed via spread immutable.

## Test plan

- [x] `move-handlers-immutability.test.ts` (2 nouveaux tests)
  - [x] MOVE simple ne mute pas `state.players[i]`
  - [x] MOVE avec dodge ne mute pas `state.players[i].pm/pos`
- [x] 5044 game-engine tests passent
- [x] Typecheck OK

🔧 PR 5 d'une série de 6 de l'audit round 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_