### PR TITLE
docs: Add NFL Fantasy module documentation (10 files)

### DIFF
--- a/docs/nfl-fantasy/00-vision.md
+++ b/docs/nfl-fantasy/00-vision.md
@@ -1,0 +1,105 @@
+# 00 — Vision & Scope
+
+## Le pitch
+
+> Mon Petit Gazon × NFL × Blood Bowl : un fantasy game où tu construis
+> une équipe BB en draftant des joueurs NFL réels (mais skinnés en
+> Throwers/Catchers/Blitzers), où les vraies performances du dimanche
+> alimentent les SPP et où tu actives des relances, inducements et
+> prières à Nuffle pour booster ta semaine.
+
+## Pourquoi un axe additionnel et pas un remplacement
+
+Le projet actuel a deux moteurs majeurs :
+- `packages/sim-engine` : Pro League simulée (matches BB automatiques)
+- `packages/game-engine` : Match BB online (head-to-head temps réel)
+
+Le module NFL Fantasy **réutilise** ces moteurs (la Gazette narrative,
+le système de SPP, la progression joueur, le mercato, le wallet, les
+badges) **sans les remplacer**. Un user peut être actif sur :
+- Pro League BB (simulation, 12 mois/an)
+- Match online BB (head-to-head)
+- NFL Fantasy (sept-février, complémentaire)
+
+## Complémentarité calendaire (argument fort)
+
+```
+       JAN  FEV  MAR  AVR  MAI  JUN  JUL  AOÛ  SEP  OCT  NOV  DEC
+NFL    ███   ★                            ▒▒▒  ███  ███  ███  ███
+       playoffs/SB                        preseason → regular
+Pro BB ███  ███  ███  ███  ███  ███  ███  ███  ███  ███  ███  ███
+       toute l'année
+```
+
+- **Pic d'engagement NFL** : sept-fév (6 mois)
+- **Off-season NFL** : mars-août (6 mois) — users restent sur Pro League BB
+- **Anti-churn naturel** : zéro période morte, l'utilisateur reste actif
+  toute l'année
+
+## Audiences ciblées
+
+| Audience | Pro League BB | NFL Fantasy | Cross |
+|---|---|---|---|
+| BB veterans | ⭐⭐⭐ Cœur | ⭐⭐ Découverte | Univers familier |
+| Fantasy NFL US | ⭐ Découverte | ⭐⭐⭐ Cœur | Gameplay original |
+| MPG / Sorare users | ⭐ | ⭐⭐⭐ | Mécaniques connues + skin BB |
+| Casual gamers FR/EU | ⭐⭐ | ⭐⭐ | Storytelling Gazette |
+
+## Scope MVP
+
+**In** (V1) :
+- 32 équipes NFL mappées aux 8 races BB
+- Roster draftable (53 joueurs NFL actifs par équipe)
+- Lineup hebdo 11 titulaires + 2 captains
+- Scoring stats → SPP via mapping pur
+- Relances (8/saison) + inducements (3 slots/match)
+- Prières à Nuffle (auto-roll si underdog)
+- Gazette narrative hebdo
+- 1 league par user (private ou public)
+- Standings + playoffs
+- Ingestion data via nflverse + ESPN hidden API (gratuit)
+
+**Out** (V2+) :
+- DFS (Daily Fantasy) — risque légal gambling
+- Auctions live (MPG real-time draft)
+- Cartes / collection NFT (cf. Sorare crash)
+- Mode "season-long persistent player" (level-ups inter-saisons)
+- Licence officielle NFLPA (à considérer si volume justifie)
+- Mode coach (choisir play calling) — out of scope
+
+## Questions ouvertes
+
+À trancher avant POC implementation :
+
+1. **Mode mercato** : draft snake (MPG-like), auction budget (Yahoo-like),
+   ou achat libre via wallet (mercato BB existant) ?
+2. **League size** : 8, 10 ou 12 users par league ?
+3. **Captain slots** : 1 captain ×2 (Sorare) ou 1 captain ×1.5 + 1 vice ×1.2 ?
+4. **Prières à Nuffle conditions** : underdog par TV (Team Value) ou
+   par classement (loser bracket) ?
+5. **Race assignment fixe ou dynamique** : un joueur NFL gagne sa race
+   intrinsèque (cf. archétype) ou hérite de la race de son équipe ?
+6. **Cross-pollution avec Pro League** : un joueur NFL "carrière fini"
+   peut-il être recruté dans une équipe Pro League BB simulée ?
+7. **Monétisation** : freemium (achievements gratuits + mercato gold)
+   ou subscription premium (boost rerolls, mercato premium) ?
+8. **NFLPA licence** : démarrer pseudonymisé full puis upgrade, ou
+   licencier dès le départ pour pas avoir à pivoter ?
+
+## KPI de succès V1
+
+- **DAU NFL Fantasy** : 30% des DAU Pro League BB convertis (cross-sell)
+- **Rétention W4** : 50% des users qui complètent une lineup S1 reviennent S5
+- **Engagement** : 3 sessions/semaine en moyenne (jeudi prep, dimanche live, mardi review)
+- **Coût API** : <100€/mois en V1 (nflverse + ESPN free)
+- **Conversion mercato** : 20% des users dépensent au moins 1× du gold mercato sur inducements/rerolls
+
+## Risques majeurs
+
+| Risque | Impact | Mitigation |
+|---|---|---|
+| Évolution juris EU sur fantasy NFL non-licencié | Bloquant | Pseudonymisation forte, disclaimer, monitoring |
+| Coût API si volume scale rapide | Élevé | Tier-up progressive (nflverse → MySportsFeeds → SportRadar) |
+| Cannibalisation de la Pro League existante | Modéré | Calendaire complémentaire, cross-promo |
+| Dilution narrative ("on est plus un jeu BB") | Modéré | Storytelling Gazette renforcé, mapping race strict |
+| Saturation marché fantasy NFL (DraftKings/FanDuel/Sleeper) | Élevé | Niche BB-flavored, audience FR/EU sous-servie |

--- a/docs/nfl-fantasy/01-legal.md
+++ b/docs/nfl-fantasy/01-legal.md
@@ -1,0 +1,191 @@
+# 01 — Cadre légal & Pseudonymisation
+
+> **⚠️ Disclaimer** : ce document est une synthèse d'orientation issue
+> d'une session d'exploration. Il **ne remplace pas** un avis juridique
+> formel. Avant lancement commercial, validation par un juriste IP/RGPD
+> (FR + US) est obligatoire.
+
+## TL;DR
+
+| Élément | Statut US | Statut EU/FR | Action recommandée |
+|---|---|---|---|
+| Noms réels joueurs NFL | ✅ Autorisés (CBC v. MLB AM) | ⚠️ Zone grise (droit à l'image) | Pseudonymiser par sécurité |
+| Stats réelles (yards, TD, sacks) | ✅ Faits, non protégés | ✅ Faits, non protégés | Libre usage |
+| Noms d'équipes NFL (Chiefs, Eagles) | ❌ Trademark NFL | ❌ Trademark NFL | Utiliser ville uniquement |
+| Logos NFL et équipes | ❌ Trademark NFL | ❌ Trademark | Bannir totalement |
+| Photos / headshots joueurs | ❌ Copyright + publicity | ❌ Droit à l'image | Bannir, créer avatars BB |
+| Uniformes / couleurs officielles | ❌ Trade dress | ❌ Trade dress | Couleurs BB de la race |
+| Surnoms trademarkés (TB12, Megatron) | ❌ Trademark individuel | ❌ | Bannir |
+
+## Précédent CBC v. MLB AM (8th Circuit, 2007)
+
+### Faits
+- CBC Distribution opérait un fantasy baseball commercial utilisant noms réels
+  et stats réelles des joueurs MLB
+- MLB Advanced Media exigeait une licence "right of publicity"
+- CBC refusait et a continué d'opérer
+
+### Décision (Cour fédérale 8e circuit)
+- Le **1er Amendement** (free speech) **prime** sur le right of publicity
+  des joueurs dans ce contexte
+- **Noms + stats des joueurs sont des informations factuelles**, protégées
+  par la liberté d'expression
+- Le fantasy sport sans licence est légal
+
+### Portée et limites
+- ✅ Précédent fédéral US, suivi dans plusieurs autres circuits
+- ✅ Confirmé en pratique : Yahoo, ESPN, CBS opèrent sans licence
+  (DraftKings/FanDuel achètent quand même pour photos + relation)
+- ⚠️ **Non transposable automatiquement en droit européen**
+- ⚠️ Ne protège PAS l'usage des marques (trademarks NFL)
+
+## Droit européen / France
+
+### Article 9 Code civil (droit à l'image)
+Toute personne a droit au respect de sa vie privée et de son image.
+Usage commercial du nom et de l'image d'une personne **liés à un produit
+ou service** nécessite consentement.
+
+### RGPD
+Le nom d'une personne physique est une **donnée personnelle**. Traitement
+commercial nécessite une **base légale** : consentement, contrat, intérêt
+légitime (à arbitrer).
+
+### Risque pratique
+Aucune jurisprudence française tranchée sur les fantasy sports US non-licenciés.
+Position défensive : pseudonymisation pour éviter le test.
+
+Référence pratique : **Sorare, MPG, Mon Petit Gazon** prennent tous des
+licences (LFP, NBA, MLB) précisément pour blinder le risque EU, même
+quand le précédent US les couvrirait.
+
+## Stratégie en 3 niveaux de risque
+
+### Niveau 1 — POC / hobby / interne
+- Noms réels joueurs NFL utilisables
+- Stats réelles, libres
+- Pas de logos NFL, pas de photos
+- Disclaimer "Not affiliated with NFL or NFLPA"
+- Usage : développement, tests internes, communauté privée
+- Risque EU : modéré, acceptable en non-commercial
+
+### Niveau 2 — Lancement commercial petit budget ✅ RECOMMANDÉ
+- **Pseudonymisation totale** des noms joueurs et équipes
+- Stats : 100% réelles
+- Noms joueurs : titres BB-flavored + numéros de maillot + ville
+- Noms équipes : `{Ville} {Race BB}`
+- Couleurs : palette de la race BB (pas couleurs NFL officielles)
+- Avatars : créés sur mesure dans style BB (pas photos)
+- Référencement croisé (vraie identité ↔ pseudo BB) **côté code privé**,
+  pas exposé publiquement
+- Disclaimer fort, terms of service explicites
+
+### Niveau 3 — Échelle commerciale (>10k DAU)
+- **NFLPA Group Licensing Agreement (GLA)** : ~$50-150k entry + royalties
+  sur revenue. Couvre ~2000 joueurs actifs.
+- Accès aux photos officielles via NFLPA
+- Pas de licence NFL équipes (Properties LLC) si on garde le `{Ville}+Race BB`
+- Possibilité de licencier individuellement les stars hors NFLPA si besoin
+- Toujours pas de logos NFL ou d'uniformes officiels
+
+## Conventions de pseudonymisation (Niveau 2)
+
+### Équipes : `{Ville canonique} {Race BB}`
+
+Les **villes** ne sont pas des marques NFL (ce sont des géonymes publics).
+Seuls **les noms d'équipes** sont protégés (NFL Properties LLC).
+
+Exemples :
+- ✅ "Kansas City Skaven", "Philadelphia Orcs", "New Orleans Necromantic"
+- ❌ "Chiefs", "Eagles", "Saints" (trademarks)
+- ❌ Logos, couleurs officielles (trade dress)
+
+Cas particuliers villes partagées :
+- Los Angeles : `Los Angeles (R-side) Wood Elves` (Rams) /
+  `Los Angeles (C-side) Khorne` (Chargers)
+- New York : `New York (G-side) Dwarfs` (Giants) /
+  `New York (J-side) Khorne` (Jets)
+- East Rutherford ou MetLife pour distinguer si on veut éviter NY ambiguïté
+
+### Joueurs : `{Titre BB} de {Ville}, #{Numéro}`
+
+Format public :
+```
+{Adjectif descriptif} {Poste BB} de {Ville}, #{Jersey number}
+```
+
+Exemples :
+- "Le Sidearm Wizard de Kansas City, #15" → identifiable comme Mahomes
+- "La Sack Beast de Bay Area, #97" → identifiable comme Bosa
+- "Le Catcher Griddy du Northland, #18" → identifiable comme Jefferson
+- "Le Thrower Barbu de Buffalo, #17" → identifiable comme Allen
+
+L'utilisateur fan de NFL fait immédiatement le lien grâce au numéro,
+la ville et le descripteur. Le mapping `(pseudo → vraie identité)` est
+**stocké côté code privé** uniquement, jamais exposé publiquement
+(pour préserver le caractère factuel de la stat mais pseudonymisé du nom).
+
+### Pseudonymisation programmatique
+
+```ts
+// nfl-mapper/src/pseudonymize.ts
+interface NflPlayerRealId {
+  realName: string;     // PRIVÉ - jamais exposé public
+  team: NflTeamCode;
+  jerseyNumber: number;
+  position: NflPosition;
+  archetype: PlayerArchetype; // speed, power, etc.
+}
+
+interface NflPlayerPublicAlias {
+  pseudonym: string;     // "Le Sidearm Wizard de Kansas City"
+  cityTag: string;       // "Kansas City"
+  jerseyNumber: number;  // 15 — OK, jersey numbers ne sont pas IP
+  bbPosition: BbPosition;
+  bbRace: BbRace;
+}
+
+// Mapping privé en base, jamais sérialisé vers le client
+// Public API renvoie uniquement NflPlayerPublicAlias
+```
+
+### Avatars BB
+
+Pas de photos réelles. Trois options :
+1. **Avatars génériques par race+poste** : 8 races × ~6 postes = 48 avatars
+2. **Génération procédurale** par traits (race, taille, couleur, équipement)
+3. **Avatars uniques sur mesure** pour les "stars" (top 50 joueurs NFL)
+
+Recommandation MVP : option 1, upgrade vers option 2 ou 3 à terme.
+
+## Disclaimer recommandé (footer + about page)
+
+> NFL Fantasy by Nuffle Arena is an independent fantasy football game.
+> NFL, the NFL shield, team names, and team logos are registered trademarks
+> of NFL Properties LLC. This product is not affiliated with, endorsed by,
+> sponsored by, or specifically approved by NFL Properties LLC, the National
+> Football League, the NFL Players Association, or any of its member teams
+> or players.
+>
+> Player names referenced in this product are used in their factual context,
+> protected under the First Amendment as established in CBC Distribution and
+> Marketing v. Major League Baseball Advanced Media (8th Cir. 2007). All
+> player statistics are obtained from publicly available factual data sources.
+
+## Terms of Service — clauses critiques
+
+- Pas d'argent réel directement misé (pas de gambling / paris d'argent)
+- Récompenses en gold virtuel et items BB uniquement (in-game)
+- Pas de cash-out (pas de retrait en monnaie réelle)
+- Pas de loot boxes aléatoires (à éviter pour ne pas tomber sous régulation gambling)
+- Cookies + RGPD compliance (déjà géré par le projet existant)
+- Restriction d'âge : 18+ (cohérence avec règles fantasy commerciales)
+
+## Veille à organiser
+
+À monitorer trimestriellement :
+- Évolutions législatives EU sur les fantasy sports (en particulier
+  ANJ France, UKGC UK, BZGA Allemagne)
+- Décisions DGCCRF ou CNIL sur les data sportives commerciales
+- Évolutions licensing NFLPA (deals, pricing)
+- Mouvements concurrents (Sorare NFL si lancé, Sleeper EU, DraftKings EU)

--- a/docs/nfl-fantasy/02-references-sorare.md
+++ b/docs/nfl-fantasy/02-references-sorare.md
@@ -1,0 +1,204 @@
+# 02 — Études de cas : Sorare et concurrents
+
+> Ce document analyse les concurrents et références du fantasy sport
+> multi-sport pour informer nos choix d'architecture et de gameplay.
+
+## Sorare — référence principale
+
+### Identité
+
+- **Fondé** : 2018, Paris, par Nicolas Julia & Adrien Montfort
+- **Funding** : Série B record sept 2021 — **680M$ menée par SoftBank**,
+  valorisation 4.3Md$
+- **Effectif** : ~200 personnes (après layoffs 2023 -13%)
+- **HQ** : Paris + bureaux NY
+
+### Produit
+
+Fantasy sport où l'utilisateur construit une lineup hebdo de 5 cartes
+joueurs (NFT sur StarkNet L2) et score selon les vraies performances
+en match. Classements, divisions, récompenses en cartes + ETH.
+
+### Multi-sport (point clé pour notre architecture)
+
+| Sport | Lancement | Licence |
+|---|---|---|
+| Football (soccer) | 2019 | 330+ clubs (PL, La Liga, Bundesliga, Ligue 1, MLS, etc.) |
+| MLB (baseball) | juillet 2022 | Officielle MLB + MLBPA |
+| NBA (basketball) | octobre 2022 | Officielle NBA + NBPA |
+| NFL | en discussion 2022-24 | Jamais lancé |
+
+**Architecture multi-sport** : chaque sport est un silo de **scoring**
+mais partage l'infra commune (wallet, marketplace, manager profile,
+divisions, ladder, gamification).
+
+**Leçon** : c'est exactement le pattern "axe additionnel" qu'on
+recherche. Tu peux ajouter un sport sans refondre l'app.
+
+### Mécaniques de jeu transposables
+
+#### Lineup hebdo
+- 5 cartes par compétition
+- 1 Captain (×1.2 ou ×2 selon mode)
+- Lock au kickoff
+- Foot : GK + Def + Mid + Fwd + Extra
+- NBA : 5 joueurs
+- MLB : 7 joueurs
+
+#### Scoring par sport
+- **Foot** : engine maison + data Opta (decisive actions, passes,
+  tackles, bonus/malus position)
+- **NBA** : fantasy points classiques (pts + reb + ast + stl + blk - to)
+- **MLB** : sabermetrics-influenced
+
+#### Compétitions en pyramide (depuis "Sorare PRO" 2024)
+- Champion Europe / Global All-Star / Underdog / Specialist /
+  Captain Mode / Single Game Week
+- Promotion/relégation entre divisions D1 → D5
+- Récompenses scalées par division
+
+#### Cartes et rareté (économie)
+
+| Rareté | Quantité | Valeur typique | Usage |
+|---|---|---|---|
+| Common | Gratuites | 0 | Compétitions Casual uniquement |
+| Limited | 1000/saison/joueur | ~5-500€ | Toutes compétitions |
+| Rare | 100/saison/joueur | ~50-5000€ | Toutes compétitions |
+| Super Rare | 10/saison/joueur | ~500-50000€ | Toutes compétitions |
+| Unique | 1/saison/joueur | jusqu'à 700k€ | Toutes compétitions |
+
+Mbappé Unique vendu **685k€** en 2022 (pic du marché).
+
+#### Mercato
+- Enchères primaires Sorare (nouvelles cartes)
+- Marché secondaire P2P (manager-à-manager)
+- Fee Sorare 5% sur secondaire
+- ETH natif, on/off-ramp Ramp/Moonpay
+
+### Business model
+
+| Source | % revenue 2022 | Notes |
+|---|---|---|
+| Vente primaire cartes | ~70% | Enchères Sorare |
+| Fee 5% marché secondaire | ~25% | P2P |
+| Subscriptions PRO | ~5% (2024+) | $8-30/mois |
+| Sponsoring (kit deals, endorsements) | indirect | Bayern, Real, PSG, Mbappé equity holder |
+
+Revenue 2022 ~115M$. 2023 en chute libre (post-NFT crash). 2024
+restructuration vers subscription + gameplay-first.
+
+### Galères / leçons pour nous
+
+1. **Bull NFT 2021 → crash 2022-23** : prix cartes -70 à -90% depuis peak
+   - **Leçon** : gameplay doit tenir SANS spéculation
+   - **Notre choix** : pas de NFT, ownership en SQL classique
+
+2. **Régulation gambling**
+   - ANJ FR enquête 2022 → conclusion 2024 borderline mais pas illégal
+   - UKGC pareil
+   - **Leçon** : frontière skill vs chance scrutée
+   - **Notre choix** : pas de loot boxes randomisées, pas de mise cash direct
+
+3. **Layoffs 2023** (-30 personnes / 13%)
+   - **Leçon** : ne pas sur-anticiper la croissance
+
+4. **NFL absent** : ~2 ans de discussions, jamais conclu
+   - **Cause** : NFLPA licence très chère + lobby DraftKings/FanDuel
+   - **Opportunité pour nous** : marché EU NFL fantasy peu servi
+
+### Ce qu'on copie de Sorare
+
+✅ Architecture multi-sport avec scoring engine plug-in par sport
+✅ Wallet + mercato + ladder + divisions mutualisés
+✅ Captain multiplier
+✅ Single Game Week mode
+✅ Pyramide promotion/relégation
+✅ Common cards gratuites pour onboarding
+
+### Ce qu'on évite (leur erreur, notre avantage)
+
+❌ **Pas de NFT** : ownership en SQL, pas de blockchain, pas de gas fees,
+   pas de volatilité crypto
+❌ **Pas de licence officielle** au départ : pseudonymisation niveau 2
+❌ **Gameplay-first dès jour 1** : pas de marketing "investissement",
+   on est un jeu
+
+## Concurrents fantasy NFL US
+
+### DraftKings / FanDuel
+- **Type** : DFS (Daily Fantasy Sports)
+- **Modèle** : entry fee $$$, prizes cash
+- **Licence** : NFLPA officielle
+- **Audience** : US, gambling-oriented
+- **Pourquoi pas pour nous** : régulation gambling EU, marché saturé US
+
+### Sleeper
+- **Type** : season-long fantasy, free-to-play
+- **Audience** : ~3M users US
+- **USP** : UX moderne, social, communautaire
+- **Levier croissance** : focus mobile-first
+- **Pourquoi étudier** : meilleure UX fantasy actuelle, à inspirer
+
+### ESPN / Yahoo / CBS Fantasy
+- **Type** : season-long, gratuit
+- **Audience** : audience massive US grâce aux portails média
+- **Modèle** : pub + premium leagues
+- **Pourquoi pas concurrent direct** : on cible EU + skin BB original
+
+### Underdog Fantasy
+- **Type** : best-ball + pick'em
+- **Levée** : valorisation 1.2Md$ en 2023
+- **USP** : draft sans gestion hebdo
+- **Inspiration** : peut-être un mode best-ball BB à terme
+
+## Concurrents fantasy FR/EU
+
+### Mon Petit Gazon (MPG)
+- **Fondée** : 2014, FR
+- **Audience** : ~3M users actifs (FR + EU + LATAM)
+- **Sports** : Foot principalement (L1, L2, Ligue des Champions, PL, Liga...)
+- **Modèle** : freemium (premium leagues payantes ~10€/saison)
+- **USP** : focus mercato à enchères live + notation post-match
+- **Acquisition** : racheté par Sorare en 2024 (annoncé)
+- **Pourquoi référence** : pattern UX/mercato/scoring à copier directement
+
+### Comunio (DE/ES)
+- **Type** : fantasy foot classique
+- **Audience** : surtout DACH + Espagne
+- **Moins intéressant** : peu d'innovation gameplay
+
+## Concurrents fantasy crypto (post-Sorare)
+
+### Olympus Reign, Fantasy.top, etc.
+- **Type** : NFT fantasy (post-Sorare clones)
+- **Audience** : crypto natifs, niche
+- **Pourquoi pas pour nous** : on s'éloigne du NFT pour audience mainstream
+
+## Tableau comparatif synthèse
+
+| Plateforme | Sport | Modèle | Audience | License | Notre takeaway |
+|---|---|---|---|---|---|
+| Sorare | Multi | NFT cards | ~1M actifs | Officielle | Archi multi-sport, pas de NFT pour nous |
+| DraftKings | NFL DFS | Pay-to-play cash | ~10M US | Officielle | Trop gambling, hors scope |
+| Sleeper | NFL season | Freemium social | ~3M US | Sans (CBC) | UX à étudier de près |
+| MPG | Foot season | Freemium | ~3M EU | Officielle | Mercato à enchères + notation |
+| Yahoo Fantasy | NFL season | Gratuit pub | massive US | Sans (CBC) | Reference UX classique |
+| Underdog | NFL best-ball | Pay-to-play | ~500k US | Sans (CBC) | Best-ball mode futur |
+
+## Inspirations design / UX
+
+À étudier pour les mockups :
+- **Sorare iOS** : lineup builder, captain selection
+- **Sleeper iOS** : feed social, league chat, transactions
+- **MPG iOS** : enchères live, notation 0-10
+- **Sorare NBA** : scoring board hebdo, breakdown stats
+- **DraftKings** : optimizer (à éviter — trop gambling-feel)
+
+## Sources
+
+- Sorare Help Center : <https://sorare.com/help>
+- Sorare blog : <https://blog.sorare.com>
+- CBS Insights Sorare profile (privé)
+- Crunchbase Sorare profile (publique)
+- Articles TechCrunch / Sifted sur layoffs 2023
+- Communiqués officiels Sorare/Olympique de Marseille/PSG sleeve deals

