### PR TITLE
Claude/nfl-fantasy-race-stats

### DIFF
--- a/apps/server/src/services/nfl-bb-derivation.test.ts
+++ b/apps/server/src/services/nfl-bb-derivation.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests : dérivation des attributs BB depuis (BbRace, BbPosition).
+ * Couvre :
+ *  - mappings connus (stats + skills lus depuis SEASON_THREE_ROSTERS),
+ *  - fallback `null` pour combinaisons non mappées,
+ *  - couverture par race (chaque race a au moins ses positions canoniques).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  deriveBbAttributes,
+  countDerivationMappings,
+} from "./nfl-bb-derivation";
+
+describe("deriveBbAttributes", () => {
+  it("dérive Skaven/Thrower depuis skaven_lanceur_skaven (S3)", () => {
+    const out = deriveBbAttributes("Skaven", "Thrower");
+    expect(out).not.toBeNull();
+    expect(out?.sourceSlug).toBe("skaven_lanceur_skaven");
+    // Source S3 : ma 7, st 3, ag 3, pa 2, av 8 (Lanceur Skaven).
+    expect(out?.stats.st).toBe(3);
+    expect(out?.stats.ag).toBe(3);
+    expect(out?.stats.pa).toBe(2);
+    expect(out?.skills).toContain("pass");
+  });
+
+  it("dérive Skaven/RatOgre (big guy)", () => {
+    const out = deriveBbAttributes("Skaven", "RatOgre");
+    expect(out?.sourceSlug).toBe("skaven_rat_ogre");
+    expect(out?.stats.st).toBeGreaterThanOrEqual(5);
+    // Rat Ogre a Sauvagerie Animale (big guy).
+    expect(out?.skills.length).toBeGreaterThan(0);
+  });
+
+  it("dérive Human/Ogre depuis human_ogre (avec Solitaire 3+ post-errata)", () => {
+    const out = deriveBbAttributes("Human", "Ogre");
+    expect(out?.sourceSlug).toBe("human_ogre");
+    expect(out?.stats.st).toBe(5);
+  });
+
+  it("dérive Dwarf/Trollslayer (Tueur de Trolls)", () => {
+    const out = deriveBbAttributes("Dwarf", "Trollslayer");
+    expect(out?.sourceSlug).toBe("dwarf_tueur_de_trolls");
+    expect(out?.skills).toContain("frenzy");
+  });
+
+  it("dérive Necromantic/Werewolf depuis loup_garou", () => {
+    const out = deriveBbAttributes("Necromantic", "Werewolf");
+    expect(out?.sourceSlug).toBe("necromantic_horror_loup_garou");
+    expect(out?.stats.ma).toBeGreaterThanOrEqual(7);
+  });
+
+  it("retourne null pour une combinaison non mappée (Skaven/Catcher)", () => {
+    // Skaven n'a pas de "Catcher" en BB ; nflPosition WR mappe vers
+    // GutterRunner. Si quelqu'un demande Skaven/Catcher : pas de mapping.
+    expect(deriveBbAttributes("Skaven", "Catcher")).toBeNull();
+  });
+
+  it("retourne null pour une race + position incompatibles (Dwarf/RatOgre)", () => {
+    expect(deriveBbAttributes("Dwarf", "RatOgre")).toBeNull();
+  });
+
+  it("Norse mappe Thrower/Catcher/Runner vers la Valkyrie (pas de Thrower S3 dédié)", () => {
+    const t = deriveBbAttributes("Norse", "Thrower");
+    const c = deriveBbAttributes("Norse", "Catcher");
+    const r = deriveBbAttributes("Norse", "Runner");
+    expect(t?.sourceSlug).toBe("norse_valkyrie");
+    expect(c?.sourceSlug).toBe("norse_valkyrie");
+    expect(r?.sourceSlug).toBe("norse_valkyrie");
+  });
+
+  it("toutes les 8 races BB ont leur Lineman/équivalent mappé", () => {
+    // Linemen / postes de base par race.
+    const baseByRace = {
+      Skaven: "Lineman",
+      WoodElf: "Lineman",
+      Orc: "Lineman",
+      Human: "Lineman",
+      Norse: "Lineman",
+      Dwarf: "Blocker",
+      Khorne: "Bloodseeker",
+      Necromantic: "Zombie",
+    } as const;
+    for (const [race, pos] of Object.entries(baseByRace)) {
+      const out = deriveBbAttributes(
+        race as keyof typeof baseByRace,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        pos as any,
+      );
+      expect(out, `${race}/${pos}`).not.toBeNull();
+    }
+  });
+
+  it("countDerivationMappings est cohérent avec le nombre attendu", () => {
+    // 5+5+6+5+7+5+4+5 = 42 entrées au moment de l'écriture.
+    expect(countDerivationMappings()).toBeGreaterThanOrEqual(40);
+  });
+});

