### PR TITLE
fix(server): friendship + kofi-claim race conditions (optimistic-lock)

### DIFF
--- a/apps/server/src/services/friendship.test.ts
+++ b/apps/server/src/services/friendship.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// Audit round 8 : respondToFriendRequest utilise maintenant updateMany
+// conditionnel WHERE { id, receiverId, status: 'pending' } + re-fetch.
 vi.mock("../prisma", () => ({
   prisma: {
     friendship: {
@@ -8,6 +10,7 @@ vi.mock("../prisma", () => ({
       findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(async () => ({ count: 1 })),
       delete: vi.fn(),
     },
     user: {
@@ -92,14 +95,11 @@ describe("Rule: Friendship service", () => {
   });
 
   describe("respondToFriendRequest", () => {
+    // Audit round 8 : la fonction utilise updateMany conditionnel.
+    // count: 1 = happy path ; count: 0 = race / authz fail.
     it("accepts a pending request addressed to the current user", async () => {
+      mockPrisma.friendship.updateMany.mockResolvedValueOnce({ count: 1 });
       mockPrisma.friendship.findUnique.mockResolvedValue({
-        id: "f-1",
-        requesterId: alice,
-        receiverId: bob,
-        status: "pending",
-      });
-      mockPrisma.friendship.update.mockResolvedValue({
         id: "f-1",
         requesterId: alice,
         receiverId: bob,
@@ -109,20 +109,15 @@ describe("Rule: Friendship service", () => {
       const result = await respondToFriendRequest("f-1", bob, "accept");
 
       expect(result.status).toBe("accepted");
-      expect(mockPrisma.friendship.update).toHaveBeenCalledWith({
-        where: { id: "f-1" },
+      expect(mockPrisma.friendship.updateMany).toHaveBeenCalledWith({
+        where: { id: "f-1", receiverId: bob, status: "pending" },
         data: { status: "accepted" },
       });
     });
 
     it("declines a pending request addressed to the current user", async () => {
+      mockPrisma.friendship.updateMany.mockResolvedValueOnce({ count: 1 });
       mockPrisma.friendship.findUnique.mockResolvedValue({
-        id: "f-1",
-        requesterId: alice,
-        receiverId: bob,
-        status: "pending",
-      });
-      mockPrisma.friendship.update.mockResolvedValue({
         id: "f-1",
         requesterId: alice,
         receiverId: bob,
@@ -135,6 +130,7 @@ describe("Rule: Friendship service", () => {
     });
 
     it("rejects if the current user is not the receiver", async () => {
+      mockPrisma.friendship.updateMany.mockResolvedValueOnce({ count: 0 });
       mockPrisma.friendship.findUnique.mockResolvedValue({
         id: "f-1",
         requesterId: alice,
@@ -145,10 +141,10 @@ describe("Rule: Friendship service", () => {
       await expect(
         respondToFriendRequest("f-1", "user-other", "accept"),
       ).rejects.toThrow(/autorise|unauthorized/i);
-      expect(mockPrisma.friendship.update).not.toHaveBeenCalled();
     });
 
     it("rejects if the request is not pending", async () => {
+      mockPrisma.friendship.updateMany.mockResolvedValueOnce({ count: 0 });
       mockPrisma.friendship.findUnique.mockResolvedValue({
         id: "f-1",
         requesterId: alice,
@@ -162,6 +158,7 @@ describe("Rule: Friendship service", () => {
     });
 
     it("rejects unknown friendship id", async () => {
+      mockPrisma.friendship.updateMany.mockResolvedValueOnce({ count: 0 });
       mockPrisma.friendship.findUnique.mockResolvedValue(null);
       await expect(
         respondToFriendRequest("missing", bob, "accept"),

--- a/apps/server/src/services/friendship.ts
+++ b/apps/server/src/services/friendship.ts
@@ -86,28 +86,53 @@ export async function respondToFriendRequest(
   currentUserId: string,
   action: FriendshipResponseAction,
 ): Promise<FriendshipRow> {
-  const friendship = await prisma.friendship.findUnique({
-    where: { id: friendshipId },
-  });
-  if (!friendship) {
-    throw new Error("Demande d'ami introuvable");
-  }
-  if (friendship.receiverId !== currentUserId) {
-    throw new Error("Non autorise a repondre a cette demande");
-  }
-  if (friendship.status !== FriendshipStatus.Pending) {
-    throw new Error("La demande n'est pas en attente (pending)");
-  }
-
   const newStatus =
     action === "accept"
       ? FriendshipStatus.Accepted
       : FriendshipStatus.Declined;
 
-  return prisma.friendship.update({
-    where: { id: friendshipId },
+  // BUG fix audit round 8 (CRITICAL/race) : avant, read `friendship`,
+  // 3 checks separes (existence, receiverId, status === Pending), puis
+  // update inconditionnel. Deux POSTs simultanes a /friends/:id/respond
+  // pouvaient tous deux passer les checks et tous deux update — last
+  // writer wins (un accept + un decline → resultat non-deterministe).
+  // Pire, un attaquant non-receveur pouvait race apres le receveur
+  // legitime puisque l'authz est verifiee sur le READ stale.
+  // Fix : updateMany avec WHERE conditionnel { id, receiverId:
+  // currentUserId, status: 'pending' } → un seul appel reussit.
+  // Si count===0, soit l'authz a echoue soit deja resolved.
+  const updateResult = await prisma.friendship.updateMany({
+    where: {
+      id: friendshipId,
+      receiverId: currentUserId,
+      status: FriendshipStatus.Pending,
+    },
     data: { status: newStatus },
   });
+  if (updateResult.count === 0) {
+    // Lookup pour discriminer entre les causes d'echec.
+    const fresh = await prisma.friendship.findUnique({
+      where: { id: friendshipId },
+    });
+    if (!fresh) {
+      throw new Error("Demande d'ami introuvable");
+    }
+    if (fresh.receiverId !== currentUserId) {
+      throw new Error("Non autorise a repondre a cette demande");
+    }
+    // Doit etre deja resolved (race detectee).
+    throw new Error("La demande n'est pas en attente (pending)");
+  }
+
+  // Re-fetch pour retourner la version courante (Prisma updateMany ne
+  // renvoie pas la row).
+  const updated = await prisma.friendship.findUnique({
+    where: { id: friendshipId },
+  });
+  if (!updated) {
+    throw new Error("Demande d'ami introuvable (post-update)");
+  }
+  return updated;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/src/services/kofi-claim.test.ts
+++ b/apps/server/src/services/kofi-claim.test.ts
@@ -109,8 +109,14 @@ describe("Rule: kofi claim service", () => {
       );
 
       expect(result).toEqual({ claimed: 2 });
+      // Audit round 8 : WHERE inclut maintenant `userId: null, email`
+      // pour eviter le hijack d'orphan deja claimed par un autre login.
       expect(mockPrisma.kofiTransaction.updateMany).toHaveBeenCalledWith({
-        where: { id: { in: ["tx-1", "tx-2"] } },
+        where: {
+          id: { in: ["tx-1", "tx-2"] },
+          userId: null,
+          email: "jane@example.com",
+        },
         data: { userId: "user-1", matchedVia: "email" },
       });
 

--- a/apps/server/src/services/kofi-claim.ts
+++ b/apps/server/src/services/kofi-claim.ts
@@ -51,22 +51,33 @@ export async function claimOrphanKofiTransactions(
   const email = normaliseEmail(userEmail);
   if (!email) return { claimed: 0 };
 
-  const orphans = await prisma.kofiTransaction.findMany({
-    where: { userId: null, email },
-    select: { id: true },
-  });
-
-  if (orphans.length === 0) {
-    return { claimed: 0 };
-  }
-
-  const orphanIds = orphans.map((o: { id: string }) => o.id);
-
+  // BUG fix audit round 8 (CRITICAL/race) : avant, le `findMany`
+  // orphan etait fait HORS transaction, puis `updateMany({ id: { in } })`
+  // sans filter `userId: null`. Si deux logins concurrents pour le
+  // meme email (e.g. account-merge case, ou admin re-assignment), le
+  // 2e claim pouvait re-assigner les memes tx (qui appartiennent deja
+  // au 1er user) → supporter state mis-attributed.
+  // Fix : tout dans la $transaction, et updateMany WHERE conditionnel
+  // `{ userId: null, email }` → garantit qu'on ne touche que les vrais
+  // orphans au moment du commit.
+  let claimed = 0;
   await prisma.$transaction(async (tx: typeof prisma) => {
-    await tx.kofiTransaction.updateMany({
-      where: { id: { in: orphanIds } },
+    // Audit round 8 : findMany DANS la tx pour cohérence.
+    const orphans = await tx.kofiTransaction.findMany({
+      where: { userId: null, email },
+      select: { id: true },
+    });
+    if (orphans.length === 0) return;
+    const orphanIds = orphans.map((o: { id: string }) => o.id);
+
+    // WHERE conditionnel : userId: null + email pour re-verifier que
+    // les rows ne sont pas deja claimed par un autre login concurrent.
+    const updateResult = await tx.kofiTransaction.updateMany({
+      where: { id: { in: orphanIds }, userId: null, email },
       data: { userId, matchedVia: "email" },
     });
+    claimed = updateResult.count;
+    if (claimed === 0) return;
 
     // Recompute supporter state from ALL transactions (fresh + past).
     const allTx = await tx.kofiTransaction.findMany({
@@ -93,5 +104,5 @@ export async function claimOrphanKofiTransactions(
     });
   });
 
-  return { claimed: orphans.length };
+  return { claimed };
 }


### PR DESCRIPTION
## Summary

Audit round 8 — 2 fixes **CRITICAL** sur des read-then-write outside-tx qui permettaient des races dangereuses.

### Bugs corriges

**1. `friendship.ts:84-111 respondToFriendRequest` — accept/decline race + auth bypass**

Avant : read `friendship`, 3 checks separes (existence, receiverId, status), puis `update` inconditionnel. Deux POSTs simultanes pouvaient tous deux passer les checks et tous deux update — last writer wins (accept + decline → non-deterministe). Pire, un attaquant **non-receveur** pouvait race apres le receveur legitime puisque l'authz etait verifiee sur le READ stale.

Fix : `updateMany` avec WHERE conditionnel `{ id, receiverId: currentUserId, status: 'pending' }` → un seul appel reussit. Si `count===0`, re-fetch pour discriminer entre les causes d'echec.

**2. `kofi-claim.ts:54-94 claimOrphanKofiTransactions` — orphan tx hijacking**

Avant : le `findMany` orphans etait fait HORS transaction, puis `updateMany({ id: { in: orphanIds } })` **SANS filter `userId: null`**. Deux logins concurrents pour le meme email (account-merge case, ou admin re-assignment) pouvaient tous deux re-assigner les memes tx → 2e clobber le 1er user → **supporter state mis-attributed**.

Fix : `findMany` DANS la `$transaction` + `updateMany` WHERE conditionnel `{ id: { in }, userId: null, email }` pour re-verifier la non-appartenance au moment du commit. `claimed = updateResult.count` reflete les rows vraiment touchees.

## Test plan

- [x] `pnpm typecheck` propre.
- [x] `friendship.test.ts` : 22 tests pass (tests ajustes pour `updateMany` + branchement `count===0`).
- [x] `kofi-claim.test.ts` : 6 tests pass (assertion WHERE elargi).
- [x] Server : **2809 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_