--- a/docs/nfl-fantasy/03-api-strategy.md
+++ b/docs/nfl-fantasy/03-api-strategy.md
@@ -1,0 +1,353 @@
+# 03 — Stratégie API : Data NFL
+
+> 3 tiers de fournisseurs selon le budget, la latence requise et la
+> richesse des données. Approche progressive : démarrer gratuit, scaler
+> selon usage.
+
+## TL;DR
+
+| Tier | Coût | Latence | Recommandation |
+|---|---|---|---|
+| Gratuit | 0€ | 5min–24h | **MVP V1** (nflverse + ESPN hidden API) |
+| Abordable | $50-500/mois | ~5-30s | V2 si DAU >5k (MySportsFeeds) |
+| Enterprise | $2000+/mois | <1s | V3 si DFS-grade requis (SportRadar) |
+
+## Tier 1 — Gratuit (recommandé MVP)
+
+### nflverse / nflfastR
+
+**URL** : <https://github.com/nflverse>
+
+**Format** : GitHub releases (Parquet, CSV), JSON via API REST légère
+
+**Couverture** :
+- Play-by-play complet depuis 1999
+- Rosters joueurs avec jersey numbers, positions, age, etc.
+- Stats agrégées par game, par drive, par play
+- Stats fantasy pré-calculées (DK/FD points)
+- Schedules saison + playoffs
+- Snap counts, route data, NextGen Stats partielles
+
+**Fréquence MAJ** :
+- Pendant la saison : commits quasi-immédiats post-match (~15min après end)
+- Off-season : mises à jour combine, FA, draft
+
+**Limites** :
+- Pas de live in-game (delay 15min minimum)
+- Pas de WebSocket / push
+- Format Parquet → besoin de pipeline conversion
+
+**Use case pour nous** :
+- Ingestion **post-match** chaque dimanche soir / lundi matin
+- Scoring users tranquillement le lundi
+- Source de vérité pour rosters + stats annuelles
+
+### ESPN Hidden API
+
+**URL base** : `https://site.api.espn.com/apis/site/v2/sports/football/nfl/`
+
+**Endpoints clés** :
+```
+GET /scoreboard                          → matches du jour, scores live
+GET /scoreboard?dates=20260920           → matches d'un jour précis
+GET /summary?event=401547417             → boxscore d'un match
+GET /teams                               → liste 32 teams
+GET /teams/{team}/roster                 → roster d'une team
+GET /athletes/{playerId}                 → fiche joueur
+GET /athletes/{playerId}/stats           → stats joueur
+GET /news                                → news NFL
+```
+
+**Format** : JSON
+**Authentification** : aucune
+**Rate limit** : non documenté, en pratique ~100 req/min OK
+**Latence live** : ~30s pendant les matches
+
+**Limites** :
+- **Non documenté** = peut changer sans préavis (a tenu ~10 ans)
+- Pas de SLA, pas de support
+- ToS ESPN gris zone (scraping vs API publique informelle)
+
+**Use case pour nous** :
+- **Live scoreboard** pendant les gameday (dimanche)
+- Boxscores rapides pour engagement temps réel
+- Compléments rosters (photos non utilisées, mais bio data utile)
+
+### Pro-Football-Reference (scraping)
+
+**Pourquoi ne pas l'utiliser** :
+- ToS interdisent explicitement le scraping commercial
+- Risque légal réel (lettres mise en demeure observées)
+- nflverse + ESPN couvrent les mêmes besoins
+
+### TheSportsDB
+
+**URL** : <https://www.thesportsdb.com/api.php>
+
+**Couverture** : Basique (équipes, matches, lineups)
+**Coût** : Gratuit (Patreon $3/mois pour clé patron)
+**Use case** : Backup / cross-check, pas suffisant standalone
+
+## Tier 2 — Abordable ($30-500/mois)
+
+### MySportsFeeds
+
+**URL** : <https://www.mysportsfeeds.com>
+
+**Pricing** :
+- Personal use : gratuit (delayed data)
+- Indie ($49/mois) : real-time NFL post-game
+- Pro ($249/mois) : live play-by-play, ~5s latence
+- Enterprise : custom
+
+**Couverture** :
+- Play-by-play live (~5s latence en Pro)
+- Boxscores temps réel
+- Stats joueurs + équipes
+- Schedules, standings, odds
+- REST API + Push API
+
+**Use case pour nous** :
+- Migration depuis Tier 1 quand DAU >5k justifie investissement
+- Live in-game engagement (notifs temps réel)
+
+### API-Sports / api-football
+
+**URL** : <https://apisports.io>
+
+**Pricing** :
+- Free : 100 req/jour (POC seulement)
+- Pro ($29/mois) : 7500 req/jour
+- Ultra ($99/mois) : illimité
+
+**Couverture NFL** :
+- Schedules, scores, lineups
+- Stats joueurs par match
+- **Pas de play-by-play live** (limitation)
+
+**Use case** :
+- Backup pas cher si nflverse down
+
+### SportsDataIO Fantasy NFL plan
+
+**URL** : <https://sportsdata.io/nfl-api>
+
+**Pricing** :
+- Trial : 14 jours gratuit
+- Fantasy plan : ~$300-500/mois
+- Premium plan : ~$1000+/mois
+
+**Couverture** :
+- Fantasy points **pré-calculés** (DK, FD, Yahoo, ESPN)
+- Player projections (saison + match)
+- Live boxscores, ~10s latence
+- Injuries, depth charts, news
+
+**USP** : fantasy-specific, gain de dev sur scoring
+
+**Use case** :
+- Si on veut comparer notre scoring BB-SPP avec scoring fantasy classique
+- Source secondaire de validation
+
+### Goalserve
+
+**URL** : <https://www.goalserve.com>
+
+**Pricing** : ~$30-100/mois selon volume
+**Couverture** : NFL live scores + box scores
+**Réputation** : OK mais moins riche que MSF
+
+## Tier 3 — Enterprise ($2000+/mois)
+
+### SportRadar
+
+**URL** : <https://sportradar.com/nfl>
+
+**Pricing** : custom, généralement >$2000/mois pour real-time NFL
+
+**Couverture** :
+- Data officielle NFL (partenariat)
+- Latence <1s, snap-by-snap
+- Tracking joueur (position sur le terrain)
+- Player props, injuries en temps réel
+- Hundreds of stats par player
+
+**Use case** :
+- Si on devient DFS-grade
+- Si on veut tracking joueur (heat maps, etc.)
+- Hors scope V1/V2
+
+### Stats Perform
+
+**URL** : <https://www.statsperform.com>
+
+**Pricing** : similar à SportRadar
+**Réputation** : très utilisé par les bookmakers
+**Coverage** : équivalent SportRadar
+**Use case** : alternative SportRadar
+
+### Genius Sports
+
+**URL** : <https://www.geniussports.com>
+
+**Pricing** : enterprise
+**USP** : data officielle NFL (deal exclusif 2022 pour data DFS)
+**Use case** : si on veut data officielle DFS-grade pour les odds
+
+## Architecture d'ingestion proposée
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     INGESTION TIER 1 (MVP)                   │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Cron daily 03:00 UTC                                       │
+│  ┌─────────────┐                                            │
+│  │  nflverse   │──► fetch latest Parquet ──► normalize     │
+│  │  releases   │    + diff vs DB           ─► upsert       │
+│  └─────────────┘                                            │
+│                                                              │
+│  Cron each 5min on gameday (Sun 13h-23h ET)                 │
+│  ┌─────────────┐                                            │
+│  │ ESPN hidden │──► scoreboard + boxscores ─► normalize    │
+│  │     API     │                            ─► upsert      │
+│  └─────────────┘                                            │
+│                                                              │
+│  Settlement cron Tuesday 12:00 UTC                          │
+│  ┌─────────────┐                                            │
+│  │ Apply rules │──► stats → SPP per player                  │
+│  │  + rerolls  │ ──► update standings + level-ups          │
+│  │  + prayers  │                                            │
+│  └─────────────┘                                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Pattern code (suivant les conventions du repo)
+
+```ts
+// apps/server/src/services/nfl-ingest.ts
+
+interface IngestResult {
+  source: "nflverse" | "espn";
+  weekId: string;
+  playersUpdated: number;
+  gamesUpdated: number;
+  errors: ReadonlyArray<{ context: string; error: string }>;
+}
+
+// Service pur sauf I/O réseau et Prisma
+export async function ingestNflverseWeek(weekId: string): Promise<IngestResult> {
+  // 1. Fetch nflverse Parquet
+  // 2. Parse + normalize via nfl-mapper (package pur)
+  // 3. Upsert Prisma (NflGame, NflGameStat)
+  // 4. Return audit log
+}
+
+export async function ingestEspnLive(): Promise<IngestResult> {
+  // 1. GET scoreboard
+  // 2. Pour chaque match in-progress, GET summary
+  // 3. Normalize + upsert (NflPlayerLiveStat)
+  // 4. Return audit log
+}
+```
+
+## Estimation coût annuel V1 (Tier 1 seulement)
+
+| Poste | Coût |
+|---|---|
+| nflverse | 0€ |
+| ESPN hidden API | 0€ |
+| Hébergement cron (déjà payé) | 0€ |
+| Stockage Postgres (déjà payé) | 0€ |
+| **Total V1** | **0€/an** |
+
+## Estimation coût V2 (~5-50k DAU)
+
+| Poste | Coût |
+|---|---|
+| MySportsFeeds Pro | $249/mois = ~$3000/an |
+| Backup nflverse | 0€ |
+| Storage incrémental | ~$50/mois |
+| **Total V2** | **~$3600/an** |
+
+## Estimation coût V3 (>50k DAU, DFS-grade)
+
+| Poste | Coût |
+|---|---|
+| SportRadar real-time | ~$30-60k/an |
+| Backup MSF | $3000/an |
+| Storage + bandwidth | ~$2000/an |
+| **Total V3** | **~$40-65k/an** |
+
+## Plan de migration tier par tier
+
+```
+V1 (POC + MVP commercial)
+└── nflverse (post-match) + ESPN (gameday live)
+    └── Tient jusqu'à ~10k DAU
+
+V2 (Scale)
+└── Si DAU >5k OU si engagement live <3min/match
+    └── + MySportsFeeds Pro ($249/mois)
+    └── Tient jusqu'à ~50k DAU
+
+V3 (DFS-grade)
+└── Si pivot DFS ou audience pro
+    └── SportRadar ou Stats Perform
+```
+
+## Décisions techniques
+
+### Cache stratégique
+
+- **Stats games passés** : immutables → cache infini Redis + DB
+- **Live scoreboard** : TTL 30s
+- **Rosters joueurs** : TTL 24h (refresh quotidien)
+- **Schedules** : TTL 7j (refresh hebdo, mais MAJ instantanée sur trade)
+
+### Idempotence ingestion
+
+Suivre le pattern Q.D.1 du CLAUDE.md (settle services idempotents) :
+- Chaque `ingestNflverseWeek(weekId)` skip les stats déjà ingérées
+- `upsert` avec contrainte `@@unique([gameId, playerId, statType])`
+- Audit log en table dédiée (`NflIngestRun`)
+
+### Replay déterministe
+
+Les events ingérés doivent être replay-friendly. Stockage en JSON
+versionné avec hash de l'event source ⇒ on peut re-jouer le scoring
+si on change les règles `stats-to-spp.ts`.
+
+```ts
+// Pattern Q.A.2 : snapshot lazy compute avec staleness
+interface NflWeekScore {
+  weekId: string;
+  computedAt: Date;
+  sourceHash: string;  // hash du payload nflverse
+  scoringVersion: string; // version de stats-to-spp.ts
+  spp: Record<NflPlayerId, number>;
+}
+
+// Si scoringVersion change ⇒ recompute
+// Si sourceHash change (data updated) ⇒ recompute
+```
+
+## Risques API
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| ESPN hidden API change format | Moyenne | Élevé | Tests automatisés daily, fallback nflverse |
+| ESPN hidden API totalement supprimée | Faible | Élevé | Migrer MSF d'urgence |
+| nflverse maintenance discontinue | Très faible | Critique | Open source community, low risk |
+| MSF rate limits dépassés | Moyenne | Modéré | Cache agressif, queue retry |
+| SportRadar price hike | Moyenne | Élevé | Contrats annuels, fallback MSF |
+
+## TODOs avant V1
+
+- [ ] POC ingestion `nflverse` : pull 1 semaine de stats, normalize, store
+- [ ] POC ESPN scoreboard : poll pendant 1 gameday, valider stabilité
+- [ ] Schéma Prisma `NflGame`, `NflGameStat`, `NflPlayer`, `NflIngestRun`
+- [ ] Service `nfl-ingest.ts` idempotent avec audit log
+- [ ] Cron orchestration (Tasks/Bull/etc. selon stack existante)
+- [ ] Monitoring : alertes si nflverse ou ESPN failent
+- [ ] Tests E2E ingestion sur fixtures saison 2025

