### PR TITLE
fix(game-engine): clear pending* a la mi-temps + GFI reroll Blizzard target

### DIFF
--- a/packages/game-engine/src/actions/reroll-choose-handler.test.ts
+++ b/packages/game-engine/src/actions/reroll-choose-handler.test.ts
@@ -89,3 +89,85 @@ describe('S27.8.14 — handleRerollChoose', () => {
     expect(JSON.stringify(state)).toBe(snapshot);
   });
 });
+
+describe('audit round 4 — GFI reroll respecte le seuil meteo Blizzard', () => {
+  function makeGfiRerollState(weather?: unknown): GameState {
+    return makeState({
+      players: [
+        {
+          id: 'A1',
+          team: 'A',
+          name: 'Alice',
+          pos: { x: 5, y: 5 },
+          stunned: false,
+          ma: 6,
+          st: 3,
+          ag: 3,
+          pa: 4,
+          av: 8,
+          pm: 6,
+          gfiUsed: 1,
+          hasBall: false,
+          dead: false,
+          ko: false,
+          casualty: false,
+          starPlayer: false,
+          skills: [],
+        } as any,
+      ],
+      pendingReroll: {
+        rollType: 'gfi',
+        playerId: 'A1',
+        team: 'A',
+        playerIndex: 0,
+        from: { x: 5, y: 5 },
+        to: { x: 5, y: 5 },
+        modifiers: 0,
+      } as any,
+      teamRerolls: { teamA: 3, teamB: 3 } as any,
+      rerollUsedThisTurn: false,
+      weatherCondition: weather as any,
+    });
+  }
+
+  it('utilise un seuil 3+ pour la relance GFI en Blizzard (vs 2+ normal)', () => {
+    // RNG produit roll=1 → fail. Mais avant fix, seuil=2 (hardcode) →
+    // serait fail aussi. On veut donc un cas qui passe a 2 et echoue a 3
+    // pour discriminer : roll = 2.
+    // Math.floor(rng() * 6) + 1 = 2 quand rng() = 0.166...
+    const rng2: RNG = () => 0.2; // floor(1.2)+1 = 2
+    const state = makeGfiRerollState({ condition: 'Blizzard' });
+    const next = handleRerollChoose(
+      state,
+      { type: 'REROLL_CHOOSE', useReroll: true },
+      rng2,
+    );
+    // Avant fix : seuil=2, roll=2 → success, pas de failure log.
+    // Apres fix : seuil=3 (Blizzard), roll=2 → fail.
+    // On verifie via le gameLog que le seuil affiche est 3.
+    const gfiRerollLog = next.gameLog.find((e) =>
+      e.message?.startsWith('Relance GFI'),
+    );
+    expect(gfiRerollLog).toBeDefined();
+    expect(gfiRerollLog?.message).toContain('/3');
+    expect(gfiRerollLog?.details?.targetNumber).toBe(3);
+    expect(gfiRerollLog?.details?.success).toBe(false);
+  });
+
+  it('utilise un seuil 2+ pour la relance GFI en temps normal', () => {
+    const rng2: RNG = () => 0.2; // roll = 2
+    const state = makeGfiRerollState(undefined);
+    const next = handleRerollChoose(
+      state,
+      { type: 'REROLL_CHOOSE', useReroll: true },
+      rng2,
+    );
+    const gfiRerollLog = next.gameLog.find((e) =>
+      e.message?.startsWith('Relance GFI'),
+    );
+    expect(gfiRerollLog).toBeDefined();
+    expect(gfiRerollLog?.message).toContain('/2');
+    expect(gfiRerollLog?.details?.targetNumber).toBe(2);
+    expect(gfiRerollLog?.details?.success).toBe(true);
+  });
+});

