### PR TITLE
feat(nfl-fantasy): garde-fous transitions championnat (roster min + retour draft)

### DIFF
--- a/apps/server/src/routes/nfl-fantasy-leagues.ts
+++ b/apps/server/src/routes/nfl-fantasy-leagues.ts
@@ -36,7 +36,10 @@ import {
   DRAFT_BUDGET_MAX,
   DRAFT_BUDGET_MIN,
 } from "../services/nfl-fantasy-league";
-import { finalizeLeague } from "../services/nfl-fantasy-draft";
+import {
+  finalizeLeague,
+  revertLeagueToDraft,
+} from "../services/nfl-fantasy-draft";
 import { lockLineups } from "../services/nfl-fantasy-lineup";
 import { autoFillTestLineups } from "../services/nfl-fantasy-bot-lineup";
 import {
@@ -596,6 +599,27 @@ router.post(
     }
   },
 );
+
+/**
+ * POST /:id/test/revert-to-draft
+ *
+ * Repasse le championnat "in_progress" -> "draft" (mode test). Permet a
+ * l'owner de relancer la phase de draft/mercato tant qu'aucune journee
+ * n'est resolue. Garde cote service : status in_progress + aucun matchup
+ * settled (sinon WEEK_ALREADY_SETTLED 409).
+ */
+router.post("/:id/test/revert-to-draft", async (req, res) => {
+  try {
+    await assertOwnerAndTestMode(req as AuthenticatedRequest, req.params.id);
+    const result = await revertLeagueToDraft({ leagueId: req.params.id });
+    res.json(result);
+  } catch (err) {
+    if (!sendNflError(res, err)) {
+      serverLog.error("[nfl-fantasy-leagues] test/revert-to-draft failed", err);
+      res.status(500).json({ error: "Erreur serveur" });
+    }
+  }
+});
 
 /**
  * POST /:id/test/settle-week

--- a/apps/server/src/services/nfl-fantasy-draft.test.ts
+++ b/apps/server/src/services/nfl-fantasy-draft.test.ts
@@ -3,8 +3,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("../prisma", () => ({
   prisma: {
     nflFantasyLeague: { findUnique: vi.fn(), update: vi.fn() },
-    nflFantasyRoster: { findMany: vi.fn() },
+    nflFantasyRoster: { findMany: vi.fn(), groupBy: vi.fn() },
+    nflFantasyMatchup: { count: vi.fn(), deleteMany: vi.fn() },
     nflPlayer: { findMany: vi.fn() },
+    $transaction: vi.fn((ops: ReadonlyArray<Promise<unknown>>) =>
+      Promise.all(ops),
+    ),
   },
 }));
 
@@ -43,8 +47,24 @@ import {
   MAX_PLAYERS_PER_ENTRY,
   MIN_PLAYERS_PER_ENTRY,
   NflFantasyDraftError,
+  revertLeagueToDraft,
   seededShuffle,
 } from "./nfl-fantasy-draft";
+
+/**
+ * Helper : mock groupBy roster pour donner `count` joueurs a chaque
+ * entryId fourni. Les entries absentes du record simulent 0 joueur
+ * drafte (absentes du resultat groupBy reel). Permet de satisfaire (ou
+ * non) le garde-fou >=11 de finalizeLeague.
+ */
+function mockRosterCounts(counts: Record<string, number>): void {
+  vi.mocked(prisma.nflFantasyRoster.groupBy).mockResolvedValue(
+    Object.entries(counts).map(([entryId, n]) => ({
+      entryId,
+      _count: { _all: n },
+    })) as never,
+  );
+}
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -52,6 +72,11 @@ beforeEach(() => {
   // vi.mock factories, donc on les redeclare ici pour les mocks "always-on".
   vi.mocked(addPlayerToRoster).mockResolvedValue({} as never);
   vi.mocked(seedStartingRerolls).mockResolvedValue({ rerollsSeeded: 8 });
+  // resetAllMocks efface aussi l'implementation du $transaction declaree
+  // dans la factory vi.mock -> on la redeclare (passe-plat Promise.all).
+  vi.mocked(prisma.$transaction).mockImplementation((ops: unknown) =>
+    Promise.all(ops as ReadonlyArray<Promise<unknown>>),
+  );
 });
 
 // ────────────────────────────────────────────────────────────────────
