### PR TITLE
fix(game-engine): changing-weather re-roll + hypnotic-gaze GFI lock

### DIFF
--- a/packages/game-engine/src/mechanics/hypnotic-gaze.test.ts
+++ b/packages/game-engine/src/mechanics/hypnotic-gaze.test.ts
@@ -206,6 +206,20 @@ describe('Regle: Hypnotic Gaze', () => {
       expect(resultGazer.pm).toBe(0);
     });
 
+    it('audit round 5 — bloque aussi le GFI sur echec (gfiUsed=2)', () => {
+      // Avant fix : seul `pm = 0` etait set, mais `gfiUsed` restait a 0
+      // → le joueur pouvait GFI 2 cases apres un Gaze rate (puisque
+      // gfiUsed < cap). Aligne avec Bone Head / Wild Animal / Really
+      // Stupid qui set { pm: 0, gfiUsed: 2 } sur echec.
+      const state = createGazeTestState();
+      const gazer = state.players.find(p => p.id === 'A1')!;
+      const target = state.players.find(p => p.id === 'B1')!;
+      const rng = makeTestRNG([0.0]); // fail
+      const result = executeHypnoticGaze(state, gazer, target, rng);
+      const resultGazer = result.players.find(p => p.id === 'A1')!;
+      expect(resultGazer.gfiUsed).toBe(2);
+    });
+
     it('does NOT cause turnover on failure', () => {
       const state = createGazeTestState();
       const gazer = state.players.find(p => p.id === 'A1')!;

--- a/packages/game-engine/src/mechanics/hypnotic-gaze.ts
+++ b/packages/game-engine/src/mechanics/hypnotic-gaze.ts
@@ -119,9 +119,15 @@ export function executeHypnoticGaze(
     );
     newState.gameLog = [...newState.gameLog, successLog];
   } else {
-    // Échec : l'activation du joueur prend fin (pm = 0), PAS de turnover
+    // Echec : l'activation du joueur prend fin, PAS de turnover.
+    // BUG fix audit round 5 (CRITICAL) : avant, seul `pm = 0` etait
+    // set, mais `gfiUsed` restait inchange → le joueur pouvait quand
+    // meme effectuer un GFI (Math.max(1, ma + 2 - gfiUsed) > 0 si
+    // gfiUsed < 2). Aligne avec tous les autres negative-traits
+    // failures (Bone Head, Wild Animal, Really Stupid) qui set
+    // `{ pm: 0, gfiUsed: 2 }`.
     newState.players = newState.players.map(p =>
-      p.id === gazer.id ? { ...p, pm: 0 } : p,
+      p.id === gazer.id ? { ...p, pm: 0, gfiUsed: 2 } : p,
     );
 
     const failLog = createLogEntry(

--- a/packages/game-engine/src/mechanics/kickoff-events.test.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.test.ts
@@ -144,5 +144,44 @@ describe('Kickoff Events', () => {
         expect(actionLog!.message).toMatch(/D3.*\+.*fans/i);
       });
     });
+
+    describe('audit round 5 — changing-weather re-roll', () => {
+      const changingWeatherEvent = KICKOFF_EVENTS[8];
+
+      it("re-roll un 2D6 et met a jour state.weatherCondition", () => {
+        // Avant fix : le case ne faisait que logger sans rouler les
+        // dés ni mettre à jour le state. Resultat : modificateurs
+        // (gfi, dodge, pass) figes sur la météo initiale du match.
+        const state = {
+          ...setup(),
+          weatherCondition: { condition: 'Nice', description: 'temps clement' },
+          preMatch: { weatherType: 'classique' } as any,
+        };
+        // rng = 0.99 → dice = 6+6 = 12 → "Sweltering Heat" en classique
+        const rng = () => 0.99;
+        const result = applyKickoffEvent(state, changingWeatherEvent, rng, 'A');
+
+        expect(result.weatherCondition?.condition).not.toBe('Nice');
+        expect(result.weatherCondition?.condition).toBeTruthy();
+      });
+
+      it("garde la meteo si re-roll donne 7 = Nice (Perfect Conditions)", () => {
+        // rng tel que 2D6 = 7 (e.g. dice=3+4 ou 4+3) : Nice → keep
+        const state = {
+          ...setup(),
+          weatherCondition: { condition: 'Rain', description: 'Pluie' },
+          preMatch: { weatherType: 'classique' } as any,
+        };
+        // 0.5 → floor(3) + 1 = 4. 4+4=8 → not 7. Need to craft 2D6=7.
+        // rng(0.34) → floor(2.04)+1 = 3, rng(0.5)→ 4. Total = 7.
+        const rngVals = [0.34, 0.5];
+        let i = 0;
+        const rng = () => rngVals[i++ % rngVals.length];
+        const result = applyKickoffEvent(state, changingWeatherEvent, rng, 'A');
+
+        // Pas de changement : on conserve la pluie initiale.
+        expect(result.weatherCondition?.condition).toBe('Rain');
+      });
+    });
   });
 });

