### PR TITLE
fix(pro-league): standings TD diff tiebreaker + PII leak + settle picks tx

### DIFF
--- a/apps/server/src/services/pro-league-hub.ts
+++ b/apps/server/src/services/pro-league-hub.ts
@@ -235,13 +235,13 @@ export async function getProLeagueHubSnapshot(
   });
 
   // Standings top N.
-  const standingsRaw = await prisma.proLeagueStandings.findMany({
+  // BUG fix audit round 5 (HIGH) : avant, orderBy `[points desc,
+  // tdFor desc]` ignorait la difference de TD. Maintenant on charge
+  // toutes les standings et on trie cote JS par (points, diffTD,
+  // tdFor) — pas de take(LIMIT) cote DB car on doit voir tout pour
+  // trier correctement. Bornees a 16 equipes max → tri trivial.
+  const standingsAll = await prisma.proLeagueStandings.findMany({
     where: { seasonId },
-    orderBy: [
-      { points: "desc" },
-      { tdFor: "desc" },
-    ],
-    take: STANDINGS_LIMIT,
     select: {
       played: true,
       wins: true,
@@ -310,7 +310,21 @@ export async function getProLeagueHubSnapshot(
       },
     })),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    standings: standingsRaw.map((s: any) => ({
+    standings: (() => {
+      // Audit round 5 : sort cote JS par (points, diffTD, tdFor),
+      // puis slice au LIMIT — voir commentaire au findMany.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sorted = [...standingsAll].sort((a: any, b: any) => {
+        const pA = (a.points as number) ?? 0;
+        const pB = (b.points as number) ?? 0;
+        if (pB !== pA) return pB - pA;
+        const diffA = ((a.tdFor as number) ?? 0) - ((a.tdAgainst as number) ?? 0);
+        const diffB = ((b.tdFor as number) ?? 0) - ((b.tdAgainst as number) ?? 0);
+        if (diffB !== diffA) return diffB - diffA;
+        return ((b.tdFor as number) ?? 0) - ((a.tdFor as number) ?? 0);
+      });
+      return sorted.slice(0, STANDINGS_LIMIT);
+    })().map((s: any) => ({
       teamSlug: s.team.slug as string,
       teamName: s.team.name as string,
       teamCity: s.team.city as string,

--- a/apps/server/src/services/pro-league-standings.ts
+++ b/apps/server/src/services/pro-league-standings.ts
@@ -129,12 +129,17 @@ export async function getProLeagueCurrentStandings(
     );
   }
 
+  // BUG fix audit round 5 (HIGH) : avant, l'orderBy etait
+  // `[points desc, tdFor desc]` — utilise tdFor brut comme tiebreaker
+  // au lieu de la difference de TD. Une equipe avec 30 TD pour / 50
+  // contre se classait devant une equipe avec 25 pour / 5 contre,
+  // malgre une difference de TD largement meilleure pour la seconde.
+  // Standard BB / football : points → diff TD → TD pour.
+  // Prisma ne supporte pas l'orderBy sur une colonne computee ; on
+  // recupere tous les rows et on trie cote JS (les ligues sont
+  // bornees a 16 equipes par saison, sort trivial).
   const rowsRaw = await prisma.proLeagueStandings.findMany({
     where: { seasonId: season.id as string },
-    orderBy: [
-      { points: "desc" },
-      { tdFor: "desc" },
-    ],
     select: {
       played: true,
       wins: true,
@@ -158,6 +163,20 @@ export async function getProLeagueCurrentStandings(
         },
       },
     },
+  });
+
+  // Audit round 5 : sort cote JS car Prisma ne supporte pas
+  // l'orderBy sur une expression. Ordre : points desc → diff TD desc
+  // → TD pour desc.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rowsRaw.sort((a: any, b: any) => {
+    const pA = (a.points as number) ?? 0;
+    const pB = (b.points as number) ?? 0;
+    if (pB !== pA) return pB - pA;
+    const diffA = ((a.tdFor as number) ?? 0) - ((a.tdAgainst as number) ?? 0);
+    const diffB = ((b.tdFor as number) ?? 0) - ((b.tdAgainst as number) ?? 0);
+    if (diffB !== diffA) return diffB - diffA;
+    return ((b.tdFor as number) ?? 0) - ((a.tdFor as number) ?? 0);
   });
 
   // Lot I — TV par équipe : somme(tvCached) des joueurs status='active'.

--- a/apps/server/src/services/pro-prediction-leagues.test.ts
+++ b/apps/server/src/services/pro-prediction-leagues.test.ts
@@ -24,10 +24,17 @@ vi.mock("../prisma", () => ({
       upsert: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     proLeagueMatch: {
       findUnique: vi.fn(),
     },
+    // Audit round 5 : settlePicksForMatch wrap dans $transaction([...])
+    // — Prisma s'attend a un tableau de PrismaPromise. On simule en
+    // resolvant juste avec le tableau (les operations sont deja
+    // mockees individuellement).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $transaction: vi.fn(async (ops: any[]) => Promise.all(ops)),
   },
 }));
 
@@ -445,11 +452,11 @@ describe("getLeagueLeaderboard", () => {
 
     const lb = await getLeagueLeaderboard("l1");
 
+    // Audit round 5 : `userEmail` retire du leaderboard (PII).
     expect(lb).toEqual([
       {
         userId: "u1",
         userName: "Alice",
-        userEmail: "a@x.com",
         totalPicks: 0,
         correctPicks: 0,
         accuracy: 0,
@@ -478,11 +485,14 @@ describe("settlePicksForMatch", () => {
       picksSettled: 3,
       correctPicks: 1,
     });
-    expect(mockedPrisma.proPredictionPick.update).toHaveBeenCalledTimes(3);
-    const firstUpdate = mockedPrisma.proPredictionPick.update.mock.calls[0][0];
-    expect(firstUpdate.data).toEqual({ result: "home", correct: true });
-    const secondUpdate = mockedPrisma.proPredictionPick.update.mock.calls[1][0];
-    expect(secondUpdate.data).toEqual({ result: "home", correct: false });
+    // Audit round 5 : settlePicksForMatch utilise maintenant 2
+    // updateMany (correct=true + correct=false) dans une $transaction.
+    expect(mockedPrisma.proPredictionPick.updateMany).toHaveBeenCalledTimes(2);
+    const calls = mockedPrisma.proPredictionPick.updateMany.mock.calls;
+    expect(calls[0][0].data).toEqual({ result: "home", correct: true });
+    expect(calls[0][0].where).toEqual({ id: { in: ["p1"] } });
+    expect(calls[1][0].data).toEqual({ result: "home", correct: false });
+    expect(calls[1][0].where).toEqual({ id: { in: ["p2", "p3"] } });
   });
 
   it("draw → tous les pickers draw sont corrects", async () => {
@@ -515,5 +525,8 @@ describe("settlePicksForMatch", () => {
       correctPicks: 0,
     });
     expect(mockedPrisma.proPredictionPick.update).not.toHaveBeenCalled();
+    // Audit round 5 : updateMany est appele meme avec un id-in vide,
+    // mais Prisma le no-op cote DB. Le test verifie juste qu'on ne
+    // touche pas .update() (loop sequentiel ancien).
   });
 });

--- a/apps/server/src/services/pro-prediction-leagues.ts
+++ b/apps/server/src/services/pro-prediction-leagues.ts
@@ -257,7 +257,12 @@ export async function submitPick(input: SubmitPickInput): Promise<{
 export interface LeaderboardEntry {
   readonly userId: string;
   readonly userName: string | null;
-  readonly userEmail: string;
+  // BUG fix audit round 5 (HIGH/PII) : avant, `userEmail` etait
+  // expose dans la response du leaderboard. Tout membre d'une mini-
+  // ligue de prediction pouvait alors harvester les emails des
+  // autres membres via l'API → fuite PII / GDPR. Champ supprime ;
+  // le UI doit utiliser `userName` (fallback sur un alias derive de
+  // `userId` cote frontend si besoin).
   readonly totalPicks: number;
   readonly correctPicks: number;
   readonly accuracy: number;
@@ -274,15 +279,16 @@ export interface LeaderboardEntry {
 export async function getLeagueLeaderboard(
   leagueId: string,
 ): Promise<LeaderboardEntry[]> {
+  // Audit round 5 : drop `email` du select pour eviter la fuite PII.
   const members = (await prisma.proPredictionLeagueMember.findMany({
     where: { leagueId },
     select: {
       userId: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as Array<{
     userId: string;
-    user: { name: string | null; email: string };
+    user: { name: string | null };
   }>;
 
   if (members.length === 0) return [];
@@ -314,7 +320,6 @@ export async function getLeagueLeaderboard(
     return {
       userId: m.userId,
       userName: m.user.name,
-      userEmail: m.user.email,
       totalPicks: s.total,
       correctPicks: s.correct,
       accuracy,
@@ -326,8 +331,9 @@ export async function getLeagueLeaderboard(
       return b.correctPicks - a.correctPicks;
     }
     if (b.accuracy !== a.accuracy) return b.accuracy - a.accuracy;
-    const nameA = a.userName ?? a.userEmail;
-    const nameB = b.userName ?? b.userEmail;
+    // Audit round 5 : fallback sur userId (pas email) pour le sort.
+    const nameA = a.userName ?? a.userId;
+    const nameB = b.userName ?? b.userId;
     return nameA.localeCompare(nameB);
   });
 
@@ -363,20 +369,37 @@ export async function settlePicksForMatch(
     select: { id: true, selection: true },
   })) as Array<{ id: string; selection: string }>;
 
-  let correctPicks = 0;
+  // BUG fix audit round 5 (HIGH) : avant, le loop d'updates etait
+  // sequentiel hors transaction. Mid-failure laissait certains picks
+  // settled et d'autres pending → re-run n'est PAS idempotent sur
+  // les picks deja settled (correct=true devient correct=true OK, mais
+  // si le result reel changeait entre temps, on aurait drift).
+  // Fix : wrap dans $transaction pour all-or-nothing.
+  const correctIds: string[] = [];
+  const wrongIds: string[] = [];
   for (const pick of picks) {
-    const isCorrect = pick.selection === input.result;
-    if (isCorrect) correctPicks += 1;
-    await prisma.proPredictionPick.update({
-      where: { id: pick.id },
-      data: { result: input.result, correct: isCorrect },
-    });
+    if (pick.selection === input.result) {
+      correctIds.push(pick.id);
+    } else {
+      wrongIds.push(pick.id);
+    }
   }
+
+  await prisma.$transaction([
+    prisma.proPredictionPick.updateMany({
+      where: { id: { in: correctIds } },
+      data: { result: input.result, correct: true },
+    }),
+    prisma.proPredictionPick.updateMany({
+      where: { id: { in: wrongIds } },
+      data: { result: input.result, correct: false },
+    }),
+  ]);
 
   return {
     matchId: input.matchId,
     result: input.result,
     picksSettled: picks.length,
-    correctPicks,
+    correctPicks: correctIds.length,
   };
 }


### PR DESCRIPTION
## Summary

Audit round 5 — 3 fixes **HIGH** dans les services Pro League autour de la correction des standings, de la PII et de la transactionnalite.

### Bugs corriges

**1. Standings tiebreaker — TD diff au lieu de TD pour (`pro-league-standings.ts` + `pro-league-hub.ts`)**

Avant : l'orderBy etait `[points desc, tdFor desc]` — utilisait `tdFor` brut comme tiebreaker au lieu de la **difference de TD**. Une equipe avec `30 TD pour / 50 contre` se classait devant `25 pour / 5 contre`, malgre une difference de TD largement meilleure pour la seconde.

Fix : standard BB / football (`points → diff TD → TD pour`). Prisma ne supporte pas `orderBy` sur une colonne computee → sort cote JS apres `findMany`. Les standings sont bornees a 16 equipes max → tri trivial.

**2. Leaderboard PII leak (`pro-prediction-leagues.ts:280`) — fuite emails GDPR**

Avant : `getLeagueLeaderboard` selectionnait `user.email` du DB et le retournait dans la response. Tout membre d'une mini-ligue de prediction pouvait alors **harvester les emails des autres membres via l'API** → fuite PII / GDPR.

Fix :
- Drop `email` du `select` Prisma.
- Drop `userEmail` du type `LeaderboardEntry`.
- Fallback sur `userId` (non plus email) pour le sort par nom.

**3. `settlePicksForMatch` transaction (`pro-prediction-leagues.ts:367`) — partial settle**

Avant : le loop d'updates `pick.update` etait sequentiel hors transaction. Mid-failure laissait certains picks settled et d'autres pending → ce n'est PAS idempotent sur re-run si l'etat du match a derive entre temps.

Fix : remplacer le loop par 2 `updateMany` (`correct=true` + `correct=false`) wrappes dans une seule `$transaction([...])` pour all-or-nothing.

## Test plan

- [x] `pnpm typecheck` propre sur server.
- [x] `pro-prediction-leagues.test.ts` : mock `proPredictionPick.updateMany` + `$transaction([ops])`. Test settle adapte : verifie 2 `updateMany` au lieu de 3 `update`. Test leaderboard adapte : `userEmail` retire de l'assertion.
- [x] Server : **2800 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_