### PR TITLE
fix(engine): Pass skill ne relance pas un Fumble (naturel 1)

### DIFF
--- a/packages/game-engine/src/mechanics/catch-pass-skill-reroll.test.ts
+++ b/packages/game-engine/src/mechanics/catch-pass-skill-reroll.test.ts
@@ -55,9 +55,11 @@ describe('Skill: Catch (personal reroll)', () => {
 });
 
 describe('Skill: Pass (personal reroll)', () => {
-  it('relance une passe ratee si le passeur a pass', () => {
+  it('relance une passe ratee (non-Fumble) si le passeur a pass', () => {
     const passer = makePasser(['pass']);
-    const rng = scriptedRng([0.01, 0.8]);
+    // Target ag=pa=3 → target=3. 0.3 → roll 2 (echec sans Fumble),
+    // 0.8 → roll 5 (succes apres reroll).
+    const rng = scriptedRng([0.3, 0.8]);
     const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
     expect(rerolled).toBe(true);
     expect(result.success).toBe(true);
@@ -65,7 +67,7 @@ describe('Skill: Pass (personal reroll)', () => {
 
   it('ne relance pas si le passeur n\'a pas pass', () => {
     const passer = makePasser([]);
-    const rng = scriptedRng([0.01, 0.8]);
+    const rng = scriptedRng([0.3, 0.8]);
     const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
     expect(rerolled).toBe(false);
     expect(result.success).toBe(false);
@@ -73,8 +75,8 @@ describe('Skill: Pass (personal reroll)', () => {
 
   it('relance une seule fois (succes apres reroll)', () => {
     const passer = makePasser(['pass']);
-    // echec -> reroll -> succes
-    const rng = scriptedRng([0.01, 0.9]);
+    // echec non-Fumble -> reroll -> succes
+    const rng = scriptedRng([0.3, 0.9]);
     const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
     expect(rerolled).toBe(true);
     expect(result.success).toBe(true);
@@ -82,10 +84,25 @@ describe('Skill: Pass (personal reroll)', () => {
 
   it('echec apres reroll reste un echec', () => {
     const passer = makePasser(['pass']);
-    // echec -> reroll -> echec
-    const rng = scriptedRng([0.01, 0.01]);
+    // echec non-Fumble -> reroll -> echec non-Fumble
+    const rng = scriptedRng([0.3, 0.3]);
     const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
     expect(rerolled).toBe(true);
     expect(result.success).toBe(false);
+  });
+
+  // Audit round 11 (HIGH/regle BB) : Fumble = naturel 1 sur le D6
+  // de passe. BB2020 : un Fumble n'est PAS relancable par le skill
+  // Pass (ni par un team reroll) — c'est un Turnover immediat et le
+  // ballon est lache au feet du passeur. Avant ce fix, le skill
+  // donnait un free reroll d'un Fumble.
+  it('le skill Pass ne relance PAS un Fumble (naturel 1)', () => {
+    const passer = makePasser(['pass']);
+    // 1er jet = 1 (Fumble). Si on rerollait, 2eme = 5 = succes.
+    const rng = scriptedRng([0.01, 0.8]);
+    const { result, rerolled } = performPassRollWithSkill(passer, rng, 0);
+    expect(rerolled).toBe(false);
+    expect(result.success).toBe(false);
+    expect(result.diceRoll).toBe(1);
   });
 });

--- a/packages/game-engine/src/mechanics/passing.ts
+++ b/packages/game-engine/src/mechanics/passing.ts
@@ -213,6 +213,16 @@ export function performPassRollWithSkill(
   if (first.success) {
     return { result: first, rerolled: false };
   }
+  // Audit round 11 (HIGH/regle BB) : avant, le skill `Pass` relancait
+  // n'importe quel echec, y compris un naturel 1 (Fumble). Or BB2020 :
+  // un Fumble (D6 = 1 sur le jet de passe) n'est PAS un echec
+  // ordinaire — c'est un Turnover immediat et le ballon est lache,
+  // qui ne peut PAS etre relance par le skill `Pass` (ni par un team
+  // reroll). Seuls les echecs sans Fumble peuvent etre relances.
+  // Fix : court-circuit sur diceRoll === 1.
+  if (first.diceRoll === 1) {
+    return { result: first, rerolled: false };
+  }
   const hasPass = passer.skills.some(s => s.toLowerCase() === 'pass');
   if (!hasPass) {
     return { result: first, rerolled: false };


### PR DESCRIPTION
## Summary

Audit round 11 (HIGH/regle BB) — `performPassRollWithSkill` :
avant, le skill `Pass` relancait n'importe quel echec, y compris un naturel 1 sur le D6 (Fumble). Or BB2020 :

> "If a 1 is rolled on the D6, the pass is Fumbled — the ball lands at the passer's feet and the active team's turn ends with a Turnover. A Fumble may NOT be re-rolled with the Pass skill or a Team re-roll."

Bug constate : un passeur avec skill `Pass` qui faisait un naturel 1 obtenait gratuitement une 2eme chance, contrairement a la regle.

Fix : court-circuit dans `performPassRollWithSkill` si `first.diceRoll === 1` → on retourne directement le Fumble sans offrir la relance.

Note : l'autre fix candidat (Wandering Apothecary `canPurchase`) n'est pas inclus apres verification — BB2020 limite WA aux equipes dont le roster autorise les apothecaires, ce qui matche raisonnablement l'etat actuel via `hasApothecary`.

## Test plan

- [x] Tests existants ajustes (`0.01` qui produisait roll=1 remplace par `0.3` → roll=2) — les anciens tests asserent maintenant la bonne regle
- [x] Nouveau test "le skill Pass ne relance PAS un Fumble (naturel 1)" : `rerolled=false`, `diceRoll=1`
- [x] 8/8 catch-pass-skill-reroll.test.ts
- [x] 5058/5058 full game-engine suite
- [x] game-engine typecheck OK
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_017vjokQrbftvXBGoFj2doH2)_