--- a/packages/game-engine/src/mechanics/kickoff-events.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.ts
@@ -6,6 +6,7 @@
 import { GameState, RNG, TeamId } from '../core/types';
 import { roll2D6, rollD6 } from '../utils/dice';
 import { createLogEntry } from '../utils/logging';
+import { getWeatherCondition, type WeatherType } from '../core/weather-types';
 
 export interface KickoffEvent {
   id: string;
@@ -205,8 +206,38 @@ export function applyKickoffEvent(
     }
 
     case 'changing-weather': {
-      const log = createLogEntry('action', 'La météo change ! Un nouveau jet de météo est nécessaire.');
-      newState.gameLog = [...newState.gameLog, log];
+      // BUG fix audit round 5 (CRITICAL) : avant, le case ne faisait que
+      // logger "La meteo change" SANS re-roll le 2D6 ni mettre a jour
+      // state.weatherCondition. Resultat : les modificateurs (gfi, dodge,
+      // pass) etaient figes sur la meteo initiale du match alors que la
+      // regle BB dit "Roll on the weather table again. If the result is
+      // Perfect Conditions, the weather does not change."
+      const weatherType: WeatherType =
+        ((newState as GameState & { preMatch?: { weatherType?: WeatherType } })
+          .preMatch?.weatherType ?? 'classique') as WeatherType;
+      const dice1 = Math.floor(rng() * 6) + 1;
+      const dice2 = Math.floor(rng() * 6) + 1;
+      const total = dice1 + dice2;
+      const newWeather = getWeatherCondition(weatherType, total);
+      if (newWeather && newWeather.condition !== 'Conditions parfaites') {
+        // "Conditions parfaites" (total=6-7 selon la table) : on garde
+        // la meteo courante par regle BB. Sinon, on remplace.
+        newState.weatherCondition = {
+          condition: newWeather.condition,
+          description: newWeather.description,
+        };
+        const log = createLogEntry(
+          'action',
+          `La meteo change ! 2D6=${total} → ${newWeather.condition} : ${newWeather.description}`,
+        );
+        newState.gameLog = [...newState.gameLog, log];
+      } else {
+        const log = createLogEntry(
+          'action',
+          `La meteo change ! 2D6=${total} → temps clement, pas de changement.`,
+        );
+        newState.gameLog = [...newState.gameLog, log];
+      }
       break;
     }
 


### PR DESCRIPTION
## Summary

Audit round 5 — 2 bugs **CRITICAL** dans la mecanique de match.

### Bugs corriges

**1. `Changing Weather` kickoff event (`mechanics/kickoff-events.ts:207`) — meteo figee**

Avant : le `case 'changing-weather'` ne faisait que **logger** "La meteo change" sans rouler un nouveau 2D6 ni mettre a jour `state.weatherCondition`. Resultat : les modificateurs sensibles a la meteo (`gfi target` en Blizzard, `dodge target` en Pluie, restriction de longueur des passes en Blizzard) etaient figes sur la meteo initiale du match, alors que la regle BB dit *"Roll on the weather table again. If the result is Perfect Conditions, the weather does not change."*

Fix : import `getWeatherCondition`, roule `2D6` dans le case, applique la nouvelle meteo si `condition !== 'Conditions parfaites'`.

**2. `Hypnotic Gaze` failure (`mechanics/hypnotic-gaze.ts:124`) — GFI permis apres echec**

Avant : sur echec du jet de Hypnotic Gaze, seul `pm = 0` etait set, mais `gfiUsed` restait inchange. Le joueur pouvait alors quand meme tenter un GFI (puisque la formule `Math.max(1, ma + 2 - gfiUsed) > 0`).

Fix : ajouter `gfiUsed: 2` sur la map des players. Aligne avec tous les autres `negative-traits` failures (Bone Head, Wild Animal, Really Stupid, Take Root) qui set `{ pm: 0, gfiUsed: 2 }` sur echec.

### Items skip de l'audit round 5

- **C1 (apothecary stat revert)** : refactor invasif (touche 3+ paths apothecary + injury) — defere a un PR dedie.
- **C2 (tryRegeneration mutation)** : changement de signature (5 callers) — defere a un PR dedie.
- **H5 (FOUL ends activation)** : audit incorrect — la logique est en fait deja geree par `canPlayerContinueMoving` + `isSneakyGitActive` (cf. `core/game-state.ts:1048-1078`). Sneaky Git autorise la poursuite, sinon l'activation se termine bien apres une faute. Pas de bug reel.

## Test plan

- [x] `pnpm typecheck` propre sur game-engine.
- [x] `hypnotic-gaze.test.ts` : **1 nouveau test** verifie `gfiUsed === 2` apres echec.
- [x] `kickoff-events.test.ts` : **2 nouveaux tests** :
  - changing-weather met a jour `weatherCondition` pour un total != 'Conditions parfaites'.
  - garde la meteo courante si total = 'Conditions parfaites'.
- [x] Test suites au global :
  - game-engine : **5052 tests pass** (+3 nouveaux)
  - sim-engine : **429 tests pass**
  - server : **2800 tests pass**

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_