### PR TITLE
fix(engine): Brilliant Coaching kickoff event adds assistant coaches

### DIFF
--- a/packages/game-engine/src/core/types.ts
+++ b/packages/game-engine/src/core/types.ts
@@ -253,6 +253,13 @@ export interface GameState {
   fanAttendance?: number;
   // Dedicated fans par équipe (préservés depuis pré-match pour calcul post-match)
   dedicatedFans?: { teamA: number; teamB: number };
+  // Audit round 10 (HIGH/regle BB3) : assistant coaches par equipe,
+  // utilises au kickoff event 'brilliant-coaching' : chaque coach jette
+  // 1D3 + son nombre d'assistant coaches ; le plus haut total gagne une
+  // relance d'equipe. Avant ce champ, seul le D3 etait compare → une
+  // equipe avec 6 assistant coaches devrait quasi toujours gagner mais
+  // gagnait 50/50. Optionnel pour back-compat ; defaut 0 par equipe.
+  assistantCoaches?: { teamA: number; teamB: number };
   // Résultats finaux (rempli en fin de match)
   matchResult?: {
     winner?: TeamId;

--- a/packages/game-engine/src/mechanics/kickoff-events.test.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.test.ts
@@ -145,6 +145,65 @@ describe('Kickoff Events', () => {
       });
     });
 
