### PR TITLE
fix(team): atomic treasury/count updates + star-player hire tx (round 6)

### DIFF
--- a/apps/server/src/routes/team-purchase-handler.ts
+++ b/apps/server/src/routes/team-purchase-handler.ts
@@ -189,9 +189,13 @@ export async function handlePurchase(
               skills: positionData.skills,
             },
           }),
+          // Audit round 6 (CRITICAL/race) : avant, `treasury - cost`
+          // sur le snapshot read pre-transaction → 2 player buys
+          // concurrents pouvaient overwrite la treasury avec la meme
+          // valeur stale. Fix : decrement atomique au niveau DB.
           prisma.team.update({
             where: { id: teamId },
-            data: { treasury: team.treasury - cost },
+            data: { treasury: { decrement: cost } },
           }),
         ]);
 
@@ -200,136 +204,154 @@ export async function handlePurchase(
       }
 
       case 'reroll': {
-        if (team.rerolls >= 8) {
-          sendError(res, 'Maximum 8 relances par equipe', 400);
-          return;
-        }
+        // BUG fix audit round 6 (CRITICAL/race) : avant, le check
+        // `team.treasury < cost` et l'update `treasury - cost` etaient
+        // fait sur un snapshot read pre-transaction → 2 requetes
+        // concurrentes pouvaient toutes deux passer la verif et
+        // toutes deux ecrire `stale - cost` (lost-update). Fix :
+        // updateMany conditionnelle WHERE treasury >= cost AND
+        // rerolls < 8, avec decrement/increment atomiques. Si
+        // count===0, soit budget insuffisant soit limite atteinte.
         cost = getRerollCost(team.roster) * 2;
-
-        if (team.treasury < cost) {
-          sendError(
-            res,
-            `Tresorerie insuffisante. Cout: ${Math.round(cost / 1000)}k po, Tresorerie: ${Math.round(team.treasury / 1000)}k po`,
-            400,
-          );
-          return;
-        }
-
-        await prisma.team.update({
-          where: { id: teamId },
+        const updateResult = await prisma.team.updateMany({
+          where: { id: teamId, treasury: { gte: cost }, rerolls: { lt: 8 } },
           data: {
-            rerolls: team.rerolls + 1,
-            treasury: team.treasury - cost,
+            rerolls: { increment: 1 },
+            treasury: { decrement: cost },
           },
         });
+        if (updateResult.count === 0) {
+          const fresh = await prisma.team.findUnique({
+            where: { id: teamId },
+            select: { rerolls: true, treasury: true },
+          });
+          if (fresh && fresh.rerolls >= 8) {
+            sendError(res, 'Maximum 8 relances par equipe', 400);
+          } else {
+            sendError(
+              res,
+              `Tresorerie insuffisante. Cout: ${Math.round(cost / 1000)}k po`,
+              400,
+            );
+          }
+          return;
+        }
         description = `Relance achetee (cout double: ${Math.round(cost / 1000)}k po)`;
         break;
       }
 
       case 'cheerleader': {
-        if (team.cheerleaders >= 12) {
-          sendError(res, 'Maximum 12 cheerleaders', 400);
-          return;
-        }
         cost = 10000;
-
-        if (team.treasury < cost) {
-          sendError(
-            res,
-            `Tresorerie insuffisante. Cout: 10k po, Tresorerie: ${Math.round(team.treasury / 1000)}k po`,
-            400,
-          );
-          return;
-        }
-
-        await prisma.team.update({
-          where: { id: teamId },
+        const updateResult = await prisma.team.updateMany({
+          where: {
+            id: teamId,
+            treasury: { gte: cost },
+            cheerleaders: { lt: 12 },
+          },
           data: {
-            cheerleaders: team.cheerleaders + 1,
-            treasury: team.treasury - cost,
+            cheerleaders: { increment: 1 },
+            treasury: { decrement: cost },
           },
         });
+        if (updateResult.count === 0) {
+          const fresh = await prisma.team.findUnique({
+            where: { id: teamId },
+            select: { cheerleaders: true },
+          });
+          if (fresh && fresh.cheerleaders >= 12) {
+            sendError(res, 'Maximum 12 cheerleaders', 400);
+          } else {
+            sendError(res, 'Tresorerie insuffisante. Cout: 10k po', 400);
+          }
+          return;
+        }
         description = 'Cheerleader recrutee';
         break;
       }
 
       case 'assistant': {
-        if (team.assistants >= 6) {
-          sendError(res, 'Maximum 6 assistants', 400);
-          return;
-        }
         cost = 10000;
-
-        if (team.treasury < cost) {
-          sendError(
-            res,
-            `Tresorerie insuffisante. Cout: 10k po, Tresorerie: ${Math.round(team.treasury / 1000)}k po`,
-            400,
-          );
-          return;
-        }
-
-        await prisma.team.update({
-          where: { id: teamId },
+        const updateResult = await prisma.team.updateMany({
+          where: {
+            id: teamId,
+            treasury: { gte: cost },
+            assistants: { lt: 6 },
+          },
           data: {
-            assistants: team.assistants + 1,
-            treasury: team.treasury - cost,
+            assistants: { increment: 1 },
+            treasury: { decrement: cost },
           },
         });
+        if (updateResult.count === 0) {
+          const fresh = await prisma.team.findUnique({
+            where: { id: teamId },
+            select: { assistants: true },
+          });
+          if (fresh && fresh.assistants >= 6) {
+            sendError(res, 'Maximum 6 assistants', 400);
+          } else {
+            sendError(res, 'Tresorerie insuffisante. Cout: 10k po', 400);
+          }
+          return;
+        }
         description = 'Assistant recrute';
         break;
       }
 
       case 'apothecary': {
-        if (team.apothecary) {
-          sendError(res, "L'equipe a deja un apothicaire", 400);
-          return;
-        }
         cost = 50000;
-
-        if (team.treasury < cost) {
-          sendError(
-            res,
-            `Tresorerie insuffisante. Cout: 50k po, Tresorerie: ${Math.round(team.treasury / 1000)}k po`,
-            400,
-          );
-          return;
-        }
-
-        await prisma.team.update({
-          where: { id: teamId },
+        const updateResult = await prisma.team.updateMany({
+          where: {
+            id: teamId,
+            treasury: { gte: cost },
+            apothecary: false,
+          },
           data: {
             apothecary: true,
-            treasury: team.treasury - cost,
+            treasury: { decrement: cost },
           },
         });
+        if (updateResult.count === 0) {
+          const fresh = await prisma.team.findUnique({
+            where: { id: teamId },
+            select: { apothecary: true },
+          });
+          if (fresh && fresh.apothecary) {
+            sendError(res, "L'equipe a deja un apothicaire", 400);
+          } else {
+            sendError(res, 'Tresorerie insuffisante. Cout: 50k po', 400);
+          }
+          return;
+        }
         description = 'Apothicaire recrute';
         break;
       }
 
       case 'dedicated_fan': {
-        if (team.dedicatedFans >= 6) {
-          sendError(res, 'Maximum 6 fans devoues', 400);
-          return;
-        }
         cost = 10000;
-
-        if (team.treasury < cost) {
-          sendError(
-            res,
-            `Tresorerie insuffisante. Cout: 10k po, Tresorerie: ${Math.round(team.treasury / 1000)}k po`,
-            400,
-          );
-          return;
-        }
-
-        await prisma.team.update({
-          where: { id: teamId },
+        const updateResult = await prisma.team.updateMany({
+          where: {
+            id: teamId,
+            treasury: { gte: cost },
+            dedicatedFans: { lt: 6 },
+          },
           data: {
-            dedicatedFans: team.dedicatedFans + 1,
-            treasury: team.treasury - cost,
+            dedicatedFans: { increment: 1 },
+            treasury: { decrement: cost },
           },
         });
+        if (updateResult.count === 0) {
+          const fresh = await prisma.team.findUnique({
+            where: { id: teamId },
+            select: { dedicatedFans: true },
+          });
+          if (fresh && fresh.dedicatedFans >= 6) {
+            sendError(res, 'Maximum 6 fans devoues', 400);
+          } else {
+            sendError(res, 'Tresorerie insuffisante. Cout: 10k po', 400);
+          }
+          return;
+        }
         description = 'Fan devoue recrute';
         break;
       }

--- a/apps/server/src/routes/team-star-player-hire-handler.ts
+++ b/apps/server/src/routes/team-star-player-hire-handler.ts
@@ -159,7 +159,13 @@ export async function handleHireStarPlayer(
       }
     }
 
-    const createdStarPlayers = await Promise.all(
+    // BUG fix audit round 6 (HIGH) : avant, `Promise.all(creates)` lancait
+    // chaque create dans une transaction Prisma independante. Pour un
+    // pairing (e.g. Morg + partner), si le 2e create echoue (unique
+    // constraint, partner deja hire par une autre team), le 1er
+    // persiste et la team est laissee avec un demi-pairing illegal.
+    // Fix : `prisma.$transaction([...creates])` pour all-or-nothing.
+    const createdStarPlayers = await prisma.$transaction(
       starPlayersToHire.map((sp) =>
         prisma.teamStarPlayer.create({
           data: {

--- a/apps/server/src/routes/team.test.ts
+++ b/apps/server/src/routes/team.test.ts
@@ -18,6 +18,9 @@ vi.mock("../prisma", () => ({
       findFirst: vi.fn(),
       findUnique: vi.fn(),
       update: vi.fn(),
+      // Audit round 6 : updateMany conditionnel pour eviter race
+      // condition sur le treasury / counters.
+      updateMany: vi.fn(),
       count: vi.fn(),
     },
     teamSelection: {
@@ -1185,6 +1188,10 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
       teamFindFirst: prismaMock.team.findFirst as ReturnType<typeof vi.fn>,
       teamFindUnique: prismaMock.team.findUnique as ReturnType<typeof vi.fn>,
       teamUpdate: prismaMock.team.update as ReturnType<typeof vi.fn>,
+      // Audit round 6 : team purchase utilise maintenant updateMany
+      // conditionnel (where treasury >= cost AND count < max) pour
+      // eviter le race condition lost-update.
+      teamUpdateMany: prismaMock.team.updateMany as ReturnType<typeof vi.fn>,
       selectionFindFirst: prismaMock.teamSelection.findFirst as ReturnType<
         typeof vi.fn
       >,
@@ -1237,7 +1244,7 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
     const {
       teamFindFirst,
       teamFindUnique,
-      teamUpdate,
+      teamUpdateMany,
       selectionFindFirst,
       updateValues,
     } = await getMocks();
@@ -1253,7 +1260,9 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
       players: [],
     });
     selectionFindFirst.mockResolvedValue(null);
-    teamUpdate.mockResolvedValue({});
+    // Audit round 6 : updateMany conditionnel renvoie { count: 1 } si
+    // OK (treasury suffisante + count < max).
+    teamUpdateMany.mockResolvedValue({ count: 1 });
     updateValues.mockResolvedValue({ teamValue: 1000, currentValue: 1000 });
     const updatedTeam = { id: "team-1", players: [], cheerleaders: 1 };
     teamFindUnique.mockResolvedValue(updatedTeam);
@@ -1265,11 +1274,16 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
     const res = createRes();
     await handlePurchase(req, res);
 
-    expect(teamUpdate).toHaveBeenCalledWith(
+    expect(teamUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: expect.objectContaining({
+          id: "team-1",
+          treasury: { gte: 10000 },
+          cheerleaders: { lt: 12 },
+        }),
         data: expect.objectContaining({
-          cheerleaders: 1,
-          treasury: 40000,
+          cheerleaders: { increment: 1 },
+          treasury: { decrement: 10000 },
         }),
       }),
     );
@@ -1284,7 +1298,8 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
   });
 
   it("returns 400 ApiError when treasury insufficient (cheerleader)", async () => {
-    const { teamFindFirst, selectionFindFirst } = await getMocks();
+    const { teamFindFirst, teamFindUnique, teamUpdateMany, selectionFindFirst } =
+      await getMocks();
     teamFindFirst.mockResolvedValue({
       id: "team-1",
       ownerId: "user-1",
@@ -1297,6 +1312,10 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
       players: [],
     });
     selectionFindFirst.mockResolvedValue(null);
+    // Audit round 6 : updateMany retourne count=0 si treasury insuffisante.
+    teamUpdateMany.mockResolvedValue({ count: 0 });
+    // Re-fetch pour discriminer treasury vs limite max → ici treasury bas.
+    teamFindUnique.mockResolvedValue({ cheerleaders: 0 });
 
     const req = createReq({
       params: { id: "team-1" },
@@ -1313,7 +1332,8 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
   });
 
   it("returns 400 ApiError when apothecary already hired", async () => {
-    const { teamFindFirst, selectionFindFirst } = await getMocks();
+    const { teamFindFirst, teamFindUnique, teamUpdateMany, selectionFindFirst } =
+      await getMocks();
     teamFindFirst.mockResolvedValue({
       id: "team-1",
       ownerId: "user-1",
@@ -1326,6 +1346,9 @@ describe("Route: POST /team/:id/purchase (S25.5w)", () => {
       players: [],
     });
     selectionFindFirst.mockResolvedValue(null);
+    // Audit round 6 : updateMany retourne count=0 si limite atteinte.
+    teamUpdateMany.mockResolvedValue({ count: 0 });
+    teamFindUnique.mockResolvedValue({ apothecary: true });
 
     const req = createReq({
       params: { id: "team-1" },
@@ -2135,6 +2158,7 @@ describe("Route: POST /team/:id/star-players (S25.5ab)", () => {
       mockValidate,
       mockRequiresPair,
     } = await getMocks();
+    const prismaMock = vi.mocked(await import("../prisma")).prisma;
     teamFindFirst.mockResolvedValue({
       id: "team-1",
       ownerId: "user-1",
@@ -2152,6 +2176,15 @@ describe("Route: POST /team/:id/star-players (S25.5ab)", () => {
     mockRequiresPair.mockReturnValue(null);
     starPlayerCreate.mockRejectedValue(
       Object.assign(new Error("Unique constraint failed"), { code: "P2002" }),
+    );
+    // Audit round 6 : star-player hire wrap maintenant les creates dans
+    // un $transaction([...]). On simule en attendant chaque promise.
+    (prismaMock.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (ops: any) => {
+        if (Array.isArray(ops)) return Promise.all(ops);
+        return ops(prismaMock);
+      },
     );
 
     const req = createReq({


### PR DESCRIPTION
## Summary

Audit round 6 — 2 fixes CRITICAL sur les achats team qui causaient des money-loss / illegal-state races.

### Bugs corriges

1. team-purchase-handler.ts — chaque case lisait `team.treasury` et `team.<counter>` depuis un snapshot pre-transaction, puis ecrivait des absolute values. Deux requetes concurrentes pouvaient toutes deux passer la verif et toutes deux ecrire la meme valeur stale → team paye 1x mais recoit 2x l'item, OU treasury negatif. Fix : `updateMany` avec WHERE conditionnel et data `{ decrement }`/`{ increment }` atomiques.

2. case 'player' : meme race condition. Fix : `treasury: { decrement: cost }` dans la `$transaction` existante.

3. team-star-player-hire-handler.ts : `Promise.all(creates)` lancait chaque create dans une tx independante → pairing pouvait laisser un demi-pair illegal. Fix : `prisma.$transaction([...creates])`.

## Test plan

- typecheck propre server
- team.test.ts : 98 tests pass
- server : 2807 tests pass

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_