### PR TITLE
fix(cup): drop email PII from 17 select sites in cup endpoints (round 7)

### DIFF
--- a/apps/server/src/routes/cup.ts
+++ b/apps/server/src/routes/cup.ts
@@ -85,7 +85,7 @@ router.get("/", authUser, async (req: AuthenticatedRequest, res) => {
           select: {
             id: true,
             coachName: true,
-            email: true,
+            // Audit round 7 (CRITICAL/PII) : email retire du select public.
           },
         },
         participants: {
@@ -100,7 +100,7 @@ router.get("/", authUser, async (req: AuthenticatedRequest, res) => {
                   select: {
                     id: true,
                     coachName: true,
-                    email: true,
+                    // Audit round 7 (CRITICAL/PII) : email retire du select public.
                   },
                 },
               },
@@ -182,7 +182,7 @@ router.get("/archived", authUser, async (req: AuthenticatedRequest, res) => {
           select: {
             id: true,
             coachName: true,
-            email: true,
+            // Audit round 7 (CRITICAL/PII) : email retire du select public.
           },
         },
         participants: {
@@ -197,7 +197,7 @@ router.get("/archived", authUser, async (req: AuthenticatedRequest, res) => {
                   select: {
                     id: true,
                     coachName: true,
-                    email: true,
+                    // Audit round 7 (CRITICAL/PII) : email retire du select public.
                   },
                 },
               },
@@ -318,7 +318,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
           select: {
             id: true,
             coachName: true,
-            email: true,
+            // Audit round 7 (CRITICAL/PII) : email retire du select public.
           },
         },
         participants: {
@@ -333,7 +333,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
                   select: {
                     id: true,
                     coachName: true,
-                    email: true,
+                    // Audit round 7 (CRITICAL/PII) : email retire du select public.
                   },
                 },
               },
@@ -379,7 +379,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
             select: {
               id: true,
               coachName: true,
-              email: true,
+              // Audit round 7 (CRITICAL/PII) : email retire du select public.
             },
           },
           participants: {
@@ -393,7 +393,7 @@ router.get("/:id", authUser, async (req: AuthenticatedRequest, res) => {
                     select: {
                       id: true,
                       coachName: true,
-                      email: true,
+                      // Audit round 7 (CRITICAL/PII) : email retire du select public.
                     },
                   },
                 },
@@ -624,7 +624,7 @@ router.post("/", authUser, validate(createCupSchema), async (req: AuthenticatedR
           select: {
             id: true,
             coachName: true,
-            email: true,
+            // Audit round 7 (CRITICAL/PII) : email retire du select public.
           },
         },
         participants: true,
@@ -733,7 +733,7 @@ router.post(
             select: {
               id: true,
               coachName: true,
-              email: true,
+              // Audit round 7 (CRITICAL/PII) : email retire du select public.
             },
           },
           participants: {
@@ -747,7 +747,7 @@ router.post(
                     select: {
                       id: true,
                       coachName: true,
-                      email: true,
+                      // Audit round 7 (CRITICAL/PII) : email retire du select public.
                     },
                   },
                 },
@@ -853,7 +853,7 @@ router.post(
             select: {
               id: true,
               coachName: true,
-              email: true,
+              // Audit round 7 (CRITICAL/PII) : email retire du select public.
             },
           },
           participants: {
@@ -867,7 +867,7 @@ router.post(
                     select: {
                       id: true,
                       coachName: true,
-                      email: true,
+                      // Audit round 7 (CRITICAL/PII) : email retire du select public.
                     },
                   },
                 },
@@ -948,7 +948,7 @@ router.post(
             select: {
               id: true,
               coachName: true,
-              email: true,
+              // Audit round 7 (CRITICAL/PII) : email retire du select public.
             },
           },
           participants: {
@@ -962,7 +962,7 @@ router.post(
                     select: {
                       id: true,
                       coachName: true,
-                      email: true,
+                      // Audit round 7 (CRITICAL/PII) : email retire du select public.
                     },
                   },
                 },
@@ -1060,7 +1060,7 @@ router.post(
             select: {
               id: true,
               coachName: true,
-              email: true,
+              // Audit round 7 (CRITICAL/PII) : email retire du select public.
             },
           },
           participants: {
@@ -1074,7 +1074,7 @@ router.post(
                     select: {
                       id: true,
                       coachName: true,
-                      email: true,
+                      // Audit round 7 (CRITICAL/PII) : email retire du select public.
                     },
                   },
                 },


### PR DESCRIPTION
## Summary

Audit round 7 CRITICAL — fuite PII massive sur les endpoints `/cup`.

Avant, chaque `cup.findMany` / `cup.findUnique` selectait `creator.email` et `participants.team.owner.email`, et la response formattee spreadait `creator: cup.creator` et `owner: p.team.owner` brut → emails ship a tous les clients (incluant non-friends, non-participants).

Meme pattern que les match endpoints fixed en round 6 (PR #855). **17 occurrences** `email: true` dans `cup.ts` touchant 7+ endpoints (list cups, get cup detail, list participants, brackets, etc.).

Fix : `sed -i` sur tous les `email: true` du fichier, remplaces par un commentaire d'audit. Le select retourne maintenant uniquement `{ id, coachName }` pour creator et owners.

## Test plan

- typecheck propre server + web
- server : 2807 tests pass

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_