### PR TITLE
fix(game-engine): cleanup blitzingPlayerId + helper reset dice notifications

### DIFF
--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -186,8 +186,6 @@ export interface GameState {
   };
   // Suivi des actions par joueur par tour
   playerActions: Record<string, ActionType>; // playerId -> action effectuée ce tour
-  // Joueur actuellement en train de blitzer (peut se déplacer puis bloquer)
-  blitzingPlayerId?: string;
   // Compteur de blitz par équipe par tour
   teamBlitzCount: Record<string, number>; // teamId -> nombre de blitz effectués ce tour
   // Compteur de foul par équipe par tour

--- a/packages/game-engine/src/utils/dice-notifications.ts
+++ b/packages/game-engine/src/utils/dice-notifications.ts
@@ -1,6 +1,23 @@
 /**
  * Système de notifications pour les jets de dés
- * Intègre les notifications toaster avec le système de dés existant
+ * Intègre les notifications toaster avec le système de dés existant.
+ *
+ * AUDIT round 4 — Note de dette technique
+ * ----------------------------------------
+ * Les callbacks sont stockes dans des variables module-level. Cela
+ * pose plusieurs problemes connus mais difficile a fix sans
+ * refactor invasif :
+ *   - Pas de support concurrent : deux matchs en parallele dans le
+ *     meme process partagent le meme callback.
+ *   - Pas d'isolation entre tests : un test qui set un callback peut
+ *     contaminer le suivant — d'ou le helper `resetDiceNotifications`
+ *     ci-dessous a appeler en `beforeEach`.
+ *   - Aucun impact sur la determinisme du sim (les callbacks ne sont
+ *     PAS appeles dans le path full-driver, juste depuis l'UI demo).
+ *
+ * Refactor cible (pas dans ce PR) : passer le callback en argument
+ * de `rollD6WithNotification` etc., ou utiliser un Context React. La
+ * seule consommatrice actuelle est `DiceNotificationDemo` (sandbox UI).
  */
 
 import { RNG, Player, DiceResult, BlockResult } from '../core/types';
@@ -10,7 +27,7 @@ import { calculateArmorTarget } from './dice';
 export type DiceNotificationCallback = (playerName: string, diceResult: DiceResult) => void;
 export type BlockDiceNotificationCallback = (playerName: string, blockResult: BlockResult) => void;
 
-// Variables globales pour stocker les callbacks
+// Variables globales pour stocker les callbacks. Cf. note ci-dessus.
 let diceNotificationCallback: DiceNotificationCallback | null = null;
 let blockDiceNotificationCallback: BlockDiceNotificationCallback | null = null;
 
@@ -26,6 +43,16 @@ export function setDiceNotificationCallback(callback: DiceNotificationCallback |
  */
 export function setBlockDiceNotificationCallback(callback: BlockDiceNotificationCallback | null) {
   blockDiceNotificationCallback = callback;
+}
+
+/**
+ * Audit round 4 — helper pour reset les 2 globals en `beforeEach`
+ * test ou au demarrage d'un match isole. Evite les fuites de callback
+ * entre suites de tests / matchs.
+ */
+export function resetDiceNotifications(): void {
+  diceNotificationCallback = null;
+  blockDiceNotificationCallback = null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Audit round 4 — cleanup final apres les 5 PR precedentes.

### Changes

**1. `GameState.blitzingPlayerId` — champ dead**

Le champ optionnel `blitzingPlayerId?: string` etait declare dans `core/types.ts:190` mais **jamais ecrit ni lu nulle part** dans le repo (verifie via `grep -r`). Vestige d'un design abandonne — un blitz se fait via le triplet MOVE+BLOCK actuel, pas via un flag d'etat top-level.

Fix : suppression du champ. Reduit la surface du GameState et empeche un futur dev d'essayer de l'utiliser sans realiser qu'il n'est pas alimente.

**2. `dice-notifications.ts` — helper `resetDiceNotifications()`**

Les callbacks `diceNotificationCallback` / `blockDiceNotificationCallback` sont stockes en variables module-level. Probleme : pas d'isolation entre tests / matchs paralleles. Un test qui set un callback contamine le suivant.

Fix : ajout d'un helper public `resetDiceNotifications()` qui clear les 2 callbacks. A appeler en `beforeEach` ou au demarrage d'un match isole. Plus une note de dette technique au top du module qui documente le besoin d'un refactor futur (passer le callback en argument plutot que module-level state).

Pas de removal des globals dans ce PR : le `DiceNotificationDemo` sandbox UI (`apps/web/app/dice-notifications/page.tsx`) est le seul consommateur reel des setters, donc un refactor invasif n'est pas justifie ici.

## Test plan

- [x] `pnpm typecheck` propre sur game-engine, sim-engine, server, web.
- [x] Test suites au global :
  - game-engine : **5049 tests pass**
  - sim-engine : **429 tests pass**
  - server : **2800 tests pass**
  - web : typecheck propre
- [x] Aucun test ne dependait de `blitzingPlayerId` (champ orphelin).

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_