### PR TITLE
fix(pro-league): atomicité wallet/bet/settlement transactions (CRITICAL)

### DIFF
--- a/apps/server/src/routes/local-match.ts
+++ b/apps/server/src/routes/local-match.ts
@@ -581,13 +581,13 @@ router.post("/:id/start", authUser, async (req: AuthenticatedRequest, res) => {
       const ctxA: InducementContext = {
         teamId: "A",
         regionalRules: [],
-        hasApothecary: gameState.apothecaryAvailable?.teamA ?? false,
+        hasApothecary: (gameState.apothecaryAvailable?.teamA ?? 0) > 0,
         rosterSlug: localMatch.teamA.roster,
       };
       const ctxB: InducementContext = {
         teamId: "B",
         regionalRules: [],
-        hasApothecary: gameState.apothecaryAvailable?.teamB ?? false,
+        hasApothecary: (gameState.apothecaryAvailable?.teamB ?? 0) > 0,
         rosterSlug: localMatch.teamB.roster,
       };
 
@@ -707,13 +707,13 @@ router.post("/:id/inducements", authUser, validate(localMatchInducementsSchema),
     const ctxA: InducementContext = {
       teamId: "A",
       regionalRules: [],
-      hasApothecary: gameState.apothecaryAvailable?.teamA ?? false,
+      hasApothecary: (gameState.apothecaryAvailable?.teamA ?? 0) > 0,
       rosterSlug: rosterA,
     };
     const ctxB: InducementContext = {
       teamId: "B",
       regionalRules: [],
-      hasApothecary: gameState.apothecaryAvailable?.teamB ?? false,
+      hasApothecary: (gameState.apothecaryAvailable?.teamB ?? 0) > 0,
       rosterSlug: rosterB,
     };
 

--- a/apps/server/src/services/inducement-processor.ts
+++ b/apps/server/src/services/inducement-processor.ts
@@ -125,13 +125,13 @@ export async function processInducementSubmission(
   const ctxA: InducementContext = {
     teamId: "A",
     regionalRules: [],
-    hasApothecary: gameState.apothecaryAvailable?.teamA ?? false,
+    hasApothecary: (gameState.apothecaryAvailable?.teamA ?? 0) > 0,
     rosterSlug: teamA?.roster || "",
   };
   const ctxB: InducementContext = {
     teamId: "B",
     regionalRules: [],
-    hasApothecary: gameState.apothecaryAvailable?.teamB ?? false,
+    hasApothecary: (gameState.apothecaryAvailable?.teamB ?? 0) > 0,
     rosterSlug: teamB?.roster || "",
   };
 

--- a/apps/server/src/services/pro-bet-settlement.test.ts
+++ b/apps/server/src/services/pro-bet-settlement.test.ts
@@ -1,29 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn() },
-    proBetMarket: {
-      findMany: vi.fn(),
-      update: vi.fn(),
+// Audit round 4 : settlement wrap maintenant update bets + credit users
+// + create settlement + update market dans une seule $transaction. On
+// simule en partageant les memes mocks entre prisma top-level et le `tx`
+// passe au callback du $transaction.
+vi.mock("../prisma", () => {
+  const proBet = { findMany: vi.fn(), update: vi.fn() };
+  const proBetMarket = {
+    findMany: vi.fn(),
+    update: vi.fn(),
+  };
+  const proBetSettlement = { findUnique: vi.fn(), create: vi.fn() };
+  return {
+    prisma: {
+      proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn() },
+      proBet,
+      proBetMarket,
+      proBetSettlement,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) =>
+        cb({ proBet, proBetMarket, proBetSettlement }),
+      ),
     },
-    proBet: {
-      findMany: vi.fn(),
-      update: vi.fn(),
-    },
-    proBetSettlement: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-    },
-  },
-}));
+  };
+});
 
 vi.mock("./pro-wallet", () => ({
   credit: vi.fn(),
+  creditInTx: vi.fn(),
+  ensureWalletExists: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Q.D.1 / Q.D.2 / Q.B.3 — hooks post-settlement mockes pour eviter de
+// drag in tout l'arbre Prisma dans ce test.
+vi.mock("./pro-prediction-leagues", () => ({
+  settlePicksForMatch: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./pro-survivor", () => ({
+  settleSurvivorRound: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./pro-match-predictions", () => ({
+  settlePredictions: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { prisma } from "../prisma";
-import { credit } from "./pro-wallet";
+import { creditInTx, ensureWalletExists } from "./pro-wallet";
 import {
   SettlementError,
   settleMarketsForMatch,
@@ -47,10 +68,12 @@ interface MockedPrisma {
     findUnique: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
+  $transaction: ReturnType<typeof vi.fn>;
 }
 
 const mocked = prisma as unknown as MockedPrisma;
-const mockedCredit = vi.mocked(credit);
+const mockedCreditInTx = vi.mocked(creditInTx);
+const mockedEnsureWallet = vi.mocked(ensureWalletExists);
 
 const MATCH_ID = "m_1";
 
@@ -72,6 +95,18 @@ beforeEach(() => {
   mocked.proBet.update.mockResolvedValue({});
   mocked.proBetSettlement.findUnique.mockResolvedValue(null);
   mocked.proBetSettlement.create.mockResolvedValue({});
+  mockedEnsureWallet.mockResolvedValue(undefined);
+  // Re-attache le comportement par defaut du $transaction (clearAllMocks
+  // l'a vide).
+  mocked.$transaction.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (cb: any) =>
+      cb({
+        proBet: mocked.proBet,
+        proBetMarket: mocked.proBetMarket,
+        proBetSettlement: mocked.proBetSettlement,
+      }),
+  );
 });
 
 describe("settleMarketsForMatch — sprint 1.D.5", () => {
@@ -105,7 +140,7 @@ describe("settleMarketsForMatch — sprint 1.D.5", () => {
     expect(out.settled).toBe(0);
     expect(out.skipped).toBe(0);
     expect(out.summaries).toEqual([]);
-    expect(mockedCredit).not.toHaveBeenCalled();
+    expect(mockedCreditInTx).not.toHaveBeenCalled();
   });
 
   it("settle 1X2 : home win → bets home gagnent, draw/away perdent", async () => {
@@ -153,8 +188,19 @@ describe("settleMarketsForMatch — sprint 1.D.5", () => {
     expect(s.totalPayout).toBe(200);
 
     // u1 (home) credité 200, u2/u3 non.
-    expect(mockedCredit).toHaveBeenCalledTimes(1);
-    expect(mockedCredit).toHaveBeenCalledWith("u1", 200, "WIN", "b_home");
+    expect(mockedCreditInTx).toHaveBeenCalledTimes(1);
+    expect(mockedCreditInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      "u1",
+      200,
+      "WIN",
+      "b_home",
+    );
+    // Pre-ensure wallet uniquement pour les gagnants (1 ici).
+    expect(mockedEnsureWallet).toHaveBeenCalledTimes(1);
+    expect(mockedEnsureWallet).toHaveBeenCalledWith("u1");
+    // Tout settle dans une seule $transaction par market.
+    expect(mocked.$transaction).toHaveBeenCalledTimes(1);
 
     // proBet.update : 3 fois (1 won + 2 lost)
     expect(mocked.proBet.update).toHaveBeenCalledTimes(3);
@@ -199,7 +245,8 @@ describe("settleMarketsForMatch — sprint 1.D.5", () => {
     ]);
     const out = await settleMarketsForMatch(MATCH_ID);
     expect(out.summaries[0].winningSelection).toBe("over");
-    expect(mockedCredit).toHaveBeenCalledWith(
+    expect(mockedCreditInTx).toHaveBeenCalledWith(
+      expect.anything(),
       "u1",
       170, // round(100 * 1.7)
       "WIN",
@@ -254,7 +301,7 @@ describe("settleMarketsForMatch — sprint 1.D.5", () => {
     expect(out.settled).toBe(0);
     expect(out.skipped).toBe(1);
     expect(mocked.proBet.findMany).not.toHaveBeenCalled();
-    expect(mockedCredit).not.toHaveBeenCalled();
+    expect(mockedCreditInTx).not.toHaveBeenCalled();
   });
 
   it("skip si winningSelection introuvable (counter null)", async () => {

--- a/apps/server/src/services/pro-bet-settlement.ts
+++ b/apps/server/src/services/pro-bet-settlement.ts
@@ -25,7 +25,7 @@
 
 import { prisma } from "../prisma";
 
-import { credit } from "./pro-wallet";
+import { creditInTx, ensureWalletExists } from "./pro-wallet";
 import {
   settlePicksForMatch,
   type PickSelection,
@@ -226,49 +226,67 @@ export async function settleMarketsForMatch(
     let lostCount = 0;
     const voidCount = 0;
 
+    // BUG fix audit round 4 (CRITICAL) : avant, le loop update bet +
+    // credit user n'etait PAS atomique. Si le process crashait entre
+    // l'update bet.status='won' et le credit user, le bet etait marque
+    // comme `won` (status !== 'pending') donc le sweep ulterieur skipait
+    // le credit (cf. filter `status: 'pending'` ligne 213) → user perdait
+    // son gain.
+    // Inversement : crash entre boucle complete et `proBetSettlement.create`
+    // ligne 260 → bets settled mais market reste non-settled → re-run de
+    // settlement skip les wons (filter pending) → market jamais settled
+    // → boucle infinie au sweep.
+    // Fix : tout le settlement (update bets + credit users + create
+    // settlement row + update market.status) dans UNE seule $transaction.
+    // Pre-ensure wallets HORS transaction pour eviter rollback partiel.
     for (const bet of bets) {
-      const stake = bet.stake as number;
-      const oddsAtPlace = bet.oddsAtPlace as number;
-      const userId = bet.userId as string;
-      const won = (bet.selection as string) === winningSelection;
-      totalStake += stake;
-      if (won) {
-        const payoutAmount = Math.round(stake * oddsAtPlace);
-        totalPayout += payoutAmount;
-        wonCount += 1;
-        await prisma.proBet.update({
-          where: { id: bet.id as string },
-          data: {
-            status: "won",
-            payoutAmount,
-          },
-        });
-        await credit(userId, payoutAmount, "WIN", bet.id as string);
-      } else {
-        lostCount += 1;
-        await prisma.proBet.update({
-          where: { id: bet.id as string },
-          data: {
-            status: "lost",
-            payoutAmount: 0,
-          },
-        });
+      if ((bet.selection as string) === winningSelection) {
+        await ensureWalletExists(bet.userId as string);
       }
     }
 
-    // Audit row + market settled.
-    await prisma.proBetSettlement.create({
-      data: {
-        marketId,
-        winningSelection,
-        totalStake,
-        totalPayout,
-        betCount: bets.length,
-      },
-    });
-    await prisma.proBetMarket.update({
-      where: { id: marketId },
-      data: { status: "settled" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await prisma.$transaction(async (tx: any) => {
+      for (const bet of bets) {
+        const stake = bet.stake as number;
+        const oddsAtPlace = bet.oddsAtPlace as number;
+        const userId = bet.userId as string;
+        const won = (bet.selection as string) === winningSelection;
+        if (won) {
+          const payoutAmount = Math.round(stake * oddsAtPlace);
+          totalPayout += payoutAmount;
+          wonCount += 1;
+          await tx.proBet.update({
+            where: { id: bet.id as string },
+            data: { status: "won", payoutAmount },
+          });
+          await creditInTx(tx, userId, payoutAmount, "WIN", bet.id as string);
+        } else {
+          lostCount += 1;
+          await tx.proBet.update({
+            where: { id: bet.id as string },
+            data: { status: "lost", payoutAmount: 0 },
+          });
+        }
+        totalStake += stake;
+      }
+
+      // Audit row + market settled — meme transaction pour garantir
+      // que market.status='settled' apparait UNIQUEMENT si tous les
+      // bets sont traites + tous les wins credites.
+      await tx.proBetSettlement.create({
+        data: {
+          marketId,
+          winningSelection,
+          totalStake,
+          totalPayout,
+          betCount: bets.length,
+        },
+      });
+      await tx.proBetMarket.update({
+        where: { id: marketId },
+        data: { status: "settled" },
+      });
     });
 
     settled += 1;

--- a/apps/server/src/services/pro-bet.test.ts
+++ b/apps/server/src/services/pro-bet.test.ts
@@ -1,14 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Helper: chaque appel a `$transaction(cb)` execute le callback avec un
+// `tx` qui partage les memes mocks (proBet, proWallet, proTransaction).
+// Audit round 4 : placeBet utilise une seule $transaction qui wrap
+// debit + create, donc on simule ce comportement ici.
+const txMocks = {
+  proWallet: { findUnique: vi.fn(), update: vi.fn() },
+  proTransaction: { create: vi.fn() },
+  proBet: { create: vi.fn() },
+};
+
 vi.mock("../prisma", () => ({
   prisma: {
     proBetMarket: { findMany: vi.fn(), findUnique: vi.fn() },
     proBet: { findUnique: vi.fn(), findMany: vi.fn(), create: vi.fn() },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $transaction: vi.fn(async (cb: any) => cb(txMocks)),
   },
 }));
 
 vi.mock("./pro-wallet", () => ({
-  debit: vi.fn(),
+  ensureWalletExists: vi.fn().mockResolvedValue(undefined),
+  debitInTx: vi.fn(),
   InsufficientFundsError: class InsufficientFundsError extends Error {
     code = "WALLET_INSUFFICIENT_FUNDS";
     available = 0;
@@ -17,7 +30,7 @@ vi.mock("./pro-wallet", () => ({
 }));
 
 import { prisma } from "../prisma";
-import { debit } from "./pro-wallet";
+import { debitInTx, ensureWalletExists } from "./pro-wallet";
 import {
   BetValidationError,
   MarketNotFoundError,
@@ -36,16 +49,23 @@ interface MockedPrisma {
     findMany: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
+  $transaction: ReturnType<typeof vi.fn>;
 }
 
 const mocked = prisma as unknown as MockedPrisma;
-const mockedDebit = vi.mocked(debit);
+const mockedDebitInTx = vi.mocked(debitInTx);
+const mockedEnsureWallet = vi.mocked(ensureWalletExists);
 
 const USER = "user_1";
 const VALID_TOKEN = "ckabc12345xyz";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  txMocks.proBet.create.mockReset();
+  // Re-attache le comportement par defaut du $transaction apres clear.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mocked.$transaction.mockImplementation(async (cb: any) => cb(txMocks));
+  mockedEnsureWallet.mockResolvedValue(undefined);
 });
 
 describe("listMarketsForMatch — sprint 1.D.4", () => {
@@ -143,8 +163,8 @@ describe("placeBet — sprint 1.D.4", () => {
       clientToken: VALID_TOKEN,
     });
     expect(out.id).toBe("b1");
-    expect(mocked.proBet.create).not.toHaveBeenCalled();
-    expect(mockedDebit).not.toHaveBeenCalled();
+    expect(txMocks.proBet.create).not.toHaveBeenCalled();
+    expect(mockedDebitInTx).not.toHaveBeenCalled();
   });
 
   async function expectCode(
@@ -298,8 +318,8 @@ describe("placeBet — sprint 1.D.4", () => {
   it("accepte un drift < 2%", async () => {
     mocked.proBet.findUnique.mockResolvedValue(null);
     mocked.proBetMarket.findUnique.mockResolvedValue(buildOpenMarket());
-    mockedDebit.mockResolvedValue(900);
-    mocked.proBet.create.mockResolvedValue(
+    mockedDebitInTx.mockResolvedValue(900);
+    txMocks.proBet.create.mockResolvedValue(
       buildBetRow({ oddsAtPlace: 2.01 }),
     );
     const out = await placeBet({
@@ -311,14 +331,19 @@ describe("placeBet — sprint 1.D.4", () => {
       clientToken: VALID_TOKEN,
     });
     expect(out.id).toBe("b1");
-    expect(mockedDebit).toHaveBeenCalledWith(USER, 100, "BET");
+    expect(mockedDebitInTx).toHaveBeenCalledWith(
+      txMocks,
+      USER,
+      100,
+      "BET",
+    );
   });
 
-  it("place pari OK : debit + create + renvoie summary", async () => {
+  it("place pari OK : debit + create dans une seule $transaction", async () => {
     mocked.proBet.findUnique.mockResolvedValue(null);
     mocked.proBetMarket.findUnique.mockResolvedValue(buildOpenMarket());
-    mockedDebit.mockResolvedValue(900);
-    mocked.proBet.create.mockResolvedValue(buildBetRow());
+    mockedDebitInTx.mockResolvedValue(900);
+    txMocks.proBet.create.mockResolvedValue(buildBetRow());
 
     const out = await placeBet({
       userId: USER,
@@ -335,8 +360,15 @@ describe("placeBet — sprint 1.D.4", () => {
     expect(out.selection).toBe("home");
     expect(out.stake).toBe(100);
     expect(out.status).toBe("pending");
-    expect(mockedDebit).toHaveBeenCalledWith(USER, 100, "BET");
-    expect(mocked.proBet.create).toHaveBeenCalledWith(
+    expect(mockedEnsureWallet).toHaveBeenCalledWith(USER);
+    expect(mocked.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockedDebitInTx).toHaveBeenCalledWith(
+      txMocks,
+      USER,
+      100,
+      "BET",
+    );
+    expect(txMocks.proBet.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           userId: USER,
@@ -348,6 +380,35 @@ describe("placeBet — sprint 1.D.4", () => {
         }),
       }),
     );
+  });
+
+  it("rollback : si create-bet throw, le debit doit etre rollback (atomicite)", async () => {
+    mocked.proBet.findUnique.mockResolvedValue(null);
+    mocked.proBetMarket.findUnique.mockResolvedValue(buildOpenMarket());
+    mockedDebitInTx.mockResolvedValue(900);
+    txMocks.proBet.create.mockRejectedValue(new Error("DB crashed"));
+    // Simule Prisma : si le callback throw, la $transaction propage
+    // l'erreur (et n'aurait pas commit en vrai).
+    mocked.$transaction.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (cb: any) => {
+        return cb(txMocks);
+      },
+    );
+    await expect(
+      placeBet({
+        userId: USER,
+        marketId: "mkt1",
+        selection: "home",
+        stake: 100,
+        oddsAtPlace: 2.0,
+        clientToken: VALID_TOKEN,
+      }),
+    ).rejects.toThrow("DB crashed");
+    // L'important : debit ET create ont ete tentes dans la meme
+    // $transaction (le rollback est garanti par Prisma cote runtime).
+    expect(mockedDebitInTx).toHaveBeenCalled();
+    expect(mocked.$transaction).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/server/src/services/pro-bet.ts
+++ b/apps/server/src/services/pro-bet.ts
@@ -21,7 +21,8 @@ import { prisma } from "../prisma";
 
 import {
   type ProTransactionEntry,
-  debit,
+  debitInTx,
+  ensureWalletExists,
 } from "./pro-wallet";
 
 const MARKET_STATUS_OPEN = "open";
@@ -286,22 +287,29 @@ export async function placeBet(input: PlaceBetInput): Promise<ProBetSummary> {
     );
   }
 
-  // Debit wallet + create bet — atomique via service wallet
-  // (lui-même $transaction). En cas d'échec wallet, le bet n'est
-  // pas créé — la cohérence est garantie par l'ordre.
-  await debit(input.userId, input.stake, "BET");
+  // BUG fix audit round 4 (CRITICAL) : avant, `debit()` ouvrait sa
+  // propre transaction Prisma. En cas de crash entre `debit` et
+  // `create proBet`, l'utilisateur etait debite SANS bet associe
+  // (money loss). Maintenant tout est dans une seule $transaction :
+  // soit le debit ET le bet sont crees, soit aucun. Ensure-wallet
+  // hors transaction pour ne pas creer une commit cassee.
+  await ensureWalletExists(input.userId);
 
-  const created = await prisma.proBet.create({
-    data: {
-      userId: input.userId,
-      marketId: input.marketId,
-      selection: input.selection,
-      stake: input.stake,
-      oddsAtPlace: input.oddsAtPlace,
-      status: "pending",
-      clientToken: input.clientToken,
-    },
-    select: betSelect(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const created = await prisma.$transaction(async (tx: any) => {
+    await debitInTx(tx, input.userId, input.stake, "BET");
+    return tx.proBet.create({
+      data: {
+        userId: input.userId,
+        marketId: input.marketId,
+        selection: input.selection,
+        stake: input.stake,
+        oddsAtPlace: input.oddsAtPlace,
+        status: "pending",
+        clientToken: input.clientToken,
+      },
+      select: betSelect(),
+    });
   });
 
   return toBetSummary(created);

--- a/apps/server/src/services/pro-wallet-rewards.test.ts
+++ b/apps/server/src/services/pro-wallet-rewards.test.ts
@@ -1,11 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    proTransaction: { findFirst: vi.fn() },
-    proWallet: { findUnique: vi.fn() },
-  },
-}));
+// Audit round 4 : `claimDailyBonus` execute desormais le check + credit
+// dans une seule $transaction Prisma. On simule en faisant que
+// `prisma.$transaction(cb)` execute le callback avec un `tx` qui
+// partage les memes mocks (proTransaction, proWallet) — comme ca le test
+// peut configurer les retours via `mocked.proTransaction.findFirst.mockResolvedValue`
+// et le code voit le meme mock dans la $transaction.
+vi.mock("../prisma", () => {
+  const proTransaction = { findFirst: vi.fn(), create: vi.fn() };
+  const proWallet = { findUnique: vi.fn(), update: vi.fn() };
+  return {
+    prisma: {
+      proTransaction,
+      proWallet,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) =>
+        cb({ proTransaction, proWallet }),
+      ),
+    },
+  };
+});
 
 vi.mock("./pro-wallet", () => ({
   credit: vi.fn(),
@@ -23,8 +37,15 @@ import {
 } from "./pro-wallet-rewards";
 
 interface MockedPrisma {
-  proTransaction: { findFirst: ReturnType<typeof vi.fn> };
-  proWallet: { findUnique: ReturnType<typeof vi.fn> };
+  proTransaction: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  proWallet: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
 }
 
 const mocked = prisma as unknown as MockedPrisma;
@@ -37,6 +58,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockedEnsure.mockResolvedValue({ userId: USER, crowns: 0 });
   mocked.proWallet.findUnique.mockResolvedValue({ crowns: 0 });
+  // Re-attache le comportement par defaut du $transaction (vi.clearAllMocks
+  // l'a vide).
+  mocked.$transaction.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (cb: any) =>
+      cb({
+        proTransaction: mocked.proTransaction,
+        proWallet: mocked.proWallet,
+      }),
+  );
 });
 
 describe("grantFirstTimeBonus — sprint 1.D.6", () => {
@@ -72,14 +103,33 @@ describe("grantFirstTimeBonus — sprint 1.D.6", () => {
 describe("claimDailyBonus — sprint 1.D.6", () => {
   it("crédite 50 si pas de DAILY antérieur", async () => {
     mocked.proTransaction.findFirst.mockResolvedValue(null);
-    mockedCredit.mockResolvedValue(50);
+    // Le code lit le solde via findUnique DANS la $transaction, puis
+    // update. On simule current=0 → updated=50.
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 0 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 50 });
+    mocked.proTransaction.create.mockResolvedValue({ id: "tx_new" });
 
     const out = await claimDailyBonus(USER);
     expect(out.granted).toBe(true);
     expect(out.amount).toBe(DAILY_BONUS_AMOUNT);
     expect(out.balance).toBe(50);
     expect(out.nextEligibleAt).not.toBeNull();
-    expect(mockedCredit).toHaveBeenCalledWith(USER, 50, "DAILY");
+    expect(mocked.$transaction).toHaveBeenCalledTimes(1);
+    expect(mocked.proWallet.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER },
+        data: { crowns: 50 },
+      }),
+    );
+    expect(mocked.proTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletId: USER,
+          type: "DAILY",
+          amount: DAILY_BONUS_AMOUNT,
+        }),
+      }),
+    );
   });
 
   it("rejette si dernier DAILY < 24h", async () => {
@@ -96,6 +146,8 @@ describe("claimDailyBonus — sprint 1.D.6", () => {
     expect(out.balance).toBe(250);
     // nextEligibleAt = recentDaily + 24h
     expect(out.nextEligibleAt).toBe("2026-09-16T08:00:00.000Z");
+    expect(mocked.proWallet.update).not.toHaveBeenCalled();
+    expect(mocked.proTransaction.create).not.toHaveBeenCalled();
     expect(mockedCredit).not.toHaveBeenCalled();
   });
 
@@ -105,11 +157,14 @@ describe("claimDailyBonus — sprint 1.D.6", () => {
     mocked.proTransaction.findFirst.mockResolvedValue({
       createdAt: oldDaily,
     });
-    mockedCredit.mockResolvedValue(300);
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 250 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 300 });
+    mocked.proTransaction.create.mockResolvedValue({ id: "tx_new" });
 
     const out = await claimDailyBonus(USER, now);
     expect(out.granted).toBe(true);
     expect(out.amount).toBe(DAILY_BONUS_AMOUNT);
+    expect(out.balance).toBe(300);
   });
 });
 

--- a/apps/server/src/services/pro-wallet-rewards.ts
+++ b/apps/server/src/services/pro-wallet-rewards.ts
@@ -89,6 +89,13 @@ export async function grantFirstTimeBonus(
  * Crédite le daily bonus (50 Crowns) si la dernière transaction
  * DAILY date d'il y a > 24h. Renvoie `granted=false` + `nextEligibleAt`
  * sinon (UI peut afficher un compte à rebours).
+ *
+ * BUG fix audit round 4 : avant, le check de la fenetre DAILY etait
+ * fait HORS transaction → deux appels concurrents pouvaient tous deux
+ * passer la verif et crediter deux fois (race condition). Fix : tout
+ * le check + credit dans une seule $transaction, en se basant sur la
+ * derniere transaction DAILY lue DANS la transaction (lecture
+ * sequentielle par Prisma → coherente).
  */
 export async function claimDailyBonus(
   userId: string,
@@ -96,32 +103,60 @@ export async function claimDailyBonus(
 ): Promise<RewardOutcome> {
   await getOrCreateWallet(userId);
 
-  const lastDaily = await prisma.proTransaction.findFirst({
-    where: { walletId: userId, type: "DAILY" },
-    orderBy: { createdAt: "desc" },
-    select: { createdAt: true },
-  });
-  if (lastDaily) {
-    const lastAt = (lastDaily.createdAt as Date).getTime();
-    const windowEnd = lastAt + DAILY_BONUS_WINDOW_MS;
-    if (now.getTime() < windowEnd) {
-      const balance = await getCurrentBalance(userId);
-      return {
-        granted: false,
-        balance,
-        amount: 0,
-        nextEligibleAt: new Date(windowEnd).toISOString(),
-      };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = await prisma.$transaction(async (tx: any) => {
+    const lastDaily = await tx.proTransaction.findFirst({
+      where: { walletId: userId, type: "DAILY" },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    });
+    if (lastDaily) {
+      const lastAt = (lastDaily.createdAt as Date).getTime();
+      const windowEnd = lastAt + DAILY_BONUS_WINDOW_MS;
+      if (now.getTime() < windowEnd) {
+        const w = await tx.proWallet.findUnique({
+          where: { userId },
+          select: { crowns: true },
+        });
+        return {
+          granted: false as const,
+          balance: (w?.crowns as number | undefined) ?? 0,
+          amount: 0,
+          nextEligibleAt: new Date(windowEnd).toISOString(),
+        };
+      }
     }
-  }
 
-  const balance = await credit(userId, DAILY_BONUS_AMOUNT, "DAILY");
-  return {
-    granted: true,
-    balance,
-    amount: DAILY_BONUS_AMOUNT,
-    nextEligibleAt: new Date(now.getTime() + DAILY_BONUS_WINDOW_MS).toISOString(),
-  };
+    // Credit dans la meme transaction. La lecture suivante est garantie
+    // de voir nos writes intermediaires (snapshot isolation).
+    const w = await tx.proWallet.findUnique({
+      where: { userId },
+      select: { crowns: true },
+    });
+    const current = (w?.crowns as number | undefined) ?? 0;
+    const updated = await tx.proWallet.update({
+      where: { userId },
+      data: { crowns: current + DAILY_BONUS_AMOUNT },
+      select: { crowns: true },
+    });
+    await tx.proTransaction.create({
+      data: {
+        walletId: userId,
+        type: "DAILY",
+        amount: DAILY_BONUS_AMOUNT,
+        ref: null,
+      },
+    });
+    return {
+      granted: true as const,
+      balance: updated.crowns as number,
+      amount: DAILY_BONUS_AMOUNT,
+      nextEligibleAt: new Date(
+        now.getTime() + DAILY_BONUS_WINDOW_MS,
+      ).toISOString(),
+    };
+  });
+  return result;
 }
 
 /**

--- a/apps/server/src/services/pro-wallet.ts
+++ b/apps/server/src/services/pro-wallet.ts
@@ -249,6 +249,97 @@ export async function credit(
 }
 
 /**
+ * Garantit que le wallet existe pour `userId`. Idempotent. A appeler
+ * AVANT une transaction qui utilise `debitInTx` / `creditInTx`, pour
+ * eviter d'inserer le wallet et la transaction debit dans la meme
+ * commit (qui peut casser la coherence en cas de rollback partiel).
+ */
+export async function ensureWalletExists(userId: string): Promise<void> {
+  await getOrCreateWallet(userId);
+}
+
+/**
+ * Variante de `debit` qui s'execute dans une transaction Prisma existante
+ * (passee en argument `tx`). Permet de composer debit + create-bet dans
+ * la meme transaction atomique. Cf. `pro-bet.ts:placeBet` qui doit garantir
+ * « debit + create bet » all-or-nothing (avant fix, debit pouvait reussir
+ * et create-bet echouer → money loss).
+ *
+ * @param tx Prisma transaction client passe par le caller.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function debitInTx(
+  tx: any,
+  userId: string,
+  amount: number,
+  type: ProTxType,
+  ref?: string,
+): Promise<number> {
+  ensureValidAmount(amount);
+  ensureValidType(type);
+  // Note : pas de getOrCreateWallet ici — le caller doit s'assurer que
+  // le wallet existe (ou appeler en dehors de la $transaction si neuf).
+  const w = await tx.proWallet.findUnique({
+    where: { userId },
+    select: { crowns: true },
+  });
+  const current = (w?.crowns as number | undefined) ?? 0;
+  if (current < amount) {
+    throw new InsufficientFundsError(current, amount);
+  }
+  const updated = await tx.proWallet.update({
+    where: { userId },
+    data: { crowns: current - amount },
+    select: { crowns: true },
+  });
+  await tx.proTransaction.create({
+    data: {
+      walletId: userId,
+      type,
+      amount: -amount,
+      ref: ref ?? null,
+    },
+  });
+  return updated.crowns as number;
+}
+
+/**
+ * Variante de `credit` qui s'execute dans une transaction Prisma
+ * existante. Cf. `pro-bet-settlement.ts` qui doit garantir
+ * « update bet status + credit user » all-or-nothing.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function creditInTx(
+  tx: any,
+  userId: string,
+  amount: number,
+  type: ProTxType,
+  ref?: string,
+): Promise<number> {
+  ensureValidAmount(amount);
+  ensureValidType(type);
+  const w = await tx.proWallet.findUnique({
+    where: { userId },
+    select: { crowns: true },
+  });
+  const current = (w?.crowns as number | undefined) ?? 0;
+  const updated = await tx.proWallet.update({
+    where: { userId },
+    data: { crowns: current + amount },
+    select: { crowns: true },
+  });
+  await tx.proTransaction.create({
+    data: {
+      walletId: userId,
+      type,
+      amount: amount,
+      ref: ref ?? null,
+    },
+  });
+  return updated.crowns as number;
+}
+
+/**
  * Liste les `limit` dernières transactions de l'user, ordre desc
  * (plus récentes d'abord). Renvoie [] si le wallet n'existe pas.
  */


### PR DESCRIPTION
## Summary

Audit round 4 — 3 bugs CRITIQUES de race condition / money-loss sur le wallet Crowns Pro League. Toutes corrigees en wrappant les operations multi-step dans une seule `prisma.$transaction`.

### Bugs corriges

**1. `placeBet` (`pro-bet.ts`) — money loss permanent**

Avant : `debit()` ouvrait sa propre `$transaction`, puis `prisma.proBet.create()` etait separe. Si le process crashait entre les deux, l'utilisateur etait debite SANS bet associe — money loss permanent car `placeBet` est idempotent par `clientToken` (retry impossible).

Fix : `ensureWalletExists()` hors transaction (evite rollback partiel sur nouveau wallet), puis `debitInTx + proBet.create` dans **une seule** `$transaction`.

**2. `settleMarketsForMatch` (`pro-bet-settlement.ts`) — gain perdu + sweep infini**

Avant : le loop `update bet.status='won'` + `credit user` + `create settlement` + `update market.status='settled'` etait sequentiel sans transaction.
- Crash entre `bet.status='won'` et `credit user` → user perdait son gain (le filter `status: 'pending'` exclut le bet au retry).
- Crash entre boucle bets et `proBetSettlement.create` → bets settled mais market jamais flag → sweep ulterieur retombe dessus mais skip tous les bets (pending exclus) → boucle infinie au cron.

Fix : tout le settlement d'un market (update bets + credit users + create settlement row + update market.status) wrappe dans **une seule** `$transaction`. Pre-ensure wallets HORS transaction.

**3. `claimDailyBonus` (`pro-wallet-rewards.ts`) — double-claim race**

Avant : check fenetre 24h HORS transaction puis appel `credit()` (qui ouvre sa propre transaction). Deux appels concurrents pouvaient tous deux passer la verif avant qu'aucun n'ait commit → 100 Crowns gratuits par race condition.

Fix : check + credit dans **une seule** `$transaction`, lecture du `lastDaily` DANS la transaction (Prisma garantit la coherence en serializable).

### Helpers ajoutes (`pro-wallet.ts`)

- `ensureWalletExists(userId)` — idempotent, garantit l'existence du wallet AVANT d'ouvrir une transaction qui le manipule.
- `debitInTx(tx, userId, amount, type, ref?)` — variante de `debit` qui s'execute dans une transaction Prisma existante.
- `creditInTx(tx, userId, amount, type, ref?)` — idem pour le credit.

### Bonus : fix typecheck pre-existant

`local-match.ts:584,590,710,716` et `inducement-processor.ts:128,134` — `apothecaryAvailable` a change de `boolean` a `number` (compte) en audit round 2 (PR #828), mais le coercion via `?? false` retournait un `number`. Converti en `(... ?? 0) > 0` pour repondre au contrat `hasApothecary: boolean`.

## Test plan

- [x] `pnpm typecheck` passe (0 erreur)
- [x] `pnpm vitest run` — 2797 tests pass (213 suites)
- [x] Suites bet/wallet/settlement/rewards mises a jour pour mocker `prisma.$transaction` (52 tests dedies pass)
- [x] Test ajoute : `placeBet` rollback si `proBet.create` throw — verifie que debit ET create sont dans la meme `$transaction`
- [x] Test ajoute : `settleMarketsForMatch` verifie 1 seule `$transaction` par market settled + pre-ensure-wallet uniquement pour les gagnants

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_