--- a/apps/server/src/services/nfl-bb-derivation.ts
+++ b/apps/server/src/services/nfl-bb-derivation.ts
@@ -1,0 +1,178 @@
+/**
+ * Dérivation des attributs Blood Bowl d'un joueur NFL Fantasy.
+ *
+ * Contexte
+ * --------
+ * `NflPlayer.bbPosition` est déjà dérivé à l'ingest via
+ * `getBbPosition(nflPosition, race)`. Ses **stats** (MA/ST/AG/PA/AV) et
+ * **compétences de base** ne l'étaient pas : tous les joueurs avaient
+ * `bbStats: {}` et `bbSkills: []`. Ce module dérive les deux depuis la
+ * source de vérité des rosters BB Saison 3 (`SEASON_THREE_ROSTERS`).
+ *
+ * Pour chaque (BbRace, BbPosition), on désigne **une** position de roster
+ * S3 équivalente (mapping curé `RACE_POSITION_TO_SLUG`). On lit alors ses
+ * MA/ST/AG/PA/AV et ses compétences (CSV) depuis `PositionDefinition`.
+ *
+ * Pour les positions sans équivalent direct (ex: Norse n'a pas de Catcher
+ * en S3), on retombe sur la position la plus proche (souvent le specialist
+ * AG-primary). Les mappings sont best-effort et peuvent être affinés.
+ */
+
+import type { BbPosition, BbRace } from "@bb/nfl-mapper";
+import {
+  TEAM_ROSTERS_BY_RULESET,
+  type PositionDefinition,
+} from "../../../../packages/game-engine/src/rosters/positions";
+
+export interface BbAttributeStats {
+  readonly ma: number;
+  readonly st: number;
+  readonly ag: number;
+  readonly pa: number;
+  readonly av: number;
+}
+
+export interface DerivedBbAttributes {
+  readonly stats: BbAttributeStats;
+  readonly skills: readonly string[];
+  /** Slug de la position S3 utilisée comme source. Trace pour debug/audit. */
+  readonly sourceSlug: string;
+}
+
+/**
+ * Mapping curé (BbRace, BbPosition) -> slug de position dans SEASON_THREE_ROSTERS.
+ * Sources : packages/game-engine/src/rosters/season3-rosters.ts.
+ */
+const RACE_POSITION_TO_SLUG: Readonly<
+  Record<BbRace, Partial<Record<BbPosition, string>>>
+> = {
+  Skaven: {
+    Lineman: "skaven_rat_des_clans_skaven",
+    Thrower: "skaven_lanceur_skaven",
+    GutterRunner: "skaven_coureur_d_egouts",
+    StormVermin: "skaven_blitzer_skaven",
+    RatOgre: "skaven_rat_ogre",
+  },
+  WoodElf: {
+    Lineman: "wood_elf_trois_quart_elfe_sylvain",
+    Thrower: "wood_elf_lanceur_elfe_sylvain",
+    Catcher: "wood_elf_receveur_elfe_sylvain",
+    Wardancer: "wood_elf_danceur_de_guerre",
+    Treeman: "wood_elf_homme_arbre_de_la_loren",
+  },
+  Orc: {
+    Lineman: "orc_trois_quart_orque",
+    Goblin: "orc_trois_quart_gobelin",
+    Thrower: "orc_lanceur_orque",
+    Blitzer: "orc_blitzer_orque",
+    BlackOrc: "orc_bloqueur_kosto",
+    Troll: "orc_troll",
+  },
+  Human: {
+    Lineman: "human_trois_quart",
+    Thrower: "human_lanceur",
+    Catcher: "human_receveur",
+    Blitzer: "human_blitzer",
+    Ogre: "human_ogre",
+  },
+  Norse: {
+    Lineman: "norse_trois_quart",
+    // Norse S3 n'a pas de Thrower dédié ; la Valkyrie est l'AG-primary
+    // passing-capable, on l'utilise pour Thrower/Catcher/Runner.
+    Thrower: "norse_valkyrie",
+    Catcher: "norse_valkyrie",
+    Runner: "norse_valkyrie",
+    Berserker: "norse_berzerker",
+    Ulfwerener: "norse_ulfwerener",
+    Yhetee: "norse_yeti",
+  },
+  Dwarf: {
+    // Dwarf S3 utilise "Trois-quart Nain" comme blocker de ligne ; pas de
+    // position "Runner" dédiée hors Coureur Nain.
+    Blocker: "dwarf_trois_quart_nain",
+    Runner: "dwarf_coureur_nain",
+    Blitzer: "dwarf_blitzer_nain",
+    Trollslayer: "dwarf_tueur_de_trolls",
+    Deathroller: "dwarf_roule_mort",
+  },
+  Khorne: {
+    Bloodseeker: "khorne_marauder_sanglant",
+    Khorngor: "khorne_khorngor",
+    Bloodspawn: "khorne_rabatteur_sanglant",
+    Bloodthirster: "khorne_rejeton_sanglant",
+  },
+  Necromantic: {
+    Zombie: "necromantic_horror_trois_quart_zombie",
+    Ghoul: "necromantic_horror_coureur_goule",
+    // Wight -> Spectre (closest AG/G specialist undead).
+    Wight: "necromantic_horror_spectre",
+    FleshGolem: "necromantic_horror_golem_de_chair",
+    Werewolf: "necromantic_horror_loup_garou",
+  },
+};
+
+/** Clé du roster S3 pour une race (alignée sur season3-rosters.ts). */
+const RACE_TO_ROSTER_KEY: Readonly<Record<BbRace, string>> = {
+  Skaven: "skaven",
+  WoodElf: "wood_elf",
+  Orc: "orc",
+  Human: "human",
+  Norse: "norse",
+  Dwarf: "dwarf",
+  Khorne: "khorne",
+  Necromantic: "necromantic_horror",
+};
+
+/** Cache : slug -> PositionDefinition (rempli paresseusement à la 1ère lecture). */
+let positionBySlugCache: Map<string, PositionDefinition> | null = null;
+
+function getPositionBySlug(): Map<string, PositionDefinition> {
+  if (positionBySlugCache) return positionBySlugCache;
+  const map = new Map<string, PositionDefinition>();
+  const season3 = TEAM_ROSTERS_BY_RULESET.season_3;
+  for (const roster of Object.values(season3)) {
+    for (const pos of roster.positions) {
+      map.set(pos.slug, pos);
+    }
+  }
+  positionBySlugCache = map;
+  return map;
+}
+
+function parseSkillsCsv(csv: string): readonly string[] {
+  return csv
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Dérive stats + skills BB pour un joueur (race + position BB).
+ * Retourne `null` si la combinaison n'est pas supportée (race inconnue,
+ * position non mappée, ou slug introuvable dans season3-rosters).
+ */
+export function deriveBbAttributes(
+  race: BbRace,
+  bbPosition: BbPosition,
+): DerivedBbAttributes | null {
+  const positionMap = RACE_POSITION_TO_SLUG[race];
+  if (!positionMap) return null;
+  const slug = positionMap[bbPosition];
+  if (!slug) return null;
+  const def = getPositionBySlug().get(slug);
+  if (!def) return null;
+  return {
+    stats: { ma: def.ma, st: def.st, ag: def.ag, pa: def.pa, av: def.av },
+    skills: parseSkillsCsv(def.skills),
+    sourceSlug: slug,
+  };
+}
+
+/** Pour les tests / debug : nombre total de mappings configurés. */
+export function countDerivationMappings(): number {
+  let n = 0;
+  for (const m of Object.values(RACE_POSITION_TO_SLUG)) {
+    n += Object.keys(m).length;
+  }
+  return n;
+}

