### PR TITLE
fix(auth): redact PII dans les logs (emails, roles) — GDPR

### DIFF
--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -23,6 +23,7 @@ import {
 } from "../services/kofi-claim";
 import { isSupporter } from "../services/kofi";
 import { serverLog } from "../utils/server-log";
+import { redactEmail, userTag } from "../utils/redact";
 import {
   REFRESH_TOKEN_TTL_SECONDS,
   signAccessToken,
@@ -166,21 +167,26 @@ router.post("/login", validate(loginSchema), async (req, res) => {
   try {
     const { email, password } = req.body;
 
+    // BUG fix audit round 5 (HIGH/PII) : tous les logs auth utilisaient
+    // l'email brut + le role + le flag valid. Les logs typiquement
+    // flow vers un aggregator (Loki/Sentry) ; emails = PII sous GDPR,
+    // role = aide attaquant qui gagne acces aux logs. Maintenant on
+    // redacte l'email (`u***@example.com`) et on drop role/valid.
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
-      serverLog.log(`[LOGIN] Utilisateur non trouvé: ${email}`);
+      serverLog.log(`[LOGIN] Utilisateur non trouve: ${redactEmail(email)}`);
       return res.status(401).json({ error: "Identifiants invalides" });
     }
 
-    serverLog.log(
-      `[LOGIN] Tentative de connexion pour ${email}: valid=${user.valid}, role=${user.role}`,
-    );
-    
+    // Audit round 5 : log par userTag (8 premiers chars de l'id) au
+    // lieu d'email + role + valid. Le tag suffit pour debug operationnel.
+    serverLog.debug(`[LOGIN] Tentative de connexion ${userTag(user.id)}`);
+
     // Le champ `valid` n'existe que dans le schéma Postgres (pré-alpha gate).
     // Sur les autres schémas (ex: SQLite de test), il est undefined et le
     // compte doit être traité comme valide.
     if (user.valid === false) {
-      serverLog.log(`[LOGIN] Compte non validé pour ${email}`);
+      serverLog.log(`[LOGIN] Compte non valide ${userTag(user.id)}`);
       return res.status(403).json({ error: "Votre compte n'est pas encore validé. Veuillez contacter un administrateur." });
     }
 
@@ -188,7 +194,7 @@ router.post("/login", validate(loginSchema), async (req, res) => {
     // ban pour les memes raisons (pas de leak). Message neutre.
     const deletedAt = (user as { deletedAt?: Date | null }).deletedAt ?? null;
     if (deletedAt !== null) {
-      serverLog.log(`[LOGIN] Compte supprime pour ${email} (deletedAt=${deletedAt.toISOString()})`);
+      serverLog.log(`[LOGIN] Compte supprime ${userTag(user.id)}`);
       return res.status(403).json({
         error: "Identifiants invalides",
       });
@@ -199,7 +205,7 @@ router.post("/login", validate(loginSchema), async (req, res) => {
     // arret. Le message reste neutre, sans exposer la raison interne.
     const bannedUntil = (user as { bannedUntil?: Date | null }).bannedUntil ?? null;
     if (bannedUntil && bannedUntil.getTime() > Date.now()) {
-      serverLog.log(`[LOGIN] Compte banni pour ${email} jusqu'a ${bannedUntil.toISOString()}`);
+      serverLog.log(`[LOGIN] Compte banni ${userTag(user.id)} jusqu'a ${bannedUntil.toISOString()}`);
       return res.status(403).json({
         error: "Compte suspendu. Contactez un administrateur pour plus d'informations.",
         bannedUntil: bannedUntil.toISOString(),
@@ -208,11 +214,11 @@ router.post("/login", validate(loginSchema), async (req, res) => {
 
     const ok = await bcrypt.compare(password, user.passwordHash);
     if (!ok) {
-      serverLog.log(`[LOGIN] Mot de passe incorrect pour ${email}`);
+      serverLog.log(`[LOGIN] Mot de passe incorrect ${userTag(user.id)}`);
       return res.status(401).json({ error: "Identifiants invalides" });
     }
 
-    serverLog.log(`[LOGIN] Connexion réussie pour ${email}`);
+    serverLog.debug(`[LOGIN] Connexion reussie ${userTag(user.id)}`);
 
     // Rattrape les dons orphelins reçus avant l'inscription et garantit que
     // le compte a un kofiLinkCode. Jamais bloquant sur le login.

--- a/apps/server/src/utils/redact.test.ts
+++ b/apps/server/src/utils/redact.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+import { redactEmail, userTag } from "./redact";
+
+describe("redactEmail — audit round 5 PII", () => {
+  it("masque le local-part en gardant le domaine pour debug operationnel", () => {
+    expect(redactEmail("alice@example.com")).toBe("a***@example.com");
+    expect(redactEmail("bob@nuffle.io")).toBe("b***@nuffle.io");
+  });
+
+  it("gere les local-parts de 1 char", () => {
+    expect(redactEmail("a@x.com")).toBe("*@x.com");
+  });
+
+  it("gere les emails sans @ (fallback)", () => {
+    expect(redactEmail("notAnEmail")).toBe("***");
+  });
+
+  it("string vide → vide", () => {
+    expect(redactEmail("")).toBe("");
+    expect(redactEmail(null)).toBe("");
+    expect(redactEmail(undefined)).toBe("");
+  });
+});
+
+describe("userTag — audit round 5 PII", () => {
+  it("retourne user_ + 8 premiers chars de l'id", () => {
+    expect(userTag("clxyz123abcdef")).toBe("user_clxyz123");
+  });
+
+  it("user_unknown si id absent", () => {
+    expect(userTag(null)).toBe("user_unknown");
+    expect(userTag(undefined)).toBe("user_unknown");
+    expect(userTag("")).toBe("user_unknown");
+  });
+
+  it("ne leak pas l'email dans le tag", () => {
+    expect(userTag("clxyz123")).not.toContain("@");
+  });
+});

--- a/apps/server/src/utils/redact.ts
+++ b/apps/server/src/utils/redact.ts
@@ -1,0 +1,46 @@
+/**
+ * Audit round 5 (HIGH/PII) — helpers de redaction pour les logs.
+ *
+ * Avant, les routes auth (login, register, password reset) loggaient
+ * l'email brut + le role + le flag valid de chaque tentative. Les
+ * logs typiquement flow vers un aggregator (Loki / Sentry / etc.) :
+ *  - Email en cleartext = PII sous GDPR.
+ *  - Role en cleartext = aide a un attaquant qui gagne acces aux logs
+ *    en identifiant les comptes a forte privilege.
+ *
+ * Les helpers ci-dessous remplacent l'identifiant log par :
+ *  - `redactEmail(email)` → "u***@example.com" (preserve domaine
+ *    pour le debug operationnel).
+ *  - `userTag(id)` → "user_abc12345" (prefix + 8 chars de l'id, sans
+ *    leak de l'email ni de l'id complet).
+ *
+ * Les deux sont volontairement non-reversibles cote logs : pour
+ * remonter a l'email reel, il faut une requete DB explicite.
+ */
+
+/**
+ * Masque le local-part d'un email tout en gardant le domaine pour
+ * permettre le filtrage par tenant / ESP. Exemples :
+ *   "alice@example.com" → "a***@example.com"
+ *   "a@x"               → "*@x"
+ *   ""                  → ""
+ */
+export function redactEmail(email: string | null | undefined): string {
+  if (typeof email !== "string" || email.length === 0) return "";
+  const atIdx = email.indexOf("@");
+  if (atIdx < 0) return "***";
+  const local = email.slice(0, atIdx);
+  const domain = email.slice(atIdx);
+  if (local.length === 0) return `***${domain}`;
+  if (local.length === 1) return `*${domain}`;
+  return `${local[0]}***${domain}`;
+}
+
+/**
+ * Retourne un identifiant log court derive de `id` (CUID). Format :
+ * `user_<8 premiers chars>` ou `user_unknown` si id absent.
+ */
+export function userTag(id: string | null | undefined): string {
+  if (typeof id !== "string" || id.length === 0) return "user_unknown";
+  return `user_${id.slice(0, 8)}`;
+}


### PR DESCRIPTION
## Summary

Audit round 5 — fuite PII dans les logs auth (route `/login`).

### Bug corrige

Avant, plusieurs lignes `serverLog.log` dans `/login` emettaient :
- L'**email brut** de chaque tentative (success + failure).
- Le **role utilisateur**.
- Le flag **`valid`** du compte.

Les logs serveur typiquement flow vers un aggregator (Loki / Sentry / ELK / etc.) :
- Emails en cleartext = **PII sous GDPR**.
- Role en cleartext = aide a un attaquant qui gagne acces aux logs en identifiant les comptes a forte privilege (admin/staff/etc.).

### Fix

- Nouveau helper `apps/server/src/utils/redact.ts` :
  - `redactEmail(email)` → `"a***@example.com"` (preserve domaine pour debug operationnel par tenant / ESP).
  - `userTag(id)` → `"user_abc12345"` (8 premiers chars du cuid).
- Routes `auth.ts` `/login` refactorees :
  - Email log uniquement quand l'utilisateur n'est pas trouve (pas d'identite reelle a leak) → via `redactEmail`.
  - Si user trouve : log par `userTag(user.id)` sans email ni role ni valid.
  - Les success-login logs demotes de `serverLog.log` a `serverLog.debug` (volume reduit cote aggregator).

## Test plan

- [x] `pnpm typecheck` propre sur server.
- [x] `redact.test.ts` : **7 nouveaux tests** :
  - `redactEmail` : alice@example.com → a***@example.com.
  - Local-part de 1 char : `*@x.com`.
  - Email sans `@` → `***`.
  - String vide / null / undefined → `""`.
  - `userTag` : 8 premiers chars du cuid, fallback `user_unknown`, ne leak pas d'email.
- [x] `auth.test.ts` existant : 4 tests pass (pas de regression sur les flows fonctionnels).
- [x] Server : **2807 tests pass** (+7 nouveaux).

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_