### PR TITLE
Phase 1.A : @bb/nfl-mapper package + team-to-race (32 teams → 8 BB races)

### DIFF
--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -9,6 +9,7 @@
     "baseUrl": ".",
     "paths": {
       "@bb/game-engine": ["../game-engine/src"],
+      "@bb/nfl-mapper": ["../nfl-mapper/src"],
       "@bb/shared-types": ["../shared-types/src"],
       "@bb/sim-engine": ["../sim-engine/src"],
       "@bb/ui": ["../ui/src"]

--- a/packages/nfl-mapper/README.md
+++ b/packages/nfl-mapper/README.md
@@ -1,0 +1,34 @@
+# @bb/nfl-mapper
+
+> Package pur (TypeScript, sans I/O) qui traduit les entites NFL
+> reelles en entites Blood Bowl pour le module **NFL Fantasy**.
+> Suit le pattern des autres packages purs (`@bb/sim-engine`,
+> `@bb/game-engine`) : pas de Prisma, pas de fetch, pas de side effects.
+
+## Modules
+
+| Module | Statut | Description |
+|---|---|---|
+| [types.ts](./src/types.ts) | ✅ | Types fondamentaux (`BbRace`, `NflTeamCode`, `TeamMeta`) |
+| [team-to-race.ts](./src/team-to-race.ts) | ✅ | 32 NFL teams → 8 BB races (mapping fixe par equipe, cf. Q5) |
+| `position-to-bb.ts` | 🚧 V1.B | NFL pos → BB pos par race |
+| `stats-to-spp.ts` | 🚧 V1.C | Stats NFL → SPP BB |
+| `pseudonymize.ts` | 🚧 V1.D | Generation de pseudonymes pour la pseudonymisation legale |
+
+## Reference
+
+- Mapping race : `docs/nfl-fantasy/04-race-mapping.md`
+- Architecture : `docs/nfl-fantasy/10-architecture.md`
+- Decisions Q5 (race fixe par equipe) : `docs/nfl-fantasy/00-vision.md`
+
+## Usage
+
+```ts
+import { getTeamMeta, getAllTeams, getTeamsByRace } from '@bb/nfl-mapper';
+
+const kc = getTeamMeta('KC');
+// → { code: 'KC', city: 'Kansas City', race: 'Skaven', raceLabel: 'Kansas City Skaven', ... }
+
+const skavenTeams = getTeamsByRace('Skaven');
+// → 4 teams (KC, MIA, HOU, ARI)
+```

--- a/packages/nfl-mapper/data/teams.json
+++ b/packages/nfl-mapper/data/teams.json
@@ -1,0 +1,54 @@
+{
+  "$comment": "32 equipes NFL -> 8 races BB (Q5 race fixe par equipe). Source: docs/nfl-fantasy/04-race-mapping.md. Les palettes sont themees par race BB (PAS les couleurs NFL officielles -> Q8 pseudonymisation, respect du skin Blood Bowl). raceLabel = 'Ville Race' pour le branding UI.",
+  "teams": [
+    { "code": "KC",  "city": "Kansas City",       "race": "Skaven",      "raceLabel": "Kansas City Skaven" },
+    { "code": "MIA", "city": "Miami",             "race": "Skaven",      "raceLabel": "Miami Skaven" },
+    { "code": "HOU", "city": "Houston",           "race": "Skaven",      "raceLabel": "Houston Skaven" },
+    { "code": "ARI", "city": "Arizona",           "race": "Skaven",      "raceLabel": "Arizona Skaven" },
+
+    { "code": "CIN", "city": "Cincinnati",        "race": "WoodElf",     "raceLabel": "Cincinnati Wood Elf" },
+    { "code": "LAR", "city": "Los Angeles (R)",   "race": "WoodElf",     "raceLabel": "Los Angeles Wood Elf" },
+    { "code": "JAX", "city": "Jacksonville",      "race": "WoodElf",     "raceLabel": "Jacksonville Wood Elf" },
+    { "code": "WAS", "city": "Washington",        "race": "WoodElf",     "raceLabel": "Washington Wood Elf" },
+
+    { "code": "BAL", "city": "Baltimore",         "race": "Orc",         "raceLabel": "Baltimore Orcs" },
+    { "code": "PHI", "city": "Philadelphia",      "race": "Orc",         "raceLabel": "Philadelphia Orcs" },
+    { "code": "PIT", "city": "Pittsburgh",        "race": "Orc",         "raceLabel": "Pittsburgh Orcs" },
+    { "code": "SF",  "city": "San Francisco",     "race": "Orc",         "raceLabel": "San Francisco Orcs" },
+
+    { "code": "DAL", "city": "Dallas",            "race": "Human",       "raceLabel": "Dallas Humans" },
+    { "code": "GB",  "city": "Green Bay",         "race": "Human",       "raceLabel": "Green Bay Humans" },
+    { "code": "ATL", "city": "Atlanta",           "race": "Human",       "raceLabel": "Atlanta Humans" },
+    { "code": "SEA", "city": "Seattle",           "race": "Human",       "raceLabel": "Seattle Humans" },
+
+    { "code": "BUF", "city": "Buffalo",           "race": "Norse",       "raceLabel": "Buffalo Norse" },
+    { "code": "MIN", "city": "Minnesota",         "race": "Norse",       "raceLabel": "Minnesota Norse" },
+    { "code": "DET", "city": "Detroit",           "race": "Norse",       "raceLabel": "Detroit Norse" },
+    { "code": "CHI", "city": "Chicago",           "race": "Norse",       "raceLabel": "Chicago Norse" },
+
+    { "code": "NYG", "city": "New York (G)",      "race": "Dwarf",       "raceLabel": "New York Dwarfs" },
+    { "code": "CLE", "city": "Cleveland",         "race": "Dwarf",       "raceLabel": "Cleveland Dwarfs" },
+    { "code": "IND", "city": "Indianapolis",      "race": "Dwarf",       "raceLabel": "Indianapolis Dwarfs" },
+    { "code": "NE",  "city": "New England",       "race": "Dwarf",       "raceLabel": "New England Dwarfs" },
+
+    { "code": "NYJ", "city": "New York (J)",      "race": "Khorne",      "raceLabel": "New York Khorne" },
+    { "code": "LV",  "city": "Las Vegas",         "race": "Khorne",      "raceLabel": "Las Vegas Khorne" },
+    { "code": "LAC", "city": "Los Angeles (C)",   "race": "Khorne",      "raceLabel": "Los Angeles Khorne" },
+    { "code": "TB",  "city": "Tampa Bay",         "race": "Khorne",      "raceLabel": "Tampa Bay Khorne" },
+
+    { "code": "TEN", "city": "Tennessee",         "race": "Necromantic", "raceLabel": "Tennessee Necromantic" },
+    { "code": "DEN", "city": "Denver",            "race": "Necromantic", "raceLabel": "Denver Necromantic" },
+    { "code": "CAR", "city": "Carolina",          "race": "Necromantic", "raceLabel": "Carolina Necromantic" },
+    { "code": "NO",  "city": "New Orleans",       "race": "Necromantic", "raceLabel": "New Orleans Necromantic" }
+  ],
+  "palettesByRace": {
+    "Skaven":      { "primary": "#5C6F2F", "secondary": "#B8B055", "accent": "#2A2A1F" },
+    "WoodElf":     { "primary": "#2F5C3E", "secondary": "#A8B86E", "accent": "#4A3520" },
+    "Orc":         { "primary": "#3A4A2F", "secondary": "#1A1A1A", "accent": "#8B6F2F" },
+    "Human":       { "primary": "#1E3A5F", "secondary": "#B8344A", "accent": "#D4AF37" },
+    "Norse":       { "primary": "#1F3A5F", "secondary": "#A0A8AE", "accent": "#8C2A2A" },
+    "Dwarf":       { "primary": "#5C3520", "secondary": "#B8902F", "accent": "#3A2418" },
+    "Khorne":      { "primary": "#8C1A1A", "secondary": "#1A1A1A", "accent": "#D4AF37" },
+    "Necromantic": { "primary": "#3A2A4A", "secondary": "#1A1A1A", "accent": "#7A7A8C" }
+  }
+}

--- a/packages/nfl-mapper/eslint.config.js
+++ b/packages/nfl-mapper/eslint.config.js
@@ -1,0 +1,30 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      'prefer-const': 'error',
+      'no-var': 'error',
+      'no-console': 'warn',
+      'no-undef': 'off',
+    },
+  },
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
+    },
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  }
+);