+    describe('audit round 10 — Brilliant Coaching adds assistant coaches', () => {
+      const brilliantCoachingEvent = KICKOFF_EVENTS[7];
+
+      it('adds assistantCoaches to D3 roll for each team', () => {
+        // teamA: D3 (1-3) + 5 coaches = score 6-8.
+        // teamB: D3 (1-3) + 1 coach  = score 2-4.
+        // teamA should ALWAYS win.
+        const state = {
+          ...setup(),
+          assistantCoaches: { teamA: 5, teamB: 1 },
+        };
+        let teamAWins = 0;
+        for (let i = 0; i < 20; i++) {
+          const rng = makeRNG(`brilliant-coaching-A-${i}`);
+          const result = applyKickoffEvent(state, brilliantCoachingEvent, rng, 'A');
+          if (result.teamRerolls.teamA > state.teamRerolls.teamA) {
+            teamAWins++;
+          }
+        }
+        expect(teamAWins).toBe(20);
+      });
+
+      it('works when assistantCoaches is undefined (defaults to 0)', () => {
+        const state = setup(); // no assistantCoaches
+        const rng = makeRNG('brilliant-no-coaches');
+        const result = applyKickoffEvent(state, brilliantCoachingEvent, rng, 'A');
+        expect(result.gameLog.length).toBeGreaterThan(state.gameLog.length);
+      });
+
+      it('grants reroll to teamB when teamB has higher assistant coaches', () => {
+        const state = {
+          ...setup(),
+          assistantCoaches: { teamA: 1, teamB: 5 },
+        };
+        let teamBWins = 0;
+        for (let i = 0; i < 10; i++) {
+          const rng = makeRNG(`brilliant-coaching-B-${i}`);
+          const result = applyKickoffEvent(state, brilliantCoachingEvent, rng, 'A');
+          if (result.teamRerolls.teamB > state.teamRerolls.teamB) {
+            teamBWins++;
+          }
+        }
+        expect(teamBWins).toBe(10);
+      });
+
+      it('includes assistant coaches in log message', () => {
+        const state = {
+          ...setup(),
+          assistantCoaches: { teamA: 3, teamB: 1 },
+        };
+        const rng = makeRNG('brilliant-coaching-log');
+        const result = applyKickoffEvent(state, brilliantCoachingEvent, rng, 'A');
+        const lastLogs = result.gameLog.slice(state.gameLog.length);
+        const actionLog = lastLogs.find(l => l.type === 'action');
+        expect(actionLog).toBeDefined();
+        expect(actionLog!.message).toMatch(/D3.*\+.*coach/i);
+      });
+    });
+
     describe('audit round 5 — changing-weather re-roll', () => {
       const changingWeatherEvent = KICKOFF_EVENTS[8];
 

--- a/packages/game-engine/src/mechanics/kickoff-events.ts
+++ b/packages/game-engine/src/mechanics/kickoff-events.ts
@@ -188,18 +188,28 @@ export function applyKickoffEvent(
     }
 
     case 'brilliant-coaching': {
+      // Audit round 10 (HIGH/regle BB3) : la regle BB3 dit
+      // "Each coach rolls a D3 and adds the number of Assistant
+      // Coaches they have. The team with the highest total gains
+      // an extra Team Re-roll." Avant ce fix, seul le D3 brut etait
+      // compare — une equipe avec 6 assistant coaches gagnait 50/50.
+      // Pattern aligne sur 'cheering-fans' qui ajoute dedicatedFans.
       const d3A = Math.floor(rng() * 3) + 1;
       const d3B = Math.floor(rng() * 3) + 1;
-      if (d3A > d3B) {
+      const acA = newState.assistantCoaches?.teamA ?? 0;
+      const acB = newState.assistantCoaches?.teamB ?? 0;
+      const scoreA = d3A + acA;
+      const scoreB = d3B + acB;
+      if (scoreA > scoreB) {
         newState.teamRerolls = { ...newState.teamRerolls, teamA: (newState.teamRerolls?.teamA ?? 0) + 1 };
-        const log = createLogEntry('action', `Coaching brillant : ${newState.teamNames.teamA} gagne 1 relance`);
+        const log = createLogEntry('action', `Coaching brillant : ${newState.teamNames.teamA} gagne 1 relance (D3:${d3A} + ${acA} coachs = ${scoreA} vs D3:${d3B} + ${acB} coachs = ${scoreB})`);
         newState.gameLog = [...newState.gameLog, log];
-      } else if (d3B > d3A) {
+      } else if (scoreB > scoreA) {
         newState.teamRerolls = { ...newState.teamRerolls, teamB: (newState.teamRerolls?.teamB ?? 0) + 1 };
-        const log = createLogEntry('action', `Coaching brillant : ${newState.teamNames.teamB} gagne 1 relance`);
+        const log = createLogEntry('action', `Coaching brillant : ${newState.teamNames.teamB} gagne 1 relance (D3:${d3B} + ${acB} coachs = ${scoreB} vs D3:${d3A} + ${acA} coachs = ${scoreA})`);
         newState.gameLog = [...newState.gameLog, log];
       } else {
-        const log = createLogEntry('action', 'Coaching brillant : égalité, pas de relance');
+        const log = createLogEntry('action', `Coaching brillant : égalité (D3:${d3A} + ${acA} coachs = ${scoreA} vs D3:${d3B} + ${acB} coachs = ${scoreB}), pas de relance`);
         newState.gameLog = [...newState.gameLog, log];
       }
       break;


### PR DESCRIPTION
## Summary

Audit round 10 (HIGH/regle BB3) — Brilliant Coaching kickoff event.

La regle BB3 dit "Each coach rolls a D3 and adds the number of Assistant Coaches they have. The team with the highest total gains an extra Team Re-roll." Avant ce fix, seul le D3 brut etait compare — une equipe avec 6 assistant coaches gagnait 50/50 contre une equipe sans coaches.

Pattern aligne sur `cheering-fans` qui ajoute deja `dedicatedFans` au D3. Nouveau champ optionnel `state.assistantCoaches?: { teamA, teamB }` sur `GameState`, defaut 0 par equipe pour back-compat. Le log affiche maintenant le breakdown D3+coachs.

## Test plan

- [x] teamA: D3+5 (6-8) vs teamB: D3+1 (2-4) → teamA win 20/20
- [x] inverse: teamB win 10/10
- [x] undefined `assistantCoaches` : pas de throw, defaut 0
- [x] log message contient "D3.*\+.*coach"
- [x] 17/17 kickoff-events.test.ts
- [x] game-engine typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_