### PR TITLE
feat(feature-flags): bouton admin pour synchroniser les flags du code vers la BDD

### DIFF
--- a/apps/server/src/routes/feature-flags.ts
+++ b/apps/server/src/routes/feature-flags.ts
@@ -21,6 +21,7 @@ import {
   listUsersForFlag,
   addUserOverride,
   removeUserOverride,
+  syncFlagsFromCode,
 } from "../services/featureFlags";
 import { sendSuccess, sendError } from "../utils/api-response";
 import { serverLog } from "../utils/server-log";
@@ -101,6 +102,20 @@ adminFeatureFlagsRouter.get("/", async (_req, res) => {
     return sendSuccess(res, flags);
   } catch (error: unknown) {
     serverLog.error("[featureFlags] GET / error:", error);
+    return sendError(res, errorMessage(error));
+  }
+});
+
+// Synchronise la BDD avec les flags déclarés dans le code (KNOWN_FLAGS) :
+// crée les flags manquants (enabled: false), laisse les existants intacts.
+// Doit être déclaré avant les routes paramétrées pour éviter toute
+// ambiguïté de matching.
+adminFeatureFlagsRouter.post("/sync", async (_req, res) => {
+  try {
+    const result = await syncFlagsFromCode();
+    return sendSuccess(res, result);
+  } catch (error: unknown) {
+    serverLog.error("[featureFlags] POST /sync error:", error);
     return sendError(res, errorMessage(error));
   }
 });

--- a/apps/server/src/services/featureFlags.test.ts
+++ b/apps/server/src/services/featureFlags.test.ts
@@ -29,8 +29,11 @@ import {
   addUserOverride,
   removeUserOverride,
   invalidateFeatureFlagsCache,
+  syncFlagsFromCode,
+  KNOWN_FLAGS,
   ONLINE_PLAY_FLAG,
   AI_TRAINING_FLAG,
+  NUFFLE_COACH_FLAG,
 } from "./featureFlags";
 
 const mockPrisma = prisma as any;
@@ -139,9 +142,7 @@ describe("featureFlags service", () => {
       mockPrisma.featureFlag.findMany.mockResolvedValue([
         flag("f-reg", "registration_requires_validation", false),
       ]);
-      expect(
-        await isEnabled("registration_requires_validation"),
-      ).toBe(false);
+      expect(await isEnabled("registration_requires_validation")).toBe(false);
       // Et lookup DB exectue (pas de short-circuit).
       expect(mockPrisma.featureFlag.findMany).toHaveBeenCalled();
     });
