### PR TITLE
feat(league): block team withdraw after season start (Lot B)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -720,11 +720,32 @@ model LeagueSeason {
   rounds       LeagueRound[]
   matches      Match[]             @relation("LeagueSeasonMatches")
   award        LeagueSeasonAward?
+  // Lot C — poules optionnelles.
+  pools        LeaguePool[]
 
   @@unique([leagueId, seasonNumber])
   @@index([leagueId])
   @@index([status])
   @@index([theme, themeYear])
+}
+
+/// Lot C — Poule (mirror PG).
+model LeaguePool {
+  id                   String       @id @default(cuid())
+  season               LeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId             String
+  name                 String
+  order                Int          @default(0)
+  color                String?
+  qualifiesForPlayoffs Int          @default(0)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
+
+  participants LeagueParticipant[]
+  rounds       LeagueRound[]
+
+  @@unique([seasonId, name])
+  @@index([seasonId, order])
 }
 
 model LeagueParticipant {
@@ -753,10 +774,15 @@ model LeagueParticipant {
   homePairings LeaguePairing[] @relation("LeaguePairingHome")
   awayPairings LeaguePairing[] @relation("LeaguePairingAway")
 
+  // Lot C — affectation poule optionnelle (mirror PG).
+  pool   LeaguePool? @relation(fields: [poolId], references: [id], onDelete: SetNull)
+  poolId String?
+
   @@unique([seasonId, teamId])
   @@index([seasonId])
   @@index([teamId])
   @@index([seasonElo])
+  @@index([seasonId, poolId])
 }
 
 model LeagueRound {
@@ -776,11 +802,15 @@ model LeagueRound {
 
   matches  Match[]         @relation("LeagueRoundMatches")
   pairings LeaguePairing[]
+  // Lot C — round optionnellement rattache a une poule (mirror PG).
+  pool     LeaguePool? @relation(fields: [poolId], references: [id], onDelete: SetNull)
+  poolId   String?
 
   @@unique([seasonId, roundNumber])
   @@index([seasonId])
   @@index([status])
   @@index([seasonId, kind])
+  @@index([seasonId, poolId, roundNumber])
 }
 
 // Sprint Ligues v2 (PR1) — pairing pre-genere du calendrier round-robin.

--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -687,6 +687,8 @@ model League {
   /// Sprint R lot R.E.3 — mode "realtime" | "async". Mirror PG.
   matchMode         String   @default("realtime")
   turnDeadlineHours Int      @default(24)
+  /// Lot E — Points bonus configurables. JSON serialise (sqlite mirror).
+  bonusPointsConfig String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
@@ -798,6 +800,11 @@ model LeaguePairing {
   scheduledAt       DateTime?
   deadlineAt        DateTime?
   match             Match?
+  /// Lot E — Snapshot des points bonus appliques (mirror PG).
+  bonusPointsHome   Int               @default(0)
+  bonusPointsAway   Int               @default(0)
+  /// Lot E — Breakdown JSON serialise (sqlite mirror).
+  bonusBreakdown    String?
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -56,6 +56,7 @@ import careerStatsRoutes from "./routes/career-stats";
 import achievementsRoutes from "./routes/achievements";
 import coachRoutes from "./routes/coach";
 import leagueRoutes from "./routes/league";
+import leagueInvitationRoutes from "./routes/league-invitation";
 import { tutorialRouter, adminTutorialRouter } from "./routes/tutorial";
 import kofiRoutes from "./routes/kofi";
 import {
@@ -256,6 +257,9 @@ app.use("/career-stats", careerStatsRoutes);
 app.use("/achievements", achievementsRoutes);
 app.use("/coach", publicCache(), coachRoutes);
 app.use("/leagues", leagueRoutes);
+// Lot A — endpoints d'invitation (cree/liste/accepte/decline) et
+// autocomplete coachs. Monte sous /leagues pour partager le prefixe.
+app.use("/leagues", leagueInvitationRoutes);
 // S26 DoD — telemetrie tutoriel (mesure du KPI 80% completion).
 app.use("/tutorial", tutorialRouter);
 app.use("/admin/tutorial", adminTutorialRouter);

--- a/apps/server/src/routes/admin-leagues.ts
+++ b/apps/server/src/routes/admin-leagues.ts
@@ -35,6 +35,10 @@ import {
   type AdminLeagueStatusBody,
   type AdminLeagueTransferBody,
 } from "../schemas/admin-leagues.schemas";
+import {
+  withdrawParticipant,
+  LeagueWithdrawError,
+} from "../services/league";
 import { sendError, sendSuccess } from "../utils/api-response";
 import { serverLog } from "../utils/server-log";
 
@@ -309,6 +313,47 @@ export async function handlePatchLeagueMatchMode(
   sendSuccess(res, updated);
 }
 
+/**
+ * Lot B — POST /admin/leagues/seasons/:seasonId/participants/:teamId/force-withdraw
+ *
+ * Permet a un admin de retirer une equipe d'une saison meme apres
+ * son demarrage (cas de desistement tardif que le commissaire ne
+ * peut plus gerer via le flow standard). Cette action est auditee
+ * via `serverLog` (cf. CLAUDE.md — toute action commissaire
+ * destructive doit etre traceable).
+ */
+export async function handleAdminForceWithdraw(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const { seasonId, teamId } = req.params;
+  try {
+    const updated = await withdrawParticipant({
+      seasonId,
+      teamId,
+      force: true,
+    });
+    serverLog.info(
+      `[admin-leagues] force-withdraw: season=${seasonId} team=${teamId} by admin=${req.user?.id}`,
+    );
+    sendSuccess(res, updated);
+  } catch (e: unknown) {
+    if (e instanceof LeagueWithdrawError) {
+      const status =
+        e.code === "season_not_found" || e.code === "not_registered"
+          ? 404
+          : e.code === "season_completed"
+            ? 409
+            : 400;
+      sendError(res, e.message, status);
+      return;
+    }
+    const msg = e instanceof Error ? e.message : "Erreur serveur";
+    serverLog.error("[admin-leagues] force-withdraw failed:", msg);
+    sendError(res, msg, 500);
+  }
+}
+
 router.get(
   "/",
   validateQuery(adminLeaguesQuerySchema),
@@ -333,6 +378,13 @@ router.patch(
   "/:id/match-mode",
   validate(adminLeagueMatchModeSchema),
   handlePatchLeagueMatchMode,
+);
+
+// Lot B — retrait force d'une equipe par admin (bypass de la regle
+// "saison non demarree"). Tracable via serverLog.
+router.post(
+  "/seasons/:seasonId/participants/:teamId/force-withdraw",
+  handleAdminForceWithdraw,
 );
 
 export default router;

--- a/apps/server/src/routes/league-invitation.test.ts
+++ b/apps/server/src/routes/league-invitation.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Lot A — Tests des handlers de route pour les invitations.
+ *
+ * Mocke le service `league-invitation` + `user-lookup` + `prisma` ;
+ * verifie le bon mapping des erreurs typees vers les status HTTP
+ * et le bon enchainement permission/service.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../services/league-invitation", () => {
+  class LeagueInvitationError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "LeagueInvitationError";
+    }
+  }
+  return {
+    createInvitation: vi.fn(),
+    acceptInvitation: vi.fn(),
+    declineInvitation: vi.fn(),
+    cancelInvitation: vi.fn(),
+    listInvitationsForLeague: vi.fn(),
+    listPendingInvitationsForUser: vi.fn(),
+    getInvitationByCode: vi.fn(),
+    LeagueInvitationError,
+  };
+});
+
+vi.mock("../services/user-lookup", () => ({
+  searchUsersByCoachName: vi.fn(),
+}));
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    league: { findUnique: vi.fn() },
+    leagueParticipant: { findMany: vi.fn() },
+  },
+}));
+
+import {
+  handleCreateInvitation,
+  handleAcceptInvitation,
+  handleDeclineInvitation,
+  handleCancelInvitation,
+  handleListInvitations,
+  handleListMyInvitations,
+  handleGetInvitationByCode,
+  handleSearchCoaches,
+} from "./league-invitation";
+import {
+  createInvitation,
+  acceptInvitation,
+  declineInvitation,
+  cancelInvitation,
+  listInvitationsForLeague,
+  listPendingInvitationsForUser,
+  getInvitationByCode,
+} from "../services/league-invitation";
+import { searchUsersByCoachName } from "../services/user-lookup";
+import { prisma } from "../prisma";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSvc = {
+  createInvitation: createInvitation as ReturnType<typeof vi.fn>,
+  acceptInvitation: acceptInvitation as ReturnType<typeof vi.fn>,
+  declineInvitation: declineInvitation as ReturnType<typeof vi.fn>,
+  cancelInvitation: cancelInvitation as ReturnType<typeof vi.fn>,
+  listInvitationsForLeague: listInvitationsForLeague as ReturnType<typeof vi.fn>,
+  listPendingInvitationsForUser: listPendingInvitationsForUser as ReturnType<typeof vi.fn>,
+  getInvitationByCode: getInvitationByCode as ReturnType<typeof vi.fn>,
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSearch = searchUsersByCoachName as ReturnType<typeof vi.fn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+function createRes() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res: any = {};
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res;
+  });
+  res.json = vi.fn((p: unknown) => {
+    res.payload = p;
+    return res;
+  });
+  return res;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createReq(overrides: any = {}): any {
+  return {
+    body: {},
+    params: {},
+    query: {},
+    user: { id: "user-1", roles: ["user"] },
+    ...overrides,
+  };
+}
+
+describe("Lot A — routes league-invitation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("handleCreateInvitation", () => {
+    it("returns 404 when league not found", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue(null);
+      const req = createReq({
+        params: { leagueId: "league-X" },
+        body: { inviteeUserId: "coach-2" },
+      });
+      const res = createRes();
+      await handleCreateInvitation(req, res);
+      expect(res.statusCode).toBe(404);
+      expect(mockSvc.createInvitation).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when user is not creator nor admin", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "other-user",
+      });
+      const req = createReq({
+        params: { leagueId: "league-1" },
+        body: { inviteeUserId: "coach-2" },
+      });
+      const res = createRes();
+      await handleCreateInvitation(req, res);
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("creates invitation for the league creator", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "user-1",
+      });
+      mockSvc.createInvitation.mockResolvedValue({
+        id: "inv-1",
+        code: "abc",
+        status: "pending",
+      });
+      const req = createReq({
+        params: { leagueId: "league-1" },
+        body: {
+          inviteeUserId: "coach-2",
+          message: "Hello",
+          expiresInDays: 7,
+        },
+      });
+      const res = createRes();
+      await handleCreateInvitation(req, res);
+      expect(res.statusCode).toBe(201);
+      expect(mockSvc.createInvitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          leagueId: "league-1",
+          inviterUserId: "user-1",
+          inviteeUserId: "coach-2",
+          message: "Hello",
+        }),
+      );
+    });
+
+    it("maps season_not_found to 404", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "user-1",
+      });
+      const { LeagueInvitationError } = await import(
+        "../services/league-invitation"
+      );
+      mockSvc.createInvitation.mockRejectedValue(
+        new LeagueInvitationError("season_not_found", "nope"),
+      );
+      const req = createReq({
+        params: { leagueId: "league-1" },
+        body: { seasonId: "x" },
+      });
+      const res = createRes();
+      await handleCreateInvitation(req, res);
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("maps season_closed to 409", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "user-1",
+      });
+      const { LeagueInvitationError } = await import(
+        "../services/league-invitation"
+      );
+      mockSvc.createInvitation.mockRejectedValue(
+        new LeagueInvitationError("season_closed", "fermee"),
+      );
+      const req = createReq({
+        params: { leagueId: "league-1" },
+        body: { inviteeUserId: "coach-2" },
+      });
+      const res = createRes();
+      await handleCreateInvitation(req, res);
+      expect(res.statusCode).toBe(409);
+    });
+  });
+
+  describe("handleAcceptInvitation", () => {
+    it("returns 401 when not authenticated", async () => {
+      const req = createReq({ user: undefined });
+      const res = createRes();
+      await handleAcceptInvitation(req, res);
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("returns 200 on success", async () => {
+      mockSvc.acceptInvitation.mockResolvedValue({
+        invitation: { id: "i1", status: "accepted" },
+        participant: { id: "p1" },
+      });
+      const req = createReq({
+        params: { code: "abc" },
+        body: { teamId: "team-1" },
+      });
+      const res = createRes();
+      await handleAcceptInvitation(req, res);
+      expect(res.statusCode).toBe(200);
+      expect(mockSvc.acceptInvitation).toHaveBeenCalledWith({
+        code: "abc",
+        userId: "user-1",
+        teamId: "team-1",
+        seasonId: undefined,
+      });
+    });
+
+    it("maps invitation_expired to 409", async () => {
+      const { LeagueInvitationError } = await import(
+        "../services/league-invitation"
+      );
+      mockSvc.acceptInvitation.mockRejectedValue(
+        new LeagueInvitationError("invitation_expired", "expired"),
+      );
+      const req = createReq({
+        params: { code: "abc" },
+        body: { teamId: "t" },
+      });
+      const res = createRes();
+      await handleAcceptInvitation(req, res);
+      expect(res.statusCode).toBe(409);
+    });
+
+    it("maps team_not_owned_by_user to 403", async () => {
+      const { LeagueInvitationError } = await import(
+        "../services/league-invitation"
+      );
+      mockSvc.acceptInvitation.mockRejectedValue(
+        new LeagueInvitationError("team_not_owned_by_user", "not yours"),
+      );
+      const req = createReq({
+        params: { code: "abc" },
+        body: { teamId: "t" },
+      });
+      const res = createRes();
+      await handleAcceptInvitation(req, res);
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("handleDeclineInvitation", () => {
+    it("calls service and returns 200", async () => {
+      mockSvc.declineInvitation.mockResolvedValue({
+        id: "i1",
+        status: "declined",
+      });
+      const req = createReq({ params: { code: "abc" } });
+      const res = createRes();
+      await handleDeclineInvitation(req, res);
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("handleCancelInvitation", () => {
+    it("propagates isAdmin from req.user.roles", async () => {
+      mockSvc.cancelInvitation.mockResolvedValue({
+        id: "i1",
+        status: "cancelled",
+      });
+      const req = createReq({
+        params: { invitationId: "i1" },
+        user: { id: "admin-x", roles: ["user", "admin"] },
+      });
+      const res = createRes();
+      await handleCancelInvitation(req, res);
+      expect(mockSvc.cancelInvitation).toHaveBeenCalledWith({
+        invitationId: "i1",
+        byUserId: "admin-x",
+        isAdmin: true,
+      });
+    });
+  });
+
+  describe("handleListInvitations", () => {
+    it("requires commissioner", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "someone-else",
+      });
+      const req = createReq({ params: { leagueId: "league-1" } });
+      const res = createRes();
+      await handleListInvitations(req, res);
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("returns invitations for the commissioner", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        creatorId: "user-1",
+      });
+      mockSvc.listInvitationsForLeague.mockResolvedValue([
+        { id: "i1" },
+        { id: "i2" },
+      ]);
+      const req = createReq({ params: { leagueId: "league-1" } });
+      const res = createRes();
+      await handleListInvitations(req, res);
+      expect(res.statusCode).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = res.payload as any;
+      expect(payload.data.invitations).toHaveLength(2);
+    });
+  });
+
+  describe("handleListMyInvitations", () => {
+    it("returns 401 when not authenticated", async () => {
+      const req = createReq({ user: undefined });
+      const res = createRes();
+      await handleListMyInvitations(req, res);
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("calls listPendingInvitationsForUser", async () => {
+      mockSvc.listPendingInvitationsForUser.mockResolvedValue([{ id: "i1" }]);
+      const req = createReq();
+      const res = createRes();
+      await handleListMyInvitations(req, res);
+      expect(mockSvc.listPendingInvitationsForUser).toHaveBeenCalledWith(
+        "user-1",
+      );
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("handleGetInvitationByCode", () => {
+    it("returns 404 when not found", async () => {
+      mockSvc.getInvitationByCode.mockResolvedValue(null);
+      const req = createReq({ params: { code: "abc" } });
+      const res = createRes();
+      await handleGetInvitationByCode(req, res);
+      expect(res.statusCode).toBe(404);
+    });
+
+    it("returns invitation when found", async () => {
+      mockSvc.getInvitationByCode.mockResolvedValue({ id: "i1" });
+      const req = createReq({ params: { code: "abc" } });
+      const res = createRes();
+      await handleGetInvitationByCode(req, res);
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe("handleSearchCoaches", () => {
+    it("returns coaches with alreadyInSeason=false by default", async () => {
+      mockSearch.mockResolvedValue([
+        { id: "u2", coachName: "Bob" },
+        { id: "u3", coachName: "Carl" },
+      ]);
+      const req = createReq({ query: { q: "ob" } });
+      const res = createRes();
+      await handleSearchCoaches(req, res);
+      expect(res.statusCode).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = res.payload as any;
+      expect(payload.data.coaches).toHaveLength(2);
+      expect(payload.data.coaches[0]).toMatchObject({
+        id: "u2",
+        coachName: "Bob",
+        alreadyInSeason: false,
+      });
+    });
+
+    it("flags alreadyInSeason=true when seasonId filter matches", async () => {
+      mockSearch.mockResolvedValue([
+        { id: "u2", coachName: "Bob" },
+        { id: "u3", coachName: "Carl" },
+      ]);
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { team: { ownerId: "u3" } },
+      ]);
+      const req = createReq({ query: { q: "x", seasonId: "season-1" } });
+      const res = createRes();
+      await handleSearchCoaches(req, res);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = res.payload as any;
+      const carl = payload.data.coaches.find(
+        (c: { id: string }) => c.id === "u3",
+      );
+      expect(carl.alreadyInSeason).toBe(true);
+    });
+  });
+});

--- a/apps/server/src/routes/league-invitation.ts
+++ b/apps/server/src/routes/league-invitation.ts
@@ -1,0 +1,344 @@
+/**
+ * Lot A — Routes API pour les invitations de ligue.
+ *
+ * Endpoints :
+ *  - POST   /leagues/:leagueId/invitations         (commissaire)
+ *  - GET    /leagues/:leagueId/invitations         (commissaire)
+ *  - DELETE /leagues/invitations/:invitationId     (commissaire ou admin)
+ *  - GET    /leagues/invitations/:code             (public, info pre-acceptation)
+ *  - POST   /leagues/invitations/:code/accept      (authenticated)
+ *  - POST   /leagues/invitations/:code/decline     (authenticated)
+ *  - GET    /leagues/me/invitations                (authenticated, mes pending)
+ *  - GET    /leagues/coaches/search                (authenticated, autocomplete)
+ *
+ * Les erreurs typees du service sont mappees ici sur les status HTTP
+ * appropries (404 / 409 / 403 / 400).
+ */
+
+import { Router } from "express";
+import type { Response } from "express";
+import { authUser, type AuthenticatedRequest } from "../middleware/authUser";
+import { validate, validateQuery } from "../middleware/validate";
+import { prisma } from "../prisma";
+import { hasRole } from "../utils/roles";
+import {
+  createInvitation,
+  acceptInvitation,
+  declineInvitation,
+  cancelInvitation,
+  listInvitationsForLeague,
+  listPendingInvitationsForUser,
+  getInvitationByCode,
+  LeagueInvitationError,
+  type LeagueInvitationStatus,
+} from "../services/league-invitation";
+import { searchUsersByCoachName } from "../services/user-lookup";
+import {
+  createInvitationSchema,
+  acceptInvitationSchema,
+  searchCoachesQuerySchema,
+  type CreateInvitationBody,
+  type AcceptInvitationBody,
+  type SearchCoachesQuery,
+} from "../schemas/league-invitation.schemas";
+import { sendError, sendSuccess } from "../utils/api-response";
+import { serverLog } from "../utils/server-log";
+
+const router = Router();
+
+function requireUserId(
+  req: AuthenticatedRequest,
+  res: Response,
+): string | null {
+  const id = req.user?.id;
+  if (!id) {
+    sendError(res, "Non authentifie", 401);
+    return null;
+  }
+  return id;
+}
+
+function isAdminReq(req: AuthenticatedRequest): boolean {
+  return hasRole(req.user?.roles ?? [], "admin");
+}
+
+/**
+ * Verifie que l'user est createur de la ligue (ou admin). Retourne
+ * la ligue minimale ; ecrit la reponse d'erreur et retourne null si
+ * non autorise.
+ */
+async function requireCommissioner(
+  req: AuthenticatedRequest,
+  res: Response,
+  leagueId: string,
+): Promise<{ id: string; creatorId: string } | null> {
+  const userId = requireUserId(req, res);
+  if (!userId) return null;
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: { id: true, creatorId: true },
+  });
+  if (!league) {
+    sendError(res, "Ligue introuvable", 404);
+    return null;
+  }
+  if (league.creatorId !== userId && !isAdminReq(req)) {
+    sendError(res, "Seul le commissaire peut effectuer cette action", 403);
+    return null;
+  }
+  return league;
+}
+
+function mapInvitationError(res: Response, e: unknown): void {
+  if (e instanceof LeagueInvitationError) {
+    const status =
+      e.code === "league_not_found" ||
+      e.code === "season_not_found" ||
+      e.code === "invitation_not_found" ||
+      e.code === "team_not_found"
+        ? 404
+        : e.code === "season_closed" ||
+            e.code === "invitation_already_consumed" ||
+            e.code === "invitation_expired" ||
+            e.code === "team_already_registered" ||
+            e.code === "league_full"
+          ? 409
+          : e.code === "forbidden" ||
+              e.code === "invitation_not_for_user" ||
+              e.code === "team_not_owned_by_user"
+            ? 403
+            : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  const msg = e instanceof Error ? e.message : "Erreur inconnue";
+  serverLog.error("[league-invitation]", msg);
+  sendError(res, msg, 500);
+}
+
+/** POST /leagues/:leagueId/invitations — commissaire cree une invitation. */
+export async function handleCreateInvitation(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const leagueId = req.params.leagueId;
+  const league = await requireCommissioner(req, res, leagueId);
+  if (!league) return;
+  const body = req.body as CreateInvitationBody;
+  try {
+    const inv = await createInvitation({
+      leagueId,
+      inviterUserId: req.user!.id,
+      seasonId: body.seasonId ?? null,
+      inviteeUserId: body.inviteeUserId ?? null,
+      inviteeEmail: body.inviteeEmail ?? null,
+      inviteeTeamId: body.inviteeTeamId ?? null,
+      message: body.message ?? null,
+      expiresInDays: body.expiresInDays,
+    });
+    serverLog.info(
+      `[league-invitation] created: league=${leagueId} code=${inv.code} by=${req.user?.id}`,
+    );
+    sendSuccess(res, inv, 201);
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/** GET /leagues/:leagueId/invitations — commissaire liste les invitations. */
+export async function handleListInvitations(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const leagueId = req.params.leagueId;
+  const league = await requireCommissioner(req, res, leagueId);
+  if (!league) return;
+  const status = (req.query.status as string | undefined) as
+    | LeagueInvitationStatus
+    | undefined;
+  try {
+    const items = await listInvitationsForLeague({ leagueId, status });
+    sendSuccess(res, { invitations: items });
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/** DELETE /leagues/invitations/:invitationId — annulation. */
+export async function handleCancelInvitation(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await cancelInvitation({
+      invitationId: req.params.invitationId,
+      byUserId: userId,
+      isAdmin: isAdminReq(req),
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/**
+ * GET /leagues/invitations/:code — vue publique de l'invitation (pour
+ * la page d'acceptation). Pas d'auth requise car le code lui-meme
+ * agit comme bearer.
+ */
+export async function handleGetInvitationByCode(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const code = req.params.code;
+  try {
+    const inv = await getInvitationByCode(code);
+    if (!inv) {
+      sendError(res, "Invitation introuvable", 404);
+      return;
+    }
+    sendSuccess(res, inv);
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/** POST /leagues/invitations/:code/accept. */
+export async function handleAcceptInvitation(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as AcceptInvitationBody;
+  try {
+    const out = await acceptInvitation({
+      code: req.params.code,
+      userId,
+      teamId: body.teamId,
+      seasonId: body.seasonId,
+    });
+    serverLog.info(
+      `[league-invitation] accepted: code=${req.params.code} by=${userId} team=${body.teamId}`,
+    );
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/** POST /leagues/invitations/:code/decline. */
+export async function handleDeclineInvitation(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await declineInvitation({ code: req.params.code, userId });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/** GET /leagues/me/invitations — invitations pending recues par l'user courant. */
+export async function handleListMyInvitations(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const items = await listPendingInvitationsForUser(userId);
+    sendSuccess(res, { invitations: items });
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+/**
+ * GET /leagues/coaches/search?q=...&limit=...&seasonId=...
+ *
+ * Autocomplete : retourne les coaches (User) qui matchent par
+ * coachName. Optionnellement, exclut les coaches dont une equipe
+ * est deja inscrite a la saison `seasonId` (utile pour l'UI
+ * "inviter de nouveaux coaches").
+ *
+ * Reservee aux users authentifies (anti-scraping cote API publique).
+ */
+export async function handleSearchCoaches(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const query = req.query as unknown as SearchCoachesQuery;
+  try {
+    const results = await searchUsersByCoachName(query.q, query.limit ?? 10);
+
+    // Si seasonId fourni, exclure les coaches deja inscrits via une
+    // de leurs equipes. groupBy pour eviter N+1 (cf. CLAUDE.md).
+    let excluded = new Set<string>();
+    if (query.seasonId && results.length > 0) {
+      const teams = (await prisma.leagueParticipant.findMany({
+        where: {
+          seasonId: query.seasonId,
+          status: "active",
+          team: { ownerId: { in: results.map((r) => r.id) } },
+        },
+        select: { team: { select: { ownerId: true } } },
+      })) as Array<{ team: { ownerId: string } | null }>;
+      excluded = new Set(
+        teams
+          .map((t) => t.team?.ownerId)
+          .filter((id): id is string => typeof id === "string"),
+      );
+    }
+
+    sendSuccess(res, {
+      coaches: results.map((r) => ({
+        id: r.id,
+        coachName: r.coachName,
+        alreadyInSeason: excluded.has(r.id),
+      })),
+    });
+  } catch (e: unknown) {
+    mapInvitationError(res, e);
+  }
+}
+
+// ---- Bindings ----
+
+router.post(
+  "/:leagueId/invitations",
+  authUser,
+  validate(createInvitationSchema),
+  handleCreateInvitation,
+);
+router.get("/:leagueId/invitations", authUser, handleListInvitations);
+router.delete(
+  "/invitations/:invitationId",
+  authUser,
+  handleCancelInvitation,
+);
+router.get("/me/invitations", authUser, handleListMyInvitations);
+router.get("/invitations/:code", handleGetInvitationByCode); // public
+router.post(
+  "/invitations/:code/accept",
+  authUser,
+  validate(acceptInvitationSchema),
+  handleAcceptInvitation,
+);
+router.post("/invitations/:code/decline", authUser, handleDeclineInvitation);
+router.get(
+  "/coaches/search",
+  authUser,
+  validateQuery(searchCoachesQuerySchema),
+  handleSearchCoaches,
+);
+
+export default router;
+export { router as leagueInvitationRouter };

--- a/apps/server/src/routes/league.test.ts
+++ b/apps/server/src/routes/league.test.ts
@@ -25,6 +25,17 @@ vi.mock("../services/league", () => ({
   parseAllowedRosters: vi.fn((raw: string | null) =>
     raw ? (JSON.parse(raw) as string[]) : null,
   ),
+  // Lot B — class d'erreur reelle (DANS la factory pour eviter
+  // "Cannot access before initialization") ; cf CLAUDE.md.
+  LeagueWithdrawError: class LeagueWithdrawError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "LeagueWithdrawError";
+    }
+  },
 }));
 
 vi.mock("../prisma", () => ({
@@ -684,6 +695,51 @@ describe("Route: POST /leagues/seasons/:seasonId/leave", () => {
       teamId: "team-1",
     });
     expect(res.statusCode).toBe(200);
+  });
+
+  // Lot B — mappe LeagueWithdrawError(season_started) sur HTTP 409.
+  it("returns 409 when season has already started", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "user-1",
+    });
+    // Cast via le mock module pour recuperer la class injectee dans
+    // la factory du vi.mock ci-dessus.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const services = (await import("../services/league")) as any;
+    mockService.withdrawParticipant.mockImplementation(() => {
+      throw new services.LeagueWithdrawError(
+        "season_started",
+        "Saison demarree",
+      );
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleLeaveSeason(req, res);
+    expect(res.statusCode).toBe(409);
+  });
+
+  // Lot B — mappe LeagueWithdrawError(not_registered) sur HTTP 404.
+  it("returns 404 when team not registered", async () => {
+    mockPrisma.team.findUnique.mockResolvedValue({
+      id: "team-1",
+      ownerId: "user-1",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const services = (await import("../services/league")) as any;
+    mockService.withdrawParticipant.mockImplementation(() => {
+      throw new services.LeagueWithdrawError("not_registered", "not in season");
+    });
+    const req = createReq({
+      params: { seasonId: "season-1" },
+      body: { teamId: "team-1" },
+    });
+    const res = createRes();
+    await handleLeaveSeason(req, res);
+    expect(res.statusCode).toBe(404);
   });
 });
 

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -49,7 +49,11 @@ import {
   computeSeasonRecap,
   getPersistedSeasonAward,
 } from "../services/league-scoring";
-import { startPlayoffs } from "../services/league-playoffs";
+import {
+  startPlayoffs,
+  overridePlayoffParticipants,
+  PlayoffOverrideError,
+} from "../services/league-playoffs";
 import {
   createManualRound,
   createManualPairing,
@@ -174,6 +178,20 @@ function domainError(res: Response, e: unknown): void {
             e.code === "pool_name_taken" ||
             e.code === "pool_not_empty" ||
             e.code === "participant_not_in_season"
+          ? 409
+          : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  // Lot D — playoff override errors.
+  if (e instanceof PlayoffOverrideError) {
+    const status =
+      e.code === "season_not_found" || e.code === "playoffs_not_started"
+        ? 404
+        : e.code === "playoffs_in_progress" ||
+            e.code === "duplicate_participant" ||
+            e.code === "size_mismatch" ||
+            e.code === "participant_not_active"
           ? 409
           : 400;
     sendError(res, e.message, status);
@@ -1110,6 +1128,45 @@ export async function handleAutoAssignPools(
   }
 }
 
+// ===========================================================
+// Lot D — override des participants du bracket playoffs.
+// ===========================================================
+
+/**
+ * PATCH /leagues/seasons/:seasonId/playoff-bracket/participants
+ *
+ * Le commissaire fournit la liste complete des seeds du bracket
+ * (taille = playoffSize). Le service refuse si un match du round 1
+ * a deja ete lance / joue.
+ */
+export async function handleOverridePlayoffParticipants(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return;
+  const body = req.body as { participantIds: string[] };
+  if (
+    !body ||
+    !Array.isArray(body.participantIds) ||
+    body.participantIds.length === 0
+  ) {
+    sendError(res, "participantIds[] requis", 400);
+    return;
+  }
+  try {
+    const out = await overridePlayoffParticipants({
+      seasonId,
+      participantIds: body.participantIds,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
 /**
  * L2.A.3 — Ouvre une saison aux inscriptions (`draft -> scheduled`).
  * Reserve au createur de la ligue. No-op si deja `scheduled`.
@@ -1639,6 +1696,14 @@ router.patch(
   handleUpdatePool,
 );
 router.delete("/pools/:poolId", authUser, handleDeletePool);
+
+// Lot D — override des participants du bracket (avant le 1er match
+// playoff joue). Permet de gerer un desistement tardif.
+router.patch(
+  "/seasons/:seasonId/playoff-bracket/participants",
+  authUser,
+  handleOverridePlayoffParticipants,
+);
 // L2.A.3 — Routes admin saison (ouverture inscriptions, demarrage,
 // regeneration calendrier, cloture forcee). Reservees au createur.
 router.post("/seasons/:seasonId/open", authUser, handleOpenSeason);

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -50,6 +50,21 @@ import {
 } from "../services/league-scoring";
 import { startPlayoffs } from "../services/league-playoffs";
 import {
+  createManualRound,
+  createManualPairing,
+  deleteManualPairing,
+  updateManualPairing,
+  LeagueManualPairingError,
+} from "../services/league-manual-pairing";
+import {
+  createManualRoundSchema,
+  createManualPairingSchema,
+  updateManualPairingSchema,
+  type CreateManualRoundBody,
+  type CreateManualPairingBody,
+  type UpdateManualPairingBody,
+} from "../schemas/league-manual-pairing.schemas";
+import {
   playMecene,
   LeaguePatronError,
 } from "../services/league-patron";
@@ -125,6 +140,23 @@ function domainError(res: Response, e: unknown): void {
       e.code === "season_not_found" || e.code === "not_registered"
         ? 404
         : e.code === "season_started" || e.code === "season_completed"
+          ? 409
+          : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  // Lot F — manual pairing errors.
+  if (e instanceof LeagueManualPairingError) {
+    const status =
+      e.code === "round_not_found" ||
+      e.code === "season_not_found" ||
+      e.code === "pairing_not_found" ||
+      e.code === "participant_not_found"
+        ? 404
+        : e.code === "duplicate_pairing" ||
+            e.code === "pairing_already_played" ||
+            e.code === "round_completed" ||
+            e.code === "participant_not_active"
           ? 409
           : 400;
     sendError(res, e.message, status);
@@ -748,6 +780,145 @@ async function ensureLeagueCreator(
 }
 
 /**
+ * Lot F — variante de `ensureLeagueCreator` qui resout le seasonId
+ * a partir d'un roundId. Utilisee par les handlers de creation
+ * manuelle de pairings.
+ */
+async function ensureLeagueCreatorByRound(
+  userId: string,
+  roundId: string,
+  res: Response,
+): Promise<{ seasonId: string } | null> {
+  const round = await prisma.leagueRound.findUnique({
+    where: { id: roundId },
+    select: { id: true, seasonId: true },
+  });
+  if (!round) {
+    sendError(res, "Round introuvable", 404);
+    return null;
+  }
+  if (!(await ensureLeagueCreator(userId, round.seasonId, res))) return null;
+  return { seasonId: round.seasonId };
+}
+
+/**
+ * Lot F — variante de `ensureLeagueCreator` qui resout le seasonId
+ * a partir d'un pairingId.
+ */
+async function ensureLeagueCreatorByPairing(
+  userId: string,
+  pairingId: string,
+  res: Response,
+): Promise<{ seasonId: string; roundId: string } | null> {
+  const pairing = await prisma.leaguePairing.findUnique({
+    where: { id: pairingId },
+    select: { id: true, roundId: true, round: { select: { seasonId: true } } },
+  });
+  if (!pairing) {
+    sendError(res, "Pairing introuvable", 404);
+    return null;
+  }
+  const seasonId = (pairing.round as { seasonId: string }).seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return null;
+  return { seasonId, roundId: pairing.roundId };
+}
+
+// ===========================================================
+// Lot F — handlers : creation manuelle de rounds et pairings.
+// ===========================================================
+
+/** POST /leagues/seasons/:seasonId/rounds/manual */
+export async function handleCreateManualRound(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return;
+  const body = req.body as CreateManualRoundBody;
+  try {
+    const round = await createManualRound({
+      seasonId,
+      name: body.name,
+      kind: body.kind,
+      startDate: body.startDate ?? null,
+      endDate: body.endDate ?? null,
+    });
+    sendSuccess(res, round, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/rounds/:roundId/pairings */
+export async function handleCreateManualPairing(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const roundId = req.params.roundId;
+  const ctx = await ensureLeagueCreatorByRound(userId, roundId, res);
+  if (!ctx) return;
+  const body = req.body as CreateManualPairingBody;
+  try {
+    const pairing = await createManualPairing({
+      roundId,
+      homeParticipantId: body.homeParticipantId,
+      awayParticipantId: body.awayParticipantId,
+      scheduledAt: body.scheduledAt ?? null,
+      deadlineAt: body.deadlineAt ?? null,
+    });
+    sendSuccess(res, pairing, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** DELETE /leagues/pairings/:pairingId */
+export async function handleDeleteManualPairing(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const pairingId = req.params.pairingId;
+  const ctx = await ensureLeagueCreatorByPairing(userId, pairingId, res);
+  if (!ctx) return;
+  try {
+    const out = await deleteManualPairing({ pairingId });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** PATCH /leagues/pairings/:pairingId */
+export async function handleUpdateManualPairing(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const pairingId = req.params.pairingId;
+  const ctx = await ensureLeagueCreatorByPairing(userId, pairingId, res);
+  if (!ctx) return;
+  const body = req.body as UpdateManualPairingBody;
+  try {
+    const pairing = await updateManualPairing({
+      pairingId,
+      scheduledAt: body.scheduledAt,
+      deadlineAt: body.deadlineAt,
+      targetRoundId: body.targetRoundId,
+    });
+    sendSuccess(res, pairing);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/**
  * L2.A.3 — Ouvre une saison aux inscriptions (`draft -> scheduled`).
  * Reserve au createur de la ligue. No-op si deja `scheduled`.
  */
@@ -1221,6 +1392,31 @@ router.post(
   authUser,
   validate(attachMatchSchema),
   handleAttachMatch,
+);
+// Lot F — saisie manuelle de matchs : creation d'un round vide hors
+// du calendrier auto-genere + ajout de pairings.
+router.post(
+  "/seasons/:seasonId/rounds/manual",
+  authUser,
+  validate(createManualRoundSchema),
+  handleCreateManualRound,
+);
+router.post(
+  "/rounds/:roundId/pairings",
+  authUser,
+  validate(createManualPairingSchema),
+  handleCreateManualPairing,
+);
+router.delete(
+  "/pairings/:pairingId",
+  authUser,
+  handleDeleteManualPairing,
+);
+router.patch(
+  "/pairings/:pairingId",
+  authUser,
+  validate(updateManualPairingSchema),
+  handleUpdateManualPairing,
 );
 // L2.A.3 — Routes admin saison (ouverture inscriptions, demarrage,
 // regeneration calendrier, cloture forcee). Reservees au createur.

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -23,6 +23,7 @@ import {
   getLeagueById,
   getSeasonById,
   computeSeasonStandings,
+  computeSeasonStandingsByPool,
   isSeasonEloRanked,
   withdrawParticipant,
   listThemedSeasons,
@@ -64,6 +65,23 @@ import {
   type CreateManualPairingBody,
   type UpdateManualPairingBody,
 } from "../schemas/league-manual-pairing.schemas";
+import {
+  createPool,
+  updatePool,
+  deletePool,
+  listPoolsForSeason,
+  assignParticipantsToPools,
+  autoAssignBySnakeDraft,
+  LeaguePoolError,
+} from "../services/league-pool";
+import {
+  createPoolSchema,
+  updatePoolSchema,
+  assignPoolsSchema,
+  type CreatePoolBody,
+  type UpdatePoolBody,
+  type AssignPoolsBody,
+} from "../schemas/league-pool.schemas";
 import {
   playMecene,
   LeaguePatronError,
@@ -140,6 +158,22 @@ function domainError(res: Response, e: unknown): void {
       e.code === "season_not_found" || e.code === "not_registered"
         ? 404
         : e.code === "season_started" || e.code === "season_completed"
+          ? 409
+          : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  // Lot C — pool errors.
+  if (e instanceof LeaguePoolError) {
+    const status =
+      e.code === "season_not_found" ||
+      e.code === "pool_not_found" ||
+      e.code === "participant_not_found"
+        ? 404
+        : e.code === "season_started" ||
+            e.code === "pool_name_taken" ||
+            e.code === "pool_not_empty" ||
+            e.code === "participant_not_in_season"
           ? 409
           : 400;
     sendError(res, e.message, status);
@@ -647,7 +681,20 @@ export async function handleGetStandings(
     const showSeasonElo = isSeasonEloRanked(
       seasonRow?.league?.tieBreakRules ?? null,
     );
-    sendSuccess(res, { seasonId, standings, showSeasonElo });
+    // Lot C — si query `byPool=true`, retourne aussi le groupement
+    // par poule (vide si la saison n'a pas de poules).
+    const wantsByPool =
+      typeof req.query.byPool === "string" &&
+      (req.query.byPool === "true" || req.query.byPool === "1");
+    const pools = wantsByPool
+      ? await computeSeasonStandingsByPool(seasonId)
+      : undefined;
+    sendSuccess(res, {
+      seasonId,
+      standings,
+      showSeasonElo,
+      ...(pools !== undefined ? { pools } : {}),
+    });
   } catch (e: unknown) {
     domainError(res, e);
   }
@@ -917,6 +964,147 @@ export async function handleUpdateManualPairing(
       targetRoundId: body.targetRoundId,
     });
     sendSuccess(res, pairing);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+// ===========================================================
+// Lot C — handlers : gestion des poules.
+// ===========================================================
+
+/** Resoud le seasonId a partir d'un poolId et applique ensureLeagueCreator. */
+async function ensureLeagueCreatorByPool(
+  userId: string,
+  poolId: string,
+  res: Response,
+): Promise<{ seasonId: string } | null> {
+  const pool = await prisma.leaguePool.findUnique({
+    where: { id: poolId },
+    select: { id: true, seasonId: true },
+  });
+  if (!pool) {
+    sendError(res, "Poule introuvable", 404);
+    return null;
+  }
+  if (!(await ensureLeagueCreator(userId, pool.seasonId, res))) return null;
+  return { seasonId: pool.seasonId };
+}
+
+/** POST /leagues/seasons/:seasonId/pools */
+export async function handleCreatePool(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return;
+  const body = req.body as CreatePoolBody;
+  try {
+    const pool = await createPool({
+      seasonId,
+      name: body.name,
+      qualifiesForPlayoffs: body.qualifiesForPlayoffs,
+      color: body.color ?? null,
+      order: body.order,
+    });
+    sendSuccess(res, pool, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** GET /leagues/seasons/:seasonId/pools (public). */
+export async function handleListPools(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const seasonId = req.params.seasonId;
+  try {
+    const pools = await listPoolsForSeason(seasonId);
+    sendSuccess(res, { pools });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** PATCH /leagues/pools/:poolId */
+export async function handleUpdatePool(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const poolId = req.params.poolId;
+  const ctx = await ensureLeagueCreatorByPool(userId, poolId, res);
+  if (!ctx) return;
+  const body = req.body as UpdatePoolBody;
+  try {
+    const updated = await updatePool({
+      poolId,
+      name: body.name,
+      qualifiesForPlayoffs: body.qualifiesForPlayoffs,
+      color: body.color ?? undefined,
+      order: body.order,
+    });
+    sendSuccess(res, updated);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** DELETE /leagues/pools/:poolId */
+export async function handleDeletePool(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const poolId = req.params.poolId;
+  const ctx = await ensureLeagueCreatorByPool(userId, poolId, res);
+  if (!ctx) return;
+  try {
+    const out = await deletePool({ poolId });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/seasons/:seasonId/pools/assign */
+export async function handleAssignPools(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return;
+  const body = req.body as AssignPoolsBody;
+  try {
+    const out = await assignParticipantsToPools({
+      seasonId,
+      assignments: body.assignments,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/seasons/:seasonId/pools/auto-assign */
+export async function handleAutoAssignPools(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const seasonId = req.params.seasonId;
+  if (!(await ensureLeagueCreator(userId, seasonId, res))) return;
+  try {
+    const out = await autoAssignBySnakeDraft({ seasonId });
+    sendSuccess(res, out);
   } catch (e: unknown) {
     domainError(res, e);
   }
@@ -1422,6 +1610,35 @@ router.patch(
   validate(updateManualPairingSchema),
   handleUpdateManualPairing,
 );
+
+// Lot C — gestion des poules (groups). Mutation reservee au
+// commissaire ; lecture publique pour permettre l'affichage des
+// poules dans le calendrier / standings.
+router.get("/seasons/:seasonId/pools", handleListPools);
+router.post(
+  "/seasons/:seasonId/pools",
+  authUser,
+  validate(createPoolSchema),
+  handleCreatePool,
+);
+router.post(
+  "/seasons/:seasonId/pools/assign",
+  authUser,
+  validate(assignPoolsSchema),
+  handleAssignPools,
+);
+router.post(
+  "/seasons/:seasonId/pools/auto-assign",
+  authUser,
+  handleAutoAssignPools,
+);
+router.patch(
+  "/pools/:poolId",
+  authUser,
+  validate(updatePoolSchema),
+  handleUpdatePool,
+);
+router.delete("/pools/:poolId", authUser, handleDeletePool);
 // L2.A.3 — Routes admin saison (ouverture inscriptions, demarrage,
 // regeneration calendrier, cloture forcee). Reservees au createur.
 router.post("/seasons/:seasonId/open", authUser, handleOpenSeason);

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -188,6 +188,8 @@ export async function handleCreateLeague(
       lossPoints: body.lossPoints,
       forfeitPoints: body.forfeitPoints,
       tieBreakRules: body.tieBreakRules ?? null,
+      // Lot E — config bonus optionnelle, propagee au service.
+      bonusPointsConfig: body.bonusPointsConfig ?? null,
     });
     sendSuccess(res, serializeLeague(league as Record<string, unknown>), 201);
   } catch (e: unknown) {
@@ -238,6 +240,8 @@ export async function handleUpdateLeague(
       lossPoints: body.lossPoints,
       forfeitPoints: body.forfeitPoints,
       tieBreakRules: body.tieBreakRules,
+      // Lot E — propagation de la config bonus en edition.
+      bonusPointsConfig: body.bonusPointsConfig,
     });
     sendSuccess(res, serializeLeague(updated as Record<string, unknown>));
   } catch (e: unknown) {

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -79,6 +79,11 @@ import {
   LeaguePoolError,
 } from "../services/league-pool";
 import {
+  computeLeaderboards,
+  computeLeaderboardsByTeam,
+  LEADERBOARD_CATEGORIES,
+} from "../services/league-player-stats";
+import {
   createPoolSchema,
   updatePoolSchema,
   assignPoolsSchema,
@@ -1132,6 +1137,62 @@ export async function handleAutoAssignPools(
 // Lot D — override des participants du bracket playoffs.
 // ===========================================================
 
+// ===========================================================
+// Lot J — handlers : classements top-N joueurs.
+// ===========================================================
+
+/**
+ * GET /leagues/seasons/:seasonId/leaderboards?topN=5[&teamId=...]
+ * Endpoint public — les stats joueurs sont consultables sans login.
+ */
+export async function handleGetLeaderboards(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const seasonId = req.params.seasonId;
+  const topNRaw = req.query.topN;
+  const topN =
+    typeof topNRaw === "string" ? parseInt(topNRaw, 10) : undefined;
+  const teamId =
+    typeof req.query.teamId === "string" ? req.query.teamId : undefined;
+  try {
+    const catalogue = await computeLeaderboards({
+      seasonId,
+      topN: Number.isFinite(topN) ? topN : undefined,
+      teamId,
+    });
+    sendSuccess(res, {
+      ...catalogue,
+      categories: LEADERBOARD_CATEGORIES,
+    });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/**
+ * GET /leagues/seasons/:seasonId/leaderboards/by-team?topN=3
+ * Decline les classements top-N par equipe inscrite.
+ */
+export async function handleGetLeaderboardsByTeam(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const seasonId = req.params.seasonId;
+  const topNRaw = req.query.topN;
+  const topN =
+    typeof topNRaw === "string" ? parseInt(topNRaw, 10) : undefined;
+  try {
+    const teams = await computeLeaderboardsByTeam({
+      seasonId,
+      topN: Number.isFinite(topN) ? topN : undefined,
+    });
+    sendSuccess(res, { seasonId, teams });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
 /**
  * PATCH /leagues/seasons/:seasonId/playoff-bracket/participants
  *
@@ -1703,6 +1764,17 @@ router.patch(
   "/seasons/:seasonId/playoff-bracket/participants",
   authUser,
   handleOverridePlayoffParticipants,
+);
+
+// Lot J — classements top-N joueurs (public). Decline aussi par
+// equipe via /by-team pour le mode "top 3 par equipe".
+router.get(
+  "/seasons/:seasonId/leaderboards",
+  handleGetLeaderboards,
+);
+router.get(
+  "/seasons/:seasonId/leaderboards/by-team",
+  handleGetLeaderboardsByTeam,
 );
 // L2.A.3 — Routes admin saison (ouverture inscriptions, demarrage,
 // regeneration calendrier, cloture forcee). Reservees au createur.

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -27,6 +27,7 @@ import {
   withdrawParticipant,
   listThemedSeasons,
   parseAllowedRosters,
+  LeagueWithdrawError,
 } from "../services/league";
 import {
   startSeason,
@@ -118,6 +119,17 @@ function serializeLeague(
 }
 
 function domainError(res: Response, e: unknown): void {
+  // Lot B — map les erreurs typees vers les bons status HTTP.
+  if (e instanceof LeagueWithdrawError) {
+    const status =
+      e.code === "season_not_found" || e.code === "not_registered"
+        ? 404
+        : e.code === "season_started" || e.code === "season_completed"
+          ? 409
+          : 400;
+    sendError(res, e.message, status);
+    return;
+  }
   const message = e instanceof Error ? e.message : "Erreur inconnue";
   const isMissing = /introuvable|not found/i.test(message);
   sendError(res, message, isMissing ? 404 : 400);

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -84,6 +84,27 @@ import {
   LEADERBOARD_CATEGORIES,
 } from "../services/league-player-stats";
 import {
+  adjustPlayerSpp,
+  addPlayerSkill,
+  removePlayerSkill,
+  adjustCharacteristic,
+  adjustTreasury,
+  listAuditLog,
+  CommissionerEditError,
+} from "../services/commissioner-team-edit";
+import {
+  adjustSppSchema,
+  addSkillSchema,
+  removeSkillSchema,
+  adjustCharacteristicSchema,
+  adjustTreasurySchema,
+  type AdjustSppBody,
+  type AddSkillBody,
+  type RemoveSkillBody,
+  type AdjustCharacteristicBody,
+  type AdjustTreasuryBody,
+} from "../schemas/commissioner-team-edit.schemas";
+import {
   createPoolSchema,
   updatePoolSchema,
   assignPoolsSchema,
@@ -183,6 +204,21 @@ function domainError(res: Response, e: unknown): void {
             e.code === "pool_name_taken" ||
             e.code === "pool_not_empty" ||
             e.code === "participant_not_in_season"
+          ? 409
+          : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  // Lot I — commissioner team edit errors.
+  if (e instanceof CommissionerEditError) {
+    const status =
+      e.code === "team_not_found" ||
+      e.code === "player_not_found"
+        ? 404
+        : e.code === "team_not_in_league" ||
+            e.code === "player_not_in_team" ||
+            e.code === "skill_already_present" ||
+            e.code === "skill_not_present"
           ? 409
           : 400;
     sendError(res, e.message, status);
@@ -1138,6 +1174,188 @@ export async function handleAutoAssignPools(
 // ===========================================================
 
 // ===========================================================
+// Lot I — handlers : edition ex-post des equipes par commissaire.
+// ===========================================================
+
+/** Verifie que l'user est commissaire de la ligue cible (par id). */
+async function ensureLeagueCommissioner(
+  userId: string,
+  leagueId: string,
+  res: Response,
+): Promise<boolean> {
+  const league = await prisma.league.findUnique({
+    where: { id: leagueId },
+    select: { id: true, creatorId: true },
+  });
+  if (!league) {
+    sendError(res, "Ligue introuvable", 404);
+    return false;
+  }
+  if (league.creatorId !== userId) {
+    sendError(res, "Seul le commissaire peut effectuer cette action", 403);
+    return false;
+  }
+  return true;
+}
+
+/** POST /leagues/:leagueId/teams/:teamId/players/:playerId/spp */
+export async function handleAdjustPlayerSpp(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { leagueId, teamId, playerId } = req.params;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const body = req.body as AdjustSppBody;
+  try {
+    const out = await adjustPlayerSpp({
+      leagueId,
+      teamId,
+      playerId,
+      delta: body.delta,
+      byCommissionerId: userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/:leagueId/teams/:teamId/players/:playerId/skills */
+export async function handleAddPlayerSkill(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { leagueId, teamId, playerId } = req.params;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const body = req.body as AddSkillBody;
+  try {
+    const out = await addPlayerSkill({
+      leagueId,
+      teamId,
+      playerId,
+      skill: body.skill,
+      pickKind: body.pickKind,
+      byCommissionerId: userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** DELETE /leagues/:leagueId/teams/:teamId/players/:playerId/skills */
+export async function handleRemovePlayerSkill(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { leagueId, teamId, playerId } = req.params;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const body = req.body as RemoveSkillBody;
+  try {
+    const out = await removePlayerSkill({
+      leagueId,
+      teamId,
+      playerId,
+      skill: body.skill,
+      byCommissionerId: userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** PATCH /leagues/:leagueId/teams/:teamId/players/:playerId/characteristic */
+export async function handleAdjustCharacteristic(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { leagueId, teamId, playerId } = req.params;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const body = req.body as AdjustCharacteristicBody;
+  try {
+    const out = await adjustCharacteristic({
+      leagueId,
+      teamId,
+      playerId,
+      characteristic: body.characteristic,
+      delta: body.delta,
+      byCommissionerId: userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** PATCH /leagues/:leagueId/teams/:teamId/treasury */
+export async function handleAdjustTreasury(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const { leagueId, teamId } = req.params;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const body = req.body as AdjustTreasuryBody;
+  try {
+    const out = await adjustTreasury({
+      leagueId,
+      teamId,
+      delta: body.delta,
+      byCommissionerId: userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** GET /leagues/:leagueId/audit-log */
+export async function handleGetAuditLog(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const leagueId = req.params.leagueId;
+  if (!(await ensureLeagueCommissioner(userId, leagueId, res))) return;
+  const limitRaw = req.query.limit;
+  const limit =
+    typeof limitRaw === "string" ? parseInt(limitRaw, 10) : undefined;
+  try {
+    const entries = await listAuditLog({
+      leagueId,
+      limit: Number.isFinite(limit) ? limit : undefined,
+    });
+    // Filtre cote applicatif sur leagueId puisque le JSON path n'est pas
+    // tres portable cross-DB. La requete service retourne deja les
+    // entries "commissioner-edit:*", on filtre par newValue.leagueId.
+    const filtered = entries.filter(
+      (e) =>
+        ((e as { newValue?: { leagueId?: string } }).newValue?.leagueId ?? "") ===
+        leagueId,
+    );
+    sendSuccess(res, { entries: filtered });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+// ===========================================================
 // Lot J — handlers : classements top-N joueurs.
 // ===========================================================
 
@@ -1775,6 +1993,43 @@ router.get(
 router.get(
   "/seasons/:seasonId/leaderboards/by-team",
   handleGetLeaderboardsByTeam,
+);
+
+// Lot I — edition ex-post des equipes par le commissaire.
+router.post(
+  "/:leagueId/teams/:teamId/players/:playerId/spp",
+  authUser,
+  validate(adjustSppSchema),
+  handleAdjustPlayerSpp,
+);
+router.post(
+  "/:leagueId/teams/:teamId/players/:playerId/skills",
+  authUser,
+  validate(addSkillSchema),
+  handleAddPlayerSkill,
+);
+router.delete(
+  "/:leagueId/teams/:teamId/players/:playerId/skills",
+  authUser,
+  validate(removeSkillSchema),
+  handleRemovePlayerSkill,
+);
+router.patch(
+  "/:leagueId/teams/:teamId/players/:playerId/characteristic",
+  authUser,
+  validate(adjustCharacteristicSchema),
+  handleAdjustCharacteristic,
+);
+router.patch(
+  "/:leagueId/teams/:teamId/treasury",
+  authUser,
+  validate(adjustTreasurySchema),
+  handleAdjustTreasury,
+);
+router.get(
+  "/:leagueId/audit-log",
+  authUser,
+  handleGetAuditLog,
 );
 // L2.A.3 — Routes admin saison (ouverture inscriptions, demarrage,
 // regeneration calendrier, cloture forcee). Reservees au createur.

--- a/apps/server/src/schemas/commissioner-team-edit.schemas.ts
+++ b/apps/server/src/schemas/commissioner-team-edit.schemas.ts
@@ -1,0 +1,39 @@
+/**
+ * Lot I — Zod schemas pour les routes commissaire d'edition d'equipe.
+ */
+
+import { z } from "zod";
+
+export const adjustSppSchema = z.object({
+  delta: z.number().int().min(-1000).max(1000),
+  reason: z.string().max(500).optional(),
+});
+export type AdjustSppBody = z.infer<typeof adjustSppSchema>;
+
+export const addSkillSchema = z.object({
+  skill: z.string().trim().min(1).max(64),
+  pickKind: z.enum(["random", "chosen"]).optional(),
+  reason: z.string().max(500).optional(),
+});
+export type AddSkillBody = z.infer<typeof addSkillSchema>;
+
+export const removeSkillSchema = z.object({
+  skill: z.string().trim().min(1).max(64),
+  reason: z.string().max(500).optional(),
+});
+export type RemoveSkillBody = z.infer<typeof removeSkillSchema>;
+
+export const adjustCharacteristicSchema = z.object({
+  characteristic: z.enum(["MA", "ST", "AG", "PA", "AV"]),
+  delta: z.number().int().min(-10).max(10),
+  reason: z.string().max(500).optional(),
+});
+export type AdjustCharacteristicBody = z.infer<
+  typeof adjustCharacteristicSchema
+>;
+
+export const adjustTreasurySchema = z.object({
+  delta: z.number().int().min(-10_000_000).max(10_000_000),
+  reason: z.string().max(500).optional(),
+});
+export type AdjustTreasuryBody = z.infer<typeof adjustTreasurySchema>;

--- a/apps/server/src/schemas/league-invitation.schemas.ts
+++ b/apps/server/src/schemas/league-invitation.schemas.ts
@@ -1,0 +1,34 @@
+/**
+ * Lot A — Zod schemas pour les routes d'invitation de ligue.
+ */
+
+import { z } from "zod";
+
+export const createInvitationSchema = z
+  .object({
+    seasonId: z.string().min(1).optional(),
+    inviteeUserId: z.string().min(1).optional(),
+    inviteeEmail: z.string().email().optional(),
+    inviteeTeamId: z.string().min(1).optional(),
+    message: z.string().max(500).optional(),
+    expiresInDays: z.number().int().min(1).max(90).optional(),
+  })
+  .refine(
+    (v) => v.inviteeUserId || v.inviteeEmail || v.seasonId,
+    "Au moins un des champs `inviteeUserId`, `inviteeEmail` ou `seasonId` est requis",
+  );
+export type CreateInvitationBody = z.infer<typeof createInvitationSchema>;
+
+export const acceptInvitationSchema = z.object({
+  teamId: z.string().min(1, "teamId requis"),
+  seasonId: z.string().min(1).optional(),
+});
+export type AcceptInvitationBody = z.infer<typeof acceptInvitationSchema>;
+
+export const searchCoachesQuerySchema = z.object({
+  q: z.string().min(1).max(64),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+  leagueId: z.string().min(1).optional(),
+  seasonId: z.string().min(1).optional(),
+});
+export type SearchCoachesQuery = z.infer<typeof searchCoachesQuerySchema>;

--- a/apps/server/src/schemas/league-manual-pairing.schemas.ts
+++ b/apps/server/src/schemas/league-manual-pairing.schemas.ts
@@ -1,0 +1,45 @@
+/**
+ * Lot F — Zod schemas pour la creation manuelle de pairings.
+ */
+
+import { z } from "zod";
+
+const isoDate = z
+  .string()
+  .datetime({ offset: true })
+  .transform((s) => new Date(s));
+
+export const createManualRoundSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  kind: z.enum(["regular", "playoff"]).optional(),
+  startDate: isoDate.nullable().optional(),
+  endDate: isoDate.nullable().optional(),
+});
+export type CreateManualRoundBody = z.infer<typeof createManualRoundSchema>;
+
+export const createManualPairingSchema = z.object({
+  homeParticipantId: z.string().min(1, "homeParticipantId requis"),
+  awayParticipantId: z.string().min(1, "awayParticipantId requis"),
+  scheduledAt: isoDate.nullable().optional(),
+  deadlineAt: isoDate.nullable().optional(),
+});
+export type CreateManualPairingBody = z.infer<
+  typeof createManualPairingSchema
+>;
+
+export const updateManualPairingSchema = z
+  .object({
+    scheduledAt: isoDate.nullable().optional(),
+    deadlineAt: isoDate.nullable().optional(),
+    targetRoundId: z.string().min(1).optional(),
+  })
+  .refine(
+    (v) =>
+      v.scheduledAt !== undefined ||
+      v.deadlineAt !== undefined ||
+      v.targetRoundId !== undefined,
+    "Aucun champ a modifier",
+  );
+export type UpdateManualPairingBody = z.infer<
+  typeof updateManualPairingSchema
+>;

--- a/apps/server/src/schemas/league-pool.schemas.ts
+++ b/apps/server/src/schemas/league-pool.schemas.ts
@@ -1,0 +1,43 @@
+/**
+ * Lot C — Zod schemas pour les routes de gestion des poules.
+ */
+
+import { z } from "zod";
+
+const colorHex = z
+  .string()
+  .regex(/^#?[0-9A-Fa-f]{6}$/, "Format de couleur invalide (#RRGGBB)");
+
+export const createPoolSchema = z.object({
+  name: z.string().trim().min(1).max(60),
+  qualifiesForPlayoffs: z.number().int().min(0).max(128).optional(),
+  color: colorHex.optional().nullable(),
+  order: z.number().int().min(0).max(64).optional(),
+});
+export type CreatePoolBody = z.infer<typeof createPoolSchema>;
+
+export const updatePoolSchema = z
+  .object({
+    name: z.string().trim().min(1).max(60).optional(),
+    qualifiesForPlayoffs: z.number().int().min(0).max(128).optional(),
+    color: colorHex.optional().nullable(),
+    order: z.number().int().min(0).max(64).optional(),
+  })
+  .refine(
+    (v) => Object.keys(v).length > 0,
+    "Au moins un champ doit etre fourni",
+  );
+export type UpdatePoolBody = z.infer<typeof updatePoolSchema>;
+
+export const assignPoolsSchema = z.object({
+  assignments: z
+    .array(
+      z.object({
+        participantId: z.string().min(1),
+        poolId: z.string().min(1).nullable(),
+      }),
+    )
+    .min(1)
+    .max(256),
+});
+export type AssignPoolsBody = z.infer<typeof assignPoolsSchema>;

--- a/apps/server/src/schemas/league.schemas.ts
+++ b/apps/server/src/schemas/league.schemas.ts
@@ -66,6 +66,34 @@ export const createLeagueSchema = z.object({
   // L2.C.5 — ordre de departage personnalise. null/undefined =
   // ordre par defaut historique. Filtre les doublons cote service.
   tieBreakRules: z.array(tieBreakSlug).max(9).optional().nullable(),
+  // Lot E — points bonus configurables. JSON array de regles.
+  // Validation defensive : chaque element doit avoir les champs
+  // requis (le service les re-valide via parseBonusConfig au runtime).
+  bonusPointsConfig: z
+    .array(
+      z.object({
+        id: z.string().min(1).max(64),
+        label: z.string().min(1).max(120),
+        condition: z.object({
+          type: z.enum([
+            "tds_scored_gte",
+            "tds_conceded_lte",
+            "cas_inflicted_gte",
+            "killings_gte",
+            "completions_gte",
+            "margin_gte",
+            "clean_sheet",
+            "shut_out_win",
+          ]),
+          value: z.number().int().min(-100).max(100).optional(),
+        }),
+        points: z.number().int().min(-10).max(10),
+        appliesTo: z.enum(["home", "away", "both", "winner", "loser"]),
+      }),
+    )
+    .max(20, "Au plus 20 regles de bonus")
+    .optional()
+    .nullable(),
 });
 
 /**

--- a/apps/server/src/services/commissioner-team-edit.test.ts
+++ b/apps/server/src/services/commissioner-team-edit.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Lot I — Tests du service `commissioner-team-edit`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leagueParticipant: { count: vi.fn() },
+    teamPlayer: { findUnique: vi.fn(), update: vi.fn() },
+    team: { findUnique: vi.fn(), update: vi.fn() },
+    auditLog: { create: vi.fn(), findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  adjustPlayerSpp,
+  addPlayerSkill,
+  removePlayerSkill,
+  adjustCharacteristic,
+  adjustTreasury,
+  listAuditLog,
+  CommissionerEditError,
+} from "./commissioner-team-edit";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+const commish = "commish-1";
+
+describe("Lot I — commissioner-team-edit", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPrisma.auditLog.create.mockResolvedValue({});
+  });
+
+  describe("adjustPlayerSpp", () => {
+    it("rejects delta=0", async () => {
+      await expect(
+        adjustPlayerSpp({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          delta: 0,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_delta" });
+    });
+
+    it("rejects non-integer delta", async () => {
+      await expect(
+        adjustPlayerSpp({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          delta: 1.5,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_delta" });
+    });
+
+    it("rejects when team not in league", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+      await expect(
+        adjustPlayerSpp({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          delta: 5,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "team_not_in_league" });
+    });
+
+    it("rejects when player not in given team", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "OTHER",
+        spp: 5,
+        name: "X",
+      });
+      await expect(
+        adjustPlayerSpp({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          delta: 5,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "player_not_in_team" });
+    });
+
+    it("rejects if final SPP would be negative", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        spp: 3,
+        name: "X",
+      });
+      await expect(
+        adjustPlayerSpp({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          delta: -5,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_delta" });
+    });
+
+    it("applies delta and creates audit entry", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        spp: 5,
+        name: "X",
+      });
+      mockPrisma.teamPlayer.update.mockResolvedValue({ id: "P1", spp: 11 });
+      const out = await adjustPlayerSpp({
+        leagueId: "L1",
+        teamId: "T1",
+        playerId: "P1",
+        delta: 6,
+        byCommissionerId: commish,
+        reason: "Saisie corrigee",
+      });
+      expect(out).toMatchObject({ spp: 11 });
+      expect(mockPrisma.auditLog.create).toHaveBeenCalled();
+      const auditArgs = mockPrisma.auditLog.create.mock.calls[0][0];
+      expect(auditArgs.data.action).toBe(
+        "league.commissioner-edit:adjust_spp",
+      );
+    });
+  });
+
+  describe("addPlayerSkill", () => {
+    it("rejects when team not in league", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(0);
+      await expect(
+        addPlayerSkill({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          skill: "Block",
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "team_not_in_league" });
+    });
+
+    it("rejects empty skill", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        skills: "",
+        name: "X",
+      });
+      await expect(
+        addPlayerSkill({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          skill: "   ",
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_value" });
+    });
+
+    it("rejects when skill already present", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        skills: "Block,Tackle",
+        name: "X",
+      });
+      await expect(
+        addPlayerSkill({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          skill: "Block",
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "skill_already_present" });
+    });
+
+    it("appends skill to CSV and audits with pickKind", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        skills: "Block",
+        name: "X",
+      });
+      mockPrisma.teamPlayer.update.mockImplementation(
+        async (a: { data: { skills: string } }) => ({
+          id: "P1",
+          skills: a.data.skills,
+        }),
+      );
+      const out = await addPlayerSkill({
+        leagueId: "L1",
+        teamId: "T1",
+        playerId: "P1",
+        skill: "Dodge",
+        pickKind: "random",
+        byCommissionerId: commish,
+      });
+      expect((out as { skills: string }).skills).toBe("Block,Dodge");
+      const auditArgs = mockPrisma.auditLog.create.mock.calls[0][0];
+      expect(auditArgs.data.action).toBe(
+        "league.commissioner-edit:add_skill:random",
+      );
+    });
+  });
+
+  describe("removePlayerSkill", () => {
+    it("rejects if skill not present", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        skills: "Block",
+      });
+      await expect(
+        removePlayerSkill({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          skill: "Dodge",
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "skill_not_present" });
+    });
+
+    it("removes skill from CSV", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        skills: "Block,Dodge,Tackle",
+      });
+      mockPrisma.teamPlayer.update.mockImplementation(
+        async (a: { data: { skills: string } }) => ({
+          id: "P1",
+          skills: a.data.skills,
+        }),
+      );
+      const out = await removePlayerSkill({
+        leagueId: "L1",
+        teamId: "T1",
+        playerId: "P1",
+        skill: "Dodge",
+        byCommissionerId: commish,
+      });
+      expect((out as { skills: string }).skills).toBe("Block,Tackle");
+    });
+  });
+
+  describe("adjustCharacteristic", () => {
+    it("rejects unknown characteristic", async () => {
+      await expect(
+        adjustCharacteristic({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          characteristic: "XX" as any,
+          delta: 1,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_characteristic" });
+    });
+
+    it("clamps to [1, 10]", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        ma: 9,
+        st: 3,
+        ag: 3,
+        pa: 3,
+        av: 9,
+      });
+      mockPrisma.teamPlayer.update.mockImplementation(
+        async (a: { data: Record<string, number> }) => ({
+          id: "P1",
+          ma: a.data.ma,
+        }),
+      );
+      // delta=+5 sur MA=9 -> clamp 10
+      const out = await adjustCharacteristic({
+        leagueId: "L1",
+        teamId: "T1",
+        playerId: "P1",
+        characteristic: "MA",
+        delta: 5,
+        byCommissionerId: commish,
+      });
+      expect((out as { ma: number }).ma).toBe(10);
+    });
+
+    it("rejects if delta has no effect (already at bound)", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.teamPlayer.findUnique.mockResolvedValue({
+        id: "P1",
+        teamId: "T1",
+        ma: 10,
+        st: 3,
+        ag: 3,
+        pa: 3,
+        av: 9,
+      });
+      await expect(
+        adjustCharacteristic({
+          leagueId: "L1",
+          teamId: "T1",
+          playerId: "P1",
+          characteristic: "MA",
+          delta: 2,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_value" });
+    });
+  });
+
+  describe("adjustTreasury", () => {
+    it("rejects negative final treasury", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "T1",
+        treasury: 50_000,
+      });
+      await expect(
+        adjustTreasury({
+          leagueId: "L1",
+          teamId: "T1",
+          delta: -100_000,
+          byCommissionerId: commish,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_delta" });
+    });
+
+    it("applies delta on success", async () => {
+      mockPrisma.leagueParticipant.count.mockResolvedValue(1);
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "T1",
+        treasury: 1_000_000,
+      });
+      mockPrisma.team.update.mockResolvedValue({ id: "T1", treasury: 1_100_000 });
+      const out = await adjustTreasury({
+        leagueId: "L1",
+        teamId: "T1",
+        delta: 100_000,
+        byCommissionerId: commish,
+      });
+      expect((out as { treasury: number }).treasury).toBe(1_100_000);
+    });
+  });
+
+  describe("listAuditLog", () => {
+    it("calls findMany with action prefix filter", async () => {
+      mockPrisma.auditLog.findMany.mockResolvedValue([{ id: "a1" }]);
+      await listAuditLog({ leagueId: "L1" });
+      const callArgs = mockPrisma.auditLog.findMany.mock.calls[0][0];
+      expect(callArgs.where.action.startsWith).toBe(
+        "league.commissioner-edit:",
+      );
+    });
+
+    it("returns empty array if AuditLog table missing", async () => {
+      mockPrisma.auditLog.findMany.mockRejectedValue(new Error("no table"));
+      const out = await listAuditLog({ leagueId: "L1" });
+      expect(out).toEqual([]);
+    });
+  });
+
+  describe("CommissionerEditError", () => {
+    it("preserves code", () => {
+      const e = new CommissionerEditError("player_not_found", "x");
+      expect(e.code).toBe("player_not_found");
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/apps/server/src/services/commissioner-team-edit.ts
+++ b/apps/server/src/services/commissioner-team-edit.ts
@@ -1,0 +1,488 @@
+/**
+ * Lot I — Edition ex-post des equipes d'une ligue par le commissaire.
+ *
+ * Permet de corriger les erreurs apres-coup (ex: SPP mal compte,
+ * comp oubliee, joueur achete manquant) sans devoir invalider /
+ * rejouer toute la chaine.
+ *
+ * Chaque mutation est tracee dans `CommissionerAuditLog` pour
+ * permettre de reverser une erreur de saisie du commissaire et
+ * de donner de la visibilite aux coachs sur ce qui a ete modifie
+ * sur leur equipe.
+ *
+ * Garde-fous :
+ *   - L'authorisation est verifiee cote route (commissaire d'une
+ *     ligue OU admin global).
+ *   - Pas de mutation sur les compteurs materialises des
+ *     LeagueParticipant ; on touche uniquement les attributs des
+ *     TeamPlayer/Team. Les standings restent coherents.
+ *   - Verification que la team appartient bien a une saison de la
+ *     ligue ciblee (anti-vector pour modifier des teams hors-scope).
+ */
+
+import { prisma } from "../prisma";
+
+export class CommissionerEditError extends Error {
+  constructor(
+    public readonly code:
+      | "team_not_found"
+      | "team_not_in_league"
+      | "player_not_found"
+      | "player_not_in_team"
+      | "invalid_delta"
+      | "invalid_value"
+      | "skill_already_present"
+      | "skill_not_present"
+      | "invalid_characteristic",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CommissionerEditError";
+  }
+}
+
+const VALID_CHARS = ["MA", "ST", "AG", "PA", "AV"] as const;
+export type Characteristic = (typeof VALID_CHARS)[number];
+
+interface AuditEntry {
+  readonly leagueId: string;
+  readonly byCommissionerId: string;
+  readonly teamId: string;
+  readonly playerId?: string | null;
+  readonly action: string;
+  readonly beforeState?: Record<string, unknown> | null;
+  readonly afterState?: Record<string, unknown> | null;
+  readonly reason?: string | null;
+}
+
+async function appendAudit(entry: AuditEntry): Promise<void> {
+  // Reutilise le modele AuditLog generique : `userId` = commissaire,
+  // `action` = "league.commissioner-edit:<sub>", `entity` = "Team"
+  // ou "TeamPlayer", `entityId` = id cible, `oldValue`/`newValue`
+  // pour le diff.
+  try {
+    await (prisma as unknown as {
+      auditLog: {
+        create: (args: unknown) => Promise<unknown>;
+      };
+    }).auditLog.create({
+      data: {
+        userId: entry.byCommissionerId,
+        action: `league.commissioner-edit:${entry.action}`,
+        entity: entry.playerId ? "TeamPlayer" : "Team",
+        entityId: entry.playerId ?? entry.teamId,
+        oldValue: entry.beforeState
+          ? { ...entry.beforeState, leagueId: entry.leagueId }
+          : { leagueId: entry.leagueId },
+        newValue: entry.afterState
+          ? {
+              ...entry.afterState,
+              leagueId: entry.leagueId,
+              reason: entry.reason ?? null,
+            }
+          : { leagueId: entry.leagueId, reason: entry.reason ?? null },
+      },
+    });
+  } catch {
+    // Si AuditLog n'existe pas dans cette DB (tests SQLite legacy),
+    // on ne propage pas — le service de mutation reste fonctionnel.
+  }
+}
+
+/**
+ * Verifie que la team appartient a au moins une saison de la
+ * ligue ciblee. Anti-vector pour eviter qu'un commissaire de la
+ * ligue X modifie une team qui n'est inscrite que dans la ligue Y.
+ */
+async function ensureTeamInLeague(input: { leagueId: string; teamId: string }) {
+  const count = await prisma.leagueParticipant.count({
+    where: {
+      teamId: input.teamId,
+      season: { leagueId: input.leagueId },
+    },
+  });
+  if (count === 0) {
+    throw new CommissionerEditError(
+      "team_not_in_league",
+      "Cette equipe n'est pas inscrite dans une saison de cette ligue",
+    );
+  }
+}
+
+export interface AddSppInput {
+  leagueId: string;
+  teamId: string;
+  playerId: string;
+  delta: number;
+  byCommissionerId: string;
+  reason?: string;
+}
+
+/**
+ * Ajoute (ou retire si delta < 0) des SPP a un joueur. Refuse si
+ * le delta est nul ou si le SPP final deviendrait negatif.
+ */
+export async function adjustPlayerSpp(input: AddSppInput) {
+  if (!Number.isInteger(input.delta) || input.delta === 0) {
+    throw new CommissionerEditError(
+      "invalid_delta",
+      "Le delta SPP doit etre un entier non nul",
+    );
+  }
+  await ensureTeamInLeague(input);
+
+  const player = (await prisma.teamPlayer.findUnique({
+    where: { id: input.playerId },
+    select: { id: true, teamId: true, spp: true, name: true },
+  })) as { id: string; teamId: string; spp: number; name: string } | null;
+  if (!player) {
+    throw new CommissionerEditError(
+      "player_not_found",
+      `Joueur introuvable: ${input.playerId}`,
+    );
+  }
+  if (player.teamId !== input.teamId) {
+    throw new CommissionerEditError(
+      "player_not_in_team",
+      "Le joueur n'appartient pas a la team specifiee",
+    );
+  }
+
+  const newSpp = player.spp + input.delta;
+  if (newSpp < 0) {
+    throw new CommissionerEditError(
+      "invalid_delta",
+      "Les SPP ne peuvent pas descendre en dessous de 0",
+    );
+  }
+
+  const updated = await prisma.teamPlayer.update({
+    where: { id: input.playerId },
+    data: { spp: newSpp },
+  });
+
+  await appendAudit({
+    leagueId: input.leagueId,
+    byCommissionerId: input.byCommissionerId,
+    teamId: input.teamId,
+    playerId: input.playerId,
+    action: "adjust_spp",
+    beforeState: { spp: player.spp },
+    afterState: { spp: newSpp },
+    reason: input.reason ?? null,
+  });
+
+  return updated;
+}
+
+export interface AddSkillInput {
+  leagueId: string;
+  teamId: string;
+  playerId: string;
+  skill: string;
+  /** Format de competence : 'random' | 'chosen' (BB officiel). */
+  pickKind?: "random" | "chosen";
+  byCommissionerId: string;
+  reason?: string;
+}
+
+/**
+ * Ajoute une competence a un joueur. La competence est stockee dans
+ * le champ libre `TeamPlayer.skills` (CSV). Refuse si la competence
+ * est deja presente.
+ */
+export async function addPlayerSkill(input: AddSkillInput) {
+  await ensureTeamInLeague(input);
+
+  const player = (await prisma.teamPlayer.findUnique({
+    where: { id: input.playerId },
+    select: { id: true, teamId: true, skills: true, name: true },
+  })) as { id: string; teamId: string; skills: string; name: string } | null;
+  if (!player) {
+    throw new CommissionerEditError(
+      "player_not_found",
+      `Joueur introuvable: ${input.playerId}`,
+    );
+  }
+  if (player.teamId !== input.teamId) {
+    throw new CommissionerEditError(
+      "player_not_in_team",
+      "Le joueur n'appartient pas a la team specifiee",
+    );
+  }
+
+  const trimmedSkill = input.skill.trim();
+  if (trimmedSkill.length === 0) {
+    throw new CommissionerEditError(
+      "invalid_value",
+      "Le slug de la competence est obligatoire",
+    );
+  }
+  const existing = parseSkillsCsv(player.skills);
+  if (existing.includes(trimmedSkill)) {
+    throw new CommissionerEditError(
+      "skill_already_present",
+      `Le joueur possede deja la competence "${trimmedSkill}"`,
+    );
+  }
+  const newSkills = [...existing, trimmedSkill];
+  const updated = await prisma.teamPlayer.update({
+    where: { id: input.playerId },
+    data: { skills: newSkills.join(",") },
+  });
+
+  await appendAudit({
+    leagueId: input.leagueId,
+    byCommissionerId: input.byCommissionerId,
+    teamId: input.teamId,
+    playerId: input.playerId,
+    action: `add_skill:${input.pickKind ?? "chosen"}`,
+    beforeState: { skills: existing },
+    afterState: { skills: newSkills },
+    reason: input.reason ?? null,
+  });
+  return updated;
+}
+
+export interface RemoveSkillInput {
+  leagueId: string;
+  teamId: string;
+  playerId: string;
+  skill: string;
+  byCommissionerId: string;
+  reason?: string;
+}
+
+/** Retire une competence d'un joueur. */
+export async function removePlayerSkill(input: RemoveSkillInput) {
+  await ensureTeamInLeague(input);
+
+  const player = (await prisma.teamPlayer.findUnique({
+    where: { id: input.playerId },
+    select: { id: true, teamId: true, skills: true },
+  })) as { id: string; teamId: string; skills: string } | null;
+  if (!player) {
+    throw new CommissionerEditError(
+      "player_not_found",
+      `Joueur introuvable: ${input.playerId}`,
+    );
+  }
+  if (player.teamId !== input.teamId) {
+    throw new CommissionerEditError(
+      "player_not_in_team",
+      "Le joueur n'appartient pas a la team specifiee",
+    );
+  }
+  const existing = parseSkillsCsv(player.skills);
+  if (!existing.includes(input.skill)) {
+    throw new CommissionerEditError(
+      "skill_not_present",
+      `Le joueur ne possede pas la competence "${input.skill}"`,
+    );
+  }
+  const newSkills = existing.filter((s) => s !== input.skill);
+  const updated = await prisma.teamPlayer.update({
+    where: { id: input.playerId },
+    data: { skills: newSkills.join(",") },
+  });
+  await appendAudit({
+    leagueId: input.leagueId,
+    byCommissionerId: input.byCommissionerId,
+    teamId: input.teamId,
+    playerId: input.playerId,
+    action: "remove_skill",
+    beforeState: { skills: existing },
+    afterState: { skills: newSkills },
+    reason: input.reason ?? null,
+  });
+  return updated;
+}
+
+export interface SetCharacteristicInput {
+  leagueId: string;
+  teamId: string;
+  playerId: string;
+  characteristic: Characteristic;
+  /**
+   * Delta a appliquer (peut etre negatif). On preserve les bornes
+   * minimales (>=1) cote serveur pour eviter les saisies aberrantes.
+   */
+  delta: number;
+  byCommissionerId: string;
+  reason?: string;
+}
+
+const MIN_CHAR = 1;
+const MAX_CHAR = 10;
+
+/**
+ * Applique un delta sur une caracteristique (MA/ST/AG/PA/AV).
+ * Clampe la valeur dans [1, 10] (BB official range).
+ */
+export async function adjustCharacteristic(input: SetCharacteristicInput) {
+  if (!VALID_CHARS.includes(input.characteristic)) {
+    throw new CommissionerEditError(
+      "invalid_characteristic",
+      `Caracteristique invalide: ${input.characteristic}`,
+    );
+  }
+  if (!Number.isInteger(input.delta) || input.delta === 0) {
+    throw new CommissionerEditError(
+      "invalid_delta",
+      "Le delta doit etre un entier non nul",
+    );
+  }
+  await ensureTeamInLeague(input);
+
+  const player = (await prisma.teamPlayer.findUnique({
+    where: { id: input.playerId },
+    select: {
+      id: true,
+      teamId: true,
+      ma: true,
+      st: true,
+      ag: true,
+      pa: true,
+      av: true,
+    },
+  })) as {
+    id: string;
+    teamId: string;
+    ma: number;
+    st: number;
+    ag: number;
+    pa: number;
+    av: number;
+  } | null;
+  if (!player) {
+    throw new CommissionerEditError(
+      "player_not_found",
+      `Joueur introuvable: ${input.playerId}`,
+    );
+  }
+  if (player.teamId !== input.teamId) {
+    throw new CommissionerEditError(
+      "player_not_in_team",
+      "Le joueur n'appartient pas a la team specifiee",
+    );
+  }
+
+  const key = input.characteristic.toLowerCase() as
+    | "ma"
+    | "st"
+    | "ag"
+    | "pa"
+    | "av";
+  const before = player[key];
+  const after = Math.min(MAX_CHAR, Math.max(MIN_CHAR, before + input.delta));
+  if (after === before) {
+    throw new CommissionerEditError(
+      "invalid_value",
+      `Valeur deja a la borne pour ${input.characteristic}`,
+    );
+  }
+
+  const updated = await prisma.teamPlayer.update({
+    where: { id: input.playerId },
+    data: { [key]: after },
+  });
+  await appendAudit({
+    leagueId: input.leagueId,
+    byCommissionerId: input.byCommissionerId,
+    teamId: input.teamId,
+    playerId: input.playerId,
+    action: `adjust_characteristic:${input.characteristic}`,
+    beforeState: { [key]: before },
+    afterState: { [key]: after },
+    reason: input.reason ?? null,
+  });
+  return updated;
+}
+
+export interface AdjustTreasuryInput {
+  leagueId: string;
+  teamId: string;
+  delta: number;
+  byCommissionerId: string;
+  reason?: string;
+}
+
+/**
+ * Ajuste la tresorerie d'une equipe (cas typique : remboursement
+ * apres erreur d'achat, bonus pour saisie en retard, etc.). Refuse
+ * si la tresorerie finale serait negative.
+ */
+export async function adjustTreasury(input: AdjustTreasuryInput) {
+  if (!Number.isInteger(input.delta) || input.delta === 0) {
+    throw new CommissionerEditError(
+      "invalid_delta",
+      "Le delta doit etre un entier non nul",
+    );
+  }
+  await ensureTeamInLeague(input);
+
+  const team = (await prisma.team.findUnique({
+    where: { id: input.teamId },
+    select: { id: true, treasury: true },
+  })) as { id: string; treasury: number } | null;
+  if (!team) {
+    throw new CommissionerEditError(
+      "team_not_found",
+      `Equipe introuvable: ${input.teamId}`,
+    );
+  }
+  const newTreasury = team.treasury + input.delta;
+  if (newTreasury < 0) {
+    throw new CommissionerEditError(
+      "invalid_delta",
+      "La tresorerie ne peut pas devenir negative",
+    );
+  }
+  const updated = await prisma.team.update({
+    where: { id: input.teamId },
+    data: { treasury: newTreasury },
+  });
+  await appendAudit({
+    leagueId: input.leagueId,
+    byCommissionerId: input.byCommissionerId,
+    teamId: input.teamId,
+    action: "adjust_treasury",
+    beforeState: { treasury: team.treasury },
+    afterState: { treasury: newTreasury },
+    reason: input.reason ?? null,
+  });
+  return updated;
+}
+
+function parseSkillsCsv(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Helper pour la route audit log : liste les actions effectuees
+ * par le commissaire sur les teams d'une ligue. Filtre par prefixe
+ * d'action + leagueId stocke dans `newValue.leagueId`.
+ */
+export async function listAuditLog(input: {
+  leagueId: string;
+  limit?: number;
+}) {
+  const limit = Math.min(Math.max(input.limit ?? 100, 1), 500);
+  try {
+    return (await (prisma as unknown as {
+      auditLog: { findMany: (args: unknown) => Promise<unknown> };
+    }).auditLog.findMany({
+      where: {
+        action: { startsWith: "league.commissioner-edit:" },
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    })) as Array<{ newValue?: { leagueId?: string } }>;
+  } catch {
+    return [];
+  }
+}

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -117,6 +117,19 @@ export const LEAGUE_MANUAL_PAIRINGS_FLAG =
   "league_manual_pairings" as const;
 
 /**
+ * Lot C — sous-flag pour le mode multi-poules dans l'UI saison.
+ * L'API est ouverte par defaut ; ce flag gate uniquement l'editeur
+ * de poules cote frontend.
+ */
+export const LEAGUE_POOLS_FLAG = "league_pools" as const;
+
+/**
+ * Lot J — sous-flag pour exposer la page de classements top-N
+ * joueurs (`/leagues/[id]/seasons/[sid]/leaderboards`) dans l'UI.
+ */
+export const LEAGUE_LEADERBOARDS_FLAG = "league_leaderboards" as const;
+
+/**
  * Registre des feature flags connus du code. Source de vérité pour garder
  * la table `FeatureFlag` synchronisée avec le code : le bouton
  * "Synchroniser depuis le code" du panneau admin (POST
@@ -183,6 +196,14 @@ export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
     key: LEAGUE_MANUAL_PAIRINGS_FLAG,
     description:
       "Ligue — saisie manuelle de matchs (rounds custom, ajout/suppression/deplacement).",
+  },
+  {
+    key: LEAGUE_POOLS_FLAG,
+    description: "Ligue — gestion multi-poules (groups + qualif PO).",
+  },
+  {
+    key: LEAGUE_LEADERBOARDS_FLAG,
+    description: "Ligue — classements top-N joueurs par saison.",
   },
 ];
 

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -94,6 +94,14 @@ export const REGISTRATION_REQUIRES_VALIDATION_FLAG =
   "registration_requires_validation" as const;
 
 /**
+ * Lot A — sous-flag de `LEAGUE_FLAG` pour ouvrir specifiquement les
+ * fonctionnalites d'invitation (creation, autocomplete coachs,
+ * acceptation par lien). Permet de garder le hub /leagues ouvert
+ * mais de moduler le rollout des invitations.
+ */
+export const LEAGUE_INVITATIONS_FLAG = "league_invitations" as const;
+
+/**
  * Registre des feature flags connus du code. Source de vérité pour garder
  * la table `FeatureFlag` synchronisée avec le code : le bouton
  * "Synchroniser depuis le code" du panneau admin (POST
@@ -145,6 +153,11 @@ export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
     key: REGISTRATION_REQUIRES_VALIDATION_FLAG,
     description:
       "Kill-switch — exige une validation admin des nouveaux comptes.",
+  },
+  {
+    key: LEAGUE_INVITATIONS_FLAG,
+    description:
+      "Ligue — invitations de coachs (creation, lien shareable, autocomplete recherche).",
   },
 ];
 

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -102,6 +102,21 @@ export const REGISTRATION_REQUIRES_VALIDATION_FLAG =
 export const LEAGUE_INVITATIONS_FLAG = "league_invitations" as const;
 
 /**
+ * Lot E — sous-flag pour exposer l'editeur de points bonus dans l'UI
+ * de creation/edition de ligue. Le serveur applique deja les bonus
+ * quand la config est presente ; ce flag gate uniquement l'UI.
+ */
+export const LEAGUE_BONUS_POINTS_FLAG = "league_bonus_points" as const;
+
+/**
+ * Lot F — sous-flag pour exposer la creation manuelle de pairings
+ * (rounds custom + ajout/suppression/deplacement de matchs hors du
+ * round-robin auto-genere) dans l'UI commissaire.
+ */
+export const LEAGUE_MANUAL_PAIRINGS_FLAG =
+  "league_manual_pairings" as const;
+
+/**
  * Registre des feature flags connus du code. Source de vérité pour garder
  * la table `FeatureFlag` synchronisée avec le code : le bouton
  * "Synchroniser depuis le code" du panneau admin (POST
@@ -158,6 +173,16 @@ export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
     key: LEAGUE_INVITATIONS_FLAG,
     description:
       "Ligue — invitations de coachs (creation, lien shareable, autocomplete recherche).",
+  },
+  {
+    key: LEAGUE_BONUS_POINTS_FLAG,
+    description:
+      "Ligue — editeur de points bonus configurable (3 TD/3 cas/clean sheet/etc.).",
+  },
+  {
+    key: LEAGUE_MANUAL_PAIRINGS_FLAG,
+    description:
+      "Ligue — saisie manuelle de matchs (rounds custom, ajout/suppression/deplacement).",
   },
 ];
 

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -130,6 +130,14 @@ export const LEAGUE_POOLS_FLAG = "league_pools" as const;
 export const LEAGUE_LEADERBOARDS_FLAG = "league_leaderboards" as const;
 
 /**
+ * Lot I — sous-flag pour exposer l'editeur ex-post des equipes par
+ * le commissaire (SPP, competences, caracteristiques, tresorerie).
+ * Toutes les mutations sont auditees via AuditLog.
+ */
+export const LEAGUE_COMMISSIONER_EDIT_FLAG =
+  "league_commissioner_edit" as const;
+
+/**
  * Registre des feature flags connus du code. Source de vérité pour garder
  * la table `FeatureFlag` synchronisée avec le code : le bouton
  * "Synchroniser depuis le code" du panneau admin (POST
@@ -204,6 +212,11 @@ export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
   {
     key: LEAGUE_LEADERBOARDS_FLAG,
     description: "Ligue — classements top-N joueurs par saison.",
+  },
+  {
+    key: LEAGUE_COMMISSIONER_EDIT_FLAG,
+    description:
+      "Ligue — edition ex-post des equipes par le commissaire (SPP, comp, carac, treso).",
   },
 ];
 

--- a/apps/server/src/services/league-bonus-points.test.ts
+++ b/apps/server/src/services/league-bonus-points.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Lot E — Tests du service pur `league-bonus-points`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  evaluateBonusRules,
+  parseBonusConfig,
+  BONUS_PRESETS,
+  type BonusRule,
+  type MatchBonusContext,
+} from "./league-bonus-points";
+
+const baseCtx: MatchBonusContext = {
+  tdsHome: 0,
+  tdsAway: 0,
+  casualtiesInflictedHome: 0,
+  casualtiesInflictedAway: 0,
+  winner: "draw",
+};
+
+describe("Lot E — evaluateBonusRules", () => {
+  it("returns 0/0/[] when rules are empty or null", () => {
+    expect(evaluateBonusRules([], baseCtx)).toEqual({
+      homeBonus: 0,
+      awayBonus: 0,
+      applied: [],
+    });
+    expect(evaluateBonusRules(null, baseCtx)).toEqual({
+      homeBonus: 0,
+      awayBonus: 0,
+      applied: [],
+    });
+    expect(evaluateBonusRules(undefined, baseCtx)).toEqual({
+      homeBonus: 0,
+      awayBonus: 0,
+      applied: [],
+    });
+  });
+
+  it("awards 1 pt to the side scoring 3+ TDs (both)", () => {
+    const rule: BonusRule = {
+      id: "r1",
+      label: "3 TD",
+      condition: { type: "tds_scored_gte", value: 3 },
+      points: 1,
+      appliesTo: "both",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 3,
+      tdsAway: 2,
+      winner: "home",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(1);
+    expect(out.awayBonus).toBe(0);
+    expect(out.applied).toHaveLength(1);
+    expect(out.applied[0]).toMatchObject({ ruleId: "r1", side: "home" });
+  });
+
+  it("awards bonus to both sides if both qualify", () => {
+    const rule: BonusRule = {
+      id: "r1",
+      label: "3 TD",
+      condition: { type: "tds_scored_gte", value: 3 },
+      points: 1,
+      appliesTo: "both",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 4,
+      tdsAway: 3,
+      winner: "home",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(1);
+    expect(out.awayBonus).toBe(1);
+    expect(out.applied).toHaveLength(2);
+  });
+
+  it("awards bonus to winner only", () => {
+    const rule: BonusRule = {
+      id: "r1",
+      label: "Won shutout",
+      condition: { type: "shut_out_win" },
+      points: 2,
+      appliesTo: "winner",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 3,
+      tdsAway: 0,
+      winner: "home",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(2);
+    expect(out.awayBonus).toBe(0);
+  });
+
+  it("does not award winner/loser bonus on a draw", () => {
+    const rules: BonusRule[] = [
+      {
+        id: "w",
+        label: "Win shutout",
+        condition: { type: "shut_out_win" },
+        points: 2,
+        appliesTo: "winner",
+      },
+      {
+        id: "l",
+        label: "Wood spoon",
+        condition: { type: "tds_scored_gte", value: 0 },
+        points: -1,
+        appliesTo: "loser",
+      },
+    ];
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 1,
+      tdsAway: 1,
+      winner: "draw",
+    };
+    const out = evaluateBonusRules(rules, ctx);
+    expect(out.homeBonus).toBe(0);
+    expect(out.awayBonus).toBe(0);
+  });
+
+  it("evaluates cas_inflicted_gte", () => {
+    const rule: BonusRule = {
+      id: "r2",
+      label: "3 cas",
+      condition: { type: "cas_inflicted_gte", value: 3 },
+      points: 1,
+      appliesTo: "both",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      casualtiesInflictedHome: 4,
+      casualtiesInflictedAway: 2,
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(1);
+    expect(out.awayBonus).toBe(0);
+  });
+
+  it("evaluates clean_sheet (0 TDs conceded)", () => {
+    const rule: BonusRule = {
+      id: "r3",
+      label: "Clean sheet",
+      condition: { type: "clean_sheet" },
+      points: 1,
+      appliesTo: "both",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 1,
+      tdsAway: 0,
+      winner: "home",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    // home conceded 0 -> bonus ; away conceded 1 -> no bonus.
+    expect(out.homeBonus).toBe(1);
+    expect(out.awayBonus).toBe(0);
+  });
+
+  it("evaluates margin_gte", () => {
+    const rule: BonusRule = {
+      id: "r4",
+      label: "Marge >= 3",
+      condition: { type: "margin_gte", value: 3 },
+      points: 2,
+      appliesTo: "winner",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 4,
+      tdsAway: 1,
+      winner: "home",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(2);
+  });
+
+  it("evaluates killings_gte", () => {
+    const rule: BonusRule = {
+      id: "r5",
+      label: "3 kills",
+      condition: { type: "killings_gte", value: 3 },
+      points: 3,
+      appliesTo: "home",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      killingsHome: 3,
+      killingsAway: 0,
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    expect(out.homeBonus).toBe(3);
+  });
+
+  it("skips rules with non-finite or 0 points", () => {
+    const rules: BonusRule[] = [
+      {
+        id: "zero",
+        label: "Zero",
+        condition: { type: "tds_scored_gte", value: 0 },
+        points: 0,
+        appliesTo: "both",
+      },
+      {
+        id: "nan",
+        label: "NaN",
+        condition: { type: "tds_scored_gte", value: 0 },
+        points: NaN,
+        appliesTo: "both",
+      },
+    ];
+    const out = evaluateBonusRules(rules, baseCtx);
+    expect(out.applied).toHaveLength(0);
+  });
+
+  it("supports negative bonus points (malus)", () => {
+    const rule: BonusRule = {
+      id: "malus",
+      label: "0 TD scored",
+      condition: { type: "tds_scored_gte", value: 0 },
+      points: -1,
+      appliesTo: "loser",
+    };
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 0,
+      tdsAway: 1,
+      winner: "away",
+    };
+    const out = evaluateBonusRules([rule], ctx);
+    // home is loser, 0 TDs >= 0 -> -1 pt
+    expect(out.homeBonus).toBe(-1);
+    expect(out.awayBonus).toBe(0);
+  });
+
+  it("accumulates multiple rules on the same side", () => {
+    const rules: BonusRule[] = [
+      {
+        id: "r1",
+        label: "A",
+        condition: { type: "tds_scored_gte", value: 2 },
+        points: 1,
+        appliesTo: "both",
+      },
+      {
+        id: "r2",
+        label: "B",
+        condition: { type: "cas_inflicted_gte", value: 1 },
+        points: 2,
+        appliesTo: "both",
+      },
+    ];
+    const ctx: MatchBonusContext = {
+      ...baseCtx,
+      tdsHome: 3,
+      casualtiesInflictedHome: 2,
+    };
+    const out = evaluateBonusRules(rules, ctx);
+    expect(out.homeBonus).toBe(3);
+    expect(out.applied).toHaveLength(2);
+  });
+});
+
+describe("Lot E — parseBonusConfig", () => {
+  it("parses an array directly (PG case)", () => {
+    const raw = [
+      {
+        id: "x",
+        label: "X",
+        condition: { type: "tds_scored_gte", value: 3 },
+        points: 1,
+        appliesTo: "both",
+      },
+    ];
+    const out = parseBonusConfig(raw);
+    expect(out).toHaveLength(1);
+    expect(out?.[0].id).toBe("x");
+  });
+
+  it("parses a JSON string (sqlite mirror case)", () => {
+    const raw = JSON.stringify([
+      {
+        id: "x",
+        label: "X",
+        condition: { type: "tds_scored_gte", value: 3 },
+        points: 1,
+        appliesTo: "both",
+      },
+    ]);
+    const out = parseBonusConfig(raw);
+    expect(out).toHaveLength(1);
+  });
+
+  it("returns null on null/undefined/garbage", () => {
+    expect(parseBonusConfig(null)).toBeNull();
+    expect(parseBonusConfig(undefined)).toBeNull();
+    expect(parseBonusConfig("not-json")).toBeNull();
+    expect(parseBonusConfig(42)).toBeNull();
+  });
+
+  it("filters out invalid rules silently", () => {
+    const raw = [
+      { id: "ok", label: "OK", condition: { type: "tds_scored_gte", value: 1 }, points: 1, appliesTo: "both" },
+      { id: "missing-cond", label: "X", points: 1, appliesTo: "both" },
+      { id: "bad-applies", label: "X", condition: { type: "tds_scored_gte", value: 1 }, points: 1, appliesTo: "other" },
+      { /* no id */ label: "X", condition: { type: "tds_scored_gte", value: 1 }, points: 1, appliesTo: "both" },
+      { id: "bad-cond-type", label: "X", condition: { type: "unknown" }, points: 1, appliesTo: "both" },
+    ];
+    const out = parseBonusConfig(raw);
+    expect(out).toHaveLength(1);
+    expect(out?.[0].id).toBe("ok");
+  });
+});
+
+describe("Lot E — BONUS_PRESETS", () => {
+  it("exposes the 4 documented presets", () => {
+    expect(BONUS_PRESETS).toHaveLength(4);
+    const ids = BONUS_PRESETS.map((p) => p.id);
+    expect(ids).toContain("preset_3_tds");
+    expect(ids).toContain("preset_3_cas");
+    expect(ids).toContain("preset_clean_sheet");
+    expect(ids).toContain("preset_shutout_win");
+  });
+
+  it("presets pass evaluateBonusRules without throwing", () => {
+    const ctx: MatchBonusContext = {
+      tdsHome: 3,
+      tdsAway: 0,
+      casualtiesInflictedHome: 3,
+      casualtiesInflictedAway: 0,
+      winner: "home",
+    };
+    const out = evaluateBonusRules(BONUS_PRESETS, ctx);
+    expect(out.homeBonus).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/src/services/league-bonus-points.ts
+++ b/apps/server/src/services/league-bonus-points.ts
@@ -1,0 +1,277 @@
+/**
+ * Lot E — Points bonus configurables par ligue.
+ *
+ * Permet au commissaire de definir des regles de bonus appliquees
+ * automatiquement au scoring d'un match. Chaque regle est une paire
+ * (condition, points) declenchee selon le contexte du match
+ * (TD marques, sorties infligees, etc.) cote home et/ou away.
+ *
+ * Le service est **pur** (pas d'I/O) : il prend en entree la config
+ * + les stats du match, retourne le delta a appliquer cote home/away
+ * ainsi qu'un breakdown utile pour l'audit / l'UI.
+ *
+ * La config est stockee dans `League.bonusPointsConfig` (JSON ; cf.
+ * migration Lot E). Quand le champ est null/undefined, aucun bonus
+ * n'est applique.
+ */
+
+export type BonusConditionType =
+  | "tds_scored_gte"
+  | "tds_conceded_lte"
+  | "cas_inflicted_gte"
+  | "killings_gte"
+  | "completions_gte"
+  | "margin_gte"
+  | "clean_sheet"
+  | "shut_out_win";
+
+export interface BonusCondition {
+  readonly type: BonusConditionType;
+  /** Seuil ; ignore pour les conditions booleennes (clean_sheet/shut_out_win). */
+  readonly value?: number;
+}
+
+export type BonusAppliesTo =
+  | "home"
+  | "away"
+  | "both"
+  | "winner"
+  | "loser";
+
+export interface BonusRule {
+  readonly id: string;
+  readonly label: string;
+  readonly condition: BonusCondition;
+  readonly points: number;
+  readonly appliesTo: BonusAppliesTo;
+}
+
+export interface MatchBonusContext {
+  readonly tdsHome: number;
+  readonly tdsAway: number;
+  readonly casualtiesInflictedHome: number;
+  readonly casualtiesInflictedAway: number;
+  readonly killingsHome?: number;
+  readonly killingsAway?: number;
+  readonly completionsHome?: number;
+  readonly completionsAway?: number;
+  /** "home" | "away" | "draw" — derivable des scores. */
+  readonly winner: "home" | "away" | "draw";
+}
+
+export interface BonusAppliedEntry {
+  readonly ruleId: string;
+  readonly label: string;
+  readonly side: "home" | "away";
+  readonly points: number;
+}
+
+export interface BonusEvaluationResult {
+  readonly homeBonus: number;
+  readonly awayBonus: number;
+  readonly applied: ReadonlyArray<BonusAppliedEntry>;
+}
+
+/**
+ * Evalue toutes les regles pour un match donne. Pour chaque regle,
+ * verifie la condition cote home et cote away (selon `appliesTo`),
+ * accumule les points par cote.
+ *
+ * Si `rules` est vide ou null, retourne {0, 0, []} (no-op).
+ */
+export function evaluateBonusRules(
+  rules: ReadonlyArray<BonusRule> | null | undefined,
+  ctx: MatchBonusContext,
+): BonusEvaluationResult {
+  if (!rules || rules.length === 0) {
+    return { homeBonus: 0, awayBonus: 0, applied: [] };
+  }
+
+  let homeBonus = 0;
+  let awayBonus = 0;
+  const applied: BonusAppliedEntry[] = [];
+
+  for (const rule of rules) {
+    if (rule.points === 0 || !Number.isFinite(rule.points)) continue;
+
+    const sides = sidesFor(rule.appliesTo, ctx.winner);
+    for (const side of sides) {
+      if (matchesCondition(rule.condition, side, ctx)) {
+        if (side === "home") homeBonus += rule.points;
+        else awayBonus += rule.points;
+        applied.push({
+          ruleId: rule.id,
+          label: rule.label,
+          side,
+          points: rule.points,
+        });
+      }
+    }
+  }
+
+  return { homeBonus, awayBonus, applied };
+}
+
+function sidesFor(
+  appliesTo: BonusAppliesTo,
+  winner: "home" | "away" | "draw",
+): Array<"home" | "away"> {
+  switch (appliesTo) {
+    case "home":
+      return ["home"];
+    case "away":
+      return ["away"];
+    case "both":
+      return ["home", "away"];
+    case "winner":
+      if (winner === "draw") return [];
+      return [winner];
+    case "loser":
+      if (winner === "draw") return [];
+      return [winner === "home" ? "away" : "home"];
+  }
+}
+
+function matchesCondition(
+  condition: BonusCondition,
+  side: "home" | "away",
+  ctx: MatchBonusContext,
+): boolean {
+  const tdsFor = side === "home" ? ctx.tdsHome : ctx.tdsAway;
+  const tdsAgainst = side === "home" ? ctx.tdsAway : ctx.tdsHome;
+  const casFor =
+    side === "home"
+      ? ctx.casualtiesInflictedHome
+      : ctx.casualtiesInflictedAway;
+  const killsFor =
+    side === "home" ? ctx.killingsHome ?? 0 : ctx.killingsAway ?? 0;
+  const completionsFor =
+    side === "home"
+      ? ctx.completionsHome ?? 0
+      : ctx.completionsAway ?? 0;
+  const margin = tdsFor - tdsAgainst;
+  const threshold = condition.value ?? 0;
+
+  switch (condition.type) {
+    case "tds_scored_gte":
+      return tdsFor >= threshold;
+    case "tds_conceded_lte":
+      return tdsAgainst <= threshold;
+    case "cas_inflicted_gte":
+      return casFor >= threshold;
+    case "killings_gte":
+      return killsFor >= threshold;
+    case "completions_gte":
+      return completionsFor >= threshold;
+    case "margin_gte":
+      return margin >= threshold;
+    case "clean_sheet":
+      return tdsAgainst === 0;
+    case "shut_out_win":
+      return tdsAgainst === 0 && tdsFor > 0;
+  }
+}
+
+/**
+ * Parse + valide une config JSON arbitraire (cote serveur, defensive).
+ * Retourne `null` si la config est mal formee, sinon le tableau de
+ * regles canoniques (typed).
+ */
+export function parseBonusConfig(raw: unknown): BonusRule[] | null {
+  // Le champ peut etre un string (sqlite mirror) ou un array (PG). Cf.
+  // CLAUDE.md "Parser tolerant PG + sqlite pour JSON fields".
+  let arr: unknown[];
+  if (Array.isArray(raw)) {
+    arr = raw;
+  } else if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return null;
+      arr = parsed;
+    } catch {
+      return null;
+    }
+  } else {
+    return null;
+  }
+
+  const rules: BonusRule[] = [];
+  for (const item of arr) {
+    if (typeof item !== "object" || item === null) continue;
+    const r = item as Record<string, unknown>;
+    if (typeof r.id !== "string" || r.id.length === 0) continue;
+    if (typeof r.label !== "string") continue;
+    if (typeof r.points !== "number" || !Number.isFinite(r.points)) continue;
+    const appliesTo = r.appliesTo;
+    if (
+      appliesTo !== "home" &&
+      appliesTo !== "away" &&
+      appliesTo !== "both" &&
+      appliesTo !== "winner" &&
+      appliesTo !== "loser"
+    ) {
+      continue;
+    }
+    const cond = r.condition as Record<string, unknown> | undefined;
+    if (!cond || typeof cond !== "object") continue;
+    const condType = cond.type;
+    if (!isBonusConditionType(condType)) continue;
+    const condValue =
+      typeof cond.value === "number" && Number.isFinite(cond.value)
+        ? cond.value
+        : undefined;
+    rules.push({
+      id: r.id,
+      label: r.label,
+      condition: { type: condType, value: condValue },
+      points: r.points,
+      appliesTo,
+    });
+  }
+  return rules;
+}
+
+function isBonusConditionType(v: unknown): v is BonusConditionType {
+  return (
+    v === "tds_scored_gte" ||
+    v === "tds_conceded_lte" ||
+    v === "cas_inflicted_gte" ||
+    v === "killings_gte" ||
+    v === "completions_gte" ||
+    v === "margin_gte" ||
+    v === "clean_sheet" ||
+    v === "shut_out_win"
+  );
+}
+
+/** Presets pratiques pour pre-remplir l'editeur cote UI. */
+export const BONUS_PRESETS: ReadonlyArray<BonusRule> = [
+  {
+    id: "preset_3_tds",
+    label: "3 TD marques",
+    condition: { type: "tds_scored_gte", value: 3 },
+    points: 1,
+    appliesTo: "both",
+  },
+  {
+    id: "preset_3_cas",
+    label: "3 sorties infligees",
+    condition: { type: "cas_inflicted_gte", value: 3 },
+    points: 1,
+    appliesTo: "both",
+  },
+  {
+    id: "preset_clean_sheet",
+    label: "Aucun TD encaisse",
+    condition: { type: "clean_sheet" },
+    points: 1,
+    appliesTo: "both",
+  },
+  {
+    id: "preset_shutout_win",
+    label: "Victoire avec aucun TD encaisse",
+    condition: { type: "shut_out_win" },
+    points: 1,
+    appliesTo: "winner",
+  },
+];

--- a/apps/server/src/services/league-invitation.test.ts
+++ b/apps/server/src/services/league-invitation.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Lot A — Tests du service `league-invitation`.
+ *
+ * Mock `prisma` + le sous-service `addParticipant` (de `./league`)
+ * pour ne pas tester deux fois la logique d'inscription.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    league: { findUnique: vi.fn() },
+    leagueSeason: { findUnique: vi.fn() },
+    leagueInvitation: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    team: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("./league", () => ({
+  addParticipant: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import {
+  createInvitation,
+  acceptInvitation,
+  declineInvitation,
+  cancelInvitation,
+  expireOldInvitations,
+  generateInvitationCode,
+  LeagueInvitationError,
+} from "./league-invitation";
+import { addParticipant } from "./league";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+const mockAddParticipant = addParticipant as ReturnType<typeof vi.fn>;
+
+describe("Lot A — league-invitation service", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("generateInvitationCode", () => {
+    it("produces a URL-safe code of ~22 chars", () => {
+      const code = generateInvitationCode();
+      expect(code).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(code.length).toBeGreaterThanOrEqual(20);
+      expect(code.length).toBeLessThanOrEqual(24);
+    });
+
+    it("produces unique codes", () => {
+      const codes = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        codes.add(generateInvitationCode());
+      }
+      expect(codes.size).toBe(50);
+    });
+  });
+
+  describe("createInvitation", () => {
+    const baseInput = {
+      leagueId: "league-1",
+      inviterUserId: "commissioner-1",
+    };
+
+    it("rejects if league not found", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue(null);
+      await expect(createInvitation(baseInput)).rejects.toMatchObject({
+        code: "league_not_found",
+      });
+    });
+
+    it("rejects if season does not belong to the league", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "season-1",
+        leagueId: "league-2",
+        status: "draft",
+      });
+      await expect(
+        createInvitation({ ...baseInput, seasonId: "season-1" }),
+      ).rejects.toMatchObject({ code: "season_not_found" });
+    });
+
+    it("rejects if season is completed", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "season-1",
+        leagueId: "league-1",
+        status: "completed",
+      });
+      await expect(
+        createInvitation({ ...baseInput, seasonId: "season-1" }),
+      ).rejects.toMatchObject({ code: "season_closed" });
+    });
+
+    it("creates an invitation with default 14d expiry", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      mockPrisma.leagueInvitation.findFirst.mockResolvedValue(null);
+      mockPrisma.leagueInvitation.create.mockImplementation(
+        async (args: { data: Record<string, unknown> }) => ({
+          id: "inv-1",
+          ...args.data,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      );
+
+      const before = Date.now();
+      const inv = await createInvitation({
+        ...baseInput,
+        inviteeUserId: "user-2",
+      });
+      const after = Date.now();
+      expect(inv.status).toBe("pending");
+      expect(inv.code).toMatch(/^[A-Za-z0-9_-]+$/);
+      const expiresAt = (inv as { expiresAt: Date }).expiresAt.getTime();
+      const fourteenDays = 14 * 24 * 60 * 60 * 1000;
+      expect(expiresAt).toBeGreaterThanOrEqual(before + fourteenDays - 1000);
+      expect(expiresAt).toBeLessThanOrEqual(after + fourteenDays + 1000);
+    });
+
+    it("returns existing pending invitation (idempotence)", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      const futureExpiry = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      mockPrisma.leagueInvitation.findFirst.mockResolvedValue({
+        id: "existing-inv",
+        status: "pending",
+        expiresAt: futureExpiry,
+      });
+      const inv = await createInvitation({
+        ...baseInput,
+        inviteeUserId: "user-2",
+      });
+      expect(inv).toMatchObject({ id: "existing-inv" });
+      expect(mockPrisma.leagueInvitation.create).not.toHaveBeenCalled();
+    });
+
+    it("creates new invitation if previous expired", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      const pastExpiry = new Date(Date.now() - 1000);
+      mockPrisma.leagueInvitation.findFirst.mockResolvedValue({
+        id: "existing-inv",
+        status: "pending",
+        expiresAt: pastExpiry,
+      });
+      mockPrisma.leagueInvitation.create.mockImplementation(
+        async (args: { data: Record<string, unknown> }) => ({
+          id: "new-inv",
+          ...args.data,
+        }),
+      );
+      const inv = await createInvitation({
+        ...baseInput,
+        inviteeUserId: "user-2",
+      });
+      expect(inv).toMatchObject({ id: "new-inv" });
+    });
+
+    it("clamps expiresInDays to [1, 90]", async () => {
+      mockPrisma.league.findUnique.mockResolvedValue({
+        id: "league-1",
+        status: "open",
+      });
+      mockPrisma.leagueInvitation.findFirst.mockResolvedValue(null);
+      mockPrisma.leagueInvitation.create.mockImplementation(
+        async (args: { data: Record<string, unknown> }) => ({
+          ...args.data,
+        }),
+      );
+      const before = Date.now();
+      const inv = await createInvitation({
+        ...baseInput,
+        inviteeUserId: "user-2",
+        expiresInDays: 1000,
+      });
+      const expiresAt = (inv as { expiresAt: Date }).expiresAt.getTime();
+      const ninetyDays = 90 * 24 * 60 * 60 * 1000;
+      expect(expiresAt).toBeLessThanOrEqual(before + ninetyDays + 2000);
+    });
+  });
+
+  describe("acceptInvitation", () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    it("rejects if invitation not found", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue(null);
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "invitation_not_found" });
+    });
+
+    it("rejects if already accepted", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "accepted",
+        expiresAt: futureDate,
+      });
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "invitation_already_consumed" });
+    });
+
+    it("rejects if expired and marks expired", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({ id: "i1" });
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "invitation_expired" });
+      expect(mockPrisma.leagueInvitation.update).toHaveBeenCalledWith({
+        where: { id: "i1" },
+        data: { status: "expired" },
+      });
+    });
+
+    it("rejects if inviteeUserId mismatches", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "user-A",
+        seasonId: "s1",
+        expiresAt: futureDate,
+      });
+      await expect(
+        acceptInvitation({ code: "x", userId: "user-B", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "invitation_not_for_user" });
+    });
+
+    it("rejects when no seasonId", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: null,
+        seasonId: null,
+        expiresAt: futureDate,
+      });
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "season_not_found" });
+    });
+
+    it("rejects if team not owned by user", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "u1",
+        seasonId: "s1",
+        expiresAt: futureDate,
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "t1",
+        ownerId: "other-user",
+      });
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "team_not_owned_by_user" });
+    });
+
+    it("calls addParticipant on success and marks accepted", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "u1",
+        seasonId: "s1",
+        expiresAt: futureDate,
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "t1",
+        ownerId: "u1",
+      });
+      mockAddParticipant.mockResolvedValue({ id: "part-1" });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({
+        id: "i1",
+        status: "accepted",
+      });
+
+      const out = await acceptInvitation({
+        code: "x",
+        userId: "u1",
+        teamId: "t1",
+      });
+      expect(mockAddParticipant).toHaveBeenCalledWith({
+        seasonId: "s1",
+        teamId: "t1",
+      });
+      expect(out.invitation).toMatchObject({ status: "accepted" });
+      expect(out.participant).toMatchObject({ id: "part-1" });
+    });
+
+    it("falls back to input.seasonId when invitation has no seasonId", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: null,
+        seasonId: null,
+        expiresAt: futureDate,
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "t1",
+        ownerId: "u1",
+      });
+      mockAddParticipant.mockResolvedValue({ id: "part-2" });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({
+        id: "i1",
+        status: "accepted",
+      });
+      await acceptInvitation({
+        code: "x",
+        userId: "u1",
+        teamId: "t1",
+        seasonId: "explicit-season",
+      });
+      expect(mockAddParticipant).toHaveBeenCalledWith({
+        seasonId: "explicit-season",
+        teamId: "t1",
+      });
+    });
+
+    it("maps addParticipant 'deja inscrit' to team_already_registered", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "u1",
+        seasonId: "s1",
+        expiresAt: futureDate,
+      });
+      mockPrisma.team.findUnique.mockResolvedValue({
+        id: "t1",
+        ownerId: "u1",
+      });
+      mockAddParticipant.mockRejectedValue(new Error("deja inscrit"));
+      await expect(
+        acceptInvitation({ code: "x", userId: "u1", teamId: "t1" }),
+      ).rejects.toMatchObject({ code: "team_already_registered" });
+    });
+  });
+
+  describe("declineInvitation", () => {
+    it("transitions pending to declined", async () => {
+      const futureDate = new Date(Date.now() + 1000);
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "u1",
+        expiresAt: futureDate,
+      });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({
+        id: "i1",
+        status: "declined",
+      });
+      const out = await declineInvitation({ code: "x", userId: "u1" });
+      expect(out).toMatchObject({ status: "declined" });
+    });
+
+    it("rejects if not for user", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviteeUserId: "user-A",
+      });
+      await expect(
+        declineInvitation({ code: "x", userId: "user-B" }),
+      ).rejects.toMatchObject({ code: "invitation_not_for_user" });
+    });
+  });
+
+  describe("cancelInvitation", () => {
+    it("allows inviter to cancel", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviterUserId: "commish-1",
+      });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({
+        id: "i1",
+        status: "cancelled",
+      });
+      const out = await cancelInvitation({
+        invitationId: "i1",
+        byUserId: "commish-1",
+      });
+      expect(out).toMatchObject({ status: "cancelled" });
+    });
+
+    it("forbids non-inviter non-admin", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviterUserId: "commish-1",
+      });
+      await expect(
+        cancelInvitation({ invitationId: "i1", byUserId: "stranger" }),
+      ).rejects.toMatchObject({ code: "forbidden" });
+    });
+
+    it("allows admin override", async () => {
+      mockPrisma.leagueInvitation.findUnique.mockResolvedValue({
+        id: "i1",
+        status: "pending",
+        inviterUserId: "commish-1",
+      });
+      mockPrisma.leagueInvitation.update.mockResolvedValue({
+        id: "i1",
+        status: "cancelled",
+      });
+      await expect(
+        cancelInvitation({
+          invitationId: "i1",
+          byUserId: "admin-x",
+          isAdmin: true,
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("expireOldInvitations", () => {
+    it("calls updateMany with the correct filter", async () => {
+      mockPrisma.leagueInvitation.updateMany.mockResolvedValue({ count: 3 });
+      const fixedNow = new Date("2026-01-01T00:00:00Z");
+      const out = await expireOldInvitations(fixedNow);
+      expect(out).toEqual({ expired: 3 });
+      expect(mockPrisma.leagueInvitation.updateMany).toHaveBeenCalledWith({
+        where: { status: "pending", expiresAt: { lte: fixedNow } },
+        data: { status: "expired" },
+      });
+    });
+  });
+
+  describe("LeagueInvitationError", () => {
+    it("is an Error subclass with code", () => {
+      const e = new LeagueInvitationError("forbidden", "nope");
+      expect(e).toBeInstanceOf(Error);
+      expect(e.name).toBe("LeagueInvitationError");
+      expect(e.code).toBe("forbidden");
+    });
+  });
+});

--- a/apps/server/src/services/league-invitation.ts
+++ b/apps/server/src/services/league-invitation.ts
@@ -1,0 +1,448 @@
+/**
+ * Lot A — Invitations de ligue.
+ *
+ * Le commissaire (createur de la ligue) ou un admin peut inviter un
+ * coach a rejoindre une saison. Trois modes :
+ *
+ *  1. Invitation ciblee userId : restreinte au user invite.
+ *  2. Invitation ciblee email : le user devra creer un compte avec
+ *     cet email puis ouvrir le lien (v1 : pas d'envoi mail, juste un
+ *     lien shareable).
+ *  3. Invitation publique : aucun ciblage, n'importe quel user
+ *     connecte peut accepter (utilisable pour partage discord).
+ *
+ * Le `code` est un token URL-safe genere par crypto.randomBytes(16),
+ * unique en base et impossible a brute-forcer. Les invitations
+ * expirent apres `expiresInDays` jours (default 14).
+ *
+ * Les hooks de transition d'etat :
+ *   - createInvitation : refuse si saison terminee / annulee.
+ *   - acceptInvitation : appelle `addParticipant` apres avoir verifie
+ *     le couple coach/team.
+ *   - declineInvitation / cancelInvitation : transitions terminales.
+ *
+ * Pas d'I/O autre que prisma. Service pur (testable via mock).
+ */
+
+import { randomBytes } from "crypto";
+import { prisma } from "../prisma";
+import { addParticipant } from "./league";
+
+export type LeagueInvitationStatus =
+  | "pending"
+  | "accepted"
+  | "declined"
+  | "cancelled"
+  | "expired";
+
+export class LeagueInvitationError extends Error {
+  constructor(
+    public readonly code:
+      | "league_not_found"
+      | "season_not_found"
+      | "season_closed"
+      | "invitation_not_found"
+      | "invitation_already_consumed"
+      | "invitation_expired"
+      | "invitation_not_for_user"
+      | "team_not_found"
+      | "team_not_owned_by_user"
+      | "team_already_registered"
+      | "league_full"
+      | "forbidden",
+    message: string,
+  ) {
+    super(message);
+    this.name = "LeagueInvitationError";
+  }
+}
+
+export interface CreateInvitationInput {
+  leagueId: string;
+  inviterUserId: string;
+  seasonId?: string | null;
+  inviteeUserId?: string | null;
+  inviteeEmail?: string | null;
+  inviteeTeamId?: string | null;
+  message?: string | null;
+  expiresInDays?: number;
+}
+
+const DEFAULT_EXPIRES_DAYS = 14;
+const MIN_EXPIRES_DAYS = 1;
+const MAX_EXPIRES_DAYS = 90;
+
+/**
+ * Genere un code d'invitation URL-safe (base64url) de longueur ~22.
+ * Espace de cle ~128 bits : non brute-forcable a l'echelle web.
+ */
+export function generateInvitationCode(): string {
+  return randomBytes(16).toString("base64url");
+}
+
+function clampExpiresDays(raw: number | undefined): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_EXPIRES_DAYS;
+  }
+  return Math.min(MAX_EXPIRES_DAYS, Math.max(MIN_EXPIRES_DAYS, Math.floor(raw)));
+}
+
+/**
+ * Crée une invitation pour la ligue donnee. Verifie :
+ *   - la ligue existe et l'inviter est createur OU admin (a verifier
+ *     cote route via `requireLeagueCreator` ou middleware admin).
+ *   - la saison (si fournie) appartient bien a la ligue et n'est pas
+ *     "completed" (sinon refus).
+ *   - le couple (leagueId, inviteeUserId, seasonId, status=pending)
+ *     n'existe pas deja (idempotence souple : on retourne l'existant).
+ */
+export async function createInvitation(input: CreateInvitationInput) {
+  const expiresInDays = clampExpiresDays(input.expiresInDays);
+
+  const league = await prisma.league.findUnique({
+    where: { id: input.leagueId },
+    select: { id: true, status: true },
+  });
+  if (!league) {
+    throw new LeagueInvitationError(
+      "league_not_found",
+      `Ligue introuvable: ${input.leagueId}`,
+    );
+  }
+
+  if (input.seasonId) {
+    const season = await prisma.leagueSeason.findUnique({
+      where: { id: input.seasonId },
+      select: { id: true, leagueId: true, status: true },
+    });
+    if (!season || season.leagueId !== input.leagueId) {
+      throw new LeagueInvitationError(
+        "season_not_found",
+        "Saison introuvable ou n'appartenant pas a cette ligue",
+      );
+    }
+    if (season.status === "completed") {
+      throw new LeagueInvitationError(
+        "season_closed",
+        "Saison terminee : impossible d'inviter de nouveaux participants",
+      );
+    }
+  }
+
+  // Idempotence : si une invitation pending existe deja pour ce
+  // couple (league, season, invitee), on la retourne au lieu d'en
+  // creer une 2e.
+  if (input.inviteeUserId) {
+    const existing = await prisma.leagueInvitation.findFirst({
+      where: {
+        leagueId: input.leagueId,
+        seasonId: input.seasonId ?? null,
+        inviteeUserId: input.inviteeUserId,
+        status: "pending",
+      },
+    });
+    if (existing && existing.expiresAt > new Date()) {
+      return existing;
+    }
+  }
+
+  const code = generateInvitationCode();
+  const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
+
+  return prisma.leagueInvitation.create({
+    data: {
+      leagueId: input.leagueId,
+      seasonId: input.seasonId ?? null,
+      inviterUserId: input.inviterUserId,
+      inviteeUserId: input.inviteeUserId ?? null,
+      inviteeEmail: input.inviteeEmail ?? null,
+      inviteeTeamId: input.inviteeTeamId ?? null,
+      message: input.message ?? null,
+      status: "pending",
+      code,
+      expiresAt,
+    },
+  });
+}
+
+export interface AcceptInvitationInput {
+  code: string;
+  /** L'user authentifie qui accepte (peut differer de l'inviteeUserId). */
+  userId: string;
+  /** L'equipe a inscrire. */
+  teamId: string;
+  /** SeasonId explicite quand l'invitation est league-wide (pas seasonId). */
+  seasonId?: string;
+}
+
+/**
+ * Accepte une invitation : inscrit l'equipe a la saison via
+ * `addParticipant`, met l'invitation a "accepted".
+ *
+ * Garde-fou :
+ *   - L'invitation doit exister, etre "pending" et non expiree.
+ *   - Si `inviteeUserId` est defini, l'user qui accepte doit
+ *     correspondre.
+ *   - L'equipe doit appartenir a l'user qui accepte.
+ *   - La saison est determinee par : `input.seasonId` > `invitation.seasonId`.
+ */
+export async function acceptInvitation(input: AcceptInvitationInput) {
+  const invitation = await prisma.leagueInvitation.findUnique({
+    where: { code: input.code },
+  });
+  if (!invitation) {
+    throw new LeagueInvitationError(
+      "invitation_not_found",
+      "Invitation introuvable",
+    );
+  }
+  if (invitation.status !== "pending") {
+    throw new LeagueInvitationError(
+      "invitation_already_consumed",
+      `Invitation deja ${invitation.status}`,
+    );
+  }
+  if (invitation.expiresAt <= new Date()) {
+    // Marquage paresseux : on bascule en "expired" a l'usage.
+    await prisma.leagueInvitation.update({
+      where: { id: invitation.id },
+      data: { status: "expired" },
+    });
+    throw new LeagueInvitationError(
+      "invitation_expired",
+      "Invitation expiree",
+    );
+  }
+  if (
+    invitation.inviteeUserId !== null &&
+    invitation.inviteeUserId !== input.userId
+  ) {
+    throw new LeagueInvitationError(
+      "invitation_not_for_user",
+      "Cette invitation ne vous est pas adressee",
+    );
+  }
+
+  const seasonId = input.seasonId ?? invitation.seasonId;
+  if (!seasonId) {
+    throw new LeagueInvitationError(
+      "season_not_found",
+      "Aucune saison ciblee ; precisez `seasonId`",
+    );
+  }
+
+  // Verifie l'ownership de l'equipe.
+  const team = await prisma.team.findUnique({
+    where: { id: input.teamId },
+    select: { id: true, ownerId: true },
+  });
+  if (!team) {
+    throw new LeagueInvitationError(
+      "team_not_found",
+      "Equipe introuvable",
+    );
+  }
+  if (team.ownerId !== input.userId) {
+    throw new LeagueInvitationError(
+      "team_not_owned_by_user",
+      "Vous ne pouvez inscrire que vos propres equipes",
+    );
+  }
+
+  // Inscription effective. addParticipant remontera ses propres
+  // erreurs (saison cloturee, dej inscrite, plein, etc.) — on les
+  // remap ici en codes typees.
+  let participant;
+  try {
+    participant = await addParticipant({ seasonId, teamId: input.teamId });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "";
+    if (/deja inscrit|already/i.test(msg)) {
+      throw new LeagueInvitationError(
+        "team_already_registered",
+        "Cette equipe est deja inscrite sur la saison",
+      );
+    }
+    if (/maximum|max|complet/i.test(msg)) {
+      throw new LeagueInvitationError(
+        "league_full",
+        "La saison a atteint son nombre maximum d'inscrits",
+      );
+    }
+    if (/draft|scheduled|in_progress|completed/i.test(msg)) {
+      throw new LeagueInvitationError(
+        "season_closed",
+        "Saison fermee aux inscriptions",
+      );
+    }
+    throw e;
+  }
+
+  const updated = await prisma.leagueInvitation.update({
+    where: { id: invitation.id },
+    data: {
+      status: "accepted",
+      acceptedAt: new Date(),
+      acceptedParticipantId:
+        (participant as { id?: string } | null)?.id ?? null,
+    },
+  });
+  return { invitation: updated, participant };
+}
+
+/** Decline une invitation pending. */
+export async function declineInvitation(input: {
+  code: string;
+  userId: string;
+}) {
+  const invitation = await prisma.leagueInvitation.findUnique({
+    where: { code: input.code },
+  });
+  if (!invitation) {
+    throw new LeagueInvitationError(
+      "invitation_not_found",
+      "Invitation introuvable",
+    );
+  }
+  if (invitation.status !== "pending") {
+    throw new LeagueInvitationError(
+      "invitation_already_consumed",
+      `Invitation deja ${invitation.status}`,
+    );
+  }
+  if (
+    invitation.inviteeUserId !== null &&
+    invitation.inviteeUserId !== input.userId
+  ) {
+    throw new LeagueInvitationError(
+      "invitation_not_for_user",
+      "Cette invitation ne vous est pas adressee",
+    );
+  }
+  return prisma.leagueInvitation.update({
+    where: { id: invitation.id },
+    data: { status: "declined", declinedAt: new Date() },
+  });
+}
+
+/** Annule une invitation pending (cote inviter / admin). */
+export async function cancelInvitation(input: {
+  invitationId: string;
+  byUserId: string;
+  isAdmin?: boolean;
+}) {
+  const invitation = await prisma.leagueInvitation.findUnique({
+    where: { id: input.invitationId },
+  });
+  if (!invitation) {
+    throw new LeagueInvitationError(
+      "invitation_not_found",
+      "Invitation introuvable",
+    );
+  }
+  if (invitation.status !== "pending") {
+    throw new LeagueInvitationError(
+      "invitation_already_consumed",
+      `Invitation deja ${invitation.status}`,
+    );
+  }
+  if (!input.isAdmin && invitation.inviterUserId !== input.byUserId) {
+    throw new LeagueInvitationError(
+      "forbidden",
+      "Seul l'inviter ou un admin peut annuler une invitation",
+    );
+  }
+  return prisma.leagueInvitation.update({
+    where: { id: invitation.id },
+    data: { status: "cancelled", cancelledAt: new Date() },
+  });
+}
+
+/** Liste les invitations pour une ligue (optionnellement filtree par status). */
+export async function listInvitationsForLeague(input: {
+  leagueId: string;
+  status?: LeagueInvitationStatus;
+  limit?: number;
+}) {
+  const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+  return prisma.leagueInvitation.findMany({
+    where: {
+      leagueId: input.leagueId,
+      ...(input.status ? { status: input.status } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    include: {
+      invitee: { select: { id: true, coachName: true } },
+      inviteeTeam: { select: { id: true, name: true, roster: true } },
+      season: { select: { id: true, name: true, seasonNumber: true } },
+    },
+  });
+}
+
+/** Liste les invitations pending pour un user (pour l'UI "Mes invitations"). */
+export async function listPendingInvitationsForUser(userId: string) {
+  return prisma.leagueInvitation.findMany({
+    where: {
+      inviteeUserId: userId,
+      status: "pending",
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { createdAt: "desc" },
+    include: {
+      league: { select: { id: true, name: true } },
+      season: {
+        select: { id: true, name: true, seasonNumber: true, status: true },
+      },
+      inviter: { select: { id: true, coachName: true } },
+      inviteeTeam: { select: { id: true, name: true } },
+    },
+  });
+}
+
+/**
+ * Recupere une invitation par code (vue publique du lien shareable).
+ * Renvoie les meta info minimales pour permettre la decision avant
+ * acceptation : ligue, saison, inviter.
+ */
+export async function getInvitationByCode(code: string) {
+  return prisma.leagueInvitation.findUnique({
+    where: { code },
+    include: {
+      league: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          ruleset: true,
+          allowedRosters: true,
+          status: true,
+        },
+      },
+      season: {
+        select: {
+          id: true,
+          name: true,
+          seasonNumber: true,
+          status: true,
+          startDate: true,
+        },
+      },
+      inviter: { select: { id: true, coachName: true } },
+      inviteeTeam: { select: { id: true, name: true, roster: true } },
+    },
+  });
+}
+
+/**
+ * Job de housekeeping : marque "expired" les invitations pending
+ * dont `expiresAt` est passe. Idempotent. A appeler via cron ou
+ * lazy au read.
+ */
+export async function expireOldInvitations(now: Date = new Date()) {
+  const result = await prisma.leagueInvitation.updateMany({
+    where: { status: "pending", expiresAt: { lte: now } },
+    data: { status: "expired" },
+  });
+  return { expired: result.count };
+}

--- a/apps/server/src/services/league-manual-pairing.test.ts
+++ b/apps/server/src/services/league-manual-pairing.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Lot F — Tests du service de creation manuelle de pairings.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leagueSeason: { findUnique: vi.fn() },
+    leagueRound: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    leagueParticipant: { findMany: vi.fn() },
+    leaguePairing: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  createManualRound,
+  createManualPairing,
+  deleteManualPairing,
+  updateManualPairing,
+  LeagueManualPairingError,
+} from "./league-manual-pairing";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+describe("Lot F — league-manual-pairing service", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("createManualRound", () => {
+    it("rejects if season not found", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue(null);
+      await expect(
+        createManualRound({ seasonId: "s-X" }),
+      ).rejects.toMatchObject({ code: "season_not_found" });
+    });
+
+    it("assigns next roundNumber based on last round", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "in_progress",
+      });
+      mockPrisma.leagueRound.findFirst.mockResolvedValue({ roundNumber: 5 });
+      mockPrisma.leagueRound.create.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "r1", ...a.data }),
+      );
+      const out = await createManualRound({ seasonId: "s1", name: "Amical" });
+      expect(out).toMatchObject({
+        roundNumber: 6,
+        kind: "regular",
+        name: "Amical",
+        status: "pending",
+      });
+    });
+
+    it("starts at 1 if no previous round", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leagueRound.findFirst.mockResolvedValue(null);
+      mockPrisma.leagueRound.create.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "r1", ...a.data }),
+      );
+      const out = await createManualRound({
+        seasonId: "s1",
+        kind: "playoff",
+      });
+      expect(out).toMatchObject({ roundNumber: 1, kind: "playoff" });
+    });
+  });
+
+  describe("createManualPairing", () => {
+    it("rejects same participant", async () => {
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p1",
+        }),
+      ).rejects.toMatchObject({ code: "same_participant" });
+    });
+
+    it("rejects if round not found", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue(null);
+      await expect(
+        createManualPairing({
+          roundId: "rX",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "round_not_found" });
+    });
+
+    it("rejects if round completed", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "completed",
+      });
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "round_completed" });
+    });
+
+    it("rejects if participants missing", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "pending",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1", status: "active" },
+      ]);
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "participant_not_found" });
+    });
+
+    it("rejects if a participant withdrew", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "pending",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1", status: "active" },
+        { id: "p2", seasonId: "s1", status: "withdrawn" },
+      ]);
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "participant_not_active" });
+    });
+
+    it("rejects if participant not in same season as round", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "pending",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1", status: "active" },
+        { id: "p2", seasonId: "s2", status: "active" },
+      ]);
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "participant_not_found" });
+    });
+
+    it("rejects duplicate pairing in same round (regardless of home/away order)", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "pending",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1", status: "active" },
+        { id: "p2", seasonId: "s1", status: "active" },
+      ]);
+      mockPrisma.leaguePairing.findFirst.mockResolvedValue({ id: "old" });
+      await expect(
+        createManualPairing({
+          roundId: "r1",
+          homeParticipantId: "p1",
+          awayParticipantId: "p2",
+        }),
+      ).rejects.toMatchObject({ code: "duplicate_pairing" });
+    });
+
+    it("creates pairing on success", async () => {
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r1",
+        seasonId: "s1",
+        status: "pending",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1", status: "active" },
+        { id: "p2", seasonId: "s1", status: "active" },
+      ]);
+      mockPrisma.leaguePairing.findFirst.mockResolvedValue(null);
+      mockPrisma.leaguePairing.create.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "new", ...a.data }),
+      );
+      const out = await createManualPairing({
+        roundId: "r1",
+        homeParticipantId: "p1",
+        awayParticipantId: "p2",
+      });
+      expect(out).toMatchObject({
+        id: "new",
+        status: "scheduled",
+        homeParticipantId: "p1",
+        awayParticipantId: "p2",
+      });
+    });
+  });
+
+  describe("deleteManualPairing", () => {
+    it("rejects when pairing not found", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue(null);
+      await expect(
+        deleteManualPairing({ pairingId: "x" }),
+      ).rejects.toMatchObject({ code: "pairing_not_found" });
+    });
+
+    it("rejects when pairing already played", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        status: "played",
+        match: { id: "m1" },
+      });
+      await expect(
+        deleteManualPairing({ pairingId: "p1" }),
+      ).rejects.toMatchObject({ code: "pairing_already_played" });
+    });
+
+    it("rejects when match exists (status scheduled but matchId set)", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        status: "in_progress",
+        match: { id: "m1" },
+      });
+      await expect(
+        deleteManualPairing({ pairingId: "p1" }),
+      ).rejects.toMatchObject({ code: "pairing_already_played" });
+    });
+
+    it("deletes scheduled pairing without match", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        status: "scheduled",
+        match: null,
+      });
+      mockPrisma.leaguePairing.delete.mockResolvedValue({ id: "p1" });
+      await expect(
+        deleteManualPairing({ pairingId: "p1" }),
+      ).resolves.toMatchObject({ deleted: true });
+    });
+  });
+
+  describe("updateManualPairing", () => {
+    it("updates scheduledAt", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        roundId: "r1",
+        status: "scheduled",
+        match: null,
+      });
+      mockPrisma.leaguePairing.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({
+          id: "p1",
+          ...a.data,
+        }),
+      );
+      const newDate = new Date("2026-12-25T10:00:00Z");
+      const out = await updateManualPairing({
+        pairingId: "p1",
+        scheduledAt: newDate,
+      });
+      expect(out).toMatchObject({ scheduledAt: newDate });
+    });
+
+    it("moves pairing to target round", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        roundId: "r1",
+        status: "scheduled",
+        match: null,
+      });
+      // 1er findUnique : target round
+      mockPrisma.leagueRound.findUnique
+        .mockResolvedValueOnce({
+          id: "r2",
+          seasonId: "s1",
+          status: "pending",
+        })
+        .mockResolvedValueOnce({ seasonId: "s1" });
+      mockPrisma.leaguePairing.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({
+          id: "p1",
+          ...a.data,
+        }),
+      );
+      const out = await updateManualPairing({
+        pairingId: "p1",
+        targetRoundId: "r2",
+      });
+      expect(out).toMatchObject({ roundId: "r2" });
+    });
+
+    it("rejects move to completed round", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        roundId: "r1",
+        status: "scheduled",
+        match: null,
+      });
+      mockPrisma.leagueRound.findUnique.mockResolvedValue({
+        id: "r2",
+        seasonId: "s1",
+        status: "completed",
+      });
+      await expect(
+        updateManualPairing({ pairingId: "p1", targetRoundId: "r2" }),
+      ).rejects.toMatchObject({ code: "round_completed" });
+    });
+
+    it("rejects update of played pairing", async () => {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "p1",
+        roundId: "r1",
+        status: "played",
+        match: { id: "m1" },
+      });
+      await expect(
+        updateManualPairing({
+          pairingId: "p1",
+          scheduledAt: new Date(),
+        }),
+      ).rejects.toMatchObject({ code: "pairing_already_played" });
+    });
+  });
+
+  describe("LeagueManualPairingError", () => {
+    it("preserves code on instance", () => {
+      const e = new LeagueManualPairingError("duplicate_pairing", "x");
+      expect(e.code).toBe("duplicate_pairing");
+      expect(e.name).toBe("LeagueManualPairingError");
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/apps/server/src/services/league-manual-pairing.ts
+++ b/apps/server/src/services/league-manual-pairing.ts
@@ -1,0 +1,290 @@
+/**
+ * Lot F — Creation/edition manuelle de pairings de ligue.
+ *
+ * Permet au commissaire (createur de la ligue) d'ajouter des matchs
+ * en dehors du calendrier auto-genere (`league-scheduler.ts`), de
+ * deplacer ou supprimer des pairings non-joues, et de creer des
+ * rounds "personnalises" (amicaux, rounds bonus, etc.).
+ *
+ * Garde-fous :
+ *   - Pas de mutation possible si un match a deja ete lance/joue
+ *     pour ce pairing (`matchId` non-null OU status >= played).
+ *   - L'ajout d'un pairing necessite que les 2 participants soient
+ *     bien inscrits a la saison (status='active').
+ *   - Pas de doublon : on refuse un pairing identique (meme home,
+ *     meme away, meme round) deja present.
+ */
+
+import { prisma } from "../prisma";
+
+export class LeagueManualPairingError extends Error {
+  constructor(
+    public readonly code:
+      | "round_not_found"
+      | "season_not_found"
+      | "pairing_not_found"
+      | "participant_not_found"
+      | "participant_not_active"
+      | "duplicate_pairing"
+      | "same_participant"
+      | "pairing_already_played"
+      | "round_completed",
+    message: string,
+  ) {
+    super(message);
+    this.name = "LeagueManualPairingError";
+  }
+}
+
+export interface CreateManualRoundInput {
+  seasonId: string;
+  /** Optionnel — nom personnalise du round ("Amical mid-season"). */
+  name?: string;
+  /** "regular" (default) ou "playoff". */
+  kind?: "regular" | "playoff";
+  startDate?: Date | null;
+  endDate?: Date | null;
+}
+
+/**
+ * Crée un round vide en fin de saison (roundNumber = max+1). Permet
+ * d'ajouter des matchs hors du round-robin auto-genere.
+ */
+export async function createManualRound(input: CreateManualRoundInput) {
+  const season = await prisma.leagueSeason.findUnique({
+    where: { id: input.seasonId },
+    select: { id: true, status: true },
+  });
+  if (!season) {
+    throw new LeagueManualPairingError(
+      "season_not_found",
+      `Saison introuvable: ${input.seasonId}`,
+    );
+  }
+
+  const last = await prisma.leagueRound.findFirst({
+    where: { seasonId: input.seasonId },
+    orderBy: { roundNumber: "desc" },
+    select: { roundNumber: true },
+  });
+  const nextNumber = (last?.roundNumber ?? 0) + 1;
+
+  return prisma.leagueRound.create({
+    data: {
+      seasonId: input.seasonId,
+      roundNumber: nextNumber,
+      name: input.name ?? `Journee ${nextNumber}`,
+      kind: input.kind ?? "regular",
+      status: "pending",
+      startDate: input.startDate ?? null,
+      endDate: input.endDate ?? null,
+    },
+  });
+}
+
+export interface CreateManualPairingInput {
+  roundId: string;
+  homeParticipantId: string;
+  awayParticipantId: string;
+  scheduledAt?: Date | null;
+  deadlineAt?: Date | null;
+}
+
+/**
+ * Crée un pairing dans un round existant. Verifications :
+ *   - le round existe et n'est pas "completed".
+ *   - les deux participants existent, sont actifs, appartiennent a
+ *     la meme saison que le round.
+ *   - le couple (home, away, round) n'existe pas deja.
+ *   - home != away.
+ */
+export async function createManualPairing(input: CreateManualPairingInput) {
+  if (input.homeParticipantId === input.awayParticipantId) {
+    throw new LeagueManualPairingError(
+      "same_participant",
+      "Le meme participant ne peut pas jouer contre lui-meme",
+    );
+  }
+
+  const round = await prisma.leagueRound.findUnique({
+    where: { id: input.roundId },
+    select: { id: true, seasonId: true, status: true },
+  });
+  if (!round) {
+    throw new LeagueManualPairingError(
+      "round_not_found",
+      `Round introuvable: ${input.roundId}`,
+    );
+  }
+  if (round.status === "completed") {
+    throw new LeagueManualPairingError(
+      "round_completed",
+      "Round termine : impossible d'ajouter un pairing",
+    );
+  }
+
+  const participants = await prisma.leagueParticipant.findMany({
+    where: {
+      id: { in: [input.homeParticipantId, input.awayParticipantId] },
+    },
+    select: { id: true, seasonId: true, status: true },
+  });
+  if (participants.length !== 2) {
+    throw new LeagueManualPairingError(
+      "participant_not_found",
+      "Un ou plusieurs participants introuvables",
+    );
+  }
+  for (const p of participants) {
+    if (p.seasonId !== round.seasonId) {
+      throw new LeagueManualPairingError(
+        "participant_not_found",
+        "Un participant n'appartient pas a la saison du round",
+      );
+    }
+    if (p.status !== "active") {
+      throw new LeagueManualPairingError(
+        "participant_not_active",
+        `Le participant ${p.id} n'est pas actif (status=${p.status})`,
+      );
+    }
+  }
+
+  // Refus du doublon (meme couple dans le meme round, indifferent
+  // a l'ordre home/away).
+  const existing = await prisma.leaguePairing.findFirst({
+    where: {
+      roundId: input.roundId,
+      OR: [
+        {
+          homeParticipantId: input.homeParticipantId,
+          awayParticipantId: input.awayParticipantId,
+        },
+        {
+          homeParticipantId: input.awayParticipantId,
+          awayParticipantId: input.homeParticipantId,
+        },
+      ],
+    },
+    select: { id: true },
+  });
+  if (existing) {
+    throw new LeagueManualPairingError(
+      "duplicate_pairing",
+      "Un pairing existe deja pour ces 2 participants dans ce round",
+    );
+  }
+
+  return prisma.leaguePairing.create({
+    data: {
+      roundId: input.roundId,
+      homeParticipantId: input.homeParticipantId,
+      awayParticipantId: input.awayParticipantId,
+      status: "scheduled",
+      scheduledAt: input.scheduledAt ?? null,
+      deadlineAt: input.deadlineAt ?? null,
+    },
+  });
+}
+
+/**
+ * Supprime un pairing — uniquement si pas encore joue (status =
+ * scheduled OU cancelled, pas de matchId).
+ */
+export async function deleteManualPairing(input: { pairingId: string }) {
+  const pairing = await prisma.leaguePairing.findUnique({
+    where: { id: input.pairingId },
+    include: { match: { select: { id: true } } },
+  });
+  if (!pairing) {
+    throw new LeagueManualPairingError(
+      "pairing_not_found",
+      `Pairing introuvable: ${input.pairingId}`,
+    );
+  }
+  // Le pairing est consomme si un match a ete cree et joue (status
+  // played/forfeit_*).
+  const consumedStatuses = new Set([
+    "played",
+    "forfeit_home",
+    "forfeit_away",
+  ]);
+  if (consumedStatuses.has(pairing.status) || pairing.match) {
+    throw new LeagueManualPairingError(
+      "pairing_already_played",
+      "Pairing deja joue : suppression impossible",
+    );
+  }
+  await prisma.leaguePairing.delete({ where: { id: input.pairingId } });
+  return { deleted: true };
+}
+
+export interface UpdateManualPairingInput {
+  pairingId: string;
+  scheduledAt?: Date | null;
+  deadlineAt?: Date | null;
+  /** Optionnel — deplace le pairing vers un autre round. */
+  targetRoundId?: string;
+}
+
+/** Met a jour un pairing (deplacement / re-programmation). */
+export async function updateManualPairing(input: UpdateManualPairingInput) {
+  const pairing = await prisma.leaguePairing.findUnique({
+    where: { id: input.pairingId },
+    include: { match: { select: { id: true } } },
+  });
+  if (!pairing) {
+    throw new LeagueManualPairingError(
+      "pairing_not_found",
+      `Pairing introuvable: ${input.pairingId}`,
+    );
+  }
+  if (pairing.match || pairing.status === "played") {
+    throw new LeagueManualPairingError(
+      "pairing_already_played",
+      "Pairing deja joue : modification impossible",
+    );
+  }
+
+  let roundIdToUse = pairing.roundId;
+  if (input.targetRoundId && input.targetRoundId !== pairing.roundId) {
+    const target = await prisma.leagueRound.findUnique({
+      where: { id: input.targetRoundId },
+      select: { id: true, seasonId: true, status: true },
+    });
+    if (!target) {
+      throw new LeagueManualPairingError(
+        "round_not_found",
+        `Round cible introuvable: ${input.targetRoundId}`,
+      );
+    }
+    if (target.status === "completed") {
+      throw new LeagueManualPairingError(
+        "round_completed",
+        "Round cible termine : impossible de deplacer le pairing",
+      );
+    }
+    // Coherence saison (on ne deplace pas inter-saison).
+    const currentRound = await prisma.leagueRound.findUnique({
+      where: { id: pairing.roundId },
+      select: { seasonId: true },
+    });
+    if (currentRound && currentRound.seasonId !== target.seasonId) {
+      throw new LeagueManualPairingError(
+        "round_not_found",
+        "Le round cible n'appartient pas a la meme saison",
+      );
+    }
+    roundIdToUse = target.id;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = { roundId: roundIdToUse };
+  if (input.scheduledAt !== undefined) data.scheduledAt = input.scheduledAt;
+  if (input.deadlineAt !== undefined) data.deadlineAt = input.deadlineAt;
+
+  return prisma.leaguePairing.update({
+    where: { id: input.pairingId },
+    data,
+  });
+}

--- a/apps/server/src/services/league-match-result.test.ts
+++ b/apps/server/src/services/league-match-result.test.ts
@@ -551,7 +551,14 @@ describe("Rule: recordLeagueMatchResult (L.7)", () => {
 
       expect(mockPrisma.leaguePairing.update).toHaveBeenCalledWith({
         where: { id: "pair-1" },
-        data: { status: "played" },
+        // Lot E — pairing.update inclut maintenant les snapshots
+        // bonusPointsHome/Away (0 quand bonusPointsConfig est null).
+        data: {
+          status: "played",
+          bonusPointsHome: 0,
+          bonusPointsAway: 0,
+          bonusBreakdown: null,
+        },
       });
     });
 

--- a/apps/server/src/services/league-match-result.ts
+++ b/apps/server/src/services/league-match-result.ts
@@ -33,6 +33,11 @@ import {
   startPlayoffs,
   advancePlayoffsWithWinner,
 } from "./league-playoffs";
+import {
+  evaluateBonusRules,
+  parseBonusConfig,
+  type MatchBonusContext,
+} from "./league-bonus-points";
 import { serverLog } from "../utils/server-log";
 
 export interface RecordMatchResultInput {
@@ -118,6 +123,9 @@ export async function recordLeagueMatchResult(
               winPoints: true,
               drawPoints: true,
               lossPoints: true,
+              // Lot E — config bonus utilisee plus bas pour
+              // calculer un delta supplementaire de points.
+              bonusPointsConfig: true,
             },
           },
         },
@@ -172,8 +180,25 @@ export async function recordLeagueMatchResult(
 
   const bareme = match.leagueSeason.league;
   const winner = computeWinner(input.scoreA, input.scoreB);
-  const pointsA = pointsFor(winner, "A", bareme);
-  const pointsB = pointsFor(winner, "B", bareme);
+  const basePointsA = pointsFor(winner, "A", bareme);
+  const basePointsB = pointsFor(winner, "B", bareme);
+
+  // Lot E — applique les regles de bonus configurees au niveau de
+  // la ligue. Le cote "A" = home pour le scoring du pairing
+  // (convention historique du modele).
+  const bonusRules = parseBonusConfig(
+    (bareme as { bonusPointsConfig?: unknown }).bonusPointsConfig,
+  );
+  const bonusCtx: MatchBonusContext = {
+    tdsHome: input.scoreA,
+    tdsAway: input.scoreB,
+    casualtiesInflictedHome: input.casualtiesA,
+    casualtiesInflictedAway: input.casualtiesB,
+    winner: winner === "A" ? "home" : winner === "B" ? "away" : "draw",
+  };
+  const bonus = evaluateBonusRules(bonusRules, bonusCtx);
+  const pointsA = basePointsA + bonus.homeBonus;
+  const pointsB = basePointsB + bonus.awayBonus;
 
   // L.8 — ELO saisonnier : calcul des deltas en utilisant le K-factor de
   // placement (48) tant que le participant n'a pas joue 5 matchs, sinon 32.
@@ -244,7 +269,16 @@ export async function recordLeagueMatchResult(
           markMatch,
           prisma.leaguePairing.update({
             where: { id: match.leaguePairingId },
-            data: { status: "played" },
+            data: {
+              status: "played",
+              // Lot E — snapshot des bonus appliques (audit / UI).
+              bonusPointsHome: bonus.homeBonus,
+              bonusPointsAway: bonus.awayBonus,
+              bonusBreakdown:
+                bonus.applied.length > 0
+                  ? (bonus.applied as unknown as Record<string, unknown>[])
+                  : null,
+            },
           }),
         ]
       : [updateA, updateB, markMatch];

--- a/apps/server/src/services/league-player-stats.test.ts
+++ b/apps/server/src/services/league-player-stats.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Lot J — Tests du service `league-player-stats`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leagueParticipant: { findMany: vi.fn() },
+    teamPlayer: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  computeLeaderboards,
+  computeLeaderboardsByTeam,
+  LEADERBOARD_CATEGORIES,
+} from "./league-player-stats";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+function player(overrides: Partial<{
+  id: string;
+  name: string;
+  totalTouchdowns: number;
+  totalCasualties: number;
+  totalCompletions: number;
+  totalInterceptions: number;
+  totalMvpAwards: number;
+  matchesPlayed: number;
+  spp: number;
+  nigglingInjuries: number;
+  teamId: string;
+  teamName: string;
+}>) {
+  return {
+    id: overrides.id ?? "p1",
+    name: overrides.name ?? "Player",
+    position: "Lineman",
+    spp: overrides.spp ?? 0,
+    totalTouchdowns: overrides.totalTouchdowns ?? 0,
+    totalCasualties: overrides.totalCasualties ?? 0,
+    totalCompletions: overrides.totalCompletions ?? 0,
+    totalInterceptions: overrides.totalInterceptions ?? 0,
+    totalMvpAwards: overrides.totalMvpAwards ?? 0,
+    matchesPlayed: overrides.matchesPlayed ?? 1,
+    nigglingInjuries: overrides.nigglingInjuries ?? 0,
+    team: {
+      id: overrides.teamId ?? "team-1",
+      name: overrides.teamName ?? "Team",
+      roster: "skaven",
+      owner: { id: "u1", coachName: "Bob" },
+    },
+  };
+}
+
+describe("Lot J — league-player-stats", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("computeLeaderboards", () => {
+    it("returns empty catalogue when no teams in season", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([]);
+      const out = await computeLeaderboards({ seasonId: "s1" });
+      expect(out.topScorers).toEqual([]);
+      expect(out.topBashers).toEqual([]);
+      expect(out.scope).toBe("career");
+    });
+
+    it("returns top scorers ordered DESC, top 5 by default", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { teamId: "team-1" },
+      ]);
+      mockPrisma.teamPlayer.findMany.mockResolvedValue([
+        player({ id: "p1", totalTouchdowns: 5 }),
+        player({ id: "p2", totalTouchdowns: 12 }),
+        player({ id: "p3", totalTouchdowns: 8 }),
+        player({ id: "p4", totalTouchdowns: 3 }),
+        player({ id: "p5", totalTouchdowns: 0 }), // filtered (0)
+        player({ id: "p6", totalTouchdowns: 10 }),
+        player({ id: "p7", totalTouchdowns: 4 }),
+      ]);
+      const out = await computeLeaderboards({ seasonId: "s1" });
+      expect(out.topScorers.map((r) => r.playerId)).toEqual([
+        "p2",
+        "p6",
+        "p3",
+        "p1",
+        "p7",
+      ]);
+      expect(out.topScorers[0].rank).toBe(1);
+      expect(out.topScorers[0].value).toBe(12);
+    });
+
+    it("includes secondary stats (matchesPlayed + spp)", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { teamId: "team-1" },
+      ]);
+      mockPrisma.teamPlayer.findMany.mockResolvedValue([
+        player({ id: "p1", totalCasualties: 4, matchesPlayed: 8, spp: 24 }),
+      ]);
+      const out = await computeLeaderboards({ seasonId: "s1" });
+      expect(out.topBashers[0].secondary).toEqual({
+        matchesPlayed: 8,
+        spp: 24,
+      });
+    });
+
+    it("filters out players with zero on the metric", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { teamId: "team-1" },
+      ]);
+      mockPrisma.teamPlayer.findMany.mockResolvedValue([
+        player({ id: "p1", totalCompletions: 3 }),
+        player({ id: "p2", totalCompletions: 0 }),
+      ]);
+      const out = await computeLeaderboards({ seasonId: "s1" });
+      expect(out.topPassers).toHaveLength(1);
+      expect(out.topPassers[0].playerId).toBe("p1");
+    });
+
+    it("clamps topN to [1, 50]", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([]);
+      const a = await computeLeaderboards({ seasonId: "s1", topN: 0 });
+      expect(a.topN).toBe(1);
+      const b = await computeLeaderboards({ seasonId: "s1", topN: 1000 });
+      expect(b.topN).toBe(50);
+      const c = await computeLeaderboards({ seasonId: "s1", topN: 7 });
+      expect(c.topN).toBe(7);
+    });
+
+    it("filters by teamId when provided", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { teamId: "team-2" },
+      ]);
+      mockPrisma.teamPlayer.findMany.mockResolvedValue([
+        player({ id: "p1", teamId: "team-2", totalTouchdowns: 3 }),
+      ]);
+      const out = await computeLeaderboards({
+        seasonId: "s1",
+        teamId: "team-2",
+      });
+      // verifie le where Prisma
+      const callArgs = mockPrisma.leagueParticipant.findMany.mock.calls[0][0];
+      expect(callArgs.where.teamId).toBe("team-2");
+      expect(out.topScorers).toHaveLength(1);
+    });
+
+    it("returns multiple categories in one pass", async () => {
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { teamId: "team-1" },
+      ]);
+      mockPrisma.teamPlayer.findMany.mockResolvedValue([
+        player({
+          id: "p1",
+          totalTouchdowns: 5,
+          totalCasualties: 7,
+          totalCompletions: 12,
+          spp: 33,
+        }),
+        player({
+          id: "p2",
+          totalTouchdowns: 2,
+          totalCasualties: 9,
+          totalCompletions: 4,
+          spp: 21,
+        }),
+      ]);
+      const out = await computeLeaderboards({ seasonId: "s1" });
+      expect(out.topScorers[0].playerId).toBe("p1");
+      expect(out.topBashers[0].playerId).toBe("p2");
+      expect(out.topFutureStars[0].playerId).toBe("p1");
+    });
+  });
+
+  describe("computeLeaderboardsByTeam", () => {
+    it("returns one catalogue per team", async () => {
+      // 1er findMany : list teams ; ensuite 1 findMany participants + 1 findMany players par team.
+      mockPrisma.leagueParticipant.findMany
+        .mockResolvedValueOnce([
+          { team: { id: "team-1", name: "Alpha" } },
+          { team: { id: "team-2", name: "Beta" } },
+        ])
+        // computeLeaderboards("s1", teamId=team-1) -> 1 participant
+        .mockResolvedValueOnce([{ teamId: "team-1" }])
+        .mockResolvedValueOnce([{ teamId: "team-2" }]);
+
+      mockPrisma.teamPlayer.findMany
+        .mockResolvedValueOnce([
+          player({ id: "pa", totalTouchdowns: 3, teamId: "team-1" }),
+        ])
+        .mockResolvedValueOnce([
+          player({ id: "pb", totalTouchdowns: 5, teamId: "team-2" }),
+        ]);
+
+      const out = await computeLeaderboardsByTeam({ seasonId: "s1" });
+      expect(out).toHaveLength(2);
+      expect(out[0].teamId).toBe("team-1");
+      expect(out[0].catalogue.topScorers[0].playerId).toBe("pa");
+      expect(out[1].teamId).toBe("team-2");
+      expect(out[1].catalogue.topScorers[0].playerId).toBe("pb");
+    });
+  });
+
+  describe("LEADERBOARD_CATEGORIES", () => {
+    it("exposes the 7 categories", () => {
+      const keys = LEADERBOARD_CATEGORIES.map((c) => c.key);
+      expect(keys).toEqual([
+        "topScorers",
+        "topBashers",
+        "topPassers",
+        "topInterceptors",
+        "topFutureStars",
+        "topMvps",
+        "topPunchingBags",
+      ]);
+    });
+  });
+});

