### PR TITLE
fix(sim-engine): full driver casualty outcome + yardline + cause + TD scorer

### DIFF
--- a/packages/sim-engine/src/driver/full-driver-events.ts
+++ b/packages/sim-engine/src/driver/full-driver-events.ts
@@ -366,12 +366,23 @@ export function diffStatesToEvents(
  * Heuristique : transforme la position de la balle (cellule x) en
  * yardline 0..26 du modèle hybrid. La position du porteur est
  * privilégiée si la balle a un porteur.
+ *
+ * BUG fix audit round 5 (HIGH) : la convention hybrid est
+ * `ballYardline ∈ [0..26]` ou **0 = own goal de l'equipe qui drive**
+ * et **26 = endzone adverse**. Avant, le full driver retournait `ballX`
+ * brut, ce qui est correct pour team A (driving vers x=26) mais
+ * inverse pour team B (driving vers x=0 → un porteur a x=21 etait
+ * yardline=21 alors qu'il devrait etre yardline=5). Tous les
+ * consommateurs (Gazette narrator, hybrid vs full comparison, odds
+ * calculator) lisaient des valeurs incorrectes pour les tours team B.
+ * Fix : normaliser via `currentPlayer` (A → ballX, B → 26-ballX).
  */
 function estimateBallYardline(state: GameState): number {
   const carrier = state.players.find((p) => p.hasBall);
   const ballX = carrier?.pos.x ?? state.ball?.x ?? 0;
-  // Le board fait 26 cells de large = yardline.
-  return Math.max(0, Math.min(26, ballX));
+  const drivingIsA = state.currentPlayer === 'A';
+  const normalized = drivingIsA ? ballX : 26 - ballX;
+  return Math.max(0, Math.min(26, normalized));
 }
 
 /**
@@ -402,7 +413,12 @@ function causeFromMove(move: Move): string {
       return 'dodge_failed';
     case 'MOVE':
     case 'LEAP':
-      return 'gfi_failed';
+      // BUG fix audit round 5 (HIGH) : avant, tout MOVE/LEAP turnover
+      // etait tag `gfi_failed`. Or un MOVE peut turnover sur dodge
+      // rate, GFI rate, ou Both Down/negative-trait trigger. Le tag
+      // `movement_failed` est un fallback honnete ; les consommateurs
+      // (Gazette narrator) ont desormais a distinguer eux-memes.
+      return 'movement_failed';
     case 'FOUL':
       return 'foul_sent_off';
     default:

--- a/packages/sim-engine/src/driver/full-driver-roster-fixes.test.ts
+++ b/packages/sim-engine/src/driver/full-driver-roster-fixes.test.ts
@@ -57,7 +57,7 @@ describe('Ball carrier idx variable (C3)', () => {
 });
 
 describe('getInitialBallYardline (H2)', () => {
-  it("retourne la position du carrier au lieu d'un hardcode 4", () => {
+  it("retourne la position du carrier normalisee selon l'equipe qui drive", () => {
     const homeRoster = Array.from({ length: 11 }, (_, i) =>
       rosterPlayer({ id: `H${i}`, name: `H${i}`, number: i + 1 }),
     );
@@ -69,8 +69,26 @@ describe('getInitialBallYardline (H2)', () => {
     });
 
     const yardline = getInitialBallYardline(state);
-    // Le carrier est place sur TEAM_B_FORMATION[9] — sa position x est
-    // utilisee comme yardline.
+    // Audit round 5 : la convention hybrid est yardline ∈ [0..26] ou
+    // 0 = own goal de l'equipe qui drive. Team B drive (receivingTeam),
+    // donc yardline = 26 - carrier.pos.x (B drive vers x=0, donc
+    // commence pres de son own goal qui est x=26).
+    const carrier = state.players.find((p) => p.hasBall)!;
+    expect(yardline).toBe(26 - carrier.pos.x);
+  });
+
+  it("audit round 5 : team A driving → yardline = ballX (non normalise)", () => {
+    const homeRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `H${i}`, name: `H${i}`, number: i + 1 }),
+    );
+    const awayRoster = Array.from({ length: 11 }, (_, i) =>
+      rosterPlayer({ id: `A${i}`, name: `A${i}`, number: i + 1 }),
+    );
+    const state = buildGameStateFromRosters({
+      homeRoster, awayRoster, receivingTeam: 'A',
+    });
+
+    const yardline = getInitialBallYardline(state);
     const carrier = state.players.find((p) => p.hasBall)!;
     expect(yardline).toBe(carrier.pos.x);
   });

--- a/packages/sim-engine/src/driver/full-driver.ts
+++ b/packages/sim-engine/src/driver/full-driver.ts
@@ -233,12 +233,19 @@ function buildCasualties(state: GameState): Casualty[] {
   // Casualty.outcome n'a pas de variante 'sent_off' (c'est un état joueur,
   // pas une issue casualty). Lot 3.C.1 affinera la classification
   // (lasting injuries, dead, etc.) en lisant les events.
+  // BUG fix audit round 5 (HIGH) : avant, TOUS les casualties etaient
+  // tagges `outcome: 'badly_hurt'`. Le game-engine stocke pourtant la
+  // severite reelle dans `state.casualtyResults[playerId]` (badly_hurt
+  // | seriously_hurt | serious_injury | lasting_injury | dead). Le pro-
+  // league wiring (lasting-injury accumulation, retire/dead transitions,
+  // apothecary stats) perdait ce signal. Fix : lire `casualtyResults`
+  // pour chaque casualty, fallback `'badly_hurt'` si absent.
   return state.players
     .filter((p) => p.state === 'casualty')
     .map<Casualty>((p) => ({
       playerId: p.id,
       team: p.team as TeamId,
-      outcome: 'badly_hurt',
+      outcome: (state.casualtyResults?.[p.id] as Casualty['outcome'] | undefined) ?? 'badly_hurt',
     }));
 }
 

--- a/packages/sim-engine/src/driver/hybrid-driver.ts
+++ b/packages/sim-engine/src/driver/hybrid-driver.ts
@@ -548,23 +548,35 @@ function emitTurnStart(m: MutableMatch): void {
   });
 }
 
+/**
+ * BUG fix audit round 5 (HIGH) : avant, `emitTd` computait son propre
+ * `scorerId` via `pickHybridScorer` mais l'appelant utilisait
+ * `${team}-LOS` pour `recordTouchdown`. Resultat : la `momentum`
+ * snapshot du MatchSummary attribuait le TD a la LOS proxy alors
+ * que l'event MatchEvent portait le vrai scorer → consommateurs
+ * cross-referencant les 2 (stats per-player) avaient des donnees
+ * incoherentes. Fix : exposer un helper `pickTdScorerId` que le
+ * caller peut utiliser pour `recordTouchdown` ET passer ici, garant
+ * d'une attribution unique.
+ */
+function pickTdScorerId(
+  m: MutableMatch,
+  scoringTeam: Side,
+  rngs: DriverRng,
+): string | null {
+  const roster =
+    scoringTeam === 'home' ? m.homeRoster : m.awayRoster;
+  return roster.length > 0
+    ? pickHybridScorer(roster, () => rngs.scorer.next())
+    : null;
+}
+
 function emitTd(
   m: MutableMatch,
   scoringTeam: Side,
   displayAtMs: number,
-  rngs: DriverRng,
+  scorerId: string | null,
 ): void {
-  // Lot 4.D.4 — quand un roster reel est fourni cote `SimInput`, on
-  // attribue un `scorerId` pseudo-aleatoire pondere par position
-  // (Catcher / Runner > Lineman > Big Guy). Sans roster (mode legacy
-  // archetype-vs-archetype), on omet `scorerId` -> SPP service
-  // ignore le TD.
-  const roster =
-    scoringTeam === 'home' ? m.homeRoster : m.awayRoster;
-  const scorerId =
-    roster.length > 0
-      ? pickHybridScorer(roster, () => rngs.scorer.next())
-      : null;
   m.events.push({
     type: 'TD',
     displayAtMs,
@@ -815,8 +827,10 @@ function processTurn(
         if (scoring === 'home') m.state = { ...m.state, scoreHome: m.state.scoreHome + 1 };
         else m.state = { ...m.state, scoreAway: m.state.scoreAway + 1 };
         m.touchdowns += 1;
-        recordTouchdown(m.momentum, drivingPlayerId);
-        emitTd(m, scoring, momentAtMs, rngs);
+        // Audit round 5 : un seul pick scorer pour TD event + momentum.
+        const scorerId = pickTdScorerId(m, scoring, rngs);
+        recordTouchdown(m.momentum, scorerId ?? drivingPlayerId);
+        emitTd(m, scoring, momentAtMs, scorerId);
         m.state = { ...m.state, drive: nextDrive(m.state.drive) };
         // A scoring play ends the team's turn ; treat it like a
         // turnover-on-the-positive-side so the bulk yard advancement
@@ -880,8 +894,10 @@ function processTurn(
       if (scoring === 'home') m.state = { ...m.state, scoreHome: m.state.scoreHome + 1 };
       else m.state = { ...m.state, scoreAway: m.state.scoreAway + 1 };
       m.touchdowns += 1;
-      recordTouchdown(m.momentum, `${scoring}-LOS`);
-      emitTd(m, scoring, bulkAtMs, rngs);
+      // Audit round 5 : un seul pick scorer pour TD event + momentum.
+      const scorerId = pickTdScorerId(m, scoring, rngs);
+      recordTouchdown(m.momentum, scorerId ?? `${scoring}-LOS`);
+      emitTd(m, scoring, bulkAtMs, scorerId);
       m.state = { ...m.state, drive: nextDrive(m.state.drive) };
     } else {
       m.state = {


### PR DESCRIPTION
## Summary

Audit round 5 — 4 fixes **HIGH** dans le sim-engine pour ameliorer la fidelite et la coherence des events / MatchSummary entre drivers.

### Bugs corriges

**1. `full-driver.ts:236` `buildCasualties` — perte de la severite casualty**

Avant : TOUS les casualties etaient tagges `outcome: 'badly_hurt'`. Le game-engine stocke pourtant la severite reelle dans `state.casualtyResults[playerId]` (`badly_hurt | seriously_hurt | serious_injury | lasting_injury | dead`). Le pro-league wiring (lasting-injury accumulation, retire/dead transitions, apothecary stats) perdait ce signal cote sim driver.

Fix : lire `casualtyResults` pour chaque casualty, fallback `'badly_hurt'` si absent.

**2. `full-driver-events.ts:370` `estimateBallYardline` — yardline non-normalisee pour team B**

La convention hybrid est `yardline ∈ [0..26]` ou `0 = own goal de l'equipe qui drive`, `26 = endzone adverse`. Avant, le full driver retournait `ballX` brut → correct pour team A (driving vers `x=26`) mais inverse pour team B (driving vers `x=0` → un porteur a `x=21` etait yardline=21 alors qu'il devrait etre `26-21 = 5`).

Tous les consommateurs (Gazette narrator, hybrid vs full comparison, odds calculator) lisaient des valeurs incorrectes pour les tours team B.

Fix : normaliser via `currentPlayer` (A → ballX, B → 26-ballX).

**3. `full-driver-events.ts:414` `causeFromMove` — taxonomie incorrecte**

Avant : tout `MOVE`/`LEAP` turnover etait tag `'gfi_failed'`. Or un MOVE peut turnover sur dodge rate, GFI rate, ou Both Down / negative-trait trigger. La Gazette LLM et l'odds calculator key off `meta.cause`.

Fix : utiliser `'movement_failed'` comme tag fallback honnete (les consommateurs distinguent eux-memes les causes precises via les events dice).

**4. `hybrid-driver.ts:551` `emitTd` — TD momentum attribution mismatch**

Avant : `emitTd` computait son propre `scorerId` via `pickHybridScorer`, mais l'appelant utilisait `${team}-LOS` pour `recordTouchdown` (momentum). Resultat : la `momentum` snapshot du `MatchSummary` attribuait le TD a la LOS proxy alors que l'event MatchEvent portait le vrai scorer → consommateurs cross-referencant les 2 (stats per-player) avaient des donnees incoherentes.

Fix : extraire `pickTdScorerId` helper, le caller pick une fois, passe a `recordTouchdown` ET `emitTd`.

## Test plan

- [x] `pnpm typecheck` propre sur sim-engine.
- [x] `full-driver-roster-fixes.test.ts` : test H2 mis a jour pour refleter la normalisation team B (`yardline = 26 - carrier.pos.x`) + **1 nouveau test** verifie team A driving = `ballX` direct.
- [x] Test suites au global :
  - sim-engine : **430 tests pass** (+1 nouveau)
  - game-engine : **5052 tests pass**
  - server : **2800 tests pass**

### Items skip de l'audit round 5

- **#2 (opening book vs 2-ply)** : refactor invasif du full driver dispatch — defere a un PR dedie.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_