### PR TITLE
fix(security): forgot-password origin allowlist + metrics auth + join code CSPRNG

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import compression from "compression";
 import bodyParser from "body-parser";
 import { createServer } from "node:http";
+import { timingSafeEqual } from "node:crypto";
 import authRoutes from "./routes/auth";
 import authPrivacyRoutes from "./routes/auth-privacy";
 import authRefreshRoutes from "./routes/auth-refresh";
@@ -174,8 +175,32 @@ app.get("/health/pro-league", async (_req, res) => {
 
 // Endpoint Prometheus (S25.3). Format texte standard, scrape par
 // Prometheus qui le pousse ensuite vers Grafana LGTM.
-app.get("/metrics", async (_req, res, next) => {
+//
+// Audit round 10 (HIGH) : avant, /metrics etait publiquement reachable
+// sans auth. Permettait de fingerprint la version Node (CVE targeting),
+// le heap, les connexions WS actives, la profondeur de la queue
+// matchmaking. Maintenant : bearer token via env `METRICS_BEARER_TOKEN`.
+// Si la variable n'est pas definie, le endpoint reste accessible
+// (compat dev local) ; en prod un missing token doit etre traite
+// comme misconfig deployment.
+app.get("/metrics", async (req, res, next) => {
   try {
+    const expectedToken = process.env.METRICS_BEARER_TOKEN;
+    if (expectedToken) {
+      const auth = req.header("authorization") || "";
+      const provided = auth.startsWith("Bearer ")
+        ? auth.slice(7).trim()
+        : "";
+      const expectedBuf = Buffer.from(expectedToken, "utf8");
+      const providedBuf = Buffer.from(provided, "utf8");
+      const ok =
+        expectedBuf.length === providedBuf.length &&
+        timingSafeEqual(expectedBuf, providedBuf);
+      if (!ok) {
+        res.status(401).type("text/plain").send("Unauthorized");
+        return;
+      }
+    }
     const body = await metricsExposition(appMetrics.registry);
     res.setHeader("Content-Type", appMetrics.registry.contentType);
     res.send(body);

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -23,6 +23,7 @@ import {
 } from "../services/kofi-claim";
 import { isSupporter } from "../services/kofi";
 import { serverLog } from "../utils/server-log";
+import { CORS_ORIGINS } from "../config";
 import { redactEmail, userTag } from "../utils/redact";
 import {
   REFRESH_TOKEN_TTL_SECONDS,
@@ -332,13 +333,20 @@ router.post(
   async (req: Request, res: Response) => {
     try {
       const { email } = req.body as { email: string };
-      // Lit l'origin depuis le header (X-Forwarded-Host / Origin) en
-      // fallback vers l'env publique. Cap a 256 chars pour eviter un
-      // injection log.
+      // Audit round 10 (HIGH) : avant, on lisait `req.get("Origin")`
+      // brut. Un attaquant pouvait POST avec `Origin: https://evil.com`
+      // pour fabriquer un lien malveillant integre dans l'email de
+      // reset (ou dans les logs serveur). Maintenant on valide le
+      // header contre `CORS_ORIGINS` ; si absent ou invalide, fallback
+      // sur `FRONTEND_PUBLIC_URL` puis sur le defaut prod.
+      const rawOrigin = (req.get("Origin") || "").toString().slice(0, 256);
+      const allowedOrigin = CORS_ORIGINS.includes(rawOrigin)
+        ? rawOrigin
+        : null;
       const origin =
-        (req.get("Origin") || process.env.FRONTEND_PUBLIC_URL || "")
-          .toString()
-          .slice(0, 256) || "https://nufflearena.fr";
+        allowedOrigin ||
+        process.env.FRONTEND_PUBLIC_URL ||
+        "https://nufflearena.fr";
       const ip =
         (req.headers["x-forwarded-for"] as string | undefined)
           ?.split(",")[0]

--- a/apps/server/src/routes/pro-league.ts
+++ b/apps/server/src/routes/pro-league.ts
@@ -28,6 +28,7 @@ import { Router, type Request, type Response } from "express";
 import type { MatchEvent } from "@bb/sim-engine";
 
 import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
+import { adminOnly } from "../middleware/adminOnly";
 import {
   BetValidationError,
   MarketNotFoundError,
@@ -1515,7 +1516,13 @@ router.post(
   handleEnterTournament,
 );
 
-router.get("/_internal/broadcaster-stats", handleBroadcasterStats);
+// Audit round 10 (MEDIUM/sec) : avant, /_internal/broadcaster-stats
+// etait publiquement reachable malgre son nom `_internal`. Le handler
+// ne leak rien de sensible aujourd'hui (counts d'agregats) mais la
+// convention `_internal` signale "internal-only" — futur ajout de
+// champs sensibles risquerait d'etre expose en prod. Fix : authUser
+// + adminOnly comme pour le namespace /admin/.
+router.get("/_internal/broadcaster-stats", authUser, adminOnly, handleBroadcasterStats);
 
 // Sprint 1.C.4 — endpoints auth-protected pour le mode "fan".
 router.post("/teams/:slug/follow", authUser, handleFollowTeam);

--- a/apps/server/src/services/password-reset.ts
+++ b/apps/server/src/services/password-reset.ts
@@ -124,17 +124,26 @@ export async function requestPasswordReset(
   });
 
   const link = `${input.origin}/reset-password?token=${tokenPlain}`;
+  // Audit round 10 (HIGH) : avant, on loggait `link` complet (donc le
+  // token plain) en prod. Un attaquant qui POST forgot-password avec
+  // `Origin: https://evil.com` pour l'email d'une victime laissait
+  // dans les logs un lien `evil.com/reset-password?token=<live>`.
+  // N'importe qui avec acces aux logs (scraper Loki/Datadog mal
+  // configure, support reading prod logs) pouvait recuperer un token
+  // exploitable pendant son TTL.
+  // Fix : en prod on log uniquement les metadata (tokenId, expiresAt) ;
+  // le link n'est conserve qu'en dev pour faciliter le debug.
+  const isProd = process.env.NODE_ENV === "production";
   serverLog.info("[password-reset] link generated", {
     event: "auth.password_reset.requested",
     userId: user.id,
     tokenId: persisted.id,
     expiresAt: expiresAt.toISOString(),
-    // Le link contient le token plain — visible UNIQUEMENT cote logs
-    // serveur. Ne pas le retourner via response API en prod.
-    link,
+    // En prod : pas de link (contient le token plain + un origin
+    // potentiellement attacker-controlled). En dev : link complet.
+    link: isProd ? undefined : link,
   });
 
-  const isProd = process.env.NODE_ENV === "production";
   return {
     requested: true,
     devLink: isProd ? null : link,

--- a/apps/server/src/services/pro-prediction-leagues.ts
+++ b/apps/server/src/services/pro-prediction-leagues.ts
@@ -13,6 +13,7 @@
  * ProPredictionPick. Erreurs typees via `PredictionLeagueError`.
  */
 
+import { randomInt } from "node:crypto";
 import { prisma } from "../prisma";
 
 export type PredictionLeagueErrorCode =
@@ -40,7 +41,20 @@ const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // sans 0/O/1/I
 const JOIN_CODE_LENGTH = 8;
 const MAX_GENERATION_RETRIES = 5;
 
-export function generateJoinCode(rng: () => number = Math.random): string {
+/**
+ * Audit round 10 (MEDIUM/sec) : avant, on utilisait `Math.random()`
+ * pour generer les join codes. PRNG non-CSPRNG → un attaquant peut
+ * brute-forcer les codes de ligues privees a ~6000 tentatives/min IP
+ * (le rate-limiter global est 100 req/min mais on peut tourner sur
+ * plusieurs IP). 8 chars * 32-alphabet = 2^40 valeurs nominales.
+ *
+ * Fix : `crypto.randomInt` (CSPRNG). Le parametre `rng` reste pour
+ * permettre l'injection deterministe en tests, mais en prod on
+ * delegue toujours a `randomInt`.
+ */
+export function generateJoinCode(
+  rng: () => number = () => randomInt(0, JOIN_CODE_ALPHABET.length) / JOIN_CODE_ALPHABET.length,
+): string {
   let code = "";
   for (let i = 0; i < JOIN_CODE_LENGTH; i += 1) {
     code += JOIN_CODE_ALPHABET[Math.floor(rng() * JOIN_CODE_ALPHABET.length)];


### PR DESCRIPTION
## Summary

Audit round 10 — 4 security fixes regroupes :

**1. HIGH/leak — Reset token logged with attacker-controlled origin**
`apps/server/src/routes/auth.ts` + `services/password-reset.ts`. Avant : `req.get("Origin")` lu brut sans allowlist, puis le `link` complet (token plain) etait log via `serverLog.info`. Un POST `/auth/forgot-password` avec `Origin: https://evil.com` laissait `evil.com/reset-password?token=<live>` dans les logs.

Fix : (a) valide l'Origin contre `CORS_ORIGINS` ; fallback `FRONTEND_PUBLIC_URL` puis defaut prod. (b) En prod, ne log plus `link` ; uniquement les metadata.

**2. HIGH/exposure — `/metrics` Prometheus endpoint sans auth**
`apps/server/src/index.ts`. Permettait fingerprint Node version (CVE targeting), heap, connexions WS, queue matchmaking. Fix : bearer token `METRICS_BEARER_TOKEN` + `timingSafeEqual`. Si var non definie → ouvert (compat dev local).

**3. MEDIUM/sec — `Math.random()` join codes pour mini-ligues privees**
`apps/server/src/services/pro-prediction-leagues.ts`. 8 chars * 32-alphabet = 2^40 via PRNG non-CSPRNG → brute-force facilite multi-IP. Fix : `crypto.randomInt`.

**4. MEDIUM/sec — `/_internal/broadcaster-stats` sans auth**
`apps/server/src/routes/pro-league.ts`. Fix : `authUser + adminOnly`.

## Test plan

- [x] 145/145 sur auth/auth-privacy/auth-refresh/admin-password-reset
- [x] 53/53 sur pro-prediction-leagues
- [x] server typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_