### PR TITLE
feat(league): match sheet v2 — model, validation effects, commissioner alerts (Lots G + H)

### DIFF
--- a/apps/server/prisma/sqlite/schema.prisma
+++ b/apps/server/prisma/sqlite/schema.prisma
@@ -835,6 +835,8 @@ model LeaguePairing {
   bonusPointsAway   Int               @default(0)
   /// Lot E — Breakdown JSON serialise (sqlite mirror).
   bonusBreakdown    String?
+  /// Lot G — feuille de match v2 (1-1, mirror PG).
+  matchSheet        LeagueMatchSheet?
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 
@@ -843,6 +845,64 @@ model LeaguePairing {
   @@index([deadlineAt, status])
   @@index([homeParticipantId])
   @@index([awayParticipantId])
+}
+
+/// Lot G — Feuille de match v2 (mirror PG). Les champs Json PG sont
+/// des String serialisees en sqlite.
+model LeagueMatchSheet {
+  id                String        @id @default(cuid())
+  pairing           LeaguePairing @relation(fields: [pairingId], references: [id], onDelete: Cascade)
+  pairingId         String        @unique
+  status            String        @default("draft")
+  submittedByHomeAt DateTime?
+  submittedByAwayAt DateTime?
+  validatedAt       DateTime?
+  validatedById     String?
+  invalidatedAt     DateTime?
+  invalidationReason String?
+  weather           String?
+  popularityHome    Int?
+  popularityAway    Int?
+  inducementsHome   String?
+  inducementsAway   String?
+  prayersHome       String?
+  prayersAway       String?
+  scoreHome         Int           @default(0)
+  scoreAway         Int           @default(0)
+  winningsHome      Int           @default(0)
+  winningsAway      Int           @default(0)
+  winningsHomeManual Int?
+  winningsAwayManual Int?
+  dedicatedFansDeltaHome Int?
+  dedicatedFansDeltaAway Int?
+  costlyErrorsHome  String?
+  costlyErrorsAway  String?
+  motmPlayerIds     String        @default("[]")
+  purchasesHome     String?
+  purchasesAway     String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  events            LeagueMatchEvent[]
+
+  @@index([status])
+}
+
+/// Lot G — Evenement unitaire de feuille de match (mirror PG).
+model LeagueMatchEvent {
+  id           String           @id @default(cuid())
+  matchSheet   LeagueMatchSheet @relation(fields: [matchSheetId], references: [id], onDelete: Cascade)
+  matchSheetId String
+  kind         String
+  team         String?
+  actorPlayerId  String?
+  targetPlayerId String?
+  causeDetail  String?
+  injurySeverity String?
+  meta         String?
+  occurredAt   DateTime         @default(now())
+
+  @@index([matchSheetId, kind])
 }
 
 /// Catalogue des Règles Spéciales d'équipe (S3 — OCR officielle).

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -121,6 +121,7 @@ import {
   unsubmitByCoach,
   validateByCommissioner,
   getMatchSheet,
+  listPendingValidationsForCommissioner,
   MatchSheetError,
 } from "../services/league-match-sheet";
 import {
@@ -1542,6 +1543,26 @@ export async function handleValidateMatchSheet(
   }
 }
 
+/**
+ * Lot H — GET /leagues/me/pending-validations
+ *
+ * Liste tous les matchs (toutes ligues du commissaire) en attente de
+ * validation (`both_submitted`). Source de la cloche de notification.
+ */
+export async function handleListPendingValidations(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const items = await listPendingValidationsForCommissioner(userId);
+    sendSuccess(res, { pending: items, count: items.length });
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
 // ===========================================================
 // Lot J — handlers : classements top-N joueurs.
 // ===========================================================
@@ -2213,6 +2234,12 @@ router.post(
   "/pairings/:pairingId/sheet/validate",
   authUser,
   handleValidateMatchSheet,
+);
+// Lot H — liste des matchs a valider pour le commissaire (cloche).
+router.get(
+  "/me/pending-validations",
+  authUser,
+  handleListPendingValidations,
 );
 
 // Lot J — classements top-N joueurs (public). Decline aussi par

--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -113,6 +113,23 @@ import {
   type AssignPoolsBody,
 } from "../schemas/league-pool.schemas";
 import {
+  createMatchSheet,
+  addEvent as addMatchSheetEvent,
+  removeEvent as removeMatchSheetEvent,
+  updatePreMatch,
+  submitByCoach,
+  unsubmitByCoach,
+  validateByCommissioner,
+  getMatchSheet,
+  MatchSheetError,
+} from "../services/league-match-sheet";
+import {
+  addEventSchema,
+  preMatchSchema,
+  type AddEventBody,
+  type PreMatchBody,
+} from "../schemas/league-match-sheet.schemas";
+import {
   playMecene,
   LeaguePatronError,
 } from "../services/league-patron";
@@ -190,6 +207,23 @@ function domainError(res: Response, e: unknown): void {
         : e.code === "season_started" || e.code === "season_completed"
           ? 409
           : 400;
+    sendError(res, e.message, status);
+    return;
+  }
+  // Lot G — match sheet errors.
+  if (e instanceof MatchSheetError) {
+    const status =
+      e.code === "pairing_not_found" ||
+      e.code === "sheet_not_found" ||
+      e.code === "event_not_found"
+        ? 404
+        : e.code === "forbidden" || e.code === "not_a_participant"
+          ? 403
+          : e.code === "already_validated" ||
+              e.code === "not_validated" ||
+              e.code === "invalid_status"
+            ? 409
+            : 400;
     sendError(res, e.message, status);
     return;
   }
@@ -1356,6 +1390,159 @@ export async function handleGetAuditLog(
 }
 
 // ===========================================================
+// Lot G — handlers : feuille de match v2.
+// ===========================================================
+
+/** GET /leagues/pairings/:pairingId/sheet */
+export async function handleGetMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await getMatchSheet({
+      pairingId: req.params.pairingId,
+      userId,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet (init lazy) */
+export async function handleCreateMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const sheet = await createMatchSheet({
+      pairingId: req.params.pairingId,
+      userId,
+    });
+    sendSuccess(res, sheet, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** PATCH /leagues/pairings/:pairingId/sheet/pre-match */
+export async function handleUpdatePreMatch(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as PreMatchBody;
+  try {
+    const sheet = await updatePreMatch({
+      pairingId: req.params.pairingId,
+      userId,
+      payload: body,
+    });
+    sendSuccess(res, sheet);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet/events */
+export async function handleAddMatchSheetEvent(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as AddEventBody;
+  try {
+    const ev = await addMatchSheetEvent({
+      pairingId: req.params.pairingId,
+      userId,
+      event: body,
+    });
+    sendSuccess(res, ev, 201);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** DELETE /leagues/pairings/:pairingId/sheet/events/:eventId */
+export async function handleRemoveMatchSheetEvent(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await removeMatchSheetEvent({
+      pairingId: req.params.pairingId,
+      userId,
+      eventId: req.params.eventId,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet/submit */
+export async function handleSubmitMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const sheet = await submitByCoach({
+      pairingId: req.params.pairingId,
+      userId,
+    });
+    sendSuccess(res, sheet);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet/unsubmit */
+export async function handleUnsubmitMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const sheet = await unsubmitByCoach({
+      pairingId: req.params.pairingId,
+      userId,
+    });
+    sendSuccess(res, sheet);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet/validate */
+export async function handleValidateMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await validateByCommissioner({
+      pairingId: req.params.pairingId,
+      userId,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+// ===========================================================
 // Lot J — handlers : classements top-N joueurs.
 // ===========================================================
 
@@ -1982,6 +2169,50 @@ router.patch(
   "/seasons/:seasonId/playoff-bracket/participants",
   authUser,
   handleOverridePlayoffParticipants,
+);
+
+// Lot G — feuille de match v2 (saisie joueurs + validation commissaire).
+router.get(
+  "/pairings/:pairingId/sheet",
+  authUser,
+  handleGetMatchSheet,
+);
+router.post(
+  "/pairings/:pairingId/sheet",
+  authUser,
+  handleCreateMatchSheet,
+);
+router.patch(
+  "/pairings/:pairingId/sheet/pre-match",
+  authUser,
+  validate(preMatchSchema),
+  handleUpdatePreMatch,
+);
+router.post(
+  "/pairings/:pairingId/sheet/events",
+  authUser,
+  validate(addEventSchema),
+  handleAddMatchSheetEvent,
+);
+router.delete(
+  "/pairings/:pairingId/sheet/events/:eventId",
+  authUser,
+  handleRemoveMatchSheetEvent,
+);
+router.post(
+  "/pairings/:pairingId/sheet/submit",
+  authUser,
+  handleSubmitMatchSheet,
+);
+router.post(
+  "/pairings/:pairingId/sheet/unsubmit",
+  authUser,
+  handleUnsubmitMatchSheet,
+);
+router.post(
+  "/pairings/:pairingId/sheet/validate",
+  authUser,
+  handleValidateMatchSheet,
 );
 
 // Lot J — classements top-N joueurs (public). Decline aussi par

--- a/apps/server/src/schemas/league-match-sheet.schemas.ts
+++ b/apps/server/src/schemas/league-match-sheet.schemas.ts
@@ -1,0 +1,46 @@
+/**
+ * Lot G — Zod schemas pour les routes de feuille de match v2.
+ */
+
+import { z } from "zod";
+
+export const addEventSchema = z.object({
+  kind: z.enum([
+    "kickoff",
+    "touchdown",
+    "casualty",
+    "pass_complete",
+    "interception",
+    "aggression",
+    "expulsion",
+    "crowd_surge",
+    "stalling",
+    "other_elim",
+  ]),
+  team: z.enum(["home", "away"]).optional().nullable(),
+  actorPlayerId: z.string().min(1).optional().nullable(),
+  targetPlayerId: z.string().min(1).optional().nullable(),
+  causeDetail: z.string().max(64).optional().nullable(),
+  injurySeverity: z
+    .enum(["badly_hurt", "mng", "niggling", "stat_loss", "dead"])
+    .optional()
+    .nullable(),
+  meta: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+export type AddEventBody = z.infer<typeof addEventSchema>;
+
+export const preMatchSchema = z
+  .object({
+    weather: z.string().max(64).optional().nullable(),
+    popularityHome: z.number().int().min(0).max(20).optional().nullable(),
+    popularityAway: z.number().int().min(0).max(20).optional().nullable(),
+    inducementsHome: z.array(z.record(z.string(), z.unknown())).optional().nullable(),
+    inducementsAway: z.array(z.record(z.string(), z.unknown())).optional().nullable(),
+    prayersHome: z.array(z.record(z.string(), z.unknown())).optional().nullable(),
+    prayersAway: z.array(z.record(z.string(), z.unknown())).optional().nullable(),
+  })
+  .refine(
+    (v) => Object.keys(v).length > 0,
+    "Au moins un champ d'avant-match requis",
+  );
+export type PreMatchBody = z.infer<typeof preMatchSchema>;

--- a/apps/server/src/services/featureFlags.ts
+++ b/apps/server/src/services/featureFlags.ts
@@ -138,6 +138,13 @@ export const LEAGUE_COMMISSIONER_EDIT_FLAG =
   "league_commissioner_edit" as const;
 
 /**
+ * Lot G — sous-flag pour la feuille de match v2 (saisie collaborative
+ * joueurs + journal d'evenements + validation commissaire). Gate l'UI
+ * dediee ; l'API reste protegee par auth + roles.
+ */
+export const LEAGUE_MATCH_SHEET_FLAG = "league_match_sheet" as const;
+
+/**
  * Registre des feature flags connus du code. Source de vérité pour garder
  * la table `FeatureFlag` synchronisée avec le code : le bouton
  * "Synchroniser depuis le code" du panneau admin (POST
@@ -217,6 +224,11 @@ export const KNOWN_FLAGS: ReadonlyArray<KnownFlagSpec> = [
     key: LEAGUE_COMMISSIONER_EDIT_FLAG,
     description:
       "Ligue — edition ex-post des equipes par le commissaire (SPP, comp, carac, treso).",
+  },
+  {
+    key: LEAGUE_MATCH_SHEET_FLAG,
+    description:
+      "Ligue — feuille de match v2 (saisie joueurs + evenements + validation commissaire).",
   },
 ];
 

--- a/apps/server/src/services/league-match-sheet.test.ts
+++ b/apps/server/src/services/league-match-sheet.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Lot G — Tests du service `league-match-sheet` (machine a etats +
+ * autorisation). Mocke prisma ; le summarizer pur est reutilise tel quel.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../prisma", () => ({
+  prisma: {
+    leaguePairing: { findUnique: vi.fn() },
+    leagueMatchSheet: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    leagueMatchEvent: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "../prisma";
+import {
+  createMatchSheet,
+  addEvent,
+  removeEvent,
+  submitByCoach,
+  unsubmitByCoach,
+  validateByCommissioner,
+  getMatchSheet,
+  MatchSheetError,
+} from "./league-match-sheet";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+const HOME = "home-owner";
+const AWAY = "away-owner";
+const COMMISH = "commish";
+
+function mockPairing() {
+  mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+    id: "pair-1",
+    round: { season: { league: { id: "L1", creatorId: COMMISH } } },
+    homeParticipant: { team: { ownerId: HOME } },
+    awayParticipant: { team: { ownerId: AWAY } },
+  });
+}
+
+describe("Lot G — league-match-sheet", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPairing();
+  });
+
+  describe("createMatchSheet", () => {
+    it("rejects a non-participant", async () => {
+      await expect(
+        createMatchSheet({ pairingId: "pair-1", userId: "stranger" }),
+      ).rejects.toMatchObject({ code: "not_a_participant" });
+    });
+
+    it("returns existing sheet (idempotent)", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      const out = await createMatchSheet({ pairingId: "pair-1", userId: HOME });
+      expect(out).toMatchObject({ id: "ms1" });
+      expect(mockPrisma.leagueMatchSheet.create).not.toHaveBeenCalled();
+    });
+
+    it("creates a draft sheet for a coach", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue(null);
+      mockPrisma.leagueMatchSheet.create.mockResolvedValue({
+        id: "ms-new",
+        status: "draft",
+      });
+      const out = await createMatchSheet({ pairingId: "pair-1", userId: AWAY });
+      expect(out).toMatchObject({ status: "draft" });
+    });
+
+    it("allows the commissioner to open it", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue(null);
+      mockPrisma.leagueMatchSheet.create.mockResolvedValue({ id: "ms" });
+      await expect(
+        createMatchSheet({ pairingId: "pair-1", userId: COMMISH }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("addEvent", () => {
+    it("rejects invalid kind", async () => {
+      await expect(
+        addEvent({
+          pairingId: "pair-1",
+          userId: HOME,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          event: { kind: "nope" as any },
+        }),
+      ).rejects.toMatchObject({ code: "invalid_event" });
+    });
+
+    it("rejects when sheet missing", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue(null);
+      await expect(
+        addEvent({
+          pairingId: "pair-1",
+          userId: HOME,
+          event: { kind: "touchdown", team: "home" },
+        }),
+      ).rejects.toMatchObject({ code: "sheet_not_found" });
+    });
+
+    it("rejects editing a validated sheet", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      await expect(
+        addEvent({
+          pairingId: "pair-1",
+          userId: HOME,
+          event: { kind: "touchdown", team: "home" },
+        }),
+      ).rejects.toMatchObject({ code: "already_validated" });
+    });
+
+    it("creates an event for a coach", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      mockPrisma.leagueMatchEvent.create.mockResolvedValue({ id: "e1" });
+      const out = await addEvent({
+        pairingId: "pair-1",
+        userId: AWAY,
+        event: {
+          kind: "casualty",
+          team: "away",
+          actorPlayerId: "a1",
+          targetPlayerId: "h2",
+          injurySeverity: "dead",
+        },
+      });
+      expect(out).toMatchObject({ id: "e1" });
+      const args = mockPrisma.leagueMatchEvent.create.mock.calls[0][0];
+      expect(args.data.kind).toBe("casualty");
+      expect(args.data.injurySeverity).toBe("dead");
+    });
+  });
+
+  describe("removeEvent", () => {
+    it("rejects event from another sheet", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      mockPrisma.leagueMatchEvent.findUnique.mockResolvedValue({
+        id: "e1",
+        matchSheetId: "OTHER",
+      });
+      await expect(
+        removeEvent({ pairingId: "pair-1", userId: HOME, eventId: "e1" }),
+      ).rejects.toMatchObject({ code: "event_not_found" });
+    });
+
+    it("deletes an event", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      mockPrisma.leagueMatchEvent.findUnique.mockResolvedValue({
+        id: "e1",
+        matchSheetId: "ms1",
+      });
+      mockPrisma.leagueMatchEvent.delete.mockResolvedValue({});
+      await expect(
+        removeEvent({ pairingId: "pair-1", userId: HOME, eventId: "e1" }),
+      ).resolves.toMatchObject({ deleted: true });
+    });
+  });
+
+  describe("submitByCoach", () => {
+    it("rejects a non-coach (commissioner cannot submit)", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      await expect(
+        submitByCoach({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toMatchObject({ code: "not_a_participant" });
+    });
+
+    it("home submit on draft -> submitted_home", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+        submittedByHomeAt: null,
+        submittedByAwayAt: null,
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await submitByCoach({ pairingId: "pair-1", userId: HOME });
+      expect((out as { status: string }).status).toBe("submitted_home");
+    });
+
+    it("away submit when home already submitted -> both_submitted", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "submitted_home",
+        submittedByHomeAt: new Date(),
+        submittedByAwayAt: null,
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await submitByCoach({ pairingId: "pair-1", userId: AWAY });
+      expect((out as { status: string }).status).toBe("both_submitted");
+    });
+  });
+
+  describe("unsubmitByCoach", () => {
+    it("away unsubmit from both_submitted -> submitted_home", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+        submittedByHomeAt: new Date(),
+        submittedByAwayAt: new Date(),
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await unsubmitByCoach({ pairingId: "pair-1", userId: AWAY });
+      expect((out as { status: string }).status).toBe("submitted_home");
+    });
+
+    it("home unsubmit when alone -> draft", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "submitted_home",
+        submittedByHomeAt: new Date(),
+        submittedByAwayAt: null,
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await unsubmitByCoach({ pairingId: "pair-1", userId: HOME });
+      expect((out as { status: string }).status).toBe("draft");
+    });
+  });
+
+  describe("validateByCommissioner", () => {
+    it("rejects a coach", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+      });
+      await expect(
+        validateByCommissioner({ pairingId: "pair-1", userId: HOME }),
+      ).rejects.toMatchObject({ code: "forbidden" });
+    });
+
+    it("freezes derived score from events", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+      });
+      mockPrisma.leagueMatchEvent.findMany.mockResolvedValue([
+        { kind: "touchdown", team: "home", actorPlayerId: "h1" },
+        { kind: "touchdown", team: "home", actorPlayerId: "h1" },
+        { kind: "touchdown", team: "away", actorPlayerId: "a1" },
+      ]);
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await validateByCommissioner({
+        pairingId: "pair-1",
+        userId: COMMISH,
+      });
+      expect(out.summary.scoreHome).toBe(2);
+      expect(out.summary.scoreAway).toBe(1);
+      const updateArgs = mockPrisma.leagueMatchSheet.update.mock.calls[0][0];
+      expect(updateArgs.data).toMatchObject({
+        status: "validated",
+        scoreHome: 2,
+        scoreAway: 1,
+        validatedById: COMMISH,
+      });
+    });
+
+    it("rejects double validation", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      await expect(
+        validateByCommissioner({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toMatchObject({ code: "already_validated" });
+    });
+  });
+
+  describe("getMatchSheet", () => {
+    it("returns sheet + summary + viewerRole", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+        events: [{ kind: "touchdown", team: "away", actorPlayerId: "a1" }],
+      });
+      const out = await getMatchSheet({ pairingId: "pair-1", userId: AWAY });
+      expect(out.viewerRole).toBe("away");
+      expect(out.summary.scoreAway).toBe(1);
+    });
+
+    it("marks commissioner role", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+        events: [],
+      });
+      const out = await getMatchSheet({ pairingId: "pair-1", userId: COMMISH });
+      expect(out.viewerRole).toBe("commissioner");
+    });
+  });
+
+  describe("MatchSheetError", () => {
+    it("preserves code", () => {
+      const e = new MatchSheetError("forbidden", "x");
+      expect(e.code).toBe("forbidden");
+      expect(e).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/apps/server/src/services/league-match-sheet.test.ts
+++ b/apps/server/src/services/league-match-sheet.test.ts
@@ -10,6 +10,7 @@ vi.mock("../prisma", () => ({
     leaguePairing: { findUnique: vi.fn() },
     leagueMatchSheet: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -27,6 +28,11 @@ vi.mock("./league-offline-result", () => ({
   recordOfflineLeagueResult: vi.fn(),
 }));
 
+// Lot H — mock du push commissaire (fire-and-forget).
+vi.mock("./push-notifications", () => ({
+  sendLeagueMatchValidationPush: vi.fn(),
+}));
+
 import { prisma } from "../prisma";
 import {
   createMatchSheet,
@@ -37,14 +43,17 @@ import {
   validateByCommissioner,
   getMatchSheet,
   buildOfflineInputFromSummary,
+  listPendingValidationsForCommissioner,
   MatchSheetError,
 } from "./league-match-sheet";
 import { recordOfflineLeagueResult } from "./league-offline-result";
+import { sendLeagueMatchValidationPush } from "./push-notifications";
 import type { MatchSummary } from "./league-match-summary";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockPrisma = prisma as any;
 const mockRecordOffline = recordOfflineLeagueResult as ReturnType<typeof vi.fn>;
+const mockPush = sendLeagueMatchValidationPush as ReturnType<typeof vi.fn>;
 
 const HOME = "home-owner";
 const AWAY = "away-owner";
@@ -218,7 +227,7 @@ describe("Lot G — league-match-sheet", () => {
       expect((out as { status: string }).status).toBe("submitted_home");
     });
 
-    it("away submit when home already submitted -> both_submitted", async () => {
+    it("away submit when home already submitted -> both_submitted + notifies commissioner", async () => {
       mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
         id: "ms1",
         status: "submitted_home",
@@ -228,8 +237,43 @@ describe("Lot G — league-match-sheet", () => {
       mockPrisma.leagueMatchSheet.update.mockImplementation(
         async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
       );
+      // notifyCommissionerSheetReady re-reads the pairing for team names.
+      mockPrisma.leaguePairing.findUnique.mockResolvedValueOnce({
+        id: "pair-1",
+        round: { season: { league: { id: "L1", creatorId: COMMISH } } },
+        homeParticipant: { team: { ownerId: HOME } },
+        awayParticipant: { team: { ownerId: AWAY } },
+      });
+      mockPrisma.leaguePairing.findUnique.mockResolvedValueOnce({
+        homeParticipant: { team: { name: "Reikland" } },
+        awayParticipant: { team: { name: "Gouged Eye" } },
+      });
       const out = await submitByCoach({ pairingId: "pair-1", userId: AWAY });
       expect((out as { status: string }).status).toBe("both_submitted");
+      // fire-and-forget : laisse la microtask s'executer.
+      await Promise.resolve();
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commissionerUserId: COMMISH,
+          leagueId: "L1",
+          pairingId: "pair-1",
+        }),
+      );
+    });
+
+    it("does not notify when only one coach submitted", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+        submittedByHomeAt: null,
+        submittedByAwayAt: null,
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      await submitByCoach({ pairingId: "pair-1", userId: HOME });
+      await Promise.resolve();
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 
@@ -388,6 +432,58 @@ describe("Lot G — league-match-sheet", () => {
       });
       const out = await getMatchSheet({ pairingId: "pair-1", userId: COMMISH });
       expect(out.viewerRole).toBe("commissioner");
+    });
+  });
+
+  // Lot H — liste des matchs a valider pour le commissaire.
+  describe("listPendingValidationsForCommissioner", () => {
+    it("maps both_submitted sheets to a flat pending list", async () => {
+      const homeAt = new Date("2026-06-01T10:00:00Z");
+      const awayAt = new Date("2026-06-01T11:00:00Z");
+      mockPrisma.leagueMatchSheet.findMany.mockResolvedValue([
+        {
+          id: "ms1",
+          pairingId: "pair-1",
+          submittedByHomeAt: homeAt,
+          submittedByAwayAt: awayAt,
+          pairing: {
+            round: {
+              roundNumber: 3,
+              season: {
+                id: "s1",
+                name: "Saison 1",
+                league: { id: "L1", name: "Ma Ligue" },
+              },
+            },
+            homeParticipant: { team: { name: "Reikland" } },
+            awayParticipant: { team: { name: "Gouged Eye" } },
+          },
+        },
+      ]);
+      const out = await listPendingValidationsForCommissioner(COMMISH);
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({
+        pairingId: "pair-1",
+        matchSheetId: "ms1",
+        leagueId: "L1",
+        leagueName: "Ma Ligue",
+        seasonId: "s1",
+        roundNumber: 3,
+        homeTeamName: "Reikland",
+        awayTeamName: "Gouged Eye",
+      });
+      // bothSubmittedAt = max(home, away)
+      expect(out[0].bothSubmittedAt?.toISOString()).toBe(awayAt.toISOString());
+      // Filtre Prisma : creatorId du commissaire + status both_submitted.
+      const where = mockPrisma.leagueMatchSheet.findMany.mock.calls[0][0].where;
+      expect(where.status).toBe("both_submitted");
+      expect(where.pairing.round.season.league.creatorId).toBe(COMMISH);
+    });
+
+    it("returns empty list when nothing pending", async () => {
+      mockPrisma.leagueMatchSheet.findMany.mockResolvedValue([]);
+      const out = await listPendingValidationsForCommissioner(COMMISH);
+      expect(out).toEqual([]);
     });
   });
 

--- a/apps/server/src/services/league-match-sheet.test.ts
+++ b/apps/server/src/services/league-match-sheet.test.ts
@@ -22,6 +22,11 @@ vi.mock("../prisma", () => ({
   },
 }));
 
+// Lot G.2 — mock du pipeline offline branche a la validation.
+vi.mock("./league-offline-result", () => ({
+  recordOfflineLeagueResult: vi.fn(),
+}));
+
 import { prisma } from "../prisma";
 import {
   createMatchSheet,
@@ -31,11 +36,15 @@ import {
   unsubmitByCoach,
   validateByCommissioner,
   getMatchSheet,
+  buildOfflineInputFromSummary,
   MatchSheetError,
 } from "./league-match-sheet";
+import { recordOfflineLeagueResult } from "./league-offline-result";
+import type { MatchSummary } from "./league-match-summary";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockPrisma = prisma as any;
+const mockRecordOffline = recordOfflineLeagueResult as ReturnType<typeof vi.fn>;
 
 const HOME = "home-owner";
 const AWAY = "away-owner";
@@ -265,16 +274,24 @@ describe("Lot G — league-match-sheet", () => {
       ).rejects.toMatchObject({ code: "forbidden" });
     });
 
-    it("freezes derived score from events", async () => {
+    it("freezes derived score from events and applies offline effects", async () => {
       mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
         id: "ms1",
         status: "both_submitted",
+        motmPlayerIds: [],
       });
       mockPrisma.leagueMatchEvent.findMany.mockResolvedValue([
         { kind: "touchdown", team: "home", actorPlayerId: "h1" },
         { kind: "touchdown", team: "home", actorPlayerId: "h1" },
         { kind: "touchdown", team: "away", actorPlayerId: "a1" },
       ]);
+      mockRecordOffline.mockResolvedValue({
+        recorded: true,
+        pairingId: "pair-1",
+        matchId: "m1",
+        winner: "home",
+        sppPlayersUpdated: 2,
+      });
       mockPrisma.leagueMatchSheet.update.mockImplementation(
         async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
       );
@@ -284,6 +301,14 @@ describe("Lot G — league-match-sheet", () => {
       });
       expect(out.summary.scoreHome).toBe(2);
       expect(out.summary.scoreAway).toBe(1);
+      expect(out.effects).toEqual({ applied: true });
+      // Le pipeline offline a bien ete appele avec le score derive.
+      const offlineArgs = mockRecordOffline.mock.calls[0][0];
+      expect(offlineArgs).toMatchObject({
+        pairingId: "pair-1",
+        scoreHome: 2,
+        scoreAway: 1,
+      });
       const updateArgs = mockPrisma.leagueMatchSheet.update.mock.calls[0][0];
       expect(updateArgs.data).toMatchObject({
         status: "validated",
@@ -291,6 +316,45 @@ describe("Lot G — league-match-sheet", () => {
         scoreAway: 1,
         validatedById: COMMISH,
       });
+    });
+
+    it("marks validated even when offline pipeline skips (already scored)", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+        motmPlayerIds: [],
+      });
+      mockPrisma.leagueMatchEvent.findMany.mockResolvedValue([]);
+      mockRecordOffline.mockResolvedValue({
+        skipped: true,
+        reason: "match-already-scored",
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await validateByCommissioner({
+        pairingId: "pair-1",
+        userId: COMMISH,
+      });
+      expect(out.effects).toEqual({
+        applied: false,
+        reason: "match-already-scored",
+      });
+      expect(mockPrisma.leagueMatchSheet.update).toHaveBeenCalled();
+    });
+
+    it("does not validate if offline pipeline throws", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+        motmPlayerIds: [],
+      });
+      mockPrisma.leagueMatchEvent.findMany.mockResolvedValue([]);
+      mockRecordOffline.mockRejectedValue(new Error("boom"));
+      await expect(
+        validateByCommissioner({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toThrow(/boom/);
+      expect(mockPrisma.leagueMatchSheet.update).not.toHaveBeenCalled();
     });
 
     it("rejects double validation", async () => {
@@ -332,6 +396,152 @@ describe("Lot G — league-match-sheet", () => {
       const e = new MatchSheetError("forbidden", "x");
       expect(e.code).toBe("forbidden");
       expect(e).toBeInstanceOf(Error);
+    });
+  });
+
+  // Lot G.2 — mapping pur summary -> input offline.
+  describe("buildOfflineInputFromSummary (Lot G.2)", () => {
+    const baseSummary: MatchSummary = {
+      scoreHome: 2,
+      scoreAway: 1,
+      casualtiesHome: 1,
+      casualtiesAway: 0,
+      injuries: [],
+      playerStats: [
+        {
+          playerId: "h1",
+          side: "home",
+          touchdowns: 2,
+          casualtiesInflicted: 1,
+          completions: 0,
+          interceptions: 0,
+          aggressions: 0,
+        },
+      ],
+    };
+
+    it("maps player stats and flags MVP from motmPlayerIds", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        { motmPlayerIds: ["h1"] },
+        [],
+      );
+      expect(out.scoreHome).toBe(2);
+      expect(out.casualtiesHome).toBe(1);
+      expect(out.playerStats).toEqual([
+        {
+          teamPlayerId: "h1",
+          touchdowns: 2,
+          casualties: 1,
+          completions: 0,
+          interceptions: 0,
+          mvp: true,
+        },
+      ]);
+    });
+
+    it("adds MVP-only players who had no stat line", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        { motmPlayerIds: ["h1", "bench9"] },
+        [],
+      );
+      const bench = out.playerStats.find((p) => p.teamPlayerId === "bench9");
+      expect(bench).toEqual({ teamPlayerId: "bench9", mvp: true });
+    });
+
+    it("maps mng/niggling/dead injuries; skips badly_hurt", () => {
+      const summary: MatchSummary = {
+        ...baseSummary,
+        injuries: [
+          { playerId: "a1", severity: "dead", side: "away", cause: "block" },
+          { playerId: "a2", severity: "mng", side: "away", cause: "block" },
+          { playerId: "a3", severity: "niggling", side: "away", cause: "block" },
+          { playerId: "a4", severity: "badly_hurt", side: "away", cause: "block" },
+        ],
+      };
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        summary,
+        { motmPlayerIds: [] },
+        [],
+      );
+      expect(out.injuries).toEqual([
+        { teamPlayerId: "a1", type: "dead" },
+        { teamPlayerId: "a2", type: "mng" },
+        { teamPlayerId: "a3", type: "niggling" },
+      ]);
+    });
+
+    it("maps stat_loss using event meta.stat", () => {
+      const summary: MatchSummary = {
+        ...baseSummary,
+        injuries: [
+          { playerId: "a5", severity: "stat_loss", side: "away", cause: "block" },
+        ],
+      };
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        summary,
+        { motmPlayerIds: [] },
+        [
+          {
+            kind: "casualty",
+            team: "home",
+            targetPlayerId: "a5",
+            injurySeverity: "stat_loss",
+            meta: { stat: "st" },
+          },
+        ],
+      );
+      expect(out.injuries).toEqual([{ teamPlayerId: "a5", type: "st" }]);
+    });
+
+    it("skips stat_loss when no specific stat is provided", () => {
+      const summary: MatchSummary = {
+        ...baseSummary,
+        injuries: [
+          { playerId: "a6", severity: "stat_loss", side: "away", cause: "block" },
+        ],
+      };
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        summary,
+        { motmPlayerIds: [] },
+        [],
+      );
+      expect(out.injuries).toEqual([]);
+    });
+
+    it("passes manual winnings and fans deltas through", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        {
+          motmPlayerIds: [],
+          winningsHomeManual: 60000,
+          winningsAwayManual: 30000,
+          dedicatedFansDeltaHome: 1,
+          dedicatedFansDeltaAway: -1,
+        },
+        [],
+      );
+      expect(out.winningsHome).toBe(60000);
+      expect(out.winningsAway).toBe(30000);
+      expect(out.dedicatedFansDeltaHome).toBe(1);
+      expect(out.dedicatedFansDeltaAway).toBe(-1);
+    });
+
+    it("parses motmPlayerIds from a serialized JSON string (sqlite)", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        { motmPlayerIds: JSON.stringify(["h1"]) },
+        [],
+      );
+      expect(out.playerStats[0].mvp).toBe(true);
     });
   });
 });

--- a/apps/server/src/services/league-match-sheet.ts
+++ b/apps/server/src/services/league-match-sheet.ts
@@ -32,6 +32,7 @@ import {
   type OfflineInjuryInput,
   type OfflineInjuryType,
 } from "./league-offline-result";
+import { sendLeagueMatchValidationPush } from "./push-notifications";
 import { serverLog } from "../utils/server-log";
 
 export type MatchSheetStatus =
@@ -316,7 +317,7 @@ export async function submitByCoach(input: {
   }
 
   const next = nextStatusOnSubmit(sheet.status, side);
-  return prisma.leagueMatchSheet.update({
+  const updated = await prisma.leagueMatchSheet.update({
     where: { id: sheet.id },
     data: {
       status: next,
@@ -324,6 +325,43 @@ export async function submitByCoach(input: {
         ? { submittedByHomeAt: new Date() }
         : { submittedByAwayAt: new Date() }),
     },
+  });
+
+  // Lot H — quand les 2 coachs ont soumis, alerte le commissaire
+  // (fire-and-forget, non-bloquant). On a deja `ctx` (creator + teams).
+  if (next === "both_submitted") {
+    notifyCommissionerSheetReady(ctx).catch((e: unknown) => {
+      const msg = e instanceof Error ? e.message : "unknown";
+      serverLog.error(`[league-match-sheet] notify commissioner failed: ${msg}`);
+    });
+  }
+
+  return updated;
+}
+
+/**
+ * Lot H — Resout les noms d'equipe et declenche le push commissaire.
+ * Isole pour rester testable / non-bloquant.
+ */
+async function notifyCommissionerSheetReady(
+  ctx: PairingContext,
+): Promise<void> {
+  const pairing = (await prisma.leaguePairing.findUnique({
+    where: { id: ctx.pairingId },
+    select: {
+      homeParticipant: { select: { team: { select: { name: true } } } },
+      awayParticipant: { select: { team: { select: { name: true } } } },
+    },
+  })) as {
+    homeParticipant: { team: { name: string } } | null;
+    awayParticipant: { team: { name: string } } | null;
+  } | null;
+  sendLeagueMatchValidationPush({
+    commissionerUserId: ctx.creatorId,
+    leagueId: ctx.leagueId,
+    pairingId: ctx.pairingId,
+    homeTeamName: pairing?.homeParticipant?.team.name ?? "?",
+    awayTeamName: pairing?.awayParticipant?.team.name ?? "?",
   });
 }
 
@@ -569,6 +607,100 @@ export async function validateByCommissioner(input: {
     },
   });
   return { sheet: updated, summary, effects };
+}
+
+/**
+ * Lot H — Liste des feuilles de match en attente de validation pour
+ * un commissaire (status `both_submitted`). Source de la cloche de
+ * notification + page "Matchs a valider".
+ *
+ * Filtre les pairings dont la ligue a `creatorId === userId`. Une
+ * seule requete Prisma (nested filter), ordonnee par anciennete.
+ */
+export async function listPendingValidationsForCommissioner(
+  userId: string,
+): Promise<
+  Array<{
+    pairingId: string;
+    matchSheetId: string;
+    leagueId: string;
+    leagueName: string;
+    seasonId: string;
+    seasonName: string;
+    roundNumber: number;
+    homeTeamName: string;
+    awayTeamName: string;
+    bothSubmittedAt: Date | null;
+  }>
+> {
+  const sheets = (await prisma.leagueMatchSheet.findMany({
+    where: {
+      status: "both_submitted",
+      pairing: {
+        round: { season: { league: { creatorId: userId } } },
+      },
+    },
+    orderBy: { updatedAt: "asc" },
+    select: {
+      id: true,
+      pairingId: true,
+      submittedByHomeAt: true,
+      submittedByAwayAt: true,
+      pairing: {
+        select: {
+          round: {
+            select: {
+              roundNumber: true,
+              season: {
+                select: {
+                  id: true,
+                  name: true,
+                  league: { select: { id: true, name: true } },
+                },
+              },
+            },
+          },
+          homeParticipant: { select: { team: { select: { name: true } } } },
+          awayParticipant: { select: { team: { select: { name: true } } } },
+        },
+      },
+    },
+  })) as Array<{
+    id: string;
+    pairingId: string;
+    submittedByHomeAt: Date | null;
+    submittedByAwayAt: Date | null;
+    pairing: {
+      round: {
+        roundNumber: number;
+        season: {
+          id: string;
+          name: string;
+          league: { id: string; name: string };
+        };
+      };
+      homeParticipant: { team: { name: string } } | null;
+      awayParticipant: { team: { name: string } } | null;
+    };
+  }>;
+
+  return sheets.map((s) => {
+    const home = s.submittedByHomeAt?.getTime() ?? 0;
+    const away = s.submittedByAwayAt?.getTime() ?? 0;
+    const bothMs = Math.max(home, away);
+    return {
+      pairingId: s.pairingId,
+      matchSheetId: s.id,
+      leagueId: s.pairing.round.season.league.id,
+      leagueName: s.pairing.round.season.league.name,
+      seasonId: s.pairing.round.season.id,
+      seasonName: s.pairing.round.season.name,
+      roundNumber: s.pairing.round.roundNumber,
+      homeTeamName: s.pairing.homeParticipant?.team.name ?? "?",
+      awayTeamName: s.pairing.awayParticipant?.team.name ?? "?",
+      bothSubmittedAt: bothMs > 0 ? new Date(bothMs) : null,
+    };
+  });
 }
 
 /**

--- a/apps/server/src/services/league-match-sheet.ts
+++ b/apps/server/src/services/league-match-sheet.ts
@@ -24,7 +24,15 @@ import {
   isMatchEventKind,
   type MatchEventInput,
   type MatchSummary,
+  type InjurySeverity,
 } from "./league-match-summary";
+import {
+  recordOfflineLeagueResult,
+  type OfflinePlayerStatInput,
+  type OfflineInjuryInput,
+  type OfflineInjuryType,
+} from "./league-offline-result";
+import { serverLog } from "../utils/server-log";
 
 export type MatchSheetStatus =
   | "draft"
@@ -356,10 +364,145 @@ export async function unsubmitByCoach(input: {
 }
 
 /**
- * Le commissaire valide la feuille. Fige le score derive des events.
- * G.1 : transition de status + snapshot score. G.2 branchera
- * l'application des effets (classement, SPP, blessures) via le
- * pipeline `recordOfflineLeagueResult`.
+ * Lot G.2 — Mappe la severite du summarizer vers le type de blessure
+ * du pipeline offline. `badly_hurt` n'a pas d'effet durable (BB) ⇒
+ * non mappe. `stat_loss` necessite la carac visee : on la lit dans
+ * `meta.stat` (ma/st/ag/pa/av), sinon la blessure est ignoree.
+ */
+function mapInjurySeverity(
+  severity: InjurySeverity,
+  metaStat: string | null,
+): OfflineInjuryType | null {
+  switch (severity) {
+    case "mng":
+      return "mng";
+    case "niggling":
+      return "niggling";
+    case "dead":
+      return "dead";
+    case "stat_loss": {
+      const stat = (metaStat ?? "").toLowerCase();
+      if (
+        stat === "ma" ||
+        stat === "st" ||
+        stat === "ag" ||
+        stat === "pa" ||
+        stat === "av"
+      ) {
+        return stat as OfflineInjuryType;
+      }
+      return null;
+    }
+    case "badly_hurt":
+    default:
+      return null;
+  }
+}
+
+/**
+ * Lot G.2 — Construit l'input du pipeline offline a partir du summary
+ * derive + des champs de la feuille (winnings override, fans, MVP).
+ * Pur (testable). Les statLines portent deja le `side` ; le pipeline
+ * offline resout l'equipe via le teamPlayerId.
+ */
+export function buildOfflineInputFromSummary(
+  pairingId: string,
+  summary: MatchSummary,
+  sheet: {
+    motmPlayerIds?: unknown;
+    winningsHomeManual?: number | null;
+    winningsAwayManual?: number | null;
+    dedicatedFansDeltaHome?: number | null;
+    dedicatedFansDeltaAway?: number | null;
+  },
+  eventsForMeta: ReadonlyArray<MatchEventInput & { meta?: unknown }>,
+) {
+  const motm = parseStringArray(sheet.motmPlayerIds);
+  const motmSet = new Set(motm);
+
+  const playerStats: OfflinePlayerStatInput[] = summary.playerStats.map(
+    (p) => ({
+      teamPlayerId: p.playerId,
+      touchdowns: p.touchdowns,
+      casualties: p.casualtiesInflicted,
+      completions: p.completions,
+      interceptions: p.interceptions,
+      mvp: motmSet.has(p.playerId),
+    }),
+  );
+
+  // Les MVP sans stat-line (joueur primé sans event) doivent quand meme
+  // recevoir le flag mvp -> on les ajoute.
+  for (const id of motm) {
+    if (!playerStats.some((p) => p.teamPlayerId === id)) {
+      playerStats.push({ teamPlayerId: id, mvp: true });
+    }
+  }
+
+  // Map stat de blessure via meta de l'event source (best-effort : on
+  // associe par targetPlayerId+severity au 1er event matchant).
+  const injuries: OfflineInjuryInput[] = [];
+  for (const inj of summary.injuries) {
+    const src = eventsForMeta.find(
+      (e) =>
+        e.targetPlayerId === inj.playerId &&
+        (e.injurySeverity as string | null) === inj.severity,
+    );
+    const metaStat =
+      src && src.meta && typeof src.meta === "object"
+        ? ((src.meta as Record<string, unknown>).stat as string | undefined) ??
+          null
+        : null;
+    const type = mapInjurySeverity(inj.severity, metaStat);
+    if (type) {
+      injuries.push({ teamPlayerId: inj.playerId, type });
+    }
+  }
+
+  return {
+    pairingId,
+    scoreHome: summary.scoreHome,
+    scoreAway: summary.scoreAway,
+    casualtiesHome: summary.casualtiesHome,
+    casualtiesAway: summary.casualtiesAway,
+    playerStats,
+    winningsHome: sheet.winningsHomeManual ?? undefined,
+    winningsAway: sheet.winningsAwayManual ?? undefined,
+    dedicatedFansDeltaHome: sheet.dedicatedFansDeltaHome ?? undefined,
+    dedicatedFansDeltaAway: sheet.dedicatedFansDeltaAway ?? undefined,
+    injuries,
+  };
+}
+
+function parseStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed)
+        ? parsed.filter((s): s is string => typeof s === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * Le commissaire valide la feuille.
+ *
+ * Lot G.2 — Applique les effets via `recordOfflineLeagueResult`
+ * (classement W/D/L + points + bonus Lot E, SPP + level-up, blessures
+ * durables, tresorerie, fans devoues, pairing -> played). Le pipeline
+ * est idempotent : si le match a deja ete compte (skip), on marque
+ * quand meme la feuille validee.
+ *
+ * Si l'application des effets echoue (throw), la feuille reste en
+ * `both_submitted` et l'erreur est propagee — pas de validation
+ * partielle.
  */
 export async function validateByCommissioner(input: {
   pairingId: string;
@@ -367,6 +510,7 @@ export async function validateByCommissioner(input: {
 }): Promise<{
   sheet: unknown;
   summary: MatchSummary;
+  effects: { applied: boolean; reason?: string };
 }> {
   const ctx = await loadPairingContext(input.pairingId);
   if (!isCommissioner(ctx, input.userId)) {
@@ -383,8 +527,36 @@ export async function validateByCommissioner(input: {
   const events = (await prisma.leagueMatchEvent.findMany({
     where: { matchSheetId: sheet.id },
     orderBy: { occurredAt: "asc" },
-  })) as MatchEventInput[];
+  })) as Array<MatchEventInput & { meta?: unknown }>;
   const summary = summarizeMatchSheet(events);
+
+  // Applique les effets (peut throw -> on ne valide pas).
+  const offlineInput = buildOfflineInputFromSummary(
+    input.pairingId,
+    summary,
+    sheet as {
+      motmPlayerIds?: unknown;
+      winningsHomeManual?: number | null;
+      winningsAwayManual?: number | null;
+      dedicatedFansDeltaHome?: number | null;
+      dedicatedFansDeltaAway?: number | null;
+    },
+    events,
+  );
+  const outcome = await recordOfflineLeagueResult(offlineInput);
+
+  let effects: { applied: boolean; reason?: string };
+  if ("recorded" in outcome && outcome.recorded) {
+    effects = { applied: true };
+  } else if ("skipped" in outcome) {
+    // already-scored / not-terminal-eligible : effets deja en place.
+    effects = { applied: false, reason: outcome.reason };
+    serverLog.info(
+      `[league-match-sheet] validate: offline skipped (${outcome.reason}) pairing=${input.pairingId}`,
+    );
+  } else {
+    effects = { applied: false };
+  }
 
   const updated = await prisma.leagueMatchSheet.update({
     where: { id: sheet.id },
@@ -396,7 +568,7 @@ export async function validateByCommissioner(input: {
       scoreAway: summary.scoreAway,
     },
   });
-  return { sheet: updated, summary };
+  return { sheet: updated, summary, effects };
 }
 
 /**

--- a/apps/server/src/services/league-match-sheet.ts
+++ b/apps/server/src/services/league-match-sheet.ts
@@ -1,0 +1,438 @@
+/**
+ * Lot G — Service de feuille de match v2.
+ *
+ * Gere le cycle de vie collaboratif d'une feuille de match :
+ *   draft -> submitted_home/away -> both_submitted -> validated
+ *   (-> invalidated dans la fenetre de correction).
+ *
+ * Responsabilites G.1 (ce fichier) :
+ *   - createMatchSheet (lazy, a l'ouverture de la feuille) ;
+ *   - addEvent / removeEvent (journal) ;
+ *   - updatePreMatch (meteo, popularite, inducements, prieres) ;
+ *   - submitByCoach / unsubmitByCoach (saisie joueur) ;
+ *   - validateByCommissioner (fige le score derive ; l'application des
+ *     effets sur le classement est branchee en G.2).
+ *
+ * L'autorisation fine (coach home/away vs commissaire) est resolue ici
+ * en lisant le pairing : owner des teams home/away + creator de la ligue.
+ * Le summarizer pur (`league-match-summary`) derive score + blesses.
+ */
+
+import { prisma } from "../prisma";
+import {
+  summarizeMatchSheet,
+  isMatchEventKind,
+  type MatchEventInput,
+  type MatchSummary,
+} from "./league-match-summary";
+
+export type MatchSheetStatus =
+  | "draft"
+  | "submitted_home"
+  | "submitted_away"
+  | "both_submitted"
+  | "validated"
+  | "invalidated";
+
+export class MatchSheetError extends Error {
+  constructor(
+    public readonly code:
+      | "pairing_not_found"
+      | "sheet_not_found"
+      | "forbidden"
+      | "not_a_participant"
+      | "already_validated"
+      | "not_validated"
+      | "invalid_status"
+      | "invalid_event"
+      | "event_not_found",
+    message: string,
+  ) {
+    super(message);
+    this.name = "MatchSheetError";
+  }
+}
+
+export type CoachSide = "home" | "away";
+
+interface PairingContext {
+  pairingId: string;
+  leagueId: string;
+  creatorId: string;
+  homeOwnerId: string;
+  awayOwnerId: string;
+}
+
+/**
+ * Resout le contexte d'autorisation d'un pairing : ligue, commissaire,
+ * owners des deux equipes. Source unique pour tous les checks de role.
+ */
+async function loadPairingContext(
+  pairingId: string,
+): Promise<PairingContext> {
+  const pairing = (await prisma.leaguePairing.findUnique({
+    where: { id: pairingId },
+    select: {
+      id: true,
+      round: {
+        select: {
+          season: {
+            select: { league: { select: { id: true, creatorId: true } } },
+          },
+        },
+      },
+      homeParticipant: { select: { team: { select: { ownerId: true } } } },
+      awayParticipant: { select: { team: { select: { ownerId: true } } } },
+    },
+  })) as {
+    id: string;
+    round: { season: { league: { id: string; creatorId: string } } };
+    homeParticipant: { team: { ownerId: string } } | null;
+    awayParticipant: { team: { ownerId: string } } | null;
+  } | null;
+
+  if (!pairing) {
+    throw new MatchSheetError(
+      "pairing_not_found",
+      `Pairing introuvable: ${pairingId}`,
+    );
+  }
+  const league = pairing.round.season.league;
+  return {
+    pairingId: pairing.id,
+    leagueId: league.id,
+    creatorId: league.creatorId,
+    homeOwnerId: pairing.homeParticipant?.team.ownerId ?? "",
+    awayOwnerId: pairing.awayParticipant?.team.ownerId ?? "",
+  };
+}
+
+/** Determine le cote (home/away) d'un coach, ou null s'il n'est pas joueur. */
+function coachSide(ctx: PairingContext, userId: string): CoachSide | null {
+  if (userId === ctx.homeOwnerId) return "home";
+  if (userId === ctx.awayOwnerId) return "away";
+  return null;
+}
+
+function isCommissioner(ctx: PairingContext, userId: string): boolean {
+  return userId === ctx.creatorId;
+}
+
+/**
+ * Crée (ou retourne) la feuille de match d'un pairing. Idempotent :
+ * si elle existe deja, on la retourne. Accessible aux 2 coachs + au
+ * commissaire.
+ */
+export async function createMatchSheet(input: {
+  pairingId: string;
+  userId: string;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  const side = coachSide(ctx, input.userId);
+  if (!side && !isCommissioner(ctx, input.userId)) {
+    throw new MatchSheetError(
+      "not_a_participant",
+      "Seuls les 2 coachs et le commissaire peuvent ouvrir la feuille",
+    );
+  }
+  const existing = await prisma.leagueMatchSheet.findUnique({
+    where: { pairingId: input.pairingId },
+  });
+  if (existing) return existing;
+
+  return prisma.leagueMatchSheet.create({
+    data: { pairingId: input.pairingId, status: "draft" },
+  });
+}
+
+async function loadSheetOrThrow(pairingId: string) {
+  const sheet = await prisma.leagueMatchSheet.findUnique({
+    where: { pairingId },
+  });
+  if (!sheet) {
+    throw new MatchSheetError(
+      "sheet_not_found",
+      "Feuille de match inexistante (ouvrez-la d'abord)",
+    );
+  }
+  return sheet;
+}
+
+function ensureEditable(status: string): void {
+  if (status === "validated") {
+    throw new MatchSheetError(
+      "already_validated",
+      "Feuille validee : editez via invalidation (commissaire)",
+    );
+  }
+}
+
+/** Ajoute un evenement au journal. Coachs + commissaire, avant validation. */
+export async function addEvent(input: {
+  pairingId: string;
+  userId: string;
+  event: MatchEventInput & { meta?: Record<string, unknown> | null };
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  const side = coachSide(ctx, input.userId);
+  if (!side && !isCommissioner(ctx, input.userId)) {
+    throw new MatchSheetError("forbidden", "Action reservee aux participants");
+  }
+  if (!isMatchEventKind(input.event.kind)) {
+    throw new MatchSheetError(
+      "invalid_event",
+      `Type d'evenement invalide: ${String(input.event.kind)}`,
+    );
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  ensureEditable(sheet.status);
+
+  return prisma.leagueMatchEvent.create({
+    data: {
+      matchSheetId: sheet.id,
+      kind: input.event.kind,
+      team: input.event.team ?? null,
+      actorPlayerId: input.event.actorPlayerId ?? null,
+      targetPlayerId: input.event.targetPlayerId ?? null,
+      causeDetail: input.event.causeDetail ?? null,
+      injurySeverity: (input.event.injurySeverity as string | null) ?? null,
+      meta: (input.event.meta as object | null) ?? undefined,
+    },
+  });
+}
+
+/** Supprime un evenement (correction de saisie). */
+export async function removeEvent(input: {
+  pairingId: string;
+  userId: string;
+  eventId: string;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  if (
+    !coachSide(ctx, input.userId) &&
+    !isCommissioner(ctx, input.userId)
+  ) {
+    throw new MatchSheetError("forbidden", "Action reservee aux participants");
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  ensureEditable(sheet.status);
+
+  const ev = await prisma.leagueMatchEvent.findUnique({
+    where: { id: input.eventId },
+    select: { id: true, matchSheetId: true },
+  });
+  if (!ev || ev.matchSheetId !== sheet.id) {
+    throw new MatchSheetError("event_not_found", "Evenement introuvable");
+  }
+  await prisma.leagueMatchEvent.delete({ where: { id: input.eventId } });
+  return { deleted: true };
+}
+
+export interface PreMatchPayload {
+  weather?: string | null;
+  popularityHome?: number | null;
+  popularityAway?: number | null;
+  inducementsHome?: unknown;
+  inducementsAway?: unknown;
+  prayersHome?: unknown;
+  prayersAway?: unknown;
+}
+
+/** Met a jour les infos d'avant-match. */
+export async function updatePreMatch(input: {
+  pairingId: string;
+  userId: string;
+  payload: PreMatchPayload;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  if (
+    !coachSide(ctx, input.userId) &&
+    !isCommissioner(ctx, input.userId)
+  ) {
+    throw new MatchSheetError("forbidden", "Action reservee aux participants");
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  ensureEditable(sheet.status);
+
+  const p = input.payload;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {};
+  if (p.weather !== undefined) data.weather = p.weather;
+  if (p.popularityHome !== undefined) data.popularityHome = p.popularityHome;
+  if (p.popularityAway !== undefined) data.popularityAway = p.popularityAway;
+  if (p.inducementsHome !== undefined) data.inducementsHome = p.inducementsHome ?? undefined;
+  if (p.inducementsAway !== undefined) data.inducementsAway = p.inducementsAway ?? undefined;
+  if (p.prayersHome !== undefined) data.prayersHome = p.prayersHome ?? undefined;
+  if (p.prayersAway !== undefined) data.prayersAway = p.prayersAway ?? undefined;
+
+  return prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data,
+  });
+}
+
+function nextStatusOnSubmit(
+  current: string,
+  side: CoachSide,
+): MatchSheetStatus {
+  // home submit
+  if (side === "home") {
+    if (current === "submitted_away") return "both_submitted";
+    return "submitted_home";
+  }
+  // away submit
+  if (current === "submitted_home") return "both_submitted";
+  return "submitted_away";
+}
+
+/**
+ * Un coach valide sa saisie. Met a jour `submittedByHomeAt/AwayAt` et
+ * transitionne le status. Quand les 2 ont valide -> `both_submitted`
+ * (le commissaire sera notifie en G.H/Lot H).
+ */
+export async function submitByCoach(input: {
+  pairingId: string;
+  userId: string;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  const side = coachSide(ctx, input.userId);
+  if (!side) {
+    throw new MatchSheetError(
+      "not_a_participant",
+      "Seuls les 2 coachs peuvent soumettre leur saisie",
+    );
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  if (sheet.status === "validated") {
+    throw new MatchSheetError("already_validated", "Feuille deja validee");
+  }
+
+  const next = nextStatusOnSubmit(sheet.status, side);
+  return prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data: {
+      status: next,
+      ...(side === "home"
+        ? { submittedByHomeAt: new Date() }
+        : { submittedByAwayAt: new Date() }),
+    },
+  });
+}
+
+/** Un coach retire sa soumission (revient en arriere). */
+export async function unsubmitByCoach(input: {
+  pairingId: string;
+  userId: string;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  const side = coachSide(ctx, input.userId);
+  if (!side) {
+    throw new MatchSheetError("not_a_participant", "Reserve aux coachs");
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  if (sheet.status === "validated") {
+    throw new MatchSheetError("already_validated", "Feuille deja validee");
+  }
+
+  // Determine le status apres retrait : si l'autre coach a soumis,
+  // on retombe sur son submitted_*, sinon draft.
+  const homeStill = side === "home" ? false : sheet.submittedByHomeAt != null;
+  const awayStill = side === "away" ? false : sheet.submittedByAwayAt != null;
+  const next: MatchSheetStatus = homeStill
+    ? "submitted_home"
+    : awayStill
+      ? "submitted_away"
+      : "draft";
+
+  return prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data: {
+      status: next,
+      ...(side === "home"
+        ? { submittedByHomeAt: null }
+        : { submittedByAwayAt: null }),
+    },
+  });
+}
+
+/**
+ * Le commissaire valide la feuille. Fige le score derive des events.
+ * G.1 : transition de status + snapshot score. G.2 branchera
+ * l'application des effets (classement, SPP, blessures) via le
+ * pipeline `recordOfflineLeagueResult`.
+ */
+export async function validateByCommissioner(input: {
+  pairingId: string;
+  userId: string;
+}): Promise<{
+  sheet: unknown;
+  summary: MatchSummary;
+}> {
+  const ctx = await loadPairingContext(input.pairingId);
+  if (!isCommissioner(ctx, input.userId)) {
+    throw new MatchSheetError(
+      "forbidden",
+      "Seul le commissaire peut valider la feuille",
+    );
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  if (sheet.status === "validated") {
+    throw new MatchSheetError("already_validated", "Feuille deja validee");
+  }
+
+  const events = (await prisma.leagueMatchEvent.findMany({
+    where: { matchSheetId: sheet.id },
+    orderBy: { occurredAt: "asc" },
+  })) as MatchEventInput[];
+  const summary = summarizeMatchSheet(events);
+
+  const updated = await prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data: {
+      status: "validated",
+      validatedAt: new Date(),
+      validatedById: input.userId,
+      scoreHome: summary.scoreHome,
+      scoreAway: summary.scoreAway,
+    },
+  });
+  return { sheet: updated, summary };
+}
+
+/**
+ * Lecture de la feuille + summary derive (pour l'UI). Accessible aux
+ * 2 coachs + commissaire. Le summary est recalcule a chaque read
+ * (cheap, pur) pour refleter l'etat courant des events.
+ */
+export async function getMatchSheet(input: {
+  pairingId: string;
+  userId: string;
+}): Promise<{
+  sheet: unknown;
+  summary: MatchSummary;
+  viewerRole: "home" | "away" | "commissioner" | "none";
+}> {
+  const ctx = await loadPairingContext(input.pairingId);
+  const side = coachSide(ctx, input.userId);
+  const commissioner = isCommissioner(ctx, input.userId);
+  const sheet = await prisma.leagueMatchSheet.findUnique({
+    where: { pairingId: input.pairingId },
+    include: { events: { orderBy: { occurredAt: "asc" } } },
+  });
+  if (!sheet) {
+    throw new MatchSheetError("sheet_not_found", "Feuille inexistante");
+  }
+  const events = ((sheet as { events?: MatchEventInput[] }).events ??
+    []) as MatchEventInput[];
+  return {
+    sheet,
+    summary: summarizeMatchSheet(events),
+    viewerRole: commissioner
+      ? "commissioner"
+      : side === "home"
+        ? "home"
+        : side === "away"
+          ? "away"
+          : "none",
+  };
+}

--- a/apps/server/src/services/league-match-summary.test.ts
+++ b/apps/server/src/services/league-match-summary.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Lot G — Tests du summarizer pur `summarizeMatchSheet`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  summarizeMatchSheet,
+  isMatchEventKind,
+  MATCH_EVENT_KINDS,
+  type MatchEventInput,
+} from "./league-match-summary";
+
+describe("Lot G — summarizeMatchSheet", () => {
+  it("empty events -> zero summary", () => {
+    const out = summarizeMatchSheet([]);
+    expect(out).toEqual({
+      scoreHome: 0,
+      scoreAway: 0,
+      casualtiesHome: 0,
+      casualtiesAway: 0,
+      injuries: [],
+      playerStats: [],
+    });
+  });
+
+  it("counts touchdowns per team and per player", () => {
+    const events: MatchEventInput[] = [
+      { kind: "touchdown", team: "home", actorPlayerId: "h1" },
+      { kind: "touchdown", team: "home", actorPlayerId: "h1" },
+      { kind: "touchdown", team: "away", actorPlayerId: "a1" },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.scoreHome).toBe(2);
+    expect(out.scoreAway).toBe(1);
+    const h1 = out.playerStats.find((p) => p.playerId === "h1");
+    expect(h1?.touchdowns).toBe(2);
+    const a1 = out.playerStats.find((p) => p.playerId === "a1");
+    expect(a1?.touchdowns).toBe(1);
+  });
+
+  it("counts casualties inflicted and injured player on opposite side (block)", () => {
+    const events: MatchEventInput[] = [
+      {
+        kind: "casualty",
+        team: "home",
+        actorPlayerId: "h1",
+        targetPlayerId: "a5",
+        causeDetail: "block",
+        injurySeverity: "dead",
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.casualtiesHome).toBe(1);
+    expect(out.casualtiesAway).toBe(0);
+    expect(out.injuries).toHaveLength(1);
+    expect(out.injuries[0]).toEqual({
+      playerId: "a5",
+      severity: "dead",
+      side: "away", // victim is opposite of the actor's team
+      cause: "block",
+    });
+    const h1 = out.playerStats.find((p) => p.playerId === "h1");
+    expect(h1?.casualtiesInflicted).toBe(1);
+  });
+
+  it("other_elim (failed dodge) injures a player on the SAME team (self-cause)", () => {
+    const events: MatchEventInput[] = [
+      {
+        kind: "other_elim",
+        team: "home",
+        targetPlayerId: "h7",
+        causeDetail: "failed_dodge",
+        injurySeverity: "badly_hurt",
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    // self-cause: counts as a casualty "for" home? No — it's an
+    // elimination but not inflicted by the opponent. We still tally
+    // it under the team that owns the event for casualty count.
+    expect(out.injuries).toHaveLength(1);
+    expect(out.injuries[0]).toEqual({
+      playerId: "h7",
+      severity: "badly_hurt",
+      side: "home", // self-cause: victim is in `team`
+      cause: "failed_dodge",
+    });
+  });
+
+  it("aggression increments aggressions and casualty when injured", () => {
+    const events: MatchEventInput[] = [
+      { kind: "aggression", team: "away", actorPlayerId: "a3" },
+      {
+        kind: "aggression",
+        team: "away",
+        actorPlayerId: "a3",
+        targetPlayerId: "h2",
+        causeDetail: "foul",
+        injurySeverity: "mng",
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    const a3 = out.playerStats.find((p) => p.playerId === "a3");
+    expect(a3?.aggressions).toBe(2);
+    expect(a3?.casualtiesInflicted).toBe(1);
+    expect(out.casualtiesAway).toBe(1);
+    expect(out.injuries[0]).toMatchObject({
+      playerId: "h2",
+      severity: "mng",
+      side: "home",
+    });
+  });
+
+  it("crowd_surge injures without crediting a player (no actor stat)", () => {
+    const events: MatchEventInput[] = [
+      {
+        kind: "crowd_surge",
+        team: "home",
+        targetPlayerId: "a9",
+        causeDetail: "crowd",
+        injurySeverity: "stat_loss",
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.casualtiesHome).toBe(1);
+    // no actor -> no playerStats entry
+    expect(out.playerStats).toHaveLength(0);
+    expect(out.injuries[0]).toMatchObject({
+      playerId: "a9",
+      side: "away",
+      severity: "stat_loss",
+    });
+  });
+
+  it("counts completions and interceptions", () => {
+    const events: MatchEventInput[] = [
+      { kind: "pass_complete", team: "home", actorPlayerId: "h4" },
+      { kind: "pass_complete", team: "home", actorPlayerId: "h4" },
+      { kind: "interception", team: "away", actorPlayerId: "a8" },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.playerStats.find((p) => p.playerId === "h4")?.completions).toBe(2);
+    expect(
+      out.playerStats.find((p) => p.playerId === "a8")?.interceptions,
+    ).toBe(1);
+  });
+
+  it("ignores kickoff/expulsion/stalling for score and casualties", () => {
+    const events: MatchEventInput[] = [
+      { kind: "kickoff", team: "home" },
+      { kind: "expulsion", team: "away", actorPlayerId: "a1" },
+      { kind: "stalling", team: "home" },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.scoreHome).toBe(0);
+    expect(out.scoreAway).toBe(0);
+    expect(out.casualtiesHome).toBe(0);
+    expect(out.injuries).toHaveLength(0);
+  });
+
+  it("ignores casualty with unknown severity (no injury recorded)", () => {
+    const events: MatchEventInput[] = [
+      {
+        kind: "casualty",
+        team: "home",
+        actorPlayerId: "h1",
+        targetPlayerId: "a5",
+        injurySeverity: "scratch", // unknown
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.casualtiesHome).toBe(0);
+    expect(out.injuries).toHaveLength(0);
+  });
+
+  it("is deterministic", () => {
+    const events: MatchEventInput[] = [
+      { kind: "touchdown", team: "home", actorPlayerId: "h1" },
+      {
+        kind: "casualty",
+        team: "away",
+        actorPlayerId: "a1",
+        targetPlayerId: "h2",
+        injurySeverity: "niggling",
+        causeDetail: "block",
+      },
+    ];
+    expect(summarizeMatchSheet(events)).toEqual(summarizeMatchSheet(events));
+  });
+
+  it("full match scenario", () => {
+    const events: MatchEventInput[] = [
+      { kind: "kickoff", team: "home" },
+      { kind: "pass_complete", team: "home", actorPlayerId: "h_thrower" },
+      { kind: "touchdown", team: "home", actorPlayerId: "h_catcher" },
+      {
+        kind: "casualty",
+        team: "home",
+        actorPlayerId: "h_blitz",
+        targetPlayerId: "a_line",
+        causeDetail: "block",
+        injurySeverity: "dead",
+      },
+      { kind: "touchdown", team: "away", actorPlayerId: "a_runner" },
+      { kind: "touchdown", team: "away", actorPlayerId: "a_runner" },
+      {
+        kind: "other_elim",
+        team: "away",
+        targetPlayerId: "a_gfi",
+        causeDetail: "failed_gfi",
+        injurySeverity: "badly_hurt",
+      },
+    ];
+    const out = summarizeMatchSheet(events);
+    expect(out.scoreHome).toBe(1);
+    expect(out.scoreAway).toBe(2);
+    expect(out.casualtiesHome).toBe(1); // the block kill
+    expect(out.injuries).toHaveLength(2);
+    const runner = out.playerStats.find((p) => p.playerId === "a_runner");
+    expect(runner?.touchdowns).toBe(2);
+  });
+});
+
+describe("Lot G — isMatchEventKind / MATCH_EVENT_KINDS", () => {
+  it("exposes 10 kinds", () => {
+    expect(MATCH_EVENT_KINDS).toHaveLength(10);
+  });
+  it("validates known kinds", () => {
+    expect(isMatchEventKind("touchdown")).toBe(true);
+    expect(isMatchEventKind("crowd_surge")).toBe(true);
+    expect(isMatchEventKind("nope")).toBe(false);
+    expect(isMatchEventKind(42)).toBe(false);
+  });
+});

--- a/apps/server/src/services/league-match-summary.ts
+++ b/apps/server/src/services/league-match-summary.ts
@@ -1,0 +1,247 @@
+/**
+ * Lot G — Summarizer PUR de feuille de match.
+ *
+ * A partir d'un journal d'evenements (`LeagueMatchEvent`), derive :
+ *   - le score (count des touchdowns par equipe) ;
+ *   - les casualties infligees par equipe (events `casualty` +
+ *     `other_elim`/`crowd_surge`/`aggression` ayant une `injurySeverity`) ;
+ *   - la liste des joueurs blesses (cible + severite) ;
+ *   - les stats par joueur (TD, casualties infligees, passes, interceptions,
+ *     aggressions) utiles pour les SPP / classements.
+ *
+ * 100% pur (pas de Prisma) ⇒ testable en unit sans DB. Le service
+ * `league-match-sheet` appelle cette fonction au read et a la validation
+ * pour figer `scoreHome/scoreAway` et alimenter le pipeline post-match.
+ */
+
+export type MatchEventKind =
+  | "kickoff"
+  | "touchdown"
+  | "casualty"
+  | "pass_complete"
+  | "interception"
+  | "aggression"
+  | "expulsion"
+  | "crowd_surge"
+  | "stalling"
+  | "other_elim";
+
+export type MatchEventTeam = "home" | "away";
+
+export type InjurySeverity =
+  | "badly_hurt"
+  | "mng"
+  | "niggling"
+  | "stat_loss"
+  | "dead";
+
+export interface MatchEventInput {
+  readonly kind: MatchEventKind;
+  readonly team?: MatchEventTeam | null;
+  readonly actorPlayerId?: string | null;
+  readonly targetPlayerId?: string | null;
+  readonly causeDetail?: string | null;
+  readonly injurySeverity?: InjurySeverity | string | null;
+}
+
+export interface InjuredPlayer {
+  readonly playerId: string;
+  readonly severity: InjurySeverity;
+  /** Equipe du joueur blesse (cote oppose a `team` de l'event source). */
+  readonly side: MatchEventTeam;
+  /** Cause de l'elimination (block, failed_dodge, crowd, ...). */
+  readonly cause: string | null;
+}
+
+export interface PlayerStatLine {
+  readonly playerId: string;
+  readonly side: MatchEventTeam;
+  touchdowns: number;
+  casualtiesInflicted: number;
+  completions: number;
+  interceptions: number;
+  aggressions: number;
+}
+
+export interface MatchSummary {
+  readonly scoreHome: number;
+  readonly scoreAway: number;
+  /** Casualties infligees (toutes causes avec injury) par equipe. */
+  readonly casualtiesHome: number;
+  readonly casualtiesAway: number;
+  readonly injuries: ReadonlyArray<InjuredPlayer>;
+  readonly playerStats: ReadonlyArray<PlayerStatLine>;
+}
+
+const INJURY_SEVERITIES = new Set<string>([
+  "badly_hurt",
+  "mng",
+  "niggling",
+  "stat_loss",
+  "dead",
+]);
+
+function opposite(team: MatchEventTeam): MatchEventTeam {
+  return team === "home" ? "away" : "home";
+}
+
+function normalizeSeverity(raw: unknown): InjurySeverity | null {
+  if (typeof raw === "string" && INJURY_SEVERITIES.has(raw)) {
+    return raw as InjurySeverity;
+  }
+  return null;
+}
+
+/**
+ * Evenements qui peuvent porter une casualty/blessure quand
+ * `injurySeverity` est present. Une `aggression` reussie qui blesse
+ * compte aussi comme casualty infligee.
+ */
+const CASUALTY_BEARING = new Set<MatchEventKind>([
+  "casualty",
+  "aggression",
+  "other_elim",
+  "crowd_surge",
+]);
+
+/**
+ * Resume un journal d'evenements. Determinisme total : meme entree ->
+ * meme sortie. Les events `kind` inconnus sont ignores silencieusement
+ * (defensif vis-a-vis d'un futur kind non gere).
+ */
+export function summarizeMatchSheet(
+  events: ReadonlyArray<MatchEventInput>,
+): MatchSummary {
+  let scoreHome = 0;
+  let scoreAway = 0;
+  let casualtiesHome = 0;
+  let casualtiesAway = 0;
+  const injuries: InjuredPlayer[] = [];
+  const statsByPlayer = new Map<string, PlayerStatLine>();
+
+  const ensureStat = (
+    playerId: string,
+    side: MatchEventTeam,
+  ): PlayerStatLine => {
+    let line = statsByPlayer.get(playerId);
+    if (!line) {
+      line = {
+        playerId,
+        side,
+        touchdowns: 0,
+        casualtiesInflicted: 0,
+        completions: 0,
+        interceptions: 0,
+        aggressions: 0,
+      };
+      statsByPlayer.set(playerId, line);
+    }
+    return line;
+  };
+
+  for (const ev of events) {
+    const team = ev.team === "home" || ev.team === "away" ? ev.team : null;
+
+    switch (ev.kind) {
+      case "touchdown": {
+        if (team === "home") scoreHome += 1;
+        else if (team === "away") scoreAway += 1;
+        if (ev.actorPlayerId && team) {
+          ensureStat(ev.actorPlayerId, team).touchdowns += 1;
+        }
+        break;
+      }
+      case "pass_complete": {
+        if (ev.actorPlayerId && team) {
+          ensureStat(ev.actorPlayerId, team).completions += 1;
+        }
+        break;
+      }
+      case "interception": {
+        if (ev.actorPlayerId && team) {
+          ensureStat(ev.actorPlayerId, team).interceptions += 1;
+        }
+        break;
+      }
+      case "aggression":
+      case "casualty":
+      case "other_elim":
+      case "crowd_surge": {
+        const severity = normalizeSeverity(ev.injurySeverity);
+        if (ev.kind === "aggression" && ev.actorPlayerId && team) {
+          ensureStat(ev.actorPlayerId, team).aggressions += 1;
+        }
+        if (CASUALTY_BEARING.has(ev.kind) && severity) {
+          // L'acteur inflige une casualty (sauf crowd_surge : la foule
+          // n'a pas d'acteur ; on credite l'equipe via `team` = celle
+          // qui beneficie, mais pas de stat joueur).
+          if (team === "home") casualtiesHome += 1;
+          else if (team === "away") casualtiesAway += 1;
+          if (
+            ev.actorPlayerId &&
+            team &&
+            ev.kind !== "crowd_surge"
+          ) {
+            ensureStat(ev.actorPlayerId, team).casualtiesInflicted += 1;
+          }
+          // Le joueur blesse est dans l'equipe opposee a `team`
+          // (l'auteur). Pour other_elim (esquive ratee, etc.) la
+          // victime EST dans `team` (auto-elimination) : on gere via
+          // un flag `causeDetail` self-cause.
+          if (ev.targetPlayerId) {
+            const isSelfCause =
+              ev.kind === "other_elim" || ev.causeDetail === "self";
+            const side = team
+              ? isSelfCause
+                ? team
+                : opposite(team)
+              : "home";
+            injuries.push({
+              playerId: ev.targetPlayerId,
+              severity,
+              side,
+              cause: ev.causeDetail ?? ev.kind,
+            });
+          }
+        }
+        break;
+      }
+      // kickoff / expulsion / stalling : pas d'impact sur score/casualty.
+      case "kickoff":
+      case "expulsion":
+      case "stalling":
+      default:
+        break;
+    }
+  }
+
+  return {
+    scoreHome,
+    scoreAway,
+    casualtiesHome,
+    casualtiesAway,
+    injuries,
+    playerStats: [...statsByPlayer.values()],
+  };
+}
+
+/** Liste blanche des kinds valides (validation cote service/Zod). */
+export const MATCH_EVENT_KINDS: ReadonlyArray<MatchEventKind> = [
+  "kickoff",
+  "touchdown",
+  "casualty",
+  "pass_complete",
+  "interception",
+  "aggression",
+  "expulsion",
+  "crowd_surge",
+  "stalling",
+  "other_elim",
+];
+
+export function isMatchEventKind(v: unknown): v is MatchEventKind {
+  return (
+    typeof v === "string" &&
+    (MATCH_EVENT_KINDS as readonly string[]).includes(v)
+  );
+}

--- a/apps/server/src/services/notification-preferences.ts
+++ b/apps/server/src/services/notification-preferences.ts
@@ -14,6 +14,13 @@ export enum NotificationType {
    * (`startSeason`) pour informer chaque coach de ses pairings.
    */
   LeagueRoundReminder = "leagueRoundReminder",
+  /**
+   * Lot H — "Un match est pret a valider". Envoye au commissaire quand
+   * les 2 coachs ont soumis leur feuille (`both_submitted`). Reutilise
+   * la preference league-umbrella `leagueRoundReminderNotification`
+   * (pas de colonne dediee pour eviter une migration).
+   */
+  LeagueMatchValidation = "leagueMatchValidation",
 }
 
 export interface NotificationPreferences {
@@ -108,6 +115,9 @@ export async function shouldSendNotification(
     case NotificationType.FriendMatchStarted:
       return prefs.friendMatchStartedNotification;
     case NotificationType.LeagueRoundReminder:
+      return prefs.leagueRoundReminderNotification;
+    // Lot H — reutilise l'umbrella league pour l'alerte commissaire.
+    case NotificationType.LeagueMatchValidation:
       return prefs.leagueRoundReminderNotification;
     default:
       return true;

--- a/apps/server/src/services/push-notifications.ts
+++ b/apps/server/src/services/push-notifications.ts
@@ -458,3 +458,49 @@ export function sendLeagueRoundReminderPush(
       // Push failure is non-blocking — match the existing pattern.
     });
 }
+
+/**
+ * Lot H — Alerte le commissaire qu'un match est pret a valider (les 2
+ * coachs ont soumis leur feuille). Non-bloquant. Deep-link vers la
+ * page "Matchs a valider" de la ligue.
+ */
+export interface LeagueMatchValidationInput {
+  readonly commissionerUserId: string;
+  readonly leagueId: string;
+  readonly pairingId: string;
+  readonly homeTeamName: string;
+  readonly awayTeamName: string;
+}
+
+export function sendLeagueMatchValidationPush(
+  input: LeagueMatchValidationInput,
+): void {
+  shouldSendNotification(
+    input.commissionerUserId,
+    NotificationType.LeagueMatchValidation,
+  )
+    .then(async (allowed) => {
+      if (!allowed) return;
+      const url = `/leagues/${input.leagueId}/pending-validations`;
+      const payload: PushPayload = {
+        title: "Nuffle Arena",
+        body: `Match a valider : ${input.homeTeamName} vs ${input.awayTeamName}`,
+        icon: "/images/favicon-optimized.png",
+        url,
+        tag: `league-validate-${input.pairingId}`,
+        data: {
+          kind: "leagueMatchValidation",
+          leagueId: input.leagueId,
+          pairingId: input.pairingId,
+          url,
+        },
+      };
+      await Promise.all([
+        sendPushToUser(input.commissionerUserId, payload),
+        sendExpoPushToUser(input.commissionerUserId, payload),
+      ]);
+    })
+    .catch(() => {
+      // Push failure is non-blocking.
+    });
+}

--- a/apps/web/app/leagues/[id]/pending-validations/page.tsx
+++ b/apps/web/app/leagues/[id]/pending-validations/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { apiRequest } from "../../../lib/api-client";
+
+// Lot H — Page "Matchs a valider" du commissaire (cible du deep-link
+// de la notification push). Liste les feuilles `both_submitted`.
+
+interface PendingValidation {
+  pairingId: string;
+  matchSheetId: string;
+  leagueId: string;
+  leagueName: string;
+  seasonId: string;
+  seasonName: string;
+  roundNumber: number;
+  homeTeamName: string;
+  awayTeamName: string;
+  bothSubmittedAt: string | null;
+}
+
+export default function PendingValidationsPage() {
+  const params = useParams<{ id: string }>();
+  const leagueId = params?.id ?? "";
+
+  const [items, setItems] = useState<PendingValidation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiRequest<{
+        pending: PendingValidation[];
+        count: number;
+      }>("/leagues/me/pending-validations");
+      setItems(data.pending ?? []);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Erreur");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // La page est ciblee par ligue (deep-link) : on filtre la liste
+  // globale du commissaire sur la ligue courante.
+  const forThisLeague = useMemo(
+    () => items.filter((i) => i.leagueId === leagueId),
+    [items, leagueId],
+  );
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-1 text-2xl font-bold">Matchs a valider</h1>
+      <p className="mb-4 text-sm text-slate-600">
+        Feuilles de match soumises par les 2 coachs, en attente de votre
+        validation.
+      </p>
+
+      <div className="mb-4">
+        <Link
+          href={`/leagues/${leagueId}`}
+          className="text-sm text-blue-600 underline"
+        >
+          ← Retour a la ligue
+        </Link>
+      </div>
+
+      {loading && <p>Chargement...</p>}
+      {error && (
+        <p className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</p>
+      )}
+      {!loading && forThisLeague.length === 0 && (
+        <p className="text-slate-600">Aucun match en attente de validation.</p>
+      )}
+
+      <ul className="space-y-3" data-testid="pending-validations-list">
+        {forThisLeague.map((m) => (
+          <li
+            key={m.pairingId}
+            className="rounded border border-amber-200 bg-amber-50 p-4 shadow-sm"
+            data-testid={`pending-${m.pairingId}`}
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-semibold">
+                  {m.homeTeamName} <span className="text-slate-400">vs</span>{" "}
+                  {m.awayTeamName}
+                </p>
+                <p className="text-xs text-slate-500">
+                  {m.seasonName} — Journee {m.roundNumber}
+                  {m.bothSubmittedAt && (
+                    <>
+                      {" "}
+                      · soumis le{" "}
+                      {new Date(m.bothSubmittedAt).toLocaleString("fr-FR", {
+                        dateStyle: "short",
+                        timeStyle: "short",
+                      })}
+                    </>
+                  )}
+                </p>
+              </div>
+              <Link
+                href={`/leagues/pairings/${m.pairingId}/sheet`}
+                className="rounded bg-amber-600 px-3 py-1 text-sm font-medium text-white"
+                data-testid={`validate-link-${m.pairingId}`}
+              >
+                Ouvrir la feuille
+              </Link>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/app/leagues/pairings/[id]/sheet/page.tsx
+++ b/apps/web/app/leagues/pairings/[id]/sheet/page.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { apiRequest, ApiClientError } from "../../../../lib/api-client";
+
+// Lot G.3 (minimal) — Feuille de match v2 : saisie d'evenements,
+// soumission par coach, validation par commissaire. Le score et les
+// blesses sont derives cote serveur (summary).
+
+type EventKind =
+  | "kickoff"
+  | "touchdown"
+  | "casualty"
+  | "pass_complete"
+  | "interception"
+  | "aggression"
+  | "expulsion"
+  | "crowd_surge"
+  | "stalling"
+  | "other_elim";
+
+interface MatchEvent {
+  id: string;
+  kind: EventKind;
+  team: "home" | "away" | null;
+  actorPlayerId: string | null;
+  targetPlayerId: string | null;
+  causeDetail: string | null;
+  injurySeverity: string | null;
+}
+
+interface InjuredPlayer {
+  playerId: string;
+  severity: string;
+  side: "home" | "away";
+  cause: string | null;
+}
+
+interface Summary {
+  scoreHome: number;
+  scoreAway: number;
+  casualtiesHome: number;
+  casualtiesAway: number;
+  injuries: InjuredPlayer[];
+}
+
+interface SheetResponse {
+  sheet: {
+    id: string;
+    status: string;
+    events?: MatchEvent[];
+  };
+  summary: Summary;
+  viewerRole: "home" | "away" | "commissioner" | "none";
+}
+
+const EVENT_KINDS: EventKind[] = [
+  "kickoff",
+  "touchdown",
+  "casualty",
+  "pass_complete",
+  "interception",
+  "aggression",
+  "expulsion",
+  "crowd_surge",
+  "stalling",
+  "other_elim",
+];
+
+const INJURY_SEVERITIES = ["", "badly_hurt", "mng", "niggling", "stat_loss", "dead"];
+
+export default function MatchSheetPage() {
+  const params = useParams<{ id: string }>();
+  const pairingId = params?.id ?? "";
+
+  const [data, setData] = useState<SheetResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Form pour ajouter un event.
+  const [kind, setKind] = useState<EventKind>("touchdown");
+  const [team, setTeam] = useState<"home" | "away">("home");
+  const [actorPlayerId, setActorPlayerId] = useState("");
+  const [targetPlayerId, setTargetPlayerId] = useState("");
+  const [injurySeverity, setInjurySeverity] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiRequest<SheetResponse>(
+        `/leagues/pairings/${pairingId}/sheet`,
+      );
+      setData(res);
+    } catch (e: unknown) {
+      // 404 -> la feuille n'existe pas encore : on propose de l'ouvrir.
+      if (e instanceof ApiClientError && e.status === 404) {
+        setData(null);
+      } else {
+        setError(e instanceof Error ? e.message : "Erreur");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [pairingId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const run = useCallback(
+    async (fn: () => Promise<unknown>) => {
+      setBusy(true);
+      setError(null);
+      try {
+        await fn();
+        await load();
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : "Erreur");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [load],
+  );
+
+  const createSheet = () =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet`, { method: "POST" }),
+    );
+
+  const addEvent = () =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/events`, {
+        method: "POST",
+        body: JSON.stringify({
+          kind,
+          team,
+          actorPlayerId: actorPlayerId.trim() || undefined,
+          targetPlayerId: targetPlayerId.trim() || undefined,
+          injurySeverity: injurySeverity || undefined,
+        }),
+      }),
+    );
+
+  const removeEvent = (eventId: string) =>
+    run(() =>
+      apiRequest(
+        `/leagues/pairings/${pairingId}/sheet/events/${eventId}`,
+        { method: "DELETE" },
+      ),
+    );
+
+  const submit = () =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/submit`, {
+        method: "POST",
+      }),
+    );
+  const unsubmit = () =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/unsubmit`, {
+        method: "POST",
+      }),
+    );
+  const validate = () =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/validate`, {
+        method: "POST",
+      }),
+    );
+
+  const events = useMemo(() => data?.sheet.events ?? [], [data]);
+  const role = data?.viewerRole ?? "none";
+  const status = data?.sheet.status ?? "";
+  const isCoach = role === "home" || role === "away";
+  const isCommissioner = role === "commissioner";
+  const editable = status !== "validated";
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <p>Chargement de la feuille...</p>
+      </main>
+    );
+  }
+
+  if (!data) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="mb-3 text-2xl font-bold">Feuille de match</h1>
+        <p className="mb-4 text-slate-600">
+          Aucune feuille ouverte pour ce match.
+        </p>
+        {error && (
+          <p className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+          onClick={createSheet}
+          disabled={busy}
+          data-testid="open-sheet"
+        >
+          Ouvrir la feuille
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl p-6" data-testid="match-sheet">
+      <h1 className="mb-1 text-2xl font-bold">Feuille de match</h1>
+      <p className="mb-4 text-sm text-slate-600">
+        Statut : <strong data-testid="sheet-status">{status}</strong> · vous
+        etes <strong>{role}</strong>
+      </p>
+
+      {error && (
+        <p className="mb-3 rounded bg-red-50 p-2 text-sm text-red-700">
+          {error}
+        </p>
+      )}
+
+      {/* Score derive */}
+      <section className="mb-4 rounded border bg-slate-50 p-4">
+        <h2 className="mb-2 font-semibold">Score (calcule)</h2>
+        <p className="text-2xl font-bold" data-testid="derived-score">
+          {data.summary.scoreHome} – {data.summary.scoreAway}
+        </p>
+        <p className="text-xs text-slate-500">
+          Sorties : {data.summary.casualtiesHome} / {data.summary.casualtiesAway}{" "}
+          · Blesses : {data.summary.injuries.length}
+        </p>
+      </section>
+
+      {/* Journal d'evenements */}
+      <section className="mb-4">
+        <h2 className="mb-2 font-semibold">Evenements</h2>
+        {events.length === 0 ? (
+          <p className="text-sm text-slate-500">Aucun evenement saisi.</p>
+        ) : (
+          <ul className="space-y-1" data-testid="events-list">
+            {events.map((ev) => (
+              <li
+                key={ev.id}
+                className="flex items-center justify-between rounded border px-2 py-1 text-sm"
+              >
+                <span>
+                  <strong>{ev.kind}</strong>
+                  {ev.team ? ` (${ev.team})` : ""}
+                  {ev.actorPlayerId ? ` — par ${ev.actorPlayerId}` : ""}
+                  {ev.targetPlayerId ? ` → ${ev.targetPlayerId}` : ""}
+                  {ev.injurySeverity ? ` [${ev.injurySeverity}]` : ""}
+                </span>
+                {editable && (isCoach || isCommissioner) && (
+                  <button
+                    type="button"
+                    className="ml-2 text-xs text-red-600"
+                    onClick={() => removeEvent(ev.id)}
+                    disabled={busy}
+                  >
+                    retirer
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Saisie d'un evenement */}
+      {editable && (isCoach || isCommissioner) && (
+        <section className="mb-4 rounded border p-3">
+          <h3 className="mb-2 text-sm font-semibold">Ajouter un evenement</h3>
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="text-xs">
+              Type
+              <select
+                value={kind}
+                onChange={(e) => setKind(e.target.value as EventKind)}
+                className="block rounded border px-2 py-1"
+                data-testid="event-kind"
+              >
+                {EVENT_KINDS.map((k) => (
+                  <option key={k} value={k}>
+                    {k}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs">
+              Equipe
+              <select
+                value={team}
+                onChange={(e) => setTeam(e.target.value as "home" | "away")}
+                className="block rounded border px-2 py-1"
+              >
+                <option value="home">home</option>
+                <option value="away">away</option>
+              </select>
+            </label>
+            <label className="text-xs">
+              Acteur (id)
+              <input
+                value={actorPlayerId}
+                onChange={(e) => setActorPlayerId(e.target.value)}
+                className="block w-28 rounded border px-2 py-1"
+              />
+            </label>
+            <label className="text-xs">
+              Cible (id)
+              <input
+                value={targetPlayerId}
+                onChange={(e) => setTargetPlayerId(e.target.value)}
+                className="block w-28 rounded border px-2 py-1"
+              />
+            </label>
+            <label className="text-xs">
+              Blessure
+              <select
+                value={injurySeverity}
+                onChange={(e) => setInjurySeverity(e.target.value)}
+                className="block rounded border px-2 py-1"
+              >
+                {INJURY_SEVERITIES.map((s) => (
+                  <option key={s} value={s}>
+                    {s || "—"}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              className="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+              onClick={addEvent}
+              disabled={busy}
+              data-testid="add-event"
+            >
+              Ajouter
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* Actions de workflow */}
+      <section className="flex flex-wrap gap-2">
+        {isCoach && status !== "validated" && (
+          <>
+            <button
+              type="button"
+              className="rounded bg-green-600 px-4 py-2 text-sm text-white disabled:opacity-50"
+              onClick={submit}
+              disabled={busy}
+              data-testid="submit-sheet"
+            >
+              Valider ma saisie
+            </button>
+            <button
+              type="button"
+              className="rounded bg-slate-300 px-4 py-2 text-sm disabled:opacity-50"
+              onClick={unsubmit}
+              disabled={busy}
+            >
+              Retirer ma validation
+            </button>
+          </>
+        )}
+        {isCommissioner && status !== "validated" && (
+          <button
+            type="button"
+            className="rounded bg-amber-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            onClick={validate}
+            disabled={busy}
+            data-testid="validate-sheet"
+          >
+            Valider le match (commissaire)
+          </button>
+        )}
+        {status === "validated" && (
+          <p className="rounded bg-green-50 px-3 py-2 text-sm text-green-700">
+            Match valide ✓
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/prisma/migrations/20260605160000_add_league_match_sheet/migration.sql
+++ b/prisma/migrations/20260605160000_add_league_match_sheet/migration.sql
@@ -1,0 +1,69 @@
+-- Lot G — Feuille de match v2 (saisie joueurs + validation commissaire).
+--
+-- LeagueMatchSheet : 1-1 avec LeaguePairing. Workflow status
+-- draft -> submitted_home/away -> both_submitted -> validated
+-- -> invalidated. Scores + blesses derives des events.
+--
+-- LeagueMatchEvent : evenements unitaires normalises (kickoff, TD,
+-- casualty, pass, interception, aggression, expulsion, crowd_surge,
+-- stalling, other_elim) pour agregation + edition fine.
+
+CREATE TABLE "LeagueMatchSheet" (
+  "id" TEXT NOT NULL,
+  "pairingId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'draft',
+  "submittedByHomeAt" TIMESTAMP(3),
+  "submittedByAwayAt" TIMESTAMP(3),
+  "validatedAt" TIMESTAMP(3),
+  "validatedById" TEXT,
+  "invalidatedAt" TIMESTAMP(3),
+  "invalidationReason" TEXT,
+  "weather" TEXT,
+  "popularityHome" INTEGER,
+  "popularityAway" INTEGER,
+  "inducementsHome" JSONB,
+  "inducementsAway" JSONB,
+  "prayersHome" JSONB,
+  "prayersAway" JSONB,
+  "scoreHome" INTEGER NOT NULL DEFAULT 0,
+  "scoreAway" INTEGER NOT NULL DEFAULT 0,
+  "winningsHome" INTEGER NOT NULL DEFAULT 0,
+  "winningsAway" INTEGER NOT NULL DEFAULT 0,
+  "winningsHomeManual" INTEGER,
+  "winningsAwayManual" INTEGER,
+  "dedicatedFansDeltaHome" INTEGER,
+  "dedicatedFansDeltaAway" INTEGER,
+  "costlyErrorsHome" JSONB,
+  "costlyErrorsAway" JSONB,
+  "motmPlayerIds" JSONB NOT NULL DEFAULT '[]',
+  "purchasesHome" JSONB,
+  "purchasesAway" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "LeagueMatchSheet_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "LeagueMatchSheet_pairingId_key" ON "LeagueMatchSheet"("pairingId");
+CREATE INDEX "LeagueMatchSheet_status_idx" ON "LeagueMatchSheet"("status");
+
+ALTER TABLE "LeagueMatchSheet" ADD CONSTRAINT "LeagueMatchSheet_pairingId_fkey"
+  FOREIGN KEY ("pairingId") REFERENCES "LeaguePairing"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "LeagueMatchEvent" (
+  "id" TEXT NOT NULL,
+  "matchSheetId" TEXT NOT NULL,
+  "kind" TEXT NOT NULL,
+  "team" TEXT,
+  "actorPlayerId" TEXT,
+  "targetPlayerId" TEXT,
+  "causeDetail" TEXT,
+  "injurySeverity" TEXT,
+  "meta" JSONB,
+  "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "LeagueMatchEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "LeagueMatchEvent_matchSheetId_kind_idx" ON "LeagueMatchEvent"("matchSheetId", "kind");
+
+ALTER TABLE "LeagueMatchEvent" ADD CONSTRAINT "LeagueMatchEvent_matchSheetId_fkey"
+  FOREIGN KEY ("matchSheetId") REFERENCES "LeagueMatchSheet"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1179,6 +1179,8 @@ model LeaguePairing {
   /// Lot E — Breakdown des regles appliquees pour audit / UI :
   /// [{ ruleId, label, side, points }]. null si aucune regle.
   bonusBreakdown    Json?
+  // Lot G — feuille de match v2 (1-1, optionnelle).
+  matchSheet        LeagueMatchSheet?
   createdAt         DateTime          @default(now())
   updatedAt         DateTime          @updatedAt
 
@@ -1187,6 +1189,103 @@ model LeaguePairing {
   @@index([deadlineAt, status])
   @@index([homeParticipantId])
   @@index([awayParticipantId])
+}
+
+/// Lot G — Feuille de match collaborative (saisie joueurs + validation
+/// commissaire). 1-1 avec un LeaguePairing.
+///
+/// Workflow `status` :
+///   draft            -> en cours de saisie (avant soumission)
+///   submitted_home   -> coach domicile a valide sa saisie
+///   submitted_away   -> coach visiteur a valide sa saisie
+///   both_submitted   -> les 2 ont valide (alerte commissaire)
+///   validated        -> commissaire a valide (effets appliques)
+///   invalidated      -> annulee apres validation (fenetre de correction)
+///
+/// Les scores et la liste des blesses sont DERIVES des events
+/// (`LeagueMatchEvent`) par le summarizer pur ; ils sont aussi
+/// snapshotes ici a la validation pour audit + lecture rapide.
+model LeagueMatchSheet {
+  id                String        @id @default(cuid())
+  pairing           LeaguePairing @relation(fields: [pairingId], references: [id], onDelete: Cascade)
+  pairingId         String        @unique
+  status            String        @default("draft")
+
+  submittedByHomeAt DateTime?
+  submittedByAwayAt DateTime?
+  validatedAt       DateTime?
+  validatedById     String?
+  invalidatedAt     DateTime?
+  invalidationReason String?
+
+  // ── Avant-match ──
+  weather           String?
+  popularityHome    Int?
+  popularityAway    Int?
+  /// Coups de pouce (inducements) selectionnes : [{ id, name, cost, qty }].
+  inducementsHome   Json?
+  inducementsAway   Json?
+  /// Prieres de Nuffle : [{ playerId, effect, sppBonus }].
+  prayersHome       Json?
+  prayersAway       Json?
+
+  // ── Score derive des events (snapshot a la validation) ──
+  scoreHome         Int           @default(0)
+  scoreAway         Int           @default(0)
+
+  // ── Apres-match (snapshot, editable commissaire) ──
+  /// Gain de tresorerie calcule (auto). Override possible via *Manual.
+  winningsHome      Int           @default(0)
+  winningsAway      Int           @default(0)
+  winningsHomeManual Int?
+  winningsAwayManual Int?
+  dedicatedFansDeltaHome Int?
+  dedicatedFansDeltaAway Int?
+  /// Erreurs couteuses : [{ playerId?, cost, reason }].
+  costlyErrorsHome  Json?
+  costlyErrorsAway  Json?
+  /// Joueurs du match (MVP) : [playerId].
+  motmPlayerIds     Json          @default("[]")
+  /// Achats post-match : [{ kind: 'player'|'reroll'|'staff', name, cost }].
+  purchasesHome     Json?
+  purchasesAway     Json?
+
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  events            LeagueMatchEvent[]
+
+  @@index([status])
+}
+
+/// Lot G — Evenement unitaire d'une feuille de match. Normalise pour
+/// permettre l'agregation (stats joueurs, blesses, score) et l'edition
+/// fine (ajout/suppression d'un event).
+model LeagueMatchEvent {
+  id           String           @id @default(cuid())
+  matchSheet   LeagueMatchSheet @relation(fields: [matchSheetId], references: [id], onDelete: Cascade)
+  matchSheetId String
+  /// 'kickoff' | 'touchdown' | 'casualty' | 'pass_complete' |
+  /// 'interception' | 'aggression' | 'expulsion' | 'crowd_surge' |
+  /// 'stalling' | 'other_elim'
+  kind         String
+  /// 'home' | 'away' — equipe a l'origine de l'event.
+  team         String?
+  /// Acteur (auteur de l'action), rosterId TeamPlayer.
+  actorPlayerId  String?
+  /// Cible (subit l'action), rosterId TeamPlayer.
+  targetPlayerId String?
+  /// Pour other_elim/casualty : 'block' | 'failed_dodge' | 'failed_leap'
+  /// | 'failed_gfi' | 'secret_weapon' | 'crowd' | ...
+  causeDetail  String?
+  /// Severite de blessure : 'badly_hurt' | 'mng' | 'niggling' |
+  /// 'stat_loss' | 'dead' | null.
+  injurySeverity String?
+  /// Donnees additionnelles libres (turn number, dice, etc.).
+  meta         Json?
+  occurredAt   DateTime         @default(now())
+
+  @@index([matchSheetId, kind])
 }
 
 /// Catalogue des Règles Spéciales d'équipe (Bagarreurs Brutaux, Chantage et


### PR DESCRIPTION
## Contexte

Suite de l'audit "gestion des ligues" (fichier _Liste de course Nuffle Arena_). Les lots A, B, C.1, C.2, D, E, F, I, J ont été mergés via #886. Cette PR livre la **feuille de match v2** (Lot G) et les **alertes commissaire** (Lot H) — la dernière brique du plan.

Tout est derrière des feature flags `league_*` pour un rollout au compte-goutte.

## Lot G.1 — Fondations feuille de match (`24c0502`)

- Modèles Prisma `LeagueMatchSheet` (1-1 avec `LeaguePairing`) + `LeagueMatchEvent` (journal normalisé de 10 types d'événements) + migration + mirror SQLite.
- Workflow de statut : `draft → submitted_home/away → both_submitted → validated (→ invalidated)`.
- **Summarizer pur** `summarizeMatchSheet` : dérive le score, les sorties infligées, la liste des blessés (blocage → équipe adverse ; esquive/foncé raté → self ; sortie public → sans acteur) et les stats par joueur (TD/cas/passes/interceptions/agressions). 100 % testable sans DB.
- Service machine à états (create lazy, add/remove event, pre-match, submit/unsubmit, validate) avec autorisation home/away/commissaire résolue depuis le pairing.
- 8 routes REST sous `/leagues/pairings/:id/sheet/*`.

## Lot G.2 — Application des effets à la validation (`6b1239a`)

- À la validation commissaire, branchement sur le pipeline existant `recordOfflineLeagueResult` → classement W/D/L + **points bonus (Lot E)**, SPP + séquence de level-up, blessures durables, trésorerie, fans dévoués, `pairing → played`.
- Mapping pur `buildOfflineInputFromSummary` (MVP depuis `motmPlayerIds`, blessures `mng/niggling/dead/stat_loss` via `meta.stat`, winnings manuels, fans).
- Idempotent (skip si déjà comptabilisé) ; **pas de validation partielle** (si le pipeline throw, la feuille reste `both_submitted`).

## Lot H + G.3 minimal — Alertes + UI (`bb7ecf1`)

- Push commissaire fire-and-forget quand les 2 coachs ont soumis (`both_submitted`), non bloquant. Nouveau `NotificationType.LeagueMatchValidation` réutilisant la préférence league-umbrella (pas de migration de préférence).
- `GET /leagues/me/pending-validations` → liste des matchs à valider (source de la cloche).
- Pages UI : **« Matchs à valider »** (cible du deep-link push) + **feuille de match fonctionnelle** (résumé dérivé, journal, saisie d'événements, submit/validate).

## Tests & vérifs

- **+~80 tests** sur cette PR (summarizer 13, service feuille 33, mapping G.2, notif/push, pending list).
- Suite ligue : **165 tests verts**.
- Typecheck serveur : ✅. Le pattern `Link` dynamique des nouvelles pages est identique aux pages déjà mergées en #886 (typedRoutes-safe au `next build`).

## Test plan

- [ ] Ouvrir une feuille sur un pairing, saisir des événements (TD, casualty avec sévérité), vérifier le score/blessés dérivés.
- [ ] Soumission par les 2 coachs → statut `both_submitted` + notification commissaire.
- [ ] Validation commissaire → classement/SPP/blessures/tréso appliqués (idempotent).
- [ ] `GET /leagues/me/pending-validations` retourne bien les matchs en attente.

## Reste en polish (hors scope, backend prêt)

- Panneaux pré-match détaillés (météo/inducements/prières) et post-match (achats/erreurs coûteuses) — UI minimale pour l'instant.
- Auto-calcul de la trésorerie (actuellement override manuel).

https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub)_