### PR TITLE
fix(perf): single-flight lock sur getCareerSnapshot (thunder-herd)

### DIFF
--- a/apps/server/src/services/pro-player-career-stats.test.ts
+++ b/apps/server/src/services/pro-player-career-stats.test.ts
@@ -544,6 +544,46 @@ describe("getCareerSnapshot", () => {
     expect(snap.topNemesisIds).toEqual(["n1"]);
     expect(snap.topVictoryIds).toEqual(["v1"]);
   });
+
+  // Audit round 9 (HIGH/perf) : single-flight lock contre la thunder-herd.
+  it("partage la promesse de recompute entre N appels concurrents pour le meme playerId", async () => {
+    // Snapshot stale ou absent → 2 appels concurrents devraient partager
+    // le meme recompute (un seul upsert, pas N).
+    mockedPrisma.proPlayerCareerSnapshot.findUnique.mockResolvedValue(null);
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValue({
+      teamId: "team-A",
+    });
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValue([]);
+    mockedPrisma.proPlayerCareerSnapshot.upsert.mockResolvedValue({});
+
+    const [s1, s2, s3] = await Promise.all([
+      getCareerSnapshot("p-thunder"),
+      getCareerSnapshot("p-thunder"),
+      getCareerSnapshot("p-thunder"),
+    ]);
+
+    expect(s1.playerId).toBe("p-thunder");
+    expect(s2.playerId).toBe("p-thunder");
+    expect(s3.playerId).toBe("p-thunder");
+    // 3 appels concurrents → 1 seul recompute partage.
+    expect(mockedPrisma.proPlayerCareerSnapshot.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-cree un recompute apres completion (lock libere en .finally)", async () => {
+    mockedPrisma.proPlayerCareerSnapshot.findUnique.mockResolvedValue(null);
+    mockedPrisma.proTeamRoster.findUnique.mockResolvedValue({
+      teamId: "team-A",
+    });
+    mockedPrisma.proLeagueMatch.findMany.mockResolvedValue([]);
+    mockedPrisma.proPlayerCareerSnapshot.upsert.mockResolvedValue({});
+
+    await getCareerSnapshot("p-seq");
+    await getCareerSnapshot("p-seq");
+
+    // 2 appels sequentiels (pas concurrents) → lock libere apres le 1er
+    // → 2 recomputes distincts.
+    expect(mockedPrisma.proPlayerCareerSnapshot.upsert).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("topOpponents", () => {

--- a/apps/server/src/services/pro-player-career-stats.ts
+++ b/apps/server/src/services/pro-player-career-stats.ts
@@ -459,7 +459,22 @@ export async function recomputeCareerSnapshot(
 /**
  * Retourne le snapshot. Si manquant ou stale (recomputedAt >
  * STALE_WINDOW_MS), declenche un recompute synchrone.
+ *
+ * Audit round 9 (HIGH/perf) : single-flight lock in-process pour eviter
+ * la thunder-herd au moment ou la TTL expire. Sans cela, N requetes
+ * concurrentes pour le meme `playerId` declenchent N
+ * `recomputeCareerSnapshot` (scan replays + attributeSpp + upsert),
+ * saturent le pool DB et upsertent en concurrent. Le lock par `playerId`
+ * partage la promesse de recompute entre les appelants concurrents ; le
+ * gagnant fait le travail, les autres attendent le meme resultat. Reset
+ * automatique sur completion / failure via `.finally`.
+ *
+ * Limite : in-process uniquement (par worker Node). Multi-replica n'est
+ * pas couvert — acceptable car le pire cas est N recomputes par worker
+ * et la finalite (upsert idempotent) reste correcte.
  */
+const inflightRecomputes = new Map<string, Promise<CareerSnapshotData>>();
+
 export async function getCareerSnapshot(
   playerId: string,
 ): Promise<CareerSnapshotData> {
@@ -494,7 +509,15 @@ export async function getCareerSnapshot(
     Date.now() - new Date(existing.recomputedAt).getTime() >= STALE_WINDOW_MS;
 
   if (isStale) {
-    return recomputeCareerSnapshot(playerId);
+    const inflight = inflightRecomputes.get(playerId);
+    if (inflight) {
+      return inflight;
+    }
+    const promise = recomputeCareerSnapshot(playerId).finally(() => {
+      inflightRecomputes.delete(playerId);
+    });
+    inflightRecomputes.set(playerId, promise);
+    return promise;
   }
 
   return {


### PR DESCRIPTION
## Summary

Audit round 9 (HIGH/perf) — `getCareerSnapshot` single-flight lock contre thunder-herd.

Quand la TTL du snapshot expire et que N requetes concurrentes arrivent pour le meme `playerId`, chaque appel declenche un `recomputeCareerSnapshot` complet (scan replays + `attributeSpp` + upsert). Sur une page detail joueur populaire, ca peut saturer le pool DB et faire des upserts concurrents.

Fix : `Map<playerId, Promise>` in-process. Le premier appelant lance le recompute ; les suivants attendent la meme promesse. Lock libere en `.finally`.

**Limite documentee** : single-flight in-process uniquement (par worker Node). Multi-replica → N recomputes par worker au pire, et l'upsert est idempotent donc la finalite reste correcte.

## Test plan

- [x] 3 appels concurrents partagent 1 seul recompute (upsert called once)
- [x] 2 appels sequentiels → 2 recomputes distincts (lock libere via `.finally`)
- [x] 52/52 `pro-player-career-stats.test.ts`
- [x] server typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_