### PR TITLE
fix: password reset TOCTOU + bounceBall recursion guard

### DIFF
--- a/apps/server/src/services/password-reset.test.ts
+++ b/apps/server/src/services/password-reset.test.ts
@@ -4,20 +4,31 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-vi.mock("../prisma", () => ({
-  prisma: {
-    user: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
+// Audit round 7 : consumeResetToken utilise maintenant updateMany
+// conditionnel WHERE usedAt: null + $transaction(cb). Mock partage les
+// mocks entre prisma top-level et le `tx` callback.
+vi.mock("../prisma", () => {
+  const user = { findUnique: vi.fn(), update: vi.fn() };
+  const passwordResetToken = {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(async () => ({ count: 1 })),
+  };
+  return {
+    prisma: {
+      user,
+      passwordResetToken,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $transaction: vi.fn(async (cb: any) => {
+        if (typeof cb === "function") {
+          return cb({ user, passwordResetToken });
+        }
+        return Promise.all(cb);
+      }),
     },
-    passwordResetToken: {
-      create: vi.fn(),
-      findUnique: vi.fn(),
-      update: vi.fn(),
-    },
-    $transaction: vi.fn(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[])),
-  },
-}));
+  };
+});
 
 vi.mock("./refresh-token-store-singleton", () => ({
   getRefreshTokenStore: () => ({
@@ -44,9 +55,20 @@ const mocked = vi.mocked(prisma, true);
 
 beforeEach(() => {
   vi.resetAllMocks();
-  mocked.$transaction.mockImplementation(async (ops: unknown[]) =>
-    Promise.all(ops as Promise<unknown>[]),
-  );
+  // Audit round 7 : $transaction accepte maintenant un callback. Mock
+  // execute le callback avec les memes prisma mocks comme `tx`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mocked.$transaction.mockImplementation(async (cb: any) => {
+    if (typeof cb === "function") {
+      return cb({
+        user: mocked.user,
+        passwordResetToken: mocked.passwordResetToken,
+      });
+    }
+    return Promise.all(cb as Promise<unknown>[]);
+  });
+  // updateMany default = count: 1 (happy path).
+  mocked.passwordResetToken.updateMany.mockResolvedValue({ count: 1 } as never);
 });
 
 describe("requestPasswordReset", () => {
@@ -252,13 +274,14 @@ describe("consumeResetToken", () => {
     });
 
     expect(result).toEqual({ userId: "u_1", email: "user@ex.com" });
-    // transaction lance user.update + token.update
+    // Audit round 7 : transaction utilise maintenant updateMany
+    // conditionnel WHERE usedAt: null pour le token, suivi de user.update.
     expect(mocked.user.update).toHaveBeenCalledWith({
       where: { id: "u_1" },
       data: expect.objectContaining({ mustChangePassword: false }),
     });
-    expect(mocked.passwordResetToken.update).toHaveBeenCalledWith({
-      where: { id: "tk_1" },
+    expect(mocked.passwordResetToken.updateMany).toHaveBeenCalledWith({
+      where: { id: "tk_1", usedAt: null },
       data: { usedAt: expect.any(Date) },
     });
   });

--- a/apps/server/src/services/password-reset.ts
+++ b/apps/server/src/services/password-reset.ts
@@ -197,16 +197,31 @@ export async function consumeResetToken(
 
   const passwordHash = await bcrypt.hash(input.newPassword, 10);
 
-  await prisma.$transaction([
-    prisma.user.update({
+  // BUG fix audit round 7 (HIGH/TOCTOU) : avant, `record.usedAt` etait
+  // check hors transaction, et l'update du token etait inconditionnel
+  // (`update({ where: { id }, data: { usedAt } })`). Deux soumissions
+  // simultanees du meme token : both check usedAt=null, both succeed,
+  // last passwordHash wins. Pire, un attaquant qui steal le token et
+  // race le user legitime peut set son propre password.
+  // Fix : updateMany conditionnel WHERE usedAt: null → un seul appel
+  // reussit. Si count === 0, throw TOKEN_USED (race detectee).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await prisma.$transaction(async (tx: any) => {
+    const tokenUpdate = await tx.passwordResetToken.updateMany({
+      where: { id: record.id, usedAt: null },
+      data: { usedAt: new Date() },
+    });
+    if (tokenUpdate.count === 0) {
+      throw new PasswordResetError(
+        "TOKEN_USED",
+        "Ce lien a deja ete utilise.",
+      );
+    }
+    await tx.user.update({
       where: { id: record.userId },
       data: { passwordHash, mustChangePassword: false },
-    }),
-    prisma.passwordResetToken.update({
-      where: { id: record.id },
-      data: { usedAt: new Date() },
-    }),
-  ]);
+    });
+  });
 
   // Revoque toutes les sessions actives — force re-login avec le
   // nouveau password. Best-effort : si la revocation echoue, le

--- a/packages/game-engine/src/mechanics/ball.ts
+++ b/packages/game-engine/src/mechanics/ball.ts
@@ -125,8 +125,55 @@ export function getRandomDirection(rng: RNG): Position {
  * @param rng - Générateur de nombres aléatoires
  * @returns Nouvel état du jeu après rebond
  */
+/**
+ * BUG fix audit round 7 (HIGH) — bounceBall avait une recursion non
+ * bornee : chaque rebond echoue → recurse, chaque No-Hands deflection
+ * → recurse. Avec une suite de No-Hands players adjacents ou une
+ * RNG pathologique, la pile pouvait deborder (stack overflow) → sim
+ * crash. Fix : convertir la recursion en boucle iterative avec un
+ * compteur d'echappement (MAX_BOUNCES). Si depasse, la balle s'arrete
+ * sur la case courante et on log un BOUNCE_TIMEOUT info entry.
+ */
+const MAX_BOUNCES = 32;
+
 export function bounceBall(state: GameState, rng: RNG): GameState {
   if (!state.ball) return state;
+
+  let workingState: GameState = state;
+  for (let iter = 0; iter < MAX_BOUNCES; iter += 1) {
+    const result = bounceBallStep(workingState, rng);
+    if (result.kind === 'final') {
+      return result.state;
+    }
+    workingState = result.state;
+  }
+  // Garde-fou : si on depasse MAX_BOUNCES (cas pathologique), on
+  // arrete la balle ou elle est et on log un avertissement.
+  const timeoutLog = createLogEntry(
+    'info',
+    `Ballon : limite de rebonds atteinte (${MAX_BOUNCES}). Balle arretee.`,
+    undefined,
+    undefined,
+    { bounceTimeout: true },
+  );
+  return {
+    ...workingState,
+    gameLog: [...workingState.gameLog, timeoutLog],
+  };
+}
+
+/**
+ * Une iteration de rebond. Retourne soit `final` (la balle s'est
+ * arretee, a ete recue, ou un TD a ete marque) — l'appelant arrete la
+ * boucle ; soit `bounce_again` avec le state intermediaire pour la
+ * prochaine iteration. Pas de recursion.
+ */
+type BounceStepResult =
+  | { kind: 'final'; state: GameState }
+  | { kind: 'bounce_again'; state: GameState };
+
+function bounceBallStep(state: GameState, rng: RNG): BounceStepResult {
+  if (!state.ball) return { kind: 'final', state };
 
   const newState = structuredClone(state) as GameState;
   const currentBallPos = { ...state.ball };
@@ -164,7 +211,7 @@ export function bounceBall(state: GameState, rng: RNG): GameState {
       );
       newState.gameLog = [...newState.gameLog, noHandsLog];
       newState.ball = newBallPos;
-      return bounceBall(newState, rng);
+      return { kind: 'bounce_again', state: newState };
     }
 
     // Le joueur doit tenter de réceptionner la balle
@@ -214,8 +261,9 @@ export function bounceBall(state: GameState, rng: RNG): GameState {
       // Si réception dans l'en-but adverse, touchdown immédiat
       const scorer = newState.players.find(p => p.id === playerAtNewPos.id)!;
       if (isInOpponentEndzone(newState, scorer)) {
-        return awardTouchdown(newState, scorer.team, scorer);
+        return { kind: 'final', state: awardTouchdown(newState, scorer.team, scorer) };
       }
+      return { kind: 'final', state: checkTouchdowns(newState) };
     } else {
       // Échec de réception : la balle continue à rebondir
       newState.ball = newBallPos;
@@ -229,8 +277,7 @@ export function bounceBall(state: GameState, rng: RNG): GameState {
       );
       newState.gameLog = [...newState.gameLog, failCatchLogEntry];
 
-      // Appel récursif pour continuer le rebond
-      return bounceBall(newState, rng);
+      return { kind: 'bounce_again', state: newState };
     }
   } else {
     // Case vide ou joueur sans Zone de Tackle : la balle s'arrête là
@@ -246,7 +293,7 @@ export function bounceBall(state: GameState, rng: RNG): GameState {
     newState.gameLog = [...newState.gameLog, stopLogEntry];
   }
 
-  return checkTouchdowns(newState);
+  return { kind: 'final', state: checkTouchdowns(newState) };
 }
 
 /**


### PR DESCRIPTION
## Summary

Audit round 7 — 2 fixes **HIGH**.

### Bugs corriges

**1. `password-reset.ts:200-209` — TOCTOU sur token reset**

Avant : `record.usedAt` etait check hors transaction, et l'update du token etait inconditionnel (`update({ where: { id }, data: { usedAt } })`). Deux soumissions simultanees du meme token : both check `usedAt=null`, both succeed, **last passwordHash wins**. Pire, un attaquant qui steal le token et race le user legitime peut set son propre password.

Fix : `updateMany` conditionnel WHERE `usedAt: null` DANS la `$transaction` → un seul appel reussit. Si `count===0`, throw `TOKEN_USED` (race detectee). `user.update` suit dans la meme tx.

**2. `ball.ts bounceBall` — stack overflow / unbounded recursion**

Avant : `bounceBall` recursait sur chaque echec de catch (ligne 233) et chaque No-Hands deflection (ligne 167). Avec une suite de No-Hands players adjacents ou une RNG pathologique, la pile pouvait **deborder → sim crash**.

Fix : convertir la recursion en boucle iterative avec un compteur `MAX_BOUNCES=32`. Si depasse, balle s'arrete sur la case courante avec un log info `bounceTimeout: true`. Extraction d'un helper `bounceBallStep` qui retourne `'final' | 'bounce_again'` au lieu de s'appeler recursivement.

## Test plan

- [x] `pnpm typecheck` propre sur server + game-engine.
- [x] `password-reset.test.ts` : mock `passwordResetToken.updateMany` + `$transaction(cb)`. **14 tests pass**.
- [x] game-engine : **5053 tests pass** (bounceBall comportement preserve via tests existants).
- [x] server : **2807 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_