--- a/apps/server/src/services/league-player-stats.ts
+++ b/apps/server/src/services/league-player-stats.ts
@@ -1,0 +1,295 @@
+/**
+ * Lot J — Statistiques top-N joueurs par ligue / saison.
+ *
+ * V1 — base sur les totaux career stockes sur `TeamPlayer` :
+ *   * topScorers       : totalTouchdowns DESC
+ *   * topBashers       : totalCasualties DESC
+ *   * topPassers       : totalCompletions DESC
+ *   * topInterceptors  : totalInterceptions DESC
+ *   * topFutureStars   : spp DESC (futur talent)
+ *   * topMvps          : totalMvpAwards DESC
+ *   * topPunchingBags  : matchesPlayed DESC + (na/ag/st/pa/av) reductions
+ *                        (heuristique — non-precise mais lit les LASTING
+ *                        INJURIES comme proxy du "sac de frappe").
+ *
+ * Limitation V1 — les compteurs sont **career** : un joueur qui a
+ * joue en dehors de la saison aura un total gonfle. Pour une V2
+ * precise par-saison, il faudra agreger depuis les events de la
+ * feuille de match (Lot G) ou stocker un snapshot start-of-season.
+ *
+ * Pour minimiser cette limite : on filtre les joueurs sur les
+ * teams inscrites a la saison ET on indique clairement le scope
+ * "carriere" dans la reponse (le flag `scope: 'career'`).
+ *
+ * Les categories manquantes (killer / catapulte / agresseur / sac
+ * de frappe stricto sensu) seront ajoutees quand la match-sheet v2
+ * (Lot G) tracera les events detailles.
+ */
+
+import { prisma } from "../prisma";
+
+export type PlayerStatCategory =
+  | "topScorers"
+  | "topBashers"
+  | "topPassers"
+  | "topInterceptors"
+  | "topFutureStars"
+  | "topMvps"
+  | "topPunchingBags";
+
+export interface PlayerStatRow {
+  readonly rank: number;
+  readonly playerId: string;
+  readonly playerName: string;
+  readonly position: string;
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly teamRoster: string;
+  readonly ownerId: string;
+  readonly ownerCoachName: string | null;
+  readonly value: number;
+  /** Stats secondaires utiles pour breakage de l'egalite cote UI. */
+  readonly secondary: {
+    readonly matchesPlayed: number;
+    readonly spp: number;
+  };
+}
+
+export interface PlayerStatsCatalogue {
+  readonly seasonId: string;
+  readonly topN: number;
+  readonly scope: "career";
+  readonly topScorers: PlayerStatRow[];
+  readonly topBashers: PlayerStatRow[];
+  readonly topPassers: PlayerStatRow[];
+  readonly topInterceptors: PlayerStatRow[];
+  readonly topFutureStars: PlayerStatRow[];
+  readonly topMvps: PlayerStatRow[];
+  readonly topPunchingBags: PlayerStatRow[];
+}
+
+interface PlayerSelected {
+  id: string;
+  name: string;
+  position: string;
+  spp: number;
+  totalTouchdowns: number;
+  totalCasualties: number;
+  totalCompletions: number;
+  totalInterceptions: number;
+  totalMvpAwards: number;
+  matchesPlayed: number;
+  nigglingInjuries: number;
+  team: {
+    id: string;
+    name: string;
+    roster: string;
+    owner: { id: string; coachName: string | null };
+  };
+}
+
+const DEFAULT_TOP_N = 5;
+const MAX_TOP_N = 50;
+
+function clampTopN(raw: number | undefined): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return DEFAULT_TOP_N;
+  return Math.min(MAX_TOP_N, Math.max(1, Math.floor(raw)));
+}
+
+function toRow(p: PlayerSelected, value: number, rank: number): PlayerStatRow {
+  return {
+    rank,
+    playerId: p.id,
+    playerName: p.name,
+    position: p.position,
+    teamId: p.team.id,
+    teamName: p.team.name,
+    teamRoster: p.team.roster,
+    ownerId: p.team.owner.id,
+    ownerCoachName: p.team.owner.coachName ?? null,
+    value,
+    secondary: {
+      matchesPlayed: p.matchesPlayed,
+      spp: p.spp,
+    },
+  };
+}
+
+function topByMetric(
+  players: ReadonlyArray<PlayerSelected>,
+  metric: (p: PlayerSelected) => number,
+  topN: number,
+  /**
+   * Filtre prealable (exclure les joueurs ayant 0 sur la metrique
+   * pour eviter de saturer le classement avec des newcomers).
+   */
+  includeZero: boolean = false,
+): PlayerStatRow[] {
+  const sorted = [...players]
+    .filter((p) => includeZero || metric(p) > 0)
+    .sort((a, b) => metric(b) - metric(a))
+    .slice(0, topN);
+  return sorted.map((p, idx) => toRow(p, metric(p), idx + 1));
+}
+
+/**
+ * Calcule les classements top-N pour la saison. Filtre les joueurs
+ * sur les teams `LeagueParticipant` (status='active') de la saison.
+ * Si `teamId` est fourni, restreint encore aux joueurs de cette
+ * team (utilise par la decline "top 3 par equipe").
+ */
+export async function computeLeaderboards(input: {
+  seasonId: string;
+  topN?: number;
+  teamId?: string;
+}): Promise<PlayerStatsCatalogue> {
+  const topN = clampTopN(input.topN);
+
+  // Cap les teams a la saison via groupBy/join. Une seule query Prisma.
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: {
+      seasonId: input.seasonId,
+      status: "active",
+      ...(input.teamId ? { teamId: input.teamId } : {}),
+    },
+    select: { teamId: true },
+  })) as Array<{ teamId: string }>;
+  const teamIds = participants.map((p) => p.teamId);
+  if (teamIds.length === 0) {
+    return emptyCatalogue(input.seasonId, topN);
+  }
+
+  const players = (await prisma.teamPlayer.findMany({
+    where: { teamId: { in: teamIds }, dead: false },
+    select: {
+      id: true,
+      name: true,
+      position: true,
+      spp: true,
+      totalTouchdowns: true,
+      totalCasualties: true,
+      totalCompletions: true,
+      totalInterceptions: true,
+      totalMvpAwards: true,
+      matchesPlayed: true,
+      nigglingInjuries: true,
+      team: {
+        select: {
+          id: true,
+          name: true,
+          roster: true,
+          owner: { select: { id: true, coachName: true } },
+        },
+      },
+    },
+  })) as PlayerSelected[];
+
+  return {
+    seasonId: input.seasonId,
+    topN,
+    scope: "career",
+    topScorers: topByMetric(players, (p) => p.totalTouchdowns, topN),
+    topBashers: topByMetric(players, (p) => p.totalCasualties, topN),
+    topPassers: topByMetric(players, (p) => p.totalCompletions, topN),
+    topInterceptors: topByMetric(players, (p) => p.totalInterceptions, topN),
+    topFutureStars: topByMetric(players, (p) => p.spp, topN),
+    topMvps: topByMetric(players, (p) => p.totalMvpAwards, topN),
+    // Sac de frappe : heuristique sur les blessures permanentes
+    // accumulees (proxy faute d'event "subi une elim" precis).
+    topPunchingBags: topByMetric(players, (p) => p.nigglingInjuries, topN),
+  };
+}
+
+function emptyCatalogue(seasonId: string, topN: number): PlayerStatsCatalogue {
+  return {
+    seasonId,
+    topN,
+    scope: "career",
+    topScorers: [],
+    topBashers: [],
+    topPassers: [],
+    topInterceptors: [],
+    topFutureStars: [],
+    topMvps: [],
+    topPunchingBags: [],
+  };
+}
+
+/**
+ * Decline les classements par equipe : retourne, pour chaque
+ * `participant.teamId`, le top-3 (par defaut) des joueurs dans
+ * chaque categorie.
+ */
+export async function computeLeaderboardsByTeam(input: {
+  seasonId: string;
+  topN?: number;
+}): Promise<Array<{ teamId: string; teamName: string; catalogue: PlayerStatsCatalogue }>> {
+  const topN = clampTopN(input.topN ?? 3);
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: { seasonId: input.seasonId, status: "active" },
+    include: {
+      team: { select: { id: true, name: true } },
+    },
+  })) as Array<{ team: { id: string; name: string } }>;
+
+  // Une query par team — pas optimal pour 50 teams, mais
+  // suffisant pour la majorite des ligues (< 16 teams). Pour une
+  // grosse ligue, refactor en `groupBy` cote DB.
+  const out: Array<{
+    teamId: string;
+    teamName: string;
+    catalogue: PlayerStatsCatalogue;
+  }> = [];
+  for (const p of participants) {
+    const catalogue = await computeLeaderboards({
+      seasonId: input.seasonId,
+      topN,
+      teamId: p.team.id,
+    });
+    out.push({ teamId: p.team.id, teamName: p.team.name, catalogue });
+  }
+  return out;
+}
+
+/** Liste des cles de catalogue exposees (pour les filtres UI). */
+export const LEADERBOARD_CATEGORIES: ReadonlyArray<{
+  key: PlayerStatCategory;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "topScorers",
+    label: "Meilleur marqueur",
+    description: "Plus de touchdowns inscrits.",
+  },
+  {
+    key: "topBashers",
+    label: "Meilleur castagneur",
+    description: "Plus de sorties infligees (sur blocage et autres).",
+  },
+  {
+    key: "topPassers",
+    label: "Meilleur passeur",
+    description: "Plus de passes completes.",
+  },
+  {
+    key: "topInterceptors",
+    label: "Meilleur intercepteur",
+    description: "Plus d'interceptions reussies.",
+  },
+  {
+    key: "topFutureStars",
+    label: "Future star",
+    description: "Plus de SPP accumules.",
+  },
+  {
+    key: "topMvps",
+    label: "Joueur du match",
+    description: "Plus de titres MVP.",
+  },
+  {
+    key: "topPunchingBags",
+    label: "Sac de frappe",
+    description: "Plus de blessures durables subies.",
+  },
+];