--- a/apps/server/src/services/nfl-ingest-rosters.test.ts
+++ b/apps/server/src/services/nfl-ingest-rosters.test.ts
@@ -263,8 +263,9 @@ describe("ingestNflverseRosters", () => {
           jerseyNumber: 87,
           heightInches: 77,
           weightLbs: 250,
-          bbStats: {},
-          bbSkills: [],
+          // bbStats/bbSkills sont dérivés via deriveBbAttributes
+          // (testé dans nfl-bb-derivation.test.ts) ; on n'asserte plus
+          // {} / [] qui était le placeholder pré-dérivation.
         }),
       }),
     );

--- a/apps/server/src/services/nfl-ingest-rosters.ts
+++ b/apps/server/src/services/nfl-ingest-rosters.ts
@@ -33,6 +33,7 @@ import {
 
 import { prisma } from "../prisma";
 import { NflIngestError, normalizeNflverseTeamCode } from "./nfl-ingest";
+import { deriveBbAttributes } from "./nfl-bb-derivation";
 import { serverLog } from "../utils/server-log";
 
 // ────────────────────────────────────────────────────────────────────
@@ -266,10 +267,18 @@ export async function ingestNflverseRosters(
       })) as { id: string; teamCode: string | null; bbPosition: string } | null;
 
       const effectiveTeamCode = parsed.teamCode ?? existing?.teamCode ?? null;
