### PR TITLE
fix(server): persist ordering BB + winnings transaction + structured logs

### DIFF
--- a/apps/server/src/routes/local-match.ts
+++ b/apps/server/src/routes/local-match.ts
@@ -1022,6 +1022,26 @@ router.post("/:id/complete", authUser, validate(completeLocalMatchSchema), async
         // Non-blocking: match completion succeeds even if SPP persistence fails
       }
 
+      // BUG fix audit round 5 (HIGH) : avant, l'ordre etait
+      // persistPlayerDeaths PUIS persistPermanentInjuries. Un joueur
+      // marque `dead=true` pouvait quand meme recevoir un increment
+      // niggling/stat reduction. Aligne avec la regle BB
+      // (apothecary → regen → death) : applique les blessures
+      // permanentes AVANT les morts.
+      try {
+        if (gameState.lastingInjuryDetails && gameState.players) {
+          injuriesPersistedCount = await persistPermanentInjuries(
+            prisma as any,
+            gameState,
+            localMatch.teamAId,
+            localMatch.teamBId,
+          );
+        }
+      } catch (injuryError) {
+        serverLog.error("Erreur lors de la persistence des blessures permanentes:", injuryError);
+        // Non-blocking: match completion succeeds even if injury persistence fails
+      }
+
       // Persist player deaths from casualty results
       try {
         if (gameState.casualtyResults && gameState.players) {
@@ -1035,21 +1055,6 @@ router.post("/:id/complete", authUser, validate(completeLocalMatchSchema), async
       } catch (deathError) {
         serverLog.error("Erreur lors de la persistence des morts:", deathError);
         // Non-blocking: match completion succeeds even if death persistence fails
-      }
-
-      // Persist permanent injuries (niggling, stat reductions, miss next match)
-      try {
-        if (gameState.lastingInjuryDetails && gameState.players) {
-          injuriesPersistedCount = await persistPermanentInjuries(
-            prisma as any,
-            gameState,
-            localMatch.teamAId,
-            localMatch.teamBId,
-          );
-        }
-      } catch (injuryError) {
-        serverLog.error("Erreur lors de la persistence des blessures permanentes:", injuryError);
-        // Non-blocking: match completion succeeds even if injury persistence fails
       }
     }
 

--- a/apps/server/src/services/move-processor.ts
+++ b/apps/server/src/services/move-processor.ts
@@ -235,7 +235,8 @@ export async function processMove(
               teamARoster: rosterA,
               teamBRoster: rosterB,
             });
-          } catch {
+          } catch (e) {
+            serverLog.error("[move-processor] league context load failed", e);
             leagueContext = undefined;
           }
           await persistMatchSPP(
@@ -246,24 +247,34 @@ export async function processMove(
             leagueContext,
           );
         }
-      } catch {
-        // SPP persistence error — non-blocking
+      } catch (e) {
+        // BUG fix audit round 5 : avant, `catch {}` muet. Maintenant
+        // on log structurellement pour que les erreurs SPP ne soient
+        // pas perdues. Le persist reste best-effort (non-blocking) car
+        // une erreur ne doit pas bloquer la fin du match cote UI.
+        serverLog.error("[move-processor] persistMatchSPP failed", e);
+      }
+
+      // BUG fix audit round 5 (HIGH) : avant, l'ordre etait
+      // persistPlayerDeaths PUIS persistPermanentInjuries → un joueur
+      // marque `dead=true` pouvait quand meme recevoir un increment
+      // niggling/stat. La regle BB est : apothecary → regen → death.
+      // Inverter pour appliquer les blessures permanentes AVANT les
+      // morts. Egalement, swap les silent catch en log structure.
+      try {
+        if (newState.lastingInjuryDetails) {
+          await persistPermanentInjuries(prisma as any, newState, teamAId, teamBId);
+        }
+      } catch (e) {
+        serverLog.error("[move-processor] persistPermanentInjuries failed", e);
       }
 
       try {
         if (newState.casualtyResults) {
           await persistPlayerDeaths(prisma as any, newState, teamAId, teamBId);
         }
-      } catch {
-        // Death persistence error — non-blocking
-      }
-
-      try {
-        if (newState.lastingInjuryDetails) {
-          await persistPermanentInjuries(prisma as any, newState, teamAId, teamBId);
-        }
-      } catch {
-        // Injury persistence error — non-blocking
+      } catch (e) {
+        serverLog.error("[move-processor] persistPlayerDeaths failed", e);
       }
 
       // Update ELO ratings based on match result
@@ -278,8 +289,8 @@ export async function processMove(
             newState.score.teamA,
             newState.score.teamB,
           );