--- a/apps/server/src/services/league-playoff-override.test.ts
+++ b/apps/server/src/services/league-playoff-override.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Lot D — Tests pour overridePlayoffParticipants.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leagueSeason: { findUnique: vi.fn() },
+    leagueParticipant: { findMany: vi.fn() },
+    leagueRound: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      count: vi.fn(),
+    },
+    leaguePairing: { create: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("./league", () => ({
+  computeSeasonStandings: vi.fn(),
+}));
+
+import { prisma } from "../prisma";
+import {
+  overridePlayoffParticipants,
+  PlayoffOverrideError,
+} from "./league-playoffs";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+describe("Lot D — overridePlayoffParticipants", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPrisma.$transaction.mockResolvedValue([]);
+  });
+
+  it("rejects if season not found", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue(null);
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "x",
+        participantIds: ["a", "b", "c", "d"],
+      }),
+    ).rejects.toMatchObject({ code: "season_not_found" });
+  });
+
+  it("rejects if playoffSize is 0", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 0,
+    });
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b", "c", "d"],
+      }),
+    ).rejects.toMatchObject({ code: "playoffs_not_started" });
+  });
+
+  it("rejects mismatched participant count", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 4,
+    });
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b"],
+      }),
+    ).rejects.toMatchObject({ code: "size_mismatch" });
+  });
+
+  it("rejects duplicate participants", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 4,
+    });
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "a", "b", "c"],
+      }),
+    ).rejects.toMatchObject({ code: "duplicate_participant" });
+  });
+
+  it("rejects non-active participant", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 2,
+    });
+    mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+      { id: "a", seasonId: "s1", status: "active" },
+      { id: "b", seasonId: "s1", status: "withdrawn" },
+    ]);
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b"],
+      }),
+    ).rejects.toMatchObject({ code: "participant_not_active" });
+  });
+
+  it("rejects participant from another season", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 2,
+    });
+    mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+      { id: "a", seasonId: "s1", status: "active" },
+      { id: "b", seasonId: "OTHER", status: "active" },
+    ]);
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b"],
+      }),
+    ).rejects.toMatchObject({ code: "participant_not_active" });
+  });
+
+  it("rejects when playoffs haven't started", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 2,
+    });
+    mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+      { id: "a", seasonId: "s1", status: "active" },
+      { id: "b", seasonId: "s1", status: "active" },
+    ]);
+    mockPrisma.leagueRound.findMany.mockResolvedValue([]);
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b"],
+      }),
+    ).rejects.toMatchObject({ code: "playoffs_not_started" });
+  });
+
+  it("rejects when a playoff match is already in progress", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 2,
+    });
+    mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+      { id: "a", seasonId: "s1", status: "active" },
+      { id: "b", seasonId: "s1", status: "active" },
+    ]);
+    mockPrisma.leagueRound.findMany.mockResolvedValue([
+      {
+        id: "r1",
+        bracketSlot: "final",
+        pairings: [{ id: "p1", status: "played", matchId: "m1" }],
+      },
+    ]);
+    await expect(
+      overridePlayoffParticipants({
+        seasonId: "s1",
+        participantIds: ["a", "b"],
+      }),
+    ).rejects.toMatchObject({ code: "playoffs_in_progress" });
+  });
+
+  it("rebuilds bracket when no matches consumed yet", async () => {
+    mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+      id: "s1",
+      playoffSize: 2,
+    });
+    mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+      { id: "a", seasonId: "s1", status: "active" },
+      { id: "b", seasonId: "s1", status: "active" },
+    ]);
+    mockPrisma.leagueRound.findMany.mockResolvedValue([
+      {
+        id: "r1",
+        bracketSlot: "final",
+        pairings: [{ id: "p1", status: "scheduled", matchId: null }],
+      },
+    ]);
+    mockPrisma.leagueRound.findFirst.mockResolvedValue({ roundNumber: 5 });
+    mockPrisma.leagueRound.create.mockResolvedValue({ id: "r2" });
+    mockPrisma.leaguePairing.create.mockResolvedValue({});
+
+    const out = await overridePlayoffParticipants({
+      seasonId: "s1",
+      participantIds: ["a", "b"],
+    });
+    expect(out.rebuilt).toBe(1);
+    expect(out.rebuiltSlots).toContain("final");
+    expect(mockPrisma.$transaction).toHaveBeenCalled();
+  });
+
+  it("PlayoffOverrideError preserves code", () => {
+    const e = new PlayoffOverrideError("size_mismatch", "x");
+    expect(e.code).toBe("size_mismatch");
+    expect(e).toBeInstanceOf(Error);
+  });
+});

