### PR TITLE
POC ingestion NFL : nflverse + ESPN + normalize StatLine

### DIFF
--- a/docs/nfl-fantasy/03-api-strategy.md
+++ b/docs/nfl-fantasy/03-api-strategy.md
@@ -54,7 +54,14 @@
 - Scoring users tranquillement le lundi
 - Source de vérité pour rosters + stats annuelles
 
-**POC validé** : 963 rows pour Week 10 2025, 19421 rows toute la saison, toutes les positions BB cibles présentes (cf. `scripts/nfl-poc/`).
+**POC validé** : 963 rows W10 / 1071 rows W1 / 1067 rows W18 (saison 2025), 19421 rows toute la saison, toutes les positions BB cibles présentes (cf. `scripts/nfl-poc/`).
+
+**Gotchas découverts au POC** :
+- 1 CSV unifié couvre toute la saison → un seul fetch + cache local suffit pour tous les weeks (très friendly côté ingestion)
+- Filtrer par `week` (Number) sur les rows : valeurs 1-22 (regular 1-18 + post 19-22)
+- Toujours filtrer aussi `season_type` (`REG` / `POST` / `PRE`) pour ne pas mixer preseason quand on settle un weekend
+- 1 row avec `position_group` vide observée sur W10 (joueur sans poste assigné, edge case à logger sans crasher)
+- Format `.qs` / `.rds` à ignorer côté ingestion JS (R-specific) ; choisir `.csv` ou `.parquet`
 
 ### ESPN Hidden API
 
