### PR TITLE
feat(nfl-fantasy): style de jeu (presets de composition) + UI mobile-first du lineup

### DIFF
--- a/apps/server/src/routes/nfl-fantasy-entries.ts
+++ b/apps/server/src/routes/nfl-fantasy-entries.ts
@@ -23,10 +23,7 @@
 import { Router } from "express";
 import { z } from "zod";
 
-import {
-  authUser,
-  type AuthenticatedRequest,
-} from "../middleware/authUser";
+import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
 import { validate, validateQuery } from "../middleware/validate";
 import { prisma } from "../prisma";
 import {
@@ -39,7 +36,9 @@ import {
   getLineup,
   NflFantasyLineupError,
   setLineup,
+  updateEntryPlayStyle,
 } from "../services/nfl-fantasy-lineup";
+import { PLAY_STYLES } from "@bb/nfl-mapper";
 import {
   carryOverLineupFromPreviousWeek,
   findPreviousLineupSummary,
@@ -84,11 +83,15 @@ async function loadOwnedEntry(
     select: { userId: true },
   });
   if (!entry) {
-    res.status(404).json({ error: `Entry ${entryId} introuvable`, code: "ENTRY_NOT_FOUND" });
+    res
+      .status(404)
+      .json({ error: `Entry ${entryId} introuvable`, code: "ENTRY_NOT_FOUND" });
     return null;
   }
   if (entry.userId !== req.user!.id) {
-    res.status(403).json({ error: "Acces refuse a cette entry", code: "NOT_OWNER" });
+    res
+      .status(403)
+      .json({ error: "Acces refuse a cette entry", code: "NOT_OWNER" });
     return null;
   }
   return entry;
@@ -106,7 +109,11 @@ const addPlayerSchema = z.object({
 
 router.get("/:entryId/roster", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const roster = await getRosterWithPlayers(req.params.entryId);
     res.json({ roster });
@@ -118,28 +125,35 @@ router.get("/:entryId/roster", async (req, res) => {
   }
 });
 
-router.post(
-  "/:entryId/roster",
-  validate(addPlayerSchema),
-  async (req, res) => {
-    try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
-      if (!entry) return;
-      const body = req.body as z.infer<typeof addPlayerSchema>;
-      const row = await addPlayerToRoster({ entryId: req.params.entryId, ...body });
-      res.status(201).json(row);
-    } catch (err) {
-      if (!sendNflError(res, err) && !(err instanceof NflFantasyRosterError)) {
-        serverLog.error("[nfl-fantasy-entries] addPlayer failed", err);
-        res.status(500).json({ error: "Erreur serveur" });
-      }
+router.post("/:entryId/roster", validate(addPlayerSchema), async (req, res) => {
+  try {
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
+    if (!entry) return;
+    const body = req.body as z.infer<typeof addPlayerSchema>;
+    const row = await addPlayerToRoster({
+      entryId: req.params.entryId,
+      ...body,
+    });
+    res.status(201).json(row);
+  } catch (err) {
+    if (!sendNflError(res, err) && !(err instanceof NflFantasyRosterError)) {
+      serverLog.error("[nfl-fantasy-entries] addPlayer failed", err);
+      res.status(500).json({ error: "Erreur serveur" });
     }
-  },
-);
+  }
+});
 
 router.delete("/:entryId/roster/:playerId", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     await removePlayerFromRoster({
       entryId: req.params.entryId,
@@ -160,7 +174,11 @@ router.delete("/:entryId/roster/:playerId", async (req, res) => {
 // une plus-value au moment de la vente.
 router.post("/:entryId/roster/:playerId/sell", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const out = await sellPlayer({
       entryId: req.params.entryId,
@@ -204,9 +222,15 @@ router.get(
   validateQuery(lineupQuerySchema),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
-      const { weekId } = req.query as unknown as z.infer<typeof lineupQuerySchema>;
+      const { weekId } = req.query as unknown as z.infer<
+        typeof lineupQuerySchema
+      >;
       // Parallelisable : lineup courante + suggestion carry-over
       const [lineup, previousLineup] = await Promise.all([
         getLineup({ entryId: req.params.entryId, weekId }),
@@ -227,7 +251,11 @@ router.get(
 
 router.put("/:entryId/lineup", validate(setLineupSchema), async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const body = req.body as z.infer<typeof setLineupSchema>;
     const lineup = await setLineup({ entryId: req.params.entryId, ...body });
@@ -239,6 +267,46 @@ router.put("/:entryId/lineup", validate(setLineupSchema), async (req, res) => {
     }
   }
 });
+
+const playStyleSchema = z.object({
+  playStyle: z.enum(PLAY_STYLES as readonly [string, ...string[]]),
+});
+
+/**
+ * PATCH /:entryId/play-style
+ *
+ * Change le style de jeu de l'entry (definit les plafonds de composition
+ * de lineup). Modifiable tant qu'aucune semaine verrouillee n'est en
+ * attente de resolution (cf. updateEntryPlayStyle).
+ */
+router.patch(
+  "/:entryId/play-style",
+  validate(playStyleSchema),
+  async (req, res) => {
+    try {
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
+      if (!entry) return;
+      const body = req.body as z.infer<typeof playStyleSchema>;
+      const updated = await updateEntryPlayStyle({
+        entryId: req.params.entryId,
+        playStyle: body.playStyle,
+      });
+      res.json(updated);
+    } catch (err) {
+      if (!sendNflError(res, err) && !(err instanceof NflFantasyLineupError)) {
+        serverLog.error(
+          "[nfl-fantasy-entries] updateEntryPlayStyle failed",
+          err,
+        );
+        res.status(500).json({ error: "Erreur serveur" });
+      }
+    }
+  },
+);
 
 const carryOverLineupSchema = z.object({
   weekId: z.string().min(1),
@@ -305,7 +373,11 @@ router.get(
   validateQuery(listRerollsQuery),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
       const q = req.query as unknown as z.infer<typeof listRerollsQuery>;
       const used = q.used === undefined ? undefined : q.used === "true";
@@ -326,7 +398,11 @@ router.post(
   validate(consumeRerollSchema),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
       const body = req.body as z.infer<typeof consumeRerollSchema>;
       const out = await consumeReroll({ entryId: req.params.entryId, ...body });
@@ -364,7 +440,11 @@ router.get(
   validateQuery(listInducementsQuery),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
       const q = req.query as unknown as z.infer<typeof listInducementsQuery>;
       const inducements = await listInducements({
@@ -395,10 +475,17 @@ router.post(
   validate(consumeInducementSchema),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
       const body = req.body as z.infer<typeof consumeInducementSchema>;
-      const out = await consumeInducement({ entryId: req.params.entryId, ...body });
+      const out = await consumeInducement({
+        entryId: req.params.entryId,
+        ...body,
+      });
       res.status(201).json(out);
     } catch (err) {
       if (!sendNflError(res, err) && !(err instanceof NflFantasyMercatoError)) {
@@ -415,7 +502,11 @@ router.post(
 
 router.get("/:entryId/careers", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const careers = await listCareersForEntry(req.params.entryId);
     res.json({ careers });
@@ -427,14 +518,20 @@ router.get("/:entryId/careers", async (req, res) => {
 
 router.get("/:entryId/careers/:playerId", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const career = await getCareerForPlayer({
       entryId: req.params.entryId,
       playerId: req.params.playerId,
     });
     if (!career) {
-      res.status(404).json({ error: "Carriere non trouvee", code: "CAREER_NOT_FOUND" });
+      res
+        .status(404)
+        .json({ error: "Carriere non trouvee", code: "CAREER_NOT_FOUND" });
       return;
     }
     const access = await getSkillAccessView(req.params.playerId);
@@ -447,7 +544,11 @@ router.get("/:entryId/careers/:playerId", async (req, res) => {
 
 router.get("/:entryId/careers/:playerId/available-skills", async (req, res) => {
   try {
-    const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+    const entry = await loadOwnedEntry(
+      req as AuthenticatedRequest,
+      res,
+      req.params.entryId,
+    );
     if (!entry) return;
     const out = await listAvailableSkillsForCareer({
       entryId: req.params.entryId,
@@ -462,7 +563,10 @@ router.get("/:entryId/careers/:playerId/available-skills", async (req, res) => {
     }
     res.json(out);
   } catch (err) {
-    serverLog.error("[nfl-fantasy-entries] listAvailableSkillsForCareer failed", err);
+    serverLog.error(
+      "[nfl-fantasy-entries] listAvailableSkillsForCareer failed",
+      err,
+    );
     res.status(500).json({ error: "Erreur serveur" });
   }
 });
@@ -492,7 +596,11 @@ router.post(
   validate(unlockSkillSchema),
   async (req, res) => {
     try {
-      const entry = await loadOwnedEntry(req as AuthenticatedRequest, res, req.params.entryId);
+      const entry = await loadOwnedEntry(
+        req as AuthenticatedRequest,
+        res,
+        req.params.entryId,
+      );
       if (!entry) return;
       const body = req.body as z.infer<typeof unlockSkillSchema>;
       const out = await unlockSkill({

--- a/apps/server/src/scripts/nfl-fantasy-composition-report.ts
+++ b/apps/server/src/scripts/nfl-fantasy-composition-report.ts
@@ -1,0 +1,234 @@
+/**
+ * Mini-rapport data — composition de lineup Nuffle Coach.
+ *
+ * Analyse les lineups DEJA settled (resultats reels) pour repondre a la
+ * question de game design : "empiler des postes premium (receveurs /
+ * passers / rushers) surperforme-t-il vraiment un lineup equilibre ?".
+ *
+ * Source de donnees : `NflFantasyLineupStarter.finalSpp` (SPP reel apres
+ * multiplicateurs capitaine). Aucune recompute : on agrege le resultat de
+ * production. Classification par archetype via @bb/nfl-mapper (poste NFL
+ * d'abord, fallback poste BB pour les vieux snapshots sans nflPosition).
+ *
+ * Read-only : aucune ecriture en base.
+ *
+ * Lancement :
+ *   pnpm --filter @bb/server exec tsx src/scripts/nfl-fantasy-composition-report.ts
+ *   # ou en filtrant une saison :
+ *   SEASON=2024 pnpm --filter @bb/server exec tsx src/scripts/nfl-fantasy-composition-report.ts
+ *
+ * DATABASE_URL doit pointer sur la base a analyser (Prisma le lit via env).
+ */
+import { PrismaClient } from "@prisma/client";
+import {
+  getArchetypeFromNflPosition,
+  getArchetypeFromBbPosition,
+  type CompositionArchetype as PlayerArchetype,
+  type BbPosition,
+} from "@bb/nfl-mapper";
+
+const prisma = new PrismaClient();
+
+/** Ordre d'affichage stable des archetypes. */
+const ARCHETYPES: readonly PlayerArchetype[] = [
+  "passer",
+  "rusher",
+  "receiver",
+  "frontSeven",
+  "secondary",
+  "bigGuy",
+  "lineman",
+];
+
+/** Archetypes consideres "premium" (forte production attendue). */
+const PREMIUM: ReadonlySet<PlayerArchetype> = new Set<PlayerArchetype>([
+  "passer",
+  "rusher",
+  "receiver",
+]);
+
+interface StarterRow {
+  readonly nflPosition: string | null;
+  readonly bbPosition: string;
+  readonly finalSpp: number | null;
+  /** Cle de regroupement par lineup (FK detectee au runtime). */
+  readonly lineupKey: string;
+}
+
+function classify(nflPosition: string | null, bbPosition: string): PlayerArchetype {
+  if (nflPosition && nflPosition.trim() !== "") {
+    return getArchetypeFromNflPosition(nflPosition);
+  }
+  return getArchetypeFromBbPosition(bbPosition as BbPosition);
+}
+
+function pct(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.round((p / 100) * (sorted.length - 1))));
+  return sorted[idx];
+}
+
+function mean(xs: readonly number[]): number {
+  if (xs.length === 0) return 0;
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function round1(x: number): number {
+  return Math.round(x * 10) / 10;
+}
+
+/**
+ * Detecte la FK vers le lineup parent sur un enregistrement starter, sans
+ * dependre du nom exact du champ (robuste aux variations de schema).
+ */
+function detectLineupKey(record: Record<string, unknown>): string | null {
+  for (const key of Object.keys(record)) {
+    if (key === "id") continue;
+    if (/lineup.*id$/i.test(key)) {
+      const v = record[key];
+      if (typeof v === "string") return key;
+    }
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const seasonEnv = process.env.SEASON ? Number(process.env.SEASON) : undefined;
+
+  // Lecture des starters settled (finalSpp renseigne). Pas de `select` :
+  // on recupere l'enregistrement complet pour pouvoir detecter la FK lineup
+  // au runtime (et rester tolerant au nom exact du champ).
+  const raw = (await prisma.nflFantasyLineupStarter.findMany({
+    where: { finalSpp: { not: null } },
+  })) as unknown as Array<Record<string, unknown>>;
+
+  if (raw.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log(
+      "Aucun lineup settled trouve (NflFantasyLineupStarter.finalSpp tous nuls).\n" +
+        "Lance ce script sur une base avec au moins une semaine settled.",
+    );
+    return;
+  }
+
+  const lineupKeyField = detectLineupKey(raw[0]);
+
+  const rows: StarterRow[] = raw.map((r) => ({
+    nflPosition: (r.nflPosition as string | null) ?? null,
+    bbPosition: String(r.bbPosition ?? "Lineman"),
+    finalSpp: (r.finalSpp as number | null) ?? null,
+    lineupKey: lineupKeyField ? String(r[lineupKeyField] ?? "?") : "?",
+  }));
+
+  // ── Rapport 1 : distribution SPP par archetype ──────────────────────
+  const byArch = new Map<PlayerArchetype, number[]>();
+  for (const a of ARCHETYPES) byArch.set(a, []);
+  let grandTotal = 0;
+  for (const row of rows) {
+    if (row.finalSpp === null) continue;
+    const arch = classify(row.nflPosition, row.bbPosition);
+    byArch.get(arch)!.push(row.finalSpp);
+    grandTotal += row.finalSpp;
+  }
+
+  const lines: string[] = [];
+  lines.push(`\n=== Rapport 1 — SPP reel par archetype (${rows.length} titularisations) ===`);
+  if (seasonEnv) lines.push(`(note: filtre SEASON=${seasonEnv} non applique — voir TODO en bas)`);
+  lines.push(
+    "archetype".padEnd(12) +
+      "n".padStart(7) +
+      "moy".padStart(8) +
+      "med".padStart(7) +
+      "p10".padStart(7) +
+      "p90".padStart(7) +
+      "%SPP".padStart(8),
+  );
+  for (const a of ARCHETYPES) {
+    const xs = byArch.get(a)!;
+    if (xs.length === 0) continue;
+    const sorted = [...xs].sort((x, y) => x - y);
+    const sum = xs.reduce((p, c) => p + c, 0);
+    lines.push(
+      a.padEnd(12) +
+        String(xs.length).padStart(7) +
+        String(round1(mean(xs))).padStart(8) +
+        String(pct(sorted, 50)).padStart(7) +
+        String(pct(sorted, 10)).padStart(7) +
+        String(pct(sorted, 90)).padStart(7) +
+        (grandTotal > 0 ? `${Math.round((sum / grandTotal) * 100)}%` : "0%").padStart(8),
+    );
+  }
+
+  // ── Rapport 2 : lineups equilibres vs stacks premium ────────────────
+  if (lineupKeyField) {
+    interface LineupAgg {
+      total: number;
+      premiumCount: number;
+      fillerCount: number;
+      starters: number;
+    }
+    const lineups = new Map<string, LineupAgg>();
+    for (const row of rows) {
+      if (row.finalSpp === null) continue;
+      const agg = lineups.get(row.lineupKey) ?? {
+        total: 0,
+        premiumCount: 0,
+        fillerCount: 0,
+        starters: 0,
+      };
+      const arch = classify(row.nflPosition, row.bbPosition);
+      agg.total += row.finalSpp;
+      agg.starters += 1;
+      if (PREMIUM.has(arch)) agg.premiumCount += 1;
+      else agg.fillerCount += 1;
+      lineups.set(row.lineupKey, agg);
+    }
+
+    // Bucket : "stack premium" = >= 8 postes premium sur 11 ; "equilibre"
+    // = entre 4 et 7 ; "defensif/filler" = < 4. Seuils ajustables.
+    const buckets = {
+      "stack premium (>=8 prem.)": [] as number[],
+      "equilibre (4-7 prem.)": [] as number[],
+      "filler-lourd (<4 prem.)": [] as number[],
+    };
+    for (const agg of lineups.values()) {
+      if (agg.premiumCount >= 8) buckets["stack premium (>=8 prem.)"].push(agg.total);
+      else if (agg.premiumCount >= 4) buckets["equilibre (4-7 prem.)"].push(agg.total);
+      else buckets["filler-lourd (<4 prem.)"].push(agg.total);
+    }
+
+    lines.push(`\n=== Rapport 2 — total SPP par type de lineup (${lineups.size} lineups settled) ===`);
+    lines.push("type".padEnd(28) + "n".padStart(6) + "moy SPP".padStart(10) + "med SPP".padStart(10));
+    for (const [label, xs] of Object.entries(buckets)) {
+      if (xs.length === 0) continue;
+      const sorted = [...xs].sort((a, b) => a - b);
+      lines.push(
+        label.padEnd(28) +
+          String(xs.length).padStart(6) +
+          String(round1(mean(xs))).padStart(10) +
+          String(pct(sorted, 50)).padStart(10),
+      );
+    }
+    lines.push(
+      "\nLecture : si 'stack premium' >> 'equilibre' en moy SPP, le meta " +
+        "favorise l'empilement -> un cap de composition au lineup se justifie.",
+    );
+  } else {
+    lines.push(
+      "\n(Rapport 2 ignore : FK lineup non detectee sur NflFantasyLineupStarter.)",
+    );
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(lines.join("\n"));
+}
+
+main()
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("[composition-report] echec:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void prisma.$disconnect();
+  });

--- a/apps/server/src/services/nfl-fantasy-lineup.test.ts
+++ b/apps/server/src/services/nfl-fantasy-lineup.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../prisma", () => ({
   prisma: {
-    nflFantasyEntry: { findUnique: vi.fn() },
+    nflFantasyEntry: { findUnique: vi.fn(), update: vi.fn() },
     nflFantasyLineup: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
@@ -14,6 +15,7 @@ vi.mock("../prisma", () => ({
       createMany: vi.fn(),
     },
     nflFantasyRoster: { findMany: vi.fn() },
+    nflPlayer: { findMany: vi.fn() },
     $transaction: vi.fn(),
   },
 }));
@@ -31,6 +33,8 @@ import {
   lockLineups,
   NflFantasyLineupError,
   setLineup,
+  updateEntryPlayStyle,
+  validateComposition,
   validateLineupStructure,
   VICE_CAPTAIN_MULTIPLIER,
 } from "./nfl-fantasy-lineup";
@@ -146,7 +150,9 @@ describe("validateLineupStructure", () => {
 
 describe("setLineup", () => {
   function happyMocks() {
-    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({ id: "e1" } as never);
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
     vi.mocked(prisma.nflFantasyLineup.findUnique)
       .mockResolvedValueOnce(null) // existence check
       .mockResolvedValueOnce({
@@ -161,7 +167,16 @@ describe("setLineup", () => {
     vi.mocked(prisma.nflFantasyRoster.findMany).mockResolvedValue(
       fakeStarters().map((s) => ({ playerId: s.playerId })) as never,
     );
-    vi.mocked(prisma.nflFantasyLineup.create).mockResolvedValue({ id: "l1" } as never);
+    // Resolution archetype : 1 QB (passer) + 10 OL (lineman) — conforme balanced.
+    vi.mocked(prisma.nflPlayer.findMany).mockResolvedValue(
+      fakeStarters().map((s, i) => ({
+        id: s.playerId,
+        nflPosition: i === 0 ? "QB" : "OL",
+      })) as never,
+    );
+    vi.mocked(prisma.nflFantasyLineup.create).mockResolvedValue({
+      id: "l1",
+    } as never);
   }
 
   it("cree un nouveau lineup si absent", async () => {
@@ -180,7 +195,9 @@ describe("setLineup", () => {
   });
 
   it("met a jour si lineup existe (non locked)", async () => {
-    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({ id: "e1" } as never);
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
     vi.mocked(prisma.nflFantasyLineup.findUnique)
       .mockResolvedValueOnce({ id: "l-existing", lockedAt: null } as never)
       .mockResolvedValueOnce({
@@ -189,6 +206,12 @@ describe("setLineup", () => {
       } as never);
     vi.mocked(prisma.nflFantasyRoster.findMany).mockResolvedValue(
       fakeStarters().map((s) => ({ playerId: s.playerId })) as never,
+    );
+    vi.mocked(prisma.nflPlayer.findMany).mockResolvedValue(
+      fakeStarters().map((s, i) => ({
+        id: s.playerId,
+        nflPosition: i === 0 ? "QB" : "OL",
+      })) as never,
     );
     vi.mocked(prisma.$transaction).mockResolvedValue([] as never);
 
@@ -204,8 +227,76 @@ describe("setLineup", () => {
     expect(prisma.nflFantasyLineup.create).not.toHaveBeenCalled();
   });
 
+  it("COMPOSITION_CAP_EXCEEDED si trop de receveurs pour le style", async () => {
+    // Entry en style 'balanced' (receiver cap 3). On aligne 5 WR.
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+      playStyle: "balanced",
+    } as never);
+    vi.mocked(prisma.nflFantasyLineup.findUnique).mockResolvedValue(null);
+    const starters = Array.from({ length: 11 }, (_, i) => ({
+      playerId: `p${i + 1}`,
+      bbPosition: "Catcher",
+    }));
+    vi.mocked(prisma.nflFantasyRoster.findMany).mockResolvedValue(
+      starters.map((s) => ({ playerId: s.playerId })) as never,
+    );
+    vi.mocked(prisma.nflPlayer.findMany).mockResolvedValue(
+      starters.map((s, i) => ({
+        id: s.playerId,
+        nflPosition: i < 5 ? "WR" : "OL", // 5 receveurs, 6 linemen
+      })) as never,
+    );
+
+    await expect(
+      setLineup({
+        entryId: "e1",
+        weekId: "2025:W10",
+        starters,
+        captainId: "p1",
+      }),
+    ).rejects.toThrow(/Composition invalide.*receveurs/);
+  });
+
+  it("accepte 6 receveurs en style air_raid", async () => {
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+      playStyle: "air_raid",
+    } as never);
+    vi.mocked(prisma.nflFantasyLineup.findUnique)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "l1", starters: [] } as never);
+    const starters = Array.from({ length: 11 }, (_, i) => ({
+      playerId: `p${i + 1}`,
+      bbPosition: "Catcher",
+    }));
+    vi.mocked(prisma.nflFantasyRoster.findMany).mockResolvedValue(
+      starters.map((s) => ({ playerId: s.playerId })) as never,
+    );
+    vi.mocked(prisma.nflPlayer.findMany).mockResolvedValue(
+      starters.map((s, i) => ({
+        id: s.playerId,
+        nflPosition: i < 6 ? "WR" : "OL", // 6 receveurs (cap air_raid), 5 linemen
+      })) as never,
+    );
+    vi.mocked(prisma.nflFantasyLineup.create).mockResolvedValue({
+      id: "l1",
+    } as never);
+
+    await expect(
+      setLineup({
+        entryId: "e1",
+        weekId: "2025:W10",
+        starters,
+        captainId: "p1",
+      }),
+    ).resolves.toBeDefined();
+  });
+
   it("LINEUP_LOCKED si lockedAt set", async () => {
-    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({ id: "e1" } as never);
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
     vi.mocked(prisma.nflFantasyLineup.findUnique).mockResolvedValue({
       id: "l1",
       lockedAt: new Date("2025-11-09T17:00:00Z"),
@@ -235,11 +326,15 @@ describe("setLineup", () => {
   });
 
   it("PLAYER_NOT_ON_ROSTER si un starter pas dans le roster", async () => {
-    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({ id: "e1" } as never);
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
     vi.mocked(prisma.nflFantasyLineup.findUnique).mockResolvedValue(null);
     // Roster ne contient que 10 des 11 starters
     vi.mocked(prisma.nflFantasyRoster.findMany).mockResolvedValue(
-      fakeStarters().slice(0, 10).map((s) => ({ playerId: s.playerId })) as never,
+      fakeStarters()
+        .slice(0, 10)
+        .map((s) => ({ playerId: s.playerId })) as never,
     );
 
     await expect(
@@ -327,6 +422,75 @@ describe("getLineup / isLineupLocked", () => {
   it("isLineupLocked false si lineup absent", async () => {
     vi.mocked(prisma.nflFantasyLineup.findUnique).mockResolvedValue(null);
     expect(await isLineupLocked({ entryId: "e1", weekId: "w" })).toBe(false);
+  });
+});
+
+describe("validateComposition (pur)", () => {
+  it("ne throw pas si conforme", () => {
+    expect(() =>
+      validateComposition({
+        archetypes: ["passer", "rusher", "rusher", "receiver", "lineman"],
+        playStyle: "balanced",
+      }),
+    ).not.toThrow();
+  });
+
+  it("throw COMPOSITION_CAP_EXCEEDED avec libelle FR si depassement", () => {
+    expect(() =>
+      validateComposition({
+        archetypes: ["receiver", "receiver", "receiver", "receiver"],
+        playStyle: "balanced",
+      }),
+    ).toThrow(/receveurs.*4\/3 max/);
+  });
+});
+
+describe("updateEntryPlayStyle", () => {
+  it("met a jour le style si pas de semaine lockee en attente", async () => {
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
+    vi.mocked(prisma.nflFantasyLineup.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.nflFantasyEntry.update).mockResolvedValue({
+      id: "e1",
+      playStyle: "offensive",
+    } as never);
+
+    const out = await updateEntryPlayStyle({
+      entryId: "e1",
+      playStyle: "offensive",
+    });
+    expect(out).toEqual({ id: "e1", playStyle: "offensive" });
+    expect(prisma.nflFantasyEntry.update).toHaveBeenCalledWith({
+      where: { id: "e1" },
+      data: { playStyle: "offensive" },
+      select: { id: true, playStyle: true },
+    });
+  });
+
+  it("rejette un style inconnu (INVALID_STARTERS)", async () => {
+    await expect(
+      updateEntryPlayStyle({ entryId: "e1", playStyle: "chaos" }),
+    ).rejects.toThrow(/Style de jeu inconnu/);
+  });
+
+  it("ENTRY_NOT_FOUND si entry absente", async () => {
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue(null);
+    await expect(
+      updateEntryPlayStyle({ entryId: "missing", playStyle: "defensive" }),
+    ).rejects.toThrow(/introuvable/);
+  });
+
+  it("LINEUP_LOCKED si une semaine verrouillee est en attente de resolution", async () => {
+    vi.mocked(prisma.nflFantasyEntry.findUnique).mockResolvedValue({
+      id: "e1",
+    } as never);
+    vi.mocked(prisma.nflFantasyLineup.findFirst).mockResolvedValue({
+      id: "l1",
+    } as never);
+    await expect(
+      updateEntryPlayStyle({ entryId: "e1", playStyle: "defensive" }),
+    ).rejects.toThrow(/non modifiable/);
   });
 });
 

--- a/apps/server/src/services/nfl-fantasy-lineup.ts
+++ b/apps/server/src/services/nfl-fantasy-lineup.ts
@@ -21,6 +21,17 @@
  */
 
 import type { NflFantasyLineup, NflFantasyLineupStarter } from "@prisma/client";
+import {
+  checkComposition,
+  coercePlayStyle,
+  getArchetypeFromBbPosition,
+  getArchetypeFromNflPosition,
+  isPlayStyle,
+  PLAY_STYLES,
+  type BbPosition,
+  type CompositionArchetype,
+  type PlayStyle,
+} from "@bb/nfl-mapper";
 
 import { prisma } from "../prisma";
 
@@ -40,6 +51,7 @@ export type NflFantasyLineupErrorCode =
   | "INVALID_LINEUP_SIZE"
   | "NO_PREVIOUS_LINEUP"
   | "ROSTER_TOO_DIVERGENT"
+  | "COMPOSITION_CAP_EXCEEDED"
   | "WEEK_NOT_FOUND";
 
 export class NflFantasyLineupError extends Error {
@@ -156,6 +168,61 @@ export function validateLineupStructure(opts: {
   }
 }
 
+/** Libelles FR des archetypes pour des messages d'erreur lisibles. */
+const ARCHETYPE_LABELS: Readonly<Record<CompositionArchetype, string>> = {
+  passer: "passeurs (QB)",
+  rusher: "coureurs (RB)",
+  receiver: "receveurs (WR/TE)",
+  lineman: "linemen",
+  frontSeven: "defenseurs (front 7)",
+  secondary: "defenseurs (secondary)",
+  bigGuy: "big guys (DT/NT)",
+};
+
+/**
+ * Resout l'archetype de composition d'un starter.
+ *
+ * Priorite au **poste NFL** (universel, race-agnostique) : un RB reste un
+ * `rusher` que sa race le mappe en Blitzer, Ulfwerener ou Bloodspawn. On
+ * retombe sur le poste BB seulement si le poste NFL est inconnu (vieux
+ * snapshots sans nflPosition en base).
+ */
+function resolveArchetype(
+  nflPosition: string | null | undefined,
+  bbPosition: string,
+): CompositionArchetype {
+  if (nflPosition && nflPosition.trim() !== "") {
+    return getArchetypeFromNflPosition(nflPosition);
+  }
+  return getArchetypeFromBbPosition(bbPosition as BbPosition);
+}
+
+/**
+ * Verifie que la composition du lineup respecte les plafonds du style de
+ * jeu de l'entry. Pur (pas d'I/O) : le caller fournit deja l'archetype
+ * resolu de chaque starter.
+ *
+ * Plafonds = max only sur les postes premium ; les fillers (lineman,
+ * defense) sont illimites → ne bloque jamais la faisabilite des 11.
+ *
+ * @throws NflFantasyLineupError(COMPOSITION_CAP_EXCEEDED) si un cap saute.
+ */
+export function validateComposition(opts: {
+  archetypes: readonly CompositionArchetype[];
+  playStyle: PlayStyle;
+}): void {
+  const violations = checkComposition(opts.archetypes, opts.playStyle);
+  if (violations.length === 0) return;
+
+  const detail = violations
+    .map((v) => `${ARCHETYPE_LABELS[v.archetype]} : ${v.count}/${v.cap} max`)
+    .join(", ");
+  throw new NflFantasyLineupError(
+    "COMPOSITION_CAP_EXCEEDED",
+    `Composition invalide pour le style "${opts.playStyle}" — ${detail}`,
+  );
+}
+
 // ────────────────────────────────────────────────────────────────────
 // API
 // ────────────────────────────────────────────────────────────────────
@@ -184,7 +251,9 @@ export async function getLineup(opts: {
  *
  * @throws NflFantasyLineupError pour toutes les violations
  */
-export async function setLineup(opts: SetLineupOpts): Promise<LineupWithStarters> {
+export async function setLineup(
+  opts: SetLineupOpts,
+): Promise<LineupWithStarters> {
   validateLineupStructure(opts);
 
   const entry = await prisma.nflFantasyEntry.findUnique({
@@ -225,6 +294,23 @@ export async function setLineup(opts: SetLineupOpts): Promise<LineupWithStarters
       );
     }
   }
+
+  // Validation composition : plafonds par archetype selon le style de jeu
+  // de l'entry. On resout l'archetype via le poste NFL d'origine (universel)
+  // en chargeant les NflPlayer correspondants. Fallback poste BB si absent.
+  const players: ReadonlyArray<{ id: string; nflPosition: string | null }> =
+    await prisma.nflPlayer.findMany({
+      where: { id: { in: opts.starters.map((s) => s.playerId) } },
+      select: { id: true, nflPosition: true },
+    });
+  const nflPosById = new Map(players.map((p) => [p.id, p.nflPosition]));
+  const archetypes = opts.starters.map((s) =>
+    resolveArchetype(nflPosById.get(s.playerId), s.bbPosition),
+  );
+  validateComposition({
+    archetypes,
+    playStyle: coercePlayStyle(entry.playStyle),
+  });
 
   // Upsert atomique du lineup + remplacement des starters
   const lineupId = existing?.id;
@@ -315,6 +401,63 @@ export async function lockLineups(weekId: string): Promise<LockLineupsResult> {
     defaultsCreated: ensured.defaultsCreated,
     defaultsTooSmall: ensured.defaultsTooSmall,
   };
+}
+
+/**
+ * Change le style de jeu d'une entry.
+ *
+ * Modifiable tant qu'aucun lineup de l'entry n'est encore locked sur une
+ * week non settlee : on autorise le changement si l'entry n'a pas de
+ * lineup `lockedAt != null && totalSpp == null` (= semaine en cours
+ * verrouillee mais pas encore resolue). Au-dela, le style est fige pour
+ * cette semaine pour eviter de contourner les caps apres le lock.
+ *
+ * Note : ce garde-fou est volontairement souple — les caps eux-memes sont
+ * re-valides a chaque setLineup, donc un changement de style ne peut jamais
+ * produire un lineup deja persiste non conforme.
+ *
+ * @throws NflFantasyLineupError(ENTRY_NOT_FOUND | INVALID_STARTERS | LINEUP_LOCKED)
+ */
+export async function updateEntryPlayStyle(opts: {
+  entryId: string;
+  playStyle: string;
+}): Promise<{ id: string; playStyle: PlayStyle }> {
+  if (!isPlayStyle(opts.playStyle)) {
+    throw new NflFantasyLineupError(
+      "INVALID_STARTERS",
+      `Style de jeu inconnu : "${opts.playStyle}" (attendu : ${PLAY_STYLES.join(", ")})`,
+    );
+  }
+
+  const entry = await prisma.nflFantasyEntry.findUnique({
+    where: { id: opts.entryId },
+    select: { id: true },
+  });
+  if (!entry) {
+    throw new NflFantasyLineupError(
+      "ENTRY_NOT_FOUND",
+      `Entry ${opts.entryId} introuvable`,
+    );
+  }
+
+  // Garde-fou : refuse si une semaine en cours est lockee mais pas settlee.
+  const lockedPending = await prisma.nflFantasyLineup.findFirst({
+    where: { entryId: opts.entryId, lockedAt: { not: null }, totalSpp: null },
+    select: { id: true },
+  });
+  if (lockedPending) {
+    throw new NflFantasyLineupError(
+      "LINEUP_LOCKED",
+      "Style de jeu non modifiable : une semaine verrouillee est en attente de resolution",
+    );
+  }
+
+  const updated = await prisma.nflFantasyEntry.update({
+    where: { id: opts.entryId },
+    data: { playStyle: opts.playStyle },
+    select: { id: true, playStyle: true },
+  });
+  return { id: updated.id, playStyle: coercePlayStyle(updated.playStyle) };
 }
 
 /**

--- a/apps/server/src/utils/nfl-error-mapper.ts
+++ b/apps/server/src/utils/nfl-error-mapper.ts
@@ -85,6 +85,7 @@ export function statusForCode(code: string): number {
     case "INVALID_WEEK_NUMBER":
     case "INVALID_LINEUP_SIZE":
     case "INVALID_STARTERS":
+    case "COMPOSITION_CAP_EXCEEDED":
     case "DUPLICATE_PLAYER":
     case "CAPTAIN_NOT_IN_STARTERS":
     case "VICE_NOT_IN_STARTERS":

--- a/apps/web/app/nfl-fantasy/leagues/[id]/lineup/PlayStyleSelector.test.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/lineup/PlayStyleSelector.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { PlayStyleSelector } from "./PlayStyleSelector";
+
+describe("PlayStyleSelector", () => {
+  it("affiche les 4 styles et marque l'actif", () => {
+    render(<PlayStyleSelector value="offensive" onChange={() => {}} />);
+
+    for (const style of ["balanced", "offensive", "air_raid", "defensive"]) {
+      expect(screen.getByTestId(`play-style-option-${style}`)).toBeTruthy();
+    }
+    expect(
+      screen
+        .getByTestId("play-style-option-offensive")
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByTestId("play-style-option-balanced")
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("coerce une valeur invalide vers balanced", () => {
+    render(<PlayStyleSelector value="garbage" onChange={() => {}} />);
+    expect(
+      screen
+        .getByTestId("play-style-option-balanced")
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("appelle onChange avec le style clique", () => {
+    const onChange = vi.fn();
+    render(<PlayStyleSelector value="balanced" onChange={onChange} />);
+    fireEvent.click(screen.getByTestId("play-style-option-air_raid"));
+    expect(onChange).toHaveBeenCalledWith("air_raid");
+  });
+
+  it("affiche les plafonds du style actif (air_raid : 6 receveurs max)", () => {
+    render(<PlayStyleSelector value="air_raid" onChange={() => {}} />);
+    expect(screen.getByTitle(/WR\/TE : 6 max/)).toBeTruthy();
+    expect(screen.getByText(/Linemen \/ défense ∞/)).toBeTruthy();
+  });
+
+  it("desactive les boutons quand disabled", () => {
+    const onChange = vi.fn();
+    render(<PlayStyleSelector value="balanced" onChange={onChange} disabled />);
+    const opt = screen.getByTestId(
+      "play-style-option-offensive",
+    ) as HTMLButtonElement;
+    expect(opt.disabled).toBe(true);
+    fireEvent.click(opt);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("affiche l'indicateur d'enregistrement", () => {
+    render(<PlayStyleSelector value="balanced" onChange={() => {}} saving />);
+    expect(screen.getByText("Enregistrement…")).toBeTruthy();
+  });
+});

--- a/apps/web/app/nfl-fantasy/leagues/[id]/lineup/PlayStyleSelector.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/lineup/PlayStyleSelector.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * Selecteur de style de jeu pour le lineup builder (Nuffle Coach).
+ *
+ * Le style definit les plafonds (max) de composition par archetype
+ * (cf. @bb/nfl-mapper PLAY_STYLE_CAPS). Mobile-first : controle segmente
+ * scrollable horizontalement sur petit ecran, grille sur desktop, + une
+ * carte recap des plafonds du style actif.
+ *
+ * Presentational pur : aucun fetch. Le parent gere la persistance (PATCH
+ * /play-style) et passe `disabled` quand le lineup est locked.
+ */
+import {
+  PLAY_STYLES,
+  PLAY_STYLE_CAPS,
+  coercePlayStyle,
+  type ArchetypeCaps,
+  type CompositionArchetype,
+  type PlayStyle,
+} from "@bb/nfl-mapper";
+
+interface StyleMeta {
+  readonly label: string;
+  readonly icon: string;
+  readonly tagline: string;
+}
+
+/** Metadonnees d'affichage par style (FR hardcode, cf. CLAUDE.md). */
+const STYLE_META: Readonly<Record<PlayStyle, StyleMeta>> = {
+  balanced: {
+    label: "Équilibré",
+    icon: "⚖️",
+    tagline: "Roster polyvalent, anti-stack léger.",
+  },
+  offensive: {
+    label: "Offensif",
+    icon: "🔥",
+    tagline: "Course et réception généreuses.",
+  },
+  air_raid: {
+    label: "Air Raid",
+    icon: "🎯",
+    tagline: "Jeu aérien extrême, course bridée.",
+  },
+  defensive: {
+    label: "Défensif",
+    icon: "🛡️",
+    tagline: "Offense limitée, mur défensif.",
+  },
+};
+
+/** Ordre + libelles des archetypes plafonnables affiches dans le recap. */
+const CAP_ARCHETYPES: ReadonlyArray<{
+  readonly key: CompositionArchetype;
+  readonly label: string;
+}> = [
+  { key: "passer", label: "QB" },
+  { key: "rusher", label: "RB" },
+  { key: "receiver", label: "WR/TE" },
+  { key: "bigGuy", label: "DT/NT" },
+];
+
+function capLabel(caps: ArchetypeCaps, key: CompositionArchetype): string {
+  const v = caps[key];
+  return v === undefined ? "∞" : `${v} max`;
+}
+
+interface PlayStyleSelectorProps {
+  readonly value: string | undefined;
+  readonly onChange: (style: PlayStyle) => void;
+  readonly disabled?: boolean;
+  readonly saving?: boolean;
+}
+
+export function PlayStyleSelector({
+  value,
+  onChange,
+  disabled = false,
+  saving = false,
+}: PlayStyleSelectorProps): JSX.Element {
+  const active = coercePlayStyle(value);
+  const caps = PLAY_STYLE_CAPS[active];
+
+  return (
+    <section
+      className="rounded-xl border border-nuffle-bronze/20 bg-white p-3 shadow-sm sm:p-4"
+      data-testid="play-style-selector"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-base font-semibold text-nuffle-anthracite">
+          Style de jeu
+        </h2>
+        {saving && (
+          <span className="text-xs text-nuffle-anthracite/50">
+            Enregistrement…
+          </span>
+        )}
+      </div>
+
+      {/* Controle segmente : scroll-x sur mobile, grille 4 cols sur sm+. */}
+      <div
+        className="mt-2 -mx-1 flex gap-2 overflow-x-auto px-1 pb-1 sm:mx-0 sm:grid sm:grid-cols-4 sm:overflow-visible sm:px-0"
+        role="radiogroup"
+        aria-label="Style de jeu"
+      >
+        {PLAY_STYLES.map((style) => {
+          const meta = STYLE_META[style];
+          const isActive = style === active;
+          return (
+            <button
+              key={style}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              disabled={disabled}
+              onClick={() => onChange(style)}
+              data-testid={`play-style-option-${style}`}
+              className={`flex min-w-[7.5rem] shrink-0 flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left transition-colors sm:min-w-0 ${
+                isActive
+                  ? "border-nuffle-gold bg-nuffle-gold/10"
+                  : "border-nuffle-bronze/25 bg-white hover:border-nuffle-gold/50"
+              } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+            >
+              <span className="text-sm font-semibold text-nuffle-anthracite">
+                <span aria-hidden>{meta.icon}</span> {meta.label}
+              </span>
+              <span className="text-[11px] leading-tight text-nuffle-anthracite/60">
+                {meta.tagline}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Recap des plafonds du style actif. */}
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        <span className="text-[11px] font-medium text-nuffle-anthracite/50">
+          Plafonds :
+        </span>
+        {CAP_ARCHETYPES.map(({ key, label }) => (
+          <span
+            key={key}
+            className="rounded-full bg-nuffle-ivory/60 px-2 py-0.5 text-[11px] font-medium text-nuffle-anthracite"
+            title={`${label} : ${capLabel(caps, key)}`}
+          >
+            {label} <strong>{capLabel(caps, key)}</strong>
+          </span>
+        ))}
+        <span
+          className="rounded-full bg-nuffle-ivory/40 px-2 py-0.5 text-[11px] text-nuffle-anthracite/70"
+          title="Linemen et défenseurs : illimités — un lineup de 11 reste toujours possible"
+        >
+          Linemen / défense ∞
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/nfl-fantasy/leagues/[id]/lineup/page.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/lineup/page.tsx
@@ -14,15 +14,35 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  checkComposition,
+  coercePlayStyle,
+  getArchetypeFromNflPosition,
+  type CompositionArchetype,
+  type PlayStyle,
+} from "@bb/nfl-mapper";
+
 import { apiRequest, ApiClientError } from "../../../../lib/api-client";
 import { WeekPicker, type WeekPickerOption } from "../WeekPicker";
 import { OpponentBanner } from "./OpponentBanner";
 import { PlayerCard } from "./PlayerCard";
+import { PlayStyleSelector } from "./PlayStyleSelector";
 import type {
   LeagueWithEntries,
   NflFantasyEntry,
   NflFantasyMatchup,
 } from "../../../types";
+
+/** Libelles FR des archetypes pour les messages de violation. */
+const ARCHETYPE_LABELS: Readonly<Record<CompositionArchetype, string>> = {
+  passer: "QB",
+  rusher: "RB",
+  receiver: "WR/TE",
+  lineman: "linemen",
+  frontSeven: "défense (front 7)",
+  secondary: "défense (secondary)",
+  bigGuy: "DT/NT",
+};
 
 interface NflPlayerInfo {
   id: string;
@@ -147,9 +167,14 @@ export default function LineupBuilderPage(): JSX.Element {
   const [captainId, setCaptainId] = useState<string | null>(null);
   const [viceCaptainId, setViceCaptainId] = useState<string | null>(null);
 
-  const [error, setError] = useState<{ message: string; status?: number } | null>(
-    null,
-  );
+  // Style de jeu : initialise depuis l'entry, modifiable hors lock.
+  const [playStyle, setPlayStyle] = useState<PlayStyle>("balanced");
+  const [savingStyle, setSavingStyle] = useState(false);
+
+  const [error, setError] = useState<{
+    message: string;
+    status?: number;
+  } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -165,7 +190,9 @@ export default function LineupBuilderPage(): JSX.Element {
     try {
       const [lg, me, wks] = await Promise.all([
         apiRequest<LeagueWithEntries>(`/api/nfl-fantasy/leagues/${leagueId}`),
-        apiRequest<MeResponse>("/auth/me").catch(() => ({ user: null }) as MeResponse),
+        apiRequest<MeResponse>("/auth/me").catch(
+          () => ({ user: null }) as MeResponse,
+        ),
         apiRequest<LeagueWeeksResponse>(
           `/api/nfl-fantasy/leagues/${leagueId}/weeks`,
         ).catch(
@@ -179,9 +206,10 @@ export default function LineupBuilderPage(): JSX.Element {
       }
       const userId = me.user?.id ?? null;
       const entry = userId
-        ? lg.entries.find((e) => e.userId === userId) ?? null
+        ? (lg.entries.find((e) => e.userId === userId) ?? null)
         : null;
       setMyEntry(entry);
+      if (entry) setPlayStyle(coercePlayStyle(entry.playStyle));
       setError(null);
 
       if (entry) {
@@ -329,6 +357,34 @@ export default function LineupBuilderPage(): JSX.Element {
     }
   }
 
+  async function onChangePlayStyle(next: PlayStyle): Promise<void> {
+    if (!myEntry || next === playStyle) return;
+    const previous = playStyle;
+    setPlayStyle(next); // optimiste
+    setSavingStyle(true);
+    setActionError(null);
+    try {
+      await apiRequest(`/api/nfl-fantasy/entries/${myEntry.id}/play-style`, {
+        method: "PATCH",
+        body: JSON.stringify({ playStyle: next }),
+      });
+      setMyEntry({ ...myEntry, playStyle: next });
+    } catch (err) {
+      setPlayStyle(previous); // rollback
+      if (err instanceof ApiClientError && err.code === "LINEUP_LOCKED") {
+        setActionError(
+          "Style non modifiable : une semaine verrouillée est en attente de résolution.",
+        );
+      } else {
+        setActionError(
+          err instanceof Error ? err.message : "Erreur changement de style",
+        );
+      }
+    } finally {
+      setSavingStyle(false);
+    }
+  }
+
   async function onSubmit(): Promise<void> {
     if (!myEntry) return;
     if (selected.size !== REQUIRED_STARTERS) {
@@ -337,6 +393,12 @@ export default function LineupBuilderPage(): JSX.Element {
     }
     if (!captainId) {
       setActionError("Choisis un captain.");
+      return;
+    }
+    if (hasCompositionViolation) {
+      setActionError(
+        "Composition hors style de jeu — ajuste tes titulaires ou ton style.",
+      );
       return;
     }
     setSubmitting(true);
@@ -381,10 +443,8 @@ export default function LineupBuilderPage(): JSX.Element {
     inSelection.sort((a, b) => {
       const aId = a.player!.id;
       const bId = b.player!.id;
-      const aRank =
-        aId === captainId ? 0 : aId === viceCaptainId ? 1 : 2;
-      const bRank =
-        bId === captainId ? 0 : bId === viceCaptainId ? 1 : 2;
+      const aRank = aId === captainId ? 0 : aId === viceCaptainId ? 1 : 2;
+      const bRank = bId === captainId ? 0 : bId === viceCaptainId ? 1 : 2;
       if (aRank !== bRank) return aRank - bRank;
       // tiebreak: par cote desc pour visibilite des meilleurs
       const av = a.player!.currentValue ?? 0;
@@ -396,9 +456,7 @@ export default function LineupBuilderPage(): JSX.Element {
   }, [roster, selected, captainId, viceCaptainId]);
 
   const availableRoster = useMemo(() => {
-    return roster.filter(
-      (r) => r.player && !selected.has(r.player.id),
-    );
+    return roster.filter((r) => r.player && !selected.has(r.player.id));
   }, [roster, selected]);
 
   // Liste des positions BB presentes dans le roster (pour chips filtre).
@@ -419,6 +477,18 @@ export default function LineupBuilderPage(): JSX.Element {
     }
     return counts;
   }, [selectedRoster]);
+
+  // Violations de composition vs style de jeu (live, cote client).
+  // Classification via le poste NFL (universel) — meme logique que le
+  // serveur. Les fillers (lineman/defense) ne sont jamais plafonnes.
+  const compositionViolations = useMemo(() => {
+    const archetypes: CompositionArchetype[] = selectedRoster.map((r) =>
+      getArchetypeFromNflPosition(r.player?.nflPosition ?? ""),
+    );
+    return checkComposition(archetypes, playStyle);
+  }, [selectedRoster, playStyle]);
+
+  const hasCompositionViolation = compositionViolations.length > 0;
 
   // Pipe filtre + tri sur la liste Available.
   const filteredAvailable = useMemo(() => {
@@ -472,7 +542,9 @@ export default function LineupBuilderPage(): JSX.Element {
   if (!myEntry) {
     return (
       <div className="rounded-lg border border-nuffle-bronze/20 bg-white p-6">
-        <h1 className="text-xl font-semibold">Tu n&apos;es pas membre de ce championnat</h1>
+        <h1 className="text-xl font-semibold">
+          Tu n&apos;es pas membre de ce championnat
+        </h1>
         <Link
           href={`/nfl-fantasy/leagues/${league.id}`}
           className="mt-4 inline-block text-sm text-nuffle-gold"
@@ -535,6 +607,14 @@ export default function LineupBuilderPage(): JSX.Element {
         matchup={matchup}
         myEntryId={myEntry.id}
         entries={league.entries}
+      />
+
+      {/* Style de jeu : definit les plafonds de composition. */}
+      <PlayStyleSelector
+        value={playStyle}
+        onChange={(s) => void onChangePlayStyle(s)}
+        disabled={locked || savingStyle}
+        saving={savingStyle}
       />
 
       {locked && (
@@ -608,10 +688,27 @@ export default function LineupBuilderPage(): JSX.Element {
               </div>
             )}
 
+            {hasCompositionViolation && (
+              <div
+                className="mt-2 rounded-md border border-red-300 bg-red-500/10 p-2.5 text-xs text-red-800"
+                role="alert"
+                data-testid="composition-violation"
+              >
+                <span className="font-semibold">Composition hors style :</span>{" "}
+                {compositionViolations
+                  .map(
+                    (v) =>
+                      `${ARCHETYPE_LABELS[v.archetype]} ${v.count}/${v.cap} max`,
+                  )
+                  .join(" · ")}
+                . Retire des titulaires ou change de style de jeu.
+              </div>
+            )}
+
             {selectedRoster.length === 0 ? (
               <p className="mt-3 rounded-md border border-dashed border-nuffle-bronze/20 px-3 py-6 text-center text-sm text-nuffle-anthracite/60">
-                Aucun starter sélectionné. Pick-toi 11 joueurs depuis le
-                banc ci-dessous, puis un captain.
+                Aucun starter sélectionné. Pick-toi 11 joueurs depuis le banc
+                ci-dessous, puis un captain.
               </p>
             ) : (
               <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -764,6 +861,10 @@ export default function LineupBuilderPage(): JSX.Element {
                     <p className="mt-0.5 truncate text-xs text-red-700">
                       {actionError}
                     </p>
+                  ) : hasCompositionViolation ? (
+                    <p className="mt-0.5 truncate text-xs text-red-700">
+                      Composition hors style de jeu
+                    </p>
                   ) : !captainId && selected.size > 0 ? (
                     <p className="mt-0.5 text-xs text-amber-700">
                       Choisis un captain pour valider
@@ -776,7 +877,8 @@ export default function LineupBuilderPage(): JSX.Element {
                     locked ||
                     submitting ||
                     selected.size !== REQUIRED_STARTERS ||
-                    !captainId
+                    !captainId ||
+                    hasCompositionViolation
                   }
                   className="shrink-0 rounded-md bg-nuffle-gold px-4 py-2.5 text-sm font-semibold text-nuffle-anthracite shadow-sm hover:bg-nuffle-gold/90 disabled:cursor-not-allowed disabled:bg-nuffle-bronze/20 disabled:text-nuffle-anthracite/40"
                   data-testid="lineup-submit"
@@ -895,4 +997,3 @@ function CarryOverBanner({
     </div>
   );
 }
-

--- a/apps/web/app/nfl-fantasy/types.ts
+++ b/apps/web/app/nfl-fantasy/types.ts
@@ -42,6 +42,12 @@ export interface NflFantasyEntry {
   userId: string;
   teamName: string;
   bbRace: string | null;
+  /**
+   * Style de jeu : definit les plafonds de composition de lineup par
+   * archetype (cf. @bb/nfl-mapper PLAY_STYLE_CAPS). Optionnel pour
+   * retro-compat pre-feature (defaut "balanced" cote serveur).
+   */
+  playStyle?: string;
   totalTV: number;
   /** V2 mercato : budget restant apres encheres remportees. */
   budgetRemaining?: number;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,13 +7,25 @@ const nextConfig = {
     typedRoutes: true,
     optimizePackageImports: ["@bb/ui", "@bb/game-engine"],
   },
-  transpilePackages: ["@bb/ui", "@bb/game-engine", "jose"],
+  transpilePackages: ["@bb/ui", "@bb/game-engine", "@bb/nfl-mapper", "jose"],
+  // @bb/nfl-mapper utilise des imports ESM NodeNext avec extension .js
+  // explicite (ex: "./position-to-bb.js") alors que la source est en .ts
+  // (resolue via tsconfig paths, pas de dist). Webpack ne sait pas mapper
+  // .js -> .ts par defaut : extensionAlias le lui apprend. Fallback sur
+  // les vrais fichiers .js (aucun impact sur les autres imports).
+  webpack: (config) => {
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias ?? {}),
+      ".js": [".ts", ".tsx", ".js"],
+    };
+    return config;
+  },
   // Optimisations SEO
   compress: true,
   poweredByHeader: false,
   // Optimisation des images
   images: {
-    formats: ['image/avif', 'image/webp'],
+    formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -6,8 +6,15 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@bb/game-engine": path.resolve(__dirname, "../../packages/game-engine/src"),
+      "@bb/game-engine": path.resolve(
+        __dirname,
+        "../../packages/game-engine/src",
+      ),
       "@bb/ui": path.resolve(__dirname, "../../packages/ui/src"),
+      "@bb/nfl-mapper": path.resolve(
+        __dirname,
+        "../../packages/nfl-mapper/src",
+      ),
     },
   },
   test: {

--- a/packages/nfl-mapper/src/archetype.test.ts
+++ b/packages/nfl-mapper/src/archetype.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getArchetypeFromNflPosition,
+  getArchetypeFromBbPosition,
+  getBbPosition,
+  NFL_POSITIONS,
+  type CompositionArchetype as PlayerArchetype,
+  type BbRace,
+} from './index.js';
+
+describe('getArchetypeFromNflPosition', () => {
+  it('maps offensive skill positions to fine archetypes', () => {
+    expect(getArchetypeFromNflPosition('QB')).toBe('passer');
+    expect(getArchetypeFromNflPosition('RB')).toBe('rusher');
+    expect(getArchetypeFromNflPosition('FB')).toBe('rusher');
+    expect(getArchetypeFromNflPosition('WR')).toBe('receiver');
+    expect(getArchetypeFromNflPosition('TE')).toBe('receiver');
+  });
+
+  it('maps O-line and kickers to lineman (filler)', () => {
+    for (const p of ['OL', 'C', 'G', 'OT', 'K', 'P']) {
+      expect(getArchetypeFromNflPosition(p)).toBe('lineman');
+    }
+  });
+
+  it('maps DT/NT to bigGuy (consistent with BB Big Guy mapping)', () => {
+    expect(getArchetypeFromNflPosition('DT')).toBe('bigGuy');
+    expect(getArchetypeFromNflPosition('NT')).toBe('bigGuy');
+  });
+
+  it('splits defense into frontSeven vs secondary', () => {
+    for (const p of ['DE', 'EDGE', 'LB', 'ILB', 'OLB', 'MLB']) {
+      expect(getArchetypeFromNflPosition(p)).toBe('frontSeven');
+    }
+    for (const p of ['CB', 'DB', 'S', 'SAF', 'FS', 'SS', 'NB']) {
+      expect(getArchetypeFromNflPosition(p)).toBe('secondary');
+    }
+  });
+
+  it('is case-insensitive and trims', () => {
+    expect(getArchetypeFromNflPosition('  qb ')).toBe('passer');
+    expect(getArchetypeFromNflPosition('Wr')).toBe('receiver');
+  });
+
+  it('falls back to lineman for unknown positions (never a premium slot)', () => {
+    expect(getArchetypeFromNflPosition('LS')).toBe('lineman');
+    expect(getArchetypeFromNflPosition('')).toBe('lineman');
+  });
+
+  it('classifies every canonical NFL position (exhaustive, no fallback leak)', () => {
+    // Aucun poste NFL canonique ne doit tomber sur le fallback "lineman"
+    // par accident, sauf ceux explicitement lineman (OL/C/G/OT/K/P).
+    const linemanPositions = new Set(['OL', 'C', 'G', 'OT', 'K', 'P']);
+    for (const p of NFL_POSITIONS) {
+      const a = getArchetypeFromNflPosition(p);
+      if (!linemanPositions.has(p)) {
+        expect(a).not.toBe('lineman');
+      }
+    }
+  });
+});
+
+describe('getArchetypeFromBbPosition (fallback)', () => {
+  it('maps unambiguous BB positions', () => {
+    expect(getArchetypeFromBbPosition('Thrower')).toBe('passer');
+    expect(getArchetypeFromBbPosition('Catcher')).toBe('receiver');
+    expect(getArchetypeFromBbPosition('Ghoul')).toBe('receiver');
+    expect(getArchetypeFromBbPosition('Lineman')).toBe('lineman');
+    expect(getArchetypeFromBbPosition('Blocker')).toBe('lineman');
+    expect(getArchetypeFromBbPosition('RatOgre')).toBe('bigGuy');
+    expect(getArchetypeFromBbPosition('Treeman')).toBe('bigGuy');
+  });
+
+  it('routes ambiguous specialists to frontSeven by default', () => {
+    expect(getArchetypeFromBbPosition('Blitzer')).toBe('frontSeven');
+    expect(getArchetypeFromBbPosition('Wardancer')).toBe('frontSeven');
+    expect(getArchetypeFromBbPosition('Berserker')).toBe('frontSeven');
+  });
+});
+
+describe('archetype is race-agnostic via NFL position', () => {
+  it('same NFL position yields same archetype across races (despite BB name divergence)', () => {
+    const races: BbRace[] = ['Human', 'Orc', 'WoodElf', 'Norse', 'Skaven'];
+    // WR maps to Catcher/Blitzer/GutterRunner/... selon la race, mais
+    // l'archetype derive du poste NFL doit rester 'receiver' partout.
+    for (const race of races) {
+      const bb = getBbPosition('WR', race);
+      // sanity: la race produit bien des noms BB differents
+      expect(typeof bb).toBe('string');
+      const arch: PlayerArchetype = getArchetypeFromNflPosition('WR');
+      expect(arch).toBe('receiver');
+    }
+  });
+});

--- a/packages/nfl-mapper/src/index.ts
+++ b/packages/nfl-mapper/src/index.ts
@@ -1,37 +1,49 @@
-export type {
-  BbRace,
-  NflTeamCode,
-  TeamMeta,
-  TeamPalette,
-} from './types.js';
-export { BB_RACES } from './types.js';
+export type { BbRace, NflTeamCode, TeamMeta, TeamPalette } from "./types.js";
+export { BB_RACES } from "./types.js";
 export {
   getAllTeams,
   getTeamMeta,
   getTeamsByRace,
   tryGetTeamMeta,
-} from './team-to-race.js';
+} from "./team-to-race.js";
 export type {
   BbPosition,
   BbPositionRole,
+  CompositionArchetype,
   NflPosition,
-} from './position-to-bb.js';
+} from "./position-to-bb.js";
 export {
   NFL_POSITIONS,
+  getArchetypeFromBbPosition,
+  getArchetypeFromNflPosition,
   getBbPosition,
   getBbPositionRole,
   getBbPositionsForRace,
-} from './position-to-bb.js';
+} from "./position-to-bb.js";
 export type {
   BbEventType,
   NflPlayerStatLine,
   SppBreakdown,
   SppEvent,
-} from './stats-to-spp.js';
-export { applyCaptainMultiplier, computeSpp } from './stats-to-spp.js';
-export type { PlayerArchetype, PseudonymOptions } from './pseudonymize.js';
+} from "./stats-to-spp.js";
+export { applyCaptainMultiplier, computeSpp } from "./stats-to-spp.js";
+export type { PlayerArchetype, PseudonymOptions } from "./pseudonymize.js";
 export {
   generatePseudonym,
   generateShortPseudonym,
   getDescriptor,
-} from './pseudonymize.js';
+} from "./pseudonymize.js";
+export type {
+  ArchetypeCaps,
+  CompositionViolation,
+  PlayStyle,
+} from "./lineup-composition.js";
+export {
+  DEFAULT_PLAY_STYLE,
+  PLAY_STYLES,
+  PLAY_STYLE_CAPS,
+  checkComposition,
+  coercePlayStyle,
+  getCapsForStyle,
+  isPlayStyle,
+} from "./lineup-composition.js";

--- a/packages/nfl-mapper/src/lineup-composition.test.ts
+++ b/packages/nfl-mapper/src/lineup-composition.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkComposition,
+  coercePlayStyle,
+  DEFAULT_PLAY_STYLE,
+  getCapsForStyle,
+  isPlayStyle,
+  PLAY_STYLES,
+  PLAY_STYLE_CAPS,
+  type PlayStyle,
+} from "./lineup-composition.js";
+import type { CompositionArchetype } from "./position-to-bb.js";
+
+/** Helper : repete un archetype n fois. */
+function rep(arch: CompositionArchetype, n: number): CompositionArchetype[] {
+  return Array.from({ length: n }, () => arch);
+}
+
+describe("PlayStyle guards", () => {
+  it("isPlayStyle reconnait les 4 styles", () => {
+    for (const s of PLAY_STYLES) expect(isPlayStyle(s)).toBe(true);
+  });
+
+  it("isPlayStyle rejette les valeurs inconnues", () => {
+    expect(isPlayStyle("chaos")).toBe(false);
+    expect(isPlayStyle(null)).toBe(false);
+    expect(isPlayStyle(42)).toBe(false);
+    expect(isPlayStyle(undefined)).toBe(false);
+  });
+
+  it("coercePlayStyle fallback sur balanced", () => {
+    expect(coercePlayStyle("offensive")).toBe("offensive");
+    expect(coercePlayStyle("garbage")).toBe(DEFAULT_PLAY_STYLE);
+    expect(coercePlayStyle(null)).toBe("balanced");
+  });
+});
+
+describe("PLAY_STYLE_CAPS invariants", () => {
+  it("definit les 4 styles", () => {
+    expect(Object.keys(PLAY_STYLE_CAPS).sort()).toEqual(
+      [...PLAY_STYLES].sort(),
+    );
+  });
+
+  it("ne plafonne JAMAIS les fillers (lineman/frontSeven/secondary)", () => {
+    // Garantie de faisabilite : ces archetypes doivent rester illimites
+    // pour qu'un coach puisse toujours completer 11 titulaires.
+    for (const style of PLAY_STYLES) {
+      const caps = PLAY_STYLE_CAPS[style];
+      expect(caps.lineman).toBeUndefined();
+      expect(caps.frontSeven).toBeUndefined();
+      expect(caps.secondary).toBeUndefined();
+    }
+  });
+
+  it("laisse assez de slots non plafonnes pour atteindre 11", () => {
+    // Somme des caps premium + fillers illimites doit permettre 11.
+    // Comme fillers = illimites, il suffit que les caps premium soient >= 0.
+    for (const style of PLAY_STYLES) {
+      const caps = PLAY_STYLE_CAPS[style];
+      const premiumMax = Object.values(caps).reduce((a, b) => a + (b ?? 0), 0);
+      // Au pire on remplit avec des fillers : 11 - premiumMax >= 0 pas requis
+      // (premium peut depasser 11 en theorie), mais on verifie qu'il existe
+      // au moins un archetype non plafonne (filler) pour completer.
+      expect(premiumMax).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("checkComposition", () => {
+  it("lineup conforme → aucune violation", () => {
+    // balanced: passer<=2 rusher<=3 receiver<=3 bigGuy<=2
+    const lineup: CompositionArchetype[] = [
+      ...rep("passer", 1),
+      ...rep("rusher", 2),
+      ...rep("receiver", 3),
+      ...rep("bigGuy", 1),
+      ...rep("lineman", 4), // filler illimite
+    ];
+    expect(checkComposition(lineup, "balanced")).toEqual([]);
+  });
+
+  it("detecte un depassement simple", () => {
+    const lineup = [...rep("receiver", 5), ...rep("lineman", 6)];
+    const v = checkComposition(lineup, "balanced"); // receiver cap 3
+    expect(v).toHaveLength(1);
+    expect(v[0]).toEqual({ archetype: "receiver", count: 5, cap: 3 });
+  });
+
+  it("detecte plusieurs depassements, tries par archetype", () => {
+    const lineup = [...rep("passer", 3), ...rep("rusher", 5)];
+    const v = checkComposition(lineup, "balanced"); // passer 2, rusher 3
+    expect(v).toHaveLength(2);
+    expect(v.map((x) => x.archetype)).toEqual(["passer", "rusher"]);
+  });
+
+  it("fillers jamais en violation meme en grand nombre", () => {
+    const lineup = [
+      ...rep("lineman", 6),
+      ...rep("frontSeven", 3),
+      ...rep("secondary", 2),
+    ];
+    expect(checkComposition(lineup, "defensive")).toEqual([]);
+  });
+
+  it("air_raid autorise 6 receveurs mais bride la course", () => {
+    const ok = [...rep("receiver", 6), ...rep("lineman", 5)];
+    expect(checkComposition(ok, "air_raid")).toEqual([]);
+
+    const tooManyRushers = [...rep("rusher", 2), ...rep("lineman", 9)];
+    const v = checkComposition(tooManyRushers, "air_raid"); // rusher cap 1
+    expect(v).toEqual([{ archetype: "rusher", count: 2, cap: 1 }]);
+  });
+
+  it("style invalide → coerce vers balanced (pas de crash)", () => {
+    const lineup = [...rep("receiver", 5), ...rep("lineman", 6)];
+    // 'garbage' coerce vers balanced (receiver cap 3) → violation
+    expect(checkComposition(lineup, "garbage")).toEqual([
+      { archetype: "receiver", count: 5, cap: 3 },
+    ]);
+  });
+
+  it("lineup vide → aucune violation", () => {
+    expect(checkComposition([], "offensive")).toEqual([]);
+  });
+
+  it("getCapsForStyle retourne le bon preset", () => {
+    expect(getCapsForStyle("defensive")).toBe(PLAY_STYLE_CAPS.defensive);
+    expect(getCapsForStyle("???" as PlayStyle)).toBe(PLAY_STYLE_CAPS.balanced);
+  });
+});

--- a/packages/nfl-mapper/src/lineup-composition.ts
+++ b/packages/nfl-mapper/src/lineup-composition.ts
@@ -1,0 +1,125 @@
+/**
+ * Caps de composition de lineup par "style de jeu" (Nuffle Coach).
+ *
+ * Game design (cf. session 2026-05-30) : pour eviter le meta degenere
+ * "11 postes offensifs premium empiles", le coach choisit un STYLE DE JEU
+ * en debut de saison. Ce style definit des PLAFONDS (max) par archetype.
+ *
+ * Principes :
+ *  - Ce sont des **maximums uniquement**, jamais des minimums. Un plafond
+ *    n'oblige jamais a aligner un joueur qu'on n'a pas → robuste aux
+ *    blessures (si ton QB se blesse, "max 2 passers" ne te force a rien).
+ *  - Seuls les archetypes **offensifs premium** sont plafonnes
+ *    (passer / rusher / receiver / bigGuy). Les fillers — lineman,
+ *    frontSeven, secondary — restent **non plafonnes** (absents du
+ *    tableau). Garantit qu'un coach peut TOUJOURS completer ses 11
+ *    titulaires meme avec un roster decime.
+ *  - Pur, deterministe, sans I/O : reutilisable cote serveur (validation
+ *    setLineup) et cote web (preview des caps dans l'UI).
+ *
+ * La classification d'un titulaire en archetype se fait via le **poste
+ * NFL** (`getArchetypeFromNflPosition`), pas le poste BB : un RB reste un
+ * `rusher` quelle que soit la race (Blitzer / Ulfwerener / Bloodspawn...).
+ */
+import type { CompositionArchetype } from "./position-to-bb.js";
+
+/**
+ * Styles de jeu disponibles. Choisis a la creation de l'entry, modifiable
+ * tant que la semaine en cours n'est pas lockee.
+ */
+export type PlayStyle = "balanced" | "offensive" | "air_raid" | "defensive";
+
+export const PLAY_STYLES: readonly PlayStyle[] = [
+  "balanced",
+  "offensive",
+  "air_raid",
+  "defensive",
+];
+
+/** Style par defaut si l'entry n'en a pas choisi (retro-compat pre-feature). */
+export const DEFAULT_PLAY_STYLE: PlayStyle = "balanced";
+
+/**
+ * Plafond par archetype. Une cle absente = archetype **non plafonne**
+ * (filler libre). On ne liste donc que les archetypes premium contraints.
+ */
+export type ArchetypeCaps = Partial<Record<CompositionArchetype, number>>;
+
+/**
+ * Tableau central des presets. Tuner ici pour ajuster le meta — une seule
+ * source de verite, partagee serveur + web.
+ *
+ * Plafonds exprimes sur 11 titulaires. lineman / frontSeven / secondary
+ * volontairement absents = illimites (faisabilite garantie).
+ */
+export const PLAY_STYLE_CAPS: Readonly<Record<PlayStyle, ArchetypeCaps>> = {
+  // Equilibre : casse le stack (max 3 receveurs + 3 rushers + 2 passers).
+  balanced: { passer: 2, rusher: 3, receiver: 3, bigGuy: 2 },
+  // Offensif : course/reception genereuses, reste cape pour eviter le full-stack.
+  offensive: { passer: 2, rusher: 4, receiver: 5, bigGuy: 2 },
+  // Air-raid : jeu aerien extreme (jusqu'a 6 receveurs) mais course bridee.
+  air_raid: { passer: 2, rusher: 1, receiver: 6, bigGuy: 1 },
+  // Defensif : offense limitee a 5 slots premium (1+2+2) → force la defense.
+  defensive: { passer: 1, rusher: 2, receiver: 2, bigGuy: 3 },
+};
+
+/** Type guard : true si `s` est un PlayStyle connu. */
+export function isPlayStyle(s: unknown): s is PlayStyle {
+  return (
+    typeof s === "string" && (PLAY_STYLES as readonly string[]).includes(s)
+  );
+}
+
+/**
+ * Normalise une valeur potentiellement nulle/inconnue (ex: champ DB
+ * optionnel) vers un PlayStyle valide. Fallback sur le style par defaut.
+ */
+export function coercePlayStyle(s: unknown): PlayStyle {
+  return isPlayStyle(s) ? s : DEFAULT_PLAY_STYLE;
+}
+
+/** Retourne les caps d'un style (tolerant aux valeurs invalides). */
+export function getCapsForStyle(style: unknown): ArchetypeCaps {
+  return PLAY_STYLE_CAPS[coercePlayStyle(style)];
+}
+
+/** Une violation de plafond detectee sur un lineup. */
+export interface CompositionViolation {
+  readonly archetype: CompositionArchetype;
+  readonly count: number;
+  readonly cap: number;
+}
+
+/**
+ * Verifie une liste d'archetypes (un par titulaire) contre les plafonds du
+ * style. Retourne la liste des violations (vide = lineup conforme).
+ *
+ * Pur : aucune exception levee, aucune I/O. Le caller decide quoi faire
+ * des violations (throw cote service, warning cote UI).
+ *
+ * @param archetypes - archetype de chaque titulaire (ordre indifferent)
+ * @param style - style de jeu de l'entry (tolerant : coerce si invalide)
+ */
+export function checkComposition(
+  archetypes: readonly CompositionArchetype[],
+  style: unknown,
+): readonly CompositionViolation[] {
+  const caps = getCapsForStyle(style);
+  const counts = new Map<CompositionArchetype, number>();
+  for (const a of archetypes) {
+    counts.set(a, (counts.get(a) ?? 0) + 1);
+  }
+
+  const violations: CompositionViolation[] = [];
+  for (const [arch, cap] of Object.entries(caps) as Array<
+    [CompositionArchetype, number]
+  >) {
+    const count = counts.get(arch) ?? 0;
+    if (count > cap) {
+      violations.push({ archetype: arch, count, cap });
+    }
+  }
+  // Ordre stable pour des messages d'erreur deterministes.
+  violations.sort((a, b) => a.archetype.localeCompare(b.archetype));
+  return violations;
+}

--- a/packages/nfl-mapper/src/position-to-bb.ts
+++ b/packages/nfl-mapper/src/position-to-bb.ts
@@ -100,6 +100,64 @@ export type BbPosition =
  */
 export type BbPositionRole = 'lineman' | 'specialist' | 'bigGuy';
 
+/**
+ * Archetype fin pour les caps de composition de lineup (option A : plafonner
+ * les postes premium plutot que forcer un plancher de linemen).
+ *
+ * Contrairement a `BbPositionRole` (3 buckets grossiers), l'archetype
+ * distingue les sous-roles offensifs/defensifs pour permettre des plafonds
+ * fins ("max 1 passer", "max 4 receveurs"). Il est derive du **poste NFL**
+ * (couche universelle : chaque equipe a un QB/RB/WR quelle que soit la race)
+ * et NON du poste BB — ce qui evite le probleme des noms divergents
+ * (Blitzer / Berserker / Wardancer sont tous des specialistes selon la race
+ * mais proviennent de postes NFL identiques).
+ *
+ * - `passer`     : QB
+ * - `rusher`     : RB, FB
+ * - `receiver`   : WR, TE
+ * - `lineman`    : OL/C/G/OT + K/P (filler bas-cout)
+ * - `frontSeven` : DE/EDGE/LB/ILB/OLB/MLB (defense front)
+ * - `secondary`  : CB/DB/S/SAF/FS/SS/NB (defense arriere)
+ * - `bigGuy`     : DT/NT (mappes Big Guy dans toutes les races)
+ */
+export type CompositionArchetype =
+  | 'passer'
+  | 'rusher'
+  | 'receiver'
+  | 'lineman'
+  | 'frontSeven'
+  | 'secondary'
+  | 'bigGuy';
+
+const NFL_POSITION_ARCHETYPE: Readonly<Record<NflPosition, CompositionArchetype>> = {
+  QB: 'passer',
+  RB: 'rusher',
+  FB: 'rusher',
+  WR: 'receiver',
+  TE: 'receiver',
+  OL: 'lineman',
+  C: 'lineman',
+  G: 'lineman',
+  OT: 'lineman',
+  K: 'lineman',
+  P: 'lineman',
+  DT: 'bigGuy',
+  NT: 'bigGuy',
+  DE: 'frontSeven',
+  EDGE: 'frontSeven',
+  LB: 'frontSeven',
+  ILB: 'frontSeven',
+  OLB: 'frontSeven',
+  MLB: 'frontSeven',
+  CB: 'secondary',
+  DB: 'secondary',
+  S: 'secondary',
+  SAF: 'secondary',
+  FS: 'secondary',
+  SS: 'secondary',
+  NB: 'secondary',
+};
+
 const POSITION_ROLE: Readonly<Record<BbPosition, BbPositionRole>> = {
   Lineman: 'lineman', Thrower: 'specialist', Catcher: 'specialist',
   Blitzer: 'specialist', Runner: 'specialist',
@@ -291,6 +349,69 @@ export function getBbPosition(nflPosition: string, race: BbRace): BbPosition {
  */
 export function getBbPositionRole(position: BbPosition): BbPositionRole {
   return POSITION_ROLE[position];
+}
+
+/**
+ * Archetype fin d'un poste NFL (source de verite des caps de composition).
+ * Insensible a la casse / au trim. Poste inconnu -> `lineman` (filler safe :
+ * un poste non reconnu ne doit jamais consommer un slot premium plafonne).
+ */
+export function getArchetypeFromNflPosition(nflPosition: string): CompositionArchetype {
+  const normalized = normalizeNflPosition(nflPosition);
+  const direct = (NFL_POSITION_ARCHETYPE as Record<string, CompositionArchetype | undefined>)[normalized];
+  return direct ?? 'lineman';
+}
+
+/**
+ * Fallback best-effort : archetype derive du poste BB quand le poste NFL
+ * d'origine n'est pas disponible (ex: vieux snapshots de lineup sans
+ * `nflPosition`). Plus grossier que `getArchetypeFromNflPosition` car le
+ * poste BB perd l'info offense/defense : les specialistes ambigus sont
+ * routes vers `frontSeven` par defaut. Preferer le poste NFL quand il existe.
+ */
+export function getArchetypeFromBbPosition(position: BbPosition): CompositionArchetype {
+  switch (position) {
+    case 'Thrower':
+      return 'passer';
+    case 'Catcher':
+    case 'Ghoul':
+      return 'receiver';
+    case 'Runner':
+    case 'GutterRunner':
+    case 'Werewolf':
+      return 'rusher';
+    case 'Lineman':
+    case 'Blocker':
+    case 'Zombie':
+    case 'Bloodseeker':
+    case 'Goblin':
+      return 'lineman';
+    case 'RatOgre':
+    case 'Treeman':
+    case 'Troll':
+    case 'Ogre':
+    case 'Yhetee':
+    case 'Deathroller':
+    case 'Bloodthirster':
+    case 'FleshGolem':
+      return 'bigGuy';
+    case 'Blitzer':
+    case 'StormVermin':
+    case 'BlackOrc':
+    case 'Wardancer':
+    case 'Berserker':
+    case 'Ulfwerener':
+    case 'Wight':
+    case 'Trollslayer':
+    case 'Khorngor':
+    case 'Bloodspawn':
+      return 'frontSeven';
+    default: {
+      const _exhaustive: never = position;
+      void _exhaustive;
+      return 'lineman';
+    }
+  }
 }
 
 /**

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2613,6 +2613,14 @@ model NflFantasyEntry {
   /// Race BB optionnelle (V2 variant "Pure BB"). null en V1 (Q5 = race
   /// fixe par equipe via NflPlayer.teamCode -> NflTeam.bbRace).
   bbRace    String?
+  /// Style de jeu choisi a la creation (modifiable tant que la semaine
+  /// courante n'est pas lockee). Definit les plafonds de composition de
+  /// lineup par archetype (PLAY_STYLE_CAPS dans @bb/nfl-mapper) :
+  /// "balanced" | "offensive" | "air_raid" | "defensive". Default
+  /// "balanced". Plafonds = max only sur les postes offensifs premium ;
+  /// les fillers (lineman/defense) restent illimites → 11 titulaires
+  /// toujours faisables meme avec des blessures.
+  playStyle String   @default("balanced")
   /// Total Team Value (somme des tvCost sur les NflFantasyRoster).
   /// Mis a jour par le service mercato Phase 2.F.
   totalTV   Int      @default(0)


### PR DESCRIPTION
## Contexte

Suite de la réflexion game design : empiler 11 postes offensifs premium surperforme un lineup équilibré (~**+76 %** de SPP médian en simulation sur le moteur `computeSpp`). Plutôt que de forcer un plancher de linemen (qui punit les coachs touchés par les blessures), le coach choisit un **style de jeu** qui définit des **plafonds (max)** par archétype, appliqués **au lineup** (pas au draft).

Cette PR contient le **backend** (caps + style) et la **UI mobile-first** associée.

## Principes de design

- **Plafonds = max only, jamais de minimum** → robuste aux blessures (si ton QB se blesse, « max 2 QB » ne te force à rien).
- **Seuls les postes offensifs premium sont plafonnés** (passer / rusher / receiver / bigGuy). Les fillers (lineman, front 7, secondary) restent **illimités** → un lineup de 11 titulaires reste **toujours** faisable.
- **Classification par poste NFL** (universel) : un RB reste `rusher` quelle que soit la race (Blitzer / Berserker / Wardancer / Bloodspawn…). Évite le problème des noms BB divergents.
- **Une seule source de vérité** : la logique pure (`@bb/nfl-mapper`) est partagée serveur (validation) + web (preview live).

## 4 styles (PLAY_STYLE_CAPS — un seul tableau à tuner)

| archétype | Équilibré | Offensif | Air Raid | Défensif |
|---|--|--|--|--|
| passer (QB) | 2 | 2 | 2 | 1 |
| rusher (RB) | 3 | 4 | 1 | 2 |
| receiver (WR/TE) | 3 | 5 | 6 | 2 |
| bigGuy (DT/NT) | 2 | 2 | 1 | 3 |
| lineman / front7 / secondary | ∞ | ∞ | ∞ | ∞ |

Style choisi à la création, **modifiable tant qu'aucune semaine verrouillée n'est en attente de résolution**.

## Backend

- **`@bb/nfl-mapper`** : `CompositionArchetype` (7 valeurs) + helpers (poste NFL → archétype) ; `PlayStyle`, `PLAY_STYLE_CAPS`, `checkComposition` (pur).
- **Prisma** : champ `playStyle` sur `NflFantasyEntry` (default `balanced`). ⚠️ géré via `prisma db push` (les modèles `Nfl*` n'ont pas de fichiers de migration).
- **Service lineup** : `validateComposition` + `updateEntryPlayStyle` + wiring dans `setLineup` (résout l'archétype via `NflPlayer.nflPosition`) ; code d'erreur `COMPOSITION_CAP_EXCEEDED` (422).
- **Route** : `PATCH /api/nfl-fantasy/entries/:entryId/play-style`.
- **Script read-only** `nfl-fantasy-composition-report.ts` : analyse les SPP réels par archétype + lineups équilibrés vs stacks. Lancement :
  ```
  pnpm --filter @bb/server exec tsx src/scripts/nfl-fantasy-composition-report.ts
  SEASON=2024 pnpm --filter @bb/server exec tsx src/scripts/nfl-fantasy-composition-report.ts
  ```

## UI (mobile-first)

- **`PlayStyleSelector`** : contrôle segmenté scrollable horizontalement sur mobile, grille 4 colonnes sur `sm+`, carte recap des plafonds (`∞` pour linemen/défense). Tokens `nuffle-*`, FR hardcodé (cf. CLAUDE.md).
- **Page lineup** : sélecteur câblé (PATCH optimiste + rollback sur `LINEUP_LOCKED`), **preview live des violations** via `checkComposition` (classification par poste NFL), bannière d'alerte rouge + **blocage du bouton Enregistrer** tant que la compo est hors style.
- **types web** : `playStyle?` optionnel sur `NflFantasyEntry` (rétro-compat).
- **`next.config`** : `@bb/nfl-mapper` ajouté à `transpilePackages` + `extensionAlias` webpack (`.js` → `.ts`) car le package utilise des imports ESM NodeNext. **Validé par un build de prod complet** (la page lineup compile, 11.1 kB).
- **`vitest.config`** : alias `@bb/nfl-mapper` pour les tests web.

## Tests

- `@bb/nfl-mapper` : **184** (dont `checkComposition`, archétypes).
- `@bb/server` NFL fantasy : **469** (cap exceeded, air_raid OK, `updateEntryPlayStyle`).
- `@bb/web` : **1192** (dont 6 nouveaux sur `PlayStyleSelector`).
- Typecheck serveur + web ✓ · **build de prod web ✓** · prettier ✓.

## Déploiement

- [ ] `prisma db push` (champ `playStyle`).

## Plan de test manuel

- [ ] Ouvrir `/nfl-fantasy/leagues/{id}/lineup`, vérifier le sélecteur de style sous l'adversaire.
- [ ] Changer de style (mobile + desktop) → persistance immédiate, recap des plafonds mis à jour.
- [ ] Sélectionner trop de receveurs pour le style → bannière rouge + bouton Enregistrer désactivé.
- [ ] Passer en Air Raid → 6 receveurs deviennent OK.
- [ ] Lineup lockée → sélecteur désactivé.

https://claude.ai/code/session_01NqACDMiYH8nveqbjREecL5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqACDMiYH8nveqbjREecL5)_