+      const effectiveRace = effectiveTeamCode
+        ? getRace(effectiveTeamCode)
+        : null;
       const bbPosition: BbPosition =
-        effectiveTeamCode && parsed.nflPosition
-          ? getBbPosition(parsed.nflPosition, getRace(effectiveTeamCode))
+        effectiveRace && parsed.nflPosition
+          ? getBbPosition(parsed.nflPosition, effectiveRace)
           : ((existing?.bbPosition as BbPosition | undefined) ?? "Lineman");
+      // Dérive stats + skills BB depuis (race, bbPosition). null si combo
+      // non mappée -> on laisse vide (les fallbacks UI gèrent l'absence).
+      const derivedBb = effectiveRace
+        ? deriveBbAttributes(effectiveRace, bbPosition)
+        : null;
 
       const cityTag = effectiveTeamCode
         ? getTeamMeta(effectiveTeamCode as NflTeamCode).city
@@ -302,10 +311,17 @@ export async function ingestNflverseRosters(
         yearsExp: parsed.yearsExp,
       };
 
+      // Stats + compétences BB : on les écrit uniquement si la dérivation
+      // a réussi. Sinon, en update on ne les touche pas (préserve un
+      // éventuel backfill antérieur) ; en create on initialise à vide.
+      const bbAttrPatch = derivedBb
+        ? { bbStats: derivedBb.stats, bbSkills: [...derivedBb.skills] }
+        : null;
+
       if (existing) {
         await prisma.nflPlayer.update({
           where: { id: parsed.playerId },
-          data,
+          data: bbAttrPatch ? { ...data, ...bbAttrPatch } : data,
         });
         playersUpdated++;
       } else {
@@ -313,8 +329,8 @@ export async function ingestNflverseRosters(
           data: {
             id: parsed.playerId,
             ...data,
-            bbStats: {},
-            bbSkills: [],
+            bbStats: bbAttrPatch?.bbStats ?? {},
+            bbSkills: bbAttrPatch?.bbSkills ?? [],
           },
         });
         playersCreated++;

--- a/apps/web/app/nfl-fantasy/RaceIcon.tsx
+++ b/apps/web/app/nfl-fantasy/RaceIcon.tsx
@@ -1,0 +1,46 @@
+/**
+ * Icône (emoji) de race BB pour les pages NFL Fantasy.
+ * Le code de race vient de `NflTeam.bbRace` ; le label localisé de
+ * `NflTeam.raceLabel`. Pas d'asset image (cf. emoji déjà utilisés sur la
+ * page d'accueil et l'avatar du détail joueur).
+ */
+
+const RACE_EMOJI: Readonly<Record<string, string>> = {
+  Skaven: "🐀",
+  WoodElf: "🌳",
+  Orc: "🐗",
+  Human: "🛡️",
+  Norse: "🪓",
+  Dwarf: "⛏️",
+  Khorne: "💀",
+  Necromantic: "🧟",
+};
+
+export function getRaceEmoji(race: string | null | undefined): string | null {
+  if (!race) return null;
+  return RACE_EMOJI[race] ?? null;
+}
+
+interface RaceIconProps {
+  /** Code race BB (cf. NflTeam.bbRace). */
+  race: string | null | undefined;
+  /** Label public (raceLabel) pour le title/aria. Optionnel. */
+  label?: string | null;
+  className?: string;
+}
+
+export function RaceIcon({ race, label, className }: RaceIconProps) {
+  const emoji = getRaceEmoji(race);
+  if (!emoji) return null;
+  const title = label ? `${label} (${race})` : (race ?? "");
+  return (
+    <span
+      title={title}
+      aria-label={title}
+      role="img"
+      className={className ?? "inline-block"}
+    >
+      {emoji}
+    </span>
+  );
+}