@@ -220,6 +245,7 @@ describe("finalizeLeague", () => {
       status: "draft",
       entries: [{ id: "e1" }, { id: "e2" }, { id: "e3" }],
     } as never);
+    mockRosterCounts({ e1: 11, e2: 15, e3: 30 });
     vi.mocked(prisma.nflFantasyLeague.update).mockResolvedValue({} as never);
 
     const out = await finalizeLeague({ leagueId: "lg1" });
@@ -266,6 +292,101 @@ describe("finalizeLeague", () => {
     await expect(finalizeLeague({ leagueId: "lg1" })).rejects.toThrow(
       /sans entries/,
     );
+  });
+
+  it("INSUFFICIENT_ROSTER si un coach a moins de 11 joueurs", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue({
+      id: "lg1",
+      status: "draft",
+      entries: [{ id: "e1" }, { id: "e2" }],
+    } as never);
+    // e1 complet (11), e2 incomplet (10) -> blocage.
+    mockRosterCounts({ e1: 11, e2: 10 });
+
+    await expect(finalizeLeague({ leagueId: "lg1" })).rejects.toMatchObject({
+      code: "INSUFFICIENT_ROSTER",
+    });
+    // Ne doit PAS avoir transitionne le status.
+    expect(prisma.nflFantasyLeague.update).not.toHaveBeenCalled();
+  });
+
+  it("INSUFFICIENT_ROSTER si un coach n'a aucun joueur (absent du groupBy)", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue({
+      id: "lg1",
+      status: "draft",
+      entries: [{ id: "e1" }, { id: "e2" }],
+    } as never);
+    // e2 absent du resultat groupBy => 0 joueur => blocage.
+    mockRosterCounts({ e1: 12 });
+
+    await expect(finalizeLeague({ leagueId: "lg1" })).rejects.toMatchObject({
+      code: "INSUFFICIENT_ROSTER",
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// revertLeagueToDraft
+// ────────────────────────────────────────────────────────────────────
+
+describe("revertLeagueToDraft", () => {
+  it("repasse in_progress -> draft et supprime les matchups non-settled", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue({
+      id: "lg1",
+      status: "in_progress",
+    } as never);
+    vi.mocked(prisma.nflFantasyMatchup.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.nflFantasyMatchup.deleteMany).mockResolvedValue({
+      count: 6,
+    } as never);
+    vi.mocked(prisma.nflFantasyLeague.update).mockResolvedValue({} as never);
+
+    const out = await revertLeagueToDraft({ leagueId: "lg1" });
+
+    expect(out.status).toBe("draft");
+    expect(out.matchupsDeleted).toBe(6);
+    expect(prisma.nflFantasyMatchup.count).toHaveBeenCalledWith({
+      where: { leagueId: "lg1", settledAt: { not: null } },
+    });
+    expect(prisma.nflFantasyMatchup.deleteMany).toHaveBeenCalledWith({
+      where: { leagueId: "lg1" },
+    });
+    expect(prisma.nflFantasyLeague.update).toHaveBeenCalledWith({
+      where: { id: "lg1" },
+      data: { status: "draft" },
+    });
+  });
+
+  it("LEAGUE_NOT_FOUND si introuvable", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue(null);
+    await expect(
+      revertLeagueToDraft({ leagueId: "missing" }),
+    ).rejects.toMatchObject({ code: "LEAGUE_NOT_FOUND" });
+  });
+
+  it("INVALID_STATUS si pas en in_progress", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue({
+      id: "lg1",
+      status: "draft",
+    } as never);
+    await expect(
+      revertLeagueToDraft({ leagueId: "lg1" }),
+    ).rejects.toMatchObject({ code: "INVALID_STATUS" });
+  });
+
+  it("WEEK_ALREADY_SETTLED si une journee est resolue", async () => {
+    vi.mocked(prisma.nflFantasyLeague.findUnique).mockResolvedValue({
+      id: "lg1",
+      status: "in_progress",
+    } as never);
+    vi.mocked(prisma.nflFantasyMatchup.count).mockResolvedValue(1 as never);
+
+    await expect(
+      revertLeagueToDraft({ leagueId: "lg1" }),
+    ).rejects.toMatchObject({ code: "WEEK_ALREADY_SETTLED" });
+    // Ne doit ni supprimer ni transitionner.
+    expect(prisma.nflFantasyMatchup.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.nflFantasyLeague.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/src/services/nfl-fantasy-draft.ts
+++ b/apps/server/src/services/nfl-fantasy-draft.ts
@@ -35,7 +35,11 @@ export type NflFantasyDraftErrorCode =
   | "INVALID_STATUS"
   | "NO_ENTRIES"
   | "POOL_TOO_SMALL"
-  | "INVALID_PLAYERS_PER_ENTRY";
+  | "INVALID_PLAYERS_PER_ENTRY"
+  /** Au moins un coach a moins de MIN_PLAYERS_PER_ENTRY joueurs draftes. */
+  | "INSUFFICIENT_ROSTER"
+  /** Retour en draft impossible : une journee est deja resolue. */
+  | "WEEK_ALREADY_SETTLED";
 
 export class NflFantasyDraftError extends Error {
   constructor(
@@ -335,6 +339,30 @@ export async function finalizeLeague(
     );
   }
 
+  // Garde-fou (s'applique aussi en mode test) : tous les coachs doivent
+  // avoir au moins MIN_PLAYERS_PER_ENTRY joueurs draftes. Sinon ils ne
+  // peuvent pas composer de lineup valide (11 titulaires) et la saison
+  // est ingerable. Un seul round-trip via groupBy (cf. CLAUDE.md).
+  const entryIds = league.entries.map((e: { id: string }) => e.id);
+  const rosterCounts = await prisma.nflFantasyRoster.groupBy({
+    by: ["entryId"],
+    where: { entryId: { in: entryIds } },
+    _count: { _all: true },
+  });
+  const countByEntry = new Map<string, number>();
+  for (const c of rosterCounts) {
+    countByEntry.set(c.entryId, c._count?._all ?? 0);
+  }
+  const understaffed = entryIds.filter(
+    (id: string) => (countByEntry.get(id) ?? 0) < MIN_PLAYERS_PER_ENTRY,
+  );
+  if (understaffed.length > 0) {
+    throw new NflFantasyDraftError(
+      "INSUFFICIENT_ROSTER",
+      `${understaffed.length} coach(s) ont moins de ${MIN_PLAYERS_PER_ENTRY} joueurs draftes ; impossible de demarrer la saison (chaque coach doit pouvoir aligner 11 titulaires)`,
+    );
+  }
+
   let rerollsSeededTotal = 0;
   for (const e of league.entries) {
     const out = await seedStartingRerolls({ entryId: e.id });
@@ -360,6 +388,94 @@ export async function finalizeLeague(
     rerollsSeededTotal,
     matchupsCreated: matchupsTotals.created,
     weeksAlreadyPaired: matchupsTotals.alreadyPaired,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// revertLeagueToDraft
+// ────────────────────────────────────────────────────────────────────
+
+export interface RevertLeagueToDraftOpts {
+  readonly leagueId: string;
+}
+
+export interface RevertLeagueToDraftResult {
+  readonly leagueId: string;
+  readonly status: "draft";
+  /** Nb de matchups pre-generes supprimes lors du retour en draft. */
+  readonly matchupsDeleted: number;
+}
+
+/**
+ * Repasse un championnat `in_progress` -> `draft` (action mode test).
+ *
+ * Utile quand l'owner s'apercoit, juste apres avoir demarre, que la
+ * saison est mal configuree (roster incomplet, mauvais cycle, etc.) et
+ * veut relancer la phase de draft/mercato.
+ *
+ * Pre-conditions :
+ *   - League existe et status = "in_progress"
+ *   - AUCUNE journee resolue : aucun NflFantasyMatchup.settledAt non-null.
+ *     Une fois la 1ere journee resolue, des SPP/carrieres ont ete
+ *     attribues -> revenir en draft corromprait ces donnees.
+ *
+ * Side effects :
+ *   - delete des matchups pre-generes (tous non-settled, garanti par la
+ *     garde) pour permettre une regeneration propre au prochain demarrage
+ *   - update NflFantasyLeague.status -> "draft"
+ *   (les 2 dans une transaction atomique)
+ *
+ * Les rerolls de demarrage seedes par finalizeLeague sont conserves :
+ * seedStartingRerolls est idempotent, donc un nouveau demarrage ne les
+ * dupliquera pas.
+ *
+ * @throws NflFantasyDraftError
+ */
+export async function revertLeagueToDraft(
+  opts: RevertLeagueToDraftOpts,
+): Promise<RevertLeagueToDraftResult> {
+  const league = await prisma.nflFantasyLeague.findUnique({
+    where: { id: opts.leagueId },
+    select: { id: true, status: true },
+  });
+  if (!league) {
+    throw new NflFantasyDraftError(
+      "LEAGUE_NOT_FOUND",
+      `League ${opts.leagueId} introuvable`,
+    );
+  }
+  if (league.status !== "in_progress") {
+    throw new NflFantasyDraftError(
+      "INVALID_STATUS",
+      `League en status '${league.status}', retour en draft requiert 'in_progress'`,
+    );
+  }
+
+  const settledCount = await prisma.nflFantasyMatchup.count({
+    where: { leagueId: league.id, settledAt: { not: null } },
+  });
+  if (settledCount > 0) {
+    throw new NflFantasyDraftError(
+      "WEEK_ALREADY_SETTLED",
+      "Au moins une journee est deja resolue ; retour en draft impossible",
+    );
+  }
+
+  // Atomique : suppression des matchups + flip du status dans une seule
+  // transaction pour eviter une fenetre incoherente (matchups supprimes
+  // mais status encore in_progress) si le 2e write echoue.
+  const [deleted] = await prisma.$transaction([
+    prisma.nflFantasyMatchup.deleteMany({ where: { leagueId: league.id } }),
+    prisma.nflFantasyLeague.update({
+      where: { id: league.id },
+      data: { status: "draft" },
+    }),
+  ]);
+
+  return {
+    leagueId: league.id,
+    status: "draft",
+    matchupsDeleted: deleted.count,
   };
 }
 

--- a/apps/server/src/utils/nfl-error-mapper.test.ts
+++ b/apps/server/src/utils/nfl-error-mapper.test.ts
@@ -42,6 +42,7 @@ describe("statusForCode", () => {
       "REROLL_ALREADY_USED",
       "INDUCEMENT_LIMIT_REACHED",
       "LINEUP_LOCKED",
+      "WEEK_ALREADY_SETTLED",
     ];
     for (const c of conflicts) {
       expect(statusForCode(c)).toBe(409);
@@ -66,6 +67,7 @@ describe("statusForCode", () => {
       "NO_ENTRIES",
       "POOL_TOO_SMALL",
       "INVALID_PLAYERS_PER_ENTRY",
+      "INSUFFICIENT_ROSTER",
     ];
     for (const c of validations) {
       expect(statusForCode(c)).toBe(422);
@@ -154,6 +156,16 @@ describe("buildErrorResponse", () => {
         new NflFantasyDraftError("INVALID_PLAYERS_PER_ENTRY", "x"),
       )?.status,
     ).toBe(422);
+    expect(
+      buildErrorResponse(
+        new NflFantasyDraftError("INSUFFICIENT_ROSTER", "x"),
+      )?.status,
+    ).toBe(422);
+    expect(
+      buildErrorResponse(
+        new NflFantasyDraftError("WEEK_ALREADY_SETTLED", "x"),
+      )?.status,
+    ).toBe(409);
   });
 
   it("retourne null pour une erreur non typee", () => {

--- a/apps/server/src/utils/nfl-error-mapper.ts
+++ b/apps/server/src/utils/nfl-error-mapper.ts
@@ -74,6 +74,7 @@ export function statusForCode(code: string): number {
     case "ENTRY_NOT_IN_LEAGUE":
     case "CYCLE_ALREADY_STARTED":
     case "NO_JOINABLE_CYCLE":
+    case "WEEK_ALREADY_SETTLED":
       return 409;
 
     // 422 — validation metier
@@ -97,6 +98,7 @@ export function statusForCode(code: string): number {
     case "NO_ENTRIES":
     case "POOL_TOO_SMALL":
     case "INVALID_PLAYERS_PER_ENTRY":
+    case "INSUFFICIENT_ROSTER":
     case "PLAYER_NO_TEAM":
     case "INVALID_BB_RACE":
     case "INVALID_TEAM_COUNT":

--- a/apps/web/app/nfl-fantasy/leagues/[id]/TestModeControlPanel.tsx
+++ b/apps/web/app/nfl-fantasy/leagues/[id]/TestModeControlPanel.tsx
@@ -146,7 +146,26 @@ export default function TestModeControlPanel({
               ? "Demarrage…"
               : "Demarrer la saison (draft → in_progress)"}
           </button>
-          {!isDraft && (
+          {status === "in_progress" && (
+            <button
+              onClick={() =>
+                callAction(
+                  "Repasser en draft",
+                  "/test/revert-to-draft",
+                  false,
+                )
+              }
+              disabled={busy !== null}
+              className="mt-2 ml-2 rounded-md border border-amber-500 bg-white px-3 py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+              data-testid="test-revert-to-draft"
+              title="Repasse le championnat en draft (impossible une fois la premiere journee resolue)"
+            >
+              {busy === "Repasser en draft"
+                ? "Retour draft…"
+                : "Repasser en draft (in_progress → draft)"}
+            </button>
+          )}
+          {!isDraft && status !== "in_progress" && (
             <p className="mt-1 text-xs text-amber-900/60">
               Status actuel : {status}. Bouton dispo uniquement en
               &quot;draft&quot;.


### PR DESCRIPTION
Empeche le demarrage d'une saison (draft -> in_progress) si un coach a
moins de 11 joueurs draftes, y compris en mode test. La garde vit dans
finalizeLeague (groupBy roster par entry), donc elle couvre la route
owner /start-season comme le bouton mode test. Nouveau code
INSUFFICIENT_ROSTER (422).

Ajoute revertLeagueToDraft (in_progress -> draft) reserve au mode test,
bloque des qu'une journee est resolue (WEEK_ALREADY_SETTLED 409) pour ne
pas corrompre les SPP/carrieres deja attribues. Suppression des matchups
pre-generes + flip du status dans une transaction atomique. Nouvelle
route POST /:id/test/revert-to-draft (owner + flag nuffle_coach_test) et
bouton "Repasser en draft" dans le panel mode test.

Tests : INSUFFICIENT_ROSTER (sous-effectif + entry absente du groupBy),
revertLeagueToDraft (succes, INVALID_STATUS, WEEK_ALREADY_SETTLED),
mapping HTTP des 2 nouveaux codes. seedStartingRerolls est idempotent,
donc un cycle revert->restart ne double-seed pas les rerolls.