### PR TITLE
fix(pro-league): 3 transactions critiques (casualty, first-time bonus, advancement)

### DIFF
--- a/apps/server/src/services/post-match-league-integration.test.ts
+++ b/apps/server/src/services/post-match-league-integration.test.ts
@@ -213,6 +213,15 @@ vi.mock("../prisma", () => ({
         },
       ),
     },
+    // Audit round 5 : `applyAdvancementChoice` wrap les 2 updates dans
+    // une $transaction. Le mock execute simplement le callback en
+    // passant `this` (le meme stub stateful) — `tx.teamPlayer.update`
+    // resout vers la meme fonction que `prisma.teamPlayer.update`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $transaction: vi.fn(async function (this: any, cb: any) {
+      // `this` est le stub prisma au moment de l'appel — on le repasse.
+      return cb(this);
+    }),
   },
 }));
 

--- a/apps/server/src/services/post-match-league-sequence.test.ts
+++ b/apps/server/src/services/post-match-league-sequence.test.ts
@@ -14,18 +14,27 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    match: { findUnique: vi.fn() },
-    teamPlayer: { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
-    team: { update: vi.fn(), findUnique: vi.fn() },
-    leaguePostMatchSequence: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
+// Audit round 5 : `applyAdvancementChoice` wrap maintenant les 2 updates
+// (teamPlayer + team) + re-read final dans une seule $transaction. Simule
+// en partageant les memes mocks.
+vi.mock("../prisma", () => {
+  const teamPlayer = { findMany: vi.fn(), findUnique: vi.fn(), update: vi.fn() };
+  const team = { update: vi.fn(), findUnique: vi.fn() };
+  return {
+    prisma: {
+      match: { findUnique: vi.fn() },
+      teamPlayer,
+      team,
+      leaguePostMatchSequence: {
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) => cb({ teamPlayer, team })),
     },
-  },
-}));
+  };
+});
 
 import { prisma } from "../prisma";
 import {

--- a/apps/server/src/services/post-match-league-sequence.ts
+++ b/apps/server/src/services/post-match-league-sequence.ts
@@ -360,27 +360,34 @@ export async function applyAdvancementChoice(
   // Calcul du surcout en po pour la TV courante.
   const surcharge = SURCHARGE_PER_ADVANCEMENT[input.type];
 
-  await prisma.teamPlayer.update({
-    where: { id: input.playerId },
-    data: {
-      spp: { decrement: cost },
-      advancements: JSON.stringify(updatedAdvancements),
-      skills: updatedSkills,
-    },
-  });
-
-  // Update Team.currentValue (additif : on ne recalcule pas tout,
-  // juste increment by surcharge — la baseline reste correcte tant
-  // que les autres composants de currentValue ne changent pas dans
-  // cette transaction).
-  await prisma.team.update({
-    where: { id: input.teamId },
-    data: { currentValue: { increment: surcharge } },
-  });
-
-  const team = await prisma.team.findUnique({
-    where: { id: input.teamId },
-    select: { currentValue: true },
+  // BUG fix audit round 5 (CRITICAL) : avant, les 2 updates (player.spp
+  // + advancements + skills) et (team.currentValue increment by surcharge)
+  // etaient executes sequentiellement hors transaction. Crash entre les
+  // deux → joueur a paye le SPP et appris le skill, mais TV de l'equipe
+  // non incrementee → TV stale forever (impact futurs petty cash + odds).
+  // Fix : les 2 updates + le re-read final dans une seule $transaction.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const team = await prisma.$transaction(async (tx: any) => {
+    await tx.teamPlayer.update({
+      where: { id: input.playerId },
+      data: {
+        spp: { decrement: cost },
+        advancements: JSON.stringify(updatedAdvancements),
+        skills: updatedSkills,
+      },
+    });
+    // Update Team.currentValue (additif : on ne recalcule pas tout,
+    // juste increment by surcharge — la baseline reste correcte tant
+    // que les autres composants de currentValue ne changent pas dans
+    // cette transaction).
+    await tx.team.update({
+      where: { id: input.teamId },
+      data: { currentValue: { increment: surcharge } },
+    });
+    return tx.team.findUnique({
+      where: { id: input.teamId },
+      select: { currentValue: true },
+    });
   });
 
   return {

--- a/apps/server/src/services/pro-roster-casualties.test.ts
+++ b/apps/server/src/services/pro-roster-casualties.test.ts
@@ -1,12 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    proLeagueMatch: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
-    replay: { findUnique: vi.fn() },
-    proTeamRoster: { findMany: vi.fn(), update: vi.fn() },
-  },
-}));
+// Audit round 5 : `applyMatchCasualties` wrap maintenant les updates
+// rosters + flag dans une seule $transaction. Simule en partageant les
+// memes mocks entre prisma top-level et le `tx` du callback.
+vi.mock("../prisma", () => {
+  const proLeagueMatch = { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() };
+  const proTeamRoster = { findMany: vi.fn(), update: vi.fn() };
+  return {
+    prisma: {
+      proLeagueMatch,
+      replay: { findUnique: vi.fn() },
+      proTeamRoster,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) =>
+        cb({ proLeagueMatch, proTeamRoster }),
+      ),
+    },
+  };
+});
 
 vi.mock("@bb/sim-engine", () => ({
   decompressEvents: vi.fn(),
@@ -33,6 +44,7 @@ interface MockedPrisma {
     findMany: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
+  $transaction: ReturnType<typeof vi.fn>;
 }
 const mocked = prisma as unknown as MockedPrisma;
 const mockedDecompress = vi.mocked(decompressEvents);
@@ -41,6 +53,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocked.proLeagueMatch.update.mockResolvedValue({});
   mocked.proTeamRoster.update.mockResolvedValue({});
+  mocked.$transaction.mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (cb: any) =>
+      cb({
+        proLeagueMatch: mocked.proLeagueMatch,
+        proTeamRoster: mocked.proTeamRoster,
+      }),
+  );
 });
 
 describe("rollCasualtyOutcome — sprint 1.E.4", () => {

--- a/apps/server/src/services/pro-roster-casualties.ts
+++ b/apps/server/src/services/pro-roster-casualties.ts
@@ -331,7 +331,19 @@ export async function applyMatchCasualties(
   }
 
   const rng = mulberry32(hashSeed(`cas:${matchId}`));
-  const outcomes: AppliedCasualty[] = [];
+  // Audit round 5 : on accumule d'abord les outcomes + updates en memoire
+  // pour les appliquer ENSUITE dans une seule prisma.$transaction (avec
+  // le flag casualtiesAppliedAt). Avant : updates sequentiels hors tx +
+  // flag a la fin → crash mid-loop = corruption permanente niggling /
+  // stReduction sur les premiers rosters touches.
+  interface PendingCasualty {
+    readonly side: "home" | "away";
+    readonly rosterId: string;
+    readonly playerName: string;
+    readonly outcome: CasualtyOutcome;
+    readonly updateData: Record<string, unknown>;
+  }
+  const pending: PendingCasualty[] = [];
 
   // Cache du roster par teamId pour éviter une lookup par event.
   const rosterCache = new Map<string, RosterPick[]>();
@@ -354,6 +366,15 @@ export async function applyMatchCasualties(
     return roster;
   };
 
+  // BUG fix audit round 5 (CRITICAL) : avant, les updates `proTeamRoster`
+  // (niggling, maReduction, etc.) etaient executes sequentiellement
+  // hors transaction, puis `casualtiesAppliedAt` etait set en dernier.
+  // Crash mid-loop → quelques joueurs deja blesses + flag non-set →
+  // re-run du sweep applique a nouveau les casualties sur les memes
+  // rosters (niggling/maReduction doublees, corruption permanente).
+  // Fix : tout le bloc (loop updates + flag final) dans une seule
+  // prisma.$transaction. Le pick random / outcome roll reste hors tx
+  // car ils sont purs (rng deterministe).
   for (const target of targets) {
     const teamId = target.side === "home" ? homeTeamId : awayTeamId;
     const roster = await loadRoster(teamId);
@@ -367,7 +388,7 @@ export async function applyMatchCasualties(
     // 2) Sinon (synthétique OU CUID orphan) → pick random parmi les
     //    actifs encore non touchés dans ce match.
     const alreadyHitIds = new Set(
-      outcomes
+      pending
         .filter((o) => o.side === target.side)
         .map((o) => o.rosterId),
     );
@@ -382,22 +403,35 @@ export async function applyMatchCasualties(
 
     const outcome = rollCasualtyOutcome(rng());
     const { data } = applyOutcomeToData(outcome, picked);
-    await prisma.proTeamRoster.update({
-      where: { id: picked.id },
-      data,
-    });
-    outcomes.push({
+    pending.push({
       side: target.side,
       rosterId: picked.id,
       playerName: picked.name,
       outcome,
+      updateData: data,
     });
   }
 
-  await prisma.proLeagueMatch.update({
-    where: { id: matchId },
-    data: { casualtiesAppliedAt: new Date() },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    for (const o of pending) {
+      await tx.proTeamRoster.update({
+        where: { id: o.rosterId },
+        data: o.updateData,
+      });
+    }
+    await tx.proLeagueMatch.update({
+      where: { id: matchId },
+      data: { casualtiesAppliedAt: new Date() },
+    });
   });
+
+  const outcomes: AppliedCasualty[] = pending.map((p) => ({
+    side: p.side,
+    rosterId: p.rosterId,
+    playerName: p.playerName,
+    outcome: p.outcome,
+  }));
 
   return {
     matchId,

--- a/apps/server/src/services/pro-wallet-rewards.test.ts
+++ b/apps/server/src/services/pro-wallet-rewards.test.ts
@@ -72,19 +72,28 @@ beforeEach(() => {
 
 describe("grantFirstTimeBonus — sprint 1.D.6", () => {
   it("crédite 1000 si jamais réclamé", async () => {
+    // Audit round 5 : passe par $transaction directement, plus de
+    // delegation a `credit()`.
     mocked.proTransaction.findFirst.mockResolvedValue(null);
-    mockedCredit.mockResolvedValue(1000);
+    mocked.proWallet.findUnique.mockResolvedValue({ crowns: 0 });
+    mocked.proWallet.update.mockResolvedValue({ crowns: 1000 });
+    mocked.proTransaction.create.mockResolvedValue({ id: "tx_new" });
 
     const out = await grantFirstTimeBonus(USER);
     expect(out.granted).toBe(true);
     expect(out.amount).toBe(FIRST_TIME_BONUS_AMOUNT);
     expect(out.balance).toBe(1000);
     expect(out.nextEligibleAt).toBeNull();
-    expect(mockedCredit).toHaveBeenCalledWith(
-      USER,
-      1000,
-      "REWARD",
-      "first_signup",
+    expect(mocked.$transaction).toHaveBeenCalledTimes(1);
+    expect(mocked.proTransaction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletId: USER,
+          type: "REWARD",
+          amount: FIRST_TIME_BONUS_AMOUNT,
+          ref: "first_signup",
+        }),
+      }),
     );
   });
 

--- a/apps/server/src/services/pro-wallet-rewards.ts
+++ b/apps/server/src/services/pro-wallet-rewards.ts
@@ -45,44 +45,73 @@ export interface RewardOutcome {
 /**
  * Crédite le first-time bonus (1000 Crowns) si l'user ne l'a jamais
  * réclamé. Idempotent : appel répété renvoie `granted=false`.
+ *
+ * BUG fix audit round 5 (CRITICAL) : avant, le check `existing` etait
+ * fait HORS transaction, puis `credit()` ouvrait sa propre transaction.
+ * Deux appels concurrents pouvaient tous deux passer la verif (existing
+ * === null pour les deux) et tous deux crediter 1000 Crowns → user
+ * recoit 2000 au lieu de 1000 (inflation monetaire). Meme pattern que
+ * la fix `claimDailyBonus` du round 4. Fix : tout dans une seule
+ * `prisma.$transaction`.
  */
 export async function grantFirstTimeBonus(
   userId: string,
 ): Promise<RewardOutcome> {
-  // Garantit l'existence du wallet (création silencieuse).
+  // Garantit l'existence du wallet (creation silencieuse) HORS transaction
+  // pour eviter une commit cassee si le wallet est neuf.
   await getOrCreateWallet(userId);
 
-  // Idempotence : check ProTransaction REWARD + ref="first_signup".
-  const existing = await prisma.proTransaction.findFirst({
-    where: {
-      walletId: userId,
-      type: "REWARD",
-      ref: FIRST_TIME_BONUS_REF,
-    },
-    select: { id: true },
-  });
-  if (existing) {
-    const balance = await getCurrentBalance(userId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = await prisma.$transaction(async (tx: any) => {
+    // Idempotence : check ProTransaction REWARD + ref="first_signup"
+    // DANS la transaction.
+    const existing = await tx.proTransaction.findFirst({
+      where: {
+        walletId: userId,
+        type: "REWARD",
+        ref: FIRST_TIME_BONUS_REF,
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      const w = await tx.proWallet.findUnique({
+        where: { userId },
+        select: { crowns: true },
+      });
+      return {
+        granted: false as const,
+        balance: (w?.crowns as number | undefined) ?? 0,
+        amount: 0,
+        nextEligibleAt: null,
+      };
+    }
+    // Credit dans la meme transaction.
+    const w = await tx.proWallet.findUnique({
+      where: { userId },
+      select: { crowns: true },
+    });
+    const current = (w?.crowns as number | undefined) ?? 0;
+    const updated = await tx.proWallet.update({
+      where: { userId },
+      data: { crowns: current + FIRST_TIME_BONUS_AMOUNT },
+      select: { crowns: true },
+    });
+    await tx.proTransaction.create({
+      data: {
+        walletId: userId,
+        type: "REWARD",
+        amount: FIRST_TIME_BONUS_AMOUNT,
+        ref: FIRST_TIME_BONUS_REF,
+      },
+    });
     return {
-      granted: false,
-      balance,
-      amount: 0,
+      granted: true as const,
+      balance: updated.crowns as number,
+      amount: FIRST_TIME_BONUS_AMOUNT,
       nextEligibleAt: null,
     };
-  }
-
-  const balance = await credit(
-    userId,
-    FIRST_TIME_BONUS_AMOUNT,
-    "REWARD",
-    FIRST_TIME_BONUS_REF,
-  );
-  return {
-    granted: true,
-    balance,
-    amount: FIRST_TIME_BONUS_AMOUNT,
-    nextEligibleAt: null,
-  };
+  });
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Audit round 5 — 3 bugs **CRITIQUES** de race condition / money loss / data corruption sur Pro League services. Memes patterns que les fixes round 4 (wrap updates multi-step dans une seule `prisma.$transaction`).

### Bugs corriges

**1. `applyMatchCasualties` (`pro-roster-casualties.ts`) — corruption permanente niggling/stReduction**

Avant : loop d'updates `proTeamRoster` (`niggling`, `maReduction`, `stReduction`, `avReduction`, `skills`, `status`) sequentiel hors transaction, puis flag `casualtiesAppliedAt` set en dernier. Crash mid-loop → quelques joueurs deja blesses + flag non-set → re-run sweep applique a nouveau sur les memes rosters → **niggling/stReduction doublees**, corruption permanente impossible a detecter sans audit manuel.

Fix : accumule `outcomes + updateData` en memoire, puis applique tous les updates rosters + flag final dans une seule `prisma.$transaction`.

**2. `grantFirstTimeBonus` (`pro-wallet-rewards.ts`) — inflation 2x du first-time bonus**

Avant : check `existing` `ProTransaction` hors transaction, puis `credit()` ouvrait sa propre transaction. Deux appels concurrents (ex: double-clic user, retry reseau) pouvaient tous deux passer la verif (`existing === null` pour les deux) et tous deux crediter 1000 Crowns → **user recoit 2000 au lieu de 1000** (inflation monetaire).

Fix : check + update wallet + create ProTransaction dans une seule `$transaction` (meme pattern que `claimDailyBonus` round 4).

**3. `applyAdvancementChoice` (`post-match-league-sequence.ts`) — TV stale forever**

Avant : 2 updates sequentiels hors transaction :
1. `teamPlayer.spp` decrement + `advancements` JSON + `skills` array
2. `team.currentValue` increment by `surcharge`

Crash entre les deux → joueur a paye le SPP et appris le skill, mais TV de l'equipe pas incrementee → TV stale forever (impact futurs petty cash + odds calculator + drift watcher).

Fix : les 2 updates + re-read final dans une seule `$transaction`.

## Test plan

- [x] `pnpm typecheck` propre.
- [x] `pro-roster-casualties.test.ts` : mock `$transaction` ajoute. **18 tests pass.**
- [x] `pro-wallet-rewards.test.ts` : test `grantFirstTimeBonus` refactore (verifie `proTransaction.create` + `$transaction` called). **8 tests pass.**
- [x] `post-match-league-sequence.test.ts` : mock `$transaction`. **6 tests pass.**
- [x] `post-match-league-integration.test.ts` : mock `$transaction` passe le stub stateful via `this`. **4 tests pass.**
- [x] Server total : **2800 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_