### PR TITLE
fix(pro-league): MVP eligibility par participants + applyLevelUps tx

### DIFF
--- a/apps/server/src/services/pro-roster-level-up.test.ts
+++ b/apps/server/src/services/pro-roster-level-up.test.ts
@@ -12,11 +12,19 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    proTeamRoster: { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() },
-  },
-}));
+// Audit round 5 : applyLevelUps wrap maintenant read+write dans une
+// $transaction. Simule en partageant le meme mock proTeamRoster entre
+// prisma top-level et le `tx` du callback.
+vi.mock("../prisma", () => {
+  const proTeamRoster = { findUnique: vi.fn(), findMany: vi.fn(), update: vi.fn() };
+  return {
+    prisma: {
+      proTeamRoster,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) => cb({ proTeamRoster })),
+    },
+  };
+});
 
 import { prisma } from "../prisma";
 import {
@@ -484,7 +492,10 @@ describe("sweepLevelUps — Lot 3.C.4", () => {
         status: "active",
         position: "Lineman",
       })
-      .mockResolvedValueOnce(null); // 2eme = ROSTER_NOT_FOUND
+      // Audit round 5 : 2eme findUnique INSIDE $transaction pour
+      // re-read niggling+skills frais (fix race condition).
+      .mockResolvedValueOnce({ niggling: 0, skills: [] })
+      .mockResolvedValueOnce(null); // 3eme = ROSTER_NOT_FOUND pour "fail"
     const out = await sweepLevelUps();
     expect(out.inspected).toBe(2);
     expect(out.processed).toBe(1);

--- a/apps/server/src/services/pro-roster-level-up.ts
+++ b/apps/server/src/services/pro-roster-level-up.ts
@@ -433,38 +433,59 @@ export async function applyLevelUps(
   }
 
   const newSkills = [...skills, ...newSkillsAcc];
-  // Lot 3.C.5 + 4.D.1 + 4.D.2 + 4.D.3 — recompute TV inline avec :
-  //   - slugs pour pricing primary/secondary (20k/30k)
-  //   - niggling courant (-10k chacun, lu depuis le casualty applier)
-  //   - stat bonuses cumules (existing + accrued de cette session)
-  const totalStatBonuses: StatBonuses = {
-    ma: ((roster.maBonus as number) ?? 0) + accruedStats.ma,
-    ag: ((roster.agBonus as number) ?? 0) + accruedStats.ag,
-    pa: ((roster.paBonus as number) ?? 0) + accruedStats.pa,
-    av: ((roster.avBonus as number) ?? 0) + accruedStats.av,
-    st: ((roster.stBonus as number) ?? 0) + accruedStats.st,
-  };
-  const newTvCached = computePlayerTv(
-    position,
-    newSkills,
-    (roster.niggling as number) ?? 0,
-    totalStatBonuses,
-  );
-  await prisma.proTeamRoster.update({
-    where: { id: rosterId },
-    data: {
-      level: currentLevel,
-      skills: newSkills,
-      tvCached: newTvCached,
-      // Lot 4.D.1 — Prisma `increment` evite les race conditions
-      // (un casualty applier qui tournerait en parallele ne casse
-      // pas la valeur).
-      maBonus: { increment: accruedStats.ma },
-      agBonus: { increment: accruedStats.ag },
-      paBonus: { increment: accruedStats.pa },
-      avBonus: { increment: accruedStats.av },
-      stBonus: { increment: accruedStats.st },
-    },
+
+  // BUG fix audit round 5 (HIGH) : avant, le read du roster (l.316)
+  // et le write (l.453) etaient en dehors d'une transaction. Si un
+  // autre process (casualty applier d'un match concurrent) modifiait
+  // `niggling` ou `skills` entre les deux, l'update ecrasait la
+  // version fraiche avec une version stale (skills explicite + tvCached
+  // calcule avec un niggling potentiellement obsolete). Les
+  // increments de stat bonuses sont safe (Prisma `increment`), mais
+  // les champs fixes (skills, tvCached) sont vulnerables.
+  // Fix : wrap read+compute+write dans une seule $transaction, et
+  // re-read niggling/skills DANS la tx pour utiliser des valeurs
+  // fraiches au moment du commit. Le re-read est cheap (meme row).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    const fresh = (await tx.proTeamRoster.findUnique({
+      where: { id: rosterId },
+      select: { niggling: true, skills: true },
+    })) as { niggling: number | null; skills: unknown } | null;
+    if (!fresh) return;
+    // Merge skills : on prend les skills frais + les nouvelles que
+    // ce level-up ajoute. Si un casualty applier a ajoute un
+    // niggling skill entre temps, on ne l'ecrase pas.
+    const freshSkills = parseSkillsJson(fresh.skills);
+    const mergedSkills = Array.from(
+      new Set([...freshSkills, ...newSkillsAcc]),
+    );
+    const totalStatBonuses: StatBonuses = {
+      ma: ((roster.maBonus as number) ?? 0) + accruedStats.ma,
+      ag: ((roster.agBonus as number) ?? 0) + accruedStats.ag,
+      pa: ((roster.paBonus as number) ?? 0) + accruedStats.pa,
+      av: ((roster.avBonus as number) ?? 0) + accruedStats.av,
+      st: ((roster.stBonus as number) ?? 0) + accruedStats.st,
+    };
+    const newTvCached = computePlayerTv(
+      position,
+      mergedSkills,
+      (fresh.niggling as number) ?? 0,
+      totalStatBonuses,
+    );
+    await tx.proTeamRoster.update({
+      where: { id: rosterId },
+      data: {
+        level: currentLevel,
+        skills: mergedSkills,
+        tvCached: newTvCached,
+        // Prisma `increment` reste safe vs concurrent updates.
+        maBonus: { increment: accruedStats.ma },
+        agBonus: { increment: accruedStats.ag },
+        paBonus: { increment: accruedStats.pa },
+        avBonus: { increment: accruedStats.av },
+        stBonus: { increment: accruedStats.st },
+      },
+    });
   });
 
   return {

--- a/apps/server/src/services/pro-roster-spp.ts
+++ b/apps/server/src/services/pro-roster-spp.ts
@@ -179,9 +179,51 @@ export function attributeSpp(
   }
 
   // 3) MVP : 1 random par team eligible (deterministe via seed).
+  // BUG fix audit round 5 (HIGH) : avant, `eligibleHome` etait
+  // `[...input.homeRosterIds]` — incluait TOUS les rosters actifs de
+  // la team, meme ceux qui n'avaient pas joue. Un joueur nouvellement
+  // achete entre la sim et le replay processing pouvait gagner le MVP
+  // (et 4 SPP) sans avoir mis un pied sur le terrain. Fix : filtrer
+  // a partir des `actorId` rencontres dans `events` (PASS passer, TD
+  // scorer, BLOCK attacker, MOVE player, etc.). Fallback : si aucun
+  // participant identifie (sim purement synthetique), on retombe sur
+  // la liste complete pour ne pas casser la determinisme du seed.
+  const participantIds = new Set<string>();
+  for (const ev of input.events) {
+    if (!ev || typeof ev !== "object") continue;
+    const e = ev as { meta?: unknown };
+    const meta = (e.meta ?? {}) as Record<string, unknown>;
+    for (const key of [
+      "playerId",
+      "passerId",
+      "receiverId",
+      "scorerId",
+      "attackerId",
+      "defenderId",
+      "actorId",
+    ]) {
+      const v = meta[key];
+      if (typeof v === "string" && v.length > 0 && !isSyntheticId(v)) {
+        participantIds.add(v);
+      }
+    }
+  }
+  const eligibleHomeAll = [...input.homeRosterIds];
+  const eligibleAwayAll = [...input.awayRosterIds];
+  const eligibleHomeFiltered = eligibleHomeAll.filter((id) =>
+    participantIds.has(id),
+  );
+  const eligibleAwayFiltered = eligibleAwayAll.filter((id) =>
+    participantIds.has(id),
+  );
+  // Si la sim n'a remonte AUCUN participant pour une team (ex: hybrid
+  // sans roster), on retombe sur la liste complete pour conserver
+  // l'attribution MVP determinste a partir du seed.
+  const eligibleHome =
+    eligibleHomeFiltered.length > 0 ? eligibleHomeFiltered : eligibleHomeAll;
+  const eligibleAway =
+    eligibleAwayFiltered.length > 0 ? eligibleAwayFiltered : eligibleAwayAll;
   const rng = mulberry32(input.seed);
-  const eligibleHome = [...input.homeRosterIds];
-  const eligibleAway = [...input.awayRosterIds];
   if (eligibleHome.length > 0) {
     const idx = Math.floor(rng() * eligibleHome.length);
     bump(eligibleHome[idx], "mvpCount");


### PR DESCRIPTION
## Summary

Audit round 5 — 2 fixes **HIGH** cote SPP / level-up sur la fairness MVP et la race condition entre level-up et casualty applier.

### Bugs corriges

**1. `attributeSpp` MVP eligibility (`pro-roster-spp.ts:183`)**

Avant : `eligibleHome = [...input.homeRosterIds]` incluait TOUS les rosters actifs de la team, meme ceux qui n'avaient pas joue le match. Un joueur nouvellement achete entre la sim et le replay processing pouvait gagner le MVP (4 SPP) **sans avoir mis un pied sur le terrain** → inflation SPP unfair.

Fix :
- Construire un Set `participantIds` a partir des `playerId` / `passerId` / `receiverId` / `scorerId` / `attackerId` / `defenderId` rencontres dans `events`.
- Filtrer `eligibleHome`/`Away` contre ce Set.
- **Fallback** : si aucun participant identifie (sim purement synthetique sans rosters → cas legacy hybrid), on retombe sur la liste complete pour preserver la determinisme du seed.

**2. `applyLevelUps` race condition (`pro-roster-level-up.ts:316`)**

Avant : le read du roster (l.316) et le write (l.453) etaient hors transaction. Si un autre process (casualty applier d'un match concurrent) modifiait `niggling` ou `skills` entre les deux, l'update ecrasait la version fraiche avec une version stale (`skills` explicite + `tvCached` calcule avec `niggling` potentiellement obsolete). Les `increment` de stat bonuses etaient safe (Prisma), mais les champs fixes (`skills`, `tvCached`) etaient vulnerables.

Fix :
- Wrap read+compute+write dans une seule `prisma.$transaction`.
- Re-read `niggling`+`skills` DANS la tx pour utiliser des valeurs fraiches au moment du commit.
- Merge skills via `Set` evite de dupliquer ni d'ecraser un skill ajoute concurrent.

## Test plan

- [x] `pnpm typecheck` propre sur server.
- [x] `pro-roster-spp.test.ts` : 22 tests pass (fallback bien preserve dans les fixtures sans actor events).
- [x] `pro-roster-level-up.test.ts` : mock `$transaction` ajoute + ajustement test sweep pour gerer 3 `findUnique` (1 outer + 1 inner tx pour `ok` + 1 null pour `fail`). 36 tests pass.
- [x] Server : **2807 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_