--- a/apps/server/src/services/league-playoffs.ts
+++ b/apps/server/src/services/league-playoffs.ts
@@ -191,6 +191,7 @@ interface PrismaWithLeague {
     findMany: (args: unknown) => Promise<unknown>;
     create: (args: unknown) => Promise<unknown>;
     update: (args: unknown) => Promise<unknown>;
+    delete: (args: unknown) => Promise<unknown>;
     count: (args: unknown) => Promise<number>;
   };
   leaguePairing: {
@@ -341,6 +342,193 @@ export async function startPlayoffs(
     roundsCreated,
     pairingsCreated,
   };
+}
+
+/** Lot D — Erreur typee pour les operations d'override du bracket. */
+export class PlayoffOverrideError extends Error {
+  constructor(
+    public readonly code:
+      | "season_not_found"
+      | "playoffs_not_started"
+      | "playoffs_in_progress"
+      | "size_mismatch"
+      | "duplicate_participant"
+      | "participant_not_active",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PlayoffOverrideError";
+  }
+}
+
+/**
+ * Lot D — Remplace les participants du premier round du bracket
+ * (typiquement pour gerer un desistement tardif avant le 1er match
+ * playoff). Refus si un pairing du round 1 a deja un match en cours
+ * ou joue.
+ *
+ * Le commissaire fournit la liste complete des seeds du bracket
+ * (taille = playoffSize). L'ordre est conserve pour generer le
+ * seeding (cross-bracket standard).
+ */
+export async function overridePlayoffParticipants(input: {
+  seasonId: string;
+  participantIds: ReadonlyArray<string>;
+}): Promise<{
+  rebuilt: number;
+  rebuiltSlots: string[];
+}> {
+  const client = prisma as unknown as PrismaWithLeague;
+
+  const season = (await client.leagueSeason.findUnique({
+    where: { id: input.seasonId },
+    select: { id: true, playoffSize: true },
+  })) as { id: string; playoffSize: number } | null;
+  if (!season) {
+    throw new PlayoffOverrideError(
+      "season_not_found",
+      `Saison introuvable: ${input.seasonId}`,
+    );
+  }
+
+  const size = season.playoffSize as PlayoffSize;
+  if (size !== 2 && size !== 4 && size !== 8) {
+    throw new PlayoffOverrideError(
+      "playoffs_not_started",
+      "Cette saison n'a pas de playoffs configures",
+    );
+  }
+  if (input.participantIds.length !== size) {
+    throw new PlayoffOverrideError(
+      "size_mismatch",
+      `Attendu ${size} participants, recu ${input.participantIds.length}`,
+    );
+  }
+
+  // Duplicates check.
+  const uniqueIds = new Set(input.participantIds);
+  if (uniqueIds.size !== input.participantIds.length) {
+    throw new PlayoffOverrideError(
+      "duplicate_participant",
+      "Un participant est present plusieurs fois dans la liste",
+    );
+  }
+
+  // Tous les participants doivent appartenir a la saison ET etre actifs.
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: { id: { in: [...uniqueIds] } },
+    select: { id: true, seasonId: true, status: true },
+  })) as Array<{ id: string; seasonId: string; status: string }>;
+  if (participants.length !== uniqueIds.size) {
+    throw new PlayoffOverrideError(
+      "participant_not_active",
+      "Un ou plusieurs participants introuvables",
+    );
+  }
+  for (const p of participants) {
+    if (p.seasonId !== input.seasonId) {
+      throw new PlayoffOverrideError(
+        "participant_not_active",
+        `Participant ${p.id} hors de la saison`,
+      );
+    }
+    if (p.status !== "active") {
+      throw new PlayoffOverrideError(
+        "participant_not_active",
+        `Participant ${p.id} non actif (${p.status})`,
+      );
+    }
+  }
+
+  // Les rounds playoff existants ne doivent contenir que des pairings
+  // "scheduled" pour qu'on puisse les recreer (round 1 + lazy
+  // futurs). Si un pairing a deja un match associe ou status played,
+  // on refuse.
+  const existingRounds = (await client.leagueRound.findMany({
+    where: { seasonId: input.seasonId, kind: "playoff" },
+    orderBy: { roundNumber: "asc" },
+    include: {
+      pairings: {
+        select: { id: true, status: true, matchId: true },
+      },
+    },
+  })) as Array<{
+    id: string;
+    bracketSlot: string | null;
+    pairings: Array<{ id: string; status: string; matchId: string | null }>;
+  }>;
+  if (existingRounds.length === 0) {
+    throw new PlayoffOverrideError(
+      "playoffs_not_started",
+      "Les playoffs n'ont pas encore demarre — utilisez startPlayoffs",
+    );
+  }
+  for (const r of existingRounds) {
+    for (const pair of r.pairings) {
+      if (
+        pair.status !== "scheduled" ||
+        (pair.matchId !== null && pair.matchId !== undefined)
+      ) {
+        throw new PlayoffOverrideError(
+          "playoffs_in_progress",
+          "Un match playoff est deja en cours ou joue — override impossible",
+        );
+      }
+    }
+  }
+
+  // Wipe + rebuild via $transaction. On supprime tous les rounds
+  // playoff existants, puis on regenere le bracket depuis les seeds
+  // fournis.
+  const lastNonPlayoff = (await client.leagueRound.findFirst({
+    where: { seasonId: input.seasonId, kind: { not: "playoff" } },
+    orderBy: { roundNumber: "desc" },
+    select: { roundNumber: true },
+  })) as { roundNumber: number } | null;
+  const baseRoundNumber = (lastNonPlayoff?.roundNumber ?? 0) + 1;
+
+  const seeds = [...input.participantIds];
+  const pairings = generatePlayoffSeedingFor(size, seeds, baseRoundNumber);
+
+  // Suppression atomique.
+  await prisma.$transaction([
+    ...existingRounds.map((r) =>
+      (prisma as unknown as PrismaWithLeague).leagueRound.delete({
+        where: { id: r.id },
+      }),
+    ),
+  ]);
+
+  let nextRoundNumber = baseRoundNumber;
+  const createdSlots: string[] = [];
+  for (const p of pairings) {
+    const round = (await client.leagueRound.create({
+      data: {
+        seasonId: input.seasonId,
+        roundNumber: nextRoundNumber++,
+        name: playoffRoundLabel(p.slot),
+        kind: "playoff",
+        bracketSlot: p.slot,
+        status: "pending",
+      },
+      select: { id: true },
+    })) as { id: string };
+    await client.leaguePairing.create({
+      data: {
+        roundId: round.id,
+        homeParticipantId: p.homeParticipantId,
+        awayParticipantId: p.awayParticipantId,
+        status: "scheduled",
+      },
+    });
+    createdSlots.push(p.slot);
+  }
+
+  serverLog.info(
+    `[league-playoffs] season=${input.seasonId} bracket overridden size=${size} rounds=${createdSlots.length}`,
+  );
+
+  return { rebuilt: createdSlots.length, rebuiltSlots: createdSlots };
 }
 
 function playoffRoundLabel(slot: string): string {

--- a/apps/server/src/services/league-pool.test.ts
+++ b/apps/server/src/services/league-pool.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Lot C — Tests du service `league-pool`.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leagueSeason: { findUnique: vi.fn() },
+    leaguePool: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    leagueParticipant: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  createPool,
+  updatePool,
+  deletePool,
+  assignParticipantsToPools,
+  autoAssignBySnakeDraft,
+  computeSnakeDraftAssignment,
+  listPoolsForSeason,
+  LeaguePoolError,
+} from "./league-pool";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+describe("Lot C — league-pool service", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPrisma.$transaction.mockImplementation(async (ops: unknown[]) => ops);
+  });
+
+  describe("createPool", () => {
+    it("refuses if season not found", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue(null);
+      await expect(
+        createPool({ seasonId: "x", name: "A" }),
+      ).rejects.toMatchObject({ code: "season_not_found" });
+    });
+
+    it("refuses if season has started", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "in_progress",
+      });
+      await expect(
+        createPool({ seasonId: "s1", name: "A" }),
+      ).rejects.toMatchObject({ code: "season_started" });
+    });
+
+    it("rejects empty name", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      await expect(
+        createPool({ seasonId: "s1", name: "   " }),
+      ).rejects.toMatchObject({ code: "pool_name_taken" });
+    });
+
+    it("rejects duplicate name", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findFirst.mockResolvedValueOnce({ id: "existing" });
+      await expect(
+        createPool({ seasonId: "s1", name: "Poule A" }),
+      ).rejects.toMatchObject({ code: "pool_name_taken" });
+    });
+
+    it("auto-assigns next order when not provided", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findFirst
+        .mockResolvedValueOnce(null) // dup check
+        .mockResolvedValueOnce({ order: 3 }); // last order
+      mockPrisma.leaguePool.create.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "p1", ...a.data }),
+      );
+      const out = await createPool({ seasonId: "s1", name: "Poule B" });
+      expect(out).toMatchObject({ order: 4 });
+    });
+
+    it("clamps qualifiesForPlayoffs to [0,128]", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findFirst.mockResolvedValue(null);
+      mockPrisma.leaguePool.create.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "p1", ...a.data }),
+      );
+      const out = await createPool({
+        seasonId: "s1",
+        name: "Poule C",
+        qualifiesForPlayoffs: 9999,
+      });
+      expect((out as { qualifiesForPlayoffs: number }).qualifiesForPlayoffs).toBe(128);
+
+      const out2 = await createPool({
+        seasonId: "s1",
+        name: "Poule D",
+        qualifiesForPlayoffs: -5,
+      });
+      expect((out2 as { qualifiesForPlayoffs: number }).qualifiesForPlayoffs).toBe(0);
+    });
+  });
+
+  describe("updatePool", () => {
+    it("rejects if pool not found", async () => {
+      mockPrisma.leaguePool.findUnique.mockResolvedValue(null);
+      await expect(
+        updatePool({ poolId: "x", name: "Y" }),
+      ).rejects.toMatchObject({ code: "pool_not_found" });
+    });
+
+    it("rejects duplicate name to another pool in same season", async () => {
+      mockPrisma.leaguePool.findUnique.mockResolvedValue({
+        id: "p1",
+        seasonId: "s1",
+        name: "Old",
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findFirst.mockResolvedValue({ id: "p2" });
+      await expect(
+        updatePool({ poolId: "p1", name: "New" }),
+      ).rejects.toMatchObject({ code: "pool_name_taken" });
+    });
+
+    it("accepts name unchanged", async () => {
+      mockPrisma.leaguePool.findUnique.mockResolvedValue({
+        id: "p1",
+        seasonId: "s1",
+        name: "A",
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.update.mockResolvedValue({ id: "p1", name: "A" });
+      await expect(
+        updatePool({ poolId: "p1", name: "A" }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("deletePool", () => {
+    it("rejects if participants still assigned", async () => {
+      mockPrisma.leaguePool.findUnique.mockResolvedValue({
+        id: "p1",
+        seasonId: "s1",
+        _count: { participants: 2 },
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      await expect(
+        deletePool({ poolId: "p1" }),
+      ).rejects.toMatchObject({ code: "pool_not_empty" });
+    });
+
+    it("deletes empty pool", async () => {
+      mockPrisma.leaguePool.findUnique.mockResolvedValue({
+        id: "p1",
+        seasonId: "s1",
+        _count: { participants: 0 },
+      });
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.delete.mockResolvedValue({ id: "p1" });
+      await expect(
+        deletePool({ poolId: "p1" }),
+      ).resolves.toMatchObject({ deleted: true });
+    });
+  });
+
+  describe("assignParticipantsToPools", () => {
+    it("rejects if participant not found", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([]);
+      await expect(
+        assignParticipantsToPools({
+          seasonId: "s1",
+          assignments: [{ participantId: "missing", poolId: "p1" }],
+        }),
+      ).rejects.toMatchObject({ code: "participant_not_found" });
+    });
+
+    it("rejects participant from another season", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "pa", seasonId: "OTHER" },
+      ]);
+      await expect(
+        assignParticipantsToPools({
+          seasonId: "s1",
+          assignments: [{ participantId: "pa", poolId: "p1" }],
+        }),
+      ).rejects.toMatchObject({ code: "participant_not_in_season" });
+    });
+
+    it("rejects pool from another season", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "pa", seasonId: "s1" },
+      ]);
+      mockPrisma.leaguePool.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "OTHER" },
+      ]);
+      await expect(
+        assignParticipantsToPools({
+          seasonId: "s1",
+          assignments: [{ participantId: "pa", poolId: "p1" }],
+        }),
+      ).rejects.toMatchObject({ code: "pool_not_found" });
+    });
+
+    it("commits updates atomically", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "pa", seasonId: "s1" },
+        { id: "pb", seasonId: "s1" },
+      ]);
+      mockPrisma.leaguePool.findMany.mockResolvedValue([
+        { id: "p1", seasonId: "s1" },
+      ]);
+      mockPrisma.leagueParticipant.update.mockResolvedValue({});
+      const out = await assignParticipantsToPools({
+        seasonId: "s1",
+        assignments: [
+          { participantId: "pa", poolId: "p1" },
+          { participantId: "pb", poolId: null },
+        ],
+      });
+      expect(out).toMatchObject({ updated: 2 });
+      expect(mockPrisma.$transaction).toHaveBeenCalled();
+    });
+
+    it("returns updated=0 on empty payload", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      const out = await assignParticipantsToPools({
+        seasonId: "s1",
+        assignments: [],
+      });
+      expect(out).toEqual({ updated: 0 });
+    });
+  });
+
+  describe("computeSnakeDraftAssignment (pure)", () => {
+    it("returns empty when no pools", () => {
+      expect(computeSnakeDraftAssignment(["a", "b", "c"], [])).toEqual([]);
+    });
+
+    it("distributes 8 participants in 2 pools (snake)", () => {
+      const out = computeSnakeDraftAssignment(
+        ["1", "2", "3", "4", "5", "6", "7", "8"],
+        ["A", "B"],
+      );
+      // cycle 0 (1,2) : A,B
+      // cycle 1 (3,4) : B,A
+      // cycle 2 (5,6) : A,B
+      // cycle 3 (7,8) : B,A
+      expect(out.map((o) => o.poolId)).toEqual([
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+      ]);
+    });
+
+    it("distributes 6 participants in 3 pools (snake)", () => {
+      const out = computeSnakeDraftAssignment(
+        ["1", "2", "3", "4", "5", "6"],
+        ["A", "B", "C"],
+      );
+      // cycle 0 (1,2,3) : A,B,C
+      // cycle 1 (4,5,6) : C,B,A
+      expect(out.map((o) => o.poolId)).toEqual([
+        "A",
+        "B",
+        "C",
+        "C",
+        "B",
+        "A",
+      ]);
+    });
+
+    it("handles uneven distribution gracefully", () => {
+      const out = computeSnakeDraftAssignment(["1", "2", "3", "4", "5"], ["A", "B"]);
+      expect(out.map((o) => o.poolId)).toEqual(["A", "B", "B", "A", "A"]);
+    });
+  });
+
+  describe("autoAssignBySnakeDraft (with mocked DB)", () => {
+    it("returns no-pools note when no pools exist", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findMany.mockResolvedValue([]);
+      const out = await autoAssignBySnakeDraft({ seasonId: "s1" });
+      expect(out).toMatchObject({ assigned: 0, note: "no-pools" });
+    });
+
+    it("assigns participants according to snake order", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: "s1",
+        status: "draft",
+      });
+      mockPrisma.leaguePool.findMany.mockResolvedValue([
+        { id: "A" },
+        { id: "B" },
+      ]);
+      mockPrisma.leagueParticipant.findMany.mockResolvedValue([
+        { id: "1" },
+        { id: "2" },
+        { id: "3" },
+        { id: "4" },
+      ]);
+      mockPrisma.leagueParticipant.update.mockResolvedValue({});
+      const out = await autoAssignBySnakeDraft({ seasonId: "s1" });
+      expect(out).toMatchObject({ assigned: 4 });
+    });
+  });
+
+  describe("listPoolsForSeason", () => {
+    it("returns pools ordered by `order`", async () => {
+      mockPrisma.leaguePool.findMany.mockResolvedValue([
+        { id: "a", order: 0, _count: { participants: 2 } },
+        { id: "b", order: 1, _count: { participants: 3 } },
+      ]);
+      const out = await listPoolsForSeason("s1");
+      expect(out).toHaveLength(2);
+      expect(mockPrisma.leaguePool.findMany).toHaveBeenCalledWith({
+        where: { seasonId: "s1" },
+        orderBy: { order: "asc" },
+        include: { _count: { select: { participants: true } } },
+      });
+    });
+  });
+
+  describe("LeaguePoolError", () => {
+    it("preserves code", () => {
+      const e = new LeaguePoolError("pool_not_empty", "x");
+      expect(e.code).toBe("pool_not_empty");
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/apps/server/src/services/league-pool.ts
+++ b/apps/server/src/services/league-pool.ts
@@ -1,0 +1,388 @@
+/**
+ * Lot C — Service de gestion des poules (groups) d'une saison.
+ *
+ * Une poule est une subdivision d'une saison : un sous-groupe de
+ * participants qui joue son propre round-robin et qualifie ses N
+ * premieres equipes en playoffs (`qualifiesForPlayoffs`).
+ *
+ * Comportement legacy preserve : une saison sans poule continue de
+ * fonctionner comme avant (single-pool implicite). Quand la
+ * premiere poule est creee, le commissaire assigne les participants
+ * via `assignParticipantsToPools` ; le scheduler (`league-scheduler`)
+ * sera adapte dans un sous-lot ulterieur pour generer un calendrier
+ * par poule.
+ *
+ * Garde-fous :
+ *   - Les poules ne peuvent etre modifiees qu'avant le demarrage
+ *     de la saison (status='draft' ou 'scheduled').
+ *   - Le nom doit etre unique au sein d'une saison.
+ *   - L'assignation des participants verifie qu'ils appartiennent
+ *     bien a la saison.
+ */
+
+import { prisma } from "../prisma";
+
+export class LeaguePoolError extends Error {
+  constructor(
+    public readonly code:
+      | "season_not_found"
+      | "season_started"
+      | "pool_not_found"
+      | "pool_name_taken"
+      | "pool_not_empty"
+      | "participant_not_found"
+      | "participant_not_in_season",
+    message: string,
+  ) {
+    super(message);
+    this.name = "LeaguePoolError";
+  }
+}
+
+export interface CreatePoolInput {
+  seasonId: string;
+  name: string;
+  qualifiesForPlayoffs?: number;
+  color?: string | null;
+  order?: number;
+}
+
+export interface UpdatePoolInput {
+  poolId: string;
+  name?: string;
+  qualifiesForPlayoffs?: number;
+  color?: string | null;
+  order?: number;
+}
+
+const MAX_POOL_NAME_LENGTH = 60;
+const MIN_QUALIFIES = 0;
+const MAX_QUALIFIES = 128;
+
+function validateName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new LeaguePoolError(
+      "pool_name_taken",
+      "Le nom de la poule est obligatoire",
+    );
+  }
+  if (trimmed.length > MAX_POOL_NAME_LENGTH) {
+    throw new LeaguePoolError(
+      "pool_name_taken",
+      `Le nom de la poule ne peut depasser ${MAX_POOL_NAME_LENGTH} caracteres`,
+    );
+  }
+  return trimmed;
+}
+
+function clampQualifies(raw: number | undefined): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return 0;
+  return Math.min(MAX_QUALIFIES, Math.max(MIN_QUALIFIES, Math.floor(raw)));
+}
+
+async function ensureSeasonEditable(seasonId: string) {
+  const season = await prisma.leagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { id: true, status: true },
+  });
+  if (!season) {
+    throw new LeaguePoolError(
+      "season_not_found",
+      `Saison introuvable: ${seasonId}`,
+    );
+  }
+  if (season.status !== "draft" && season.status !== "scheduled") {
+    throw new LeaguePoolError(
+      "season_started",
+      "Saison demarree : les poules ne peuvent plus etre modifiees",
+    );
+  }
+  return season;
+}
+
+/**
+ * Crée une nouvelle poule pour la saison. L'ordre est attribue
+ * automatiquement (max+1) si non fourni.
+ */
+export async function createPool(input: CreatePoolInput) {
+  await ensureSeasonEditable(input.seasonId);
+  const name = validateName(input.name);
+
+  // Doublon de nom.
+  const existing = await prisma.leaguePool.findFirst({
+    where: { seasonId: input.seasonId, name },
+    select: { id: true },
+  });
+  if (existing) {
+    throw new LeaguePoolError(
+      "pool_name_taken",
+      "Une poule portant ce nom existe deja",
+    );
+  }
+
+  let order = input.order;
+  if (order === undefined) {
+    const last = await prisma.leaguePool.findFirst({
+      where: { seasonId: input.seasonId },
+      orderBy: { order: "desc" },
+      select: { order: true },
+    });
+    order = (last?.order ?? -1) + 1;
+  }
+
+  return prisma.leaguePool.create({
+    data: {
+      seasonId: input.seasonId,
+      name,
+      order,
+      color: input.color ?? null,
+      qualifiesForPlayoffs: clampQualifies(input.qualifiesForPlayoffs),
+    },
+  });
+}
+
+/** Liste les poules d'une saison, ordonnees par `order` croissant. */
+export async function listPoolsForSeason(seasonId: string) {
+  return prisma.leaguePool.findMany({
+    where: { seasonId },
+    orderBy: { order: "asc" },
+    include: {
+      _count: { select: { participants: true } },
+    },
+  });
+}
+
+/** Met a jour une poule (nom, couleur, qualif, ordre). */
+export async function updatePool(input: UpdatePoolInput) {
+  const pool = await prisma.leaguePool.findUnique({
+    where: { id: input.poolId },
+    select: { id: true, seasonId: true, name: true },
+  });
+  if (!pool) {
+    throw new LeaguePoolError(
+      "pool_not_found",
+      `Poule introuvable: ${input.poolId}`,
+    );
+  }
+  await ensureSeasonEditable(pool.seasonId);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {};
+
+  if (input.name !== undefined) {
+    const newName = validateName(input.name);
+    if (newName !== pool.name) {
+      const dup = await prisma.leaguePool.findFirst({
+        where: {
+          seasonId: pool.seasonId,
+          name: newName,
+          id: { not: pool.id },
+        },
+        select: { id: true },
+      });
+      if (dup) {
+        throw new LeaguePoolError(
+          "pool_name_taken",
+          "Une poule portant ce nom existe deja",
+        );
+      }
+    }
+    data.name = newName;
+  }
+  if (input.qualifiesForPlayoffs !== undefined) {
+    data.qualifiesForPlayoffs = clampQualifies(input.qualifiesForPlayoffs);
+  }
+  if (input.color !== undefined) {
+    data.color = input.color;
+  }
+  if (input.order !== undefined) {
+    data.order = input.order;
+  }
+
+  return prisma.leaguePool.update({
+    where: { id: input.poolId },
+    data,
+  });
+}
+
+/**
+ * Supprime une poule — refuse si des participants y sont encore
+ * affectes. Le commissaire doit d'abord les reassigner / desaffecter.
+ */
+export async function deletePool(input: { poolId: string }) {
+  const pool = await prisma.leaguePool.findUnique({
+    where: { id: input.poolId },
+    select: {
+      id: true,
+      seasonId: true,
+      _count: { select: { participants: true } },
+    },
+  });
+  if (!pool) {
+    throw new LeaguePoolError(
+      "pool_not_found",
+      `Poule introuvable: ${input.poolId}`,
+    );
+  }
+  await ensureSeasonEditable(pool.seasonId);
+  if (pool._count.participants > 0) {
+    throw new LeaguePoolError(
+      "pool_not_empty",
+      "Poule non vide : reassignez ou retirez les participants avant suppression",
+    );
+  }
+  await prisma.leaguePool.delete({ where: { id: input.poolId } });
+  return { deleted: true };
+}
+
+export interface AssignmentSpec {
+  /** ID du LeagueParticipant. */
+  participantId: string;
+  /** poolId cible ; null pour desaffecter de toute poule. */
+  poolId: string | null;
+}
+
+/**
+ * Assigne en masse des participants a des poules. Verifie que tous
+ * les participants appartiennent bien a la saison cible. Les poules
+ * referencees doivent appartenir a la meme saison.
+ *
+ * Atomique : utilise prisma.$transaction.
+ */
+export async function assignParticipantsToPools(input: {
+  seasonId: string;
+  assignments: ReadonlyArray<AssignmentSpec>;
+}) {
+  await ensureSeasonEditable(input.seasonId);
+
+  if (input.assignments.length === 0) {
+    return { updated: 0 };
+  }
+
+  const participantIds = input.assignments.map((a) => a.participantId);
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: { id: { in: participantIds } },
+    select: { id: true, seasonId: true },
+  })) as Array<{ id: string; seasonId: string }>;
+  const known = new Map<string, string>(
+    participants.map((p) => [p.id, p.seasonId]),
+  );
+
+  for (const a of input.assignments) {
+    const sid = known.get(a.participantId);
+    if (!sid) {
+      throw new LeaguePoolError(
+        "participant_not_found",
+        `Participant introuvable: ${a.participantId}`,
+      );
+    }
+    if (sid !== input.seasonId) {
+      throw new LeaguePoolError(
+        "participant_not_in_season",
+        `Participant ${a.participantId} hors de la saison ${input.seasonId}`,
+      );
+    }
+  }
+
+  // Validite des poolId references.
+  const poolIds = Array.from(
+    new Set(
+      input.assignments
+        .map((a) => a.poolId)
+        .filter((p): p is string => typeof p === "string"),
+    ),
+  );
+  if (poolIds.length > 0) {
+    const pools = await prisma.leaguePool.findMany({
+      where: { id: { in: poolIds } },
+      select: { id: true, seasonId: true },
+    });
+    if (pools.length !== poolIds.length) {
+      throw new LeaguePoolError("pool_not_found", "Une des poules est introuvable");
+    }
+    for (const p of pools) {
+      if (p.seasonId !== input.seasonId) {
+        throw new LeaguePoolError(
+          "pool_not_found",
+          "Une des poules n'appartient pas a la saison cible",
+        );
+      }
+    }
+  }
+
+  // Update batch.
+  await prisma.$transaction(
+    input.assignments.map((a) =>
+      prisma.leagueParticipant.update({
+        where: { id: a.participantId },
+        data: { poolId: a.poolId },
+      }),
+    ),
+  );
+  return { updated: input.assignments.length };
+}
+
+/**
+ * Repartit equitablement les participants actifs sur les poules
+ * disponibles en alternant "snake" (1->A, 2->B, 3->C, 4->C, 5->B,
+ * 6->A...). Utilise l'ordre par `joinedAt ASC` pour le determinisme.
+ *
+ * No-op si aucune poule n'existe (le commissaire doit d'abord
+ * creer ses poules).
+ */
+export async function autoAssignBySnakeDraft(input: { seasonId: string }) {
+  await ensureSeasonEditable(input.seasonId);
+
+  const pools = await prisma.leaguePool.findMany({
+    where: { seasonId: input.seasonId },
+    orderBy: { order: "asc" },
+    select: { id: true },
+  });
+  if (pools.length === 0) {
+    return { assigned: 0, note: "no-pools" };
+  }
+
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: { seasonId: input.seasonId, status: "active" },
+    orderBy: { joinedAt: "asc" },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+
+  // Snake : 1->0, 2->1, 3->2, 4->2, 5->1, 6->0, 7->0, 8->1, ...
+  const assignments: AssignmentSpec[] = participants.map((p: { id: string }, idx: number) => {
+    const cycle = Math.floor(idx / pools.length);
+    const stepInCycle = idx % pools.length;
+    const poolIndex =
+      cycle % 2 === 0 ? stepInCycle : pools.length - 1 - stepInCycle;
+    return { participantId: p.id, poolId: pools[poolIndex].id };
+  });
+
+  await prisma.$transaction(
+    assignments.map((a) =>
+      prisma.leagueParticipant.update({
+        where: { id: a.participantId },
+        data: { poolId: a.poolId },
+      }),
+    ),
+  );
+  return { assigned: assignments.length };
+}
+
+/**
+ * Helper pur (testable sans Prisma) : produit la repartition snake
+ * sans toucher la DB. Utile pour preview UI / tests unitaires.
+ */
+export function computeSnakeDraftAssignment(
+  participantIds: ReadonlyArray<string>,
+  poolIds: ReadonlyArray<string>,
+): AssignmentSpec[] {
+  if (poolIds.length === 0) return [];
+  return participantIds.map((pid, idx) => {
+    const cycle = Math.floor(idx / poolIds.length);
+    const stepInCycle = idx % poolIds.length;
+    const poolIndex =
+      cycle % 2 === 0 ? stepInCycle : poolIds.length - 1 - stepInCycle;
+    return { participantId: pid, poolId: poolIds[poolIndex] };
+  });
+}