--- a/docs/nfl-fantasy/04-race-mapping.md
+++ b/docs/nfl-fantasy/04-race-mapping.md
@@ -1,0 +1,254 @@
+# 04 — Mapping 32 équipes NFL → 8 races BB
+
+> Principe : **une équipe NFL = une race BB**. Le mapping reflète
+> l'identité stylistique de l'équipe (run vs pass, finesse vs power,
+> cold weather, etc.) et reste **stable** d'année en année malgré
+> les changements de roster (les rosters bougent, l'identité moins).
+
+## Tableau de synthèse (32/32)
+
+| Race BB | Trait | Équipes (4 chacune) |
+|---|---|---|
+| **Skaven** | Speed + trickery | Kansas City, Miami, Houston, Arizona |
+| **Wood Elf** | Finesse + agility | Cincinnati, Los Angeles (R-side), Jacksonville, Washington |
+| **Orc** | Physical + run-heavy | Baltimore, Philadelphia, Pittsburgh, San Francisco |
+| **Human** | Balanced | Dallas, Green Bay, Atlanta, Seattle |
+| **Norse** | Cold weather + power | Buffalo, Minnesota, Detroit, Chicago |
+| **Dwarf** | Slow + tough | New York (G-side), Cleveland, Indianapolis, New England |
+| **Khorne** | Aggro chaos | New York (J-side), Las Vegas, Los Angeles (C-side), Tampa Bay |
+| **Necromantic** | Rebuild / dark | Tennessee, Denver, Carolina, New Orleans |
+
+## Justifications détaillées par race
+
+### Skaven (4)
+
+Speed-obsessed, big play offense, fragile defenses, lots of trick plays.
+Roster BB Skaven : Throwers, Gutter Runners (MA9), Storm Vermin (Blitzer
++ extra MA), Rat Ogre (Big Guy fragile).
+
+| Team | Justification |
+|---|---|
+| **Kansas City** | Mahomes sidearm wizardry, dynasty élite Skaven. Speed Worthy/Rice, Kelce TE Storm Vermin. Chris Jones = Rat Ogre. |
+| **Miami** | McDaniel speed offense pure. Hill+Waddle = Gutter Runners. Achane = Gutter Runner. Pas de power, tout en vitesse. |
+| **Houston** | Stroud + Diggs/Collins/Dell + young O = Skaven émergent. Will Anderson Jr edge Storm Vermin. |
+| **Arizona** | Kyler Murray QB mobile = Skaven Thrower. Marvin Harrison Jr Catcher élite. Identité désertique = Skaven désertique. |
+
+### Wood Elf (4)
+
+Smooth route running, finesse pocket QB, agile receivers, modest defenses.
+Roster BB Wood Elf : Lineman, Catcher (élite), Thrower, Wardancer (Blitzer
++ Dodge/Leap), Treeman (Big Guy).
+
+| Team | Justification |
+|---|---|
+| **Cincinnati** | Burrow finesse pocket. Chase+Higgins routes gracieuses. Pas de power run. Identité Wood Elf pure. |
+| **Los Angeles (R-side)** | McVay offense finesse. Stafford vétéran. Kupp slot magicien. Nacua ascendant gracieux. |
+| **Jacksonville** | Lawrence finesse. Brian Thomas Jr rookie speed/grace. Etienne fluide. Wood Elf emergent. |
+| **Washington** | Jayden Daniels = Wood Elf Thrower (finesse + mobile). McLaurin Catcher élite. Reconstruction rapide. |
+
+### Orc (4)
+
+Power running, physical defense, hard-hitting, run-heavy offense, brutality.
+Roster BB Orc : Lineman, Black Orc (mass blocker), Blitzer (élite), Thrower
+(décent), Goblin (faible), Troll (Big Guy).
+
+| Team | Justification |
+|---|---|
+| **Baltimore** | Lamar mobile mais run-heavy avec Henry power. Physical D. Madubuike Beast. Identité Orc avec Thrower mobile spécial. |
+| **Philadelphia** | Tush push = définition du push BB. Hurts Thrower physique. AJ Brown Black Orc Catcher. J. Carter DT-Beast. Saquon power. |
+| **Pittsburgh** | TJ Watt = Blitzer élite. Heyward Cam Beast. Traditional physical D. Power run. Pure identité Orc. |
+| **San Francisco** | Shanahan power runs, Kittle TE physique. Bosa DE élite. Williams DL. Defense brutale. McCaffrey power-yards. |
+
+### Human (4)
+
+Équilibré sans extrême, polyvalent, "America's archetype", coaching classique.
+Roster BB Human : Lineman, Thrower, Catcher, Blitzer, Ogre (Big Guy)
+optionnel.
+
+| Team | Justification |
+|---|---|
+| **Dallas** | Prescott classic Thrower. Lamb Catcher balanced. Parsons Blitzer star. "America's Team" archetype. |
+| **Green Bay** | Love jeune Thrower équilibré. WR corps jeune. Jacobs Lineman/Blitzer. Cold mais pas Norse (trop technique). |
+| **Atlanta** | Penix Jr Thrower. London Catcher. Bijan Blitzer versatile. Identité reconstruite balanced. |
+| **Seattle** | Geno-era ou nouveau QB Thrower équilibré. Metcalf Catcher physique. JSN slot. Defense moyenne. |
+
+### Norse (4)
+
+Cold weather, beard culture, physical-but-not-Orc, Frenzy/Block, Vikings vibe.
+Roster BB Norse : Lineman avec Block, Runner, Catcher, Berserker (Blitzer
++ Frenzy), Ulfwerener (élite blocker), Yhetee (Big Guy).
+
+| Team | Justification |
+|---|---|
+| **Buffalo** | Allen = Norse Thrower (beard, power, cold). Cook Runner. Bills Mafia fans = Norse fans. Cold weather. |
+| **Minnesota** | Littéralement Vikings (casque cornu). Jefferson Catcher élite. Norse Catcher griddy. JJ McCarthy / new QB. |
+| **Detroit** | Goff Thrower fiable, Gibbs+Montgomery RB committee power+speed. Hutchinson Edge. Cold + physique. |
+| **Chicago** | Monsters of Midway. Caleb Williams Thrower. Defense traditionnellement physique. Cold weather. |
+
+### Dwarf (4)
+
+Slow but tough, defensive identity, run-stuffing, high armor, conservative O.
+Roster BB Dwarf : Blocker (Block + Tackle), Runner, Trollslayer (Frenzy),
+Deathroller (Big Guy à part).
+
+| Team | Justification |
+|---|---|
+| **New York (G-side)** | Rebuild long, défensive identity. Dexter Lawrence Big Guy. Conservative offense. |
+| **Cleveland** | Garrett Beast élite. Defense d'abord. Run heavy avec Chubb. Conservative passing. |
+| **Indianapolis** | Jonathan Taylor Lineman power. Buckner Beast. Defense solide. Identité old-school physique. |
+| **New England** | Post-Belichick rebuild. Defense d'abord historiquement. Maye jeune Thrower lent. (à reclasser si pass-heavy) |
+
+### Khorne (4)
+
+Chaos warriors, aggro, undisciplined, lots of personal fouls, edgy.
+Roster BB Khorne : Bloodseeker (Block + Frenzy), Khorne Marauder, Bloodspawn
+(Big Guy aggro), pas de Thrower décent (low AG).
+
+Note : Khorne en BB2020 a un Thrower acceptable (Khorne Marauder Thrower),
+on adapte.
+
+| Team | Justification |
+|---|---|
+| **New York (J-side)** | Chaos énergie, drama constant, Sauce Gardner CB élite Khorne. Q. Williams DT Beast aggro. |
+| **Las Vegas** | Maxx Crosby = Blitzer Khorne pure (Frenzy + aggressive). Identité "bad boys" historique. |
+| **Los Angeles (C-side)** | Harbaugh aggression. Mack/Bosa edges. Herbert Thrower mais culture aggro. |
+| **Tampa Bay** | Pirates = chaos aggressive. Mayfield gunslinger. Mike Evans deep Catcher physique. |
+
+### Necromantic (4)
+
+Rebuild / dark flavor / "raised from the dead" franchises, Regenerate skill,
+NOLA voodoo vibes.
+Roster BB Necromantic Horror : Zombies, Ghouls (Runners), Wights (Blitzers,
+Block), Flesh Golem (Big Guy AV9), Werewolf (Frenzy + MA).
+
+| Team | Justification |
+|---|---|
+| **Tennessee** | Rebuild après Henry-era. Ghost franchise. Cam Ward rookie 2025. Identité reconstruite. |
+| **Denver** | Post-Russ rebuild. Sean Payton aggressive. Bo Nix jeune Thrower. Identity en transition. |
+| **Carolina** | Rebuild zombie franchise. Bryce Young Thrower. Identité non-fixe. |
+| **New Orleans** | NOLA voodoo PARFAIT. Kamara aging Ghoul. Cam Jordan Werewolf vétéran. Identité Necromantic naturelle. |
+
+## Règles de promotion / déplacement de race
+
+Une équipe peut **changer de race** entre saisons si son identité bascule
+significativement :
+
+### Triggers de re-mapping
+
+1. **Coaching change majeur** (HC + OC + DC remaniés) → trigger review
+2. **Trade ou FA majeur** (>3 starters changés) → review
+3. **Style stat shift** (run% / pass% varie >15% saison-sur-saison)
+4. **Identité affichée publiquement** (rebrand, nouveau coach philosophy)
+
+### Process de re-mapping
+
+1. Détection automatique via `nfl-mapper/scripts/detect-race-drift.ts`
+2. Validation manuelle par éditorial (équipe produit)
+3. Update du fichier source `nfl-mapper/data/teams.json`
+4. Versioning : tagger la saison (`2025-26`, `2026-27`, etc.)
+5. Migration des rosters existants : utilisateurs notifiés, pas de force
+6. Documenter dans changelog (cf. `transitions-2026.md`)
+
+### Exemples de re-mapping potentiels 2025→2026
+
+- **New England** : si nouveau staff vire pass-heavy, basculer Dwarf → Human
+- **Detroit** : si offense vire moins physique, basculer Norse → Human
+- **Las Vegas** : si nouveau coach calme l'aggro, basculer Khorne → Dwarf
+
+## Couleurs de palette par race (UI)
+
+Pour éviter d'utiliser les couleurs officielles NFL (trade dress), on
+utilise une **palette BB par race** :
+
+| Race | Couleur primaire | Couleur secondaire | Accent |
+|---|---|---|---|
+| Skaven | Vert poison `#4A7C2E` | Marron rat `#5A3A1A` | Jaune toxique `#D4D424` |
+| Wood Elf | Vert forêt `#2E5C2E` | Marron clair `#8B7355` | Doré `#D4AF37` |
+| Orc | Vert orc `#3F5F3F` | Noir charbon `#1A1A1A` | Jaune dent `#C4A85A` |
+| Human | Bleu royal `#1E3A8A` | Blanc cassé `#F5F5F0` | Rouge `#B91C1C` |
+| Norse | Bleu glacier `#2C5F87` | Gris fer `#4A5568` | Argent `#C0C0C0` |
+| Dwarf | Marron rouille `#8B4513` | Cuivre `#B87333` | Doré sombre `#A87C0A` |
+| Khorne | Rouge sang `#8B0000` | Noir charbon `#1A1A1A` | Bronze `#9B6B43` |
+| Necromantic | Violet sombre `#4B0082` | Vert cadavre `#556B2F` | Os blanc `#F5F5DC` |
+
+## Notation pseudonyme finale par équipe
+
+Convention : `{Ville} {Race BB}`
+
+```
+Skaven (4)
+├── Kansas City Skaven
+├── Miami Skaven
+├── Houston Skaven
+└── Arizona Skaven
+
+Wood Elf (4)
+├── Cincinnati Wood Elves
+├── Los Angeles (R-side) Wood Elves
+├── Jacksonville Wood Elves
+└── Washington Wood Elves
+
+Orc (4)
+├── Baltimore Orcs
+├── Philadelphia Orcs
+├── Pittsburgh Orcs
+└── San Francisco Orcs
+
+Human (4)
+├── Dallas Humans
+├── Green Bay Humans
+├── Atlanta Humans
+└── Seattle Humans
+
+Norse (4)
+├── Buffalo Norse
+├── Minnesota Norse
+├── Detroit Norse
+└── Chicago Norse
+
+Dwarf (4)
+├── New York (G-side) Dwarfs
+├── Cleveland Dwarfs
+├── Indianapolis Dwarfs
+└── New England Dwarfs
+
+Khorne (4)
+├── New York (J-side) Khorne
+├── Las Vegas Khorne
+├── Los Angeles (C-side) Khorne
+└── Tampa Bay Khorne
+
+Necromantic (4)
+├── Tennessee Necromantic
+├── Denver Necromantic
+├── Carolina Necromantic
+└── New Orleans Necromantic
+```
+
+## Schéma de référence (JSON)
+
+```json
+{
+  "version": "2025-26",
+  "lastUpdated": "2026-05-19",
+  "races": {
+    "Skaven": {
+      "trait": "Speed + trickery",
+      "teams": ["KC", "MIA", "HOU", "ARI"],
+      "palette": { "primary": "#4A7C2E", "secondary": "#5A3A1A", "accent": "#D4D424" }
+    },
+    "WoodElf": {
+      "trait": "Finesse + agility",
+      "teams": ["CIN", "LAR", "JAX", "WAS"],
+      "palette": { "primary": "#2E5C2E", "secondary": "#8B7355", "accent": "#D4AF37" }
+    }
+  },
+  "teams": {
+    "KC": { "city": "Kansas City", "race": "Skaven", "raceLabel": "Kansas City Skaven" },
+    "MIA": { "city": "Miami", "race": "Skaven", "raceLabel": "Miami Skaven" }
+  }
+}
+```
+
+Voir [`nfl-mapper/data/teams.json`](../../packages/nfl-mapper/data/teams.json)
+(à créer lors de l'implémentation).

--- a/docs/nfl-fantasy/05-position-mapping.md
+++ b/docs/nfl-fantasy/05-position-mapping.md
@@ -1,0 +1,398 @@
+# 05 — Mapping postes NFL → postes BB
+
+> Mapping des positions NFL vers les positions Blood Bowl, paramétré
+> par race. Une même position NFL (ex: WR) peut se mapper sur un poste
+> BB différent selon la race (Gutter Runner pour Skaven, Catcher pour
+> Wood Elf, etc.).
+
+## Principe
+
+```
+Position NFL × Race équipe → Position BB (+ skills suggérées)
+```
+
+Variantes possibles selon le **archetype** du joueur :
+- Speed (40-yard dash < 4.4s)
+- Power (>225 lbs WR, >250 lbs LB, etc.)
+- Agility (cone < 6.7s)
+- Receiving (catch% > 70%)
+
+## Table de mapping universelle
+
+### Offense
+
+| NFL Position | BB Position (générique) | Notes |
+|---|---|---|
+| QB pocket passer | Thrower | Sure Hands, Accurate, Pass |
+| QB mobile / dual-threat | Thrower OU Runner | Selon race (Skaven : Thrower MA7) |
+| QB scrambler | Runner | Si run-first comme Lamar 2018 era |
+| RB power back | Lineman / Blitzer | Selon race (Orc : Black Orc Blitzer) |
+| RB receiving back | Runner / Gutter Runner | MA+ stat priority |
+| RB scat back | Gutter Runner | Skaven uniquement |
+| FB | Lineman | Blocking-only |
+| WR1 alpha | Catcher | Side Step, Catch, Diving Catch |
+| WR speed | Gutter Runner / Catcher MA+ | Selon race |
+| WR possession | Catcher | Sure Hands, Catch |
+| WR slot | Runner / Catcher | Agility-first |
+| TE receiving | Catcher | Race équipe |
+| TE blocking | Blitzer / Lineman | Race équipe (Orc: Black Orc) |
+| OL center | Lineman | Block, Wrestle |
+| OL guard | Lineman / Black Orc | Selon race |
+| OL tackle (élite) | Black Orc / Bull Centaur / Dwarf Blocker | Selon race |
+| K (kicker) | Kicker (BB7) ou Lineman bench | Rôle optionnel |
+| P (punter) | Lineman bench | Rôle optionnel |
+
+### Defense
+
+| NFL Position | BB Position (générique) | Notes |
+|---|---|---|
+| DT nose tackle | Big Guy (race-specific) | Mighty Blow |
+| DT 3-tech penetrator | Beast / Blitzer | Block, Mighty Blow |
+| DE / EDGE pass rusher | Blitzer | Mighty Blow, Tackle |
+| DE / EDGE power | Blitzer / Beast | Race-specific |
+| LB MIKE (middle) | Blitzer | Block, Tackle |
+| LB WILL (weak) | Blitzer / Runner | Agility-first |
+| LB SAM (strong) | Blitzer | Block, Mighty Blow |
+| CB shutdown | Catcher défensif | Diving Tackle, Pass Block |
+| CB slot | Runner | Catch, Diving Tackle |
+| S strong | Blitzer | Hit, Tackle |
+| S free | Runner / Catcher | Pass Block, Catch |
+| Nickelback | Runner | Versatile |
+
+## Mapping par race (détaillé)
+
+### Skaven roster
+
+Roster BB Skaven (BB2020) :
+- 0-12 Lineman (MA7 AG3+ AV8+ — Dodge)
+- 0-2 Thrower (MA7 AG3+ — Pass, Sure Hands)
+- 0-4 Gutter Runner (MA9 AG2+ — Dodge)
+- 0-2 Storm Vermin (MA7 ST3 AV8+ — Block)
+- 0-1 Rat Ogre (MA6 ST5 — Loner, Frenzy, Mighty Blow, Prehensile Tail, Wild Animal)
+
+| NFL Position | Skaven Position |
+|---|---|
+| QB | Thrower |
+| QB mobile | Thrower (avec Sure Feet skill) |
+| RB scat | Gutter Runner |
+| RB power | Storm Vermin |
+| WR speed | Gutter Runner |
+| WR possession | Lineman avec Catch |
+| TE receiving | Storm Vermin avec Catch |
+| TE blocking | Storm Vermin |
+| OL | Lineman |
+| DT | Rat Ogre |
+| DE | Storm Vermin |
+| LB | Storm Vermin |
+| CB / S | Gutter Runner |
+
+### Wood Elf roster
+
+Roster BB Wood Elf :
+- 0-12 Lineman (MA7 AG2+ — Dodge)
+- 0-2 Thrower (MA7 AG2+ — Pass, Dodge)
+- 0-4 Catcher (MA8 AG2+ — Catch, Dodge, Side Step)
+- 0-2 Wardancer (MA8 ST3 AG2+ — Block, Dodge, Leap)
+- 0-1 Treeman (MA2 ST6 — Loner, Mighty Blow, Stand Firm, Strong Arm, Take Root, Thick Skull, Throw Team-Mate)
+
+| NFL Position | Wood Elf Position |
+|---|---|
+| QB | Thrower |
+| RB | Lineman (ou Catcher si receiving back) |
+| WR1 alpha | Catcher élite |
+| WR speed | Catcher |
+| WR slot | Catcher |
+| TE | Catcher |
+| OL | Lineman |
+| DT | Treeman |
+| DE | Wardancer |
+| LB | Wardancer |
+| CB | Catcher (défensif) |
+| S | Catcher / Lineman |
+
+### Orc roster
+
+Roster BB Orc :
+- 0-12 Lineman (MA5 ST3 AG3+ AV9+)
+- 0-2 Thrower (MA5 AG3+ — Pass, Sure Hands)
+- 0-4 Black Orc (MA4 ST4 AV10+ — Block, Brawler, Grab)
+- 0-4 Blitzer (MA6 ST3 AV9+ — Block)
+- 0-4 Goblin (MA6 ST2 AG2+ AV7+ — Dodge, Right Stuff, Stunty)
+- 0-1 Troll (MA4 ST5 AV9+ — Loner, Always Hungry, Mighty Blow, Really Stupid, Regenerate, Throw Team-Mate)
+
+| NFL Position | Orc Position |
+|---|---|
+| QB pocket | Thrower |
+| QB mobile (Lamar) | Thrower avec Sprint skill |
+| RB power (Henry) | Black Orc / Blitzer |
+| RB receiving (Barkley) | Blitzer (avec Catch) |
+| WR physical (AJ Brown) | Black Orc avec Catch |
+| WR speed | Blitzer avec Catch |
+| TE blocking | Black Orc |
+| TE receiving | Blitzer avec Catch |
+| OL tackle | Black Orc |
+| OL guard/center | Lineman |
+| K returner | Goblin |
+| DT (J. Carter) | Troll |
+| DE pass rusher (Watt) | Blitzer |
+| LB | Blitzer |
+| CB | Lineman (défensif) |
+| S | Blitzer |
+
+### Human roster
+
+Roster BB Human :
+- 0-16 Lineman (MA6 ST3 AG3+ AV9+)
+- 0-2 Thrower (MA6 AG3+ — Pass, Sure Hands)
+- 0-4 Catcher (MA8 ST2 AV8+ — Catch, Dodge)
+- 0-4 Blitzer (MA7 ST3 AV9+ — Block)
+- 0-1 Ogre (MA5 ST5 — Loner, Bone-head, Mighty Blow, Thick Skull, Throw Team-Mate)
+
+| NFL Position | Human Position |
+|---|---|
+| QB | Thrower |
+| RB | Blitzer (ou Lineman si pure power) |
+| WR | Catcher |
+| TE | Catcher (ou Blitzer si blocking) |
+| OL | Lineman |
+| DT élite | Ogre |
+| DE | Blitzer |
+| LB | Blitzer |
+| CB | Catcher (défensif) |
+| S | Blitzer ou Catcher |
+
+### Norse roster
+
+Roster BB Norse :
+- 0-12 Lineman (MA6 ST3 AV8+ — Block)
+- 0-2 Thrower (MA6 — Block, Pass)
+- 0-2 Runner (MA7 — Block)
+- 0-2 Catcher (MA7 AG2+ — Block, Catch)
+- 0-4 Berserker (MA6 ST3 — Block, Frenzy, Jump Up)
+- 0-2 Ulfwerener (MA6 ST4 — Frenzy)
+- 0-1 Yhetee (MA5 ST5 — Loner, Claw, Disturbing Presence, Frenzy, Wild Animal)
+
+Tous les Norse standards ont **Block** — cohérent avec leur identité
+"physique mais skilled" (vs Orc qui doivent acheter Block).
+
+| NFL Position | Norse Position |
+|---|---|
+| QB (Allen) | Thrower (avec Strong Arm) |
+| RB power | Ulfwerener |
+| RB speed | Runner |
+| WR1 alpha (Jefferson) | Catcher |
+| WR | Catcher / Runner |
+| TE | Berserker avec Catch |
+| OL | Lineman |
+| DT | Yhetee |
+| DE (Hutchinson) | Berserker |
+| LB | Berserker |
+| CB | Catcher défensif |
+| S | Berserker / Runner |
+
+### Dwarf roster
+
+Roster BB Dwarf :
+- 0-16 Blocker (MA4 ST3 AV10+ — Block, Tackle, Thick Skull)
+- 0-2 Runner (MA6 ST3 — Sure Hands, Thick Skull)
+- 0-2 Blitzer (MA5 ST3 AV10+ — Block, Tackle, Thick Skull)
+- 0-2 Trollslayer (MA5 ST3 — Block, Dauntless, Frenzy, Thick Skull)
+- 0-1 Deathroller (MA4 ST7 — Loner, Break Tackle, Dirty Player, Juggernaut, Mighty Blow, No Hands, Secret Weapon, Stand Firm)
+
+Particularité Dwarf : pas de Thrower dédié. Le QB devient un Runner
+avec skills Pass via levelup, ou un Blocker exception.
+
+| NFL Position | Dwarf Position |
+|---|---|
+| QB | Runner (avec Pass skill) |
+| RB power | Blocker / Blitzer |
+| RB receiving | Runner |
+| WR | Runner avec Catch (rare en Dwarf) |
+| TE | Blocker |
+| OL | Blocker |
+| DT (Lawrence, Garrett) | Deathroller (Big Guy unique) |
+| DE | Blitzer |
+| LB | Blitzer / Trollslayer |
+| CB | Runner |
+| S | Blitzer |
+
+### Khorne roster
+
+Roster BB Khorne (Khorne Daemonkin BB2020) :
+- 0-12 Bloodseeker (MA6 ST3 AG3+ AV9+ — Frenzy)
+- 0-4 Khorngor (MA6 ST3 AG2+ AV9+ — Horns, Juggernaut)
+- 0-4 Bloodspawn (MA5 ST4 AV9+ — Block, Claws, Frenzy, Mighty Blow)
+- 0-1 Bloodthirster (MA5 ST5 — Loner, Claws, Frenzy, Mighty Blow, Unchannelled Fury, Wild Animal)
+
+Tous frénétiques, low AG → adaptation : on autorise un "Khorne Caster"
+custom (Thrower décent) pour les QBs NFL :
+
+| NFL Position | Khorne Position |
+|---|---|
+| QB (Mayfield gunslinger) | Bloodseeker avec Pass skill (custom) |
+| RB power | Bloodspawn |
+| RB speed | Khorngor |
+| WR | Khorngor avec Catch |
+| TE | Bloodspawn avec Catch |
+| OL | Bloodseeker |
+| DT (Q. Williams) | Bloodthirster |
+| DE (Crosby, Mack, Bosa) | Bloodspawn |
+| LB | Khorngor |
+| CB (Sauce Gardner) | Khorngor avec Catch |
+| S | Bloodseeker / Khorngor |
+
+### Necromantic roster
+
+Roster BB Necromantic Horror :
+- 0-12 Zombie (MA4 ST3 AG3+ AV8+ — Regenerate)
+- 0-2 Ghoul (MA7 ST3 AG2+ AV8+ — Dodge)
+- 0-4 Wight (MA6 ST3 AV9+ — Block, Regenerate)
+- 0-2 Flesh Golem (MA4 ST4 AV9+ — Regenerate, Stand Firm, Thick Skull)
+- 0-2 Werewolf (MA8 ST3 AG2+ AV8+ — Claws, Frenzy, Regenerate)
+
+Tous Regenerate ⇒ thématique parfaite pour les franchises NFL "rebuild
+qui ne meurent jamais".
+
+| NFL Position | Necromantic Position |
+|---|---|
+| QB | Ghoul avec Pass skill |
+| RB power | Wight |
+| RB speed (Kamara) | Werewolf ou Ghoul |
+| WR alpha (Olave, Sutton) | Ghoul avec Catch |
+| TE | Wight avec Catch |
+| OL | Zombie |
+| DT (Simmons) | Flesh Golem |
+| DE (Cam Jordan) | Werewolf vétéran |
+| LB | Wight |
+| CB (Surtain) | Ghoul |
+| S | Wight |
+
+## Stats BB de base → archétype NFL
+
+Pour matcher un joueur NFL à un poste BB, on dérive aussi des stats BB :
+
+```ts
+interface BbStats {
+  ma: number;   // Movement Allowance (1-9)
+  st: number;   // Strength (1-7)
+  ag: number;   // Agility (1+ to 6+, lower = better)
+  pa: number;   // Pass Ability (1+ to 6+, lower = better)
+  av: number;   // Armor Value (7+ to 11+)
+}
+```
+
+Conversion :
+- **MA** ← 40-yard dash time
+  - <4.3s = MA9, 4.3-4.4 = MA8, 4.4-4.5 = MA7, 4.5-4.6 = MA6, etc.
+- **ST** ← weight + bench press
+  - >250 lbs + 25+ reps = ST4+, etc.
+- **AG** ← cone + shuttle drills
+  - Cone <6.7s = AG2+, etc.
+- **PA** ← QB rating + completion %
+  - Élite QB (>100 rating) = PA2+, etc.
+- **AV** ← position (OL/DL plus high, WR plus low)
+  - OL/DL = AV10+, LB/TE = AV9+, RB/WR = AV8+, etc.
+
+## Génération automatique par player
+
+```ts
+// nfl-mapper/src/player-to-bb-position.ts (pure)
+
+interface NflPlayerCombineData {
+  fortyYard?: number;
+  weight?: number;
+  benchReps?: number;
+  cone?: number;
+  shuttle?: number;
+}
+
+interface NflPlayerCareerStats {
+  position: NflPosition;
+  career: { games: number; ppr: number; /* etc. */ };
+  bestSeason: { /* ... */ };
+}
+
+export function deriveBbPositionAndStats(
+  player: NflPlayerCombineData & NflPlayerCareerStats,
+  teamRace: BbRace,
+): { bbPosition: BbPosition; bbStats: BbStats; skills: readonly BbSkill[] } {
+  // 1. Archetype detection
+  // 2. Map to race-specific BB position
+  // 3. Compute BB stats from combine
+  // 4. Suggest skills from career stats
+}
+```
+
+## Cas particuliers
+
+### QB mobile (Lamar Jackson, Jayden Daniels, Justin Fields)
+
+Dilemme : Thrower (passing identity) ou Runner (mobile) ?
+
+**Solution** : Thrower avec skill **Sprint** ou stat MA améliorée :
+- Lamar 2019 (MVP) : Thrower MA7 (vs Thrower normal MA5-6 selon race)
+- Justin Fields : Thrower MA8 si race Skaven, Thrower MA6 sinon
+
+### Pass-catching RB (CMC, Bijan, Kamara)
+
+Dual-role player. Solution :
+- Skaven : Gutter Runner avec Block skill ajoutée
+- Wood Elf : Catcher (force versatile)
+- Orc : Blitzer avec Catch skill
+- Norse : Runner avec Catch
+- Human : Blitzer avec Catch
+- Dwarf : Runner
+- Khorne : Khorngor
+- Necromantic : Werewolf ou Ghoul
+
+### TE hybride (Kelce, Bowers, LaPorta, Kittle)
+
+Mapping selon race :
+- Skaven : Storm Vermin avec Catch
+- Wood Elf : Catcher
+- Orc : Black Orc avec Catch
+- Norse : Berserker avec Catch
+- etc.
+
+### Édge fluide vs power (Watt vs Garrett vs Bosa)
+
+Tous des Blitzers (ou équivalent race). Différenciation par stats :
+- Power (Garrett 270lbs, Watt 270lbs) : ST4 ou Beast
+- Speed (Parsons, Crosby) : MA+ Blitzer
+
+### Spécialistes ST (kickers, punters)
+
+Hors scope MVP. À ajouter en V2 si on veut un mode "field position"
+plus complet. En V1, on ignore les K/P (scoring trop spécifique).
+
+## Skills BB pré-attribuées par poste NFL
+
+Standard NFL → BB skill packages :
+
+```
+QB élite (Mahomes-tier)
+└── Thrower base + Pass + Sure Hands + Accurate + Strong Arm
+
+QB mobile (Allen, Lamar)
+└── Thrower base + Pass + Sprint + Sure Feet
+
+WR1 alpha (Chase, Jefferson)
+└── Catcher base + Side Step + Diving Catch + Block
+
+RB workhorse (Henry, Taylor)
+└── Blitzer base + Break Tackle + Stand Firm
+
+DE pass rusher (Watt, Crosby)
+└── Blitzer base + Mighty Blow + Tackle + Strip Ball
+
+DT elite (Donald-tier, Q. Williams)
+└── Big Guy + Mighty Blow + Multiple Block
+
+CB shutdown (Sauce, Surtain)
+└── Catcher défensif + Diving Tackle + Pass Block
+
+TE versatile (Kelce, Bowers)
+└── Catcher base + Side Step + Block + Sure Hands
+```
+
+Le mapping détaillé est dans [`08-rosters-2025.md`](./08-rosters-2025.md).

--- a/docs/nfl-fantasy/06-scoring.md
+++ b/docs/nfl-fantasy/06-scoring.md
@@ -1,0 +1,346 @@
+# 06 — Scoring : stats NFL → SPP Blood Bowl
+
+> Conversion des stats NFL réelles en SPP (Star Player Points) Blood Bowl
+> pour alimenter la progression des joueurs et le scoring des matchs
+> fantasy.
+
+## Rappel barème SPP (BB2020)
+
+| Action BB | SPP |
+|---|---|
+| Completion (CP) | 1 |
+| Pass Deflection (PD) | 1 |
+| Defensive Play (DP) — Interception, Strip Ball, Fumble Recovery | 2 |
+| Touchdown (TD) | 3 |
+| Casualty (CAS) | 2 |
+| MVP (random) | 4 |
+
+**Ordre de grandeur typique BB** :
+- Joueur lambda : 0-2 SPP/match
+- Bon joueur : 3-5 SPP/match
+- Star match : 8+ SPP
+
+**Saison BB (16 matches)** :
+- Titulaire régulier : 30-60 SPP
+- Star : 60-100 SPP
+- Level-ups BB2020 : 6, 16, 31, 51, 76, 176 SPP
+
+## Problème de calibration
+
+Un match NFL = ~60-80 plays par équipe, donc beaucoup plus d'actions
+qu'un match BB (16 turns max). Si on fait "1 completion = 1 SPP", un QB
+gagnerait 25 SPP/match — break le système.
+
+**Solution : threshold-based mapping (recommandé)**.
+
+Seuls les **moments NFL "BB-worthy"** comptent (TD, big play, sack,
+INT, etc.). Préserve la narrative BB : chaque SPP = un "moment".
+
+Alternative : **continuous scaled** (`SPP_match = round(fantasy_points / 5)`),
+plus simple mais moins narratif.
+
+## Table de mapping par poste NFL
+
+### Thrower (QB) — race équipe
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| 1 passing TD | 1× TD | 3 |
+| Passing yards par tranche de 75 (cap à 4) | 1× CP | 1 |
+| Completion >25 yards | 1× CP (long bomb) | 1 |
+| 1 interception thrown | -1× CP (annulé) | -1 |
+| Rating > 110 | bonus MVP candidate | +1 |
+| 1 rushing TD (QB run) | 1× TD | 3 |
+| 1 rushing yards >50 | bonus CP | 1 |
+| 1 sack subi | malus narratif, no SPP | 0 |
+
+**Exemple : Mahomes 31/45, 350 yds, 3 TD, 1 INT**
+= 3 TD ×3 + (350/75 = 4) CP + (-1) malus
+= 9 + 4 - 1 = **12 SPP** (gros match)
+
+### Runner / Blitzer / Gutter Runner (RB)
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| 1 rushing TD | 1× TD | 3 |
+| 1 receiving TD | 1× TD | 3 |
+| 75+ rushing yards | 1× CP-equivalent (handoff carried) | 1 |
+| 100+ rushing yards | bonus +1× CP | 1 |
+| 100+ receiving yards | bonus +1× CP | 1 |
+| 1 reception (max 3 capped) | 1× CP | 1 |
+| 1 fumble lost | malus narratif | -1 |
+
+**Exemple : Henry 24/175, 2 TD, 1 fumble**
+= 2 TD ×3 + 1 CP (100+ yards) + 1 CP (75+) + (-1) malus
+= 6 + 1 + 1 - 1 = **7 SPP**
+
+### Catcher (WR / TE)
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| 1 reception (max 5/match capped) | 1× CP | 1 |
+| 1 receiving TD | 1× TD | 3 |
+| 100+ receiving yards | bonus +1× CP | 1 |
+| 150+ receiving yards | bonus +1× CP | 1 |
+| 1 drop | -1× CP | -1 |
+
+**Exemple : Jefferson 8/142, 1 TD**
+= 5 CP (capped) + 1 TD ×3 + 1 CP (100+)
+= 5 + 3 + 1 = **9 SPP** (star match)
+
+### Big Guy (DT / NT)
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| 1 sack | 1× CAS (knocked QB down hard) | 2 |
+| 3 QB hits | 1× CAS | 2 |
+| 1 TFL | narrative, no SPP | 0 |
+| 1 forced fumble | 1× DP (strip ball) | 2 |
+| 1 fumble recovery | 1× DP | 2 |
+| 1 defensive TD | 1× TD | 3 |
+
+**Exemple : Aaron Donald 2 sacks, 1 forced fumble**
+= 2 sacks ×2 + 1 FF ×2 = **6 SPP** (star match)
+
+### Blitzer (DE / EDGE / LB)
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| Tackles ≥10 | 1× CAS-equivalent | 2 |
+| 1 sack | 1× CAS | 2 |
+| 1 INT | 1× DP | 2 |
+| 1 forced fumble | 1× DP | 2 |
+| Tackles for loss ≥2 | bonus +1× CP | 1 |
+| 1 defensive TD | 1× TD | 3 |
+
+**Exemple : TJ Watt 8 tackles, 2 sacks, 1 FF**
+= 2 sacks ×2 + 1 FF ×2 = **6 SPP**
+
+### Catcher défensif / Runner (CB / S)
+
+| NFL stat | BB event | SPP |
+|---|---|---|
+| 1 INT | 1× DP | 2 |
+| 1 pass breakup (PBU) | 1× PD | 1 |
+| 1 defensive TD (pick-six / fumble return) | 1× TD + 1× DP | 5 |
+| Tackles ≥8 | bonus narratif | 0 |
+| 1 forced fumble | 1× DP | 2 |
+
+**Exemple : Sauce Gardner 1 INT, 3 PBU, 6 tackles**
+= 1 INT ×2 + 3 PD ×1 = **5 SPP**
+
+### Lineman OL (Black Orc, Lineman)
+
+Le plus difficile à scorer car les OL ne sont pas trackés directement
+dans les stats NFL standard. Trois approches :
+
+**Approche 1 : PFF-based** (best, requiert PFF data)
+- Pancake blocks : 1 SPP par pancake
+- Run blocks réussis (par snap) : composite
+- Sacks alloués : -1 SPP chacun
+
+**Approche 2 : QB-derived** (cheap, sans PFF)
+Chaque OL gagne SPP en fonction du succès collectif du backfield :
+- QB rating de l'équipe >100 : +1 SPP pour chaque OL starter
+- Rushing yards équipe >150 : +1 SPP pour chaque OL starter
+- Sacks alloués équipe <2 : +1 SPP pour chaque OL starter
+- Sacks alloués équipe >4 : -1 SPP pour chaque OL starter
+
+**Approche 3 : participation-based** (minimal)
+- 1 SPP par match disputé en titulaire (slow progression, mais ça progresse)
+
+**Recommandation** : approche 2 (QB-derived) en MVP, upgrade vers PFF en V2.
+
+## Variantes scoring optionnelles
+
+### Captain bonus
+
+Désigner 1 joueur Captain par lineup hebdo :
+- Multiplier ×1.5 sur ses SPP (cf. Sorare classique)
+- Ou ×2 si format "Captain Mode"
+
+### Vice-captain bonus
+
+Si compétition le permet : ×1.2 sur un 2e joueur.
+
+### Specialist competitions
+
+Pour ajouter de la variété (cf. Sorare Single Game Week) :
+- **Defensive Specialist** : seuls les SPP défensifs comptent ×2
+- **Offensive Showdown** : seuls SPP offensifs comptent ×2
+- **Underdog** : limité aux joueurs TV <50k (rookies + role players)
+- **Captain Captain** : Captain ×2.5 mais reste de l'équipe ×0.5
+
+## Implémentation pure (testable)
+
+```ts
+// packages/nfl-mapper/src/stats-to-spp.ts
+
+interface NflPlayerStatLine {
+  position: NflPosition;
+  bbPosition: BbPosition;
+
+  // offensive
+  passYards?: number;
+  passTd?: number;
+  passInt?: number;
+  passComp?: number;
+  passAtt?: number;
+  rushYards?: number;
+  rushTd?: number;
+  rushAtt?: number;
+  fumbleLost?: number;
+  recYards?: number;
+  receptions?: number;
+  recTd?: number;
+  drops?: number;
+
+  // defensive
+  tackles?: number;
+  sacks?: number;
+  tfl?: number;
+  qbHits?: number;
+  defInt?: number;
+  passDefended?: number;
+  forcedFumble?: number;
+  fumbleRecovery?: number;
+  defTd?: number;
+
+  // team context (for OL)
+  teamPassRating?: number;
+  teamRushYards?: number;
+  teamSacksAllowed?: number;
+}
+
+interface SppBreakdown {
+  events: ReadonlyArray<{ type: BbEventType; count: number; spp: number; reason: string }>;
+  totalSpp: number;
+  mvpEligible: boolean;
+}
+
+export function computeSpp(stat: NflPlayerStatLine): SppBreakdown {
+  // Pure function — replay-friendly
+  // No side effects, deterministic
+}
+```
+
+## Tests à écrire (Vitest)
+
+Suivre les patterns du repo (`apps/server/src/services/*.test.ts`) :
+
+```ts
+describe("computeSpp - Thrower", () => {
+  it("computes Mahomes-style elite game", () => {
+    const result = computeSpp({
+      position: "QB", bbPosition: "Thrower",
+      passYards: 350, passTd: 3, passInt: 1,
+      passComp: 31, passAtt: 45,
+    });
+    expect(result.totalSpp).toBe(12);
+    expect(result.events).toHaveLength(4); // 3 TD + 4 CP + 1 INT malus
+  });
+
+  it("caps passing yards at 4 CP", () => {
+    const result = computeSpp({
+      position: "QB", bbPosition: "Thrower",
+      passYards: 500, passTd: 0, passInt: 0,
+      passComp: 30, passAtt: 40,
+    });
+    // 500/75 = 6.67, capped at 4
+    expect(result.totalSpp).toBe(4);
+  });
+
+  it("handles negative INT correctly", () => {
+    const result = computeSpp({
+      position: "QB", bbPosition: "Thrower",
+      passYards: 75, passTd: 0, passInt: 3,
+      passComp: 5, passAtt: 25,
+    });
+    expect(result.totalSpp).toBe(-2); // 1 CP - 3 malus
+  });
+});
+```
+
+## MVP attribution (4 SPP bonus)
+
+Sélection du MVP par algo, pas par vote (au moins en V1) :
+
+1. Liste des joueurs avec `totalSpp > 0` de l'équipe gagnante (côté
+   matchup fantasy, pas équipe NFL)
+2. Tri descending par SPP
+3. Top 3 ⇒ tirage aléatoire avec seed déterministe `${matchupId}:mvp`
+4. MVP gagne **+4 SPP** bonus
+
+Pattern existant : suit la convention BB officielle (random parmi
+top performers, pas auto-attribué au best).
+
+## Calibration empirique
+
+Sur la saison 2024 NFL complète, estimation des SPP totaux par joueur :
+
+| Tier joueur | Saison NFL 17 matches | SPP cumulés estimés |
+|---|---|---|
+| Star QB (Mahomes) | 4500 yds, 30 TD, 12 INT | ~100 SPP |
+| Star WR (Jefferson) | 100 rec, 1500 yds, 10 TD | ~70 SPP |
+| Star RB (Henry) | 1500 yds, 13 TD, 3 fumbles | ~50 SPP |
+| Star Edge (Watt) | 80 tackles, 15 sacks, 3 FF | ~40 SPP |
+| Star DT (Donald-tier) | 60 tackles, 10 sacks, 5 FF | ~30 SPP |
+| Star CB (Sauce) | 60 tackles, 4 INT, 12 PBU | ~25 SPP |
+| Role player | varies | 10-20 SPP |
+
+**Implication progression BB** :
+- Level 2 (6 SPP) atteint en ~1-2 matches pour les stars
+- Level 3 (16 SPP) en ~3-4 matches
+- Level 4 (31 SPP) en ~6-8 matches
+- Level 5 (51 SPP) en mi-saison ou fin saison
+- Level 6 (76 SPP) atteignable seulement pour les ALL-PRO
+
+Cohérent avec la progression BB d'un Pro League. À ajuster en V1 selon
+le feedback playtest (si trop lent ⇒ diviser seuils par 2, si trop
+rapide ⇒ augmenter).
+
+## Pattern d'application
+
+Réutilise `attributeSpp` du `sim-engine` :
+
+```ts
+// apps/server/src/services/nfl-fantasy-scoring.ts
+
+export async function settleNflFantasyWeek(weekId: string): Promise<void> {
+  const matchups = await prisma.nflFantasyMatchup.findMany({
+    where: { weekId, status: "pending" },
+    include: { entries: { include: { lineup: true } } },
+  });
+
+  for (const matchup of matchups) {
+    const entryScores = await Promise.all(
+      matchup.entries.map(async (entry) => {
+        const playerScores = await Promise.all(
+          entry.lineup.players.map(async (lp) => {
+            const stat = await prisma.nflGameStat.findUnique({
+              where: { gameId_playerId: { gameId: lp.gameId, playerId: lp.playerId } },
+            });
+            if (!stat) return { playerId: lp.playerId, spp: 0 };
+
+            const breakdown = computeSpp(stat); // pure
+            const captainMultiplier = lp.isCaptain ? 1.5 : 1;
+            return {
+              playerId: lp.playerId,
+              spp: Math.round(breakdown.totalSpp * captainMultiplier),
+              breakdown,
+            };
+          }),
+        );
+        return { entryId: entry.id, total: playerScores.reduce((a, p) => a + p.spp, 0), playerScores };
+      }),
+    );
+
+    // Update matchup result
+    // Persist breakdown for transparency (user sees per-player SPP)
+    // Apply rerolls/inducements/prayers via hooks (cf. mechanics.md)
+  }
+}
+```
+
+Pattern Q.D.1 : settle isolé en try/catch pour ne pas casser un matchup
+suite à l'autre.

--- a/docs/nfl-fantasy/07-mechanics.md
+++ b/docs/nfl-fantasy/07-mechanics.md
@@ -1,0 +1,416 @@
+# 07 — Mécaniques BB intégrées : relances, inducements, prières
+
+> Intégration des mécaniques iconiques de Blood Bowl dans le scoring
+> fantasy NFL. Trois mécaniques, trois rôles dans l'économie.
+
+## Aperçu des rôles
+
+| Mécanique | Rôle | Économie |
+|---|---|---|
+| **Relances** | Mitigation (annuler un échec) | Inventaire de saison (acheté + skill) |
+| **Inducements** | Upside ponctuel (booster un coup) | Marketplace + slots hebdo |
+| **Prières à Nuffle** | Catch-up anti-snowball | Auto-roll si underdog |
+
+## 1. Relances (Re-rolls)
+
+### Sémantique NFL
+
+Une relance = **annuler un échec narratif** d'un joueur sur un événement
+précis :
+- QB lance 2 INT → use 1 reroll → 1 INT "n'est jamais arrivée" pour le scoring
+- WR drop une passe critique → reroll → drop annulé (juste annulation, pas conversion en CP)
+- DL rate un sack (QB hit only) → reroll → upgrade en sack
+
+### Modèle hybride recommandé
+
+**Pool de saison (acheté)** :
+- Démarre la saison avec **8 team rerolls** (cf. roster Skaven full reroll)
+- Coût mercato : 50k-100k gp / reroll selon stade saison
+- Persistent ⇒ thésauriser pour les playoffs
+
+**Pool de match (gagné)** :
+- Joueurs avec le skill BB **Pro** ⇒ 1 reroll personnel par match auto
+- Joueurs **Loner (4+)** ⇒ reroll échoue 50% du temps (random)
+- Skill obtenu via SPP levelups (cf. `attributeSpp` existant)
+
+### Limites
+
+- Max **2 rerolls par joueur** par match (sinon dégénère)
+- Décision pré-match : "auto-use sur 1ère INT" / "manuel" / "stack for playoffs"
+- **Idempotent** : un reroll appliqué fige le résultat, pas de re-reroll en cascade
+
+### Implémentation
+
+```ts
+// packages/nfl-mapper/src/rerolls.ts
+interface RerollDecision {
+  type: "auto-mitigate-worst" | "manual-targeted" | "skill-pro";
+  playerId: string;
+  triggerStat: "INT" | "FUMBLE" | "DROP" | "MISSED_SACK";
+}
+
+interface RerollPool {
+  team: number;
+  skill: number;
+}
+
+interface RerollApplication {
+  result: NflPlayerStatLine;
+  consumed: RerollPool;
+  log: ReadonlyArray<{ playerId: string; type: string; before: number; after: number }>;
+}
+
+// Pure function — replay-friendly
+export function applyRerolls(
+  statLine: NflPlayerStatLine,
+  decisions: readonly RerollDecision[],
+  pool: RerollPool,
+): RerollApplication {
+  // 1. Sort decisions by priority (auto-mitigate from worst)
+  // 2. For each, attempt to apply (check pool, check stat exists)
+  // 3. Modify stat line + deduct pool
+  // 4. Return audit log
+}
+```
+
+### UX
+
+Page **Pre-match** (avant lock Sunday 1pm ET) :
+- "Rerolls disponibles : 5 team / 2 skill"
+- "Auto-use sur 1ère INT du QB ?" (toggle)
+- "Auto-use sur 1ère fumble du RB ?" (toggle)
+- "Save for playoffs (no auto)" (option)
+
+Page **Post-match** (Mardi review) :
+- "Reroll utilisé sur INT #2 de [QB pseudonyme]"
+- "Effet : -1 SPP malus annulé"
+- "Pool restant : 4 team / 2 skill"
+
+## 2. Inducements (Coups de pouce)
+
+### Sémantique NFL
+
+Chaque inducement BB a une transposition naturelle :
+
+| BB Inducement | NFL Fantasy version | Coût gp | Effet |
+|---|---|---|---|
+| **Bribe** | "Hidden ball trick" | 100k | Annule 1 turnover (INT ou fumble lost) |
+| **Wandering Apothecary** | "Team trainer" | 100k | Annule 1 malus injury / IR pour la semaine |
+| **Bloodweiser Keg** | "Energy drink" | 50k | Joueur en concussion protocol revient actif |
+| **Halfling Master Chef** | "Disruptive coach" | 300k | Vole 1 reroll à l'opposant (H2H league) |
+| **Cheerleader** | "Crowd boost" | 10k | +5% SPP pour les joueurs en home game cette semaine |
+| **Assistant Coach** | "Coordinator boost" | 20k | +1 reroll one-shot |
+| **Wizard (Fireball)** | "Trick play designer" | 150k | ×2 sur 1 stat ciblée (1 TD, 1 sack, 1 INT défensif) |
+| **Star Player rental** | "Free agent ringer" | 150-500k | Add 1 NFL player hors roster pour 1 match |
+| **Mercenary** | "Practice squad call-up" | 30k + skill | Idem star, tier inférieur, skill aléatoire |
+| **Riotous Rookies** | "Surprise rookie" | 80k | Wildcard joueur rookie aléatoire boost +50% |
+
+### Modèle d'intégration : slots hebdomadaires
+
+User dispose de **3 slots inducement par match** :
+- 1 slot **Defensive** (apothecary, bribe, keg, fan favors)
+- 1 slot **Offensive** (wizard, star player, cheerleader)
+- 1 slot **Wildcard** (n'importe quoi)
+
+Slots non utilisés ⇒ perdus (sinon overflow ingérable). Inducements
+achetés au mercato ou gagnés par achievements ⇒ stock persistent.
+Activation pre-match avant lock Sunday.
+
+### Star Player rental — mécanique riche
+
+Tu peux "louer" un joueur (ex: WR alpha d'une autre équipe) **une semaine**
+même s'il n'est pas dans ton roster ⇒ il rapporte des SPP **temporaires**
+non-cumulables sur le levelup. Permet de jouer les matchups (rent Jefferson
+la semaine où il joue contre une défense faible). Coût ~contrat NFL hebdo / 100.
+
+### Implémentation
+
+```ts
+// packages/nfl-mapper/src/inducements.ts
+
+type InducementId =
+  | "BRIBE" | "APOTHECARY" | "KEG" | "MASTER_CHEF"
+  | "CHEERLEADER" | "ASSISTANT_COACH" | "WIZARD"
+  | "STAR_PLAYER" | "MERCENARY" | "RIOTOUS_ROOKIES";
+
+interface InducementActivation {
+  id: InducementId;
+  slot: "defensive" | "offensive" | "wildcard";
+  targetPlayerId?: string; // si l'inducement cible un joueur
+  meta?: Record<string, unknown>; // ex: starPlayer rental → joueur ID
+}
+
+// Pure
+export function applyInducements(
+  statLines: NflPlayerStatLine[],
+  activations: readonly InducementActivation[],
+  context: { weekId: string; matchupId: string },
+): {
+  modifiedStats: NflPlayerStatLine[];
+  starPlayerStats?: NflPlayerStatLine;
+  log: ReadonlyArray<{ id: string; effect: string }>;
+} {
+  // Apply each activation in deterministic order
+  // Wildcard slot last (can override defensive/offensive)
+}
+```
+
+## 3. Prières à Nuffle
+
+### Sémantique NFL
+
+C'est le mécanisme **anti-rich-gets-richer** crucial pour la longévité
+d'une league. En BB officiel : déclenché si TV < opponent TV par 50k+
+⇒ tu rolls 1 prière (ou 2 si écart >150k).
+
+**Adaptation NFL fantasy** : Si ton roster TV est inférieur d'au moins
+**20%** à ton matchup adverse (H2H league) ou à la **médiane de la
+league** (rotisserie), tu rolls **1 Prière** automatique chaque semaine.
+Si écart >40% ⇒ 2 Prières.
+
+### Table d'adaptation
+
+Roll d12 (ou d16 BB2020) sur :
+
+| Roll | BB Prayer | NFL Fantasy adaptée | Effet |
+|---|---|---|---|
+| 1 | Treacherous Trapdoor | "Field hazard" | Annule le meilleur événement SPP d'un opponent au hasard |
+| 2 | Friends with the Ref | "Ref bias" | Tes malus INT/fumble divisés par 2 cette semaine |
+| 3 | Stiletto | "Targeted hit" | 1 DL/LB désigné : sacks comptent ×2 |
+| 4 | Iron Man | "Iron body" | 1 joueur désigné : immune aux malus |
+| 5 | Greasy Cleats | "Slippery turf" | 1 opponent désigné : SPP × 0.5 |
+| 6 | Blessed Statue | "Lucky bounce" | Tous tes joueurs : +0.5 SPP par CP |
+| 7 | Moles Under Pitch | "Sideline chaos" | 1 opponent aléatoire : score 0 |
+| 8 | Perfect Passing | "Passing clinic" | Tes QBs : INTs ne pénalisent pas |
+| 9 | Fan Interaction | "Crowd interferes" | 1 opponent aléatoire : désactivé |
+| 10 | Necessary Violence | "No flag thrown" | Tes flags 15-yd n'appliquent pas malus |
+| 11 | Fouling Frenzy | "Bounty hunter" | 1 LB désigné : +1 SPP par tackle |
+| 12 | Throw a Rock | "Object from stands" | 1 opponent aléatoire : -1 SPP sur son best play |
+
+Roll fait **automatiquement** au lock pre-match (Sunday 1pm ET en NFL).
+Notif au user : "Nuffle smiles upon you: *Friends with the Ref* activée
+cette semaine". User désigne joueur ciblé si la prière le demande
+(avant kickoff).
+
+### Implémentation
+
+```ts
+// packages/nfl-mapper/src/prayers.ts
+
+type PrayerId =
+  | "TREACHEROUS_TRAPDOOR" | "FRIENDS_REF" | "STILETTO" | "IRON_MAN"
+  | "GREASY_CLEATS" | "BLESSED_STATUE" | "MOLES" | "PERFECT_PASSING"
+  | "FAN_INTERACTION" | "NECESSARY_VIOLENCE" | "FOULING_FRENZY" | "ROCK";
+
+interface PrayerRoll {
+  id: PrayerId;
+  rolledAt: Date;
+  targetPlayerId?: string; // si user a dû désigner (sélection user dans UI)
+  weekId: string;
+  seed: string; // pour replay déterministe
+}
+
+// Pure
+export function rollPrayers(
+  seed: string,
+  count: 1 | 2,
+): PrayerRoll[] {
+  // Use seeded PRNG (e.g., seedrandom)
+  // Roll d12 count times
+  // Return PrayerRoll[]
+}
+
+// Pure
+export function applyPrayer(
+  prayer: PrayerRoll,
+  ownStats: NflPlayerStatLine[],
+  opponentStats: NflPlayerStatLine[],
+): {
+  ownModified: NflPlayerStatLine[];
+  opponentModified: NflPlayerStatLine[];
+  log: string;
+} {
+  // Apply prayer effect, return modified stats + audit log
+}
+```
+
+Seed déterministe = `${userId}:${weekId}` ⇒ replay reproductible (cf.
+pattern `attributeSpp` pure).
+
+### Détection underdog
+
+```ts
+// packages/nfl-mapper/src/underdog.ts
+
+interface MatchupContext {
+  ownTV: number;
+  opponentTV: number;
+  leagueMedianTV?: number;
+}
+
+export function shouldRollPrayers(ctx: MatchupContext): { rollCount: 0 | 1 | 2 } {
+  const referenceTV = ctx.opponentTV ?? ctx.leagueMedianTV ?? 0;
+  const diff = referenceTV - ctx.ownTV;
+  const percent = diff / referenceTV;
+
+  if (percent >= 0.40) return { rollCount: 2 };
+  if (percent >= 0.20) return { rollCount: 1 };
+  return { rollCount: 0 };
+}
+```
+
+## Architecture économique globale
+
+```
+SAISON
+├── Mercato : achète inducements + rerolls (gold persistent)
+├── Achievements : earn rerolls bonus, inducements gratuits
+└── Inventory persistent
+
+CHAQUE SEMAINE NFL
+├── Avant lock (Dimanche 12h ET)
+│   ├── Set lineup (11 titulaires)
+│   ├── Set captain (×1.5)
+│   ├── Allocate inducements (3 slots max)
+│   ├── Pre-stage rerolls (auto-use rules)
+│   └── Auto-roll prayers si underdog
+├── Pendant matches NFL (Dimanche-Lundi)
+│   └── Stats live ingérées via API
+└── Settlement (Mardi)
+    ├── Apply prayers
+    ├── Apply rerolls (manual ou auto)
+    ├── Apply inducements
+    ├── Compute final SPP par joueur
+    └── Update standings + level-ups
+```
+
+## Schéma Prisma proposé
+
+```prisma
+// prisma/schema.prisma additions
+
+model NflFantasyReroll {
+  id        String   @id @default(cuid())
+  entryId   String   // ref NflFantasyEntry (user's team in league)
+  type      String   // "team" | "skill" | "assistant_coach"
+  source    String   // "starter" | "purchased" | "achievement" | "skill_pro"
+  used      Boolean  @default(false)
+  usedAt    DateTime?
+  weekId    String?  // si used, lié à la semaine
+  matchupId String?
+  appliedTo String?  // playerId targeted
+
+  entry NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@index([entryId, used])
+}
+
+model NflFantasyInducement {
+  id        String   @id @default(cuid())
+  entryId   String
+  type      String   // InducementId
+  slot      String   // "defensive" | "offensive" | "wildcard" | null si non-utilisé
+  used      Boolean  @default(false)
+  usedAt    DateTime?
+  weekId    String?
+  matchupId String?
+  targetId  String?  // playerId targeted
+  meta      Json?    // ex: rental player ID
+
+  entry NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@index([entryId, used])
+}
+
+model NflFantasyPrayer {
+  id          String   @id @default(cuid())
+  entryId     String
+  weekId      String
+  matchupId   String
+  prayerId    String   // PrayerId
+  rolledAt    DateTime @default(now())
+  seed        String   // for replay
+  targetId    String?  // playerId if prayer requires target
+  applied     Boolean  @default(false)
+  appliedAt   DateTime?
+  effectLog   String?  // audit log of effect applied
+
+  entry NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@unique([entryId, weekId, prayerId])
+}
+```
+
+## 3 variantes selon l'audience
+
+### Casual mode
+- Pas d'inducements complexes
+- +3 rerolls/saison forfaitaires
+- Prayers auto-roll silently
+- UX minimale, focus sur la lineup
+- MPG-feel
+
+### Standard mode (recommandé)
+- Full hybrid décrit ci-dessus
+- ~10 min de gestion pre-match
+- Sweet spot engagement vs friction
+
+### Hardcore mode
+- Ajoute les **conditions de saison** (météo, niggling injuries, fan factor)
+- Mode draft auction live MPG-style
+- Pour les BB veterans qui veulent toute la profondeur
+
+## Bonus narratif : Gazette flavor
+
+Le moteur Gazette existant consomme bien ces événements :
+
+> "Mahomes lance une INT critique... mais Krak'Skar le coach orc soudoie
+> l'arbitre ! La passe est rejouée, complétée pour 47 yards !"
+> *(bribe + reroll narratif)*
+
+> "Nuffle sourit aux Underdogs : un trou s'ouvre dans la pelouse de
+> Lambeau Field, engloutissant un Norse adverse !"
+> *(Moles Under Pitch)*
+
+> "L'apothicaire vagabond bande la blessure du Catcher de Kansas City
+> en marge du terrain. Il revient au jeu, déterminé."
+> *(Wandering Apothecary)*
+
+Plus narratif et marrant que les notifs fantasy classiques. C'est
+**exactement le différenciateur BB** ⇒ vrai moat narratif vs MPG/Sleeper.
+
+## Tests à écrire
+
+```ts
+// packages/nfl-mapper/src/__tests__/prayers.test.ts
+
+describe("rollPrayers", () => {
+  it("is deterministic for the same seed", () => {
+    const a = rollPrayers("user-123:week-5", 2);
+    const b = rollPrayers("user-123:week-5", 2);
+    expect(a).toEqual(b);
+  });
+
+  it("returns count prayers", () => {
+    const result = rollPrayers("seed", 2);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("shouldRollPrayers", () => {
+  it("returns 0 for non-underdog", () => {
+    expect(shouldRollPrayers({ ownTV: 1000, opponentTV: 1000 }))
+      .toEqual({ rollCount: 0 });
+  });
+
+  it("returns 1 for 20% underdog", () => {
+    expect(shouldRollPrayers({ ownTV: 800, opponentTV: 1000 }))
+      .toEqual({ rollCount: 1 });
+  });
+
+  it("returns 2 for 40% underdog", () => {
+    expect(shouldRollPrayers({ ownTV: 600, opponentTV: 1000 }))
+      .toEqual({ rollCount: 2 });
+  });
+});
+```

--- a/docs/nfl-fantasy/08-rosters-2025.md
+++ b/docs/nfl-fantasy/08-rosters-2025.md
@@ -1,0 +1,693 @@
+# 08 — Rosters 2025 NFL mappés en postes BB
+
+> Rosters des 32 équipes NFL pour la saison **2025-26**, avec mapping
+> postes NFL → postes BB par race.
+>
+> **⚠️ Cutoff** : connaissance jusqu'à janvier 2026. Rosters reflètent
+> l'état post-saison 2024 + free agency 2025 + draft 2025. Les
+> mouvements 2026 (free agency mars 2026, draft avril 2026) sont
+> documentés séparément dans [`09-transitions-2026.md`](./09-transitions-2026.md).
+
+## Légende
+
+| Colonne | Description |
+|---|---|
+| **Vrai nom (privé)** | Nom réel du joueur, stocké côté code privé uniquement |
+| **#** | Numéro de maillot |
+| **Pos NFL** | Position NFL standard (QB, WR, RB, TE, OL, DT, DE, LB, CB, S) |
+| **Pos BB** | Poste BB mappé selon la race de l'équipe |
+| **Pseudo public** | Nom pseudonymisé exposé publiquement |
+| **Notes** | Archetype, skills suggérées, anecdotes |
+
+Format pseudo public : `{Adjectif descriptif} {Poste BB-flavored} de {Ville}, #{N°}`
+
+Chaque équipe = ~10 joueurs marquants. Le roster complet (53) sera dans
+`packages/nfl-mapper/data/rosters-2025.json`.
+
+---
+
+## SKAVEN
+
+> Speed + trickery, big play offense, Gutter Runners (MA9 fragile),
+> Storm Vermin (Blitzer fast), Rat Ogre (Big Guy).
+
+### Kansas City Skaven
+
+**Identité** : Dynasty Skaven élite. Mahomes sidearm wizardry, RPO heavy,
+deep ball spécialité. Defense pivote autour de Chris Jones (Rat Ogre).
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Patrick Mahomes | 15 | QB | Thrower | Le Sidearm Wizard de Kansas City, #15 | Élite Pass, Strong Arm, Sure Hands |
+| Travis Kelce | 87 | TE | Storm Vermin (Catch) | Le Tight End Suisse de Kansas City, #87 | Vétéran, Side Step, Block |
+| Rashee Rice | 4 | WR | Gutter Runner | Le Voltigeur de Kansas City, #4 | Speed, contested catch |
+| Xavier Worthy | 1 | WR | Gutter Runner | Le Sprinter Éclair de Kansas City, #1 | Rookie 2024, MA9 pure |
+| Isiah Pacheco | 10 | RB | Storm Vermin | Le Vermine Brute de Kansas City, #10 | Power runner |
+| Chris Jones | 95 | DT | Rat Ogre | Le Rat-Ogre de Kansas City, #95 | Élite Beast, Mighty Blow |
+| George Karlaftis | 56 | DE | Storm Vermin | Le Sack-Vermine de Kansas City, #56 | Edge rusher |
+| Nick Bolton | 32 | LB | Storm Vermin | Le Sergent-Vermine de Kansas City, #32 | Tackle machine |
+| Trent McDuffie | 22 | CB | Gutter Runner défensif | Le Stiletto de Kansas City, #22 | Élite CB |
+| Justin Reid | 20 | S | Storm Vermin | Le Garde Arrière de Kansas City, #20 | Free safety |
+
+### Miami Skaven
+
+**Identité** : McDaniel pure speed offense. Pas de power, tout en
+vitesse. Defense Skaven typique (rapide mais fragile).
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Tua Tagovailoa | 1 | QB | Thrower | Le Thrower Tropical de Miami, #1 | Accurate, Quick Release |
+| Tyrek Hill | 10 | WR | Gutter Runner (élite) | Le Sprinter Tropical de Miami, #10 | MA9 cap, fastest in NFL |
+| Jaylen Waddle | 17 | WR | Gutter Runner | L'Ailier-Fusée de Miami, #17 | Speed/agility |
+| De'Von Achane | 28 | RB | Gutter Runner | Le RB-Éclair de Miami, #28 | Speed pure, dual-threat |
+| Raheem Mostert | 31 | RB | Gutter Runner | Le Vétéran Sprint de Miami, #31 | Aging Skaven |
+| Jonnu Smith | 9 | TE | Storm Vermin (Catch) | Le TE-Vermine de Miami, #9 | Receiving TE |
+| Zach Sieler | 92 | DT | Rat Ogre | Le DT-Rat de Miami, #92 | Solid Big Guy |
+| Bradley Chubb | 2 | DE | Storm Vermin | Le Sack-Vermine de Miami, #2 | When healthy |
+| Jaelan Phillips | 15 | DE | Storm Vermin | L'Edge-Vermine de Miami, #15 | When healthy |
+| Jalen Ramsey | 5 | CB | Gutter Runner défensif | Le Stiletto Vétéran de Miami, #5 | (or traded by 2025?) |
+
+### Houston Skaven
+
+**Identité** : Stroud émergence, jeunes WRs, defense agressive avec
+Will Anderson Jr. Skaven en construction.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| CJ Stroud | 7 | QB | Thrower | Le Jeune Wizard de Houston, #7 | Cool pocket, accurate |
+| Nico Collins | 12 | WR | Storm Vermin (Catch) | Le Catcher Possession de Houston, #12 | Contested catch master |
+| Tank Dell | 3 | WR | Gutter Runner | Le Petit Sprinter de Houston, #3 | When healthy |
+| Stefon Diggs | 1 | WR | Gutter Runner | Le Vétéran Catcher de Houston, #1 | Acquired 2024 (rehab) |
+| Joe Mixon | 28 | RB | Storm Vermin | Le RB-Vermine de Houston, #28 | Acquired 2024 |
+| Dalton Schultz | 86 | TE | Storm Vermin (Catch) | Le TE Réglo de Houston, #86 | Solid TE |
+| Will Anderson Jr | 51 | DE | Storm Vermin | L'Edge-Sangsue de Houston, #51 | Élite pass rusher |
+| Danielle Hunter | 99 | DE | Storm Vermin | Le Vétéran Edge de Houston, #99 | Veteran rush |
+| Derek Stingley Jr | 24 | CB | Gutter Runner défensif | Le Verrou-Vermine de Houston, #24 | Élite CB |
+| Azeez Al-Shaair | 0 | LB | Storm Vermin | Le LB-Vermine de Houston, #0 | Tackle machine |
+
+### Arizona Skaven
+
+**Identité** : Kyler Murray QB mobile désertique. Marvin Harrison Jr
+rookie élite. Defense en construction.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Kyler Murray | 1 | QB | Thrower mobile | Le QB Désertique d'Arizona, #1 | MA+, Pass, Sprint |
+| Marvin Harrison Jr | 18 | WR | Storm Vermin (Catch élite) | Le Catcher Légendaire d'Arizona, #18 | Rookie 2024, élite |
+| Trey McBride | 85 | TE | Storm Vermin (Catch) | Le TE-Couteau-Suisse d'Arizona, #85 | Top TE 2024 |
+| James Conner | 6 | RB | Storm Vermin | Le RB Vétéran d'Arizona, #6 | Veteran power |
+| Michael Wilson | 14 | WR | Gutter Runner | L'Ailier de Soutien d'Arizona, #14 | Possession WR |
+| Walter Nolen | TBD | DT | Rat Ogre | Le Rookie DT d'Arizona, #TBD | Rookie 2025 |
+| Budda Baker | 3 | S | Storm Vermin | Le Vétéran Safety d'Arizona, #3 | All-pro |
+| Kei'Trel Clark | 13 | CB | Gutter Runner défensif | Le Verrou-Vermine d'Arizona, #13 | Emerging |
+
+---
+
+## WOOD ELF
+
+> Finesse + agility, smooth route running, agile receivers, finesse
+> pocket QB, modest defenses. Catcher (MA8 élite), Wardancer, Treeman.
+
+### Cincinnati Wood Elves
+
+**Identité** : Burrow finesse pocket. Chase + Higgins routes gracieuses.
+Pas de power run, tout passe. Defense Hendrickson edge.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Joe Burrow | 9 | QB | Thrower | Le Thrower Cool de Cincinnati, #9 | Élite Pass, Accurate, Dodge |
+| Ja'Marr Chase | 1 | WR | Catcher élite | Le Catcher Alpha de Cincinnati, #1 | Top WR, Side Step, Diving Catch |
+| Tee Higgins | 5 | WR | Catcher | Le Catcher Géant de Cincinnati, #5 | Contested catch (FA 2025/26) |
+| Chase Brown | 30 | RB | Lineman (Catch) | Le RB-Élu de Cincinnati, #30 | Receiving back |
+| Mike Gesicki | 88 | TE | Catcher | Le TE-Élu de Cincinnati, #88 | Receiving TE |
+| Trey Hendrickson | 91 | DE | Wardancer | L'Edge-Danseur de Cincinnati, #91 | Élite sack master |
+| Shemar Stewart | TBD | DE | Wardancer | Le Rookie Wardancer de Cincinnati, #TBD | Rookie 2025 |
+| Geno Stone | 22 | S | Catcher défensif | Le Verrou Cool de Cincinnati, #22 | Free safety |
+
+### Los Angeles (R-side) Wood Elves
+
+**Identité** : McVay offense finesse. Kupp slot magicien, Nacua ascendant.
+Stafford vétéran. Defense Verse émergente.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Matthew Stafford | 9 | QB | Thrower | Le Thrower Vétéran de Los Angeles (R), #9 | Veteran arm |
+| Cooper Kupp | 10 | WR | Catcher élite | Le Slot Magicien de Los Angeles (R), #10 | Side Step, Catch, Diving Catch |
+| Puka Nacua | 17 | WR | Catcher | L'Ascendant de Los Angeles (R), #17 | Rising star |
+| Kyren Williams | 23 | RB | Lineman | Le RB-Lineman de Los Angeles (R), #23 | Volume back |
+| Tyler Higbee | 89 | TE | Catcher | Le TE-Élu de Los Angeles (R), #89 | Receiving |
+| Jared Verse | 8 | DE | Wardancer | Le Jeune Wardancer de Los Angeles (R), #8 | Rookie 2024, edge |
+| Kobie Turner | 91 | DT | Treeman | Le Treeman de Los Angeles (R), #91 | Emerging DT |
+| Byron Young | 0 | DE | Wardancer | Le Wardancer Émergent de Los Angeles (R), #0 | Edge rush |
+| Kamren Kinchens | 26 | S | Catcher défensif | Le Verrou-Élu de Los Angeles (R), #26 | Rookie 2024 |
+
+### Jacksonville Wood Elves
+
+**Identité** : Lawrence finesse. Brian Thomas Jr rookie speed. Etienne
+fluide. Wood Elf émergent.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Trevor Lawrence | 16 | QB | Thrower | Le Thrower du Sud de Jacksonville, #16 | Pass, Accurate |
+| Brian Thomas Jr | 7 | WR | Catcher | Le Rookie Stretch-Field de Jacksonville, #7 | Speed + size, rookie 2024 |
+| Travis Hunter | TBD | WR/CB | Catcher / Verrou-Élu | Le Two-Way Phénomène de Jacksonville, #TBD | Rookie 2025 #2 pick, two-way player |
+| Travis Etienne | 1 | RB | Lineman (Catch) | Le RB-Élu de Jacksonville, #1 | Receiving back |
+| Evan Engram | 17 | TE | Catcher | Le TE-Élu de Jacksonville, #17 | Receiving TE |
+| Josh Hines-Allen | 41 | DE | Wardancer | L'Edge-Danseur de Jacksonville, #41 | Élite |
+| Devin Lloyd | 33 | LB | Wardancer | Le LB-Danseur de Jacksonville, #33 | Coverage LB |
+| Tyson Campbell | 32 | CB | Catcher défensif | Le Verrou de Jacksonville, #32 | Solid CB |
+
+### Washington Wood Elves
+
+**Identité** : Jayden Daniels = Wood Elf Thrower (finesse + mobile).
+McLaurin Catcher élite. Reconstruction rapide.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Jayden Daniels | 5 | QB | Thrower mobile | Le Phénomène Rookie de Washington, #5 | Pass + Sprint, MA+ |
+| Terry McLaurin | 17 | WR | Catcher | Le Vétéran Fiable de Washington, #17 | Reliable |
+| Brian Robinson Jr | 8 | RB | Lineman | Le RB-Élu de Washington, #8 | Power back |
+| Zach Ertz | 86 | TE | Catcher | Le TE Vétéran de Washington, #86 | Veteran |
+| Frankie Luvu | 49 | LB | Wardancer | Le LB-Danseur de Washington, #49 | Tackle machine |
+| Dorance Armstrong | 92 | DE | Wardancer | L'Edge-Danseur de Washington, #92 | Veteran edge |
+| Mike Sainristil | 0 | CB | Catcher défensif | Le Rookie Verrou de Washington, #0 | Rookie 2024 |
+| Quan Martin | 24 | S | Catcher défensif | Le Safety-Élu de Washington, #24 | Free safety |
+| Josh Conerly Jr | TBD | OT | Lineman élite | Le Rookie Lineman de Washington, #TBD | Rookie 2025 |
+
+---
+
+## ORC
+
+> Physical + run-heavy, brutal defense. Black Orc (Block + ST4),
+> Blitzer Orc (Block), Troll (Big Guy), Goblin (utility).
+
+### Baltimore Orcs
+
+**Identité** : Lamar mobile mais run-heavy avec Henry power. Physical D.
+Madubuike Beast. Orc avec Thrower mobile spécial.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Lamar Jackson | 8 | QB | Thrower mobile | Le Thrower Mobile de Baltimore, #8 | Pass, Sprint, Sure Feet, MA+ |
+| Derrick Henry | 22 | RB | Black Orc / Blitzer | Le Bélier Vétéran de Baltimore, #22 | Élite power, Mighty Blow |
+| Zay Flowers | 4 | WR | Blitzer (Catch) | Le Catcher-Sprinter de Baltimore, #4 | Speed slot |
+| Rashod Bateman | 7 | WR | Blitzer (Catch) | Le Catcher Émergent de Baltimore, #7 | Outside WR |
+| Mark Andrews | 89 | TE | Blitzer (Catch) | Le TE Vétéran de Baltimore, #89 | Veteran |
+| Justin Madubuike | 92 | DT | Troll | Le Troll-DT de Baltimore, #92 | Élite Big Guy |
+| Kyle Van Noy | 53 | LB | Blitzer Orc | Le LB-Veterantous de Baltimore, #53 | Veteran |
+| Roquan Smith | 0 | LB | Blitzer Orc | Le LB Élite de Baltimore, #0 | Tackle machine |
+| Kyle Hamilton | 14 | S | Blitzer | Le Hammer Safety de Baltimore, #14 | Versatile |
+| Marlon Humphrey | 44 | CB | Blitzer | Le Verrou Physique de Baltimore, #44 | Veteran |
+| Malaki Starks | TBD | S | Blitzer | Le Rookie Safety de Baltimore, #TBD | Rookie 2025 |
+| Mike Green | TBD | DE | Blitzer Orc | Le Rookie Edge de Baltimore, #TBD | Rookie 2025 |
+
+### Philadelphia Orcs
+
+**Identité** : Tush push = définition push BB. Hurts Thrower physique.
+AJ Brown Black Orc Catcher. J. Carter DT Beast. Saquon power.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Jalen Hurts | 1 | QB | Thrower physique | Le Thrower Tush-Push de Philadelphia, #1 | Pass + Sprint, Mighty Blow rare |
+| Saquon Barkley | 26 | RB | Blitzer élite | Le Bélier Acquis de Philadelphia, #26 | Power + speed |
+| AJ Brown | 11 | WR | Black Orc (Catch) | Le Catcher Physique de Philadelphia, #11 | Contested catch monster |
+| DeVonta Smith | 6 | WR | Blitzer (Catch) | Le Catcher Filiforme de Philadelphia, #6 | Route runner |
+| Dallas Goedert | 88 | TE | Blitzer (Catch) | Le TE-Veteran de Philadelphia, #88 | Receiving TE |
+| Jalen Carter | 98 | DT | Troll | Le Troll-DT de Philadelphia, #98 | Élite Beast |
+| Nolan Smith | 3 | DE | Blitzer Orc | L'Edge Émergent de Philadelphia, #3 | Rising |
+| Zack Baun | 53 | LB | Blitzer Orc | Le LB-Veteran de Philadelphia, #53 | All-pro 2024 |
+| Quinyon Mitchell | 27 | CB | Blitzer | Le Rookie Verrou de Philadelphia, #27 | Rookie 2024 |
+| Reed Blankenship | 32 | S | Blitzer | Le Safety-Reed de Philadelphia, #32 | Solid |
+| Jihaad Campbell | TBD | LB | Blitzer Orc | Le Rookie LB de Philadelphia, #TBD | Rookie 2025 |
+
+### Pittsburgh Orcs
+
+**Identité** : TJ Watt = Blitzer élite. Heyward Cam Beast. Defense
+traditionnelle physique. Power run. Pure Orc.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Russell Wilson | 3 | QB | Thrower | Le Vétéran Thrower de Pittsburgh, #3 | Veteran (if still starter 2025) |
+| Justin Fields | 2 | QB | Thrower mobile | Le Mobile Thrower de Pittsburgh, #2 | Backup mobile or starter |
+| George Pickens | 14 | WR | Blitzer (Catch) | Le Catcher Diva de Pittsburgh, #14 | Contested catch |
+| Calvin Austin III | 19 | WR | Blitzer (Catch speed) | Le Petit Sprinter de Pittsburgh, #19 | Speed slot |
+| Pat Freiermuth | 88 | TE | Blitzer (Catch) | Le TE-Allemand de Pittsburgh, #88 | Reliable |
+| Najee Harris | 22 | RB | Black Orc | Le Bélier Vétéran de Pittsburgh, #22 | Power back |
+| TJ Watt | 90 | DE | Blitzer élite | Le Sack Master de Pittsburgh, #90 | Élite Orc Blitzer, Mighty Blow |
+| Cameron Heyward | 97 | DT | Troll | Le Cam-Troll de Pittsburgh, #97 | Veteran Beast |
+| Alex Highsmith | 56 | DE | Blitzer Orc | L'Edge-Highsmith de Pittsburgh, #56 | Solid |
+| Patrick Queen | 6 | LB | Blitzer Orc | Le LB-Queen de Pittsburgh, #6 | Acquired 2024 |
+| Joey Porter Jr | 24 | CB | Blitzer | Le Verrou-Porter de Pittsburgh, #24 | Rising |
+| Minkah Fitzpatrick | 39 | S | Blitzer | Le Vétéran Safety de Pittsburgh, #39 | All-pro |
+| Derrick Harmon | TBD | DT | Troll | Le Rookie Troll de Pittsburgh, #TBD | Rookie 2025 |
+
+### San Francisco Orcs
+
+**Identité** : Shanahan power runs, Kittle TE physique. Bosa DE élite.
+Defense brutale. McCaffrey power-yards. Pure Orc Bay Area.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Brock Purdy | 13 | QB | Thrower | Le QB-Magicien de Bay Area, #13 | Accurate, modest power |
+| Christian McCaffrey | 23 | RB | Blitzer élite | Le Couteau-Suisse de Bay Area, #23 | Dual-threat, Mighty Blow |
+| Deebo Samuel | 19 | WR | Black Orc (Catch) | Le Catcher Brutal de Bay Area, #19 | YAC monster |
+| Brandon Aiyuk | 11 | WR | Blitzer (Catch) | Le Catcher Smooth de Bay Area, #11 | Route runner |
+| George Kittle | 85 | TE | Black Orc (Catch) | Le TE Brutal de Bay Area, #85 | Élite TE, Mighty Blow |
+| Nick Bosa | 97 | DE | Blitzer élite | La Sack Beast de Bay Area, #97 | Élite Edge, MA+ |
+| Javon Hargrave | 98 | DT | Troll | Le Troll-Hargrave de Bay Area, #98 | Solid DT |
+| Fred Warner | 54 | LB | Blitzer Orc élite | Le Warner Beast de Bay Area, #54 | Élite LB |
+| Charvarius Ward | 7 | CB | Blitzer | Le Verrou-Ward de Bay Area, #7 | Solid CB |
+| Talanoa Hufanga | 29 | S | Blitzer | Le Safety-Hufanga de Bay Area, #29 | When healthy |
+| Mykel Williams | TBD | DE | Blitzer Orc | Le Rookie Edge de Bay Area, #TBD | Rookie 2025 |
+
+---
+
+## HUMAN
+
+> Équilibré, polyvalent, "America's archetype". Lineman, Thrower,
+> Catcher, Blitzer, Ogre (Big Guy).
+
+### Dallas Humans
+
+**Identité** : Prescott classic Thrower. Lamb Catcher balanced. Parsons
+Blitzer star. America's Team archetype.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Dak Prescott | 4 | QB | Thrower | Le Thrower-Star de Dallas, #4 | Pass, Accurate |
+| CeeDee Lamb | 88 | WR | Catcher élite | Le Catcher Alpha de Dallas, #88 | Top WR |
+| Brandin Cooks | 3 | WR | Catcher | Le Catcher Vétéran de Dallas, #3 | Veteran |
+| Jake Ferguson | 87 | TE | Catcher | Le TE-Émergent de Dallas, #87 | Receiving TE |
+| Rico Dowdle | 23 | RB | Blitzer | Le RB-Émergent de Dallas, #23 | Lead back 2024 |
+| Micah Parsons | 11 | DE/LB | Blitzer élite | L'Edge-Star de Dallas, #11 | Élite Edge, hybrid |
+| DeMarcus Lawrence | 90 | DE | Blitzer | L'Edge Vétéran de Dallas, #90 | Veteran |
+| DaRon Bland | 26 | CB | Catcher défensif | Le Pick-Six Verrou de Dallas, #26 | Pick-six king |
+| Trevon Diggs | 7 | CB | Catcher défensif | Le Verrou-Diggs de Dallas, #7 | When healthy |
+| Tyler Booker | TBD | OL | Lineman | Le Rookie Lineman de Dallas, #TBD | Rookie 2025 (G) |
+
+### Green Bay Humans
+
+**Identité** : Love jeune Thrower équilibré. WR corps jeune. Jacobs
+Lineman/Blitzer. Cold mais pas Norse (trop technique).
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Jordan Love | 10 | QB | Thrower | Le Thrower Émergent de Green Bay, #10 | Cannon arm |
+| Josh Jacobs | 8 | RB | Blitzer | Le RB Acquis de Green Bay, #8 | Power + receiving |
+| Jayden Reed | 11 | WR | Catcher | Le Catcher-Speed de Green Bay, #11 | Slot speed |
+| Romeo Doubs | 87 | WR | Catcher | Le Catcher-Doubs de Green Bay, #87 | Outside |
+| Christian Watson | 9 | WR | Catcher (speed) | Le Catcher-Speed Vétéran de Green Bay, #9 | When healthy |
+| Tucker Kraft | 85 | TE | Catcher | Le TE-Émergent de Green Bay, #85 | Rising |
+| Rashan Gary | 52 | DE | Blitzer | L'Edge-Gary de Green Bay, #52 | Solid pass rusher |
+| Quay Walker | 7 | LB | Blitzer | Le LB-Walker de Green Bay, #7 | Coverage LB |
+| Jaire Alexander | 23 | CB | Catcher défensif | Le Verrou-Alexander de Green Bay, #23 | When healthy |
+| Matthew Golden | TBD | WR | Catcher | Le Rookie WR de Green Bay, #TBD | Rookie 2025 |
+
+### Atlanta Humans
+
+**Identité** : Penix Jr rookie 2024 émergent. London Catcher. Bijan
+Blitzer versatile. Identity reconstruite balanced.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Michael Penix Jr | 9 | QB | Thrower | Le Rookie QB d'Atlanta, #9 | Cannon arm |
+| Kirk Cousins | 18 | QB | Thrower | Le QB Vétéran d'Atlanta, #18 | Veteran backup/starter |
+| Drake London | 5 | WR | Catcher | Le Catcher Alpha d'Atlanta, #5 | Big body |
+| Darnell Mooney | 1 | WR | Catcher | Le Catcher-Speed d'Atlanta, #1 | Speed |
+| Bijan Robinson | 7 | RB | Blitzer versatile | Le Bélier d'Atlanta, #7 | Dual-threat |
+| Tyler Allgeier | 25 | RB | Blitzer | Le RB-Allgeier d'Atlanta, #25 | Power back |
+| Kyle Pitts | 8 | TE | Catcher | Le TE-Athlétique d'Atlanta, #8 | High potential |
+| Grady Jarrett | 97 | DT | Ogre | Le Vétéran DT d'Atlanta, #97 | Veteran |
+| Jessie Bates III | 3 | S | Blitzer | Le Safety-Bates d'Atlanta, #3 | All-pro |
+| A.J. Terrell | 24 | CB | Catcher défensif | Le Verrou-Terrell d'Atlanta, #24 | Solid |
+| James Pearce Jr | TBD | DE | Blitzer | Le Rookie Edge d'Atlanta, #TBD | Rookie 2025 |
+
+### Seattle Humans
+
+**Identité** : Geno-era ou nouveau QB Thrower équilibré. Metcalf
+Catcher physique. JSN slot. Defense moyenne.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Geno Smith | 7 | QB | Thrower | Le Thrower-Geno de Seattle, #7 | Veteran (may be elsewhere 2025) |
+| DK Metcalf | 14 | WR | Catcher | Le Catcher Costaud de Seattle, #14 | Big body |
+| Jaxon Smith-Njigba | 11 | WR | Catcher | Le Slot-Émergent de Seattle, #11 | YAC slot |
+| Tyler Lockett | 16 | WR | Catcher | Le Vétéran Catcher de Seattle, #16 | Aging |
+| Kenneth Walker III | 9 | RB | Blitzer | Le RB-Walker de Seattle, #9 | Power + speed |
+| Zach Charbonnet | 26 | RB | Blitzer | Le Backup-Charbonnet de Seattle, #26 | Backup |
+| Noah Fant | 87 | TE | Catcher | Le TE-Fant de Seattle, #87 | Receiving |
+| Leonard Williams | 99 | DT | Ogre | Le DT Vétéran de Seattle, #99 | Solid |
+| Boye Mafe | 53 | DE | Blitzer | L'Edge-Mafe de Seattle, #53 | Rising |
+| Devon Witherspoon | 21 | CB | Catcher défensif | Le Verrou-Witherspoon de Seattle, #21 | Élite emerging |
+| Grey Zabel | TBD | OL | Lineman | Le Rookie Lineman de Seattle, #TBD | Rookie 2025 |
+
+---
+
+## NORSE
+
+> Cold weather + power. Tous Norse standards ont Block. Berserker
+> (Block + Frenzy), Ulfwerener, Yhetee.
+
+### Buffalo Norse
+
+**Identité** : Allen = Norse Thrower (beard, power, cold). Cook Runner.
+Bills Mafia fans = Norse fans. Cold weather pure.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Josh Allen | 17 | QB | Thrower Norse | Le Thrower Barbu de Buffalo, #17 | Pass, Strong Arm, Block, MA+ |
+| James Cook | 4 | RB | Runner | Le RB-Speedster de Buffalo, #4 | Speed + receiving |
+| Khalil Shakir | 10 | WR | Catcher Norse | Le Catcher Émergent de Buffalo, #10 | Slot reliable |
+| Keon Coleman | 0 | WR | Catcher Norse | Le Rookie WR de Buffalo, #0 | Rookie 2024 |
+| Dalton Kincaid | 86 | TE | Berserker (Catch) | Le TE-Berserker de Buffalo, #86 | Receiving TE |
+| Dawson Knox | 88 | TE | Berserker | Le Vétéran TE de Buffalo, #88 | Blocking TE |
+| Ed Oliver | 91 | DT | Yhetee | Le Yhetee de Buffalo, #91 | Élite DT |
+| Greg Rousseau | 50 | DE | Berserker | L'Edge-Rousseau de Buffalo, #50 | Pass rusher |
+| Matt Milano | 58 | LB | Berserker | Le LB-Milano de Buffalo, #58 | When healthy |
+| Christian Benford | 47 | CB | Catcher défensif Norse | Le Verrou-Benford de Buffalo, #47 | Solid |
+| Maxwell Hairston | TBD | CB | Catcher défensif | Le Rookie Verrou de Buffalo, #TBD | Rookie 2025 |
+
+### Minnesota Norse
+
+**Identité** : Littéralement Vikings. Jefferson Catcher élite. Defense
+physique. JJ McCarthy / Sam Darnold QB. Casque cornu.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Sam Darnold | 14 | QB | Thrower Norse | Le Thrower-Réveillé du Northland, #14 | 2024 starter (FA 2025?) |
+| JJ McCarthy | 9 | QB | Thrower Norse | Le Jeune Thrower du Northland, #9 | Rookie 2024 rehab |
+| Justin Jefferson | 18 | WR | Catcher élite | Le Catcher-Griddy du Northland, #18 | Top WR, Side Step, Diving Catch |
+| Jordan Addison | 3 | WR | Catcher Norse | Le Catcher #2 du Northland, #3 | Speed |
+| TJ Hockenson | 87 | TE | Berserker (Catch) | Le TE Solide du Northland, #87 | Receiving TE |
+| Aaron Jones | 33 | RB | Runner | Le RB Vétéran du Northland, #33 | Acquired 2024 |
+| Jonathan Greenard | 58 | DE | Berserker | Le Berserker du Northland, #58 | Acquired 2024 |
+| Andrew Van Ginkel | 43 | LB | Berserker | Le LB-Van Ginkel du Northland, #43 | All-pro 2024 |
+| Harrison Smith | 22 | S | Berserker | Le Safety Vétéran du Northland, #22 | Veteran |
+| Donovan Jackson | TBD | OL | Lineman Norse | Le Rookie Lineman du Northland, #TBD | Rookie 2025 |
+
+### Detroit Norse
+
+**Identité** : Goff Thrower fiable. Gibbs+Montgomery committee
+power+speed. Hutchinson Edge. Cold + physique. Norse rebuilt.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Jared Goff | 16 | QB | Thrower Norse | L'Iron Goff de Detroit, #16 | Pocket pass, Accurate |
+| Jahmyr Gibbs | 26 | RB | Runner | Le Speed-RB de Detroit, #26 | Élite speed |
+| David Montgomery | 5 | RB | Ulfwerener | Le Bélier de Detroit, #5 | Power back |
+| Amon-Ra St. Brown | 14 | WR | Catcher Norse | Le Catcher Alpha de Detroit, #14 | Reliable |
+| Jameson Williams | 9 | WR | Catcher (speed) | Le Catcher-Speed de Detroit, #9 | Pure speed |
+| Sam LaPorta | 87 | TE | Berserker (Catch) | Le TE-Émergent de Detroit, #87 | Rookie of year |
+| Aidan Hutchinson | 97 | DE | Berserker élite | L'Edge Beast de Detroit, #97 | When healthy |
+| Penei Sewell | 58 | OT | Lineman Norse élite | Le Lineman-Beast de Detroit, #58 | Élite OT |
+| Brian Branch | 32 | S | Berserker | Le Safety-Branch de Detroit, #32 | Versatile |
+| Carlton Davis III | 27 | CB | Catcher défensif | Le Vétéran Verrou de Detroit, #27 | Acquired |
+
+### Chicago Norse
+
+**Identité** : Monsters of Midway. Caleb Williams Thrower. Defense
+traditionnellement physique. Cold weather. Norse classique.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Caleb Williams | 18 | QB | Thrower Norse | Le #1 Pick de Chicago, #18 | Pass, Strong Arm |
+| DJ Moore | 2 | WR | Catcher Norse | Le Catcher Vétéran de Chicago, #2 | Veteran reliable |
+| Rome Odunze | 15 | WR | Catcher Norse | Le Rookie WR de Chicago, #15 | Rookie 2024 |
+| Keenan Allen | 13 | WR | Catcher | Le Vétéran Catcher de Chicago, #13 | Acquired 2024 |
+| D'Andre Swift | 4 | RB | Runner | Le Speed-RB de Chicago, #4 | Veteran |
+| Cole Kmet | 85 | TE | Berserker (Catch) | Le TE-Kmet de Chicago, #85 | Receiving |
+| Montez Sweat | 98 | DE | Berserker | L'Edge-Sweat de Chicago, #98 | Pass rusher |
+| Tremaine Edmunds | 49 | LB | Berserker | Le LB-Edmunds de Chicago, #49 | Coverage LB |
+| Jaylon Johnson | 33 | CB | Catcher défensif | Le Verrou-Johnson de Chicago, #33 | All-pro |
+| Colston Loveland | TBD | TE | Berserker (Catch) | Le Rookie TE de Chicago, #TBD | Rookie 2025 |
+
+---
+
+## DWARF
+
+> Slow but tough. Defensive identity. Pas de Thrower dédié. Blocker
+> (Block + Tackle + Thick Skull), Trollslayer, Deathroller.
+
+### New York (G-side) Dwarfs
+
+**Identité** : Rebuild long. Defensive identity. Lawrence Big Guy.
+Conservative offense.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Daniel Jones | 8 | QB | Runner (Pass) | Le Thrower-Dwarf de New York (G), #8 | Veteran (may be replaced 2025) |
+| Drew Lock | 10 | QB | Runner (Pass) | Le Backup-Thrower de New York (G), #10 | Veteran backup |
+| Jaxson Dart | TBD | QB | Runner (Pass) | Le Rookie Thrower de New York (G), #TBD | Rookie 2025 |
+| Malik Nabers | 1 | WR | Runner (Catch) | Le Catcher Rookie de New York (G), #1 | Rookie 2024 élite |
+| Wan'Dale Robinson | 17 | WR | Runner (Catch) | Le Slot-Robinson de New York (G), #17 | Slot WR |
+| Devin Singletary | 26 | RB | Blocker | Le RB-Blocker de New York (G), #26 | Veteran power |
+| Daniel Bellinger | 82 | TE | Blocker (Catch) | Le TE-Blocker de New York (G), #82 | Receiving TE |
+| Dexter Lawrence | 97 | DT | Deathroller | Le Mur DT de New York (G), #97 | Élite Big Guy |
+| Brian Burns | 0 | DE | Blitzer Dwarf | L'Edge-Burns de New York (G), #0 | Acquired 2024 |
+| Kayvon Thibodeaux | 5 | DE | Blitzer Dwarf | Le Vétéran Edge de New York (G), #5 | Solid |
+| Abdul Carter | TBD | DE | Blitzer Dwarf | Le Rookie #3 Pick de New York (G), #TBD | Rookie 2025 |
+| Dru Phillips | 22 | CB | Runner | Le Verrou-Phillips de New York (G), #22 | Emerging |
+
+### Cleveland Dwarfs
+
+**Identité** : Garrett Beast élite. Defense d'abord. Run heavy avec
+Chubb. Conservative passing.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Deshaun Watson | 4 | QB | Runner (Pass) | Le Thrower Vétéran de Cleveland, #4 | Veteran (rehab + benching) |
+| Jameis Winston | 5 | QB | Runner (Pass) | Le Backup-Winston de Cleveland, #5 | Veteran backup |
+| Amari Cooper | 2 | WR | Runner (Catch) | Le Catcher Vétéran de Cleveland, #2 | Veteran (FA 2025?) |
+| Jerry Jeudy | 3 | WR | Runner (Catch) | Le Catcher-Jeudy de Cleveland, #3 | Acquired 2024 |
+| Nick Chubb | 24 | RB | Blocker | Le Bélier-Chubb de Cleveland, #24 | When healthy |
+| David Njoku | 85 | TE | Blocker (Catch) | Le TE-Njoku de Cleveland, #85 | Veteran |
+| Myles Garrett | 95 | DE | Blitzer Dwarf élite | La Bête à Sacks de Cleveland, #95 | Élite, Mighty Blow, Tackle |
+| Dalvin Tomlinson | 94 | DT | Deathroller | Le DT-Tomlinson de Cleveland, #94 | Solid |
+| Denzel Ward | 21 | CB | Runner | Le Verrou-Ward de Cleveland, #21 | All-pro when healthy |
+| Mason Graham | TBD | DT | Deathroller | Le Rookie DT de Cleveland, #TBD | Rookie 2025 #5 pick |
+
+### Indianapolis Dwarfs
+
+**Identité** : Jonathan Taylor Lineman power. Buckner Beast. Defense
+solide. Identité old-school physique.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Anthony Richardson | 5 | QB | Runner (Pass) | Le QB Athlétique d'Indianapolis, #5 | Mobile, big arm |
+| Joe Flacco | 15 | QB | Runner (Pass) | Le Vétéran Thrower d'Indianapolis, #15 | Veteran (if signed 2024) |
+| Jonathan Taylor | 28 | RB | Blocker élite | Le Bélier d'Indianapolis, #28 | Élite power |
+| Michael Pittman Jr | 11 | WR | Runner (Catch) | Le Catcher Alpha d'Indianapolis, #11 | Possession WR |
+| Josh Downs | 1 | WR | Runner (Catch) | Le Slot-Downs d'Indianapolis, #1 | Slot |
+| Adonai Mitchell | 10 | WR | Runner (Catch) | Le Rookie WR d'Indianapolis, #10 | Rookie 2024 |
+| Tyler Warren | TBD | TE | Blocker (Catch) | Le Rookie TE d'Indianapolis, #TBD | Rookie 2025 |
+| DeForest Buckner | 99 | DT | Deathroller | Le Beast d'Indianapolis, #99 | All-pro |
+| Kwity Paye | 51 | DE | Blitzer Dwarf | L'Edge-Paye d'Indianapolis, #51 | Solid |
+| Laiatu Latu | 0 | DE | Blitzer Dwarf | Le Rookie Edge d'Indianapolis, #0 | Rookie 2024 |
+| Zaire Franklin | 44 | LB | Blitzer Dwarf | Le LB-Franklin d'Indianapolis, #44 | Tackle machine |
+
+### New England Dwarfs
+
+**Identité** : Post-Belichick rebuild. Defense d'abord historiquement.
+Maye jeune Thrower lent. (À reclasser si pass-heavy en 2025).
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Drake Maye | 10 | QB | Runner (Pass) | Le Rookie QB de New England, #10 | Cannon arm rookie |
+| Jacoby Brissett | 7 | QB | Runner (Pass) | Le Vétéran QB de New England, #7 | Veteran backup |
+| Rhamondre Stevenson | 38 | RB | Blocker | Le RB-Stevenson de New England, #38 | Power back |
+| DeMario Douglas | 81 | WR | Runner (Catch) | Le Slot-Douglas de New England, #81 | Slot |
+| Kayshon Boutte | 9 | WR | Runner (Catch) | Le Catcher-Boutte de New England, #9 | Emerging |
+| Hunter Henry | 85 | TE | Blocker (Catch) | Le TE-Veteran de New England, #85 | Receiving |
+| Christian Barmore | 90 | DT | Deathroller | Le DT-Barmore de New England, #90 | When healthy |
+| Christian Gonzalez | 0 | CB | Runner | Le Verrou-Gonzalez de New England, #0 | Élite emerging |
+| Kyle Dugger | 23 | S | Blitzer Dwarf | Le Safety-Dugger de New England, #23 | Versatile |
+| Will Campbell | TBD | OT | Blocker Dwarf | Le Rookie OT #4 Pick de New England, #TBD | Rookie 2025 |
+
+---
+
+## KHORNE
+
+> Chaos warriors, aggro, undisciplined. Bloodseeker (Frenzy), Khorngor
+> (Horns + Juggernaut), Bloodspawn (Block + Claws + Frenzy + MB),
+> Bloodthirster (Big Guy).
+
+### New York (J-side) Khorne
+
+**Identité** : Chaos énergie. Drama constant. Sauce Gardner CB élite.
+Q. Williams DT Beast aggro.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Aaron Rodgers | 8 | QB | Bloodseeker (Pass) | Le Vétéran Thrower de New York (J), #8 | Veteran (may be retired by 2025) |
+| Justin Fields | 7 | QB | Bloodseeker (Pass) | Le Mobile Thrower de New York (J), #7 | If signed 2025 |
+| Garrett Wilson | 5 | WR | Khorngor (Catch) | Le Catcher Alpha de New York (J), #5 | Élite WR |
+| Davante Adams | 17 | WR | Khorngor (Catch) | Le Catcher Vétéran de New York (J), #17 | Acquired mid-2024 |
+| Breece Hall | 20 | RB | Khorngor | Le RB-Hall de New York (J), #20 | Speed + power |
+| Tyler Conklin | 83 | TE | Bloodspawn (Catch) | Le TE-Conklin de New York (J), #83 | Veteran |
+| Quinnen Williams | 95 | DT | Bloodthirster | Le DT-Bête de New York (J), #95 | Élite Big Guy |
+| Will McDonald | 99 | DE | Bloodspawn | L'Edge-McDonald de New York (J), #99 | Pass rusher |
+| Jermaine Johnson | 11 | DE | Bloodspawn | L'Edge-Johnson de New York (J), #11 | Rising |
+| Sauce Gardner | 1 | CB | Khorngor (Catch défensif) | L'Île-Verrouillage de New York (J), #1 | Élite |
+| Armand Membou | TBD | OT | Bloodseeker | Le Rookie OT de New York (J), #TBD | Rookie 2025 |
+
+### Las Vegas Khorne
+
+**Identité** : Maxx Crosby = Blitzer Khorne pure (Frenzy + aggressive).
+Identité "bad boys" historique.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Geno Smith | 7 | QB | Bloodseeker (Pass) | Le Thrower Acquis de Las Vegas, #7 | Possibly acquired 2025 |
+| Aidan O'Connell | 4 | QB | Bloodseeker (Pass) | Le Thrower-Backup de Las Vegas, #4 | Backup |
+| Brock Bowers | 89 | TE | Bloodspawn (Catch) | Le Rookie TE de Las Vegas, #89 | Élite rookie 2024 |
+| Jakobi Meyers | 16 | WR | Khorngor (Catch) | Le Catcher Vétéran de Las Vegas, #16 | Veteran possession |
+| Tre Tucker | 11 | WR | Khorngor (Catch) | Le Catcher-Tucker de Las Vegas, #11 | Speed |
+| Alexander Mattison | 31 | RB | Bloodspawn | Le RB-Mattison de Las Vegas, #31 | Power back |
+| Christian Wilkins | 94 | DT | Bloodthirster | Le DT-Wilkins de Las Vegas, #94 | Acquired 2024 |
+| Maxx Crosby | 98 | DE | Bloodspawn élite | Le Sack-Master du Désert de Las Vegas, #98 | Élite Khorne (Frenzy + MB + Block) |
+| Robert Spillane | 41 | LB | Bloodseeker | Le LB-Spillane de Las Vegas, #41 | Veteran |
+| Nate Hobbs | 39 | CB | Khorngor | Le Verrou-Hobbs de Las Vegas, #39 | Slot |
+| Ashton Jeanty | TBD | RB | Khorngor | Le Rookie RB-Star de Las Vegas, #TBD | Rookie 2025 #6 pick |
+
+### Los Angeles (C-side) Khorne
+
+**Identité** : Harbaugh aggression. Mack/Bosa edges. Herbert Thrower
+mais culture aggro.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Justin Herbert | 10 | QB | Bloodseeker (Pass) | Le Thrower Cool de Los Angeles (C), #10 | Cannon arm |
+| Ladd McConkey | 15 | WR | Khorngor (Catch) | Le Rookie WR de Los Angeles (C), #15 | Slot rookie 2024 |
+| Quentin Johnston | 1 | WR | Khorngor (Catch) | Le Catcher-Johnston de Los Angeles (C), #1 | Big body |
+| JK Dobbins | 27 | RB | Khorngor | Le RB-Dobbins de Los Angeles (C), #27 | When healthy |
+| Will Dissly | 89 | TE | Bloodspawn | Le TE-Dissly de Los Angeles (C), #89 | Receiving |
+| Joey Bosa | 97 | DE | Bloodspawn | L'Edge Vétéran de Los Angeles (C), #97 | When healthy |
+| Khalil Mack | 52 | DE | Bloodspawn | L'Edge-Mack de Los Angeles (C), #52 | Veteran star |
+| Daiyan Henley | 50 | LB | Bloodseeker | Le LB-Henley de Los Angeles (C), #50 | Emerging |
+| Derwin James | 3 | S | Bloodspawn | Le Safety-James de Los Angeles (C), #3 | All-pro |
+| Omarion Hampton | TBD | RB | Khorngor | Le Rookie RB de Los Angeles (C), #TBD | Rookie 2025 |
+
+### Tampa Bay Khorne
+
+**Identité** : Pirates = chaos aggressive. Mayfield gunslinger. Mike
+Evans deep Catcher physique.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Baker Mayfield | 6 | QB | Bloodseeker (Pass) | Le Gunslinger de Tampa Bay, #6 | Aggressive thrower |
+| Mike Evans | 13 | WR | Khorngor (Catch) | Le Deep Threat de Tampa Bay, #13 | Veteran physical |
+| Chris Godwin | 14 | WR | Khorngor (Catch) | Le Slot Vétéran de Tampa Bay, #14 | When healthy |
+| Bucky Irving | 7 | RB | Khorngor | Le RB-Rookie de Tampa Bay, #7 | Rookie 2024 |
+| Rachaad White | 1 | RB | Khorngor | Le RB-White de Tampa Bay, #1 | Dual-threat |
+| Cade Otton | 88 | TE | Bloodspawn (Catch) | Le TE-Otton de Tampa Bay, #88 | Receiving |
+| Vita Vea | 50 | DT | Bloodthirster | Le DT-Vea de Tampa Bay, #50 | Élite Big Guy |
+| Yaya Diaby | 0 | DE | Bloodspawn | L'Edge-Diaby de Tampa Bay, #0 | Rising |
+| Lavonte David | 54 | LB | Bloodseeker | Le LB-Vétéran de Tampa Bay, #54 | Aging legend |
+| Antoine Winfield Jr | 31 | S | Bloodspawn | Le Safety-Winfield de Tampa Bay, #31 | All-pro |
+| Emeka Egbuka | TBD | WR | Khorngor (Catch) | Le Rookie WR de Tampa Bay, #TBD | Rookie 2025 |
+
+---
+
+## NECROMANTIC
+
+> Rebuild / dark / "raised from the dead" franchises. Tous Regenerate.
+> Zombie, Ghoul (Runner), Wight (Blitzer + Block), Flesh Golem (Big Guy),
+> Werewolf (Frenzy + MA).
+
+### Tennessee Necromantic
+
+**Identité** : Rebuild après Henry-era. Ghost franchise. Cam Ward
+rookie 2025 #1 pick. Identité reconstruite.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Cam Ward | TBD | QB | Ghoul (Pass) | Le Rookie #1 Pick de Tennessee, #TBD | Rookie 2025, cannon arm |
+| Will Levis | 8 | QB | Ghoul (Pass) | Le Thrower Vétéran de Tennessee, #8 | Cannon arm (may be backup) |
+| Calvin Ridley | 0 | WR | Ghoul (Catch) | Le Catcher Vétéran de Tennessee, #0 | Acquired 2024 |
+| Tyler Boyd | 14 | WR | Ghoul (Catch) | Le Slot Vétéran de Tennessee, #14 | Veteran |
+| Tony Pollard | 20 | RB | Werewolf | Le RB Acquis de Tennessee, #20 | Acquired 2024 |
+| Chig Okonkwo | 85 | TE | Wight (Catch) | Le TE-Okonkwo de Tennessee, #85 | Receiving |
+| Jeffery Simmons | 98 | DT | Flesh Golem | Le DT-Beast de Tennessee, #98 | Élite Big Guy |
+| L'Jarius Sneed | 1 | CB | Ghoul | Le Verrou-Sneed de Tennessee, #1 | Acquired 2024 |
+| Roger McCreary | 21 | CB | Ghoul | Le Verrou-McCreary de Tennessee, #21 | Solid |
+
+### Denver Necromantic
+
+**Identité** : Post-Russ rebuild. Sean Payton aggressive. Bo Nix jeune
+Thrower. Identity en transition.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Bo Nix | 10 | QB | Ghoul (Pass) | Le Rookie QB de Denver, #10 | Rookie 2024 |
+| Courtland Sutton | 14 | WR | Ghoul (Catch) | Le Vétéran Catcher de Denver, #14 | Veteran |
+| Marvin Mims | 19 | WR | Ghoul (Catch) | Le Catcher-Mims de Denver, #19 | Speed/return |
+| Javonte Williams | 33 | RB | Werewolf | Le RB-Williams de Denver, #33 | Recovering from injury |
+| Lucas Krull | 80 | TE | Wight (Catch) | Le TE-Krull de Denver, #80 | Receiving |
+| Patrick Surtain II | 2 | CB | Ghoul élite | L'Île-CB Élite de Denver, #2 | Élite Catcher défensif (Wight) |
+| Jonathon Cooper | 0 | DE | Wight | L'Edge-Cooper de Denver, #0 | Rising |
+| Zach Allen | 99 | DT | Flesh Golem | Le DT-Allen de Denver, #99 | Solid |
+| Jahdae Barron | TBD | CB | Ghoul | Le Rookie Verrou de Denver, #TBD | Rookie 2025 |
+
+### Carolina Necromantic
+
+**Identité** : Rebuild zombie franchise. Bryce Young Thrower. Identité
+non-fixe.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Bryce Young | 9 | QB | Ghoul (Pass) | Le QB Mobile de Carolina, #9 | Accurate, mobile |
+| Andy Dalton | 14 | QB | Ghoul (Pass) | Le Vétéran QB de Carolina, #14 | Veteran backup |
+| Diontae Johnson | 5 | WR | Ghoul (Catch) | Le Catcher-Diontae de Carolina, #5 | (may be elsewhere 2025) |
+| Adam Thielen | 19 | WR | Ghoul (Catch) | Le Vétéran Catcher de Carolina, #19 | Veteran |
+| Chuba Hubbard | 30 | RB | Wight | Le RB-Hubbard de Carolina, #30 | Power back |
+| Tommy Tremble | 82 | TE | Wight | Le TE-Tremble de Carolina, #82 | Blocking TE |
+| Jadeveon Clowney | 7 | DE | Werewolf | L'Edge Vétéran de Carolina, #7 | Veteran |
+| DJ Wonnum | 98 | DE | Wight | L'Edge-Wonnum de Carolina, #98 | Solid |
+| Derrick Brown | 95 | DT | Flesh Golem | Le DT-Brown de Carolina, #95 | When healthy |
+| Tetairoa McMillan | TBD | WR | Ghoul (Catch) | Le Rookie WR de Carolina, #TBD | Rookie 2025 |
+
+### New Orleans Necromantic
+
+**Identité** : NOLA voodoo PARFAIT. Kamara aging Ghoul. Cam Jordan
+Werewolf vétéran. Identité Necromantic naturelle.
+
+| Vrai nom (privé) | # | Pos NFL | Pos BB | Pseudo public | Notes |
+|---|---|---|---|---|---|
+| Derek Carr | 4 | QB | Ghoul (Pass) | Le Thrower Vétéran de New Orleans, #4 | Veteran |
+| Spencer Rattler | 18 | QB | Ghoul (Pass) | Le Backup-Rattler de New Orleans, #18 | Rookie 2024 backup |
+| Chris Olave | 12 | WR | Ghoul (Catch) | Le Catcher Smooth de New Orleans, #12 | Route runner |
+| Rashid Shaheed | 22 | WR | Ghoul (Catch) | Le Speed-Catcher de New Orleans, #22 | Deep threat |
+| Alvin Kamara | 41 | RB | Werewolf | Le RB Versatile de New Orleans, #41 | Aging dual-threat (Werewolf vétéran) |
+| Taysom Hill | 7 | TE | Wight | Le Couteau-Suisse de New Orleans, #7 | Versatile |
+| Cam Jordan | 94 | DE | Werewolf | Le Vétéran Edge de New Orleans, #94 | Aging Werewolf |
+| Carl Granderson | 96 | DE | Wight | L'Edge-Granderson de New Orleans, #96 | Solid |
+| Tyrann Mathieu | 32 | S | Ghoul | Le Vétéran Safety de New Orleans, #32 | Veteran |
+| Kelvin Banks | TBD | OT | Zombie Lineman | Le Rookie OT de New Orleans, #TBD | Rookie 2025 |
+
+---
+
+## Synthèse statistique
+
+| Race | Teams | Star QBs | Star WRs | Star RBs | Star Edges | Star DTs | Star CBs |
+|---|---|---|---|---|---|---|---|
+| Skaven | 4 | Mahomes, Stroud | Hill, Worthy, MHJ, Collins | Achane, Pacheco | W. Anderson | C. Jones | McDuffie, Stingley |
+| Wood Elf | 4 | Burrow, Lawrence, Daniels | Chase, Higgins, Kupp, Nacua, McLaurin | - | Hendrickson, Verse | - | - |
+| Orc | 4 | L. Jackson, Hurts, Purdy | A.J. Brown, Deebo, Aiyuk, Pickens | Henry, Barkley, CMC | TJ Watt, Bosa | Madubuike, J. Carter, Heyward | - |
+| Human | 4 | Prescott, Love, Penix | Lamb, London, JSN, Metcalf | Bijan | Parsons | - | DaRon Bland, Witherspoon, Terrell |
+| Norse | 4 | Allen, Goff, C. Williams | Jefferson, ASB, Moore, Addison | Gibbs, Cook | Hutchinson, Greenard | E. Oliver | - |
+| Dwarf | 4 | Maye, Richardson, Watson | Nabers, Pittman, Cooper | J. Taylor, Chubb | M. Garrett | D. Lawrence, Buckner | C. Gonzalez, D. Ward |
+| Khorne | 4 | Mayfield, Herbert, A. Rodgers | M. Evans, G. Wilson, D. Adams | B. Hall, Bowers (TE) | Crosby, J. Bosa, Mack | Q. Williams, Vea, Wilkins | Sauce Gardner |
+| Necromantic | 4 | Carr, Young, Nix, Ward | Olave, Sutton, Ridley | Kamara | Cam Jordan | Simmons | Surtain |
+
+## Rookies 2025 référencés (1er round)
+
+Voir [`09-transitions-2026.md`](./09-transitions-2026.md) pour la liste exhaustive.
+
+## Source de vérité (à créer)
+
+Le mapping détaillé sera stocké dans :
+- `packages/nfl-mapper/data/teams.json` — 32 teams avec race assignment
+- `packages/nfl-mapper/data/rosters-2025.json` — 32 rosters complets avec
+  mapping joueur → poste BB
+- `packages/nfl-mapper/data/pseudonyms.json` — mapping privé `playerId → pseudo`
+- Pipeline automatique pour refresh : `scripts/sync-nfl-rosters.ts`

--- a/docs/nfl-fantasy/09-transitions-2026.md
+++ b/docs/nfl-fantasy/09-transitions-2026.md
@@ -1,0 +1,215 @@
+# 09 — Transitions 2025 → 2026-27
+
+> Suivi des mouvements de joueurs susceptibles de modifier le mapping
+> 2026-27 : free agents 2026, rookies 2025 à intégrer, retraites
+> probables, trades de printemps/été.
+>
+> **⚠️ Cutoff connaissances** : janvier 2026. Free agency 2026 (mars 2026)
+> et draft 2026 (avril 2026) **non couverts** — à compléter manuellement
+> au fil des annonces officielles.
+
+## Free agents 2026 (à monitorer)
+
+Liste des joueurs marquants dont le contrat expire après la saison 2025
+et qui pourraient changer d'équipe pour 2026-27. Source : Spotrac,
+OverTheCap (à valider via API).
+
+### QB
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Sam Darnold | Minnesota Norse | Thrower Norse | Moyenne | Aurait été starter 2024 ; peut-être backup ailleurs |
+| Aaron Rodgers | New York (J) Khorne | Bloodseeker (Pass) | Élevée | Retraite probable post 2024 |
+| Justin Fields | Pittsburgh Orcs | Thrower mobile | Élevée | Avenir incertain |
+| Mac Jones | Free agent | - | - | Backup market |
+| Daniel Jones | New York (G) Dwarf | Runner (Pass) | Élevée | Potentiel cap casualty |
+
+### WR
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Tee Higgins | Cincinnati Wood Elf | Catcher | Élevée | Franchise tagged 2025, UFA 2026 |
+| Mike Evans | Tampa Bay Khorne | Khorngor (Catch) | Modérée | Veteran, retraite possible |
+| Chris Godwin | Tampa Bay Khorne | Khorngor (Catch) | Élevée | Coming off injury |
+| Cooper Kupp | LAR Wood Elf | Catcher | Modérée | Cap casualty potentiel |
+| Davante Adams | NYJ Khorne | Khorngor (Catch) | Modérée | Aging, contract évolutif |
+| DK Metcalf | Seattle Human | Catcher | Modérée | Extension possible |
+| Amari Cooper | Cleveland Dwarf | Runner (Catch) | Élevée | Veteran |
+| Stefon Diggs | Houston Skaven | Gutter Runner | Élevée | Coming off injury |
+| Calvin Ridley | Tennessee Necromantic | Ghoul (Catch) | Modérée | Contract évolutif |
+| Diontae Johnson | Carolina Necromantic | Ghoul (Catch) | Élevée | Already moved mid-2024? |
+
+### RB
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Najee Harris | Pittsburgh Orcs | Black Orc | Élevée | UFA potentiel |
+| Aaron Jones | Minnesota Norse | Runner | Modérée | Aging |
+| Tony Pollard | Tennessee Necromantic | Werewolf | Modérée | Contract évolutif |
+| Nick Chubb | Cleveland Dwarf | Blocker | Modérée | Injury recovery |
+| Devin Singletary | NYG Dwarf | Blocker | Élevée | Veteran |
+
+### Edge / DE
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Maxx Crosby | Las Vegas Khorne | Bloodspawn élite | Faible | Extension probable |
+| Trey Hendrickson | Cincinnati Wood Elf | Wardancer | Modérée | Holdout 2024 |
+| Khalil Mack | LAC Khorne | Bloodspawn | Élevée | Aging veteran |
+| Joey Bosa | LAC Khorne | Bloodspawn | Élevée | Injury concerns |
+| Cam Jordan | New Orleans Necromantic | Werewolf | Élevée | Aging, retraite probable |
+| Bradley Chubb | Miami Skaven | Storm Vermin | Modérée | Injury recovery |
+| Jadeveon Clowney | Carolina Necromantic | Werewolf | Élevée | Veteran |
+| Joey Bosa | LAC Khorne | Bloodspawn | Modérée | Injury |
+
+### DT
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Jonathan Allen | Washington Wood Elf | Treeman | Modérée | Veteran |
+| Grady Jarrett | Atlanta Human | Ogre | Modérée | Veteran |
+| Leonard Williams | Seattle Human | Ogre | Modérée | Contract |
+
+### CB / S
+
+| Joueur | Équipe 2025 | Pos BB actuelle | Probabilité changement | Notes |
+|---|---|---|---|---|
+| Jaire Alexander | Green Bay Human | Catcher défensif | Modérée | Injury concerns |
+| Charvarius Ward | SF Orcs | Blitzer | Modérée | Contract |
+| Jalen Ramsey | Miami Skaven | Gutter Runner défensif | Modérée | Aging |
+| Marlon Humphrey | Baltimore Orcs | Blitzer | Modérée | Veteran |
+| Justin Reid | Kansas City Skaven | Storm Vermin | Modérée | Contract |
+| Harrison Smith | Minnesota Norse | Berserker | Élevée | Aging legend |
+
+## Rookies 2025 (Draft NFL avril 2025)
+
+Liste des picks majeurs à intégrer dans le mapping pour la saison 2025-26
+et au-delà. Format : `Joueur | Pick | Équipe | Pos NFL | Pos BB suggérée | Archetype`.
+
+### 1er round (Pick 1-32)
+
+| # | Joueur | Équipe | Pos NFL | Pos BB suggérée | Archetype |
+|---|---|---|---|---|---|
+| 1 | Cam Ward | Tennessee | QB | Ghoul (Pass) | Cannon arm, mobile |
+| 2 | Travis Hunter | Jacksonville | WR/CB | Catcher / Verrou-Élu | Two-way phenom |
+| 3 | Abdul Carter | NYG | DE | Blitzer Dwarf | Élite edge rusher |
+| 4 | Will Campbell | New England | OT | Blocker Dwarf | Élite OL |
+| 5 | Mason Graham | Cleveland | DT | Deathroller | Run stuffer |
+| 6 | Ashton Jeanty | Las Vegas | RB | Khorngor | Élite power + receiving |
+| 7 | Armand Membou | NYJ | OT | Bloodseeker (élite OL) | Pass protector |
+| 8 | Tetairoa McMillan | Carolina | WR | Ghoul (Catch) | Big body, X receiver |
+| 9 | Kelvin Banks Jr | New Orleans | OT | Zombie élite OL | OL prospect |
+| 10 | Colston Loveland | Chicago | TE | Berserker (Catch) | Receiving TE |
+| 11 | Tyler Warren | Indianapolis | TE | Blocker (Catch) | Versatile TE |
+| 12 | Walter Nolen | Arizona | DT | Rat Ogre | DT power |
+| 13 | Jahdae Barron | Denver | CB | Ghoul | Slot/zone CB |
+| 14 | Tyler Booker | Dallas | G | Lineman | OL prospect |
+| 15 | Shemar Stewart | Cincinnati | Edge | Wardancer | Pass rusher |
+| 16 | Mykel Williams | SF | Edge | Blitzer Orc | Bay Area edge |
+| 17 | Matthew Golden | Green Bay | WR | Catcher | Speed WR |
+| 18 | Kenneth Grant | Miami | DT | Rat Ogre | DT |
+| 19 | Donovan Jackson | Minnesota | G | Lineman Norse | OL |
+| 20 | Jihaad Campbell | Philadelphia | LB | Blitzer Orc | Coverage LB |
+| 21 | Omarion Hampton | LAC | RB | Khorngor | Power back |
+| 22 | Derrick Harmon | Pittsburgh | DT | Troll | Run stuffer |
+| 23 | Maxwell Hairston | Buffalo | CB | Catcher défensif Norse | Slot CB |
+| 24 | Emeka Egbuka | Tampa Bay | WR | Khorngor (Catch) | Possession |
+| 25 | James Pearce Jr | Atlanta | Edge | Blitzer | Pass rusher |
+| 26 | Jaxson Dart | NYG | QB | Runner (Pass) | Mobile QB |
+| 27 | Grey Zabel | Seattle | OL | Lineman | OL prospect |
+| 28 | Malaki Starks | Baltimore | S | Blitzer | Safety |
+| 29 | Josh Conerly Jr | Washington | OT | Lineman élite | OL |
+| 30 | TBD | TBD | - | - | À renseigner |
+| 31 | Mike Green | Baltimore | Edge | Blitzer Orc | Pass rusher |
+| 32 | TBD | TBD | - | - | À renseigner |
+
+> **Note** : Les picks après #29 sont à compléter avec une source à
+> jour. Le mapping vers les positions BB est suggéré ; à finaliser
+> après le training camp 2025 selon le rôle réel attribué par le coach.
+
+## Retraites probables / officielles 2024-2025
+
+Joueurs qui ont annoncé ou pourraient annoncer leur retraite :
+
+| Joueur | Équipe finale | Pos BB | Statut | Action |
+|---|---|---|---|---|
+| Aaron Donald | LAR Wood Elf | Treeman | Retraite confirmée fin 2023 | Retirer du roster |
+| Tom Brady | TB Khorne | Bloodseeker | Retraite 2023 | Déjà retiré |
+| Andrew Whitworth | LAR Wood Elf | OL élite | Retraite 2022 | Déjà retiré |
+| Justin Tucker | Baltimore Orc | Kicker | Suspension/release (allégations 2024) | Retirer |
+| Calais Campbell | Multiple | DT | Retraite probable 2024-25 | Vérifier |
+| Aaron Rodgers | NYJ Khorne | Bloodseeker | Possiblement 2024-25 | Vérifier |
+| Cam Jordan | New Orleans Necromantic | Werewolf | Possiblement 2025 | Vérifier |
+| Lavonte David | TB Khorne | Bloodseeker | Possiblement 2025 | Vérifier |
+| Travis Kelce | KC Skaven | Storm Vermin | Possiblement 2025-26 | Surveiller |
+| Mike Evans | TB Khorne | Khorngor | Possiblement 2025-26 | Surveiller |
+
+## Trades majeurs 2024 saison (déjà actés)
+
+À vérifier la propagation dans le mapping :
+
+| Joueur | De | À | Pos BB nouvelle |
+|---|---|---|---|
+| Davante Adams | Las Vegas | NYJ | Bloodspawn (LV) → Khorngor (NYJ) |
+| Stefon Diggs | Buffalo | Houston | Catcher Norse → Gutter Runner |
+| Saquon Barkley | NYG | PHI | Blocker Dwarf → Blitzer Orc élite |
+| Aaron Jones | Green Bay | Minnesota | Blitzer Human → Runner Norse |
+| Josh Jacobs | Las Vegas | Green Bay | Bloodspawn → Blitzer Human |
+| Russell Wilson | Denver | Pittsburgh | Ghoul → Thrower Orc |
+| Justin Fields | Chicago | Pittsburgh | Thrower Norse → Thrower Orc (mobile) |
+| Sam Darnold | SF | Minnesota | Thrower Orc → Thrower Norse |
+| Kirk Cousins | Minnesota | Atlanta | Thrower Norse → Thrower Human |
+| Calvin Ridley | Jacksonville | Tennessee | Catcher Wood Elf → Ghoul |
+| Brian Burns | Carolina | NYG | Wight → Blitzer Dwarf |
+| Jonathan Greenard | Houston | Minnesota | Storm Vermin → Berserker |
+| Christian Wilkins | Miami | Las Vegas | Rat Ogre → Bloodthirster |
+| Patrick Queen | Baltimore | Pittsburgh | Blitzer Orc → Blitzer Orc (intra-race) |
+| L'Jarius Sneed | Kansas City | Tennessee | Gutter Runner défensif → Ghoul |
+| Jerry Jeudy | Denver | Cleveland | Ghoul → Runner (Catch) |
+
+## Free agency 2025 actée (joueurs déplacés mars 2025)
+
+À documenter avec une source à jour. Exemples connus :
+- Geno Smith trade vers Las Vegas (à vérifier)
+- D'autres mouvements à confirmer
+
+## Process de mise à jour
+
+Quand un trade ou signing est annoncé :
+
+1. **Capturer** le mouvement dans la table "Trades majeurs" ci-dessus
+2. **Updater** `packages/nfl-mapper/data/rosters-2025.json` ou `2026.json`
+3. **Re-mapper** le joueur : nouvelle équipe ⇒ nouvelle race ⇒ poste BB
+   peut changer
+4. **Notifier** les utilisateurs ayant le joueur dans leur roster fantasy
+   (notif in-app "X a changé d'équipe, son nouveau poste BB est Y")
+5. **Logger** dans `Changelog` du `README.md`
+
+## Veille à organiser
+
+### Sources canoniques (à automatiser)
+
+- **Trades / waivers / signings** : ESPN news API, nflverse `news` table
+- **Draft 2026** : NFL.com draft tracker, Pro Football Network
+- **Retraites** : annoncées via Twitter/X officiel + nflverse `retirements`
+- **Injuries / IR** : ESPN injury report, NFL official Wire
+
+### Cadence
+
+- **Quotidien** pendant saison (sept-fév) : pull nflverse + ESPN news
+- **Hebdo** pendant offseason (mars-août) : focus FA + draft
+- **Real-time** pendant tampering window (mars) + draft (avril) :
+  alertes manuelles
+
+## Re-mapping de race en cas de changement d'identité 2026-27
+
+Si une équipe change drastiquement d'identité (nouveau HC + nouveau OC),
+voir [`04-race-mapping.md` § "Règles de re-mapping"](./04-race-mapping.md#règles-de-promotion--déplacement-de-race).
+
+Candidats potentiels post-2025 :
+- **New England** : si pass-heavy avec Maye en V2, basculer Dwarf → Human
+- **Las Vegas** : nouveau staff plus discipliné, basculer Khorne → Dwarf ?
+- **Detroit** : si offense vire plus aérienne, Norse → Human
+- **Indianapolis** : si Richardson dévie vers pass-heavy, Dwarf → Human
+
+À évaluer en mai/juin 2026 après les training camps.

--- a/docs/nfl-fantasy/10-architecture.md
+++ b/docs/nfl-fantasy/10-architecture.md
@@ -1,0 +1,720 @@
+# 10 — Architecture monorepo
+
+> Intégration du module NFL Fantasy dans le monorepo existant.
+> Respecte les conventions documentées dans `CLAUDE.md` :
+> packages purs, services Express + Prisma, Zod validation, tests
+> Vitest, patterns idempotents.
+
+## Vue d'ensemble
+
+```
+fantasy-football-game/
+├── apps/
+│   ├── server/                # Express + Prisma
+│   │   └── src/
+│   │       ├── services/
+│   │       │   ├── nfl-ingest.ts            ★ NEW
+│   │       │   ├── nfl-fantasy-league.ts    ★ NEW
+│   │       │   ├── nfl-fantasy-lineup.ts    ★ NEW
+│   │       │   ├── nfl-fantasy-scoring.ts   ★ NEW
+│   │       │   └── nfl-fantasy-mercato.ts   ★ NEW
+│   │       └── routes/
+│   │           ├── nfl-fantasy-leagues.ts   ★ NEW
+│   │           ├── nfl-fantasy-lineups.ts   ★ NEW
+│   │           ├── nfl-fantasy-mercato.ts   ★ NEW
+│   │           └── nfl-rosters.ts           ★ NEW
+│   ├── web/                   # Next.js 14
+│   │   └── app/
+│   │       └── nfl-fantasy/                 ★ NEW
+│   │           ├── page.tsx
+│   │           ├── leagues/[id]/page.tsx
+│   │           ├── lineup/page.tsx
+│   │           └── mercato/page.tsx
+│   └── mobile/                # Expo
+│       └── (équivalent web)
+├── packages/
+│   ├── nfl-mapper/                          ★ NEW package
+│   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   ├── team-to-race.ts            # 32 NFL teams → race BB
+│   │   │   ├── position-to-bb.ts          # NFL pos → BB pos par race
+│   │   │   ├── stats-to-spp.ts            # Stats NFL → SPP BB
+│   │   │   ├── rerolls.ts                 # Logique relances
+│   │   │   ├── inducements.ts             # Logique inducements
+│   │   │   ├── prayers.ts                 # Logique prières Nuffle
+│   │   │   ├── pseudonymize.ts            # Génération pseudos
+│   │   │   ├── archetype.ts               # Player → archetype (speed/power/...)
+│   │   │   └── narrative.ts               # Stat line → Gazette text
+│   │   ├── data/
+│   │   │   ├── teams.json                 # 32 teams + race assignment
+│   │   │   ├── rosters-2025.json          # Rosters 2025 mapped
+│   │   │   ├── rosters-2026.json          # Saison suivante (post-FA)
+│   │   │   └── pseudonyms.json            # Mapping privé player → pseudo
+│   │   ├── __tests__/
+│   │   │   ├── stats-to-spp.test.ts
+│   │   │   ├── prayers.test.ts
+│   │   │   ├── rerolls.test.ts
+│   │   │   └── inducements.test.ts
+│   │   └── package.json
+│   ├── sim-engine/            # existant (réutilisé : attributeSpp)
+│   ├── game-engine/           # existant
+│   └── shared-types/          # existant (étendu avec types NFL)
+├── prisma/
+│   └── schema.prisma          # étendu (cf. § Schéma Prisma)
+└── docs/
+    └── nfl-fantasy/           # cette doc
+```
+
+## Package `nfl-mapper` (pure logic)
+
+Suit le pattern existant des packages purs (`sim-engine`, `game-engine`) :
+- **Pas d'I/O** (pas de Prisma, pas de fetch)
+- **Pas de side effects**
+- **Testable** en unit avec Vitest sans setup
+- **Réutilisable** côté backend, frontend, et CLI
+
+### `team-to-race.ts`
+
+```ts
+export type BbRace =
+  | "Skaven" | "WoodElf" | "Orc" | "Human"
+  | "Norse" | "Dwarf" | "Khorne" | "Necromantic";
+
+export type NflTeamCode =
+  | "KC" | "MIA" | "HOU" | "ARI"
+  | "CIN" | "LAR" | "JAX" | "WAS"
+  | "BAL" | "PHI" | "PIT" | "SF"
+  | "DAL" | "GB"  | "ATL" | "SEA"
+  | "BUF" | "MIN" | "DET" | "CHI"
+  | "NYG" | "CLE" | "IND" | "NE"
+  | "NYJ" | "LV"  | "LAC" | "TB"
+  | "TEN" | "DEN" | "CAR" | "NO";
+
+export interface TeamMeta {
+  code: NflTeamCode;
+  city: string;        // "Kansas City"
+  race: BbRace;
+  raceLabel: string;   // "Kansas City Skaven"
+  cityDisambiguation?: string; // "(G-side)" pour NYG, "(R-side)" pour LAR
+  palette: { primary: string; secondary: string; accent: string };
+}
+
+export function getTeamMeta(code: NflTeamCode): TeamMeta;
+export function getAllTeams(): readonly TeamMeta[];
+export function getTeamsByRace(race: BbRace): readonly TeamMeta[];
+```
+
+### `stats-to-spp.ts`
+
+```ts
+import type { NflPlayerStatLine, SppBreakdown, BbPosition } from "./types";
+
+export function computeSpp(stat: NflPlayerStatLine): SppBreakdown;
+```
+
+(Voir [`06-scoring.md`](./06-scoring.md) pour la spec complète.)
+
+### `prayers.ts`, `rerolls.ts`, `inducements.ts`
+
+Voir [`07-mechanics.md`](./07-mechanics.md) pour la spec complète.
+
+### `pseudonymize.ts`
+
+```ts
+export interface PseudonymOptions {
+  cityTag: string;       // "Kansas City"
+  bbPosition: BbPosition;
+  jerseyNumber: number;
+  archetype: PlayerArchetype;
+}
+
+export function generatePseudonym(opts: PseudonymOptions): string {
+  // Ex: "Le Sidearm Wizard de Kansas City, #15"
+}
+```
+
+## Services backend (`apps/server/src/services/`)
+
+### `nfl-ingest.ts`
+
+```ts
+export async function ingestNflverseWeek(weekId: string): Promise<IngestResult>;
+export async function ingestEspnLive(): Promise<IngestResult>;
+export async function ingestRosters(seasonId: string): Promise<RosterUpdateResult>;
+```
+
+Pattern : idempotent, audit log persistent (`NflIngestRun`), retry queue.
+
+### `nfl-fantasy-league.ts`
+
+```ts
+export async function createLeague(opts: {
+  ownerId: string;
+  name: string;
+  size: number;
+  type: "public" | "private";
+  draftMode: "snake" | "auction" | "free";
+}): Promise<NflFantasyLeague>;
+
+export async function joinLeague(leagueId: string, userId: string): Promise<void>;
+export async function startSeason(leagueId: string): Promise<void>;
+```
+
+### `nfl-fantasy-lineup.ts`
+
+```ts
+export async function setLineup(opts: {
+  entryId: string;
+  weekId: string;
+  starters: ReadonlyArray<{ playerId: string; bbPosition: BbPosition }>;
+  captainId: string;
+}): Promise<NflFantasyLineup>;
+
+export async function lockLineups(weekId: string): Promise<void>;
+// Idempotent — appelé à kickoff Sunday
+```
+
+### `nfl-fantasy-scoring.ts`
+
+```ts
+export async function settleNflFantasyWeek(weekId: string): Promise<SettleResult>;
+// Pour chaque matchup, applique :
+// 1. computeSpp pour chaque starter (pure)
+// 2. Apply rerolls (pure + pool update)
+// 3. Apply inducements (pure + slot consume)
+// 4. Apply prayers (pure + log)
+// 5. Compute totals + winner
+// 6. Persist scores + standings
+// Idempotent (pattern Q.D.1)
+```
+
+### `nfl-fantasy-mercato.ts`
+
+```ts
+export async function listMarketplaceItems(filters: MercatoFilters): Promise<MercatoListing[]>;
+export async function buyItem(itemId: string, userId: string): Promise<MercatoTransaction>;
+// Réutilise Wallet existant (gold)
+```
+
+## Routes Express (`apps/server/src/routes/`)
+
+Suit le pattern existant : Zod validation, middleware `authUser` / `adminOnly`,
+erreurs typées via `class XxxError extends Error`.
+
+```ts
+// routes/nfl-fantasy-leagues.ts
+import { Router } from "express";
+import { z } from "zod";
+import { authUser } from "../middleware/auth";
+import { validate } from "../middleware/validate";
+import { createLeague, joinLeague } from "../services/nfl-fantasy-league";
+
+const router = Router();
+
+const createLeagueSchema = z.object({
+  name: z.string().min(3).max(50),
+  size: z.number().int().min(2).max(16),
+  type: z.enum(["public", "private"]),
+  draftMode: z.enum(["snake", "auction", "free"]),
+});
+
+router.post("/", authUser, validate(createLeagueSchema), async (req, res) => {
+  const league = await createLeague({
+    ownerId: req.user!.id,
+    ...req.body,
+  });
+  res.status(201).json(league);
+});
+
+// ... autres handlers
+
+export default router;
+```
+
+## Schéma Prisma (ajouts)
+
+```prisma
+// prisma/schema.prisma — additions
+
+// ─── Référentiel NFL ─────────────────────────────────────────
+
+model NflSeason {
+  id        String   @id // "2025-26"
+  startDate DateTime
+  endDate   DateTime
+  status    String   // "upcoming" | "in_progress" | "completed"
+
+  weeks     NflWeek[]
+  games     NflGame[]
+  rosters   NflRosterSnapshot[]
+}
+
+model NflWeek {
+  id          String   @id // "2025-26:W1"
+  seasonId    String
+  weekNumber  Int      // 1-18 regular + 19-22 playoffs
+  startDate   DateTime
+  endDate     DateTime
+  isPlayoffs  Boolean  @default(false)
+
+  season      NflSeason @relation(fields: [seasonId], references: [id])
+  games       NflGame[]
+  matchups    NflFantasyMatchup[]
+
+  @@index([seasonId, weekNumber])
+}
+
+model NflTeam {
+  code      String   @id // "KC", "MIA", ...
+  city      String   // "Kansas City"
+  bbRace    String   // "Skaven", "Orc", ...
+  raceLabel String   // "Kansas City Skaven"
+
+  homeGames NflGame[] @relation("HomeTeam")
+  awayGames NflGame[] @relation("AwayTeam")
+  players   NflPlayer[]
+}
+
+model NflPlayer {
+  id              String   @id // ID stable (e.g. nflverse player_id)
+  realName        String   // PRIVÉ — pour mapping seulement
+  pseudonym       String   // "Le Sidearm Wizard de Kansas City, #15"
+  teamCode        String?
+  jerseyNumber    Int?
+  nflPosition     String   // "QB", "WR", "RB", ...
+  bbPosition      String   // "Thrower", "Catcher", ...
+  bbStats         Json     // { ma, st, ag, pa, av }
+  bbSkills        Json     // string[]
+  archetype       Json     // { speedScore, powerScore, ... }
+  status          String   @default("active") // active | ir | retired | suspended
+  retiredAt       DateTime?
+
+  team            NflTeam? @relation(fields: [teamCode], references: [code])
+  gameStats       NflGameStat[]
+
+  @@index([teamCode, bbPosition])
+  @@index([status])
+}
+
+model NflGame {
+  id          String   @id // nflverse game_id
+  seasonId    String
+  weekId      String
+  homeTeam    String
+  awayTeam    String
+  homeScore   Int?
+  awayScore   Int?
+  kickoffAt   DateTime
+  status      String   // "scheduled" | "in_progress" | "final"
+
+  week        NflWeek @relation(fields: [weekId], references: [id])
+  home        NflTeam @relation("HomeTeam", fields: [homeTeam], references: [code])
+  away        NflTeam @relation("AwayTeam", fields: [awayTeam], references: [code])
+  stats       NflGameStat[]
+
+  @@index([weekId])
+}
+
+model NflGameStat {
+  id          String   @id @default(cuid())
+  gameId      String
+  playerId    String
+  rawStats    Json     // toutes stats brutes (yards, TD, etc.)
+  computedSpp Int?     // SPP calculé via computeSpp()
+  sppBreakdown Json?   // detail des events SPP
+  ingestSource String  // "nflverse" | "espn" | "manual"
+  ingestedAt  DateTime @default(now())
+
+  game        NflGame @relation(fields: [gameId], references: [id])
+  player      NflPlayer @relation(fields: [playerId], references: [id])
+
+  @@unique([gameId, playerId])
+  @@index([playerId])
+}
+
+// ─── Snapshots roster (pour historique) ──────────────────────
+
+model NflRosterSnapshot {
+  id          String   @id @default(cuid())
+  seasonId    String
+  teamCode    String
+  snapshotAt  DateTime @default(now())
+  roster      Json     // players: [{ id, jersey, pos, bbPos, ... }]
+
+  season      NflSeason @relation(fields: [seasonId], references: [id])
+
+  @@index([seasonId, teamCode])
+}
+
+model NflIngestRun {
+  id          String   @id @default(cuid())
+  source      String   // "nflverse" | "espn"
+  weekId      String?
+  startedAt   DateTime @default(now())
+  completedAt DateTime?
+  status      String   // "success" | "partial" | "failed"
+  result      Json     // { gamesUpdated, playersUpdated, errors }
+}
+
+// ─── Fantasy game (côté user) ────────────────────────────────
+
+model NflFantasyLeague {
+  id          String   @id @default(cuid())
+  name        String
+  ownerId     String
+  size        Int
+  type        String   // "public" | "private"
+  draftMode   String   // "snake" | "auction" | "free"
+  status      String   // "draft" | "in_progress" | "completed"
+  seasonId    String
+  createdAt   DateTime @default(now())
+
+  entries     NflFantasyEntry[]
+  matchups    NflFantasyMatchup[]
+
+  @@index([ownerId])
+  @@index([status])
+}
+
+model NflFantasyEntry {
+  id          String   @id @default(cuid())
+  leagueId    String
+  userId      String
+  teamName    String   // ex: "Krak'Skar Stompers"
+  bbRace      String?  // Race assignée (cf. variante "Pure BB")
+  totalTV     Int      @default(0) // somme des "team values" des joueurs
+
+  league      NflFantasyLeague @relation(fields: [leagueId], references: [id])
+  roster      NflFantasyRoster[]
+  lineups     NflFantasyLineup[]
+  rerolls     NflFantasyReroll[]
+  inducements NflFantasyInducement[]
+  prayers     NflFantasyPrayer[]
+
+  @@unique([leagueId, userId])
+}
+
+model NflFantasyRoster {
+  id          String   @id @default(cuid())
+  entryId     String
+  playerId    String   // NflPlayer.id
+  acquiredAt  DateTime @default(now())
+  acquiredVia String   // "draft" | "mercato" | "trade"
+  tvCost      Int      // valeur en gold
+
+  entry       NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@unique([entryId, playerId])
+}
+
+model NflFantasyLineup {
+  id          String   @id @default(cuid())
+  entryId     String
+  weekId      String
+  captainId   String?  // playerId du captain
+  lockedAt    DateTime?
+  totalSpp    Int?     // calculé après settlement
+
+  entry       NflFantasyEntry @relation(fields: [entryId], references: [id])
+  starters    NflFantasyLineupStarter[]
+
+  @@unique([entryId, weekId])
+}
+
+model NflFantasyLineupStarter {
+  id          String   @id @default(cuid())
+  lineupId    String
+  playerId    String
+  bbPosition  String
+  isCaptain   Boolean  @default(false)
+  rawSpp      Int?     // avant multipliers
+  finalSpp    Int?     // après multipliers + rerolls + prayers + inducements
+  sppBreakdown Json?
+
+  lineup      NflFantasyLineup @relation(fields: [lineupId], references: [id])
+
+  @@unique([lineupId, playerId])
+}
+
+model NflFantasyMatchup {
+  id          String   @id @default(cuid())
+  leagueId    String
+  weekId      String
+  homeEntryId String
+  awayEntryId String
+  homeScore   Int?
+  awayScore   Int?
+  winnerId    String?
+  settledAt   DateTime?
+
+  league      NflFantasyLeague @relation(fields: [leagueId], references: [id])
+
+  @@index([leagueId, weekId])
+}
+
+model NflFantasyReroll {
+  id          String   @id @default(cuid())
+  entryId     String
+  type        String   // "team" | "skill" | "assistant_coach"
+  source      String   // "starter" | "purchased" | "achievement" | "skill_pro"
+  used        Boolean  @default(false)
+  usedAt      DateTime?
+  weekId      String?
+  matchupId   String?
+  appliedTo   String?
+
+  entry       NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@index([entryId, used])
+}
+
+model NflFantasyInducement {
+  id          String   @id @default(cuid())
+  entryId     String
+  type        String   // InducementId
+  slot        String?  // "defensive" | "offensive" | "wildcard"
+  used        Boolean  @default(false)
+  usedAt      DateTime?
+  weekId      String?
+  matchupId   String?
+  targetId    String?
+  meta        Json?
+
+  entry       NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@index([entryId, used])
+}
+
+model NflFantasyPrayer {
+  id          String   @id @default(cuid())
+  entryId     String
+  weekId      String
+  matchupId   String
+  prayerId    String
+  rolledAt    DateTime @default(now())
+  seed        String
+  targetId    String?
+  applied     Boolean  @default(false)
+  appliedAt   DateTime?
+  effectLog   String?
+
+  entry       NflFantasyEntry @relation(fields: [entryId], references: [id])
+
+  @@unique([entryId, weekId, prayerId])
+}
+```
+
+## Cron jobs / scheduled tasks
+
+Suivant le pattern existant (vraisemblablement Bull / Task queue) :
+
+```ts
+// apps/server/src/jobs/nfl-fantasy.ts
+
+// Quotidien 03:00 UTC : pull nflverse
+cron.schedule("0 3 * * *", async () => {
+  await ingestNflverseLatest();
+});
+
+// Toutes les 5min sur gameday : pull ESPN live
+cron.schedule("*/5 13-23 * * 0", async () => {
+  // Dimanche 13h-23h ET
+  await ingestEspnLive();
+});
+
+// Settlement Mardi 12:00 UTC
+cron.schedule("0 12 * * 2", async () => {
+  const lastWeek = getPreviousWeekId();
+  await settleNflFantasyWeek(lastWeek);
+});
+
+// Lock lineups Sunday 17:00 UTC (12:00 ET)
+cron.schedule("0 17 * * 0", async () => {
+  const currentWeek = getCurrentWeekId();
+  await lockLineups(currentWeek);
+});
+```
+
+## Frontend Next.js (`apps/web/app/nfl-fantasy/`)
+
+### Pages clés
+
+```tsx
+// app/nfl-fantasy/page.tsx — Dashboard
+// app/nfl-fantasy/leagues/page.tsx — Liste des leagues
+// app/nfl-fantasy/leagues/[id]/page.tsx — Détail league + standings
+// app/nfl-fantasy/leagues/[id]/draft/page.tsx — Draft live
+// app/nfl-fantasy/lineup/page.tsx — Set lineup hebdo
+// app/nfl-fantasy/mercato/page.tsx — Marketplace inducements/rerolls
+// app/nfl-fantasy/players/[id]/page.tsx — Fiche joueur (pseudo)
+// app/nfl-fantasy/gazette/[matchupId]/page.tsx — Match report narratif
+```
+
+### Composants
+
+```tsx
+// app/nfl-fantasy/components/
+//   LineupBuilder.tsx       — Drag-and-drop lineup
+//   PlayerCard.tsx          — Avatar BB + stats + pseudo
+//   InducementSlot.tsx      — Selector d'inducement
+//   PrayerNotice.tsx        — Affiche prayers rolled
+//   RerollButton.tsx        — Toggle auto-reroll
+//   MatchupScoreboard.tsx   — Standing live
+//   GazetteCard.tsx         — Récit narratif
+```
+
+### Réutilisations
+
+- `apiRequest<T>` existant pour les fetchs
+- `useLanguage()` pour i18n (FR/EN)
+- `data-testid` parlants : `nfl-lineup-builder`, `prayer-card-friends-ref`, etc.
+- Promise.all([detail, optional]) pour load parallel (pattern Q.B.3)
+
+## Tests
+
+Coverage cible 80% suivant les rules existantes.
+
+### Unit (Vitest)
+
+```
+packages/nfl-mapper/__tests__/
+├── stats-to-spp.test.ts          # Scoring deterministe
+├── prayers.test.ts               # Roll + apply
+├── rerolls.test.ts               # Apply + pool
+├── inducements.test.ts           # Apply + slot
+├── pseudonymize.test.ts          # Génération pseudos
+└── team-to-race.test.ts          # Mapping complet 32 teams
+```
+
+### Integration (Vitest + SQLite mirror)
+
+```
+apps/server/src/services/__tests__/
+├── nfl-ingest.test.ts            # Mock nflverse + ESPN
+├── nfl-fantasy-scoring.test.ts   # Settlement end-to-end
+├── nfl-fantasy-lineup.test.ts    # Lock + validation
+└── nfl-fantasy-league.test.ts    # CRUD league
+```
+
+### E2E (Playwright)
+
+```
+apps/web/e2e/nfl-fantasy/
+├── create-league.spec.ts
+├── set-lineup.spec.ts
+├── use-inducement.spec.ts
+└── view-gazette.spec.ts
+```
+
+### Tests à écrire en priorité (TDD)
+
+1. `computeSpp` pour chaque archétype (QB, WR, RB, DE, DT, LB, CB)
+2. `rollPrayers` déterministe avec seed
+3. `applyPrayer` pour chaque prayer ID
+4. `shouldRollPrayers` selon différence TV
+5. `pseudonymize` reproductible
+
+## Migration / déploiement
+
+Pattern existant : Prisma migrations + déploiement via Turbo.
+
+```bash
+# 1. Schema diff
+npx prisma migrate dev --name add-nfl-fantasy
+
+# 2. Seed data initial
+pnpm seed:nfl-teams
+pnpm seed:nfl-players-2025
+
+# 3. Build + test
+pnpm turbo build
+pnpm turbo test
+
+# 4. Deploy (workflow existant)
+```
+
+## Dépendances externes (à ajouter)
+
+```json
+// packages/nfl-mapper/package.json
+{
+  "dependencies": {
+    "seedrandom": "^3.0.5",     // pour rollPrayers déterministe
+    "zod": "^3.x"               // déjà présent monorepo
+  },
+  "devDependencies": {
+    "vitest": "^1.x"            // déjà présent monorepo
+  }
+}
+
+// apps/server/package.json (ajouts)
+{
+  "dependencies": {
+    "parquetjs": "^0.11.x",     // pour ingest nflverse
+    "node-cron": "^3.x"         // si pas déjà présent
+  }
+}
+```
+
+## Plan d'implémentation phasé
+
+### Phase 1 — Foundation (semaine 1-2)
+- [ ] Créer package `nfl-mapper` squelette
+- [ ] Implémenter `team-to-race.ts` + `data/teams.json`
+- [ ] Implémenter `position-to-bb.ts` + tests
+- [ ] Implémenter `stats-to-spp.ts` + tests exhaustifs
+- [ ] Implémenter `pseudonymize.ts`
+- [ ] Schéma Prisma + migration
+
+### Phase 2 — Data ingestion (semaine 3-4)
+- [ ] Service `nfl-ingest.ts` (nflverse + ESPN)
+- [ ] Cron jobs configurés
+- [ ] Seed initial : 32 teams + rosters 2025
+- [ ] Tests E2E ingest sur fixtures
+
+### Phase 3 — Game logic (semaine 5-6)
+- [ ] `rerolls.ts` + tests
+- [ ] `inducements.ts` + tests
+- [ ] `prayers.ts` + tests
+- [ ] Service `nfl-fantasy-scoring.ts` (settlement)
+
+### Phase 4 — User-facing (semaine 7-9)
+- [ ] Services league + lineup + mercato
+- [ ] Routes Express
+- [ ] Pages Next.js (lineup builder, dashboard, mercato)
+- [ ] E2E Playwright golden path
+
+### Phase 5 — Polish (semaine 10-11)
+- [ ] Gazette narrative integration
+- [ ] Badge unlocks NFL Fantasy
+- [ ] i18n FR/EN
+- [ ] Avatars BB par race+poste
+
+### Phase 6 — Beta (semaine 12)
+- [ ] Beta privée 50 users
+- [ ] Monitoring + feedback
+- [ ] Itération scoring (calibration)
+
+## Risques techniques
+
+| Risque | Mitigation |
+|---|---|
+| nflverse format change | Tests automatisés daily, fallback ESPN |
+| ESPN hidden API breaks | Migration MSF rapide, alertes monitoring |
+| Calibration SPP off | Beta privée pour ajuster avant prod |
+| Conflits avec Pro League existante | Tests d'intégration, séparation claire des modules |
+| Performance ingestion volumineuse | Streaming Parquet, batch upsert |
+| Latence settlement | Queue + parallélisme par matchup |
+
+## Décisions à prendre avant Phase 1
+
+Voir [`00-vision.md` § "Questions ouvertes"](./00-vision.md#questions-ouvertes) :
+
+1. Mode mercato (draft snake / auction / free)
+2. League size (8 / 10 / 12)
+3. Captain multiplier (×1.5 / ×2)
+4. Underdog trigger (TV / classement)
+5. Race assignment (team-fixe / archetype / hybride)
+6. Cross-pollution Pro League
+7. Monétisation (freemium / subscription)
+8. NFLPA licence (jamais / dès le départ)

--- a/docs/nfl-fantasy/README.md
+++ b/docs/nfl-fantasy/README.md
@@ -1,0 +1,76 @@
+# NFL Fantasy × Blood Bowl — Documentation
+
+> Documentation vivante du module **NFL Fantasy** : un axe additionnel
+> (et non un remplacement) du jeu Blood Bowl existant, dans lequel les
+> joueurs construisent une équipe fantasy MPG-like basée sur les vraies
+> stats NFL, mais skinnée dans l'univers Blood Bowl.
+>
+> Cette documentation est issue d'une session d'exploration de 2026-05-19.
+> Elle doit évoluer au fil des décisions, validations légales, et changements
+> de roster NFL.
+
+## Vision en 3 lignes
+
+1. **Axe additionnel** : on garde la Pro League BB simulée actuelle, on ajoute un mode "NFL Fantasy" qui réutilise l'infra (auth, wallet, gazette, badges, mercato).
+2. **Skin BB sur stats NFL réelles** : chaque équipe NFL → 1 race BB, chaque joueur NFL → 1 poste BB, chaque event NFL → SPP via mapping pur.
+3. **Pseudonymisé légalement** : pas de noms d'équipes NFL (juste villes + race BB), pas de noms de joueurs (titres BB + numéros + descripteur). Stats réelles autorisées (CBC v. MLB AM, 2007).
+
+## Index des documents
+
+| # | Doc | Sujet |
+|---|---|---|
+| 00 | [vision.md](./00-vision.md) | Vision, scope, calendrier complémentaire BB/NFL |
+| 01 | [legal.md](./01-legal.md) | Cadre légal CBC v. MLB AM, RGPD, conventions pseudonymisation |
+| 02 | [references-sorare.md](./02-references-sorare.md) | Étude de cas Sorare (multi-sport) + concurrents fantasy |
+| 03 | [api-strategy.md](./03-api-strategy.md) | Stratégie API NFL : nflverse, ESPN, MySportsFeeds, SportRadar |
+| 04 | [race-mapping.md](./04-race-mapping.md) | 32 équipes NFL → 8 races BB avec justifications |
+| 05 | [position-mapping.md](./05-position-mapping.md) | Postes NFL → postes BB par race |
+| 06 | [scoring.md](./06-scoring.md) | Conversion stats NFL → SPP Blood Bowl |
+| 07 | [mechanics.md](./07-mechanics.md) | Intégration relances, inducements, prières à Nuffle |
+| 08 | [rosters-2025.md](./08-rosters-2025.md) | Rosters 2025 des 32 équipes mappés en postes BB |
+| 09 | [transitions-2026.md](./09-transitions-2026.md) | Free agents 2025 + draftees 2025 à reclasser pour 2026-27 |
+| 10 | [architecture.md](./10-architecture.md) | Intégration dans le monorepo (packages, services, Prisma) |
+
+## Statut des sections
+
+| Section | Statut | Confiance | Action |
+|---|---|---|---|
+| Vision & scope | Draft v1 | Haute | Validation produit |
+| Légal | Draft v1 | Moyenne | À faire valider par juriste (FR/EU) |
+| API stratégie | Draft v1 | Haute | POC nflverse + ESPN |
+| Race mapping (teams) | Draft v1 | Haute | Stable identités équipes |
+| Position mapping | Draft v1 | Haute | Mapping logique |
+| Scoring (stats → SPP) | Draft v1 | Moyenne | À calibrer sur saison entière |
+| Mechanics (BB) | Draft v1 | Haute | Validation prototype |
+| Rosters 2025 | Draft v1 | Moyenne | Coupure jan 2026 — à updater |
+| Transitions 2026 | Draft v1 | Faible | FA/Draft post mars-avril 2026 |
+| Architecture | Draft v1 | Haute | Pattern monorepo existant |
+
+## Convention de mise à jour
+
+Cette doc évolue en suivant les patterns du projet :
+- Branche `claude/nfl-fantasy-*` pour les évolutions
+- Commit `docs(nfl-fantasy): <description>`
+- Update `Statut des sections` ci-dessus à chaque modif
+- Ajouter une entrée dans `Changelog` ci-dessous
+
+## Changelog
+
+| Date | Version | Notes |
+|---|---|---|
+| 2026-05-19 | v1 | Création initiale (session exploratoire) |
+
+## Source de cette session
+
+Cette doc consolide une discussion exploratoire couvrant :
+1. Faisabilité du pivot NFL fantasy en axe supplémentaire
+2. Étude de cas Sorare (architecture multi-sport)
+3. Stratégie API et tiers de coût
+4. Cadre légal (CBC precedent, RGPD)
+5. Mapping racial des 32 équipes NFL
+6. Mapping postes joueurs NFL → BB
+7. Mécaniques BB (relances, inducements, prières) en seasonal bonus
+8. Rosters et transitions 2025→2026
+
+Les questions structurantes encore ouvertes sont listées dans
+[vision.md § "Questions ouvertes"](./00-vision.md).


### PR DESCRIPTION
## Résumé

Ajout de la documentation complète du module **NFL Fantasy** — un axe additionnel du jeu Blood Bowl existant où les joueurs construisent une équipe fantasy basée sur les vraies stats NFL, skinnée dans l'univers Blood Bowl.

Cette documentation couvre :
- **Vision & scope** : positionnement comme axe complémentaire (sept-février) à la Pro League BB existante
- **Cadre légal & pseudonymisation** : analyse CBC v. MLB AM, droit européen, stratégie de pseudonymisation des joueurs
- **Études de cas** : analyse de Sorare et concurrents (architecture multi-sport, mécaniques transposables)
- **Stratégie API** : 3 tiers de fournisseurs NFL (nflverse gratuit pour MVP, MySportsFeeds/SportRadar pour scale)
- **Mapping races BB** : 32 équipes NFL → 8 races BB (Skaven, Wood Elf, Orc, Human, Norse, Dwarf, Khorne, Necromantic)
- **Mapping postes** : positions NFL → postes BB paramétrisés par race (QB→Thrower, WR→Catcher/Gutter Runner, etc.)
- **Scoring** : conversion stats NFL → SPP Blood Bowl (threshold-based, narrative-focused)
- **Mécaniques** : relances, inducements, prières à Nuffle intégrées au fantasy scoring
- **Rosters 2025** : mapping détaillé des 32 équipes NFL avec pseudonymes publics et archetypes BB
- **Transitions 2026** : suivi des free agents et mouvements de joueurs
- **Architecture monorepo** : intégration dans le stack existant (package `nfl-mapper` pur, services Express+Prisma, routes Zod-validées)

## Checklist

- [x] Documentation structurée et complète
- [x] Cohérence avec conventions du repo (CLAUDE.md)
- [x] Références légales et précédents documentés
- [x] Exemples de code TypeScript alignés avec patterns existants
- [x] Mapping détaillé (32 équipes, 8 races, postes par race)

## Notes

- Documentation issue d'une session d'exploration 2026-05-19
- Cutoff connaissances : janvier 2026 (free agency 2026 et draft 2026 à compléter manuellement)
- Prête pour validation juridique formelle avant lancement commercial
- Architecture réutilise l'infra existante (sim-engine, game-engine, wallet, mercato, badges)

https://claude.ai/code/session_01PJ97zCT4xMPx5LRkBtxxSq