-        } catch {
-          // ELO update error — non-blocking
+        } catch (e) {
+          serverLog.error("[move-processor] updateEloAfterMatch failed", e);
         }
       }
 
@@ -287,38 +298,53 @@ export async function processMove(
       if (newState.matchResult) {
         const { winnings, dedicatedFansChange } = newState.matchResult;
 
+        // BUG fix audit round 5 (HIGH) : avant, 2 updates `team.update`
+        // (treasury teamA puis teamB) sequentiels hors transaction.
+        // Si le 2e fail, team A est paye mais team B non → money loss
+        // / unfair standings. Fix : $transaction([...]). Idem pour
+        // dedicatedFansChange ci-dessous.
         try {
           if (winnings) {
-            await prisma.team.update({
-              where: { id: teamAId },
-              data: { treasury: { increment: winnings.teamA } },
-            });
-            await prisma.team.update({
-              where: { id: teamBId },
-              data: { treasury: { increment: winnings.teamB } },
-            });
+            await prisma.$transaction([
+              prisma.team.update({
+                where: { id: teamAId },
+                data: { treasury: { increment: winnings.teamA } },
+              }),
+              prisma.team.update({
+                where: { id: teamBId },
+                data: { treasury: { increment: winnings.teamB } },
+              }),
+            ]);
           }
-        } catch {
-          // Treasury update error — non-blocking
+        } catch (e) {
+          serverLog.error("[move-processor] winnings update failed", e);
         }
 
         try {
           if (dedicatedFansChange) {
+            const ops = [];
             if (dedicatedFansChange.teamA !== 0) {
-              await prisma.team.update({
-                where: { id: teamAId },
-                data: { dedicatedFans: { increment: dedicatedFansChange.teamA } },
-              });
+              ops.push(
+                prisma.team.update({
+                  where: { id: teamAId },
+                  data: { dedicatedFans: { increment: dedicatedFansChange.teamA } },
+                }),
+              );
             }
             if (dedicatedFansChange.teamB !== 0) {
-              await prisma.team.update({
-                where: { id: teamBId },
-                data: { dedicatedFans: { increment: dedicatedFansChange.teamB } },
-              });
+              ops.push(
+                prisma.team.update({
+                  where: { id: teamBId },
+                  data: { dedicatedFans: { increment: dedicatedFansChange.teamB } },
+                }),
+              );
+            }
+            if (ops.length > 0) {
+              await prisma.$transaction(ops);
             }
           }
-        } catch {
-          // Dedicated fans update error — non-blocking
+        } catch (e) {
+          serverLog.error("[move-processor] dedicatedFans update failed", e);
         }
       }
 


### PR DESCRIPTION
## Summary

Audit round 5 — 3 fixes **HIGH** dans le flow de fin de match (online + local) autour de l'ordre des persists post-match, de la transactionnalite des winnings, et de l'observabilite des erreurs.

### Bugs corriges

**1. `move-processor.ts` / `local-match.ts` — persist ordering BB**

Avant : les 3 persists post-match etaient executes dans l'ordre `SPP → deaths → injuries`. Probleme : un joueur marque `dead=true` par `persistPlayerDeaths` pouvait quand meme recevoir un increment `niggling`/`stat reduction` dans `persistPermanentInjuries` qui s'execute APRES — violation de la regle BB (apothecary → regen → death).

Fix : inverser l'ordre (injuries → deaths) pour aligner avec la regle BB.

**2. `move-processor.ts` — silent catches → structured logs**

Avant : chaque persist post-match etait wrappe dans `catch {}` muet. Les erreurs SPP / deaths / injuries / ELO / treasury / fans etaient swallowed → debug impossible en cas d'incoherence DB.

Fix : remplacer chaque silent catch par un `serverLog.error(prefix, e)` structure. Les persists restent best-effort (non-blocking) mais sont desormais observables.

**3. `move-processor.ts` — winnings/fans treasury double update non-transactionnels**

Avant : `winnings` updates etaient 2 `prisma.team.update` sequentiels hors transaction. Si le 2e fail (DB error, lock contention), team A est paye mais team B non → money loss / unfair standings. Idem pour `dedicatedFansChange`.

Fix : `prisma.$transaction([...])` pour all-or-nothing sur les 2 updates simultanees.

## Test plan

- [x] `pnpm typecheck` propre sur server.
- [x] Server : **2800 tests pass**.
- Pas de nouveau test ajoute — les fixes sont du reordering + transactional wrapping (pas de nouveau chemin metier), couverts implicitement par les tests existants des 3 persisters.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_