### PR TITLE
fix(server): drop email PII from public APIs (round 6)

### DIFF
--- a/apps/server/src/routes/match-details-handlers.ts
+++ b/apps/server/src/routes/match-details-handlers.ts
@@ -65,7 +65,8 @@ export async function handleGetMatchDetailsByToken(
         where: { matchId },
         orderBy: { createdAt: 'asc' },
         include: {
-          user: { select: { id: true, name: true, email: true } },
+          // Audit round 6 (CRITICAL/PII) : retire `email` du select public.
+          user: { select: { id: true, name: true } },
           teamRef: { select: { name: true, roster: true } },
         },
       }),
@@ -144,7 +145,8 @@ export async function handleGetMatchDetails(
         where: { matchId },
         orderBy: { createdAt: 'asc' },
         include: {
-          user: { select: { id: true, name: true, email: true, eloRating: true } },
+          // Audit round 6 (CRITICAL/PII) : retire `email` du select public.
+          user: { select: { id: true, name: true, eloRating: true } },
           teamRef: { select: { name: true, roster: true } },
         },
       }),
@@ -181,7 +183,8 @@ export async function handleGetMatchDetails(
     const teamName = (sel: any) =>
       sel?.teamRef?.name || sel?.teamRef?.roster || sel?.team || '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const coachName = (sel: any) => sel?.user?.name || sel?.user?.email || '';
+    // Audit round 6 : drop fallback sur user.email pour eviter le PII leak.
+    const coachName = (sel: any) => sel?.user?.name || '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const eloRating = (sel: any) => sel?.user?.eloRating ?? 1000;
     sendSuccess(res, {

--- a/apps/server/src/routes/match-readonly-handlers.ts
+++ b/apps/server/src/routes/match-readonly-handlers.ts
@@ -124,7 +124,8 @@ export async function handleGetMatchResults(
       where: { matchId },
       orderBy: { createdAt: 'asc' },
       include: {
-        user: { select: { id: true, name: true, email: true, eloRating: true } },
+        // Audit round 6 (CRITICAL/PII) : retire `email` du select public.
+        user: { select: { id: true, name: true, eloRating: true } },
         teamRef: { select: { name: true, roster: true } },
       },
     });
@@ -149,7 +150,8 @@ export async function handleGetMatchResults(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const teamName = (sel: any) => sel?.teamRef?.name || sel?.teamRef?.roster || '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const coachName = (sel: any) => sel?.user?.name || sel?.user?.email || '';
+    // Audit round 6 : drop fallback sur user.email pour eviter le PII leak.
+    const coachName = (sel: any) => sel?.user?.name || '';
 
     const currentEloA = selA?.user?.eloRating ?? 1000;
     const currentEloB = selB?.user?.eloRating ?? 1000;

--- a/apps/server/src/routes/match-summary-handler.ts
+++ b/apps/server/src/routes/match-summary-handler.ts
@@ -51,7 +51,10 @@ export async function handleGetMatchSummary(
         where: { matchId },
         include: {
           user: {
-            select: { id: true, name: true, email: true, eloRating: true },
+            // Audit round 6 (CRITICAL/PII) : retire `email` du select.
+            // Avant, `pickCoach` fallback sur user.email → endpoint public
+            // permettait de scraper les emails via le match ID.
+            select: { id: true, name: true, eloRating: true },
           },
           teamRef: { select: { id: true, name: true, roster: true } },
         },
@@ -120,7 +123,8 @@ export async function handleGetMatchSummary(
     const pickName = (sel: any) =>
       sel?.teamRef?.name || sel?.teamRef?.roster || sel?.team || '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pickCoach = (sel: any) => sel?.user?.name || sel?.user?.email || '';
+    // Audit round 6 : drop fallback sur user.email pour eviter le PII leak.
+    const pickCoach = (sel: any) => sel?.user?.name || '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pickElo = (sel: any) => sel?.user?.eloRating ?? 1000;
     const acceptedUserIds = Array.from(

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -662,7 +662,8 @@ export async function getLeagueById(leagueId: string) {
   return prisma.league.findUnique({
     where: { id: leagueId },
     include: {
-      creator: { select: { id: true, coachName: true, email: true } },
+      // Audit round 6 (CRITICAL/PII) : retire `email` du select public.
+      creator: { select: { id: true, coachName: true } },
       seasons: { orderBy: { seasonNumber: "asc" } },
     },
   });

--- a/apps/server/src/services/pro-gazette-comments.ts
+++ b/apps/server/src/services/pro-gazette-comments.ts
@@ -94,7 +94,9 @@ export interface GazetteCommentView {
   readonly articleId: string;
   readonly userId: string;
   readonly userName: string | null;
-  readonly userEmail: string;
+  // BUG fix audit round 6 (CRITICAL/PII) : `userEmail` retire. Avant,
+  // l'API publique des comments Gazette exposait l'email de chaque
+  // auteur → PII / GDPR.
   readonly body: string;
   readonly createdAt: string;
   readonly flagged: boolean;
@@ -143,7 +145,7 @@ export async function createComment(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as {
     id: string;
@@ -154,7 +156,7 @@ export async function createComment(
     flaggedAt: Date | null;
     flagReason: string | null;
     deletedAt: Date | null;
-    user: { name: string | null; email: string };
+    user: { name: string | null };
   };
 
   return toView(created);
@@ -169,7 +171,7 @@ interface CommentRow {
   flaggedAt: Date | null;
   flagReason: string | null;
   deletedAt: Date | null;
-  user: { name: string | null; email: string };
+  user: { name: string | null };
 }
 
 function toView(row: CommentRow): GazetteCommentView {
@@ -178,7 +180,6 @@ function toView(row: CommentRow): GazetteCommentView {
     articleId: row.articleId,
     userId: row.userId,
     userName: row.user.name,
-    userEmail: row.user.email,
     body: row.body,
     createdAt: row.createdAt.toISOString(),
     flagged: row.flaggedAt !== null,
@@ -215,7 +216,7 @@ export async function listComments(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow[];
 
@@ -266,7 +267,7 @@ export async function flagComment(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow;
 
@@ -300,7 +301,7 @@ export async function unflagComment(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow;
 
@@ -355,7 +356,7 @@ export async function softDeleteComment(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow;
 
@@ -389,7 +390,7 @@ export async function restoreComment(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow;
 
@@ -427,7 +428,7 @@ export async function adminListComments(
       flaggedAt: true,
       flagReason: true,
       deletedAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as CommentRow[];
 

--- a/apps/server/src/services/pro-match-predictions.ts
+++ b/apps/server/src/services/pro-match-predictions.ts
@@ -165,7 +165,9 @@ export interface PredictionView {
   readonly matchId: string;
   readonly userId: string;
   readonly userName: string | null;
-  readonly userEmail: string;
+  // BUG fix audit round 6 (CRITICAL/PII) : `userEmail` retire. Avant,
+  // /pro-league/matches/:id/predictions exposait l'email de chaque
+  // fan ayant poste une prediction → PII / GDPR.
   readonly body: string;
   readonly score: PredictionScore | null;
   readonly createdAt: string;
@@ -180,7 +182,7 @@ interface PredictionRow {
   score: string | null;
   scoredAt: Date | null;
   createdAt: Date;
-  user: { name: string | null; email: string };
+  user: { name: string | null };
 }
 
 function toView(row: PredictionRow): PredictionView {
@@ -189,7 +191,6 @@ function toView(row: PredictionRow): PredictionView {
     matchId: row.matchId,
     userId: row.userId,
     userName: row.user.name,
-    userEmail: row.user.email,
     body: row.body,
     score: (row.score as PredictionScore | null) ?? null,
     createdAt: row.createdAt.toISOString(),
@@ -255,7 +256,7 @@ export async function createOrUpdatePrediction(
       score: true,
       scoredAt: true,
       createdAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as PredictionRow;
 
@@ -279,7 +280,7 @@ export async function listPredictions(
       score: true,
       scoredAt: true,
       createdAt: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as PredictionRow[];
 
@@ -353,7 +354,8 @@ export async function settlePredictions(
 export interface SeerLeaderboardEntry {
   readonly userId: string;
   readonly userName: string | null;
-  readonly userEmail: string;
+  // BUG fix audit round 6 (CRITICAL/PII) : `userEmail` retire de
+  // /pro-league/seer-leaderboard (etait public).
   readonly perfectCount: number;
   readonly winnerCount: number;
   readonly totalScored: number;
@@ -375,12 +377,12 @@ export async function getSeerLeaderboard(
     select: {
       userId: true,
       score: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as Array<{
     userId: string;
     score: string | null;
-    user: { name: string | null; email: string };
+    user: { name: string | null };
   }>;
 
   if (rows.length === 0) return [];
@@ -389,7 +391,6 @@ export async function getSeerLeaderboard(
     string,
     {
       userName: string | null;
-      userEmail: string;
       perfect: number;
       winner: number;
       wrong: number;
@@ -399,7 +400,6 @@ export async function getSeerLeaderboard(
     if (!byUser.has(r.userId)) {
       byUser.set(r.userId, {
         userName: r.user.name,
-        userEmail: r.user.email,
         perfect: 0,
         winner: 0,
         wrong: 0,
@@ -416,7 +416,6 @@ export async function getSeerLeaderboard(
     entries.push({
       userId,
       userName: b.userName,
-      userEmail: b.userEmail,
       perfectCount: b.perfect,
       winnerCount: b.winner,
       totalScored: b.perfect + b.winner + b.wrong,
@@ -427,8 +426,9 @@ export async function getSeerLeaderboard(
       return b.perfectCount - a.perfectCount;
     }
     if (b.winnerCount !== a.winnerCount) return b.winnerCount - a.winnerCount;
-    const nA = a.userName ?? a.userEmail;
-    const nB = b.userName ?? b.userEmail;
+    // Audit round 6 : fallback userId (pas email).
+    const nA = a.userName ?? a.userId;
+    const nB = b.userName ?? b.userId;
     return nA.localeCompare(nB);
   });
 

--- a/apps/server/src/services/pro-survivor.ts
+++ b/apps/server/src/services/pro-survivor.ts
@@ -369,7 +369,9 @@ export async function getMySurvivorStatus(
 export interface SurvivorStandingsEntry {
   readonly userId: string;
   readonly userName: string | null;
-  readonly userEmail: string;
+  // BUG fix audit round 6 (CRITICAL/PII) : `userEmail` retire.
+  // Avant, le standings public exposait chaque email participant via
+  // GET /pro-league/survivor/:seasonId/standings → PII / GDPR.
   readonly weeksSurvived: number;
   readonly isAlive: boolean;
 }
@@ -382,17 +384,19 @@ export interface SurvivorStandingsEntry {
 export async function getSurvivorStandings(
   seasonId: string,
 ): Promise<SurvivorStandingsEntry[]> {
+  // Audit round 6 (CRITICAL/PII) : drop `email` du select. Le sort
+  // fallback utilise userId (non plus email).
   const entries = (await prisma.proSurvivorEntry.findMany({
     where: { seasonId },
     select: {
       userId: true,
       status: true,
-      user: { select: { name: true, email: true } },
+      user: { select: { name: true } },
     },
   })) as Array<{
     userId: string;
     status: string;
-    user: { name: string | null; email: string };
+    user: { name: string | null };
   }>;
 
   if (entries.length === 0) return [];
@@ -401,7 +405,6 @@ export async function getSurvivorStandings(
     string,
     {
       userName: string | null;
-      userEmail: string;
       alive: number;
       eliminated: number;
       pending: number;
@@ -412,7 +415,6 @@ export async function getSurvivorStandings(
     if (!byUser.has(e.userId)) {
       byUser.set(e.userId, {
         userName: e.user.name,
-        userEmail: e.user.email,
         alive: 0,
         eliminated: 0,
         pending: 0,
@@ -429,7 +431,6 @@ export async function getSurvivorStandings(
     standings.push({
       userId,
       userName: b.userName,
-      userEmail: b.userEmail,
       weeksSurvived: b.alive,
       isAlive: b.eliminated === 0,
     });
@@ -440,8 +441,9 @@ export async function getSurvivorStandings(
       return b.weeksSurvived - a.weeksSurvived;
     }
     if (a.isAlive !== b.isAlive) return a.isAlive ? -1 : 1;
-    const nA = a.userName ?? a.userEmail;
-    const nB = b.userName ?? b.userEmail;
+    // Audit round 6 : fallback sur userId (pas email) pour le sort.
+    const nA = a.userName ?? a.userId;
+    const nB = b.userName ?? b.userId;
     return nA.localeCompare(nB);
   });
 


### PR DESCRIPTION
## Summary

Audit round 6 — fuite PII massive sur 5+ endpoints publics. Toute personne ayant un match ID / season ID / article ID pouvait scraper les emails des participants via l'API.

### Endpoints affectes

- `routes/match-summary-handler.ts`, `match-details-handlers.ts`, `match-readonly-handlers.ts` : fallback `user?.name || user?.email` exposait l'email comme coach name.
- `services/pro-survivor.ts` : `SurvivorStandingsEntry.userEmail` retourne par `/pro-league/survivor/:seasonId/standings`.
- `services/pro-match-predictions.ts` : `PredictionView.userEmail` + `SeerLeaderboardEntry.userEmail`.
- `services/pro-gazette-comments.ts` : `GazetteCommentView.userEmail`.
- `services/league.ts` : `creator.email` dans `getLeagueById`.

Fix : drop email du select et du type partout. Sort fallback utilise userId/userName.

## Test plan

- typecheck propre server + web
- Server : 2807 tests pass

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_