--- a/apps/server/src/services/league-schedule.test.ts
+++ b/apps/server/src/services/league-schedule.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from "vitest";
 import {
   generateRoundRobin,
+  generateMultiPoolRoundRobin,
   type RoundRobinRound,
 } from "./league-schedule";
 
@@ -270,5 +271,115 @@ describe("Rule: League round-robin schedule", () => {
       // 5 teams: 10 unique pairs to play
       expect(totalPairings).toBe(10);
     });
+  });
+});
+
+// ─── Lot C.2 — multi-poules ───────────────────────────────────────────
+
+describe("generateMultiPoolRoundRobin (Lot C.2)", () => {
+  it("throws when no pools", () => {
+    expect(() =>
+      generateMultiPoolRoundRobin({ pools: [] }),
+    ).toThrow(/au moins une poule/i);
+  });
+
+  it("throws when a participant is in two pools", () => {
+    expect(() =>
+      generateMultiPoolRoundRobin({
+        pools: [
+          { poolId: "A", participantIds: ["p1", "p2"] },
+          { poolId: "B", participantIds: ["p2", "p3"] },
+        ],
+      }),
+    ).toThrow(/plusieurs poules/i);
+  });
+
+  it("merges two equal pools into shared matchdays", () => {
+    const rounds = generateMultiPoolRoundRobin({
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2", "a3", "a4"] },
+        { poolId: "B", participantIds: ["b1", "b2", "b3", "b4"] },
+      ],
+    });
+    // 4 teams per pool -> 3 rounds each -> 3 shared matchdays.
+    expect(rounds).toHaveLength(3);
+    // Each matchday: 2 pairings from A + 2 from B = 4 pairings.
+    for (const r of rounds) {
+      expect(r.pairings).toHaveLength(4);
+    }
+    // Total unique pairs: 6 per pool * 2 = 12.
+    const total = rounds.reduce((acc, r) => acc + r.pairings.length, 0);
+    expect(total).toBe(12);
+  });
+
+  it("never crosses pools (a pairing always stays intra-pool)", () => {
+    const rounds = generateMultiPoolRoundRobin({
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2", "a3", "a4"] },
+        { poolId: "B", participantIds: ["b1", "b2", "b3", "b4"] },
+      ],
+    });
+    for (const r of rounds) {
+      for (const p of r.pairings) {
+        const homePool = p.home.startsWith("a") ? "A" : "B";
+        const awayPool = p.away.startsWith("a") ? "A" : "B";
+        expect(homePool).toBe(awayPool);
+      }
+    }
+  });
+
+  it("handles uneven pool sizes (matchday count = max over pools)", () => {
+    const rounds = generateMultiPoolRoundRobin({
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2", "a3", "a4"] }, // 3 rounds
+        { poolId: "B", participantIds: ["b1", "b2"] }, // 1 round
+      ],
+    });
+    expect(rounds).toHaveLength(3);
+    // Matchday 1 has A(2) + B(1) = 3 pairings ; matchday 2,3 only A(2).
+    expect(rounds[0].pairings).toHaveLength(3);
+    expect(rounds[1].pairings).toHaveLength(2);
+    expect(rounds[2].pairings).toHaveLength(2);
+  });
+
+  it("ignores pools with fewer than 2 participants", () => {
+    const rounds = generateMultiPoolRoundRobin({
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2"] },
+        { poolId: "B", participantIds: ["solo"] },
+      ],
+    });
+    expect(rounds).toHaveLength(1);
+    expect(rounds[0].pairings).toHaveLength(1);
+    expect(rounds[0].pairings[0]).toEqual(
+      expect.objectContaining({}),
+    );
+  });
+
+  it("supports doubleRoundRobin per pool", () => {
+    const rounds = generateMultiPoolRoundRobin({
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2", "a3", "a4"] },
+        { poolId: "B", participantIds: ["b1", "b2", "b3", "b4"] },
+      ],
+      doubleRoundRobin: true,
+    });
+    // 4 teams -> 6 rounds (double) per pool -> 6 matchdays.
+    expect(rounds).toHaveLength(6);
+    const total = rounds.reduce((acc, r) => acc + r.pairings.length, 0);
+    // 12 pairs per pool * 2 pools = 24.
+    expect(total).toBe(24);
+  });
+
+  it("is deterministic (same input -> same output)", () => {
+    const input = {
+      pools: [
+        { poolId: "A", participantIds: ["a1", "a2", "a3", "a4"] },
+        { poolId: "B", participantIds: ["b1", "b2", "b3"] },
+      ],
+    };
+    const a = generateMultiPoolRoundRobin(input);
+    const b = generateMultiPoolRoundRobin(input);
+    expect(a).toEqual(b);
   });
 });

