### PR TITLE
fix(web/security): admin middleware bypass + open redirect + JSON-LD XSS + SW URL guard

### DIFF
--- a/apps/web/app/admin/sync/page.tsx
+++ b/apps/web/app/admin/sync/page.tsx
@@ -3,6 +3,7 @@ import { Suspense, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { API_BASE } from "../../auth-client";
 import { syncAuthCookie } from "../../lib/auth-cookie";
+import { sanitizeRedirect } from "../../lib/safe-redirect";
 
 /**
  * Page de synchronisation du token depuis localStorage vers les cookies
@@ -20,7 +21,9 @@ export default function AdminSyncPage() {
 function AdminSyncContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const redirectTo = searchParams.get("redirect") || "/admin";
+  // Audit round 11 (HIGH/open-redirect) : sanitize avant utilisation.
+  // Voir lib/safe-redirect.ts.
+  const redirectTo = sanitizeRedirect(searchParams.get("redirect"), "/admin");
 
   useEffect(() => {
     const token = localStorage.getItem("auth_token");

--- a/apps/web/app/api/sync-auth-cookie/route.test.ts
+++ b/apps/web/app/api/sync-auth-cookie/route.test.ts
@@ -5,8 +5,14 @@
  * positionner avec httpOnly=true, sameSite=strict, et secure=true
  * en production. Sans ces flags, le cookie peut etre vole via XSS
  * ou expose en CSRF.
+ *
+ * Audit round 11 (CRITICAL) : la route valide maintenant le token
+ * contre /auth/me du backend avant de set le cookie. Sans ca, un
+ * attaquant pouvait fabriquer un JWT non-signe `{role: "admin"}` et
+ * bypass le middleware admin (Edge Runtime ne verifie pas la
+ * signature). Les tests mocks `global.fetch` pour /auth/me.
  */
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { POST } from "./route";
 
 function buildRequest(body: unknown): Request {
@@ -17,9 +23,26 @@ function buildRequest(body: unknown): Request {
   });
 }
 
