### PR TITLE
fix(socket/security): spectator bypass + chat broadcast membership check

### DIFF
--- a/apps/server/src/game-chat.ts
+++ b/apps/server/src/game-chat.ts
@@ -81,6 +81,17 @@ export function registerGameChatHandlers(gameNamespace: Namespace): void {
           return;
         }
 
+        // Audit round 11 (HIGH) : avant, n'importe quel socket
+        // authentifie pouvait broadcast `game:chat-message` a
+        // n'importe quel matchId sans avoir rejoint la room — spam
+        // cross-match, harcelement, ad injection. socket.io track
+        // les rooms natively dans `socket.rooms`, donc verifier
+        // l'appartenance est O(1).
+        if (!socket.rooms.has(matchId)) {
+          ack?.({ ok: false, error: "Not in this match room" });
+          return;
+        }
+
         // Broadcast to everyone in the room (including sender)
         const broadcast: ChatBroadcast = {
           matchId,

--- a/apps/server/src/game-resync.test.ts
+++ b/apps/server/src/game-resync.test.ts
@@ -12,8 +12,13 @@ vi.mock("./prisma", () => ({
   },
 }));
 
+vi.mock("./game-spectator", () => ({
+  getSpectateMatchId: vi.fn(),
+}));
+
 import { prisma } from "./prisma";
 import { handleResyncRequest } from "./game-resync";
+import { getSpectateMatchId } from "./game-spectator";
 
 describe("game-resync", () => {
   const userId = "user-abc";
@@ -117,6 +122,47 @@ describe("game-resync", () => {
       success: true,
       gameState,
       matchId,
+    });
+  });
+
+  // Audit round 11 (CRITICAL) : tests anti-bypass spectator.
+  describe("spectator access control", () => {
+    it("autorise un spectateur qui spectate EXACTEMENT le matchId demande", async () => {
+      vi.mocked(getSpectateMatchId).mockReturnValue(matchId);
+      vi.mocked(prisma.turn.findFirst).mockResolvedValue({
+        payload: { gameState: { foo: "bar" } },
+      } as any);
+
+      const result = await handleResyncRequest(matchId, userId, "socket-A");
+
+      expect(result.success).toBe(true);
+      // findFirst sur match NE DOIT PAS etre appele : spectator legitime.
+      expect(prisma.match.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("BLOQUE un spectateur d'un autre match qui tente de resync un match prive", async () => {
+      // Socket spectate match-OTHER, mais tente request-resync sur match-123 (prive).
+      vi.mocked(getSpectateMatchId).mockReturnValue("match-OTHER");
+      vi.mocked(prisma.match.findFirst).mockResolvedValue(null); // pas participant
+
+      const result = await handleResyncRequest(matchId, userId, "socket-attacker");
+
+      expect(result).toEqual({
+        success: false,
+        error: "You are not a participant of this match",
+      });
+      // findFirst DOIT etre appele : pas un spectator legitime → check participant.
+      expect(prisma.match.findFirst).toHaveBeenCalled();
+    });
+
+    it("BLOQUE un socket qui ne spectate rien et n'est pas participant", async () => {
+      vi.mocked(getSpectateMatchId).mockReturnValue(undefined);
+      vi.mocked(prisma.match.findFirst).mockResolvedValue(null);
+
+      const result = await handleResyncRequest(matchId, userId, "socket-X");
+
+      expect(result.success).toBe(false);
+      expect(prisma.match.findFirst).toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/src/game-resync.ts
+++ b/apps/server/src/game-resync.ts
@@ -1,6 +1,6 @@
 import type { Namespace, Socket } from "socket.io";
 import { prisma } from "./prisma";
-import { isSpectator } from "./game-spectator";
+import { getSpectateMatchId } from "./game-spectator";
 
 export interface ResyncRequestPayload {
   matchId: string;
@@ -22,10 +22,19 @@ export async function handleResyncRequest(
   userId: string,
   socketId?: string,
 ): Promise<ResyncResponse> {
-  // Spectators can also resync — skip participant check for them
-  const spectator = socketId ? isSpectator(socketId) : false;
+  // Audit round 11 (CRITICAL) : avant, `isSpectator(socketId)` etait
+  // un check global "ce socket est-il spectateur de QUOI QUE CE
+  // SOIT". Un attaquant pouvait :
+  //   1. game:spectate-match {matchId: "any-public"}
+  //   2. game:request-resync {matchId: "<victim-private>"}
+  // → recupere le `gameState` complet d'un match prive. Fix :
+  // verifier que le matchId spectate EST le matchId demande (strict).
+  const spectatedMatchId = socketId
+    ? getSpectateMatchId(socketId)
+    : undefined;
+  const isLegitimateSpectator = spectatedMatchId === matchId;
 
-  if (!spectator) {
+  if (!isLegitimateSpectator) {
     // Verify the user is a participant of this match
     const match = await prisma.match.findFirst({
       where: {

--- a/apps/server/src/game-spectator.ts
+++ b/apps/server/src/game-spectator.ts
@@ -132,6 +132,20 @@ export function isSpectator(socketId: string): boolean {
   return socketToSpectateMatch.has(socketId);
 }
 
+/**
+ * Audit round 11 (CRITICAL) : retourne le matchId que ce socket
+ * spectate, ou `undefined` si pas spectateur. Avant cette helper,
+ * `isSpectator` etait global → un attaquant pouvait spectate
+ * n'importe quelle matchId publique, puis appeler `request-resync`
+ * sur l'id d'un match prive auquel il n'appartient pas. Le bypass
+ * sautait la verification participant a cause d'un check global.
+ * Maintenant le caller doit comparer le matchId vise au matchId
+ * effectivement spectate par ce socket.
+ */
+export function getSpectateMatchId(socketId: string): string | undefined {
+  return socketToSpectateMatch.get(socketId);
+}
+
 /** Reset all spectator tracking (for testing). */
 export function resetSpectators(): void {
   spectatorSockets.clear();


### PR DESCRIPTION
## Summary

Audit round 11 — 2 fixes socket security.

**1. CRITICAL — Spectator bypass leaks any match's gameState**
`apps/server/src/game-resync.ts` + `game-spectator.ts`. Avant : `isSpectator(socketId)` etait global ("ce socket spectate QUOI QUE CE SOIT"). Combine avec `game:spectate-match` qui accepte n'importe quel matchId, un attaquant pouvait :
1. emit `game:spectate-match {matchId: "any-public"}`
2. emit `game:request-resync {matchId: "<victim-private>"}`

→ `handleResyncRequest` skip le check participant → renvoie le `gameState` complet du match prive.

Fix : helper `getSpectateMatchId(socketId): string | undefined`. Le caller compare strictement contre le matchId demande.

**2. HIGH — Chat broadcast a n'importe quelle room sans appartenance**
`apps/server/src/game-chat.ts`. Avant : `game:chat-message` emit `gameNamespace.to(matchId).emit(...)` sans verifier que le socket avait rejoint la room. N'importe quel user authentifie pouvait spam toutes les matches concurrentes.

Fix : `if (!socket.rooms.has(matchId)) return`. socket.io track les rooms nativement → O(1).

## Test plan

- [x] 8/8 game-resync (3 nouveaux : spectator legitime autorise, spectator d'un autre match bloque, socket non-spectateur non-participant bloque)
- [x] 9/9 game-spectator
- [x] server typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_