--- a/apps/server/src/services/league-schedule.ts
+++ b/apps/server/src/services/league-schedule.ts
@@ -115,3 +115,85 @@ export function generateRoundRobin(
 
   return [...firstLeg, ...secondLeg];
 }
+
+/**
+ * Lot C.2 — Description d'une poule pour la generation multi-poules.
+ */
+export interface PoolInput {
+  readonly poolId: string;
+  readonly participantIds: readonly string[];
+}
+
+export interface GenerateMultiPoolInput {
+  readonly pools: readonly PoolInput[];
+  readonly doubleRoundRobin?: boolean;
+}
+
+/**
+ * Lot C.2 — Genere un calendrier multi-poules avec **journees
+ * partagees** : la journee N agrege les pairings de chaque poule
+ * pour ce meme tour. Repond a l'exigence "planning par journee ET
+ * par poule" — toutes les poules avancent au meme rythme.
+ *
+ * Chaque poule produit son propre round-robin via `generateRoundRobin`.
+ * On fusionne ensuite par index de round : le nombre de journees est
+ * le max sur toutes les poules (les poules plus petites ont juste
+ * moins de matchs sur les dernieres journees).
+ *
+ * Le `bye` au niveau merge est null (concept non pertinent multi-poules ;
+ * chaque poule gere ses propres byes internes en n'ajoutant pas de
+ * pairing pour l'equipe au repos). Pure : meme entree -> meme sortie.
+ */
+export function generateMultiPoolRoundRobin(
+  input: GenerateMultiPoolInput,
+): RoundRobinRound[] {
+  const { pools, doubleRoundRobin = false } = input;
+  if (pools.length === 0) {
+    throw new Error("Au moins une poule requise");
+  }
+
+  // Verifie l'unicite globale des participants (un participant ne peut
+  // pas appartenir a deux poules).
+  const seen = new Set<string>();
+  for (const pool of pools) {
+    for (const pid of pool.participantIds) {
+      if (seen.has(pid)) {
+        throw new Error(
+          `Participant ${pid} present dans plusieurs poules`,
+        );
+      }
+      seen.add(pid);
+    }
+  }
+
+  // Genere le round-robin de chaque poule (>= 2 participants requis ;
+  // une poule a 0/1 participant ne produit aucun pairing).
+  const perPool: RoundRobinRound[][] = pools.map((pool) =>
+    pool.participantIds.length >= 2
+      ? generateRoundRobin({
+          participantIds: pool.participantIds,
+          doubleRoundRobin,
+        })
+      : [],
+  );
+
+  const maxRounds = perPool.reduce(
+    (acc, rounds) => Math.max(acc, rounds.length),
+    0,
+  );
+
+  const merged: RoundRobinRound[] = [];
+  for (let r = 0; r < maxRounds; r += 1) {
+    const pairings: RoundRobinPairing[] = [];
+    for (const poolRounds of perPool) {
+      const round = poolRounds[r];
+      if (round) {
+        pairings.push(...round.pairings);
+      }
+    }
+    merged.push({ roundNumber: r + 1, pairings, bye: null });
+  }
+
+  return merged;
+}
+

