### PR TITLE
fix: leap type + season factory guards (reset + cancel races)

### DIFF
--- a/apps/server/src/services/pro-season-factory.test.ts
+++ b/apps/server/src/services/pro-season-factory.test.ts
@@ -75,7 +75,7 @@ describe("resetStandings", () => {
   it("zero out tous les standings de la saison", async () => {
     mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
       id: "s1",
-      status: "in_progress",
+      status: "scheduled", // Audit round 8 : in_progress + matchs completed = refuse.
     });
     mocked.proLeagueStandings.updateMany.mockResolvedValueOnce({ count: 16 });
 
@@ -87,6 +87,20 @@ describe("resetStandings", () => {
     expect(call.data.played).toBe(0);
     expect(call.data.points).toBe(0);
     expect(call.data.form).toEqual([]);
+  });
+
+  it("audit round 8 — SEASON_HAS_RESULTS si in_progress avec matchs completed", async () => {
+    mocked.proLeagueSeason.findUnique.mockResolvedValueOnce({
+      id: "s1",
+      status: "in_progress",
+    });
+    // Mock proLeagueMatch.count : 5 matchs deja completed → reset refuse.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mocked as any).proLeagueMatch.count = vi.fn().mockResolvedValueOnce(5);
+    await expect(resetStandings("s1")).rejects.toMatchObject({
+      code: "SEASON_HAS_RESULTS",
+    });
+    expect(mocked.proLeagueStandings.updateMany).not.toHaveBeenCalled();
   });
 
   it("SEASON_NOT_FOUND si saison inexistante", async () => {
@@ -114,13 +128,19 @@ describe("cancelSeason", () => {
       id: "s1",
       status: "in_progress",
     });
-    mocked.proLeagueSeason.update.mockResolvedValueOnce({});
+    // Audit round 8 : updateMany conditionnel WHERE status not in
+    // [archived, cancelled]. count: 1 = happy path.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mocked as any).proLeagueSeason.updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 });
 
     const result = await cancelSeason("s1");
 
     expect(result).toEqual({ seasonId: "s1", previousStatus: "in_progress" });
-    expect(mocked.proLeagueSeason.update).toHaveBeenCalledWith({
-      where: { id: "s1" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mocked as any).proLeagueSeason.updateMany).toHaveBeenCalledWith({
+      where: { id: "s1", status: { notIn: ["archived", "cancelled"] } },
       data: { status: "cancelled" },
     });
   });

--- a/apps/server/src/services/pro-season-factory.ts
+++ b/apps/server/src/services/pro-season-factory.ts
@@ -184,6 +184,22 @@ export async function resetStandings(
       "Impossible de reset une saison archivee",
     );
   }
+  // BUG fix audit round 8 (HIGH) : avant, seul `archived` etait refuse.
+  // Un admin click accidentel sur "reset" pendant un season `in_progress`
+  // (matches deja completed) wipait les standings live → impact direct
+  // sur le classement public. Refuse si au moins 1 match completed
+  // sauf si la saison n'a jamais demarre (status='scheduled').
+  if (season.status === "in_progress") {
+    const completedCount = await prisma.proLeagueMatch.count({
+      where: { seasonId, status: "completed" },
+    });
+    if (completedCount > 0) {
+      throw new SeasonFactoryError(
+        "SEASON_HAS_RESULTS",
+        `Saison en cours avec ${completedCount} matchs completed — reset refuse pour eviter une perte de donnees. Cancel la saison d'abord.`,
+      );
+    }
+  }
 
   const result = await prisma.proLeagueStandings.updateMany({
     where: { seasonId },
@@ -240,8 +256,16 @@ export async function cancelSeason(
 
   const previousStatus = season.status;
   if (previousStatus !== "cancelled") {
-    await prisma.proLeagueSeason.update({
-      where: { id: seasonId },
+    // BUG fix audit round 8 (HIGH/race) : avant, read `season.status`,
+    // branch, puis `update()` inconditionnel. Un autre admin pouvant
+    // archive la saison entre read et write → cancel ecrase l'archive.
+    // Fix : updateMany WHERE conditionnel `status: { notIn: [archived,
+    // cancelled] }` → no-op si la saison est dans un etat protege.
+    await prisma.proLeagueSeason.updateMany({
+      where: {
+        id: seasonId,
+        status: { notIn: ["archived", "cancelled"] },
+      },
       data: { status: "cancelled" },
     });
   }

--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -376,7 +376,7 @@ export interface DiceResult {
   // Lot audit round 4 : ajout 'gfi' (Going For It) qui etait abusivement
   // taggue 'dodge' as never dans move-handlers.ts. Le UI peut maintenant
   // discriminer GFI vs dodge pour des messages corrects.
-  type: 'dodge' | 'pickup' | 'pass' | 'catch' | 'armor' | 'block' | 'landing' | 'gaze' | 'vomit' | 'gfi';
+  type: 'dodge' | 'pickup' | 'pass' | 'catch' | 'armor' | 'block' | 'landing' | 'gaze' | 'vomit' | 'gfi' | 'leap';
   playerId: string;
   diceRoll: number;
   targetNumber: number;

--- a/packages/game-engine/src/mechanics/leap.ts
+++ b/packages/game-engine/src/mechanics/leap.ts
@@ -68,7 +68,10 @@ export function performLeapRoll(
   const success = diceRoll !== 1 && (diceRoll === 6 || diceRoll >= targetNumber);
 
   return {
-    type: 'dodge',
+    // BUG fix audit round 8 (HIGH) : avant, `type: 'dodge'` polluait
+    // les stats dodge (histogrammes, achievements, leaderboards).
+    // Aligne avec le fix similaire 'gfi' du round 4.
+    type: 'leap',
     playerId: player.id,
     diceRoll,
     targetNumber,


### PR DESCRIPTION
## Summary

Audit round 8 — 3 fixes **HIGH**.

### Bugs corriges

**1. `game-engine leap.ts:71` — type 'dodge' pollue les stats**

Avant : `type: 'dodge'` faisait que Leap rolls etaient categorises en dodge (histogrammes, achievements, leaderboards). Meme classe de bug que GFI au round 4.

Fix : ajout `'leap'` au type union `DiceResult.type` + retour `'leap'` dans `leap.ts`.

**2. `pro-season-factory.ts resetStandings` — wipe live standings**

Avant : seul `archived` etait refuse. Un admin click accidentel sur "reset" pendant un season `in_progress` (matchs completed) **wipait les standings live** → impact direct sur le classement public.

Fix : si `status === in_progress` ET au moins 1 match completed, throw `SEASON_HAS_RESULTS`. Force l'admin a cancel la saison d'abord.

**3. `pro-season-factory.ts cancelSeason` — race avec archive**

Avant : read `season.status`, branch, puis `update()` inconditionnel. Un autre admin pouvant archive la saison entre read et write → cancel ecrase l'archive.

Fix : `updateMany` WHERE conditionnel `status: { notIn: ["archived", "cancelled"] }` → no-op si la saison est dans un etat protege.

## Test plan

- [x] `pnpm typecheck` propre sur game-engine + server.
- [x] `pro-season-factory.test.ts` : **1 nouveau test** + test cancel ajuste. **24 tests pass**.
- [x] game-engine : **5053 tests pass**.
- [x] server : **2810 tests pass**.

https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_