@@ -151,9 +152,7 @@ describe("featureFlags service", () => {
       mockPrisma.featureFlag.findMany.mockResolvedValue([
         flag("f-reg", "registration_requires_validation", true),
       ]);
-      expect(
-        await isEnabled("registration_requires_validation"),
-      ).toBe(true);
+      expect(await isEnabled("registration_requires_validation")).toBe(true);
     });
 
     it('accepts "1" as a truthy value for FEATURE_FLAGS_FORCE_ENABLED', async () => {
@@ -278,7 +277,9 @@ describe("featureFlags service", () => {
       ]);
       await isEnabled("old");
 
-      mockPrisma.featureFlag.create.mockResolvedValue(flag("f2", "fresh", true));
+      mockPrisma.featureFlag.create.mockResolvedValue(
+        flag("f2", "fresh", true),
+      );
       await createFlag({ key: "fresh", enabled: true });
 
       mockPrisma.featureFlag.findMany.mockResolvedValueOnce([
@@ -295,9 +296,7 @@ describe("featureFlags service", () => {
       ]);
       expect(await isEnabled("beta")).toBe(false);
 
-      mockPrisma.featureFlag.update.mockResolvedValue(
-        flag("f1", "beta", true),
-      );
+      mockPrisma.featureFlag.update.mockResolvedValue(flag("f1", "beta", true));
       await updateFlag("f1", { enabled: true });
 
       mockPrisma.featureFlag.findMany.mockResolvedValueOnce([
@@ -340,6 +339,102 @@ describe("featureFlags service", () => {
         new Error("not found"),
       );
       await expect(removeUserOverride("f1", "user-1")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("syncFlagsFromCode", () => {
+    it("creates every known flag when the DB is empty", async () => {
+      mockPrisma.featureFlag.findMany.mockResolvedValue([]);
+      mockPrisma.featureFlag.create.mockImplementation(
+        async ({ data }: { data: { key: string } }) =>
+          flag("new", data.key, false),
+      );
+
+      const result = await syncFlagsFromCode();
+
+      expect(result.total).toBe(KNOWN_FLAGS.length);
+      expect(result.created).toEqual(KNOWN_FLAGS.map((f) => f.key).sort());
+      expect(result.skipped).toEqual([]);
+      expect(mockPrisma.featureFlag.create).toHaveBeenCalledTimes(
+        KNOWN_FLAGS.length,
+      );
+      // Les flags sont créés désactivés : jamais d'activation auto en prod.
+      for (const call of mockPrisma.featureFlag.create.mock.calls) {
+        expect(call[0].data.enabled).toBe(false);
+      }
+    });
+
+    it("only creates flags missing from the DB and skips existing ones", async () => {
+      mockPrisma.featureFlag.findMany.mockResolvedValue(
+        KNOWN_FLAGS.filter((f) => f.key !== NUFFLE_COACH_FLAG).map((f, i) =>
+          flag(`f${i}`, f.key, false),
+        ),
+      );
+      mockPrisma.featureFlag.create.mockResolvedValue(
+        flag("new", NUFFLE_COACH_FLAG, false),
+      );
+
+      const result = await syncFlagsFromCode();
+
+      expect(result.created).toEqual([NUFFLE_COACH_FLAG]);
+      expect(result.skipped).toContain(ONLINE_PLAY_FLAG);
+      expect(result.skipped).not.toContain(NUFFLE_COACH_FLAG);
+      expect(mockPrisma.featureFlag.create).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.featureFlag.create).toHaveBeenCalledWith({
+        data: {
+          key: NUFFLE_COACH_FLAG,
+          description: expect.any(String),
+          enabled: false,
+        },
+      });
+    });
+
+    it("is a no-op (no create) when all flags already exist", async () => {
+      mockPrisma.featureFlag.findMany.mockResolvedValue(
+        KNOWN_FLAGS.map((f, i) => flag(`f${i}`, f.key, false)),
+      );
+
+      const result = await syncFlagsFromCode();
+
+      expect(result.created).toEqual([]);
+      expect(result.skipped).toHaveLength(KNOWN_FLAGS.length);
+      expect(mockPrisma.featureFlag.create).not.toHaveBeenCalled();
+    });
+
+    it("invalidates the cache after creating new flags", async () => {
+      // Amorce le cache avec un état "vide" pour beta.
+      mockPrisma.featureFlag.findMany.mockResolvedValueOnce([]);
+      expect(await isEnabled("beta")).toBe(false);
+
+      // Sync crée un flag manquant → doit invalider le cache.
+      mockPrisma.featureFlag.findMany.mockResolvedValueOnce([]);
+      mockPrisma.featureFlag.create.mockResolvedValue(
+        flag("n", "anything", false),
+      );
+      await syncFlagsFromCode();
+
+      // Le prochain isEnabled doit retaper la DB (cache invalidé).
+      mockPrisma.featureFlag.findMany.mockResolvedValueOnce([
+        flag("f1", "beta", true),
+      ]);
+      expect(await isEnabled("beta")).toBe(true);
+    });
+  });
+
+  describe("KNOWN_FLAGS registry", () => {
+    it("has unique, non-empty keys and descriptions", () => {
+      const keys = KNOWN_FLAGS.map((f) => f.key);
+      expect(new Set(keys).size).toBe(keys.length);
+      for (const spec of KNOWN_FLAGS) {
+        expect(spec.key.length).toBeGreaterThan(0);
+        expect(spec.description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("includes the canonical flag constants", () => {
+      const keys = KNOWN_FLAGS.map((f) => f.key);
+      expect(keys).toContain(ONLINE_PLAY_FLAG);
+      expect(keys).toContain(NUFFLE_COACH_FLAG);
     });
   });
 

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -91,6 +91,61 @@ export const MAINTENANCE_MODE_FLAG = "maintenance_mode" as const;
 export const REGISTRATION_REQUIRES_VALIDATION_FLAG =
   "registration_requires_validation" as const;
 
+/**
+ * Registre des feature flags connus du code. Source de vérité pour garder
+ * la table `FeatureFlag` synchronisée avec le code : le bouton
+ * "Synchroniser depuis le code" du panneau admin (POST
+ * /admin/feature-flags/sync) crée en base tout flag listé ici mais absent
+ * de la table.
+ *
+ * Convention : la synchro ne fait que *créer* les flags manquants (avec
+ * `enabled: false`). Elle ne touche jamais un flag déjà présent — ni son
+ * état global, ni sa description — pour ne pas activer une feature en prod
+ * par accident. L'activation reste un geste admin explicite (toggle ON).
+ *
+ * Quand tu ajoutes une nouvelle constante `XXX_FLAG`, ajoute-la aussi ici.
+ */
+export interface KnownFlagSpec {
+  readonly key: string;
+  readonly description: string;
+}
+
+export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
+  {
+    key: ONLINE_PLAY_FLAG,
+    description: "Jouer en ligne — matchmaking, ligues, leaderboard.",
+  },
+  {
+    key: AI_TRAINING_FLAG,
+    description: "Entraînement contre l'IA (practice + ai-next-move).",
+  },
+  {
+    key: LEAGUES_V2_UI_FLAG,
+    description:
+      "Ligues v2 — nouveaux écrans de gestion de ligue / saison (UI).",
+  },
+  {
+    key: NUFFLE_COACH_FLAG,
+    description:
+      "Nuffle Coach (fantasy NFL skinné BB) — UI publique : menu, sous-nav, pages user.",
+  },
+  {
+    key: NUFFLE_COACH_TEST_FLAG,
+    description:
+      "Nuffle Coach (test) — bypass snap-to-next-window. STRICTEMENT OFF en prod.",
+  },
+  {
+    key: MAINTENANCE_MODE_FLAG,
+    description:
+      "Kill-switch maintenance — 503 sur les routes non-essentielles.",
+  },
+  {
+    key: REGISTRATION_REQUIRES_VALIDATION_FLAG,
+    description:
+      "Kill-switch — exige une validation admin des nouveaux comptes.",
+  },
+];
+
 export interface FeatureFlagDTO {
   id: string;
   key: string;
@@ -268,6 +323,51 @@ export async function createFlag(
   })) as FeatureFlagDTO;
   invalidateFeatureFlagsCache();
   return created;
+}
+
+export interface SyncFlagsResult {
+  /** Clés créées en base par cette synchro. */
+  created: string[];
+  /** Clés déjà présentes (laissées intactes). */
+  skipped: string[];
+  /** Nombre total de flags connus du code. */
+  total: number;
+}
+
+/**
+ * Crée en base tout flag déclaré dans `KNOWN_FLAGS` mais absent de la
+ * table. Idempotent : les flags déjà présents ne sont ni activés ni
+ * modifiés. Permet de garder la BDD à jour vis-à-vis du code sans rejouer
+ * le seed complet.
+ */
+export async function syncFlagsFromCode(): Promise<SyncFlagsResult> {
+  const existing = (await prisma.featureFlag.findMany({
+    select: { key: true },
+  })) as Array<{ key: string }>;
+  const existingKeys = new Set(existing.map((f) => f.key));
+
+  const created: string[] = [];
+  const skipped: string[] = [];
+  for (const spec of KNOWN_FLAGS) {
+    if (existingKeys.has(spec.key)) {
+      skipped.push(spec.key);
+      continue;
+    }
+    await prisma.featureFlag.create({
+      data: { key: spec.key, description: spec.description, enabled: false },
+    });
+    created.push(spec.key);
+  }
+
+  if (created.length > 0) {
+    invalidateFeatureFlagsCache();
+  }
+
+  return {
+    created: created.sort(),
+    skipped: skipped.sort(),
+    total: KNOWN_FLAGS.length,
+  };
 }
 
 export interface UpdateFlagInput {

--- a/apps/web/app/admin/feature-flags/page.tsx
+++ b/apps/web/app/admin/feature-flags/page.tsx
@@ -5,6 +5,7 @@ import {
   adminCreateFlag,
   adminDeleteFlag,
   adminListFlags,
+  adminSyncFlags,
   adminUpdateFlag,
   type FeatureFlag,
 } from "../../lib/featureFlags";
@@ -18,6 +19,8 @@ export default function AdminFeatureFlagsPage() {
   const [newDescription, setNewDescription] = useState<string>("");
   const [newEnabled, setNewEnabled] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
+  const [syncing, setSyncing] = useState<boolean>(false);
+  const [notice, setNotice] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -59,6 +62,37 @@ export default function AdminFeatureFlagsPage() {
     }
   };
 
+  const syncFromCode = async () => {
+    setSyncing(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await adminSyncFlags();
+      if (result.created.length === 0) {
+        setNotice(
+          `Tout est déjà à jour — ${result.total} flag${
+            result.total !== 1 ? "s" : ""
+          } du code déjà en base.`,
+        );
+      } else {
+        setNotice(
+          `${result.created.length} flag${
+            result.created.length !== 1 ? "s" : ""
+          } créé${result.created.length !== 1 ? "s" : ""} : ${result.created.join(
+            ", ",
+          )}.`,
+        );
+      }
+      await load();
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Erreur de synchronisation",
+      );
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const submitCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitting(true);
@@ -93,18 +127,35 @@ export default function AdminFeatureFlagsPage() {
             spécifiques.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setCreateOpen((prev) => !prev)}
-          className="self-start sm:self-auto px-4 py-2 rounded-lg bg-nuffle-gold text-white hover:bg-nuffle-bronze transition"
-        >
-          {createOpen ? "Annuler" : "+ Nouveau flag"}
-        </button>
+        <div className="flex flex-wrap items-center gap-2 self-start sm:self-auto">
+          <button
+            type="button"
+            onClick={syncFromCode}
+            disabled={syncing}
+            title="Crée en base les feature flags définis dans le code mais absents de la BDD"
+            className="px-4 py-2 rounded-lg border border-nuffle-bronze text-nuffle-bronze hover:bg-nuffle-bronze hover:text-white transition disabled:opacity-50"
+          >
+            {syncing ? "Synchronisation..." : "⟳ Synchroniser depuis le code"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreateOpen((prev) => !prev)}
+            className="px-4 py-2 rounded-lg bg-nuffle-gold text-white hover:bg-nuffle-bronze transition"
+          >
+            {createOpen ? "Annuler" : "+ Nouveau flag"}
+          </button>
+        </div>
       </div>
 
       {error && (
         <div className="mb-4 p-3 rounded bg-red-50 text-red-700 border border-red-200">
           {error}
+        </div>
+      )}
+
+      {notice && (
+        <div className="mb-4 p-3 rounded bg-green-50 text-green-700 border border-green-200">
+          {notice}
         </div>
       )}
 
@@ -167,62 +218,68 @@ export default function AdminFeatureFlagsPage() {
       ) : (
         <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
           <div className="overflow-x-auto">
-          <table className="min-w-full text-sm">
-            <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
-              <tr>
-                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Clé</th>
-                <th className="px-3 sm:px-4 py-3">Description</th>
-                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Global</th>
-                <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Utilisateurs</th>
-                <th className="px-3 sm:px-4 py-3 text-right whitespace-nowrap">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {flags.map((flag) => (
-                <tr key={flag.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-mono text-xs">{flag.key}</td>
-                  <td className="px-4 py-3 text-gray-700">
-                    {flag.description || (
-                      <span className="text-gray-400">—</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <button
-                      type="button"
-                      onClick={() => toggleEnabled(flag)}
-                      className={`px-3 py-1 rounded-full text-xs font-semibold transition ${
-                        flag.enabled
-                          ? "bg-green-100 text-green-700 hover:bg-green-200"
-                          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                      }`}
-                    >
-                      {flag.enabled ? "ON" : "OFF"}
-                    </button>
-                  </td>
-                  <td className="px-4 py-3">
-                    <Link
-                      href={
-                        `/admin/feature-flags/${flag.id}` as never as string
-                      }
-                      className="text-nuffle-bronze hover:underline"
-                    >
-                      {flag.userOverrideCount} override
-                      {flag.userOverrideCount !== 1 ? "s" : ""}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <button
-                      type="button"
-                      onClick={() => removeFlag(flag)}
-                      className="text-red-600 hover:text-red-800 text-xs"
-                    >
-                      Supprimer
-                    </button>
-                  </td>
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
+                <tr>
+                  <th className="px-3 sm:px-4 py-3 whitespace-nowrap">Clé</th>
+                  <th className="px-3 sm:px-4 py-3">Description</th>
+                  <th className="px-3 sm:px-4 py-3 whitespace-nowrap">
+                    Global
+                  </th>
+                  <th className="px-3 sm:px-4 py-3 whitespace-nowrap">
+                    Utilisateurs
+                  </th>
+                  <th className="px-3 sm:px-4 py-3 text-right whitespace-nowrap">
+                    Actions
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {flags.map((flag) => (
+                  <tr key={flag.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 font-mono text-xs">{flag.key}</td>
+                    <td className="px-4 py-3 text-gray-700">
+                      {flag.description || (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => toggleEnabled(flag)}
+                        className={`px-3 py-1 rounded-full text-xs font-semibold transition ${
+                          flag.enabled
+                            ? "bg-green-100 text-green-700 hover:bg-green-200"
+                            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        }`}
+                      >
+                        {flag.enabled ? "ON" : "OFF"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Link
+                        href={
+                          `/admin/feature-flags/${flag.id}` as never as string
+                        }
+                        className="text-nuffle-bronze hover:underline"
+                      >
+                        {flag.userOverrideCount} override
+                        {flag.userOverrideCount !== 1 ? "s" : ""}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <button
+                        type="button"
+                        onClick={() => removeFlag(flag)}
+                        className="text-red-600 hover:text-red-800 text-xs"
+                      >
+                        Supprimer
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/apps/web/app/lib/featureFlags.ts
+++ b/apps/web/app/lib/featureFlags.ts
@@ -62,6 +62,22 @@ export async function adminDeleteFlag(id: string): Promise<void> {
   });
 }
 
+export interface SyncFlagsResult {
+  created: string[];
+  skipped: string[];
+  total: number;
+}
+
+/**
+ * Crée en base les feature flags déclarés dans le code mais absents de la
+ * BDD. Idempotent : ne modifie pas les flags déjà présents.
+ */
+export async function adminSyncFlags(): Promise<SyncFlagsResult> {
+  return request<SyncFlagsResult>("/admin/feature-flags/sync", {
+    method: "POST",
+  });
+}
+
 export async function adminListFlagUsers(
   id: string,
 ): Promise<FeatureFlagUser[]> {


### PR DESCRIPTION
Ajoute un registre `KNOWN_FLAGS` (source de verite cote code) et un
service `syncFlagsFromCode` qui cree en base tout flag declare dans le
code mais absent de la table `FeatureFlag` (enabled: false, idempotent,
ne modifie jamais un flag existant).

- service: KNOWN_FLAGS + syncFlagsFromCode + SyncFlagsResult
- route: POST /admin/feature-flags/sync (adminOnly)
- web: adminSyncFlags + bouton 'Synchroniser depuis le code' sur la page
  admin /admin/feature-flags avec retour du nombre de flags crees
- tests: 7 cas (creation, skip existants, no-op, invalidation cache,
  invariants du registre)

Resout le cas ou un flag (ex: nuffle_coach) defini dans le code n'est
pas present en BDD, le rendant invisible/incoherent selon l'environnement.