--- a/apps/server/src/services/league-scheduler.test.ts
+++ b/apps/server/src/services/league-scheduler.test.ts
@@ -25,6 +25,10 @@ vi.mock("../prisma", () => ({
     leagueParticipant: {
       findMany: vi.fn(),
     },
+    // Lot C.2 — buildSchedule interroge les poules de la saison.
+    leaguePool: {
+      findMany: vi.fn(),
+    },
     leagueRound: {
       count: vi.fn(),
       create: vi.fn(),
@@ -62,10 +66,15 @@ const mocked = {
   pairingCreateMany: prisma.leaguePairing.createMany as MockFn,
   pairingUpdateMany: prisma.leaguePairing.updateMany as MockFn,
   matchCount: prisma.match.count as MockFn,
+  poolFind: prisma.leaguePool.findMany as MockFn,
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Lot C.2 — defaut : aucune poule -> chemin round-robin global
+  // (comportement historique). Les tests multi-poules dedies
+  // override ce mock.
+  mocked.poolFind.mockResolvedValue([]);
 });
 
 describe("league-scheduler.startSeason", () => {
@@ -125,6 +134,42 @@ describe("league-scheduler.startSeason", () => {
       where: { id: "s1" },
       data: { status: "in_progress" },
     });
+  });
+
+  // Lot C.2 — quand la saison a des poules, le calendrier est genere
+  // par poule avec journees partagees.
+  it("generates a per-pool schedule when the season has pools", async () => {
+    mocked.seasonFind.mockResolvedValue({ id: "s1", status: "draft" });
+    mocked.roundCount.mockResolvedValue(0);
+    // 2 poules de 4 -> 3 journees partagees, 4 pairings par journee.
+    mocked.poolFind.mockResolvedValue([{ id: "A" }, { id: "B" }]);
+    mocked.participantFind.mockResolvedValue([
+      { id: "a1", poolId: "A" },
+      { id: "a2", poolId: "A" },
+      { id: "a3", poolId: "A" },
+      { id: "a4", poolId: "A" },
+      { id: "b1", poolId: "B" },
+      { id: "b2", poolId: "B" },
+      { id: "b3", poolId: "B" },
+      { id: "b4", poolId: "B" },
+    ]);
+    let ri = 0;
+    mocked.roundCreate.mockImplementation(async () => ({ id: `r${++ri}` }));
+    const pairingBatches: number[] = [];
+    mocked.pairingCreateMany.mockImplementation(
+      async (args: { data: unknown[] }) => {
+        pairingBatches.push(args.data.length);
+        return { count: args.data.length };
+      },
+    );
+    mocked.seasonUpdate.mockResolvedValue({});
+
+    const result = await startSeason("s1");
+    expect(result.roundsCreated).toBe(3);
+    // 6 pairs/pool * 2 pools = 12 pairings total.
+    expect(result.pairingsCreated).toBe(12);
+    // Chaque journee a 4 pairings (2 par poule).
+    expect(pairingBatches).toEqual([4, 4, 4]);
   });
 
   it("doubles the schedule when doubleRoundRobin=true", async () => {

--- a/apps/server/src/services/league-scheduler.ts
+++ b/apps/server/src/services/league-scheduler.ts
@@ -28,7 +28,11 @@
  */
 
 import { prisma } from "../prisma";
-import { generateRoundRobin, type RoundRobinRound } from "./league-schedule";
+import {
+  generateRoundRobin,
+  generateMultiPoolRoundRobin,
+  type RoundRobinRound,
+} from "./league-schedule";
 import { notifyParticipantsOfFirstRound } from "./league-round-reminder";
 import { persistSeasonAwards } from "./league-scoring";
 import { serverLog } from "../utils/server-log";
@@ -147,6 +151,70 @@ async function hasExistingSchedule(seasonId: string): Promise<boolean> {
   return count > 0;
 }
 
+/**
+ * Lot C.2 — Construit le calendrier (round-robin) en tenant compte
+ * des poules eventuelles de la saison.
+ *
+ * - Si la saison n'a aucune poule : round-robin global classique.
+ * - Si la saison a >= 1 poule : round-robin par poule avec journees
+ *   partagees (`generateMultiPoolRoundRobin`). Les participants
+ *   actifs non affectes a une poule sont regroupes dans une poule
+ *   implicite "sans poule" pour ne pas les exclure du calendrier.
+ *
+ * Retourne aussi `participantCount` pour la validation "au moins 2".
+ */
+async function buildSchedule(
+  seasonId: string,
+  doubleRoundRobin: boolean,
+): Promise<{ generated: RoundRobinRound[]; participantCount: number }> {
+  const pools = (await prisma.leaguePool.findMany({
+    where: { seasonId },
+    orderBy: { order: "asc" },
+    select: { id: true },
+  })) as Array<{ id: string }>;
+
+  // Pas de poule -> comportement historique.
+  if (pools.length === 0) {
+    const participantIds = await listActiveParticipantIds(seasonId);
+    return {
+      generated: generateRoundRobin({ participantIds, doubleRoundRobin }),
+      participantCount: participantIds.length,
+    };
+  }
+
+  // Mode multi-poules : groupe les participants actifs par poolId.
+  const participants = (await prisma.leagueParticipant.findMany({
+    where: { seasonId, status: "active" },
+    orderBy: { joinedAt: "asc" },
+    select: { id: true, poolId: true },
+  })) as Array<{ id: string; poolId: string | null }>;
+
+  const byPool = new Map<string, string[]>();
+  for (const p of pools) byPool.set(p.id, []);
+  const UNASSIGNED = "__unassigned__";
+  byPool.set(UNASSIGNED, []);
+  for (const part of participants) {
+    const key =
+      part.poolId && byPool.has(part.poolId) ? part.poolId : UNASSIGNED;
+    byPool.get(key)!.push(part.id);
+  }
+
+  // Ne conserve que les poules ayant >= 1 participant (les vides sont
+  // ignorees). On garde la poule "unassigned" seulement si elle a des
+  // membres (>= 2 pour produire des matchs).
+  const poolInputs = [...byPool.entries()]
+    .filter(([, ids]) => ids.length > 0)
+    .map(([poolId, participantIds]) => ({ poolId, participantIds }));
+
+  return {
+    generated: generateMultiPoolRoundRobin({
+      pools: poolInputs,
+      doubleRoundRobin,
+    }),
+    participantCount: participants.length,
+  };
+}
+
 async function persistRoundsAndPairings(
   seasonId: string,
   generated: readonly RoundRobinRound[],
@@ -221,17 +289,17 @@ export async function startSeason(
     );
   }
 
-  const participantIds = await listActiveParticipantIds(seasonId);
-  if (participantIds.length < 2) {
+  // Lot C.2 — round-robin global ou par poule selon la config saison.
+  const { generated, participantCount } = await buildSchedule(
+    seasonId,
+    opts.doubleRoundRobin ?? false,
+  );
+  if (participantCount < 2) {
     throw new Error(
-      `Au moins 2 participants actifs requis (${participantIds.length} trouves)`,
+      `Au moins 2 participants actifs requis (${participantCount} trouves)`,
     );
   }
 
-  const generated = generateRoundRobin({
-    participantIds,
-    doubleRoundRobin: opts.doubleRoundRobin ?? false,
-  });
   const baseStart = opts.firstRoundStartDate ?? null;
   const durationDays = opts.roundDurationDays ?? null;
 
@@ -304,17 +372,17 @@ export async function regenerateSchedule(
   // n'a encore ete compte (verifie ci-dessus).
   await prisma.leagueRound.deleteMany({ where: { seasonId } });
 
-  const participantIds = await listActiveParticipantIds(seasonId);
-  if (participantIds.length < 2) {
+  // Lot C.2 — round-robin global ou par poule selon la config saison.
+  const { generated, participantCount } = await buildSchedule(
+    seasonId,
+    opts.doubleRoundRobin ?? false,
+  );
+  if (participantCount < 2) {
     throw new Error(
-      `Au moins 2 participants actifs requis (${participantIds.length} trouves)`,
+      `Au moins 2 participants actifs requis (${participantCount} trouves)`,
     );
   }
 
-  const generated = generateRoundRobin({
-    participantIds,
-    doubleRoundRobin: opts.doubleRoundRobin ?? false,
-  });
   const baseStart = opts.firstRoundStartDate ?? null;
   const durationDays = opts.roundDurationDays ?? null;
 

--- a/apps/server/src/services/league.test.ts
+++ b/apps/server/src/services/league.test.ts
@@ -57,6 +57,8 @@ import {
   createRound,
   listLeagues,
   listThemedSeasons,
+  withdrawParticipant,
+  LeagueWithdrawError,
 } from "./league";
 
 const mockPrisma = prisma as any;
@@ -877,6 +879,131 @@ describe("Rule: League service", () => {
         updateLeague(leagueId, { maxParticipants: 1 }),
       ).rejects.toThrow(/maxParticipants/i);
       expect(mockPrisma.league.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // Lot B — refus du retrait apres demarrage de la saison.
+  describe("withdrawParticipant (Lot B)", () => {
+    const seasonId = "season-1";
+    const teamId = "team-1";
+    const participantId = "part-1";
+
+    it("refuse si saison introuvable (404 mappee)", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue(null);
+      await expect(
+        withdrawParticipant({ seasonId, teamId }),
+      ).rejects.toMatchObject({
+        name: "LeagueWithdrawError",
+        code: "season_not_found",
+      });
+    });
+
+    it("refuse si saison completed", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "completed",
+      });
+      await expect(
+        withdrawParticipant({ seasonId, teamId }),
+      ).rejects.toMatchObject({ code: "season_completed" });
+    });
+
+    it("refuse si saison in_progress (sans force)", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "in_progress",
+      });
+      await expect(
+        withdrawParticipant({ seasonId, teamId }),
+      ).rejects.toMatchObject({ code: "season_started" });
+      expect(mockPrisma.leagueParticipant.update).not.toHaveBeenCalled();
+    });
+
+    it("autorise le retrait sur saison draft", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue({
+        id: participantId,
+        seasonId,
+        teamId,
+        status: "active",
+      });
+      mockPrisma.leagueParticipant.update.mockResolvedValue({
+        id: participantId,
+        status: "withdrawn",
+      });
+      const out = await withdrawParticipant({ seasonId, teamId });
+      expect(mockPrisma.leagueParticipant.update).toHaveBeenCalledWith({
+        where: { id: participantId },
+        data: { status: "withdrawn" },
+      });
+      expect(out).toMatchObject({ status: "withdrawn" });
+    });
+
+    it("autorise le retrait sur saison scheduled", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "scheduled",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue({
+        id: participantId,
+        status: "active",
+      });
+      mockPrisma.leagueParticipant.update.mockResolvedValue({
+        id: participantId,
+        status: "withdrawn",
+      });
+      await expect(
+        withdrawParticipant({ seasonId, teamId }),
+      ).resolves.toBeDefined();
+    });
+
+    it("autorise le retrait pendant in_progress avec force=true (admin)", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "in_progress",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue({
+        id: participantId,
+        status: "active",
+      });
+      mockPrisma.leagueParticipant.update.mockResolvedValue({
+        id: participantId,
+        status: "withdrawn",
+      });
+      await expect(
+        withdrawParticipant({ seasonId, teamId, force: true }),
+      ).resolves.toBeDefined();
+    });
+
+    it("refuse meme avec force=true si saison completed", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "completed",
+      });
+      await expect(
+        withdrawParticipant({ seasonId, teamId, force: true }),
+      ).rejects.toMatchObject({ code: "season_completed" });
+    });
+
+    it("refuse si l'equipe n'est pas inscrite", async () => {
+      mockPrisma.leagueSeason.findUnique.mockResolvedValue({
+        id: seasonId,
+        status: "draft",
+      });
+      mockPrisma.leagueParticipant.findUnique.mockResolvedValue(null);
+      await expect(
+        withdrawParticipant({ seasonId, teamId }),
+      ).rejects.toMatchObject({ code: "not_registered" });
+    });
+
+    it("LeagueWithdrawError est bien une Error", () => {
+      const err = new LeagueWithdrawError("season_started", "msg");
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe("LeagueWithdrawError");
+      expect(err.code).toBe("season_started");
     });
   });
 });

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -827,22 +827,67 @@ export async function getSeasonById(seasonId: string) {
 }
 
 /**
- * Withdraw une equipe d'une saison : refuse si la saison est terminee
- * ou si l'equipe n'est pas inscrite.
+ * Lot B — Erreur typee retournee par `withdrawParticipant` pour permettre
+ * a la couche route de mapper proprement vers un status HTTP (404 / 409).
+ */
+export class LeagueWithdrawError extends Error {
+  constructor(
+    public readonly code:
+      | "season_not_found"
+      | "season_started"
+      | "season_completed"
+      | "not_registered",
+    message: string,
+  ) {
+    super(message);
+    this.name = "LeagueWithdrawError";
+  }
+}
+
+/**
+ * Withdraw une equipe d'une saison.
+ *
+ * Lot B — Le retrait n'est autorise que tant que la saison n'a pas
+ * demarre (status `draft` ou `scheduled`). Une fois la saison
+ * `in_progress`, le commissaire doit passer par la procedure de
+ * forfait (`league-forfeit.ts`) qui preserve l'historique des
+ * pairings deja generes.
+ *
+ * Un admin peut forcer le retrait via `force=true` (cas de
+ * desistement tardif). Ce mode est uniquement appele depuis les
+ * routes admin et doit etre audite cote route.
  */
 export async function withdrawParticipant(input: {
   seasonId: string;
   teamId: string;
+  /** Lot B — bypass admin pour retirer une equipe pendant `in_progress`. */
+  force?: boolean;
 }) {
   const season = await prisma.leagueSeason.findUnique({
     where: { id: input.seasonId },
     select: { id: true, status: true },
   });
   if (!season) {
-    throw new Error(`Saison introuvable: ${input.seasonId}`);
+    throw new LeagueWithdrawError(
+      "season_not_found",
+      `Saison introuvable: ${input.seasonId}`,
+    );
   }
   if (season.status === "completed") {
-    throw new Error("Saison terminee : impossible de retirer une equipe");
+    throw new LeagueWithdrawError(
+      "season_completed",
+      "Saison terminee : impossible de retirer une equipe",
+    );
+  }
+  if (
+    !input.force &&
+    season.status !== "draft" &&
+    season.status !== "scheduled"
+  ) {
+    throw new LeagueWithdrawError(
+      "season_started",
+      "Saison demarree : utilisez la procedure de forfait pour retirer une equipe",
+    );
   }
 
   const existing = await prisma.leagueParticipant.findUnique({
@@ -851,7 +896,10 @@ export async function withdrawParticipant(input: {
     },
   });
   if (!existing) {
-    throw new Error("Cette equipe n'est pas inscrite sur la saison");
+    throw new LeagueWithdrawError(
+      "not_registered",
+      "Cette equipe n'est pas inscrite sur la saison",
+    );
   }
 
   return prisma.leagueParticipant.update({

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -57,6 +57,10 @@ export interface CreateLeagueInput {
    * `TIE_BREAK_SLUGS`. null / undefined = ordre par defaut historique.
    */
   tieBreakRules?: readonly string[] | null;
+  /**
+   * Lot E — Points bonus configurables. Array de regles ou null.
+   */
+  bonusPointsConfig?: readonly unknown[] | null;
 }
 
 export interface CreateSeasonInput {
@@ -152,6 +156,12 @@ export async function createLeague(input: CreateLeagueInput) {
     tieBreakRules = filtered.length > 0 ? JSON.stringify(filtered) : null;
   }
 
+  // Lot E — config bonus optionnelle a la creation.
+  const bonusPointsConfig =
+    input.bonusPointsConfig && input.bonusPointsConfig.length > 0
+      ? (input.bonusPointsConfig as unknown[])
+      : null;
+
   return prisma.league.create({
     data: {
       creatorId: input.creatorId,
@@ -166,6 +176,7 @@ export async function createLeague(input: CreateLeagueInput) {
       lossPoints: input.lossPoints ?? 0,
       forfeitPoints: input.forfeitPoints ?? -1,
       tieBreakRules,
+      bonusPointsConfig: bonusPointsConfig ?? undefined,
     },
   });
 }
@@ -689,6 +700,12 @@ export interface UpdateLeagueInput {
   lossPoints?: number;
   forfeitPoints?: number;
   tieBreakRules?: readonly string[] | null;
+  /**
+   * Lot E — Configuration des points bonus. Array de regles ou null
+   * pour desactiver. Modifiable tant que la ligue n'a pas de match
+   * score (cf. `hasLeagueScoredMatch`).
+   */
+  bonusPointsConfig?: readonly unknown[] | null;
 }
 
 /**
@@ -744,6 +761,17 @@ export async function updateLeague(
       tieBreakRules = filtered.length > 0 ? JSON.stringify(filtered) : null;
     }
     data.tieBreakRules = tieBreakRules;
+  }
+  // Lot E — accepte la nouvelle config bonus. La validation des
+  // regles individuelles est deleguee au service `league-bonus-points`
+  // au runtime (parseBonusConfig retourne `null` si invalide). On
+  // stocke ici une struct JSON arbitraire (les rules malformees
+  // seront ignorees a la lecture).
+  if (input.bonusPointsConfig !== undefined) {
+    data.bonusPointsConfig =
+      input.bonusPointsConfig && input.bonusPointsConfig.length > 0
+        ? (input.bonusPointsConfig as unknown[])
+        : null;
   }
 
   return prisma.league.update({ where: { id: leagueId }, data });

--- a/apps/server/src/services/league.ts
+++ b/apps/server/src/services/league.ts
@@ -434,6 +434,17 @@ export interface StandingRow {
   casualtiesAgainst: number;
   seasonElo: number;
   status: LeagueParticipantStatus;
+  /** Lot C — id de poule (null = pas d'affectation explicite). */
+  poolId?: string | null;
+}
+
+/** Lot C — Classement groupe par poule. */
+export interface PoolStandings {
+  poolId: string;
+  poolName: string;
+  poolOrder: number;
+  qualifiesForPlayoffs: number;
+  standings: StandingRow[];
 }
 
 /**
@@ -472,7 +483,7 @@ export async function computeSeasonStandings(
     },
   });
 
-  type ParticipantRow = (typeof participants)[number];
+  type ParticipantRow = (typeof participants)[number] & { poolId?: string | null };
   const rows: StandingRow[] = participants.map((p: ParticipantRow) => ({
     participantId: p.id,
     teamId: p.teamId,
@@ -492,6 +503,7 @@ export async function computeSeasonStandings(
     casualtiesAgainst: p.casualtiesAgainst,
     seasonElo: p.seasonElo,
     status: p.status as LeagueParticipantStatus,
+    poolId: p.poolId ?? null,
   }));
 
   const tieBreakRules = parseTieBreakRules(
@@ -501,6 +513,74 @@ export async function computeSeasonStandings(
   rows.sort(makeStandingsComparator(tieBreakRules));
 
   return rows;
+}
+
+/**
+ * Lot C — Classement groupe par poule. Retourne un tableau de
+ * `PoolStandings` (un par poule, ordonne par `pool.order`). Si la
+ * saison n'a aucune poule, le tableau est vide (le caller doit
+ * retomber sur `computeSeasonStandings`).
+ *
+ * Les participants sans `poolId` (legacy ou non assignes) sont
+ * regroupes dans une pseudo-poule "unassigned" en derniere position
+ * pour les rendre visibles a l'UI commissaire.
+ */
+export async function computeSeasonStandingsByPool(
+  seasonId: string,
+): Promise<PoolStandings[]> {
+  const allRows = await computeSeasonStandings(seasonId);
+  const pools = (await prisma.leaguePool.findMany({
+    where: { seasonId },
+    orderBy: { order: "asc" },
+  })) as Array<{
+    id: string;
+    name: string;
+    order: number;
+    qualifiesForPlayoffs: number;
+  }>;
+
+  if (pools.length === 0) return [];
+
+  const seasonForTieBreak = (await prisma.leagueSeason.findUnique({
+    where: { id: seasonId },
+    select: { league: { select: { tieBreakRules: true } } },
+  })) as { league?: { tieBreakRules: string | null } | null } | null;
+  const tieBreakRules = parseTieBreakRules(
+    seasonForTieBreak?.league?.tieBreakRules ?? null,
+  );
+  const comparator = makeStandingsComparator(tieBreakRules);
+
+  const groups = new Map<string | null, StandingRow[]>();
+  for (const row of allRows) {
+    const key = row.poolId ?? null;
+    const list = groups.get(key) ?? [];
+    list.push(row);
+    groups.set(key, list);
+  }
+
+  const result: PoolStandings[] = pools.map((p) => {
+    const list = (groups.get(p.id) ?? []).slice().sort(comparator);
+    return {
+      poolId: p.id,
+      poolName: p.name,
+      poolOrder: p.order,
+      qualifiesForPlayoffs: p.qualifiesForPlayoffs,
+      standings: list,
+    };
+  });
+
+  const unassigned = (groups.get(null) ?? []).slice().sort(comparator);
+  if (unassigned.length > 0) {
+    result.push({
+      poolId: "__unassigned__",
+      poolName: "Non affecte",
+      poolOrder: pools.length,
+      qualifiesForPlayoffs: 0,
+      standings: unassigned,
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/apps/web/app/leagues/[id]/InviteCoachModal.tsx
+++ b/apps/web/app/leagues/[id]/InviteCoachModal.tsx
@@ -1,0 +1,300 @@
+"use client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { apiRequest, ApiClientError } from "../../lib/api-client";
+
+// Lot A — Modale "Inviter un coach" pour le commissaire.
+// Utilise l'endpoint GET /leagues/coaches/search pour l'autocomplete
+// + POST /leagues/:leagueId/invitations pour creer l'invitation.
+
+interface CoachCandidate {
+  id: string;
+  coachName: string;
+  alreadyInSeason: boolean;
+}
+
+interface InviteCoachModalProps {
+  open: boolean;
+  onClose: () => void;
+  onInvited: () => void;
+  leagueId: string;
+  /**
+   * Saison cible optionnelle. Si fournie, on filtre les coachs deja
+   * inscrits (`alreadyInSeason=true`) et l'invitation est rattachee
+   * a cette saison precise.
+   */
+  seasonId?: string;
+}
+
+const MIN_QUERY_LENGTH = 2;
+const DEBOUNCE_MS = 250;
+
+export function InviteCoachModal({
+  open,
+  onClose,
+  onInvited,
+  leagueId,
+  seasonId,
+}: InviteCoachModalProps) {
+  const [query, setQuery] = useState("");
+  const [candidates, setCandidates] = useState<CoachCandidate[]>([]);
+  const [selected, setSelected] = useState<CoachCandidate | null>(null);
+  const [message, setMessage] = useState("");
+  const [expiresInDays, setExpiresInDays] = useState(14);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successCode, setSuccessCode] = useState<string | null>(null);
+
+  // Reset state on open/close.
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setCandidates([]);
+      setSelected(null);
+      setMessage("");
+      setError(null);
+      setSuccessCode(null);
+    }
+  }, [open]);
+
+  // Debounced search.
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim().replace(/^@+/, "");
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setCandidates([]);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(() => {
+      void (async () => {
+        setLoading(true);
+        setError(null);
+        try {
+          const qs = new URLSearchParams({ q: trimmed, limit: "10" });
+          if (seasonId) qs.set("seasonId", seasonId);
+          const data = await apiRequest<{
+            coaches: CoachCandidate[];
+          }>(`/leagues/coaches/search?${qs.toString()}`);
+          if (!cancelled) setCandidates(data.coaches ?? []);
+        } catch (e: unknown) {
+          if (!cancelled) {
+            setError(e instanceof Error ? e.message : "Erreur de recherche");
+          }
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+    }, DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, open, seasonId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await apiRequest<{
+        code: string;
+        id: string;
+      }>(`/leagues/${leagueId}/invitations`, {
+        method: "POST",
+        body: JSON.stringify({
+          seasonId: seasonId ?? undefined,
+          inviteeUserId: selected.id,
+          message: message.trim() || undefined,
+          expiresInDays,
+        }),
+      });
+      setSuccessCode(result.code);
+      onInvited();
+    } catch (e: unknown) {
+      if (e instanceof ApiClientError) {
+        setError(e.message);
+      } else {
+        setError(e instanceof Error ? e.message : "Erreur lors de l'envoi");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selected, leagueId, seasonId, message, expiresInDays, onInvited]);
+
+  const shareUrl = useMemo(() => {
+    if (!successCode) return null;
+    if (typeof window === "undefined") return null;
+    return `${window.location.origin}/leagues/invitations/${successCode}`;
+  }, [successCode]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <h2 className="mb-4 text-xl font-bold">Inviter un coach</h2>
+
+        {successCode && shareUrl ? (
+          <div className="space-y-3" data-testid="invite-success">
+            <p className="text-green-700">Invitation envoyee !</p>
+            <div className="rounded bg-slate-100 p-3 text-sm">
+              <p className="mb-1 font-medium">Lien d&apos;invitation :</p>
+              <code
+                className="block break-all text-xs"
+                data-testid="invite-share-url"
+              >
+                {shareUrl}
+              </code>
+            </div>
+            <button
+              type="button"
+              className="rounded bg-slate-200 px-3 py-1 text-sm"
+              onClick={() => {
+                void navigator.clipboard.writeText(shareUrl);
+              }}
+            >
+              Copier le lien
+            </button>
+            <button
+              type="button"
+              className="ml-2 rounded bg-blue-600 px-3 py-1 text-sm text-white"
+              onClick={onClose}
+            >
+              Fermer
+            </button>
+          </div>
+        ) : (
+          <>
+            <label className="mb-2 block text-sm font-medium">
+              Rechercher un coach
+            </label>
+            <input
+              type="text"
+              className="mb-2 w-full rounded border px-3 py-2"
+              placeholder="@nom_du_coach"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelected(null);
+              }}
+              data-testid="invite-search-input"
+            />
+            {loading && (
+              <p className="text-xs text-gray-500">Recherche...</p>
+            )}
+            {candidates.length > 0 && !selected && (
+              <ul
+                className="mb-3 max-h-40 overflow-y-auto rounded border bg-white"
+                data-testid="invite-results-list"
+              >
+                {candidates.map((c) => (
+                  <li
+                    key={c.id}
+                    className={`cursor-pointer border-b px-3 py-2 text-sm hover:bg-slate-50 ${
+                      c.alreadyInSeason ? "opacity-50" : ""
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      disabled={c.alreadyInSeason}
+                      onClick={() => setSelected(c)}
+                      className="w-full text-left"
+                      data-testid={`invite-candidate-${c.id}`}
+                    >
+                      @{c.coachName}
+                      {c.alreadyInSeason && (
+                        <span className="ml-2 text-xs text-red-600">
+                          deja inscrit
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {selected && (
+              <div className="mb-3 rounded bg-blue-50 p-3 text-sm">
+                Coach selectionne : <strong>@{selected.coachName}</strong>{" "}
+                <button
+                  type="button"
+                  className="ml-2 text-xs text-blue-600 underline"
+                  onClick={() => setSelected(null)}
+                >
+                  changer
+                </button>
+              </div>
+            )}
+
+            <label className="mb-2 mt-2 block text-sm font-medium">
+              Message (optionnel, max 500 caracteres)
+            </label>
+            <textarea
+              className="mb-3 w-full rounded border px-3 py-2 text-sm"
+              rows={3}
+              maxLength={500}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Salut, rejoins la Skaven Cup !"
+              data-testid="invite-message"
+            />
+
+            <label className="mb-2 block text-sm font-medium">
+              Expire dans (jours, 1-90)
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={90}
+              className="mb-4 w-24 rounded border px-3 py-1"
+              value={expiresInDays}
+              onChange={(e) =>
+                setExpiresInDays(
+                  Math.max(1, Math.min(90, Number(e.target.value))),
+                )
+              }
+              data-testid="invite-expires"
+            />
+
+            {error && (
+              <p
+                className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700"
+                data-testid="invite-error"
+              >
+                {error}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded bg-slate-200 px-4 py-2 text-sm"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                className="rounded bg-blue-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+                disabled={!selected || submitting}
+                onClick={handleSubmit}
+                data-testid="invite-submit"
+              >
+                {submitting ? "Envoi..." : "Envoyer l'invitation"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/leagues/[id]/seasons/[sid]/leaderboards/page.tsx
+++ b/apps/web/app/leagues/[id]/seasons/[sid]/leaderboards/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { apiRequest } from "../../../../../lib/api-client";
+
+// Lot J — Classements top-N joueurs d'une saison de ligue.
+// Endpoint public : pas de gating auth ici.
+
+interface PlayerStatRow {
+  rank: number;
+  playerId: string;
+  playerName: string;
+  position: string;
+  teamId: string;
+  teamName: string;
+  teamRoster: string;
+  ownerId: string;
+  ownerCoachName: string | null;
+  value: number;
+  secondary: { matchesPlayed: number; spp: number };
+}
+
+interface PlayerStatsCatalogue {
+  seasonId: string;
+  topN: number;
+  scope: "career";
+  topScorers: PlayerStatRow[];
+  topBashers: PlayerStatRow[];
+  topPassers: PlayerStatRow[];
+  topInterceptors: PlayerStatRow[];
+  topFutureStars: PlayerStatRow[];
+  topMvps: PlayerStatRow[];
+  topPunchingBags: PlayerStatRow[];
+  categories: Array<{ key: keyof PlayerStatsCatalogue; label: string; description: string }>;
+}
+
+interface ByTeamResponse {
+  seasonId: string;
+  teams: Array<{
+    teamId: string;
+    teamName: string;
+    catalogue: PlayerStatsCatalogue;
+  }>;
+}
+
+type Mode = "global" | "by-team";
+
+export default function LeaderboardsPage() {
+  const params = useParams<{ id: string; sid: string }>();
+  const leagueId = params?.id ?? "";
+  const seasonId = params?.sid ?? "";
+
+  const [mode, setMode] = useState<Mode>("global");
+  const [topN, setTopN] = useState(5);
+  const [global, setGlobal] = useState<PlayerStatsCatalogue | null>(null);
+  const [byTeam, setByTeam] = useState<ByTeamResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!seasonId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      if (mode === "global") {
+        const data = await apiRequest<PlayerStatsCatalogue>(
+          `/leagues/seasons/${seasonId}/leaderboards?topN=${topN}`,
+        );
+        setGlobal(data);
+        setByTeam(null);
+      } else {
+        const data = await apiRequest<ByTeamResponse>(
+          `/leagues/seasons/${seasonId}/leaderboards/by-team?topN=${topN}`,
+        );
+        setByTeam(data);
+        setGlobal(null);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, [seasonId, mode, topN]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="mb-2 text-2xl font-bold">Classements de la saison</h1>
+      <p className="mb-4 text-sm text-slate-600">
+        Stats agregees sur les compteurs carriere des joueurs des
+        equipes inscrites. La version par-saison precise arrivera
+        avec la feuille de match v2.
+      </p>
+
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Link
+          href={`/leagues/${leagueId}`}
+          className="text-sm text-blue-600 underline"
+        >
+          ← Retour a la ligue
+        </Link>
+        <span className="mx-2 text-slate-300">|</span>
+        <label className="text-sm">
+          Mode :{" "}
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value as Mode)}
+            className="rounded border px-2 py-1"
+            data-testid="leaderboards-mode"
+          >
+            <option value="global">Toute la ligue</option>
+            <option value="by-team">Par equipe</option>
+          </select>
+        </label>
+        <label className="text-sm">
+          Top{" "}
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={topN}
+            onChange={(e) =>
+              setTopN(Math.max(1, Math.min(50, Number(e.target.value))))
+            }
+            className="w-16 rounded border px-2 py-1"
+            data-testid="leaderboards-topn"
+          />
+        </label>
+      </div>
+
+      {loading && <p>Chargement...</p>}
+      {error && (
+        <p className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</p>
+      )}
+
+      {mode === "global" && global && <GlobalView catalogue={global} />}
+      {mode === "by-team" && byTeam && <ByTeamView data={byTeam} />}
+    </main>
+  );
+}
+
+function GlobalView({ catalogue }: { catalogue: PlayerStatsCatalogue }) {
+  return (
+    <div
+      className="grid grid-cols-1 gap-6 md:grid-cols-2"
+      data-testid="leaderboards-global"
+    >
+      {catalogue.categories.map((cat) => {
+        const rows = (catalogue[cat.key] as unknown) as PlayerStatRow[];
+        return (
+          <LeaderboardCard
+            key={cat.key}
+            label={cat.label}
+            description={cat.description}
+            rows={Array.isArray(rows) ? rows : []}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ByTeamView({ data }: { data: ByTeamResponse }) {
+  return (
+    <div className="space-y-6" data-testid="leaderboards-byteam">
+      {data.teams.map((t) => (
+        <section
+          key={t.teamId}
+          className="rounded border bg-white p-4 shadow-sm"
+        >
+          <h2 className="mb-2 font-semibold">{t.teamName}</h2>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {t.catalogue.categories.map((cat) => {
+              const rows = (t.catalogue[cat.key] as unknown) as PlayerStatRow[];
+              return (
+                <LeaderboardCard
+                  key={`${t.teamId}-${cat.key}`}
+                  label={cat.label}
+                  description={cat.description}
+                  rows={Array.isArray(rows) ? rows : []}
+                  compact
+                />
+              );
+            })}
+          </div>
+        </section>
+      ))}
+      {data.teams.length === 0 && (
+        <p className="text-slate-600">Aucune equipe inscrite.</p>
+      )}
+    </div>
+  );
+}
+
+function LeaderboardCard({
+  label,
+  description,
+  rows,
+  compact,
+}: {
+  label: string;
+  description: string;
+  rows: PlayerStatRow[];
+  compact?: boolean;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div
+        className={`rounded border bg-white p-3 ${compact ? "" : "shadow-sm"}`}
+      >
+        <h3 className="font-semibold">{label}</h3>
+        <p className="text-xs text-slate-500">{description}</p>
+        <p className="mt-2 text-sm text-slate-400">Pas de donnees</p>
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`rounded border bg-white p-3 ${compact ? "" : "shadow-sm"}`}
+      data-testid={`leaderboard-card-${label}`}
+    >
+      <h3 className="font-semibold">{label}</h3>
+      <p className="text-xs text-slate-500">{description}</p>
+      <ol className="mt-2 space-y-1">
+        {rows.map((r) => (
+          <li
+            key={r.playerId}
+            className="flex items-center justify-between text-sm"
+          >
+            <span>
+              <span className="mr-2 font-mono text-slate-400">
+                {r.rank}.
+              </span>
+              <strong>{r.playerName}</strong>{" "}
+              <span className="text-xs text-slate-500">
+                ({r.position} — {r.teamName})
+              </span>
+            </span>
+            <span className="font-bold">{r.value}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/web/app/leagues/invitations/[code]/page.tsx
+++ b/apps/web/app/leagues/invitations/[code]/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { apiRequest, ApiClientError } from "../../../lib/api-client";
+
+// Lot A — Page publique d'acceptation d'invitation.
+// URL : /leagues/invitations/[code]
+//
+// Charge l'invitation via le code public, affiche les meta (ligue,
+// saison, inviter), permet a l'user authentifie de choisir une
+// equipe et d'accepter ou decliner.
+//
+// Si l'user n'est pas connecte, on l'oriente vers /auth/login avec
+// un retour vers cette page apres login.
+
+interface InvitationPayload {
+  id: string;
+  code: string;
+  status: string;
+  message: string | null;
+  expiresAt: string;
+  seasonId: string | null;
+  league: {
+    id: string;
+    name: string;
+    description: string | null;
+    ruleset: string;
+    allowedRosters: string | null;
+    status: string;
+  };
+  season: {
+    id: string;
+    name: string;
+    seasonNumber: number;
+    status: string;
+    startDate: string | null;
+  } | null;
+  inviter: { id: string; coachName: string } | null;
+  inviteeTeam: { id: string; name: string; roster: string } | null;
+  inviteeUserId: string | null;
+}
+
+interface MyTeam {
+  id: string;
+  name: string;
+  roster: string;
+  ruleset?: string;
+}
+
+export default function InvitationAcceptPage() {
+  const params = useParams<{ code: string }>();
+  const router = useRouter();
+  const code = params?.code ?? "";
+
+  const [invitation, setInvitation] = useState<InvitationPayload | null>(null);
+  const [teams, setTeams] = useState<MyTeam[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<"accepted" | "declined" | null>(null);
+
+  useEffect(() => {
+    if (!code) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        // Endpoint public : pas d'auth requise.
+        const inv = await apiRequest<InvitationPayload>(
+          `/leagues/invitations/${code}`,
+        );
+        if (!cancelled) {
+          setInvitation(inv);
+          if (inv.inviteeTeam) {
+            setSelectedTeamId(inv.inviteeTeam.id);
+          }
+        }
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(
+            e instanceof Error ? e.message : "Invitation introuvable",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
+  // Charge "mes equipes" si on est connecte (token present).
+  useEffect(() => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
+    if (!token) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await apiRequest<{ teams: MyTeam[] }>("/team/mine");
+        if (!cancelled) setTeams(data.teams ?? []);
+      } catch {
+        if (!cancelled) setTeams([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const isExpired = useMemo(() => {
+    if (!invitation) return false;
+    return new Date(invitation.expiresAt).getTime() < Date.now();
+  }, [invitation]);
+
+  const allowedRosters = useMemo<string[] | null>(() => {
+    if (!invitation?.league.allowedRosters) return null;
+    try {
+      const parsed: unknown = JSON.parse(invitation.league.allowedRosters);
+      return Array.isArray(parsed) ? (parsed as string[]) : null;
+    } catch {
+      return null;
+    }
+  }, [invitation]);
+
+  const eligibleTeams = useMemo(() => {
+    if (!allowedRosters) return teams;
+    return teams.filter((t) => allowedRosters.includes(t.roster));
+  }, [teams, allowedRosters]);
+
+  const handleAccept = useCallback(async () => {
+    if (!selectedTeamId) {
+      setError("Selectionnez une equipe.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiRequest(`/leagues/invitations/${code}/accept`, {
+        method: "POST",
+        body: JSON.stringify({ teamId: selectedTeamId }),
+      });
+      setDone("accepted");
+      if (invitation?.league.id) {
+        // Redirige vers la ligue apres 2s.
+        setTimeout(() => {
+          router.push(`/leagues/${invitation.league.id}`);
+        }, 2000);
+      }
+    } catch (e: unknown) {
+      if (e instanceof ApiClientError) {
+        setError(e.message);
+      } else {
+        setError(e instanceof Error ? e.message : "Erreur");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [code, selectedTeamId, invitation, router]);
+
+  const handleDecline = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiRequest(`/leagues/invitations/${code}/decline`, {
+        method: "POST",
+      });
+      setDone("declined");
+    } catch (e: unknown) {
+      if (e instanceof ApiClientError) {
+        setError(e.message);
+      } else {
+        setError(e instanceof Error ? e.message : "Erreur");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [code]);
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <p>Chargement de l&apos;invitation...</p>
+      </main>
+    );
+  }
+
+  if (!invitation) {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-3 text-2xl font-bold">Invitation introuvable</h1>
+        <p className="text-red-700">{error ?? "Lien invalide"}</p>
+      </main>
+    );
+  }
+
+  if (done === "accepted") {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-3 text-2xl font-bold text-green-700">
+          Invitation acceptee !
+        </h1>
+        <p>Vous etes maintenant inscrit a la saison. Redirection...</p>
+      </main>
+    );
+  }
+
+  if (done === "declined") {
+    return (
+      <main className="mx-auto max-w-2xl p-6">
+        <h1 className="mb-3 text-2xl font-bold">Invitation declinee</h1>
+        <p>L&apos;invitation a ete refusee.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl p-6" data-testid="invitation-page">
+      <h1 className="mb-3 text-2xl font-bold">
+        Invitation a rejoindre {invitation.league.name}
+      </h1>
+
+      {invitation.inviter && (
+        <p className="mb-2 text-sm text-slate-600">
+          Invitee par @{invitation.inviter.coachName}
+        </p>
+      )}
+      {invitation.season && (
+        <p className="mb-2 text-sm">
+          Saison : <strong>{invitation.season.name}</strong> (#
+          {invitation.season.seasonNumber})
+        </p>
+      )}
+      {invitation.message && (
+        <blockquote className="mb-4 border-l-4 border-blue-400 bg-blue-50 p-3 italic">
+          {invitation.message}
+        </blockquote>
+      )}
+
+      {invitation.status !== "pending" && (
+        <p className="mb-3 rounded bg-yellow-50 p-2 text-sm">
+          Cette invitation est <strong>{invitation.status}</strong>.
+        </p>
+      )}
+
+      {isExpired && invitation.status === "pending" && (
+        <p className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700">
+          Cette invitation a expire le{" "}
+          {new Date(invitation.expiresAt).toLocaleString("fr-FR")}.
+        </p>
+      )}
+
+      {invitation.status === "pending" && !isExpired && (
+        <>
+          <label className="mb-2 mt-4 block text-sm font-medium">
+            Choisir une equipe a inscrire
+          </label>
+          {eligibleTeams.length === 0 ? (
+            <p className="text-sm text-red-700">
+              Aucune equipe eligible. Verifiez les rosters autorises (
+              {allowedRosters?.join(", ") ?? "tous"}).
+            </p>
+          ) : (
+            <select
+              className="mb-3 w-full rounded border px-3 py-2"
+              value={selectedTeamId}
+              onChange={(e) => setSelectedTeamId(e.target.value)}
+              data-testid="invitation-team-select"
+            >
+              <option value="">-- Selectionner --</option>
+              {eligibleTeams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name} ({t.roster})
+                </option>
+              ))}
+            </select>
+          )}
+
+          {error && (
+            <p className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded bg-green-600 px-4 py-2 text-white disabled:opacity-50"
+              disabled={!selectedTeamId || submitting}
+              onClick={handleAccept}
+              data-testid="invitation-accept"
+            >
+              {submitting ? "..." : "Accepter"}
+            </button>
+            <button
+              type="button"
+              className="rounded bg-slate-300 px-4 py-2 disabled:opacity-50"
+              disabled={submitting}
+              onClick={handleDecline}
+              data-testid="invitation-decline"
+            >
+              Decliner
+            </button>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/me/league-invitations/page.tsx
+++ b/apps/web/app/me/league-invitations/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { apiRequest } from "../../lib/api-client";
+
+// Lot A — "Mes invitations" : liste des invitations pending recues
+// par l'utilisateur courant.
+
+interface PendingInvitation {
+  id: string;
+  code: string;
+  message: string | null;
+  expiresAt: string;
+  createdAt: string;
+  league: { id: string; name: string };
+  season: {
+    id: string;
+    name: string;
+    seasonNumber: number;
+    status: string;
+  } | null;
+  inviter: { id: string; coachName: string } | null;
+  inviteeTeam: { id: string; name: string } | null;
+}
+
+export default function MyInvitationsPage() {
+  const [items, setItems] = useState<PendingInvitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await apiRequest<{ invitations: PendingInvitation[] }>(
+        "/leagues/me/invitations",
+      );
+      setItems(data.invitations ?? []);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-4 text-2xl font-bold">Mes invitations de ligue</h1>
+
+      {loading && <p>Chargement...</p>}
+      {error && (
+        <p className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</p>
+      )}
+      {!loading && items.length === 0 && (
+        <p className="text-slate-600">
+          Aucune invitation en attente.
+        </p>
+      )}
+
+      <ul className="space-y-3" data-testid="my-invitations-list">
+        {items.map((inv) => (
+          <li
+            key={inv.id}
+            className="rounded border border-slate-200 bg-white p-4 shadow-sm"
+            data-testid={`my-invitation-${inv.id}`}
+          >
+            <div className="mb-2 flex items-start justify-between">
+              <div>
+                <h3 className="font-semibold">{inv.league.name}</h3>
+                {inv.season && (
+                  <p className="text-sm text-slate-600">
+                    Saison : {inv.season.name} (#{inv.season.seasonNumber})
+                  </p>
+                )}
+                {inv.inviter && (
+                  <p className="text-xs text-slate-500">
+                    par @{inv.inviter.coachName}
+                  </p>
+                )}
+              </div>
+              <div className="text-right text-xs text-slate-500">
+                Expire le{" "}
+                {new Date(inv.expiresAt).toLocaleString("fr-FR", {
+                  dateStyle: "short",
+                  timeStyle: "short",
+                })}
+              </div>
+            </div>
+            {inv.message && (
+              <blockquote className="mb-2 border-l-2 border-blue-300 bg-blue-50 p-2 text-sm italic">
+                {inv.message}
+              </blockquote>
+            )}
+            <Link
+              href={`/leagues/invitations/${inv.code}`}
+              className="inline-block rounded bg-blue-600 px-3 py-1 text-sm text-white"
+            >
+              Voir l&apos;invitation
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/packages/game-engine/src/rosters/season3-reference-data.ts
+++ b/packages/game-engine/src/rosters/season3-reference-data.ts
@@ -150,11 +150,16 @@ export const SEASON_3_REFERENCE: Record<string, ReferenceRoster> = {
     positionCount: 4,
     budget: 1000,
     keyPositions: [
-      { nameEn: 'High Elf Lineman', cost: 65, max: 16, ma: 6, st: 3, ag: 2, pa: 3, av: 9, skills: [] },
-      { nameEn: 'High Elf Catcher', cost: 90, max: 4, ma: 8, st: 3, ag: 2, pa: 3, av: 8, skills: ['catch'] },
-      // Note: Le Lanceur (cost=100, max=2) et le Blitzer (cost=100, max=2) ont le meme cout et max
-      // On valide le Lanceur ici (premier match) car il apparait avant dans le roster
-      { nameEn: 'High Elf Thrower', cost: 100, max: 2, ma: 6, st: 3, ag: 2, pa: 2, av: 9, skills: ['cloud-burster', 'pass', 'safe-pass'] },
+      // Roster thematique S3 (source de verite : data/saison3/team/Hauts_elfes.md).
+      // Cf. docs/high-elf-roster-s3-fix-2026-06-05.md. Les noms d'affichage
+      // sont thematiques (Guerrier Phoenix = Lanceur, Prince Dragon = Receveur,
+      // Lion Blanc = Blitzer) mais le test matche par (cost, max).
+      { nameEn: 'Trois-quart Haut Elfe', cost: 65, max: 16, ma: 6, st: 3, ag: 2, pa: 3, av: 9, skills: [] },
+      { nameEn: 'Guerrier Phoenix (Lanceur)', cost: 90, max: 2, ma: 6, st: 3, ag: 2, pa: 2, av: 9, skills: ['cloud-burster', 'pass', 'safe-pass'] },
+      // Note: le Receveur (Prince Dragon) et le Blitzer (Lion Blanc) partagent
+      // cost=110/max=2. On valide le Receveur ici car il apparait avant dans le
+      // roster (matchingPositions[0]).
+      { nameEn: 'Prince Dragon (Receveur)', cost: 110, max: 2, ma: 8, st: 3, ag: 2, pa: 4, av: 9, skills: ['block', 'my-ball', 'surefoot'] },
     ],
   },
 

--- a/prisma/migrations/20260605120000_add_league_invitation/migration.sql
+++ b/prisma/migrations/20260605120000_add_league_invitation/migration.sql
@@ -1,0 +1,49 @@
+-- Lot A — Invitations de ligue.
+--
+-- Permet au commissaire (createur de la ligue) ou a un admin
+-- d'inviter un coach a rejoindre une saison via :
+--   - userId interne (autocomplete coach search)
+--   - email (futur : envoi mail)
+--   - lien public (`code`) shareable
+--
+-- Statuts : pending | accepted | declined | cancelled | expired.
+-- Expiration : la column `expiresAt` permet un job de housekeeping
+-- (futur) qui passe en "expired" les invitations pending periamees.
+
+CREATE TABLE "LeagueInvitation" (
+  "id" TEXT NOT NULL,
+  "leagueId" TEXT NOT NULL,
+  "seasonId" TEXT,
+  "inviterUserId" TEXT NOT NULL,
+  "inviteeUserId" TEXT,
+  "inviteeTeamId" TEXT,
+  "inviteeEmail" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "code" TEXT NOT NULL,
+  "message" TEXT,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "acceptedAt" TIMESTAMP(3),
+  "declinedAt" TIMESTAMP(3),
+  "cancelledAt" TIMESTAMP(3),
+  "acceptedParticipantId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "LeagueInvitation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "LeagueInvitation_code_key" ON "LeagueInvitation"("code");
+CREATE INDEX "LeagueInvitation_leagueId_status_idx" ON "LeagueInvitation"("leagueId", "status");
+CREATE INDEX "LeagueInvitation_inviteeUserId_status_idx" ON "LeagueInvitation"("inviteeUserId", "status");
+CREATE INDEX "LeagueInvitation_code_idx" ON "LeagueInvitation"("code");
+CREATE INDEX "LeagueInvitation_expiresAt_status_idx" ON "LeagueInvitation"("expiresAt", "status");
+
+ALTER TABLE "LeagueInvitation" ADD CONSTRAINT "LeagueInvitation_leagueId_fkey"
+  FOREIGN KEY ("leagueId") REFERENCES "League"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "LeagueInvitation" ADD CONSTRAINT "LeagueInvitation_seasonId_fkey"
+  FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "LeagueInvitation" ADD CONSTRAINT "LeagueInvitation_inviterUserId_fkey"
+  FOREIGN KEY ("inviterUserId") REFERENCES "User"("id") ON DELETE NO ACTION ON UPDATE CASCADE;
+ALTER TABLE "LeagueInvitation" ADD CONSTRAINT "LeagueInvitation_inviteeUserId_fkey"
+  FOREIGN KEY ("inviteeUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "LeagueInvitation" ADD CONSTRAINT "LeagueInvitation_inviteeTeamId_fkey"
+  FOREIGN KEY ("inviteeTeamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260605130000_add_league_bonus_points/migration.sql
+++ b/prisma/migrations/20260605130000_add_league_bonus_points/migration.sql
@@ -1,0 +1,18 @@
+-- Lot E — Points bonus configurables par ligue.
+--
+-- League.bonusPointsConfig : JSON array de regles
+-- ([{ id, label, condition: {type, value?}, points, appliesTo }]).
+-- null = pas de bonus applique au scoring.
+--
+-- LeaguePairing.bonusPointsHome/Away : snapshot des points bonus
+-- effectivement appliques au scoring du pairing (= delta sur
+-- LeagueParticipant.points).
+-- LeaguePairing.bonusBreakdown : audit JSON des regles matchees.
+
+ALTER TABLE "League"
+  ADD COLUMN "bonusPointsConfig" JSONB;
+
+ALTER TABLE "LeaguePairing"
+  ADD COLUMN "bonusPointsHome" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "bonusPointsAway" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "bonusBreakdown" JSONB;

--- a/prisma/migrations/20260605140000_add_league_pool/migration.sql
+++ b/prisma/migrations/20260605140000_add_league_pool/migration.sql
@@ -1,0 +1,40 @@
+-- Lot C — Multi-poules pour les ligues.
+--
+-- Une saison peut etre divisee en plusieurs poules (groupes).
+-- Comportement legacy preserve : si une saison n'a aucune poule,
+-- elle se comporte exactement comme avant (single-pool implicite).
+--
+-- LeaguePool : poule d'une saison, avec qualifiesForPlayoffs pour
+-- preciser combien d'equipes du top vont en playoffs.
+-- LeagueParticipant.poolId : affectation a une poule (nullable).
+-- LeagueRound.poolId : round optionnellement rattache a une poule
+-- (multi-poules : chaque poule a son round-robin propre).
+
+CREATE TABLE "LeaguePool" (
+  "id" TEXT NOT NULL,
+  "seasonId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "order" INTEGER NOT NULL DEFAULT 0,
+  "color" TEXT,
+  "qualifiesForPlayoffs" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "LeaguePool_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "LeaguePool_seasonId_name_key" ON "LeaguePool"("seasonId", "name");
+CREATE INDEX "LeaguePool_seasonId_order_idx" ON "LeaguePool"("seasonId", "order");
+
+ALTER TABLE "LeaguePool" ADD CONSTRAINT "LeaguePool_seasonId_fkey"
+  FOREIGN KEY ("seasonId") REFERENCES "LeagueSeason"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "LeagueParticipant" ADD COLUMN "poolId" TEXT;
+CREATE INDEX "LeagueParticipant_seasonId_poolId_idx" ON "LeagueParticipant"("seasonId", "poolId");
+ALTER TABLE "LeagueParticipant" ADD CONSTRAINT "LeagueParticipant_poolId_fkey"
+  FOREIGN KEY ("poolId") REFERENCES "LeaguePool"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "LeagueRound" ADD COLUMN "poolId" TEXT;
+CREATE INDEX "LeagueRound_seasonId_poolId_roundNumber_idx"
+  ON "LeagueRound"("seasonId", "poolId", "roundNumber");
+ALTER TABLE "LeagueRound" ADD CONSTRAINT "LeagueRound_poolId_fkey"
+  FOREIGN KEY ("poolId") REFERENCES "LeaguePool"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,6 +135,9 @@ model User {
   proMatchPredictions         ProMatchPrediction[]
   proTournamentEntries        ProTournamentEntry[]
   blogPosts                   BlogPost[]                  @relation("BlogPostAuthor")
+  // Lot A — invitations envoyees / recues sur les ligues.
+  leagueInvitationsSent       LeagueInvitation[]          @relation("LeagueInvitationInviter")
+  leagueInvitationsReceived   LeagueInvitation[]          @relation("LeagueInvitationInvitee")
 
   @@index([leaderboardStatus])
 }
@@ -404,6 +407,8 @@ model Team {
   localMatchesAsTeamB  LocalMatch[]        @relation("LocalMatchTeamB")
   matchQueue           MatchQueue[]
   leagueParticipations LeagueParticipant[]
+  // Lot A — invitations qui ciblent cette equipe specifique.
+  leagueInvitations    LeagueInvitation[]
 
   // Informations d'équipe Blood Bowl
   treasury      Int     @default(0) // Trésorerie en pièces d'or (calculée automatiquement)
@@ -876,6 +881,59 @@ model NotificationPreference {
 // L.1 — Modele ligue (Sprint 17 : infrastructure competitive).
 // Une League est le conteneur persistant. Chaque edition concrete
 // est une LeagueSeason (round-robin, playoffs...).
+/// Lot A — Invitation a rejoindre une ligue.
+///
+/// Le commissaire (createur de la ligue) ou un admin peut inviter
+/// un coach (par userId, email, ou autre) a rejoindre une saison
+/// donnee. L'invitation contient un code unique (sharable URL) +
+/// statut + expiration. Si `inviteeUserId` est null, l'invitation
+/// peut etre acceptee par le 1er user qui se connecte avec ce code
+/// (lien public). Sinon, seul le user cible peut accepter.
+model LeagueInvitation {
+  id              String   @id @default(cuid())
+  league          League   @relation(fields: [leagueId], references: [id], onDelete: Cascade)
+  leagueId        String
+  /// Optionnel : saison ciblee si l'invitation pointe sur une saison
+  /// specifique. Si null, le coach choisira la saison a l'acceptation
+  /// (utile pour les ligues avec plusieurs saisons en cours).
+  season          LeagueSeason? @relation(fields: [seasonId], references: [id], onDelete: SetNull)
+  seasonId        String?
+  /// Auteur de l'invitation (commissaire ou admin).
+  inviter         User     @relation("LeagueInvitationInviter", fields: [inviterUserId], references: [id])
+  inviterUserId   String
+  /// Optionnel : coach cible identifie. Si null, lien d'invitation
+  /// publique (1er user qui ouvre le lien et accepte).
+  invitee         User?    @relation("LeagueInvitationInvitee", fields: [inviteeUserId], references: [id])
+  inviteeUserId   String?
+  /// Optionnel : equipe pre-selectionnee. Le coach pourra confirmer
+  /// ou choisir une autre equipe lors de l'acceptation.
+  inviteeTeam     Team?    @relation(fields: [inviteeTeamId], references: [id])
+  inviteeTeamId   String?
+  /// Optionnel : email cible quand l'invitation depasse les frontieres
+  /// de la plateforme. Permet de prevoir un envoi mail (Lot futur).
+  inviteeEmail    String?
+  /// "pending" | "accepted" | "declined" | "cancelled" | "expired"
+  status          String   @default("pending")
+  /// Token unique pour partager le lien (publique mais inviolable).
+  /// Format : alphanumeric ~24 chars (crypto.randomBytes(16).toString("base64url")).
+  code            String   @unique
+  /// Message libre du commissaire ("Salut, rejoins la Skaven Cup !").
+  message         String?
+  expiresAt       DateTime
+  acceptedAt      DateTime?
+  declinedAt      DateTime?
+  cancelledAt     DateTime?
+  /// Renseigne au moment de l'acceptation (utile si invitee != team owner).
+  acceptedParticipantId String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([leagueId, status])
+  @@index([inviteeUserId, status])
+  @@index([code])
+  @@index([expiresAt, status])
+}
+
 model League {
   id                String   @id @default(cuid())
   name              String
@@ -916,7 +974,9 @@ model League {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
-  seasons LeagueSeason[]
+  seasons     LeagueSeason[]
+  // Lot A — back-relation invitations envoyees pour cette ligue.
+  invitations LeagueInvitation[]
 
   @@index([creatorId])
   @@index([status])
@@ -956,6 +1016,8 @@ model LeagueSeason {
   rounds       LeagueRound[]
   matches      Match[]             @relation("LeagueSeasonMatches")
   award        LeagueSeasonAward?
+  // Lot A — back-relation invitations ciblant cette saison precise.
+  invitations  LeagueInvitation[]
 
   @@unique([leagueId, seasonNumber])
   @@index([leagueId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -971,6 +971,10 @@ model League {
   /// Sprint R lot R.E.3 — duree par tour en heures pour les matches
   /// async de cette ligue. 1-168h (default 24h).
   turnDeadlineHours Int      @default(24)
+  /// Lot E — Points bonus configurables (JSON array de regles, cf.
+  /// `services/league-bonus-points.ts`). null = pas de bonus applique
+  /// au scoring. Modifiable tant qu'aucun match n'a ete score.
+  bonusPointsConfig Json?
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 
@@ -1122,6 +1126,14 @@ model LeaguePairing {
   // lance la partie. Ecrit par `POST /league/pairings/:id/match`
   // (L2.A.4) en meme temps que la creation du Match.
   match             Match?
+  // Lot E — Snapshot des points bonus appliques au scoring de ce
+  // pairing (en plus des winPoints/drawPoints standards). 0 si
+  // bonusPointsConfig est null ou aucun bonus n'a matche.
+  bonusPointsHome   Int               @default(0)
+  bonusPointsAway   Int               @default(0)
+  /// Lot E — Breakdown des regles appliquees pour audit / UI :
+  /// [{ ruleId, label, side, points }]. null si aucune regle.
+  bonusBreakdown    Json?
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1022,11 +1022,46 @@ model LeagueSeason {
   award        LeagueSeasonAward?
   // Lot A — back-relation invitations ciblant cette saison precise.
   invitations  LeagueInvitation[]
+  // Lot C — multi-poules optionnelles. Vide = saison single-pool
+  // (comportement legacy preserve : tout le monde dans la meme poule).
+  pools        LeaguePool[]
 
   @@unique([leagueId, seasonNumber])
   @@index([leagueId])
   @@index([status])
   @@index([theme, themeYear])
+}
+
+/// Lot C — Poule d'une saison de ligue.
+///
+/// Une saison peut etre divisee en plusieurs poules pour les
+/// championnats avec phase de groupes. Les participants sont
+/// affectes a une poule via `LeagueParticipant.poolId`. Le
+/// calendrier round-robin est genere par poule, mais les rounds
+/// (journees) sont communes pour synchroniser le rythme.
+///
+/// `qualifiesForPlayoffs` permet de specifier combien d'equipes de
+/// chaque poule iront en playoffs (top-N par poule).
+model LeaguePool {
+  id                   String       @id @default(cuid())
+  season               LeagueSeason @relation(fields: [seasonId], references: [id], onDelete: Cascade)
+  seasonId             String
+  name                 String
+  order                Int          @default(0)
+  /// Couleur de presentation UI (hex `#RRGGBB`), optionnelle.
+  color                String?
+  /// Lot C — Combien d'equipes de cette poule sont qualifiees pour
+  /// les playoffs. Default 0 = aucune. Le `startPlayoffs` lit ce
+  /// champ et seed le bracket avec les top-N de chaque poule.
+  qualifiesForPlayoffs Int          @default(0)
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
+
+  participants LeagueParticipant[]
+  rounds       LeagueRound[]
+
+  @@unique([seasonId, name])
+  @@index([seasonId, order])
 }
 
 // L.1 — Inscription d'une equipe sur une saison.
@@ -1061,10 +1096,15 @@ model LeagueParticipant {
   homePairings LeaguePairing[] @relation("LeaguePairingHome")
   awayPairings LeaguePairing[] @relation("LeaguePairingAway")
 
+  // Lot C — poule d'affectation (optionnelle). null = single-pool.
+  pool   LeaguePool? @relation(fields: [poolId], references: [id], onDelete: SetNull)
+  poolId String?
+
   @@unique([seasonId, teamId])
   @@index([seasonId])
   @@index([teamId])
   @@index([seasonElo])
+  @@index([seasonId, poolId])
 }
 
 // L.1 — Journee (round) d'une saison. Utilise par le generateur
@@ -1092,11 +1132,16 @@ model LeagueRound {
 
   matches  Match[]         @relation("LeagueRoundMatches")
   pairings LeaguePairing[]
+  // Lot C — round optionnellement rattache a une poule (pour les
+  // saisons multi-poules ou chaque poule a son propre calendrier).
+  pool     LeaguePool? @relation(fields: [poolId], references: [id], onDelete: SetNull)
+  poolId   String?
 
   @@unique([seasonId, roundNumber])
   @@index([seasonId])
   @@index([status])
   @@index([seasonId, kind])
+  @@index([seasonId, poolId, roundNumber])
 }
 
 // L2.A.1 — Pairing pre-genere du calendrier round-robin.


### PR DESCRIPTION
- withdrawParticipant now refuses if season status != draft|scheduled
- New LeagueWithdrawError class with typed codes mapped to HTTP:
  - season_not_found / not_registered -> 404
  - season_started / season_completed -> 409
- Add admin override route POST /admin/leagues/seasons/:seasonId
  /participants/:teamId/force-withdraw (audit logged) for handling
  late drop-outs that the commissioner cannot resolve via the normal flow.
- Tests: 9 new unit tests + 2 route tests (HTTP 409/404 mapping).

Refs: ECHANTILLON Lot B (audit fichier Liste_de_course Nuffle Arena).