--- a/apps/web/app/nfl-fantasy/leagues/[id]/draft/page.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/draft/page.tsx
@@ -967,7 +967,9 @@ export default function NuffleCoachDraftPage() {
                         {p.pseudonym}
                       </Link>
                       <p className="text-xs text-nuffle-anthracite/60">
-                        {p.bbPosition} · {p.teamCode ?? "—"} ·{" "}
+                        {p.bbPosition}
+                        {race?.raceLabel ? ` · ${race.raceLabel}` : ""} ·{" "}
+                        {p.teamCode ?? "—"} ·{" "}
                         {p.totalSpp !== undefined
                           ? `${p.totalSpp.toFixed(1)} SPP`
                           : "—"}

--- a/apps/web/app/nfl-fantasy/leagues/[id]/draft/page.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/draft/page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { apiRequest, ApiClientError } from "../../../../lib/api-client";
 import type { LeagueWithEntries } from "../../../types";
+import { RaceIcon } from "../../../RaceIcon";
 
 // ─── Types remontes par l'API ───────────────────────────────────────
 
@@ -350,6 +351,15 @@ export default function NuffleCoachDraftPage() {
     return Array.from(seen.entries())
       .map(([code, label]) => ({ code, label }))
       .sort((a, b) => a.label.localeCompare(b.label));
+  }, [teams]);
+
+  // Lookup teamCode -> race pour afficher l'icone par joueur.
+  const raceByTeamCode = useMemo(() => {
+    const m = new Map<string, { bbRace: string; raceLabel: string }>();
+    for (const t of teams) {
+      m.set(t.code, { bbRace: t.bbRace, raceLabel: t.raceLabel });
+    }
+    return m;
   }, [teams]);
 
   function updateFilter<K extends keyof FilterState>(
@@ -698,6 +708,7 @@ export default function NuffleCoachDraftPage() {
               const initial = r.tvCost;
               const pnl = current - initial;
               const pnlSign = pnl > 0 ? "+" : "";
+              const race = raceByTeamCode.get(r.player.teamCode ?? "");
               return (
                 <li
                   key={r.rosterId}
@@ -708,6 +719,11 @@ export default function NuffleCoachDraftPage() {
                       href={`/nfl-fantasy/players/${r.player.id}?seasonId=${SEASON_ID}`}
                       className="font-medium text-nuffle-anthracite hover:text-nuffle-gold"
                     >
+                      <RaceIcon
+                        race={race?.bbRace}
+                        label={race?.raceLabel}
+                        className="mr-1"
+                      />
                       {r.player.pseudonym}
                     </Link>
                     <p className="text-xs text-nuffle-anthracite/60">
@@ -932,6 +948,7 @@ export default function NuffleCoachDraftPage() {
                 const current = p.currentValue ?? p.basePrice ?? 50;
                 const previous = p.previousValue ?? current;
                 const trendDelta = current - previous;
+                const race = raceByTeamCode.get(p.teamCode ?? "");
                 return (
                   <li
                     key={p.id}
@@ -942,6 +959,11 @@ export default function NuffleCoachDraftPage() {
                         href={`/nfl-fantasy/players/${p.id}?seasonId=${SEASON_ID}`}
                         className="font-medium text-nuffle-anthracite hover:text-nuffle-gold"
                       >
+                        <RaceIcon
+                          race={race?.bbRace}
+                          label={race?.raceLabel}
+                          className="mr-1"
+                        />
                         {p.pseudonym}
                       </Link>
                       <p className="text-xs text-nuffle-anthracite/60">
@@ -987,6 +1009,7 @@ export default function NuffleCoachDraftPage() {
       {bidModalPlayer && (
         <BidModal
           player={bidModalPlayer}
+          race={raceByTeamCode.get(bidModalPlayer.teamCode ?? "")}
           amount={bidAmount}
           setAmount={setBidAmount}
           budgetRemaining={budgetRemaining}
@@ -1067,6 +1090,7 @@ function SessionCountdown({
 
 function BidModal({
   player,
+  race,
   amount,
   setAmount,
   budgetRemaining,
@@ -1075,6 +1099,7 @@ function BidModal({
   onSubmit,
 }: {
   player: CatalogPlayer;
+  race: { bbRace: string; raceLabel: string } | undefined;
   amount: number;
   setAmount: (n: number) => void;
   budgetRemaining: number | undefined;
@@ -1088,7 +1113,13 @@ function BidModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
         <h3 className="text-lg font-semibold text-nuffle-anthracite">
-          Enchère sur {player.pseudonym}
+          Enchère sur{" "}
+          <RaceIcon
+            race={race?.bbRace}
+            label={race?.raceLabel}
+            className="mr-1"
+          />
+          {player.pseudonym}
         </h3>
         <p className="mt-1 text-sm text-nuffle-anthracite/70">
           {player.bbPosition} · {player.teamCode ?? "—"}

--- a/apps/web/app/nfl-fantasy/players/[id]/page.tsx
+++ b/apps/web/app/nfl-fantasy/players/[id]/page.tsx
@@ -5,6 +5,63 @@ import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { apiRequest, ApiClientError } from "../../../lib/api-client";
+import { RaceIcon } from "../../RaceIcon";
+
+// Parsing tolerant : bbStats/bbSkills viennent en JSON natif (PG) ou en
+// string sérialisée (sqlite mirror), selon l'environnement.
+interface BbStats {
+  ma?: number;
+  st?: number;
+  ag?: number;
+  pa?: number | null;
+  av?: number;
+}
+
+function parseBbStats(raw: unknown): BbStats | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    try {
+      return parseBbStats(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) return null;
+  return raw as BbStats;
+}
+
+function parseBbSkills(raw: unknown): readonly string[] {
+  if (raw == null) return [];
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return parseBbSkills(parsed);
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/** "mighty-blow-1" -> "Mighty Blow (+1)" (heuristique simple, capitalize). */
+function prettifySkillSlug(slug: string): string {
+  const m = slug.match(/^([a-z][a-z-]*?)-(\d)$/);
+  if (m) {
+    return (
+      m[1]
+        .split("-")
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(" ") + ` (+${m[2]})`
+    );
+  }
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
 
 interface CategoryStats {
   readonly passing: {
@@ -87,6 +144,10 @@ interface PlayerDetail {
   readonly categoryStats: CategoryStats;
   readonly seasons: ReadonlyArray<SeasonAggregate>;
   readonly stats: ReadonlyArray<StatRow>;
+  /** Stats Blood Bowl intrinsèques (JSON : { ma, st, ag, pa, av }). */
+  readonly bbStats?: unknown;
+  /** Compétences BB de base du joueur (JSON : string[] de slugs). */
+  readonly bbSkills?: unknown;
 }
 
 function isPasser(pos: string): boolean {
@@ -209,7 +270,13 @@ export default function NuffleCoachPlayerDetailPage() {
           </p>
           {data.team && (
             <p className="mt-2 text-sm text-nuffle-anthracite/70">
-              {data.team.city} · {data.team.raceLabel} ({data.team.bbRace})
+              {data.team.city} ·{" "}
+              <RaceIcon
+                race={data.team.bbRace}
+                label={data.team.raceLabel}
+                className="mr-1"
+              />
+              {data.team.raceLabel} ({data.team.bbRace})
             </p>
           )}
           <dl className="mt-4 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
@@ -238,6 +305,63 @@ export default function NuffleCoachPlayerDetailPage() {
           </dl>
         </div>
       </header>
+
+      {/* Caractéristiques BB intrinsèques du joueur (MA/ST/AG/PA/AV + skills). */}
+      {(() => {
+        const bb = parseBbStats(data.bbStats);
+        const skills = parseBbSkills(data.bbSkills);
+        if (!bb && skills.length === 0) return null;
+        return (
+          <section data-testid="player-bb-attributes">
+            <h2 className="text-xl font-semibold text-nuffle-anthracite">
+              Caractéristiques Blood Bowl
+            </h2>
+            {bb && (
+              <dl className="mt-3 grid grid-cols-5 gap-3 rounded-lg border border-nuffle-bronze/20 bg-white p-4">
+                {(
+                  [
+                    { key: "ma", label: "MA", value: bb.ma, suffix: "" },
+                    { key: "st", label: "ST", value: bb.st, suffix: "" },
+                    { key: "ag", label: "AG", value: bb.ag, suffix: "+" },
+                    { key: "pa", label: "PA", value: bb.pa, suffix: "+" },
+                    { key: "av", label: "AV", value: bb.av, suffix: "+" },
+                  ] as const
+                ).map((s) => (
+                  <div key={s.key} className="text-center">
+                    <dt className="text-xs uppercase text-nuffle-anthracite/60">
+                      {s.label}
+                    </dt>
+                    <dd className="font-mono text-lg font-bold text-nuffle-anthracite">
+                      {s.value != null ? `${s.value}${s.suffix}` : "—"}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+            {skills.length > 0 && (
+              <div className="mt-3">
+                <h3 className="text-xs uppercase text-nuffle-anthracite/60">
+                  Compétences
+                </h3>
+                <ul
+                  className="mt-1 flex flex-wrap gap-2"
+                  data-testid="player-bb-skills"
+                >
+                  {skills.map((slug) => (
+                    <li
+                      key={slug}
+                      className="rounded-full bg-nuffle-bronze/15 px-3 py-1 text-xs text-nuffle-anthracite"
+                      title={slug}
+                    >
+                      {prettifySkillSlug(slug)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        );
+      })()}
 
       <section data-testid="player-category-stats">
         <h2 className="text-xl font-semibold text-nuffle-anthracite">

--- a/packages/game-engine/src/rosters/season3-reference-data.ts
+++ b/packages/game-engine/src/rosters/season3-reference-data.ts
@@ -244,7 +244,7 @@ export const SEASON_3_REFERENCE: Record<string, ReferenceRoster> = {
     budget: 1000,
     keyPositions: [
       { nameEn: 'Orc Lineman', cost: 50, max: 16, ma: 5, st: 3, ag: 3, pa: 4, av: 10, skills: [] },
-      { nameEn: 'Goblin Lineman', cost: 40, max: 4, ma: 6, st: 2, ag: 3, pa: 3, av: 8, skills: ['dodge', 'right-stuff', 'titchy'] },
+      { nameEn: 'Goblin Lineman', cost: 40, max: 4, ma: 6, st: 2, ag: 3, pa: 4, av: 8, skills: ['dodge', 'right-stuff', 'titchy'] },
       { nameEn: 'Orc Blitzer', cost: 85, max: 2, ma: 6, st: 3, ag: 3, pa: 4, av: 10, skills: ['block', 'break-tackle'] },
       { nameEn: 'Troll', cost: 115, max: 1, ma: 4, st: 5, ag: 5, pa: 5, av: 10, skills: ['always-hungry', 'loner-4', 'mighty-blow-1', 'projectile-vomit', 'really-stupid', 'regeneration', 'throw-team-mate'] },
     ],

--- a/scripts/backfill-nfl-bb-attributes.ts
+++ b/scripts/backfill-nfl-bb-attributes.ts
@@ -1,0 +1,107 @@
+/**
+ * Backfill : remplit `NflPlayer.bbStats` et `bbSkills` pour tous les joueurs
+ * existants (ingest initialisait à `{}`/`[]`). Dérivation via
+ * `deriveBbAttributes(race, bbPosition)` côté serveur.
+ *
+ * Sécurités :
+ *  - DRY-RUN par défaut. Passer `--write` pour appliquer.
+ *  - Ne touche pas les joueurs dont la combinaison (race, bbPosition) n'est
+ *    pas mappée -> laissés tels quels (log).
+ *  - Idempotent : ré-exécution = même résultat.
+ *
+ * Usage :
+ *   tsx scripts/backfill-nfl-bb-attributes.ts          # rapport (dry-run)
+ *   tsx scripts/backfill-nfl-bb-attributes.ts --write  # applique
+ */
+
+import { PrismaClient } from "@prisma/client";
+import type { BbPosition, BbRace } from "@bb/nfl-mapper";
+import { deriveBbAttributes } from "../apps/server/src/services/nfl-bb-derivation";
+
+const prisma = new PrismaClient();
+const WRITE = process.argv.includes("--write");
+
+interface BackfillCounters {
+  total: number;
+  derived: number;
+  skipped_no_team: number;
+  skipped_no_mapping: number;
+  updated: number;
+}
+
+async function main(): Promise<void> {
+  const counters: BackfillCounters = {
+    total: 0,
+    derived: 0,
+    skipped_no_team: 0,
+    skipped_no_mapping: 0,
+    updated: 0,
+  };
+  const unmappedExamples = new Map<string, string>(); // "Race/Pos" -> playerId
+
+  // On lit en streaming via cursor pour éviter de charger les 4565 d'un coup.
+  // Pour la taille actuelle, findMany direct est OK mais le cursor pattern
+  // reste sain si la table grossit.
+  const players = await prisma.nflPlayer.findMany({
+    select: {
+      id: true,
+      teamCode: true,
+      bbPosition: true,
+      team: { select: { bbRace: true } },
+    },
+  });
+  counters.total = players.length;
+
+  for (const p of players) {
+    if (!p.team) {
+      counters.skipped_no_team++;
+      continue;
+    }
+    const derived = deriveBbAttributes(
+      p.team.bbRace as BbRace,
+      p.bbPosition as BbPosition,
+    );
+    if (!derived) {
+      counters.skipped_no_mapping++;
+      const key = `${p.team.bbRace}/${p.bbPosition}`;
+      if (!unmappedExamples.has(key)) unmappedExamples.set(key, p.id);
+      continue;
+    }
+    counters.derived++;
+    if (WRITE) {
+      await prisma.nflPlayer.update({
+        where: { id: p.id },
+        data: {
+          bbStats: derived.stats,
+          bbSkills: [...derived.skills],
+        },
+      });
+      counters.updated++;
+    }
+  }
+
+  console.log("=== Backfill bbStats/bbSkills ===");
+  console.log(`Total joueurs       : ${counters.total}`);
+  console.log(`Dérivés (mappés)    : ${counters.derived}`);
+  console.log(`Skip (sans équipe)  : ${counters.skipped_no_team}`);
+  console.log(`Skip (combo non mappée) : ${counters.skipped_no_mapping}`);
+  console.log(`Updates écrits      : ${counters.updated}`);
+  if (unmappedExamples.size) {
+    console.log("\nCombinaisons non mappées (1 ex. par cas) :");
+    for (const [key, id] of unmappedExamples) {
+      console.log(`  ${key.padEnd(28)} ex: ${id}`);
+    }
+  }
+  if (!WRITE) {
+    console.log("\n(dry-run — relancer avec --write pour appliquer)");
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error("ERREUR:", e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
- services/nfl-bb-derivation.ts : mapping curé (8 races x positions) -> slug
  de position S3, lecture stats/skills depuis SEASON_THREE_ROSTERS via cache
  paresseux ; deriveBbAttributes(race, pos) retourne {stats, skills, sourceSlug}
- nfl-ingest-rosters.ts : remplit bbStats/bbSkills à l'ingest (création + update
  si dérivable, sinon vide à la création / no-op à l'update pour préserver)
- scripts/backfill-nfl-bb-attributes.ts : backfill idempotent (dry-run par
  défaut, --write pour appliquer) ; couverture 4565/4565 joueurs (0 non mappé)
- tests : 10 cas dérivation (mappings connus, fallbacks, couverture par race)
- ingest test : assertion bbStats:{}/bbSkills:[] retirée (dérivés désormais)

Backfill appliqué : 4565 updates écrits. Joueur 00-0026498 (LAR Thrower) :
{ma 7, st 3, ag 2, pa 2, av 8} + [safe-pair-of-hands, pass]. tsc serveur OK,
3270 tests verts.

## Résumé

- [ ] But de la PR

## Checklist

- [ ] Lint / Types OK
- [ ] Tests unitaires
- [ ] (si applicable) Tests e2e
- [ ] Changeset ajouté (`pnpm changeset`)