+function mockFetchOk(): void {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),
+  ) as typeof fetch;
+}
+
+function mockFetch401(): void {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ error: "Invalid token" }), { status: 401 }),
+  ) as typeof fetch;
+}
+
 describe("POST /api/sync-auth-cookie", () => {
+  beforeEach(() => {
+    mockFetchOk();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it("returns 400 when token is missing", async () => {
@@ -54,5 +77,33 @@ describe("POST /api/sync-auth-cookie", () => {
     const res = await POST(buildRequest({ token: "abc" }) as never);
     const setCookie = res.headers.get("set-cookie") ?? "";
     expect(setCookie).toMatch(/;\s*Secure/i);
+  });
+
+  // Audit round 11 : tests anti-bypass admin middleware.
+  it("returns 401 si le backend rejette le token (signature invalide)", async () => {
+    mockFetch401();
+    const res = await POST(buildRequest({ token: "forged.jwt.value" }) as never);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("returns 503 si le backend est injoignable (timeout ou network error)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) as typeof fetch;
+    const res = await POST(buildRequest({ token: "abc" }) as never);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("appelle /auth/me avec Bearer <token>", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: "u1" } }), { status: 200 }),
+    );
+    globalThis.fetch = fetchSpy as typeof fetch;
+    await POST(buildRequest({ token: "validtoken" }) as never);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(/\/auth\/me$/);
+    expect((options as { headers: Record<string, string> }).headers.authorization)
+      .toBe("Bearer validtoken");
   });
 });

--- a/apps/web/app/api/sync-auth-cookie/route.ts
+++ b/apps/web/app/api/sync-auth-cookie/route.ts
@@ -9,13 +9,56 @@ import type { NextRequest } from "next/server";
  * `document.cookie` ni le rejouer en CSRF cross-site. Le token reste
  * disponible cote client via localStorage pour les appels API
  * authentifies par header `Authorization`.
+ *
+ * Audit round 11 (CRITICAL) : avant, on stockait n'importe quel
+ * string fourni par le client sans verifier la signature JWT. Le
+ * `middleware.ts` gate ensuite `/admin/*` via `isAdminToken` qui
+ * decode le JWT SANS verifier la signature (Edge Runtime ne supporte
+ * pas jose). Un attaquant pouvait fabriquer un JWT
+ * `{role: "admin"}` avec une signature arbitraire, POST a cet endpoint,
+ * et bypass le middleware admin → render des pages admin.
+ *
+ * Fix : valider le token contre le backend via `/auth/me` avant de
+ * set le cookie. Si le token est invalide ou si le backend n'est pas
+ * joignable, on refuse le set.
  */
+
+function inferApiBase(): string {
+  if (process.env.NEXT_PUBLIC_API_BASE) return process.env.NEXT_PUBLIC_API_BASE;
+  return "http://localhost:4000";
+}
+
 export async function POST(request: NextRequest) {
   const body = await request.json().catch(() => ({}));
   const token = body?.token;
 
   if (!token || typeof token !== "string") {
     return NextResponse.json({ error: "Token manquant" }, { status: 400 });
+  }
+
+  // Audit round 11 : valide le token cote serveur avant de set le cookie.
+  // Le backend signe le JWT avec un secret connu seulement de lui ;
+  // /auth/me retourne 200 uniquement si la signature est valide.
+  try {
+    const verifyResponse = await fetch(`${inferApiBase()}/auth/me`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${token}` },
+      // 5s pour eviter de bloquer le user en cas de backend lent.
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!verifyResponse.ok) {
+      return NextResponse.json(
+        { error: "Token invalide" },
+        { status: 401 },
+      );
+    }
+  } catch {
+    // Backend injoignable ou timeout : on refuse plutot que set un
+    // cookie potentiellement forge.
+    return NextResponse.json(
+      { error: "Verification token impossible" },
+      { status: 503 },
+    );
   }
 
   const response = NextResponse.json({ success: true });

--- a/apps/web/app/auth/sync/page.tsx
+++ b/apps/web/app/auth/sync/page.tsx
@@ -3,6 +3,7 @@ import { Suspense, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { API_BASE } from "../../auth-client";
 import { syncAuthCookie, clearAuthCookie } from "../../lib/auth-cookie";
+import { sanitizeRedirect } from "../../lib/safe-redirect";
 
 /**
  * Page de synchronisation du token depuis localStorage vers les cookies pour les
@@ -27,7 +28,12 @@ export default function AuthSyncPage() {
 function AuthSyncContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const redirectTo = searchParams.get("redirect") || "/me";
+  // Audit round 11 (HIGH/open-redirect) : avant, `redirectTo` etait
+  // accepte brut depuis `?redirect=...`. Un attaquant pouvait forger
+  // `https://app.com/auth/sync?redirect=https://evil.com` et detourner
+  // l'user apres login. `sanitizeRedirect` n'autorise que les paths
+  // internes (`/...`) et rejette `//`, `/\\`, et toute URL absolue.
+  const redirectTo = sanitizeRedirect(searchParams.get("redirect"), "/me");
 
   useEffect(() => {
     const token = localStorage.getItem("auth_token");

--- a/apps/web/app/leagues/[id]/seasons/[sid]/recap/page.tsx
+++ b/apps/web/app/leagues/[id]/seasons/[sid]/recap/page.tsx
@@ -22,6 +22,7 @@ import { apiRequest } from "../../../../../lib/api-client";
 import { SeasonStandings } from "../../../SeasonStandings";
 import type { StandingRow } from "../../../types";
 import { buildSeasonEventSchema } from "../../../../season-event-schema";
+import { safeJsonLd } from "../../../../../lib/safe-json-ld";
 
 interface AwardEntry {
   teamId: string;
@@ -197,8 +198,12 @@ export default function SeasonRecapPage() {
           type="application/ld+json"
           data-testid="season-recap-jsonld"
           // eslint-disable-next-line react/no-danger
+          // Audit round 11 (HIGH/XSS) : escape via safeJsonLd pour eviter
+          // le breakout `</script>` quand des champs user-controlled
+          // (championCoachName, championTeamName, leagueName) contiennent
+          // la sequence. Voir lib/safe-json-ld.ts (round 9).
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(seasonEventSchema),
+            __html: safeJsonLd(seasonEventSchema),
           }}
         />
       ) : null}

--- a/apps/web/app/lib/safe-redirect.ts
+++ b/apps/web/app/lib/safe-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Audit round 11 (HIGH/open-redirect) — helper partage pour valider
+ * la cible d'un `?redirect=` parametre.
+ *
+ * N'autorise que les chemins internes commencant par `/` qui ne
+ * peuvent pas etre interpretes comme des URLs externes ou des
+ * protocol-relative URLs. Tout autre input retombe sur le fallback.
+ *
+ * Avant ce helper, `/auth/sync` et `/admin/sync` redirigeaient
+ * inconditionnellement vers `searchParams.get("redirect")`, ce qui
+ * permettait a un attaquant de forger
+ * `https://app.com/auth/sync?redirect=https://evil.com` et de
+ * recuperer la victime apres login sur un domaine arbitraire.
+ */
+export function sanitizeRedirect(
+  raw: string | null,
+  fallback: string,
+): string {
+  if (!raw) return fallback;
+  if (!raw.startsWith("/")) return fallback;
+  if (raw.startsWith("//")) return fallback;
+  if (raw.startsWith("/\\")) return fallback;
+  return raw;
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -42,11 +42,26 @@ self.addEventListener("push", (event) => {
 
 /**
  * Notification click — open or focus the target URL.
+ *
+ * Audit round 11 (HIGH) : avant, on passait `data?.url` brut a
+ * `openWindow`. Si la cle VAPID etait volee ou si le serveur push
+ * etait compromis, un attaquant pouvait envoyer
+ * `{data: {url: "https://evil.com/phishing"}}` et chaque user qui
+ * clique sur la notif partait sur le domaine attaquant. Maintenant
+ * on restreint a des chemins internes commencant par `/`.
  */
+function isSafeInternalUrl(url) {
+  return typeof url === "string"
+    && url.startsWith("/")
+    && !url.startsWith("//")
+    && !url.startsWith("/\\");
+}
+
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
 
-  const targetUrl = event.notification.data?.url || "/";
+  const rawUrl = event.notification.data?.url;
+  const targetUrl = isSafeInternalUrl(rawUrl) ? rawUrl : "/";
 
   event.waitUntil(
     self.clients


### PR DESCRIPTION
## Summary

Audit round 11 — 4 fixes web security regroupes.

**1. CRITICAL — Admin middleware bypass via unsigned JWT**
`apps/web/app/api/sync-auth-cookie/route.ts`. Avant : la route stockait n'importe quel string fourni par le client comme cookie `auth_token` sans verifier la signature. Le middleware `/admin/*` gate via `isAdminToken` qui decode le JWT SANS verifier la signature (Edge Runtime ne supporte pas jose). Un attaquant pouvait fabriquer un JWT `{role: "admin"}`, POST a cet endpoint, et bypass le middleware admin pour render les pages admin. Fix : valide le token contre `/auth/me` du backend (qui verifie la signature) avant de set le cookie.

**2. HIGH — Open redirect dans /auth/sync et /admin/sync**
`apps/web/app/auth/sync/page.tsx` + `apps/web/app/admin/sync/page.tsx`. Fix : nouveau helper `app/lib/safe-redirect.ts` (`sanitizeRedirect`) — paths internes uniquement.

**3. HIGH — JSON-LD XSS dans recap page (manque par round 9)**
`apps/web/app/leagues/[id]/seasons/[sid]/recap/page.tsx`. Le `<script type="application/ld+json">` utilisait `JSON.stringify` brut. Fix : `safeJsonLd` (helper introduit round 9).

**4. HIGH — Service worker openWindow URL guard**
`apps/web/public/sw.js`. Fix : helper `isSafeInternalUrl`.

## Test plan

- [x] 8/8 sync-auth-cookie (3 nouveaux : 401 sur token forge, 503 sur backend down, /auth/me appele avec Bearer)
- [x] 1186/1186 full web suite
- [x] web typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_