--- a/packages/nfl-mapper/package.json
+++ b/packages/nfl-mapper/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@bb/nfl-mapper",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.35.0",
+    "@types/node": "^22.5.1",
+    "@vitest/coverage-v8": "^2.0.0",
+    "eslint": "^9.8.0",
+    "prettier": "^3.6.2",
+    "typescript": "^5.5.4",
+    "typescript-eslint": "^8.43.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/nfl-mapper/src/index.ts
+++ b/packages/nfl-mapper/src/index.ts
@@ -1,0 +1,13 @@
+export type {
+  BbRace,
+  NflTeamCode,
+  TeamMeta,
+  TeamPalette,
+} from './types.js';
+export { BB_RACES } from './types.js';
+export {
+  getAllTeams,
+  getTeamMeta,
+  getTeamsByRace,
+  tryGetTeamMeta,
+} from './team-to-race.js';

--- a/packages/nfl-mapper/src/team-to-race.test.ts
+++ b/packages/nfl-mapper/src/team-to-race.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getAllTeams,
+  getTeamMeta,
+  getTeamsByRace,
+  tryGetTeamMeta,
+} from './team-to-race.js';
+import { BB_RACES, type NflTeamCode } from './types.js';
+
+describe('getAllTeams', () => {
+  it('retourne exactement 32 equipes', () => {
+    expect(getAllTeams()).toHaveLength(32);
+  });
+
+  it('chaque equipe a un code, une ville, une race et un raceLabel non vides', () => {
+    for (const team of getAllTeams()) {
+      expect(team.code).toMatch(/^[A-Z]{2,3}$/);
+      expect(team.city.length).toBeGreaterThan(0);
+      expect(BB_RACES).toContain(team.race);
+      expect(team.raceLabel.length).toBeGreaterThan(0);
+      expect(team.palette.primary).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it('tous les codes sont uniques', () => {
+    const codes = getAllTeams().map((t) => t.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it('ordre stable a chaque appel (memoise)', () => {
+    expect(getAllTeams()).toBe(getAllTeams());
+  });
+});
+
+describe('getTeamsByRace', () => {
+  it('attribue exactement 4 equipes a chacune des 8 races BB (Q5)', () => {
+    for (const race of BB_RACES) {
+      expect(getTeamsByRace(race)).toHaveLength(4);
+    }
+  });
+
+  it('chaque equipe se trouve dans la liste de sa race', () => {
+    for (const team of getAllTeams()) {
+      const inRace = getTeamsByRace(team.race);
+      expect(inRace).toContainEqual(team);
+    }
+  });
+
+  it('Skaven contient exactement KC, MIA, HOU, ARI', () => {
+    const codes = getTeamsByRace('Skaven').map((t) => t.code).sort();
+    expect(codes).toEqual(['ARI', 'HOU', 'KC', 'MIA']);
+  });
+
+  it('WoodElf contient exactement CIN, JAX, LAR, WAS', () => {
+    const codes = getTeamsByRace('WoodElf').map((t) => t.code).sort();
+    expect(codes).toEqual(['CIN', 'JAX', 'LAR', 'WAS']);
+  });
+
+  it('Orc contient exactement BAL, PHI, PIT, SF', () => {
+    const codes = getTeamsByRace('Orc').map((t) => t.code).sort();
+    expect(codes).toEqual(['BAL', 'PHI', 'PIT', 'SF']);
+  });
+
+  it('Human contient exactement ATL, DAL, GB, SEA', () => {
+    const codes = getTeamsByRace('Human').map((t) => t.code).sort();
+    expect(codes).toEqual(['ATL', 'DAL', 'GB', 'SEA']);
+  });
+
+  it('Norse contient exactement BUF, CHI, DET, MIN', () => {
+    const codes = getTeamsByRace('Norse').map((t) => t.code).sort();
+    expect(codes).toEqual(['BUF', 'CHI', 'DET', 'MIN']);
+  });
+
+  it('Dwarf contient exactement CLE, IND, NE, NYG', () => {
+    const codes = getTeamsByRace('Dwarf').map((t) => t.code).sort();
+    expect(codes).toEqual(['CLE', 'IND', 'NE', 'NYG']);
+  });
+
+  it('Khorne contient exactement LAC, LV, NYJ, TB', () => {
+    const codes = getTeamsByRace('Khorne').map((t) => t.code).sort();
+    expect(codes).toEqual(['LAC', 'LV', 'NYJ', 'TB']);
+  });
+
+  it('Necromantic contient exactement CAR, DEN, NO, TEN', () => {
+    const codes = getTeamsByRace('Necromantic').map((t) => t.code).sort();
+    expect(codes).toEqual(['CAR', 'DEN', 'NO', 'TEN']);
+  });
+});
+
+describe('getTeamMeta', () => {
+  it('retourne les metadonnees attendues pour KC (Skaven flagship)', () => {
+    const kc = getTeamMeta('KC');
+    expect(kc.code).toBe('KC');
+    expect(kc.city).toBe('Kansas City');
+    expect(kc.race).toBe('Skaven');
+    expect(kc.raceLabel).toBe('Kansas City Skaven');
+  });
+
+  it('retourne les metadonnees attendues pour BAL (Orc)', () => {
+    const bal = getTeamMeta('BAL');
+    expect(bal.race).toBe('Orc');
+    expect(bal.raceLabel).toBe('Baltimore Orcs');
+  });
+
+  it('disambiguation NY : NYG en Dwarf, NYJ en Khorne', () => {
+    expect(getTeamMeta('NYG').race).toBe('Dwarf');
+    expect(getTeamMeta('NYJ').race).toBe('Khorne');
+    expect(getTeamMeta('NYG').city).toContain('(G)');
+    expect(getTeamMeta('NYJ').city).toContain('(J)');
+  });
+
+  it('disambiguation LA : LAR en WoodElf, LAC en Khorne', () => {
+    expect(getTeamMeta('LAR').race).toBe('WoodElf');
+    expect(getTeamMeta('LAC').race).toBe('Khorne');
+  });
+
+  it('throw avec un code inconnu', () => {
+    expect(() => getTeamMeta('XXX' as NflTeamCode)).toThrow(/unknown team code/);
+  });
+
+  it('les 32 equipes sont accessibles par leur code', () => {
+    for (const team of getAllTeams()) {
+      const fetched = getTeamMeta(team.code);
+      expect(fetched).toEqual(team);
+    }
+  });
+});
+
+describe('tryGetTeamMeta', () => {
+  it('retourne undefined pour un code inconnu (variante safe)', () => {
+    expect(tryGetTeamMeta('XXX')).toBeUndefined();
+    expect(tryGetTeamMeta('')).toBeUndefined();
+  });
+
+  it('retourne la meme valeur que getTeamMeta pour un code valide', () => {
+    expect(tryGetTeamMeta('KC')).toEqual(getTeamMeta('KC'));
+  });
+
+  it("supporte un code venu d'un payload externe (typage relâché)", () => {
+    const raw: string = 'PHI';
+    expect(tryGetTeamMeta(raw)?.race).toBe('Orc');
+  });
+});
+
+describe('palette par race', () => {
+  it('toutes les equipes d\'une race partagent la meme palette en V1', () => {
+    for (const race of BB_RACES) {
+      const teams = getTeamsByRace(race);
+      const first = teams[0]?.palette;
+      expect(first).toBeDefined();
+      for (const t of teams.slice(1)) {
+        expect(t.palette).toEqual(first);
+      }
+    }
+  });
+});

--- a/packages/nfl-mapper/src/team-to-race.ts
+++ b/packages/nfl-mapper/src/team-to-race.ts
@@ -1,0 +1,94 @@
+import teamsData from '../data/teams.json' with { type: 'json' };
+import type { BbRace, NflTeamCode, TeamMeta, TeamPalette } from './types.js';
+
+interface RawTeam {
+  readonly code: string;
+  readonly city: string;
+  readonly race: string;
+  readonly raceLabel: string;
+}
+
+interface RawData {
+  readonly teams: readonly RawTeam[];
+  readonly palettesByRace: Readonly<Record<string, TeamPalette>>;
+}
+
+const RAW = teamsData as unknown as RawData;
+
+function buildTeamMeta(raw: RawTeam, palette: TeamPalette): TeamMeta {
+  return {
+    code: raw.code as NflTeamCode,
+    city: raw.city,
+    race: raw.race as BbRace,
+    raceLabel: raw.raceLabel,
+    palette,
+  };
+}
+
+const TEAMS_BY_CODE: ReadonlyMap<NflTeamCode, TeamMeta> = (() => {
+  const map = new Map<NflTeamCode, TeamMeta>();
+  for (const raw of RAW.teams) {
+    const palette = RAW.palettesByRace[raw.race];
+    if (!palette) {
+      throw new Error(`[nfl-mapper] missing palette for race "${raw.race}" (team ${raw.code})`);
+    }
+    map.set(raw.code as NflTeamCode, buildTeamMeta(raw, palette));
+  }
+  return map;
+})();
+
+const ALL_TEAMS: readonly TeamMeta[] = Object.freeze([...TEAMS_BY_CODE.values()]);
+
+const TEAMS_BY_RACE: ReadonlyMap<BbRace, readonly TeamMeta[]> = (() => {
+  const map = new Map<BbRace, TeamMeta[]>();
+  for (const team of ALL_TEAMS) {
+    const list = map.get(team.race);
+    if (list) {
+      list.push(team);
+    } else {
+      map.set(team.race, [team]);
+    }
+  }
+  const frozen = new Map<BbRace, readonly TeamMeta[]>();
+  for (const [race, list] of map) {
+    frozen.set(race, Object.freeze([...list]));
+  }
+  return frozen;
+})();
+
+/**
+ * Retourne les metadonnees d'une equipe par son code NFL.
+ *
+ * @throws {Error} Si le code n'existe pas dans la table.
+ */
+export function getTeamMeta(code: NflTeamCode): TeamMeta {
+  const team = TEAMS_BY_CODE.get(code);
+  if (!team) {
+    throw new Error(`[nfl-mapper] unknown team code "${code}"`);
+  }
+  return team;
+}
+
+/**
+ * Variante safe : retourne undefined si le code n'existe pas.
+ * Utile cote ingestion ou un team code inattendu peut apparaitre
+ * (relocation future, typo dans le payload upstream).
+ */
+export function tryGetTeamMeta(code: string): TeamMeta | undefined {
+  return TEAMS_BY_CODE.get(code as NflTeamCode);
+}
+
+/**
+ * Retourne les 32 equipes NFL, ordre stable (ordre du JSON source).
+ */
+export function getAllTeams(): readonly TeamMeta[] {
+  return ALL_TEAMS;
+}
+
+/**
+ * Retourne les equipes assignees a une race BB donnee.
+ * Q5 : 4 equipes par race, fixe.
+ */
+export function getTeamsByRace(race: BbRace): readonly TeamMeta[] {
+  return TEAMS_BY_RACE.get(race) ?? [];
+}

--- a/packages/nfl-mapper/src/types.ts
+++ b/packages/nfl-mapper/src/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Types fondamentaux du package @bb/nfl-mapper.
+ *
+ * - 8 races BB officielles (cf. docs/nfl-fantasy/04-race-mapping.md)
+ * - 32 codes equipes NFL (standard NFL officiel : 2 lettres pour la
+ *   plupart, 3 pour quelques-unes). Aligne avec le champ `team` du CSV
+ *   nflverse `stats_player_week_{year}.csv`.
+ * - TeamMeta : metadonnees consolidees par equipe.
+ */
+
+export type BbRace =
+  | 'Skaven'
+  | 'WoodElf'
+  | 'Orc'
+  | 'Human'
+  | 'Norse'
+  | 'Dwarf'
+  | 'Khorne'
+  | 'Necromantic';
+
+export const BB_RACES: readonly BbRace[] = [
+  'Skaven',
+  'WoodElf',
+  'Orc',
+  'Human',
+  'Norse',
+  'Dwarf',
+  'Khorne',
+  'Necromantic',
+];
+
+/**
+ * Codes equipes NFL (32). Stable d'annee en annee.
+ *
+ * Note : LA disambiguation = LAR (Rams), LAC (Chargers).
+ *        NY disambiguation = NYG (Giants), NYJ (Jets).
+ *        Quelques codes ESPN utilisent "WSH" pour les Commanders alors
+ *        que nflverse utilise "WAS" — la traduction est faite au niveau
+ *        du service d'ingestion, pas ici (on s'aligne sur nflverse).
+ */
+export type NflTeamCode =
+  | 'ARI'
+  | 'ATL'
+  | 'BAL'
+  | 'BUF'
+  | 'CAR'
+  | 'CHI'
+  | 'CIN'
+  | 'CLE'
+  | 'DAL'
+  | 'DEN'
+  | 'DET'
+  | 'GB'
+  | 'HOU'
+  | 'IND'
+  | 'JAX'
+  | 'KC'
+  | 'LAC'
+  | 'LAR'
+  | 'LV'
+  | 'MIA'
+  | 'MIN'
+  | 'NE'
+  | 'NO'
+  | 'NYG'
+  | 'NYJ'
+  | 'PHI'
+  | 'PIT'
+  | 'SEA'
+  | 'SF'
+  | 'TB'
+  | 'TEN'
+  | 'WAS';
+
+export interface TeamPalette {
+  readonly primary: string;
+  readonly secondary: string;
+  readonly accent: string;
+}
+
+export interface TeamMeta {
+  readonly code: NflTeamCode;
+  /** Ville pseudonymisee utilisee dans l'UI (cf. Q8 pseudonymisation). */
+  readonly city: string;
+  /** Race BB attribuee a l'equipe (Q5 : fixe par equipe). */
+  readonly race: BbRace;
+  /** Libelle complet ex. "Kansas City Skaven", utilise en branding UI. */
+  readonly raceLabel: string;
+  /** Couleurs officielles (utilisees pour avatars BB + UI). */
+  readonly palette: TeamPalette;
+}

--- a/packages/nfl-mapper/tsconfig.json
+++ b/packages/nfl-mapper/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist"]
+}

--- a/packages/nfl-mapper/vitest.config.ts
+++ b/packages/nfl-mapper/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    passWithNoTests: false,
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['node_modules/', '**/*.d.ts', '**/*.config.*', '**/*.test.ts', 'src/index.ts'],
+      thresholds: {
+        lines: 80,
+        statements: 80,
+        functions: 80,
+        branches: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,37 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.18.0)(jsdom@29.1.1)(terser@5.43.1)
 
+  packages/nfl-mapper:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.35.0
+        version: 9.35.0
+      '@types/node':
+        specifier: ^22.5.1
+        version: 22.18.0
+      '@vitest/coverage-v8':
+        specifier: ^2.0.0
+        version: 2.1.9(vitest@2.1.9(@types/node@22.18.0)(jsdom@29.1.1)(terser@5.43.1))
+      eslint:
+        specifier: ^9.8.0
+        version: 9.34.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.43.0
+        version: 8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.18.0)(jsdom@29.1.1)(terser@5.43.1)
+
   packages/shared-types:
     devDependencies:
       '@eslint/js':
@@ -1805,7 +1836,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}


### PR DESCRIPTION
## Summary

Première étape de la **Phase 1 réelle** du module NFL Fantasy : introduction du package pur `@bb/nfl-mapper` avec le mapping `teamCode → BbRace` (décision Q5).

- 📦 Nouveau package `packages/nfl-mapper/` (pattern aligné sur `@bb/sim-engine`, `@bb/game-engine`)
- 🗺️ 32 équipes NFL mappées sur 8 races BB (4 équipes par race, source `docs/nfl-fantasy/04-race-mapping.md`)
- ✅ 24 tests, coverage 96.92% lines / 100% funcs / 87.5% branches

## Scope

| Phase | Statut | Notes |
|---|---|---|
| 1.A team-to-race | ✅ Cette PR | mapping fondamental, prérequis pour position-to-bb + ingestion |
| 1.B position-to-bb | 🚧 PR séparée | NFL pos → BB pos par race (cf. `docs/nfl-fantasy/05-position-mapping.md`) |
| 1.C stats-to-spp | 🚧 PR séparée | Stats NFL → SPP BB |
| 1.D pseudonymize | 🚧 PR séparée | Génération pseudo (Q8) |
| 1.E Prisma schema | 🚧 PR séparée | `NflPlayer`, `NflGame`, `NflGameStat`, `NflIngestRun` |

## API publique

\`\`\`ts
import { getTeamMeta, getAllTeams, getTeamsByRace, tryGetTeamMeta, BB_RACES } from '@bb/nfl-mapper';
import type { BbRace, NflTeamCode, TeamMeta, TeamPalette } from '@bb/nfl-mapper';

const kc = getTeamMeta('KC');
// → { code: 'KC', city: 'Kansas City', race: 'Skaven', raceLabel: 'Kansas City Skaven', palette: {...} }

const skaven = getTeamsByRace('Skaven');
// → 4 teams (KC, MIA, HOU, ARI)
\`\`\`

## Décisions implémentées

- **Q5 Race fixe par équipe** : `NflPlayer.teamCode` → `NflTeam.bbRace` (pas d'archétype par joueur en V1)
- **Q8 Pseudonymisation** : `city` utilisé comme tag pseudonymisé. `raceLabel` format \`Ville Race\` pour le branding UI (ex: "Kansas City Skaven"). Palettes thèmées BB, **pas** les couleurs NFL officielles.
- **Disambiguation** :
  - NY → `NYG` (Dwarf) vs `NYJ` (Khorne)
  - LA → `LAR` (Wood Elf) vs `LAC` (Khorne)
  - Alignement codes sur `team` du CSV nflverse (ex: `WAS` pas `WSH`)

## Test plan

- [x] \`pnpm test\` : 24/24 ✅
- [x] \`pnpm typecheck\` : clean ✅
- [x] \`pnpm lint\` : clean ✅
- [x] \`pnpm test:coverage\` : 96.92% lines / 100% funcs / 87.5% branches ✅
- [ ] Consommé par un service \`apps/server\` (à valider Phase 1.E avec Prisma)
- [ ] Phase 1.B \`position-to-bb\` (PR suivante)

## Commits (3, atomiques)

\`\`\`
2c246443 chore(config): register @bb/nfl-mapper in tsconfig paths
332245b7 feat(nfl-mapper): team-to-race mapping pour 32 equipes NFL (Q5)
4f4a8187 chore(nfl-mapper): bootstrap package skeleton
\`\`\`