### PR TITLE
fix(pro-league): SPP transactionnel + odds calculator driverKind/roster

### DIFF
--- a/apps/server/src/services/pro-bet-odds-calculator.test.ts
+++ b/apps/server/src/services/pro-bet-odds-calculator.test.ts
@@ -169,6 +169,115 @@ describe("computeMarketsForMatch — sprint 1.D.3", () => {
     const cas = out[2].config as { line: number };
     expect(cas.line).toBe(0.5);
   });
+
+  describe("audit round 4 — driverKind + roster", () => {
+    it("hybrid (default) : ne charge pas les rosters et passe driverKind='hybrid'", async () => {
+      const simSpy = vi
+        .spyOn(simEngine, "simulateMatch")
+        .mockReturnValue(
+          buildSimResult({ outcome: "home", td: 2, cas: 0, nuffle: 0 }) as ReturnType<
+            typeof simEngine.simulateMatch
+          >,
+        );
+      mocked.proLeagueMatch.findUnique.mockResolvedValue({
+        ...FAKE_MATCH,
+        driverKindOverride: null,
+        homeTeam: { id: "ht1", slug: "pit-smashers", name: "Smashers" },
+        awayTeam: { id: "at1", slug: "kc-soaring-hawks", name: "Soaring Hawks" },
+        season: { driverKind: "hybrid" },
+      });
+
+      await computeMarketsForMatch(MATCH_ID, { runs: 1, houseMargin: 0 });
+
+      expect(simSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          home: expect.objectContaining({ roster: undefined }),
+          away: expect.objectContaining({ roster: undefined }),
+        }),
+        { driverKind: "hybrid" },
+      );
+    });
+
+    it("full driver : charge les rosters des 2 teams et passe driverKind='full'", async () => {
+      const simSpy = vi
+        .spyOn(simEngine, "simulateMatch")
+        .mockReturnValue(
+          buildSimResult({ outcome: "home", td: 2, cas: 0, nuffle: 0 }) as ReturnType<
+            typeof simEngine.simulateMatch
+          >,
+        );
+      mocked.proLeagueMatch.findUnique.mockResolvedValue({
+        ...FAKE_MATCH,
+        driverKindOverride: null,
+        homeTeam: { id: "ht1", slug: "pit-smashers", name: "Smashers" },
+        awayTeam: { id: "at1", slug: "kc-soaring-hawks", name: "Soaring Hawks" },
+        season: { driverKind: "full" },
+      });
+      // Le test n'a pas mock proTeamRoster.findMany dans la fixture
+      // de test top-level — on l'ajoute en ad-hoc via le mocked.
+      const rosterRow = {
+        id: "p1",
+        name: "Player 1",
+        position: "Lineman",
+        ma: 6,
+        st: 3,
+        ag: 3,
+        pa: 4,
+        av: 8,
+        skills: [],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (prisma as any).proTeamRoster = {
+        findMany: vi.fn().mockResolvedValue([rosterRow]),
+      };
+
+      await computeMarketsForMatch(MATCH_ID, { runs: 1, houseMargin: 0 });
+
+      expect(simSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          home: expect.objectContaining({
+            roster: expect.arrayContaining([
+              expect.objectContaining({ id: "p1", name: "Player 1" }),
+            ]),
+          }),
+          away: expect.objectContaining({
+            roster: expect.arrayContaining([
+              expect.objectContaining({ id: "p1" }),
+            ]),
+          }),
+        }),
+        { driverKind: "full" },
+      );
+    });
+
+    it("match.driverKindOverride='full' a precedence sur season.driverKind='hybrid'", async () => {
+      const simSpy = vi
+        .spyOn(simEngine, "simulateMatch")
+        .mockReturnValue(
+          buildSimResult({ outcome: "home", td: 2, cas: 0, nuffle: 0 }) as ReturnType<
+            typeof simEngine.simulateMatch
+          >,
+        );
+      mocked.proLeagueMatch.findUnique.mockResolvedValue({
+        ...FAKE_MATCH,
+        driverKindOverride: "full",
+        homeTeam: { id: "ht1", slug: "pit-smashers", name: "Smashers" },
+        awayTeam: { id: "at1", slug: "kc-soaring-hawks", name: "Soaring Hawks" },
+        season: { driverKind: "hybrid" },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (prisma as any).proTeamRoster = {
+        findMany: vi.fn().mockResolvedValue([]),
+      };
+
+      await computeMarketsForMatch(MATCH_ID, { runs: 1, houseMargin: 0 });
+
+      expect(simSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        { driverKind: "full" },
+      );
+    });
+  });
 });
 
 describe("createOrRefreshMarketsForMatch — sprint 1.D.3", () => {

--- a/apps/server/src/services/pro-bet-odds-calculator.ts
+++ b/apps/server/src/services/pro-bet-odds-calculator.ts
@@ -40,6 +40,11 @@ import {
   computeOverUnderProbabilities,
   probabilityToDecimalOdds,
 } from "./pro-bet-odds-math";
+import { resolveDriverKind } from "./pro-league-driver-resolver";
+import {
+  mapToSimRoster,
+  type RawProRoster,
+} from "./pro-league-sim-runner";
 
 /** Types de markets supportés. */
 export type ProMarketType =
@@ -113,11 +118,25 @@ async function gatherSamples(
   casCounts: number[];
   nuffleCounts: number[];
 }> {
+  // BUG fix audit round 4 : avant, l'odds calculator chargeait
+  // uniquement les slugs des deux teams et appelait `simulateMatch`
+  // sans `driverKind` (default 'hybrid' avec teams synthetiques) et
+  // sans `roster`. Resultat : les odds etaient calculees sur le
+  // hybrid driver alors que le match reel pouvait tourner en 'full'
+  // avec les vrais rosters → odds miscalibrees (notamment si une
+  // team avait des joueurs morts/blesses non remplaces, le full
+  // driver les reflete mais le hybrid avec teams synthetiques ne
+  // les voit pas).
+  // Fix : charger season.driverKind, match.driverKindOverride et les
+  // rosters actifs des deux teams, puis passer driverKind + roster
+  // au simulateMatch.
   const match = await prisma.proLeagueMatch.findUnique({
     where: { id: matchId },
     select: {
-      homeTeam: { select: { slug: true, name: true } },
-      awayTeam: { select: { slug: true, name: true } },
+      driverKindOverride: true,
+      homeTeam: { select: { id: true, slug: true, name: true } },
+      awayTeam: { select: { id: true, slug: true, name: true } },
+      season: { select: { driverKind: true } },
     },
   });
   if (!match) {
@@ -131,6 +150,50 @@ async function gatherSamples(
     throw new ProMatchNotReadyForOddsError(
       `Slugs ProTeam introuvables : home='${match.homeTeam.slug}' away='${match.awayTeam.slug}'`,
     );
+  }
+
+  const driverKind = resolveDriverKind({
+    seasonDriverKind: (match.season?.driverKind as string) ?? "hybrid",
+    matchOverride: (match.driverKindOverride as string | null) ?? null,
+  });
+
+  // Charge les rosters actifs uniquement si on tourne en 'full' —
+  // hybrid n'utilise pas roster, eviter le round-trip DB inutile.
+  let homeRoster: ReturnType<typeof mapToSimRoster> | undefined;
+  let awayRoster: ReturnType<typeof mapToSimRoster> | undefined;
+  if (driverKind === "full") {
+    const [homeRaws, awayRaws] = await Promise.all([
+      prisma.proTeamRoster.findMany({
+        where: { teamId: match.homeTeam.id as string, status: "active" },
+        select: {
+          id: true,
+          name: true,
+          position: true,
+          ma: true,
+          st: true,
+          ag: true,
+          pa: true,
+          av: true,
+          skills: true,
+        },
+      }),
+      prisma.proTeamRoster.findMany({
+        where: { teamId: match.awayTeam.id as string, status: "active" },
+        select: {
+          id: true,
+          name: true,
+          position: true,
+          ma: true,
+          st: true,
+          ag: true,
+          pa: true,
+          av: true,
+          skills: true,
+        },
+      }),
+    ]);
+    homeRoster = mapToSimRoster(homeRaws as readonly RawProRoster[]);
+    awayRoster = mapToSimRoster(awayRaws as readonly RawProRoster[]);
   }
 
   const baseSeed = hashSeed(`odds:${matchId}`);
@@ -149,6 +212,7 @@ async function gatherSamples(
         side: "home",
         tactics: homeProfile.tactics,
         tv: homeProfile.tv,
+        roster: homeRoster,
       },
       away: {
         id: awayProfile.id,
@@ -156,9 +220,10 @@ async function gatherSamples(
         side: "away",
         tactics: awayProfile.tactics,
         tv: awayProfile.tv,
+        roster: awayRoster,
       },
     };
-    const result: SimResult = simulateMatch(sim);
+    const result: SimResult = simulateMatch(sim, { driverKind });
     if (result.summary.outcome === "home") oneXTwoCounts.home += 1;
     else if (result.summary.outcome === "away") oneXTwoCounts.away += 1;
     else oneXTwoCounts.draws += 1;

--- a/apps/server/src/services/pro-league-sim-runner.ts
+++ b/apps/server/src/services/pro-league-sim-runner.ts
@@ -110,7 +110,7 @@ const DEFAULT_MAX_BATCH = 50;
  * Hash FNV1a 32-bit pour dériver un seed numérique d'un cuid string.
  * Pas cryptographique — juste déterministe et bien distribué pour seeds.
  */
-interface RawProRoster {
+export interface RawProRoster {
   readonly id: string;
   readonly name: string;
   readonly position: string;
@@ -122,7 +122,7 @@ interface RawProRoster {
   readonly skills: unknown;
 }
 
-function parseRosterSkills(raw: unknown): readonly string[] {
+export function parseRosterSkills(raw: unknown): readonly string[] {
   if (Array.isArray(raw)) {
     return raw.filter((s): s is string => typeof s === "string");
   }
@@ -145,7 +145,7 @@ function parseRosterSkills(raw: unknown): readonly string[] {
  * `SimInput.away.roster`). Le numéro de jersey n'étant pas stocké
  * en DB, on suit l'ordre d'insertion (1..n) pour stabilité.
  */
-function mapToSimRoster(
+export function mapToSimRoster(
   raws: readonly RawProRoster[],
 ): readonly SimRosterPlayer[] {
   return raws.map((r, idx) => ({

--- a/apps/server/src/services/pro-roster-spp.test.ts
+++ b/apps/server/src/services/pro-roster-spp.test.ts
@@ -14,13 +14,25 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
-    replay: { findUnique: vi.fn() },
-    proTeamRoster: { findMany: vi.fn(), update: vi.fn() },
-  },
-}));
+// Audit round 4 : `applyMatchSpp` wrap maintenant les updates rosters
+// + update sppAppliedAt dans une seule $transaction. On simule en
+// partageant les memes mocks entre prisma top-level et le `tx` du
+// callback.
+vi.mock("../prisma", () => {
+  const proLeagueMatch = { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() };
+  const proTeamRoster = { findMany: vi.fn(), update: vi.fn() };
+  return {
+    prisma: {
+      proLeagueMatch,
+      replay: { findUnique: vi.fn() },
+      proTeamRoster,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) =>
+        cb({ proLeagueMatch, proTeamRoster }),
+      ),
+    },
+  };
+});
 
 vi.mock("@bb/sim-engine", () => ({
   decompressEvents: vi.fn(),
@@ -47,6 +59,7 @@ interface MockedPrisma {
     findMany: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
+  $transaction: ReturnType<typeof vi.fn>;
 }
 const mocked = prisma as unknown as MockedPrisma;
 const mockedDecompress = vi.mocked(decompressEvents);
@@ -55,6 +68,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocked.proLeagueMatch.update.mockResolvedValue({});
   mocked.proTeamRoster.update.mockResolvedValue({});
+  // Re-attache le comportement par defaut du $transaction (clearAllMocks
+  // l'a vide).
+  mocked.$transaction.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (cb: any) =>
+      cb({
+        proLeagueMatch: mocked.proLeagueMatch,
+        proTeamRoster: mocked.proTeamRoster,
+      }),
+  );
 });
 
 describe("SPP_VALUES — Lot 3.C.2", () => {

--- a/apps/server/src/services/pro-roster-spp.ts
+++ b/apps/server/src/services/pro-roster-spp.ts
@@ -358,24 +358,33 @@ export async function applyMatchSpp(
   for (const r of homeRoster) allById.set(r.id, r);
   for (const r of awayRoster) allById.set(r.id, r);
 
-  for (const reward of rewards) {
-    const cur = allById.get(reward.rosterId);
-    if (!cur) continue;
-    await prisma.proTeamRoster.update({
-      where: { id: reward.rosterId },
-      data: {
-        spp: cur.spp + reward.totalSpp,
-        tdCount: cur.tdCount + reward.tdCount,
-        casCount: cur.casCount + reward.casCount,
-        compCount: cur.compCount + reward.compCount,
-        mvpCount: cur.mvpCount + reward.mvpCount,
-      },
+  // BUG fix audit round 4 (CRITICAL) : avant, les updates `proTeamRoster`
+  // et le marqueur `proLeagueMatch.sppAppliedAt` etaient executes
+  // sequentiellement sans transaction. Crash entre 2 updates de rosters
+  // → SPP partiellement distribues + `sppAppliedAt` non-set → re-run
+  // double-applique sur les rosters deja mis a jour (corruption SPP).
+  // Fix : tout le bloc updates + sppAppliedAt dans une seule
+  // $transaction Prisma.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    for (const reward of rewards) {
+      const cur = allById.get(reward.rosterId);
+      if (!cur) continue;
+      await tx.proTeamRoster.update({
+        where: { id: reward.rosterId },
+        data: {
+          spp: cur.spp + reward.totalSpp,
+          tdCount: cur.tdCount + reward.tdCount,
+          casCount: cur.casCount + reward.casCount,
+          compCount: cur.compCount + reward.compCount,
+          mvpCount: cur.mvpCount + reward.mvpCount,
+        },
+      });
+    }
+    await tx.proLeagueMatch.update({
+      where: { id: matchId },
+      data: { sppAppliedAt: new Date() },
     });
-  }
-
-  await prisma.proLeagueMatch.update({
-    where: { id: matchId },
-    data: { sppAppliedAt: new Date() },
   });
 
   return {


### PR DESCRIPTION
## Summary

Audit round 4 — 2 bugs Pro League autour de la coherence cross-driver et de la transactionnalite des SPP.

### Bugs corriges

**1. `applyMatchSpp` (`pro-roster-spp.ts`) — corruption SPP definitive sur crash**

Avant : les updates `proTeamRoster` (spp + tdCount + casCount + compCount + mvpCount par roster) et le marqueur `proLeagueMatch.sppAppliedAt` etaient executes sequentiellement **sans transaction**. Un crash entre 2 updates de rosters → SPP partiellement distribues, mais `sppAppliedAt` reste `null` → le re-run scan le match comme "non applique" et **re-applique sur les rosters deja credites** → SPP doubles, corruption permanente (impossible a detecter sans audit manuel).

Fix : tout le bloc (loop updates rosters + update `sppAppliedAt`) wrap dans une seule `prisma.$transaction`. Soit tous les rosters sont credites et le match est flag, soit aucun n'est modifie.

**2. `computeMarketsForMatch` (`pro-bet-odds-calculator.ts`) — odds miscalibrees vs match reel**

Avant : `simulateMatch` etait appele SANS `driverKind` (default `'hybrid'`) et SANS `roster`. Le match reel peut tourner en `'full'` driver avec les vrais rosters → odds calculees sur un sim different du match → miscalibration. Cas concret : si une team a des joueurs morts/blesses non remplaces, le full driver les reflete (ses 6-7 joueurs disponibles vs 11), mais le hybrid avec teams synthetiques voit toujours 11 joueurs full-stats → odds favorisent la team blessee.

Fix :
- Resoudre `driverKind` via `resolveDriverKind(season.driverKind, match.driverKindOverride)`.
- Si `driverKind === 'full'`, charger les rosters actifs des 2 teams (status='active') et les mapper vers `SimRosterPlayer[]`.
- Passer `driverKind` + `roster` au `simulateMatch`.

Bonus : export `mapToSimRoster`, `parseRosterSkills`, `RawProRoster` depuis `pro-league-sim-runner.ts` pour reuse dans l'odds calculator.

### Note sur le 3e item de l'audit (drift watcher casualty team)

Le drift watcher (`pro-league-engine-drift-watcher.ts`) attribue les casualties `/2` entre home/away race au lieu de per-team. **Skip dans ce PR** : le fix necessite une schema change pour ajouter `homeCasualtyCount` / `awayCasualtyCount` au modele `proLeagueMatch` (la table actuelle stocke uniquement le total). A diferrer a un PR de migration dedie.

## Test plan

- [x] `pnpm typecheck` propre.
- [x] `pro-roster-spp.test.ts` : mocks etendus avec `$transaction`. **22 tests pass.**
- [x] `pro-bet-odds-calculator.test.ts` : **3 nouveaux tests** :
  - hybrid (default) : ne charge pas les rosters et passe `driverKind: 'hybrid'`.
  - full driver : charge les 2 rosters et passe `driverKind: 'full'`.
  - `match.driverKindOverride='full'` a precedence sur `season.driverKind='hybrid'`.
- [x] Server : **2800 tests pass (+3 nouveaux)**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_