--- a/packages/game-engine/src/actions/reroll-choose-handler.ts
+++ b/packages/game-engine/src/actions/reroll-choose-handler.ts
@@ -37,6 +37,7 @@ import {
 import { createLogEntry } from '../utils/logging';
 import { applyRollFailure, applyPickupFailure } from './failure-helpers';
 import { handleBallPickup } from './ball-pickup';
+import { getWeatherModifiers } from '../mechanics/weather-effects';
 
 /**
  * Retourne le seuil Loner du joueur (3, 4 ou 5) ou `null` s'il n'a
@@ -199,15 +200,21 @@ export function handleRerollChoose(
       return applyRollFailure(newState, playerIndex, rng, armBarBonus);
     }
   } else if (rollType === 'gfi') {
-    // Relancer le jet de GFI
+    // BUG fix audit round 4 : avant, le seuil de relance GFI etait
+    // hardcode a 2+. En Blizzard, le seuil normal devient 3+ (modifier
+    // meteo -1) → la relance ignorait cette penalite et passait sur
+    // 2+, donnant un avantage incorrect au joueur. Fix : utiliser la
+    // meme fonction de seuil que le jet original (gfiTargetFromWeather).
+    const weatherMods = getWeatherModifiers(newState.weatherCondition);
+    const gfiTarget = 2 - weatherMods.gfiModifier;
     const gfiRoll = Math.floor(rng() * 6) + 1;
-    const gfiSuccess = gfiRoll >= 2;
+    const gfiSuccess = gfiRoll >= gfiTarget;
     const logEntry = createLogEntry(
       'dice',
-      `Relance GFI: ${gfiRoll}/2 ${gfiSuccess ? '✓' : '✗'}`,
+      `Relance GFI: ${gfiRoll}/${gfiTarget} ${gfiSuccess ? '✓' : '✗'}`,
       playerId,
       team,
-      { diceRoll: gfiRoll, targetNumber: 2, success: gfiSuccess },
+      { diceRoll: gfiRoll, targetNumber: gfiTarget, success: gfiSuccess },
     );
     newState.gameLog = [...newState.gameLog, logEntry];
 

--- a/packages/game-engine/src/core/game-state.ts
+++ b/packages/game-engine/src/core/game-state.ts
@@ -615,6 +615,15 @@ export function advanceHalfIfNeeded(state: GameState, rng: RNG): GameState {
       // startKickoffSequence → placeKickoffBall → calculateKickDeviation →
       // resolveKickoffEvent → startMatchFromKickoff) — même contrat que
       // handlePostTouchdown et que la séquence pré-match initiale.
+      //
+      // BUG fix audit round 4 : avant, les champs `pending*` (apothecary,
+      // reroll, block, dumpOff, push/follow-up choice, multipleBlock,
+      // frenzyBlock, onTheBall, kickoffEvent) n'etaient PAS clears au
+      // passage de mi-temps. Si un drive 1ere mi-temps se terminait sur
+      // turnover avec un pending mid-action (ex: apothecary choice non
+      // resolu), le pending survivait au halftime → UI affichait un
+      // modal stale au debut de la 2e mi-temps, ou pire le pending etait
+      // applique au joueur d'une autre equipe. Fix : reset explicite.
       const extState = newState as ExtendedGameState;
       const resultState: GameState = {
         ...newState,
@@ -624,6 +633,16 @@ export function advanceHalfIfNeeded(state: GameState, rng: RNG): GameState {
         currentPlayer: receivingTeam,
         kickingTeam: newKickingTeam,
         isTurnover: false,
+        pendingApothecary: undefined,
+        pendingKickoffEvent: undefined,
+        pendingBlock: undefined,
+        pendingDumpOff: undefined,
+        pendingPushChoice: undefined,
+        pendingFollowUpChoice: undefined,
+        pendingReroll: undefined,
+        pendingMultipleBlock: undefined,
+        pendingFrenzyBlock: undefined,
+        pendingOnTheBall: undefined,
         ball: undefined,
         selectedPlayerId: null,
         playerActions: {} as Record<string, ActionType>,

--- a/packages/game-engine/src/core/halftime.test.ts
+++ b/packages/game-engine/src/core/halftime.test.ts
@@ -475,4 +475,55 @@ describe('Règle: Mi-temps complète (B1.7)', () => {
       expect(finalState.weatherCondition).toEqual({ condition: 'Nice', description: 'Beau temps' });
     });
   });
+
+  describe('advanceHalfIfNeeded — pending cleanup (audit round 4)', () => {
+    it('clear tous les pending* mid-action au passage de mi-temps', () => {
+      const state = createHalftimeState({
+        // Simule un drive 1ere mi-temps qui se termine sur turnover
+        // alors qu'un pending mid-action n'a pas ete resolu.
+        pendingApothecary: {
+          playerId: 'A1',
+          team: 'A',
+          severity: 'badly-hurt',
+          fallbackToRegeneration: false,
+        } as any,
+        pendingReroll: {
+          rollType: 'gfi',
+          playerId: 'A1',
+          team: 'A',
+        } as any,
+        pendingBlock: { attackerId: 'A2', defenderId: 'B1' } as any,
+        pendingDumpOff: {
+          passer: { id: 'B1', team: 'B' },
+          pendingBlockMove: { type: 'BLOCK', attackerId: 'A2', defenderId: 'B1' },
+        } as any,
+        pendingPushChoice: { attackerId: 'A2', defenderId: 'B1', squares: [] } as any,
+        pendingFollowUpChoice: {
+          attackerId: 'A2',
+          fromPos: { x: 5, y: 5 },
+          toPos: { x: 6, y: 5 },
+        } as any,
+        pendingMultipleBlock: { attackerId: 'A2', defenderIds: ['B1', 'B2'] } as any,
+        pendingFrenzyBlock: { attackerId: 'A2', defenderId: 'B1' } as any,
+        pendingOnTheBall: {
+          interceptor: 'B3',
+          pendingPassMove: { type: 'PASS', playerId: 'A1', targetId: 'A2' },
+        } as any,
+        pendingKickoffEvent: { id: 'time-out' } as any,
+      });
+      const rng = makeRNG('halftime-pendings');
+      const result = advanceHalfIfNeeded(state, rng);
+
+      expect(result.pendingApothecary).toBeUndefined();
+      expect(result.pendingReroll).toBeUndefined();
+      expect(result.pendingBlock).toBeUndefined();
+      expect(result.pendingDumpOff).toBeUndefined();
+      expect(result.pendingPushChoice).toBeUndefined();
+      expect(result.pendingFollowUpChoice).toBeUndefined();
+      expect(result.pendingMultipleBlock).toBeUndefined();
+      expect(result.pendingFrenzyBlock).toBeUndefined();
+      expect(result.pendingOnTheBall).toBeUndefined();
+      expect(result.pendingKickoffEvent).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Audit round 4 — 2 bugs comportementaux dans le game-engine qui pouvaient corrompre l'etat ou rendre la relance trop favorable.

### Bugs corriges

**1. `advanceHalfIfNeeded` — pendings non-clearaient au halftime**

Fichier : `packages/game-engine/src/core/game-state.ts`

Avant : la transition mi-temps clearait `ball`, `selectedPlayerId`, `playerActions`, `teamBlitzCount`, `teamFoulCount`, `rerollUsedThisTurn`, `lastDiceResult`, et les champs `kickoffStep/ballPosition/kickDeviation/kickoffEvent/finalBallPosition` du `preMatch`. Mais elle ignorait **10 champs `pending*` au top-level** :

- `pendingApothecary`
- `pendingKickoffEvent`
- `pendingBlock`
- `pendingDumpOff`
- `pendingPushChoice`
- `pendingFollowUpChoice`
- `pendingReroll`
- `pendingMultipleBlock`
- `pendingFrenzyBlock`
- `pendingOnTheBall`

Si un drive 1ere mi-temps se terminait sur turnover **alors qu'un pending mid-action n'avait pas ete resolu** (ex: choix apothecary que l'UI n'a pas validee, ou choix de push apres block), le pending **survivait au halftime**. Au debut de la 2e mi-temps, l'UI affichait un modal stale, ou pire le pending etait applique au joueur d'une autre equipe.

Fix : reset explicite des 10 champs `pending*` dans le `resultState`.

**2. `handleRerollChoose` `rollType='gfi'` — Blizzard target ignore**

Fichier : `packages/game-engine/src/actions/reroll-choose-handler.ts`

Avant : la relance GFI utilisait un seuil hardcode `>= 2`. En Blizzard (BB3 S3), le seuil normal du GFI est 3+ (modifier meteo -1 applique sur le seuil de base 2). Le **jet original** utilisait correctement `gfiTargetFromWeather()`, mais la **relance** ignorait la penalite et passait sur 2+ → avantage incorrect au joueur en Blizzard.

Fix : importer `getWeatherModifiers`, calculer `target = 2 - mods.gfiModifier`, et utiliser ce seuil dans le check + le log.

## Test plan

- [x] `halftime.test.ts` : nouveau cas "clear tous les pending*" qui set les 10 champs avant `advanceHalfIfNeeded` et verifie qu'ils sont tous `undefined` apres.
- [x] `reroll-choose-handler.test.ts` : 2 nouveaux cas pour la relance GFI :
  - `weatherCondition: { condition: 'Blizzard' }` → target=3, roll=2 → fail (avant fix : success).
  - `weatherCondition: undefined` → target=2, roll=2 → success.
- [x] `pnpm typecheck` propre sur game-engine.
- [x] Test suites au global :
  - game-engine : **5049 tests pass** (+3 nouveaux)
  - sim-engine : 422 tests pass
  - server : 2797 tests pass

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_