@@ -91,7 +98,14 @@ GET /news                                → news NFL
 - [`pseudo-r/Public-ESPN-API`](https://github.com/pseudo-r/Public-ESPN-API) — référence la plus complète des endpoints cachés ESPN, NFL inclus
 - [`mkreiser/ESPN-Fantasy-Football-API`](https://github.com/mkreiser/ESPN-Fantasy-Football-API) — wrapper JS/TS (utile pour notre stack), ~340 stars
 
-**POC validé** : 12 events Final retournés pour 2025-11-09 (Sunday Week 10), summary expose 19 keys (boxscore, drives, leaders, scoringPlays). Latence ~200ms par appel, aucun rate limit observé sur 2 appels (cf. `scripts/nfl-poc/`).
+**POC validé** : 13 events W1 (Sunday Sep 7 + SNF) / 12 events W10 / 14 events W18 — tous Final. Latence ~200ms par appel, aucun rate limit observé.
+
+**Gotchas découverts au POC** :
+- `?dates=YYYYMMDD` filtre par **kickoff en ET local time**, pas UTC. Conséquence : un TNF dont le kickoff UTC est `2025-09-05T00:20Z` apparaît bien dans `?dates=20250904` (Thursday ET).
+- En pratique pour une semaine NFL complète, polling **Thu + Fri (rare, jeux internationaux) + Sun + Mon** depuis ET → 4 dates max.
+- Le champ `season` n'est **pas** au top-level mais sous `leagues[0].season`. Le champ `season.type` est un **objet** (`{id, type, name, abbreviation}`), pas un Int. Code défensif requis.
+- `/summary?event={id}` retourne **18 ou 19 keys** top-level selon les events (la clé `article` est absente sur les events sans recap éditorial). Toujours utiliser `?.` à la lecture.
+- Pas de WebSocket public connu (polling only — 30-60s TTL côté cache strato recommandé).
 
 ### Pro-Football-Reference (scraping)
 

--- a/docs/nfl-fantasy/03-api-strategy.md
+++ b/docs/nfl-fantasy/03-api-strategy.md
@@ -54,7 +54,7 @@
 - Scoring users tranquillement le lundi
 - Source de vérité pour rosters + stats annuelles
 
-**POC validé** : 963 rows W10 / 1071 rows W1 / 1067 rows W18 (saison 2025), 19421 rows toute la saison, toutes les positions BB cibles présentes (cf. `scripts/nfl-poc/`).
+**POC validé** : 963 rows W10 / 1071 rows W1 / 1067 rows W18 / 398 rows W19 (Wildcard) / 280 W20 (Divisional) / 137 W21 (Conf) / 67 W22 (SB) sur la saison 2025. Total 19421 rows. Toutes les positions BB cibles présentes (cf. `scripts/nfl-poc/`).
 
 **Gotchas découverts au POC** :
 - 1 CSV unifié couvre toute la saison → un seul fetch + cache local suffit pour tous les weeks (très friendly côté ingestion)
@@ -62,6 +62,11 @@
 - Toujours filtrer aussi `season_type` (`REG` / `POST` / `PRE`) pour ne pas mixer preseason quand on settle un weekend
 - 1 row avec `position_group` vide observée sur W10 (joueur sans poste assigné, edge case à logger sans crasher)
 - Format `.qs` / `.rds` à ignorer côté ingestion JS (R-specific) ; choisir `.csv` ou `.parquet`
+- **Mapping playoffs nflverse ↔ ESPN** (cf. section ESPN ci-dessous) :
+  - nflverse W19 (POST) = ESPN post-season `week.number=1` = **Wildcard** (6 games)
+  - nflverse W20 (POST) = ESPN post-season `week.number=2` = **Divisional** (4 games)
+  - nflverse W21 (POST) = ESPN post-season `week.number=3` = **Conference Champ** (2 games)
+  - nflverse W22 (POST) = ESPN post-season `week.number=5` = **Super Bowl** (1 game ; ESPN saute 4 = Pro Bowl)
 
 ### ESPN Hidden API
 
@@ -98,12 +103,14 @@ GET /news                                → news NFL
 - [`pseudo-r/Public-ESPN-API`](https://github.com/pseudo-r/Public-ESPN-API) — référence la plus complète des endpoints cachés ESPN, NFL inclus
 - [`mkreiser/ESPN-Fantasy-Football-API`](https://github.com/mkreiser/ESPN-Fantasy-Football-API) — wrapper JS/TS (utile pour notre stack), ~340 stars
 
-**POC validé** : 13 events W1 (Sunday Sep 7 + SNF) / 12 events W10 / 14 events W18 — tous Final. Latence ~200ms par appel, aucun rate limit observé.
+**POC validé** : éprouvé sur W1 (regular kickoff), W10/W18 (regular mid+late), W19 Wildcard, Super Bowl LX (`SEA 29 @ NE 13`, 2026-02-08). Latence ~200ms par appel, aucun rate limit observé.
 
 **Gotchas découverts au POC** :
 - `?dates=YYYYMMDD` filtre par **kickoff en ET local time**, pas UTC. Conséquence : un TNF dont le kickoff UTC est `2025-09-05T00:20Z` apparaît bien dans `?dates=20250904` (Thursday ET).
-- En pratique pour une semaine NFL complète, polling **Thu + Fri (rare, jeux internationaux) + Sun + Mon** depuis ET → 4 dates max.
+- En pratique pour une semaine NFL complète, polling **Thu + Fri (international weeks) + Sat (W15-17 + playoffs) + Sun + Mon** depuis ET. **W1 complet 2025 = 4 dates / 16 games** (1 Thu, 1 Fri São Paulo, 13 Sun, 1 Mon).
 - Le champ `season` n'est **pas** au top-level mais sous `leagues[0].season`. Le champ `season.type` est un **objet** (`{id, type, name, abbreviation}`), pas un Int. Code défensif requis.
+- **Bug ESPN piège** : `leagues[0].season.type` reste figé à `"Regular Season"` même sur des dates de playoffs. Source de vérité = `event.season.slug` (`"post-season"`) ou `event.season.type=3`. Toujours lire au niveau event, pas league.
+- **Numérotation playoffs ESPN** : `event.week.number` reset à 1 en post-season : Wildcard=1, Divisional=2, Conference=3, Pro Bowl=4 (skip), **Super Bowl=5**. Mapping avec nflverse : nflverse W19-22 ≠ ESPN W1-5. À traduire dans `nfl-ingest.ts`.
 - `/summary?event={id}` retourne **18 ou 19 keys** top-level selon les events (la clé `article` est absente sur les events sans recap éditorial). Toujours utiliser `?.` à la lecture.
 - Pas de WebSocket public connu (polling only — 30-60s TTL côté cache strato recommandé).
 

--- a/docs/nfl-fantasy/03-api-strategy.md
+++ b/docs/nfl-fantasy/03-api-strategy.md
@@ -8,9 +8,14 @@
 
 | Tier | Coût | Latence | Recommandation |
 |---|---|---|---|
-| Gratuit | 0€ | 5min–24h | **MVP V1** (nflverse + ESPN hidden API) |
+| Gratuit | 0€ | 15min–24h | **MVP V1** (nflverse + ESPN hidden API) |
+| Low-cost commercial | $10-25/mois | minutes | **V1.5** redondance ESPN (Tank01 via RapidAPI) |
 | Abordable | $50-500/mois | ~5-30s | V2 si DAU >5k (MySportsFeeds) |
 | Enterprise | $2000+/mois | <1s | V3 si DFS-grade requis (SportRadar) |
+
+**Compléments free** : Sleeper API (trending/import leagues, no PBP), The Odds API (backup scores + odds).
+**Outil ID standardization** : SDX (V2+ si multi-source).
+**Sources à éviter** : Sofascore, DK/FD WS, SerpAPI, NFL.com Fantasy (cf. avertissements ToS plus bas).
 
 ## Tier 1 — Gratuit (recommandé MVP)
 
@@ -18,7 +23,14 @@
 
 **URL** : <https://github.com/nflverse>
 
-**Format** : GitHub releases (Parquet, CSV), JSON via API REST légère
+**Format** : GitHub releases (Parquet, CSV, RDS, qs), JSON via API REST légère
+
+**⚠️ Tag de release correct** (POC 2026-05-19) :
+- Saison **≤ 2024** : ancien tag `player_stats` (legacy, plus mis à jour)
+- Saison **≥ 2025** : nouveau tag `stats_player` (publié 2025-07-31)
+- URL CSV cible : `https://github.com/nflverse/nflverse-data/releases/download/stats_player/stats_player_week_{YEAR}.csv`
+- Le CSV est **unifié** : offense (passing/rushing/receiving) + défense (def_tackles, def_sacks, def_interceptions) + special teams dans un seul fichier 115 colonnes. Pas besoin d'un fichier `def` séparé.
+- Découverte des assets via : `GET https://api.github.com/repos/nflverse/nflverse-data/releases/tags/stats_player`
 
 **Couverture** :
 - Play-by-play complet depuis 1999
@@ -35,12 +47,14 @@
 **Limites** :
 - Pas de live in-game (delay 15min minimum)
 - Pas de WebSocket / push
-- Format Parquet → besoin de pipeline conversion
+- Format Parquet → besoin de pipeline conversion (CSV plus simple pour POC)
 
 **Use case pour nous** :
 - Ingestion **post-match** chaque dimanche soir / lundi matin
 - Scoring users tranquillement le lundi
 - Source de vérité pour rosters + stats annuelles
+
+**POC validé** : 963 rows pour Week 10 2025, 19421 rows toute la saison, toutes les positions BB cibles présentes (cf. `scripts/nfl-poc/`).
 
 ### ESPN Hidden API
 
@@ -73,6 +87,12 @@ GET /news                                → news NFL
 - Boxscores rapides pour engagement temps réel
 - Compléments rosters (photos non utilisées, mais bio data utile)
 
+**Références communautaires** (utiles pour mapper les endpoints) :
+- [`pseudo-r/Public-ESPN-API`](https://github.com/pseudo-r/Public-ESPN-API) — référence la plus complète des endpoints cachés ESPN, NFL inclus
+- [`mkreiser/ESPN-Fantasy-Football-API`](https://github.com/mkreiser/ESPN-Fantasy-Football-API) — wrapper JS/TS (utile pour notre stack), ~340 stars
+
+**POC validé** : 12 events Final retournés pour 2025-11-09 (Sunday Week 10), summary expose 19 keys (boxscore, drives, leaders, scoringPlays). Latence ~200ms par appel, aucun rate limit observé sur 2 appels (cf. `scripts/nfl-poc/`).
+
 ### Pro-Football-Reference (scraping)
 
 **Pourquoi ne pas l'utiliser** :
@@ -88,6 +108,72 @@ GET /news                                → news NFL
 **Coût** : Gratuit (Patreon $3/mois pour clé patron)
 **Use case** : Backup / cross-check, pas suffisant standalone
 
+### Sleeper API
+
+**URL** : <https://docs.sleeper.com/>
+
+**Coût** : **Free**, no auth, cap informel ~1000 req/min
+**Latence** : 5-10 min polling sur scoring fantasy
+**ToS** : Grey (pas de clause commerciale explicite, "no uptime guarantee")
+
+**Couverture utile** :
+- Trending players (adds/drops)
+- Transactions, drafts, league/matchups
+- Import de leagues Sleeper existantes (cross-promo audience fantasy US)
+- **Pas de PBP**, endpoint player stats deprecated
+
+**Use case pour nous** :
+- Complément engagement (trending widget Gazette)
+- Onboarding "import ta league Sleeper" pour audience US
+
+### The Odds API
+
+**URL** : <https://the-odds-api.com/>
+
+**Coût** : Freemium — 500 req/mois free, plans payants au-delà
+**Latence** : Scores ~30s, in-play odds
+**ToS** : Clear (commercial OK)
+
+**Use case pour nous** :
+- Backup scores (cross-check ESPN)
+- Affichage odds pour narratif Gazette ("underdog upset !")
+- **Pas pour PBP / player stats**
+
+### ⚠️ Sources à éviter (ToS / risque légal)
+
+- **Pro-Football-Reference** : ToS interdit scraping commercial (déjà mentionné)
+- **Sofascore wrappers** (PyPI / Apify) : auteurs préviennent "you may be at risk via Sofascore ToS"
+- **DraftKings / FanDuel WebSocket** : reverse-engineered, illégal pour usage commercial
+- **SerpAPI Google Sports** : Google a poursuivi SerpAPI en DMCA déc 2025, hearing mai 2026 — risque légal actif
+- **NFL.com Fantasy API** (apidocs.fantasy.nfl.com) : instable, 403 régulièrement, undocumented
+
+## Tier 1.5 — Low-cost commercial ($10-25/mois)
+
+### Tank01 NFL Live API (via RapidAPI)
+
+**URL** : <https://rapidapi.com/tank01/api/tank01-nfl-live-in-game-real-time-statistics-nfl>
+
+**Pricing** :
+- Free : 1000 hits/mois (test/POC)
+- Basic : ~$10/mois, 1k req/jour
+- Pro / Ultra : $25/mois, 15k req/jour
+
+**Latence** : "Live, updated multiple times an hour" (~minutes, pas seconde)
+**Auth** : RapidAPI key
+**ToS** : Clear (commercial OK via RapidAPI marketplace)
+
+**Couverture** :
+- Live in-game scores + box scores
+- Player stats par game
+- Schedules, depth charts, injuries
+
+**Use case pour nous** :
+- **Source secondaire commerciale légale** — réduit le risque mono-source ESPN
+- Plus serein que les hidden API non documentées pour un produit commercial
+- Marginal $10/mois → à intégrer dès V1.5 dès que l'audience justifie
+
+**Verdict** : **meilleur ratio prix/sécurité du marché** pour redondance ESPN.
+
 ## Tier 2 — Abordable ($30-500/mois)
 
 ### MySportsFeeds
@@ -95,10 +181,12 @@ GET /news                                → news NFL
 **URL** : <https://www.mysportsfeeds.com>
 
 **Pricing** :
-- Personal use : gratuit (delayed data)
-- Indie ($49/mois) : real-time NFL post-game
+- Personal use : gratuit **(non-commercial uniquement — ne s'applique PAS à Nuffle Arena)**
+- Indie ($49/mois) : minimum requis pour usage commercial, real-time NFL post-game
 - Pro ($249/mois) : live play-by-play, ~5s latence
 - Enterprise : custom
+
+**⚠️ Correction** : le tier gratuit était listé comme utilisable en V1 — c'est faux. Pour un produit commercial (même freemium), il faut **a minima Indie $49/mois**. À budgéter si on dépend de MSF.
 
 **Couverture** :
 - Play-by-play live (~5s latence en Pro)
@@ -261,14 +349,23 @@ export async function ingestEspnLive(): Promise<IngestResult> {
 | Stockage Postgres (déjà payé) | 0€ |
 | **Total V1** | **0€/an** |
 
+## Estimation coût V1.5 (redondance commerciale)
+
+| Poste | Coût |
+|---|---|
+| Tank01 Basic (RapidAPI) | $10/mois = ~$120/an |
+| nflverse + ESPN | 0€ |
+| **Total V1.5** | **~$120/an** |
+
 ## Estimation coût V2 (~5-50k DAU)
 
 | Poste | Coût |
 |---|---|
 | MySportsFeeds Pro | $249/mois = ~$3000/an |
-| Backup nflverse | 0€ |
+| Tank01 Pro (backup) | $25/mois = ~$300/an |
+| nflverse | 0€ |
 | Storage incrémental | ~$50/mois |
-| **Total V2** | **~$3600/an** |
+| **Total V2** | **~$3900/an** |
 
 ## Estimation coût V3 (>50k DAU, DFS-grade)
 
@@ -282,19 +379,42 @@ export async function ingestEspnLive(): Promise<IngestResult> {
 ## Plan de migration tier par tier
 
 ```
-V1 (POC + MVP commercial)
+V1 (POC + MVP commercial) — 0€/mois
 └── nflverse (post-match) + ESPN (gameday live)
     └── Tient jusqu'à ~10k DAU
 
-V2 (Scale)
+V1.5 (Redondance commerciale) — $10-25/mois
+└── Si dépendance mono-source ESPN inquiète
+    └── + Tank01 via RapidAPI (backup commercial légal)
+    └── Effort intégration trivial (REST + key)
+
+V2 (Scale + live PBP) — ~$3000/an
 └── Si DAU >5k OU si engagement live <3min/match
-    └── + MySportsFeeds Pro ($249/mois)
+    └── + MySportsFeeds Pro ($249/mois — live PBP ~5s)
     └── Tient jusqu'à ~50k DAU
 
-V3 (DFS-grade)
+V3 (DFS-grade) — ~$40-65k/an
 └── Si pivot DFS ou audience pro
     └── SportRadar ou Stats Perform
 ```
+
+## Outils complémentaires (pas des sources de data)
+
+### SDX — SportsDataExchange
+
+**URL** : <https://sportsdataexchange.com>
+
+**Nature** : **Registre d'identifiants open standard**, pas un feed de stats. Lancé en 2025 par SportsDataIO + Enetpulse.
+
+**Couverture** : ~2M IDs persistants (leagues, games, teams, players, venues) sur 100+ sports.
+
+**Coût** : Free (registry public + CLI tool). Accès dev complet via "Request Early Access".
+
+**Use case pour nous** :
+- **V1** : Pas pertinent. On utilise une source unique (nflverse) qui fournit déjà `gsis_id` (standard NFL officiel). `NflPlayer.id = gsis_id` suffit.
+- **V2+** : Si on ajoute une 2e source (Tank01, MSF) et que les `player_id` divergent, SDX évite de coder un mapping ad-hoc.
+
+**Verdict** : À surveiller, pas à intégrer en V1.
 
 ## Décisions techniques
 

--- a/docs/nfl-fantasy/README.md
+++ b/docs/nfl-fantasy/README.md
@@ -37,7 +37,7 @@
 |---|---|---|---|
 | Vision & scope | Draft v1 | Haute | Validation produit |
 | Légal | Draft v1 | Moyenne | À faire valider par juriste (FR/EU) |
-| API stratégie | Draft v1 | Haute | POC nflverse + ESPN |
+| API stratégie | Draft v1.4 | Haute | POC nflverse + ESPN ✅ — Tank01 V1.5 à intégrer |
 | Race mapping (teams) | Draft v1 | Haute | Stable identités équipes |
 | Position mapping | Draft v1 | Haute | Mapping logique |
 | Scoring (stats → SPP) | Draft v1 | Moyenne | À calibrer sur saison entière |
@@ -62,6 +62,7 @@ Cette doc évolue en suivant les patterns du projet :
 | 2026-05-19 | v1.1 | Tranchage Q1/Q3/Q4/Q5 : snake draft, captain ×1.5 + vice ×1.2, prayers par TV, race fixe par équipe |
 | 2026-05-19 | v1.2 | Tranchage Q2/Q6/Q7/Q8 : 10 users/league, silos séparés Pro League, freemium V1, pseudo full + flag DB `realNameDisplay` |
 | 2026-05-19 | v1.3 | Schéma Prisma 10-architecture.md : ajout `realNameDisplay` Bool (Q8), retrait `archetype` Json + fichier `archetype.ts` (V2, Q5 race fixe par équipe) |
+| 2026-05-19 | v1.4 | 03-api-strategy.md : correctif tag nflverse (`stats_player` ≥ 2025), correction MSF (free non-commercial uniquement), ajout Tier 1.5 Tank01 + V1.5 cost ($120/an), ajout Sleeper + Odds API + SDX, avertissements ToS (Sofascore, DK/FD WS, SerpAPI), refs repos ESPN (pseudo-r/Public-ESPN-API, mkreiser/ESPN-Fantasy-Football-API), POC findings W10 2025 |
 
 ## Source de cette session
 

--- a/docs/nfl-fantasy/README.md
+++ b/docs/nfl-fantasy/README.md
@@ -64,6 +64,7 @@ Cette doc évolue en suivant les patterns du projet :
 | 2026-05-19 | v1.3 | Schéma Prisma 10-architecture.md : ajout `realNameDisplay` Bool (Q8), retrait `archetype` Json + fichier `archetype.ts` (V2, Q5 race fixe par équipe) |
 | 2026-05-19 | v1.4 | 03-api-strategy.md : correctif tag nflverse (`stats_player` ≥ 2025), correction MSF (free non-commercial uniquement), ajout Tier 1.5 Tank01 + V1.5 cost ($120/an), ajout Sleeper + Odds API + SDX, avertissements ToS (Sofascore, DK/FD WS, SerpAPI), refs repos ESPN (pseudo-r/Public-ESPN-API, mkreiser/ESPN-Fantasy-Football-API), POC findings W10 2025 |
 | 2026-05-19 | v1.5 | 03-api-strategy.md gotchas: POC validé sur W1/W10/W18 2025 (testé sur 3 weeks). ESPN `?dates` filtre par ET local (TNF→Thu), summary 18/19 keys variable, season sous `leagues[0]`. nflverse: 1 CSV/saison cache-friendly, filter aussi `season_type`, position_group peut être vide. |
+| 2026-05-19 | v1.6 | 03-api-strategy.md edge cases playoffs + intl : POC éprouvé sur Friday Sao Paulo (KC@LAC), Wildcard W19 (LAR@CAR, BUF@JAX, SF@PHI), Super Bowl LX (SEA 29 @ NE 13). Bug ESPN découvert : `leagues[0].season.type` figé à `reg` même en playoffs ; source de vérité = `event.season.slug=post-season`. Numérotation post-season ESPN : Wildcard=1, Div=2, Conf=3, SB=5 (skip 4=Pro Bowl). Mapping nflverse W19-22 ↔ ESPN post-season W1-5 documenté. |
 
 ## Source de cette session
 

--- a/docs/nfl-fantasy/README.md
+++ b/docs/nfl-fantasy/README.md
@@ -63,6 +63,7 @@ Cette doc évolue en suivant les patterns du projet :
 | 2026-05-19 | v1.2 | Tranchage Q2/Q6/Q7/Q8 : 10 users/league, silos séparés Pro League, freemium V1, pseudo full + flag DB `realNameDisplay` |
 | 2026-05-19 | v1.3 | Schéma Prisma 10-architecture.md : ajout `realNameDisplay` Bool (Q8), retrait `archetype` Json + fichier `archetype.ts` (V2, Q5 race fixe par équipe) |
 | 2026-05-19 | v1.4 | 03-api-strategy.md : correctif tag nflverse (`stats_player` ≥ 2025), correction MSF (free non-commercial uniquement), ajout Tier 1.5 Tank01 + V1.5 cost ($120/an), ajout Sleeper + Odds API + SDX, avertissements ToS (Sofascore, DK/FD WS, SerpAPI), refs repos ESPN (pseudo-r/Public-ESPN-API, mkreiser/ESPN-Fantasy-Football-API), POC findings W10 2025 |
+| 2026-05-19 | v1.5 | 03-api-strategy.md gotchas: POC validé sur W1/W10/W18 2025 (testé sur 3 weeks). ESPN `?dates` filtre par ET local (TNF→Thu), summary 18/19 keys variable, season sous `leagues[0]`. nflverse: 1 CSV/saison cache-friendly, filter aussi `season_type`, position_group peut être vide. |
 
 ## Source de cette session
 

--- a/scripts/nfl-poc/.gitignore
+++ b/scripts/nfl-poc/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+*.log
+fixtures/*.csv
+fixtures/*.parquet
+fixtures/*.json
+!fixtures/.gitkeep

--- a/scripts/nfl-poc/README.md
+++ b/scripts/nfl-poc/README.md
@@ -1,0 +1,56 @@
+# NFL POC — Ingestion
+
+> POC jetable pour valider la faisabilite technique de l'ingestion
+> tier-1 gratuit (nflverse + ESPN) decrite dans
+> `docs/nfl-fantasy/03-api-strategy.md`.
+
+## Objectif
+
+1. **Pull nflverse** : recuperer 1 semaine de stats joueurs NFL via les
+   releases publiques GitHub (CSV) et valider le format.
+2. **Poll ESPN scoreboard** : appeler l'API cachee ESPN, sauvegarder
+   un snapshot JSON et valider la stabilite des champs.
+3. **Normaliser 5 stat lines** (QB / WR / RB / DE / LB) en `StatLine`
+   neutre, point de depart pour `stats-to-spp.ts` (Phase 1 reelle).
+
+## Cible de la session
+
+- Saison **2025**, Week **10** (sera elargie ensuite a d'autres
+  semaines pour eprouver le script).
+
+## Installation
+
+```bash
+cd scripts/nfl-poc
+npm install
+```
+
+Pas dans le workspace pnpm racine pour isoler les deps.
+
+## Run
+
+```bash
+# Pull nflverse seulement
+npm run poc:nflverse
+
+# Poll ESPN seulement
+npm run poc:espn
+
+# Tout d'un coup
+npm run poc:all
+```
+
+## Sorties
+
+Toutes les fixtures sont sauvegardees dans `fixtures/` (gitignore).
+
+- `fixtures/nflverse-player-stats-2025-w10.csv` — raw nflverse
+- `fixtures/espn-scoreboard.json` — raw ESPN
+- `fixtures/normalized-statlines.json` — 5 stat lines normalisees
+
+## Apres le POC
+
+Une fois la faisabilite confirmee :
+- Migrer le code de fetch vers `apps/server/src/services/nfl-ingest.ts`
+  (idempotent, audit log, cf. pattern Q.D.1).
+- Supprimer ce dossier `scripts/nfl-poc/`.

--- a/scripts/nfl-poc/package.json
+++ b/scripts/nfl-poc/package.json
@@ -8,6 +8,7 @@
     "poc": "tsx src/cli.ts",
     "poc:nflverse": "tsx src/cli.ts nflverse",
     "poc:espn": "tsx src/cli.ts espn",
+    "poc:normalize": "tsx src/cli.ts normalize",
     "poc:all": "tsx src/cli.ts all"
   },
   "dependencies": {

--- a/scripts/nfl-poc/package.json
+++ b/scripts/nfl-poc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "nfl-poc",
+  "version": "0.0.1",
+  "private": true,
+  "description": "POC d'ingestion NFL — valide la faisabilite technique nflverse + ESPN. Jetable.",
+  "type": "module",
+  "scripts": {
+    "poc": "tsx src/cli.ts",
+    "poc:nflverse": "tsx src/cli.ts nflverse",
+    "poc:espn": "tsx src/cli.ts espn",
+    "poc:all": "tsx src/cli.ts all"
+  },
+  "dependencies": {
+    "csv-parse": "^5.5.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.3"
+  }
+}

--- a/scripts/nfl-poc/src/cli.ts
+++ b/scripts/nfl-poc/src/cli.ts
@@ -1,20 +1,26 @@
+import { runNflversePoc } from "./fetch-nflverse.js";
+
 const [, , cmd] = process.argv;
+
+const TARGET_YEAR = 2025;
+const TARGET_WEEK = 10;
 
 async function main(): Promise<void> {
   switch (cmd) {
     case "nflverse":
-      console.log("[nfl-poc] nflverse pull — not implemented yet (commit 3)");
+      await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
       break;
     case "espn":
       console.log("[nfl-poc] espn poll — not implemented yet (commit 4)");
       break;
     case "all":
-      console.log("[nfl-poc] all — not implemented yet (commits 3 + 4 + 5)");
+      await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
+      console.log("\n[nfl-poc] espn + normalize — not implemented yet (commits 4 + 5)");
       break;
     default:
       console.log(
         "Usage: npm run poc:nflverse | poc:espn | poc:all\n" +
-          "Bootstrap OK — commits feat suivants vont implementer les sous-commandes."
+          `Cible courante: saison ${TARGET_YEAR}, week ${TARGET_WEEK}.`
       );
   }
 }

--- a/scripts/nfl-poc/src/cli.ts
+++ b/scripts/nfl-poc/src/cli.ts
@@ -1,5 +1,6 @@
 import { runNflversePoc } from "./fetch-nflverse.js";
 import { runEspnPoc } from "./fetch-espn.js";
+import { runNormalizePoc } from "./normalize.js";
 
 const [, , cmd] = process.argv;
 
@@ -16,15 +17,19 @@ async function main(): Promise<void> {
     case "espn":
       await runEspnPoc(TARGET_ESPN_DATE);
       break;
+    case "normalize":
+      await runNormalizePoc(TARGET_YEAR, TARGET_WEEK);
+      break;
     case "all":
       await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
       console.log("");
       await runEspnPoc(TARGET_ESPN_DATE);
-      console.log("\n[nfl-poc] normalize — not implemented yet (commit 5)");
+      console.log("");
+      await runNormalizePoc(TARGET_YEAR, TARGET_WEEK);
       break;
     default:
       console.log(
-        "Usage: npm run poc:nflverse | poc:espn | poc:all\n" +
+        "Usage: npm run poc:nflverse | poc:espn | poc:normalize | poc:all\n" +
           `Cible courante: saison ${TARGET_YEAR}, week ${TARGET_WEEK}, espn date ${TARGET_ESPN_DATE}.`
       );
   }

--- a/scripts/nfl-poc/src/cli.ts
+++ b/scripts/nfl-poc/src/cli.ts
@@ -1,0 +1,25 @@
+const [, , cmd] = process.argv;
+
+async function main(): Promise<void> {
+  switch (cmd) {
+    case "nflverse":
+      console.log("[nfl-poc] nflverse pull — not implemented yet (commit 3)");
+      break;
+    case "espn":
+      console.log("[nfl-poc] espn poll — not implemented yet (commit 4)");
+      break;
+    case "all":
+      console.log("[nfl-poc] all — not implemented yet (commits 3 + 4 + 5)");
+      break;
+    default:
+      console.log(
+        "Usage: npm run poc:nflverse | poc:espn | poc:all\n" +
+          "Bootstrap OK — commits feat suivants vont implementer les sous-commandes."
+      );
+  }
+}
+
+main().catch((err) => {
+  console.error("[nfl-poc] fatal:", err);
+  process.exit(1);
+});

--- a/scripts/nfl-poc/src/cli.ts
+++ b/scripts/nfl-poc/src/cli.ts
@@ -2,35 +2,72 @@ import { runNflversePoc } from "./fetch-nflverse.js";
 import { runEspnPoc } from "./fetch-espn.js";
 import { runNormalizePoc } from "./normalize.js";
 
-const [, , cmd] = process.argv;
-
-const TARGET_YEAR = 2025;
-const TARGET_WEEK = 10;
+const DEFAULT_YEAR = 2025;
+const DEFAULT_WEEK = 10;
 // NFL 2025 W10 Sunday slate (Nov 9 2025).
-const TARGET_ESPN_DATE = "20251109";
+const DEFAULT_ESPN_DATE = "20251109";
+
+interface ParsedArgs {
+  readonly cmd: string;
+  readonly year: number;
+  readonly week: number;
+  readonly date: string;
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const [, , cmd = "", ...rest] = argv;
+  let year = DEFAULT_YEAR;
+  let week = DEFAULT_WEEK;
+  let date = DEFAULT_ESPN_DATE;
+
+  for (let i = 0; i < rest.length; i++) {
+    const flag = rest[i];
+    const value = rest[i + 1];
+    if (!value) continue;
+    if (flag === "--year") {
+      year = Number(value);
+      i++;
+    } else if (flag === "--week") {
+      week = Number(value);
+      i++;
+    } else if (flag === "--date") {
+      date = value;
+      i++;
+    }
+  }
+
+  return { cmd, year, week, date };
+}
 
 async function main(): Promise<void> {
+  const { cmd, year, week, date } = parseArgs(process.argv);
+
   switch (cmd) {
     case "nflverse":
-      await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
+      await runNflversePoc(year, week);
       break;
     case "espn":
-      await runEspnPoc(TARGET_ESPN_DATE);
+      await runEspnPoc(date);
       break;
     case "normalize":
-      await runNormalizePoc(TARGET_YEAR, TARGET_WEEK);
+      await runNormalizePoc(year, week);
       break;
     case "all":
-      await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
+      await runNflversePoc(year, week);
       console.log("");
-      await runEspnPoc(TARGET_ESPN_DATE);
+      await runEspnPoc(date);
       console.log("");
-      await runNormalizePoc(TARGET_YEAR, TARGET_WEEK);
+      await runNormalizePoc(year, week);
       break;
     default:
       console.log(
-        "Usage: npm run poc:nflverse | poc:espn | poc:normalize | poc:all\n" +
-          `Cible courante: saison ${TARGET_YEAR}, week ${TARGET_WEEK}, espn date ${TARGET_ESPN_DATE}.`
+        "Usage: npm run poc:<cmd> -- [--year YYYY] [--week N] [--date YYYYMMDD]\n" +
+          "  cmd ∈ { nflverse, espn, normalize, all }\n\n" +
+          `Defaults: year=${DEFAULT_YEAR}, week=${DEFAULT_WEEK}, date=${DEFAULT_ESPN_DATE}\n` +
+          "Exemples:\n" +
+          "  npm run poc:all                                # W10 2025 par defaut\n" +
+          "  npm run poc:all -- --week 1 --date 20250904    # W1 2025 (TNF KC@CHI)\n" +
+          "  npm run poc:all -- --week 18 --date 20260104   # W18 2025 (regular season finale)\n"
       );
   }
 }

--- a/scripts/nfl-poc/src/cli.ts
+++ b/scripts/nfl-poc/src/cli.ts
@@ -1,9 +1,12 @@
 import { runNflversePoc } from "./fetch-nflverse.js";
+import { runEspnPoc } from "./fetch-espn.js";
 
 const [, , cmd] = process.argv;
 
 const TARGET_YEAR = 2025;
 const TARGET_WEEK = 10;
+// NFL 2025 W10 Sunday slate (Nov 9 2025).
+const TARGET_ESPN_DATE = "20251109";
 
 async function main(): Promise<void> {
   switch (cmd) {
@@ -11,16 +14,18 @@ async function main(): Promise<void> {
       await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
       break;
     case "espn":
-      console.log("[nfl-poc] espn poll — not implemented yet (commit 4)");
+      await runEspnPoc(TARGET_ESPN_DATE);
       break;
     case "all":
       await runNflversePoc(TARGET_YEAR, TARGET_WEEK);
-      console.log("\n[nfl-poc] espn + normalize — not implemented yet (commits 4 + 5)");
+      console.log("");
+      await runEspnPoc(TARGET_ESPN_DATE);
+      console.log("\n[nfl-poc] normalize — not implemented yet (commit 5)");
       break;
     default:
       console.log(
         "Usage: npm run poc:nflverse | poc:espn | poc:all\n" +
-          `Cible courante: saison ${TARGET_YEAR}, week ${TARGET_WEEK}.`
+          `Cible courante: saison ${TARGET_YEAR}, week ${TARGET_WEEK}, espn date ${TARGET_ESPN_DATE}.`
       );
   }
 }

--- a/scripts/nfl-poc/src/fetch-espn.ts
+++ b/scripts/nfl-poc/src/fetch-espn.ts
@@ -22,6 +22,8 @@ interface EspnEvent {
   readonly shortName?: string;
   readonly status?: { readonly type?: { readonly completed?: boolean; readonly description?: string } };
   readonly competitions?: ReadonlyArray<{ readonly competitors?: readonly EspnCompetitor[] }>;
+  readonly season?: { readonly year?: number; readonly type?: number; readonly slug?: string };
+  readonly week?: { readonly number?: number };
 }
 
 interface EspnSeasonInfo {
@@ -83,9 +85,18 @@ export async function runEspnPoc(dateYmd: string): Promise<void> {
   console.log(`[espn] saved scoreboard → ${sbPath}`);
 
   const events = scoreboard.events ?? [];
-  const season = scoreboard.leagues?.[0]?.season;
+  // ⚠️ leagues[0].season.type est figé à "Regular Season" même sur du
+  // post-season. Source de vérité = event.season (slug "post-season" ou
+  // type=3). On agrège les types par event.
+  const eventTypes = new Set<string>();
+  for (const ev of events) {
+    const slug = ev.season?.slug;
+    if (slug) eventTypes.add(slug);
+  }
+  const types = eventTypes.size > 0 ? [...eventTypes].join(",") : "?";
+  const seasonYear = scoreboard.leagues?.[0]?.season?.year ?? events[0]?.season?.year;
   console.log(
-    `[espn] season=${season?.year ?? "?"} type=${season?.type?.abbreviation ?? "?"} week=${scoreboard.week?.number ?? "?"} events=${events.length}`
+    `[espn] season=${seasonYear ?? "?"} eventTypes=${types} week=${scoreboard.week?.number ?? "?"} events=${events.length}`
   );
 
   if (events.length === 0) {

--- a/scripts/nfl-poc/src/fetch-espn.ts
+++ b/scripts/nfl-poc/src/fetch-espn.ts
@@ -24,10 +24,20 @@ interface EspnEvent {
   readonly competitions?: ReadonlyArray<{ readonly competitors?: readonly EspnCompetitor[] }>;
 }
 
+interface EspnSeasonInfo {
+  readonly year?: number;
+  readonly type?: { readonly name?: string; readonly abbreviation?: string };
+}
+
+interface EspnLeague {
+  readonly id?: string;
+  readonly season?: EspnSeasonInfo;
+}
+
 interface EspnScoreboard {
   readonly events?: readonly EspnEvent[];
   readonly week?: { readonly number?: number };
-  readonly season?: { readonly year?: number; readonly type?: number };
+  readonly leagues?: readonly EspnLeague[];
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -73,8 +83,9 @@ export async function runEspnPoc(dateYmd: string): Promise<void> {
   console.log(`[espn] saved scoreboard → ${sbPath}`);
 
   const events = scoreboard.events ?? [];
+  const season = scoreboard.leagues?.[0]?.season;
   console.log(
-    `[espn] season=${scoreboard.season?.year ?? "?"} type=${scoreboard.season?.type ?? "?"} week=${scoreboard.week?.number ?? "?"} events=${events.length}`
+    `[espn] season=${season?.year ?? "?"} type=${season?.type?.abbreviation ?? "?"} week=${scoreboard.week?.number ?? "?"} events=${events.length}`
   );
 
   if (events.length === 0) {

--- a/scripts/nfl-poc/src/fetch-espn.ts
+++ b/scripts/nfl-poc/src/fetch-espn.ts
@@ -1,0 +1,99 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "..", "fixtures");
+
+const ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports/football/nfl";
+
+interface EspnCompetitor {
+  readonly id: string;
+  readonly homeAway: "home" | "away";
+  readonly team?: { readonly abbreviation?: string; readonly displayName?: string };
+  readonly score?: string;
+  readonly winner?: boolean;
+}
+
+interface EspnEvent {
+  readonly id: string;
+  readonly date: string;
+  readonly name: string;
+  readonly shortName?: string;
+  readonly status?: { readonly type?: { readonly completed?: boolean; readonly description?: string } };
+  readonly competitions?: ReadonlyArray<{ readonly competitors?: readonly EspnCompetitor[] }>;
+}
+
+interface EspnScoreboard {
+  readonly events?: readonly EspnEvent[];
+  readonly week?: { readonly number?: number };
+  readonly season?: { readonly year?: number; readonly type?: number };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  console.log(`[espn] GET ${url}`);
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`[espn] fetch failed ${res.status} ${res.statusText} — url=${url}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function saveFixture(name: string, data: unknown): Promise<string> {
+  await mkdir(FIXTURES_DIR, { recursive: true });
+  const path = join(FIXTURES_DIR, name);
+  await writeFile(path, JSON.stringify(data, null, 2), "utf8");
+  return path;
+}
+
+export async function fetchScoreboard(dateYmd: string): Promise<EspnScoreboard> {
+  const url = `${ESPN_BASE}/scoreboard?dates=${dateYmd}`;
+  return fetchJson<EspnScoreboard>(url);
+}
+
+export async function fetchSummary(eventId: string): Promise<unknown> {
+  const url = `${ESPN_BASE}/summary?event=${eventId}`;
+  return fetchJson<unknown>(url);
+}
+
+function formatEvent(evt: EspnEvent): string {
+  const status = evt.status?.type?.description ?? "?";
+  const competitors = evt.competitions?.[0]?.competitors ?? [];
+  const home = competitors.find((c) => c.homeAway === "home");
+  const away = competitors.find((c) => c.homeAway === "away");
+  const homeStr = `${home?.team?.abbreviation ?? "?"} ${home?.score ?? "-"}`;
+  const awayStr = `${away?.team?.abbreviation ?? "?"} ${away?.score ?? "-"}`;
+  return `${evt.id.padEnd(12)} ${awayStr.padStart(8)} @ ${homeStr.padEnd(8)} [${status}] — ${evt.date}`;
+}
+
+export async function runEspnPoc(dateYmd: string): Promise<void> {
+  console.log(`[espn] === poll scoreboard ${dateYmd} ===`);
+  const scoreboard = await fetchScoreboard(dateYmd);
+  const sbPath = await saveFixture(`espn-scoreboard-${dateYmd}.json`, scoreboard);
+  console.log(`[espn] saved scoreboard → ${sbPath}`);
+
+  const events = scoreboard.events ?? [];
+  console.log(
+    `[espn] season=${scoreboard.season?.year ?? "?"} type=${scoreboard.season?.type ?? "?"} week=${scoreboard.week?.number ?? "?"} events=${events.length}`
+  );
+
+  if (events.length === 0) {
+    console.log("[espn] no events for this date — try another date (off-season ?)");
+    return;
+  }
+
+  for (const evt of events) {
+    console.log(`  ${formatEvent(evt)}`);
+  }
+
+  const sample = events[0];
+  if (!sample) return;
+  console.log(`\n[espn] fetching summary for event ${sample.id}…`);
+  const summary = await fetchSummary(sample.id);
+  const sumPath = await saveFixture(`espn-summary-${sample.id}.json`, summary);
+  console.log(`[espn] saved summary → ${sumPath}`);
+
+  const summaryAsRecord = summary as Record<string, unknown>;
+  const topKeys = Object.keys(summaryAsRecord).slice(0, 20);
+  console.log(`[espn] summary top-level keys (${Object.keys(summaryAsRecord).length}): ${topKeys.join(", ")}`);
+}

--- a/scripts/nfl-poc/src/fetch-nflverse.ts
+++ b/scripts/nfl-poc/src/fetch-nflverse.ts
@@ -1,0 +1,121 @@
+import { parse } from "csv-parse/sync";
+import { mkdir, readFile, writeFile, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "..", "fixtures");
+
+const NFLVERSE_RELEASE = "stats_player";
+
+function buildUrl(year: number): string {
+  return `https://github.com/nflverse/nflverse-data/releases/download/${NFLVERSE_RELEASE}/stats_player_week_${year}.csv`;
+}
+
+function buildCachePath(year: number): string {
+  return join(FIXTURES_DIR, `nflverse-stats-player-week-${year}.csv`);
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchAndCache(year: number): Promise<string> {
+  const url = buildUrl(year);
+  const cachePath = buildCachePath(year);
+
+  if (await fileExists(cachePath)) {
+    console.log(`[nflverse] cache hit: ${cachePath}`);
+    return readFile(cachePath, "utf8");
+  }
+
+  console.log(`[nflverse] GET ${url}`);
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`[nflverse] fetch failed ${res.status} ${res.statusText} — url=${url}`);
+  }
+  const csv = await res.text();
+  await mkdir(FIXTURES_DIR, { recursive: true });
+  await writeFile(cachePath, csv, "utf8");
+  console.log(`[nflverse] cached ${(csv.length / 1024).toFixed(1)} KB to ${cachePath}`);
+  return csv;
+}
+
+export type NflverseRow = Record<string, string>;
+
+export interface NflverseWeekData {
+  readonly year: number;
+  readonly week: number;
+  readonly rows: readonly NflverseRow[];
+  readonly columns: readonly string[];
+}
+
+function parseCsv(csv: string): { rows: NflverseRow[]; columns: string[] } {
+  const records = parse(csv, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+    relax_column_count: true,
+  }) as NflverseRow[];
+  const columns = records.length > 0 ? Object.keys(records[0]!) : [];
+  return { rows: records, columns };
+}
+
+function filterToWeek(rows: readonly NflverseRow[], week: number): NflverseRow[] {
+  return rows.filter((r) => Number(r.week) === week);
+}
+
+export async function pullNflverseWeek(year: number, week: number): Promise<NflverseWeekData> {
+  const csv = await fetchAndCache(year);
+  const { rows, columns } = parseCsv(csv);
+  const filtered = filterToWeek(rows, week);
+  console.log(`[nflverse] ${rows.length} total rows, ${filtered.length} rows for week ${week}`);
+
+  const summary = {
+    year,
+    week,
+    totalRowCount: rows.length,
+    weekRowCount: filtered.length,
+    columnCount: columns.length,
+    columns,
+    sampleRow: filtered[0] ?? null,
+    positionGroups: countByKey(filtered, "position_group"),
+    positions: countByKey(filtered, "position"),
+  };
+  await mkdir(FIXTURES_DIR, { recursive: true });
+  await writeFile(
+    join(FIXTURES_DIR, `nflverse-week-${year}-w${week}-summary.json`),
+    JSON.stringify(summary, null, 2),
+    "utf8"
+  );
+
+  return { year, week, rows: filtered, columns };
+}
+
+function countByKey(rows: readonly NflverseRow[], key: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const r of rows) {
+    const v = r[key] ?? "(empty)";
+    counts[v] = (counts[v] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export async function runNflversePoc(year: number, week: number): Promise<void> {
+  console.log(`[nflverse] === pull saison ${year} week ${week} ===`);
+  const data = await pullNflverseWeek(year, week);
+
+  console.log(`\n[nflverse] top 10 rows preview:`);
+  for (const row of data.rows.slice(0, 10)) {
+    const name = row.player_display_name ?? row.player_name ?? row.player_id ?? "?";
+    const pos = row.position ?? "?";
+    const team = row.team ?? "?";
+    console.log(`  - ${name.padEnd(28)} ${pos.padEnd(4)} ${team}`);
+  }
+  console.log(`\n[nflverse] summary saved to fixtures/nflverse-week-${year}-w${week}-summary.json`);
+}

--- a/scripts/nfl-poc/src/normalize.ts
+++ b/scripts/nfl-poc/src/normalize.ts
@@ -1,0 +1,220 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { NflverseRow, NflverseWeekData } from "./fetch-nflverse.js";
+import { pullNflverseWeek } from "./fetch-nflverse.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "..", "fixtures");
+
+export interface StatLineCommon {
+  readonly playerId: string;
+  readonly playerName: string;
+  readonly team: string;
+  readonly opponent: string;
+  readonly position: string;
+  readonly positionGroup: string;
+  readonly season: number;
+  readonly week: number;
+}
+
+export interface PassingStats {
+  readonly completions: number;
+  readonly attempts: number;
+  readonly passingYards: number;
+  readonly passingTds: number;
+  readonly interceptions: number;
+  readonly sacksSuffered: number;
+}
+
+export interface RushingStats {
+  readonly carries: number;
+  readonly rushingYards: number;
+  readonly rushingTds: number;
+  readonly rushingFumblesLost: number;
+}
+
+export interface ReceivingStats {
+  readonly targets: number;
+  readonly receptions: number;
+  readonly receivingYards: number;
+  readonly receivingTds: number;
+  readonly receivingFumblesLost: number;
+}
+
+export interface DefensiveStats {
+  readonly tacklesSolo: number;
+  readonly tackleAssists: number;
+  readonly tacklesForLoss: number;
+  readonly sacks: number;
+  readonly qbHits: number;
+  readonly interceptions: number;
+  readonly passDefended: number;
+  readonly fumblesForced: number;
+  readonly defTds: number;
+}
+
+export interface NormalizedStatLine extends StatLineCommon {
+  readonly passing?: PassingStats;
+  readonly rushing?: RushingStats;
+  readonly receiving?: ReceivingStats;
+  readonly defense?: DefensiveStats;
+}
+
+function n(raw: string | undefined): number {
+  if (raw === undefined || raw === "" || raw === "NA") return 0;
+  const v = Number(raw);
+  return Number.isFinite(v) ? v : 0;
+}
+
+function s(raw: string | undefined): string {
+  return raw ?? "";
+}
+
+export function normalizeRow(row: NflverseRow): NormalizedStatLine {
+  const positionGroup = s(row.position_group);
+  const position = s(row.position);
+
+  const hasPassing = n(row.attempts) > 0 || n(row.passing_yards) > 0;
+  const hasRushing = n(row.carries) > 0 || n(row.rushing_yards) > 0;
+  const hasReceiving = n(row.targets) > 0 || n(row.receptions) > 0;
+  const hasDefense =
+    n(row.def_tackles_solo) > 0 ||
+    n(row.def_sacks) > 0 ||
+    n(row.def_interceptions) > 0 ||
+    n(row.def_pass_defended) > 0;
+
+  return {
+    playerId: s(row.player_id),
+    playerName: s(row.player_display_name) || s(row.player_name),
+    team: s(row.team),
+    opponent: s(row.opponent_team),
+    position,
+    positionGroup,
+    season: n(row.season),
+    week: n(row.week),
+    passing: hasPassing
+      ? {
+          completions: n(row.completions),
+          attempts: n(row.attempts),
+          passingYards: n(row.passing_yards),
+          passingTds: n(row.passing_tds),
+          interceptions: n(row.passing_interceptions),
+          sacksSuffered: n(row.sacks_suffered),
+        }
+      : undefined,
+    rushing: hasRushing
+      ? {
+          carries: n(row.carries),
+          rushingYards: n(row.rushing_yards),
+          rushingTds: n(row.rushing_tds),
+          rushingFumblesLost: n(row.rushing_fumbles_lost),
+        }
+      : undefined,
+    receiving: hasReceiving
+      ? {
+          targets: n(row.targets),
+          receptions: n(row.receptions),
+          receivingYards: n(row.receiving_yards),
+          receivingTds: n(row.receiving_tds),
+          receivingFumblesLost: n(row.receiving_fumbles_lost),
+        }
+      : undefined,
+    defense: hasDefense
+      ? {
+          tacklesSolo: n(row.def_tackles_solo),
+          tackleAssists: n(row.def_tackle_assists),
+          tacklesForLoss: n(row.def_tackles_for_loss),
+          sacks: n(row.def_sacks),
+          qbHits: n(row.def_qb_hits),
+          interceptions: n(row.def_interceptions),
+          passDefended: n(row.def_pass_defended),
+          fumblesForced: n(row.def_fumbles_forced),
+          defTds: n(row.def_tds),
+        }
+      : undefined,
+  };
+}
+
+interface PickSpec {
+  readonly position: string;
+  readonly sortBy: (row: NflverseRow) => number;
+  readonly label: string;
+}
+
+const PICK_SPECS: readonly PickSpec[] = [
+  { position: "QB", sortBy: (r) => Number(r.passing_yards) || 0, label: "QB (top passing yards)" },
+  { position: "WR", sortBy: (r) => Number(r.receiving_yards) || 0, label: "WR (top receiving yards)" },
+  { position: "RB", sortBy: (r) => Number(r.rushing_yards) || 0, label: "RB (top rushing yards)" },
+  { position: "DE", sortBy: (r) => Number(r.def_sacks) || 0, label: "DE (top sacks)" },
+  { position: "LB", sortBy: (r) => Number(r.def_tackles_solo) || 0, label: "LB (top solo tackles)" },
+];
+
+interface PickResult {
+  readonly label: string;
+  readonly statLine: NormalizedStatLine;
+}
+
+export function pickRepresentatives(data: NflverseWeekData): readonly PickResult[] {
+  const results: PickResult[] = [];
+  for (const spec of PICK_SPECS) {
+    const candidates = data.rows.filter((r) => r.position === spec.position);
+    if (candidates.length === 0) continue;
+    const sorted = [...candidates].sort((a, b) => spec.sortBy(b) - spec.sortBy(a));
+    const top = sorted[0];
+    if (!top) continue;
+    results.push({ label: spec.label, statLine: normalizeRow(top) });
+  }
+  return results;
+}
+
+function formatStatLine(line: NormalizedStatLine): string {
+  const parts: string[] = [];
+  if (line.passing) {
+    parts.push(
+      `passing ${line.passing.completions}/${line.passing.attempts} ${line.passing.passingYards}yd ${line.passing.passingTds}td ${line.passing.interceptions}int`
+    );
+  }
+  if (line.rushing) {
+    parts.push(
+      `rushing ${line.rushing.carries}car ${line.rushing.rushingYards}yd ${line.rushing.rushingTds}td`
+    );
+  }
+  if (line.receiving) {
+    parts.push(
+      `receiving ${line.receiving.receptions}/${line.receiving.targets} ${line.receiving.receivingYards}yd ${line.receiving.receivingTds}td`
+    );
+  }
+  if (line.defense) {
+    parts.push(
+      `defense ${line.defense.tacklesSolo}solo ${line.defense.sacks}sk ${line.defense.qbHits}qbhit ${line.defense.interceptions}int`
+    );
+  }
+  return parts.join(" | ");
+}
+
+export async function runNormalizePoc(year: number, week: number): Promise<void> {
+  console.log(`[normalize] === pick 5 representatives + normalize for ${year} W${week} ===`);
+  const data = await pullNflverseWeek(year, week);
+  const picks = pickRepresentatives(data);
+
+  for (const pick of picks) {
+    const line = pick.statLine;
+    console.log(`\n[normalize] ${pick.label}:`);
+    console.log(`  ${line.playerName.padEnd(28)} (${line.position}, ${line.team} vs ${line.opponent})`);
+    console.log(`  ${formatStatLine(line)}`);
+  }
+
+  await mkdir(FIXTURES_DIR, { recursive: true });
+  const outPath = join(FIXTURES_DIR, `normalized-statlines-${year}-w${week}.json`);
+  await writeFile(
+    outPath,
+    JSON.stringify(
+      picks.map((p) => ({ label: p.label, statLine: p.statLine })),
+      null,
+      2
+    ),
+    "utf8"
+  );
+  console.log(`\n[normalize] saved ${picks.length} normalized stat lines → ${outPath}`);
+}

--- a/scripts/nfl-poc/tsconfig.json
+++ b/scripts/nfl-poc/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

POC d'ingestion **tier-1 gratuit** pour le module NFL Fantasy (cf. `docs/nfl-fantasy/`). Valide la faisabilité technique avant Phase 1 réelle (`apps/server/services/nfl-ingest.ts`).

- **scripts/nfl-poc/** : standalone Node/TS isolé du workspace pnpm, dépendances minimales (`tsx` + `csv-parse`)
- 3 sous-commandes : `nflverse`, `espn`, `normalize` + `all`
- CLI paramétrable (`--year --week --date`) pour tester n'importe quelle semaine
- POC éprouvé sur **5 weeks** (W1 régulière + Friday Sao Paulo, W10, W18, Wildcard W19, Super Bowl LX)

## Stack

| Source | Latence | Coût | Use case |
|---|---|---|---|
| nflverse `stats_player_week_2025.csv` | ~15min post-match | 0€ | Source de vérité post-match |
| ESPN hidden API `/scoreboard` + `/summary` | ~30s live | 0€ | Live scoreboard + boxscore gameday |

## Findings clés (tous reportés dans `03-api-strategy.md`)

**nflverse**
- ⚠️ Tag de release correct = `stats_player` pour ≥ 2025 (legacy `player_stats` plus à jour)
- 1 CSV unifié 115 colonnes (offense + défense + ST), 1 fetch couvre toute la saison
- Toujours filtrer `season_type` (REG/POST/PRE), 1 row avec `position_group` vide possible
- Mapping nflverse W19-22 (POST) ↔ ESPN post-season W1-5 documenté

**ESPN**
- `?dates=` filtre par **ET local time**, pas UTC (TNF kickoff `00:20Z` → Thu ET)
- W1 complet 2025 = 4 dates ET (Thu+Fri São Paulo+Sun+Mon) pour 16 games
- 🐛 Bug subtil : `leagues[0].season.type` reste figé à `reg` même sur playoffs. Source de vérité = `event.season.slug=post-season`
- Numérotation post-season ESPN : Wildcard=1, Div=2, Conf=3, **SB=5** (saute 4=Pro Bowl)
- `/summary` retourne 18 ou 19 keys selon events (`article` absent parfois)

## Décisions stratégiques documentées en parallèle

- 8 questions ouvertes tranchées (snake draft, 10 users, captain ×1.5+vice ×1.2, prayers par TV, race fixe par équipe, silos séparés Pro League, freemium V1, pseudo full + flag DB)
- Schéma Prisma `NflPlayer` ajusté (`realNameDisplay`, `archetype` repoussé V2)
- Tier 1.5 Tank01 (\$10-25/mois) ajouté au plan de migration pour redondance ESPN
- SDX analysé : registre d'IDs (pas un feed), à surveiller V2+

## Cleanup post-POC

Une fois Phase 1 réelle implémentée (`apps/server/services/nfl-ingest.ts`), supprimer `scripts/nfl-poc/` (cf. README POC).

## Test plan

- [x] `npm run poc:all` W10 2025 (default)
- [x] `npm run poc:all -- --week 1 --date 20250907` (régulière)
- [x] `npm run poc:espn -- --date 20250904` (TNF kickoff)
- [x] `npm run poc:espn -- --date 20250905` (Friday São Paulo)
- [x] `npm run poc:all -- --week 18 --date 20260104` (fin régulière)
- [x] `npm run poc:all -- --week 19 --date 20260110` (Wildcard playoffs)
- [x] `npm run poc:espn -- --date 20260208` (Super Bowl LX)
- [ ] Adopté dans Phase 1 `apps/server/services/nfl-ingest.ts`
- [ ] PR séparée pour migration POC → service production

## Commits (10, atomiques)

\`\`\`
9a4a9dea docs(nfl-fantasy): edge cases playoffs + jeux internationaux
54df9fa4 fix(nfl-poc): detection post-season via event.season.slug
f50f23cf docs(nfl-fantasy): gotchas API decouverts au POC W1/W10/W18 2025
eadd5ffd fix(nfl-poc): extraction season/type ESPN depuis leagues[0].season
586e168b chore(nfl-poc): support des flags CLI --year --week --date
35a25860 docs(nfl-fantasy): mise a jour strategie API post-POC + ajout Tier 1.5 Tank01
27da1c24 feat(nfl-poc): normalize 5 stat lines (QB/WR/RB/DE/LB) en StatLine neutre
cc71999c feat(nfl-poc): poll ESPN scoreboard + fetch summary for sample event
96aaca68 feat(nfl-poc): pull nflverse stats_player_week_2025 + filter Week 10
d0062ea2 chore(nfl-poc): bootstrap structure scripts/nfl-poc/
\`\`\`