### PR TITLE
fix(server): tournament entry + forceForfeit race conditions

### DIFF
--- a/apps/server/src/services/pro-season-factory.test.ts
+++ b/apps/server/src/services/pro-season-factory.test.ts
@@ -17,7 +17,12 @@ vi.mock("../prisma", () => ({
     proLeague: { findUnique: vi.fn() },
     proLeagueSeason: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
     proLeagueStandings: { updateMany: vi.fn(), createMany: vi.fn() },
-    proLeagueMatch: { findUnique: vi.fn(), update: vi.fn() },
+    proLeagueMatch: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      // Audit round 7 : forceForfeit utilise updateMany conditionnel.
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
     proTeam: { findMany: vi.fn() },
     $transaction: vi.fn(),
   },
@@ -154,17 +159,20 @@ describe("forceForfeit", () => {
       id: "m1",
       status: "scheduled",
     });
-    mocked.proLeagueMatch.update.mockResolvedValueOnce({});
+    // Audit round 7 : updateMany remplace update (optimistic-lock race).
+    mocked.proLeagueMatch.updateMany.mockResolvedValueOnce({ count: 1 });
 
     const result = await forceForfeit({ matchId: "m1", winnerSide: "home" });
 
     expect(result.previousStatus).toBe("scheduled");
-    const call = mocked.proLeagueMatch.update.mock.calls[0]![0];
+    const call = mocked.proLeagueMatch.updateMany.mock.calls[0]![0];
     expect(call.data.status).toBe("completed");
     expect(call.data.outcome).toBe("home");
     expect(call.data.scoreHome).toBe(1);
     expect(call.data.scoreAway).toBe(0);
     expect(call.data.completedAt).toBeInstanceOf(Date);
+    // WHERE filtre les matches deja completed (race guard).
+    expect(call.where).toEqual({ id: "m1", status: { not: "completed" } });
   });
 
   it("away winner : scores 0-1", async () => {
@@ -172,9 +180,9 @@ describe("forceForfeit", () => {
       id: "m1",
       status: "ready",
     });
-    mocked.proLeagueMatch.update.mockResolvedValueOnce({});
+    mocked.proLeagueMatch.updateMany.mockResolvedValueOnce({ count: 1 });
     await forceForfeit({ matchId: "m1", winnerSide: "away" });
-    const call = mocked.proLeagueMatch.update.mock.calls[0]![0];
+    const call = mocked.proLeagueMatch.updateMany.mock.calls[0]![0];
     expect(call.data.scoreHome).toBe(0);
     expect(call.data.scoreAway).toBe(1);
     expect(call.data.outcome).toBe("away");

--- a/apps/server/src/services/pro-season-factory.ts
+++ b/apps/server/src/services/pro-season-factory.ts
@@ -302,9 +302,17 @@ export async function forceForfeit(
     );
   }
 
+  // BUG fix audit round 7 (HIGH/race) : avant, read `match.status`,
+  // check, puis `update()` sequentiel hors transaction. Deux admin
+  // forfeit racing pouvaient tous deux passer le check et tous deux
+  // overwrite outcome / scoreHome / scoreAway → inversion possible
+  // (un admin set winner='home', l'autre 'away' → resultat final
+  // depend de l'ordre des writes, pas du premier admin).
+  // Fix : updateMany conditionnel WHERE status: { not: "completed" }
+  // → un seul appel reussit. Si count===0, throw MATCH_ALREADY_COMPLETED.
   const now = new Date();
-  await prisma.proLeagueMatch.update({
-    where: { id: matchId },
+  const updateResult = await prisma.proLeagueMatch.updateMany({
+    where: { id: matchId, status: { not: "completed" } },
     data: {
       status: "completed",
       outcome: winnerSide,
@@ -314,6 +322,12 @@ export async function forceForfeit(
       completedAt: now,
     },
   });
+  if (updateResult.count === 0) {
+    throw new SeasonFactoryError(
+      "MATCH_ALREADY_COMPLETED",
+      "Le match est deja completed (race condition concurrent forfeit)",
+    );
+  }
 
   return {
     matchId,

--- a/apps/server/src/services/pro-tournament-entry.test.ts
+++ b/apps/server/src/services/pro-tournament-entry.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("../prisma", () => {
+  // Audit round 7 : count maxEntries DANS la $transaction. Le `tx`
+  // mock doit aussi exposer `proTournamentEntry.count`.
   const tx = {
     proWallet: {
       findUnique: vi.fn(),
@@ -15,6 +17,7 @@ vi.mock("../prisma", () => {
     },
     proTournamentEntry: {
       create: vi.fn(),
+      count: vi.fn().mockResolvedValue(0),
     },
   };
   return {
@@ -164,7 +167,11 @@ describe("enterTournament", () => {
       status: "open",
     } as never);
     mocked.proTournamentEntry.findUnique.mockResolvedValue(null as never);
-    mocked.proTournamentEntry.count.mockResolvedValue(10 as never);
+    // Audit round 7 : le count est maintenant fait DANS la $transaction
+    // (via mocked.__tx.proTournamentEntry.count), pas sur le mock
+    // prisma top-level.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mocked as any).__tx.proTournamentEntry.count.mockResolvedValueOnce(10);
 
     await expect(enterTournament("u_1", "t_1")).rejects.toMatchObject({
       code: "TOURNAMENT_FULL",

--- a/apps/server/src/services/pro-tournament-entry.ts
+++ b/apps/server/src/services/pro-tournament-entry.ts
@@ -102,21 +102,14 @@ export async function enterTournament(
     };
   }
 
-  // Verification cap maxEntries (best-effort hors transaction ; un
-  // race condition peut creer une entry de plus, considere acceptable
-  // pour ce sink).
+  // BUG fix audit round 7 (HIGH) : avant, le count `maxEntries` etait
+  // verifie HORS transaction, puis l'entry etait creee dans une
+  // $transaction separee. Deux requetes concurrentes pouvaient toutes
+  // deux passer le check a N entries et toutes deux creer leur entry
+  // → tournament excede maxEntries de plusieurs (impact si maxEntries
+  // small, ou si payment tier important). Fix : deplacer le count
+  // dans la $transaction qui fait debit + create entry → all-or-nothing.
   const maxEntries = tournament.maxEntries as number | null;
-  if (maxEntries !== null && maxEntries !== undefined) {
-    const currentCount = await prisma.proTournamentEntry.count({
-      where: { tournamentId },
-    });
-    if (currentCount >= maxEntries) {
-      throw new TournamentError(
-        "TOURNAMENT_FULL",
-        `Tournoi complet (${maxEntries} inscrits).`,
-      );
-    }
-  }
 
   await getOrCreateWallet(userId);
 
@@ -124,6 +117,20 @@ export async function enterTournament(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result = (await prisma.$transaction(async (tx: any) => {
+    // Audit round 7 : count DANS la tx. Si depasse cap apres notre
+    // increment, on throw TOURNAMENT_FULL → la tx rollback, aucune
+    // entry creee, aucun crown debite.
+    if (maxEntries !== null && maxEntries !== undefined) {
+      const currentCount = await tx.proTournamentEntry.count({
+        where: { tournamentId },
+      });
+      if (currentCount >= maxEntries) {
+        throw new TournamentError(
+          "TOURNAMENT_FULL",
+          `Tournoi complet (${maxEntries} inscrits).`,
+        );
+      }
+    }
     const w = await tx.proWallet.findUnique({
       where: { userId },
       select: { crowns: true },


### PR DESCRIPTION
## Summary

Audit round 7 — 2 fixes **HIGH** sur les races qui pouvaient corrompre les caps ou inverser les resultats admin.

### Bugs corriges

**1. `pro-tournament-entry.ts:108-119` — TOURNAMENT_FULL race**

Avant : le check `maxEntries` count etait fait HORS transaction, puis l'entry etait creee dans une `$transaction` separee. Deux requetes concurrentes pouvaient toutes deux passer le check a N entries et toutes deux creer leur entry → **tournament excede maxEntries**.

Fix : deplacer le count DANS la `$transaction` qui fait debit + create entry → all-or-nothing. Si depasse cap apres notre check, throw `TOURNAMENT_FULL` → rollback tx, aucune entry creee, aucun crown debite.

**2. `pro-season-factory.ts:288-316 forceForfeit` — admin race**

Avant : read `match.status`, check, puis `update()` sequentiel hors transaction. **Deux admin forfeit racing** pouvaient tous deux passer le check et tous deux overwrite outcome / scoreHome / scoreAway → inversion possible.

Fix : `updateMany` conditionnel WHERE `status: { not: "completed" }` → un seul appel reussit. Si `count===0`, throw `MATCH_ALREADY_COMPLETED`.

## Test plan

- [x] `pnpm typecheck` propre.
- [x] `pro-tournament-entry.test.ts` : 8 tests pass.
- [x] `pro-season-factory.test.ts` : 23 tests pass.
- [x] Server : **2807 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_