### PR TITLE
fix(server): cron overlap guards sur les sweeps Pro League

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -75,6 +75,7 @@ import { setupSocket } from "./socket";
 import { CORS_ORIGINS } from "./config";
 import { invalidateAllMemo } from "./utils/memoize-async";
 import { serverLog, setServerLogImpl } from "./utils/server-log";
+import { runOnceAtATime } from "./utils/cron-overlap-guard";
 import { pinoServerLogImpl } from "./utils/pino-logger";
 import { requestContext } from "./middleware/requestContext";
 import { liveness, readiness } from "./utils/healthcheck";
@@ -784,7 +785,9 @@ const betSettleTickMs = Number.isFinite(betSettleTickMsEnv)
 if (!inTestBetSettleEnv && betSettleTickMs > 0) {
   void import("./services/pro-bet-settlement").then(
     ({ sweepUnsettledMarkets }) => {
-      const tick = async () => {
+      // Audit round 7 : runOnceAtATime evite que 2 sweeps concurrents
+      // re-processent les memes matchs si le tick depasse l'intervalle.
+      const tick = runOnceAtATime("pro-bet-settle", async () => {
         try {
           const out = await sweepUnsettledMarkets();
           if (out.settled > 0 || out.failed > 0) {
@@ -796,7 +799,7 @@ if (!inTestBetSettleEnv && betSettleTickMs > 0) {
           const msg = e instanceof Error ? e.message : "unknown";
           serverLog.error(`[pro-bet-settle] sweep failed: ${msg}`);
         }
-      };
+      });
       setInterval(() => {
         void tick();
       }, betSettleTickMs).unref();
@@ -864,7 +867,7 @@ const casualtyTickMs = Number.isFinite(casualtyTickMsEnv)
 if (!inTestCasualtyEnv && casualtyTickMs > 0) {
   void import("./services/pro-roster-casualties").then(
     ({ sweepMatchCasualties }) => {
-      const tick = async () => {
+      const tick = runOnceAtATime("pro-casualty", async () => {
         try {
           const out = await sweepMatchCasualties();
           if (out.processed > 0 || out.failed > 0) {
@@ -876,7 +879,7 @@ if (!inTestCasualtyEnv && casualtyTickMs > 0) {
           const msg = e instanceof Error ? e.message : "unknown";
           serverLog.error(`[pro-casualty] sweep failed: ${msg}`);
         }
-      };
+      });
       setInterval(() => {
         void tick();
       }, casualtyTickMs).unref();
@@ -903,7 +906,7 @@ const sppTickMs = Number.isFinite(sppTickMsEnv)
   : 30 * 60 * 1000;
 if (!inTestSppEnv && sppTickMs > 0) {
   void import("./services/pro-roster-spp").then(({ sweepMatchSpp }) => {
-    const tick = async () => {
+    const tick = runOnceAtATime("pro-spp", async () => {
       try {
         const out = await sweepMatchSpp();
         if (out.processed > 0 || out.failed > 0) {
@@ -915,7 +918,7 @@ if (!inTestSppEnv && sppTickMs > 0) {
         const msg = e instanceof Error ? e.message : "unknown";
         serverLog.error(`[pro-spp] sweep failed: ${msg}`);
       }
-    };
+    });
     setInterval(() => {
       void tick();
     }, sppTickMs).unref();
@@ -945,7 +948,7 @@ const levelUpTickMs = Number.isFinite(levelUpTickMsEnv)
   : 30 * 60 * 1000;
 if (!inTestLevelUpEnv && levelUpTickMs > 0) {
   void import("./services/pro-roster-level-up").then(({ sweepLevelUps }) => {
-    const tick = async () => {
+    const tick = runOnceAtATime("pro-levelup", async () => {
       try {
         const out = await sweepLevelUps();
         if (out.processed > 0 || out.failed > 0) {
@@ -957,7 +960,7 @@ if (!inTestLevelUpEnv && levelUpTickMs > 0) {
         const msg = e instanceof Error ? e.message : "unknown";
         serverLog.error(`[pro-levelup] sweep failed: ${msg}`);
       }
-    };
+    });
     setInterval(() => {
       void tick();
     }, levelUpTickMs).unref();
@@ -987,7 +990,7 @@ const tvTickMs = Number.isFinite(tvTickMsEnv)
   : 30 * 60 * 1000;
 if (!inTestTvEnv && tvTickMs > 0) {
   void import("./services/pro-roster-tv").then(({ sweepRecomputeTvs }) => {
-    const tick = async () => {
+    const tick = runOnceAtATime("pro-tv", async () => {
       try {
         const out = await sweepRecomputeTvs();
         if (out.processed > 0 || out.failed > 0) {
@@ -999,7 +1002,7 @@ if (!inTestTvEnv && tvTickMs > 0) {
         const msg = e instanceof Error ? e.message : "unknown";
         serverLog.error(`[pro-tv] sweep failed: ${msg}`);
       }
-    };
+    });
     setInterval(() => {
       void tick();
     }, tvTickMs).unref();

--- a/apps/server/src/utils/cron-overlap-guard.test.ts
+++ b/apps/server/src/utils/cron-overlap-guard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { runOnceAtATime } from "./cron-overlap-guard";
+
+vi.mock("./server-log", () => ({
+  serverLog: {
+    debug: vi.fn(),
+  },
+}));
+
+describe("runOnceAtATime — audit round 7", () => {
+  it("skip silencieusement les ticks concurrents", async () => {
+    let calls = 0;
+    let resolveTick: (() => void) | null = null;
+    const slowTick = (): Promise<void> => {
+      calls += 1;
+      return new Promise<void>((r) => {
+        resolveTick = r;
+      });
+    };
+
+    const guarded = runOnceAtATime("test", slowTick);
+
+    // Lance le premier tick — il est in-flight (running=true set sync).
+    const p1 = guarded();
+    expect(calls).toBe(1);
+    // resolveTick a ete capture lors de la 1ere invocation de slowTick.
+    expect(resolveTick).not.toBeNull();
+
+    // Lance un 2e tick pendant que le 1er est in-flight → skipped sync.
+    const p2 = guarded();
+    expect(calls).toBe(1);
+    await p2; // skip is a resolved promise
+
+    // Termine le 1er tick.
+    resolveTick!();
+    await p1;
+
+    // Apres la fin, un nouveau tick passe.
+    const p3 = guarded();
+    expect(calls).toBe(2);
+    resolveTick!();
+    await p3;
+  });
+
+  it("clear running flag meme si fn throw", async () => {
+    let calls = 0;
+    const throwingTick = async (): Promise<void> => {
+      calls += 1;
+      throw new Error("boom");
+    };
+
+    const guarded = runOnceAtATime("test-throw", throwingTick);
+
+    // Premier appel throw → le flag doit etre clear.
+    await expect(guarded()).rejects.toThrow("boom");
+    expect(calls).toBe(1);
+
+    // Le second appel passe (flag clear apres throw).
+    await expect(guarded()).rejects.toThrow("boom");
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/server/src/utils/cron-overlap-guard.ts
+++ b/apps/server/src/utils/cron-overlap-guard.ts
@@ -1,0 +1,50 @@
+/**
+ * Audit round 7 (HIGH) — helper d'overlap guard pour les cron ticks.
+ *
+ * Probleme : `setInterval(() => void tick(), tickMs)` fires sans verifier
+ * si la tick precedente est encore en cours. Si `sweepUnsettledMarkets`,
+ * `sweepMatchSpp`, etc. depassent leur intervalle (DB lente, Prisma
+ * hang), les ticks s'empilent et re-processent les memes matchs en
+ * concurrent. Le sweep idempotency aide mais reste best-effort.
+ *
+ * `runOnceAtATime(fn)` wrap une `Promise<void>` async tick et garantit
+ * qu'une seule execution est in-flight a tout moment. Si une tick est
+ * deja en cours quand l'intervalle re-fire, le skip est silencieux
+ * (log debug si serverLog passe en arg).
+ *
+ * Note : ce guard est in-process uniquement. Multi-pod deploy doit
+ * utiliser un DB-level advisory lock (Postgres pg_try_advisory_lock)
+ * en plus. Hors scope round 7 — flag pour PR ulterieur.
+ */
+
+import { serverLog } from "./server-log";
+
+export type CronTickFn = () => Promise<void>;
+
+/**
+ * Cree un wrapper d'overlap guard. Le wrapper retourne une fonction
+ * idempotente : si une tick est deja in-flight, la nouvelle invocation
+ * est skipped (logged debug).
+ *
+ * @param label Nom du tick pour les logs (e.g. "pro-bet-settle").
+ * @param fn La tick a executer.
+ * @returns Fonction wrappee a passer a `setInterval(() => void
+ *   wrapped(), tickMs)`.
+ */
+export function runOnceAtATime(label: string, fn: CronTickFn): CronTickFn {
+  let running = false;
+  return async function guardedTick(): Promise<void> {
+    if (running) {
+      serverLog.debug(
+        `[cron-overlap-guard] skip tick '${label}' (precedente toujours en cours)`,
+      );
+      return;
+    }
+    running = true;
+    try {
+      await fn();
+    } finally {
+      running = false;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Audit round 7 — **HIGH** : les ticks `setInterval` Pro League fireraient sans verifier si la tick precedente etait encore en cours. Si `sweepUnsettledMarkets` / `sweepMatchSpp` / `sweepMatchCasualties` / `sweepLevelUps` / `sweepRecomputeTvs` depassaient leur intervalle (DB lente, Prisma hang), les ticks s'empilaient et re-processaient les memes matchs en concurrent. Le sweep idempotency aide mais reste best-effort.

### Fix

- Nouveau helper `apps/server/src/utils/cron-overlap-guard.ts` :
  - `runOnceAtATime(label, fn)` wrap une tick async et garantit qu'une seule execution est in-flight a tout moment. Si une tick est deja en cours quand l'intervalle re-fire, le skip est silencieux (log debug).
- `index.ts` : wrap **5 sweep ticks** principaux avec `runOnceAtATime` :
  - `pro-bet-settle`
  - `pro-spp`
  - `pro-casualty`
  - `pro-levelup`
  - `pro-tv`

### Note operationnelle

Ce guard est in-process uniquement. Multi-pod deploy doit utiliser un DB-level advisory lock (Postgres `pg_try_advisory_lock`) en plus. Documente dans le header du module pour PR ulterieur si besoin.

## Test plan

- [x] `pnpm typecheck` propre.
- [x] `cron-overlap-guard.test.ts` : **2 tests** (skip concurrent + clear flag apres throw).
- [x] Server : **2809 tests pass** (+2 nouveaux).

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_