### PR TITLE
feat(league): match-sheet polish — pre/post-match panels, auto treasury, invalidation window

### DIFF
--- a/apps/server/src/routes/league.ts
+++ b/apps/server/src/routes/league.ts
@@ -117,9 +117,12 @@ import {
   addEvent as addMatchSheetEvent,
   removeEvent as removeMatchSheetEvent,
   updatePreMatch,
+  updatePostMatch,
   submitByCoach,
   unsubmitByCoach,
   validateByCommissioner,
+  invalidateMatchSheet,
+  canInvalidateMatchSheet,
   getMatchSheet,
   listPendingValidationsForCommissioner,
   MatchSheetError,
@@ -127,8 +130,12 @@ import {
 import {
   addEventSchema,
   preMatchSchema,
+  postMatchSchema,
+  invalidateSheetSchema,
   type AddEventBody,
   type PreMatchBody,
+  type PostMatchBody,
+  type InvalidateSheetBody,
 } from "../schemas/league-match-sheet.schemas";
 import {
   playMecene,
@@ -222,7 +229,9 @@ function domainError(res: Response, e: unknown): void {
           ? 403
           : e.code === "already_validated" ||
               e.code === "not_validated" ||
-              e.code === "invalid_status"
+              e.code === "invalid_status" ||
+              e.code === "invalidation_window_closed" ||
+              e.code === "invalidation_failed"
             ? 409
             : 400;
     sendError(res, e.message, status);
@@ -1450,6 +1459,63 @@ export async function handleUpdatePreMatch(
   }
 }
 
+/** PATCH /leagues/pairings/:pairingId/sheet/post-match */
+export async function handleUpdatePostMatch(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as PostMatchBody;
+  try {
+    const sheet = await updatePostMatch({
+      pairingId: req.params.pairingId,
+      userId,
+      payload: body,
+    });
+    sendSuccess(res, sheet);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** POST /leagues/pairings/:pairingId/sheet/invalidate (commissaire). */
+export async function handleInvalidateMatchSheet(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  const body = req.body as InvalidateSheetBody;
+  try {
+    const out = await invalidateMatchSheet({
+      pairingId: req.params.pairingId,
+      userId,
+      reason: body.reason,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
+/** GET /leagues/pairings/:pairingId/sheet/can-invalidate */
+export async function handleCanInvalidate(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<void> {
+  const userId = requireUserId(req, res);
+  if (!userId) return;
+  try {
+    const out = await canInvalidateMatchSheet({
+      pairingId: req.params.pairingId,
+    });
+    sendSuccess(res, out);
+  } catch (e: unknown) {
+    domainError(res, e);
+  }
+}
+
 /** POST /leagues/pairings/:pairingId/sheet/events */
 export async function handleAddMatchSheetEvent(
   req: AuthenticatedRequest,
@@ -2209,6 +2275,14 @@ router.patch(
   validate(preMatchSchema),
   handleUpdatePreMatch,
 );
+// Polish — apres-match (override tresorerie, fans, erreurs couteuses,
+// achats, MVP).
+router.patch(
+  "/pairings/:pairingId/sheet/post-match",
+  authUser,
+  validate(postMatchSchema),
+  handleUpdatePostMatch,
+);
 router.post(
   "/pairings/:pairingId/sheet/events",
   authUser,
@@ -2234,6 +2308,19 @@ router.post(
   "/pairings/:pairingId/sheet/validate",
   authUser,
   handleValidateMatchSheet,
+);
+// Polish — invalidation post-validation (fenetre de correction) +
+// check d'eligibilite pour piloter l'UI.
+router.get(
+  "/pairings/:pairingId/sheet/can-invalidate",
+  authUser,
+  handleCanInvalidate,
+);
+router.post(
+  "/pairings/:pairingId/sheet/invalidate",
+  authUser,
+  validate(invalidateSheetSchema),
+  handleInvalidateMatchSheet,
 );
 // Lot H — liste des matchs a valider pour le commissaire (cloche).
 router.get(

--- a/apps/server/src/schemas/league-match-sheet.schemas.ts
+++ b/apps/server/src/schemas/league-match-sheet.schemas.ts
@@ -44,3 +44,65 @@ export const preMatchSchema = z
     "Au moins un champ d'avant-match requis",
   );
 export type PreMatchBody = z.infer<typeof preMatchSchema>;
+
+// Polish — apres-match : override tresorerie, fans, erreurs couteuses,
+// achats, MVP.
+const MAX_GOLD = 10_000_000;
+export const postMatchSchema = z
+  .object({
+    winningsHomeManual: z.number().int().min(0).max(MAX_GOLD).optional().nullable(),
+    winningsAwayManual: z.number().int().min(0).max(MAX_GOLD).optional().nullable(),
+    dedicatedFansDeltaHome: z.number().int().min(-6).max(6).optional().nullable(),
+    dedicatedFansDeltaAway: z.number().int().min(-6).max(6).optional().nullable(),
+    costlyErrorsHome: z
+      .array(
+        z.object({
+          playerId: z.string().min(1).optional(),
+          cost: z.number().int().min(0).max(MAX_GOLD),
+          reason: z.string().max(120).optional(),
+        }),
+      )
+      .optional()
+      .nullable(),
+    costlyErrorsAway: z
+      .array(
+        z.object({
+          playerId: z.string().min(1).optional(),
+          cost: z.number().int().min(0).max(MAX_GOLD),
+          reason: z.string().max(120).optional(),
+        }),
+      )
+      .optional()
+      .nullable(),
+    purchasesHome: z
+      .array(
+        z.object({
+          kind: z.enum(["player", "reroll", "staff", "other"]),
+          name: z.string().max(120),
+          cost: z.number().int().min(0).max(MAX_GOLD),
+        }),
+      )
+      .optional()
+      .nullable(),
+    purchasesAway: z
+      .array(
+        z.object({
+          kind: z.enum(["player", "reroll", "staff", "other"]),
+          name: z.string().max(120),
+          cost: z.number().int().min(0).max(MAX_GOLD),
+        }),
+      )
+      .optional()
+      .nullable(),
+    motmPlayerIds: z.array(z.string().min(1)).max(20).optional(),
+  })
+  .refine(
+    (v) => Object.keys(v).length > 0,
+    "Au moins un champ d'apres-match requis",
+  );
+export type PostMatchBody = z.infer<typeof postMatchSchema>;
+
+export const invalidateSheetSchema = z.object({
+  reason: z.string().max(500).optional(),
+});
+export type InvalidateSheetBody = z.infer<typeof invalidateSheetSchema>;

--- a/apps/server/src/services/league-match-sheet.test.ts
+++ b/apps/server/src/services/league-match-sheet.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("../prisma", () => ({
   prisma: {
-    leaguePairing: { findUnique: vi.fn() },
+    leaguePairing: { findUnique: vi.fn(), count: vi.fn() },
     leagueMatchSheet: {
       findUnique: vi.fn(),
       findMany: vi.fn(),
@@ -20,12 +20,18 @@ vi.mock("../prisma", () => ({
       findMany: vi.fn(),
       delete: vi.fn(),
     },
+    match: { findFirst: vi.fn() },
   },
 }));
 
 // Lot G.2 — mock du pipeline offline branche a la validation.
 vi.mock("./league-offline-result", () => ({
   recordOfflineLeagueResult: vi.fn(),
+}));
+
+// Polish — mock de la reversion (invalidation).
+vi.mock("./league-offline-edit", () => ({
+  reverseOfflineLeagueResult: vi.fn(),
 }));
 
 // Lot H — mock du push commissaire (fire-and-forget).
@@ -38,21 +44,27 @@ import {
   createMatchSheet,
   addEvent,
   removeEvent,
+  updatePreMatch,
+  updatePostMatch,
   submitByCoach,
   unsubmitByCoach,
   validateByCommissioner,
+  invalidateMatchSheet,
+  canInvalidateMatchSheet,
   getMatchSheet,
   buildOfflineInputFromSummary,
   listPendingValidationsForCommissioner,
   MatchSheetError,
 } from "./league-match-sheet";
 import { recordOfflineLeagueResult } from "./league-offline-result";
+import { reverseOfflineLeagueResult } from "./league-offline-edit";
 import { sendLeagueMatchValidationPush } from "./push-notifications";
 import type { MatchSummary } from "./league-match-summary";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockPrisma = prisma as any;
 const mockRecordOffline = recordOfflineLeagueResult as ReturnType<typeof vi.fn>;
+const mockReverse = reverseOfflineLeagueResult as ReturnType<typeof vi.fn>;
 const mockPush = sendLeagueMatchValidationPush as ReturnType<typeof vi.fn>;
 
 const HOME = "home-owner";
@@ -487,6 +499,218 @@ describe("Lot G — league-match-sheet", () => {
     });
   });
 
+  // Polish — pre-match auto-calcule les winnings depuis la popularite.
+  describe("updatePreMatch (auto winnings)", () => {
+    it("computes winningsHome/Away from popularity", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      await updatePreMatch({
+        pairingId: "pair-1",
+        userId: HOME,
+        payload: { popularityHome: 4, popularityAway: 2 },
+      });
+      const data = mockPrisma.leagueMatchSheet.update.mock.calls[0][0].data;
+      expect(data.winningsHome).toBe(40_000);
+      expect(data.winningsAway).toBe(20_000);
+    });
+  });
+
+  // Polish — apres-match.
+  describe("updatePostMatch", () => {
+    it("rejects a non-participant", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "draft",
+      });
+      await expect(
+        updatePostMatch({
+          pairingId: "pair-1",
+          userId: "stranger",
+          payload: { winningsHomeManual: 50000 },
+        }),
+      ).rejects.toMatchObject({ code: "forbidden" });
+    });
+
+    it("rejects editing a validated sheet", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      await expect(
+        updatePostMatch({
+          pairingId: "pair-1",
+          userId: COMMISH,
+          payload: { winningsHomeManual: 50000 },
+        }),
+      ).rejects.toMatchObject({ code: "already_validated" });
+    });
+
+    it("updates winnings override, fans, MVP", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await updatePostMatch({
+        pairingId: "pair-1",
+        userId: HOME,
+        payload: {
+          winningsHomeManual: 60000,
+          dedicatedFansDeltaHome: 1,
+          motmPlayerIds: ["h1", "h2"],
+        },
+      });
+      const data = mockPrisma.leagueMatchSheet.update.mock.calls[0][0].data;
+      expect(data).toMatchObject({
+        winningsHomeManual: 60000,
+        dedicatedFansDeltaHome: 1,
+        motmPlayerIds: ["h1", "h2"],
+      });
+      expect(out).toBeDefined();
+    });
+  });
+
+  // Polish — fenetre d'invalidation.
+  describe("canInvalidateMatchSheet", () => {
+    function mockCurrentPairing() {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "pair-1",
+        homeParticipantId: "ph",
+        awayParticipantId: "pa",
+        round: { seasonId: "s1", roundNumber: 3 },
+      });
+    }
+
+    it("ok when neither team played a later match", async () => {
+      mockCurrentPairing();
+      mockPrisma.leaguePairing.count.mockResolvedValue(0);
+      const out = await canInvalidateMatchSheet({ pairingId: "pair-1" });
+      expect(out).toEqual({ ok: true });
+    });
+
+    it("ok when only one team played a later match", async () => {
+      mockCurrentPairing();
+      // home played 1 later, away played 0
+      mockPrisma.leaguePairing.count
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0);
+      const out = await canInvalidateMatchSheet({ pairingId: "pair-1" });
+      expect(out).toEqual({ ok: true });
+    });
+
+    it("closed when BOTH teams played a later match", async () => {
+      mockCurrentPairing();
+      mockPrisma.leaguePairing.count
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(2);
+      const out = await canInvalidateMatchSheet({ pairingId: "pair-1" });
+      expect(out).toEqual({ ok: false, reason: "both_teams_played_later" });
+    });
+  });
+
+  describe("invalidateMatchSheet", () => {
+    it("rejects a coach", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      await expect(
+        invalidateMatchSheet({ pairingId: "pair-1", userId: HOME }),
+      ).rejects.toMatchObject({ code: "forbidden" });
+    });
+
+    it("rejects when sheet is not validated", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "both_submitted",
+      });
+      await expect(
+        invalidateMatchSheet({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toMatchObject({ code: "not_validated" });
+    });
+
+    // Forme fusionnee : satisfait loadPairingContext (league/owners)
+    // ET canInvalidateMatchSheet (participants/round).
+    function mockMergedPairing() {
+      mockPrisma.leaguePairing.findUnique.mockResolvedValue({
+        id: "pair-1",
+        homeParticipantId: "ph",
+        awayParticipantId: "pa",
+        round: {
+          seasonId: "s1",
+          roundNumber: 3,
+          season: { league: { id: "L1", creatorId: COMMISH } },
+        },
+        homeParticipant: { team: { ownerId: HOME } },
+        awayParticipant: { team: { ownerId: AWAY } },
+      });
+    }
+
+    it("rejects when the invalidation window is closed", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      mockMergedPairing();
+      mockPrisma.leaguePairing.count.mockResolvedValue(1); // both teams later
+      await expect(
+        invalidateMatchSheet({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toMatchObject({ code: "invalidation_window_closed" });
+    });
+
+    it("reverses the offline match and sets status invalidated", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      mockMergedPairing();
+      mockPrisma.leaguePairing.count.mockResolvedValue(0); // window open
+      mockPrisma.match.findFirst.mockResolvedValue({ id: "m1" });
+      mockReverse.mockResolvedValue({
+        reversed: true,
+        matchId: "m1",
+        pairingId: "pair-1",
+      });
+      mockPrisma.leagueMatchSheet.update.mockImplementation(
+        async (a: { data: Record<string, unknown> }) => ({ id: "ms1", ...a.data }),
+      );
+      const out = await invalidateMatchSheet({
+        pairingId: "pair-1",
+        userId: COMMISH,
+        reason: "erreur de saisie",
+      });
+      expect(mockReverse).toHaveBeenCalledWith("m1");
+      const data = mockPrisma.leagueMatchSheet.update.mock.calls[0][0].data;
+      expect(data).toMatchObject({
+        status: "invalidated",
+        invalidationReason: "erreur de saisie",
+      });
+      expect(out).toBeDefined();
+    });
+
+    it("aborts when reversion is impossible (e.g. a death)", async () => {
+      mockPrisma.leagueMatchSheet.findUnique.mockResolvedValue({
+        id: "ms1",
+        status: "validated",
+      });
+      mockMergedPairing();
+      mockPrisma.leaguePairing.count.mockResolvedValue(0);
+      mockPrisma.match.findFirst.mockResolvedValue({ id: "m1" });
+      mockReverse.mockResolvedValue({ skipped: true, reason: "injury-dead" });
+      await expect(
+        invalidateMatchSheet({ pairingId: "pair-1", userId: COMMISH }),
+      ).rejects.toMatchObject({ code: "invalidation_failed" });
+      expect(mockPrisma.leagueMatchSheet.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("MatchSheetError", () => {
     it("preserves code", () => {
       const e = new MatchSheetError("forbidden", "x");
@@ -628,6 +852,36 @@ describe("Lot G — league-match-sheet", () => {
       expect(out.winningsAway).toBe(30000);
       expect(out.dedicatedFansDeltaHome).toBe(1);
       expect(out.dedicatedFansDeltaAway).toBe(-1);
+    });
+
+    it("falls back to auto-computed winnings when no manual override", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        {
+          motmPlayerIds: [],
+          // pas d'override -> on prend la valeur auto-calculee.
+          winningsHome: 50000,
+          winningsAway: 20000,
+        },
+        [],
+      );
+      expect(out.winningsHome).toBe(50000);
+      expect(out.winningsAway).toBe(20000);
+    });
+
+    it("manual override beats the computed value", () => {
+      const out = buildOfflineInputFromSummary(
+        "pair-1",
+        baseSummary,
+        {
+          motmPlayerIds: [],
+          winningsHome: 50000,
+          winningsHomeManual: 99000,
+        },
+        [],
+      );
+      expect(out.winningsHome).toBe(99000);
     });
 
     it("parses motmPlayerIds from a serialized JSON string (sqlite)", () => {

--- a/apps/server/src/services/league-match-sheet.ts
+++ b/apps/server/src/services/league-match-sheet.ts
@@ -22,6 +22,7 @@ import { prisma } from "../prisma";
 import {
   summarizeMatchSheet,
   isMatchEventKind,
+  computeWinnings,
   type MatchEventInput,
   type MatchSummary,
   type InjurySeverity,
@@ -32,6 +33,7 @@ import {
   type OfflineInjuryInput,
   type OfflineInjuryType,
 } from "./league-offline-result";
+import { reverseOfflineLeagueResult } from "./league-offline-edit";
 import { sendLeagueMatchValidationPush } from "./push-notifications";
 import { serverLog } from "../utils/server-log";
 
@@ -54,7 +56,9 @@ export class MatchSheetError extends Error {
       | "not_validated"
       | "invalid_status"
       | "invalid_event"
-      | "event_not_found",
+      | "event_not_found"
+      | "invalidation_window_closed"
+      | "invalidation_failed",
     message: string,
   ) {
     super(message);
@@ -267,12 +271,85 @@ export async function updatePreMatch(input: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data: any = {};
   if (p.weather !== undefined) data.weather = p.weather;
-  if (p.popularityHome !== undefined) data.popularityHome = p.popularityHome;
-  if (p.popularityAway !== undefined) data.popularityAway = p.popularityAway;
+  if (p.popularityHome !== undefined) {
+    data.popularityHome = p.popularityHome;
+    // Polish — auto-calcul du gain de tresorerie depuis le facteur de
+    // popularite (override manuel possible cote post-match).
+    data.winningsHome = computeWinnings(p.popularityHome);
+  }
+  if (p.popularityAway !== undefined) {
+    data.popularityAway = p.popularityAway;
+    data.winningsAway = computeWinnings(p.popularityAway);
+  }
   if (p.inducementsHome !== undefined) data.inducementsHome = p.inducementsHome ?? undefined;
   if (p.inducementsAway !== undefined) data.inducementsAway = p.inducementsAway ?? undefined;
   if (p.prayersHome !== undefined) data.prayersHome = p.prayersHome ?? undefined;
   if (p.prayersAway !== undefined) data.prayersAway = p.prayersAway ?? undefined;
+
+  return prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data,
+  });
+}
+
+export interface PostMatchPayload {
+  /** Override manuel du gain de tresorerie (prioritaire sur l'auto). */
+  winningsHomeManual?: number | null;
+  winningsAwayManual?: number | null;
+  /** Variation de fans devoues (-1/0/+1 typiquement, clampe a la validation). */
+  dedicatedFansDeltaHome?: number | null;
+  dedicatedFansDeltaAway?: number | null;
+  /** Erreurs couteuses : [{ playerId?, cost, reason }]. */
+  costlyErrorsHome?: unknown;
+  costlyErrorsAway?: unknown;
+  /** Achats post-match : [{ kind, name, cost }]. */
+  purchasesHome?: unknown;
+  purchasesAway?: unknown;
+  /** Joueurs du match (MVP) : [playerId]. */
+  motmPlayerIds?: readonly string[];
+}
+
+/**
+ * Polish — Met a jour les infos d'apres-match (override tresorerie,
+ * fans, erreurs couteuses, achats, MVP). Coachs + commissaire, avant
+ * validation.
+ */
+export async function updatePostMatch(input: {
+  pairingId: string;
+  userId: string;
+  payload: PostMatchPayload;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  if (
+    !coachSide(ctx, input.userId) &&
+    !isCommissioner(ctx, input.userId)
+  ) {
+    throw new MatchSheetError("forbidden", "Action reservee aux participants");
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  ensureEditable(sheet.status);
+
+  const p = input.payload;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any = {};
+  if (p.winningsHomeManual !== undefined)
+    data.winningsHomeManual = p.winningsHomeManual;
+  if (p.winningsAwayManual !== undefined)
+    data.winningsAwayManual = p.winningsAwayManual;
+  if (p.dedicatedFansDeltaHome !== undefined)
+    data.dedicatedFansDeltaHome = p.dedicatedFansDeltaHome;
+  if (p.dedicatedFansDeltaAway !== undefined)
+    data.dedicatedFansDeltaAway = p.dedicatedFansDeltaAway;
+  if (p.costlyErrorsHome !== undefined)
+    data.costlyErrorsHome = p.costlyErrorsHome ?? undefined;
+  if (p.costlyErrorsAway !== undefined)
+    data.costlyErrorsAway = p.costlyErrorsAway ?? undefined;
+  if (p.purchasesHome !== undefined)
+    data.purchasesHome = p.purchasesHome ?? undefined;
+  if (p.purchasesAway !== undefined)
+    data.purchasesAway = p.purchasesAway ?? undefined;
+  if (p.motmPlayerIds !== undefined)
+    data.motmPlayerIds = [...p.motmPlayerIds];
 
   return prisma.leagueMatchSheet.update({
     where: { id: sheet.id },
@@ -448,6 +525,10 @@ export function buildOfflineInputFromSummary(
   summary: MatchSummary,
   sheet: {
     motmPlayerIds?: unknown;
+    /** Polish — gain auto calcule (depuis popularite). */
+    winningsHome?: number | null;
+    winningsAway?: number | null;
+    /** Override manuel commissaire (prioritaire). */
     winningsHomeManual?: number | null;
     winningsAwayManual?: number | null;
     dedicatedFansDeltaHome?: number | null;
@@ -504,8 +585,9 @@ export function buildOfflineInputFromSummary(
     casualtiesHome: summary.casualtiesHome,
     casualtiesAway: summary.casualtiesAway,
     playerStats,
-    winningsHome: sheet.winningsHomeManual ?? undefined,
-    winningsAway: sheet.winningsAwayManual ?? undefined,
+    // Polish — override manuel prioritaire, sinon gain auto-calcule.
+    winningsHome: sheet.winningsHomeManual ?? sheet.winningsHome ?? undefined,
+    winningsAway: sheet.winningsAwayManual ?? sheet.winningsAway ?? undefined,
     dedicatedFansDeltaHome: sheet.dedicatedFansDeltaHome ?? undefined,
     dedicatedFansDeltaAway: sheet.dedicatedFansDeltaAway ?? undefined,
     injuries,
@@ -574,6 +656,8 @@ export async function validateByCommissioner(input: {
     summary,
     sheet as {
       motmPlayerIds?: unknown;
+      winningsHome?: number | null;
+      winningsAway?: number | null;
       winningsHomeManual?: number | null;
       winningsAwayManual?: number | null;
       dedicatedFansDeltaHome?: number | null;
@@ -607,6 +691,131 @@ export async function validateByCommissioner(input: {
     },
   });
   return { sheet: updated, summary, effects };
+}
+
+/**
+ * Polish — Determine si la feuille validee peut encore etre invalidee.
+ *
+ * Regle : invalidation autorisee TANT QUE les 2 equipes n'ont pas
+ * chacune rejoue un autre match (pairing `played`/`forfeit_*` a un
+ * round ULTERIEUR). Des que les DEUX equipes ont enchaine, la fenetre
+ * se ferme (le classement aval depend de ce resultat).
+ *
+ * Retourne `{ ok: true }` ou `{ ok: false, reason }`.
+ */
+export async function canInvalidateMatchSheet(input: {
+  pairingId: string;
+}): Promise<{ ok: boolean; reason?: string }> {
+  const pairing = (await prisma.leaguePairing.findUnique({
+    where: { id: input.pairingId },
+    select: {
+      id: true,
+      homeParticipantId: true,
+      awayParticipantId: true,
+      round: { select: { seasonId: true, roundNumber: true } },
+    },
+  })) as {
+    id: string;
+    homeParticipantId: string;
+    awayParticipantId: string;
+    round: { seasonId: string; roundNumber: number };
+  } | null;
+  if (!pairing) return { ok: false, reason: "pairing_not_found" };
+
+  const TERMINAL_PLAYED = ["played", "forfeit_home", "forfeit_away"];
+  const laterPlayedFor = async (participantId: string): Promise<number> =>
+    prisma.leaguePairing.count({
+      where: {
+        id: { not: pairing.id },
+        status: { in: TERMINAL_PLAYED },
+        round: {
+          seasonId: pairing.round.seasonId,
+          roundNumber: { gt: pairing.round.roundNumber },
+        },
+        OR: [
+          { homeParticipantId: participantId },
+          { awayParticipantId: participantId },
+        ],
+      },
+    });
+
+  const [homeLater, awayLater] = await Promise.all([
+    laterPlayedFor(pairing.homeParticipantId),
+    laterPlayedFor(pairing.awayParticipantId),
+  ]);
+
+  // Fenetre fermee uniquement si LES DEUX equipes ont rejoue.
+  if (homeLater > 0 && awayLater > 0) {
+    return { ok: false, reason: "both_teams_played_later" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Polish — Invalide une feuille validee (commissaire). Reverse les
+ * effets via `reverseOfflineLeagueResult` (classement/SPP/treso/fans)
+ * puis repasse la feuille en `invalidated` pour permettre une
+ * correction. Respecte la fenetre `canInvalidateMatchSheet`.
+ */
+export async function invalidateMatchSheet(input: {
+  pairingId: string;
+  userId: string;
+  reason?: string;
+}) {
+  const ctx = await loadPairingContext(input.pairingId);
+  if (!isCommissioner(ctx, input.userId)) {
+    throw new MatchSheetError(
+      "forbidden",
+      "Seul le commissaire peut invalider la feuille",
+    );
+  }
+  const sheet = await loadSheetOrThrow(input.pairingId);
+  if (sheet.status !== "validated") {
+    throw new MatchSheetError(
+      "not_validated",
+      "Seule une feuille validee peut etre invalidee",
+    );
+  }
+
+  const window = await canInvalidateMatchSheet({ pairingId: input.pairingId });
+  if (!window.ok) {
+    throw new MatchSheetError(
+      "invalidation_window_closed",
+      "Fenetre de correction fermee : les 2 equipes ont deja rejoue",
+    );
+  }
+
+  // Retrouve le Match offline synthetique du pairing pour le reverser.
+  const match = (await prisma.match.findFirst({
+    where: { leaguePairingId: input.pairingId, leagueScoredAt: { not: null } },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  })) as { id: string } | null;
+
+  if (match) {
+    const reversed = await reverseOfflineLeagueResult(match.id);
+    if ("skipped" in reversed) {
+      // Reversion impossible (mort, saison cloturee, playoffs...) :
+      // on refuse l'invalidation pour ne pas laisser un etat incoherent.
+      throw new MatchSheetError(
+        "invalidation_failed",
+        `Reversion impossible: ${reversed.reason}`,
+      );
+    }
+  }
+
+  const updated = await prisma.leagueMatchSheet.update({
+    where: { id: sheet.id },
+    data: {
+      status: "invalidated",
+      invalidatedAt: new Date(),
+      invalidationReason: input.reason ?? null,
+    },
+  });
+  serverLog.info(
+    `[league-match-sheet] invalidated pairing=${input.pairingId} by=${input.userId}`,
+  );
+  return { sheet: updated };
 }
 
 /**

--- a/apps/server/src/services/league-match-summary.test.ts
+++ b/apps/server/src/services/league-match-summary.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect } from "vitest";
 import {
   summarizeMatchSheet,
   isMatchEventKind,
+  computeWinnings,
+  WINNINGS_PER_POPULARITY,
   MATCH_EVENT_KINDS,
   type MatchEventInput,
 } from "./league-match-summary";
@@ -229,5 +231,22 @@ describe("Lot G — isMatchEventKind / MATCH_EVENT_KINDS", () => {
     expect(isMatchEventKind("crowd_surge")).toBe(true);
     expect(isMatchEventKind("nope")).toBe(false);
     expect(isMatchEventKind(42)).toBe(false);
+  });
+});
+
+describe("Polish — computeWinnings", () => {
+  it("multiplies popularity by 10k", () => {
+    expect(computeWinnings(0)).toBe(0);
+    expect(computeWinnings(3)).toBe(3 * WINNINGS_PER_POPULARITY);
+    expect(computeWinnings(6)).toBe(60_000);
+  });
+  it("clamps negatives to 0 and floors decimals", () => {
+    expect(computeWinnings(-5)).toBe(0);
+    expect(computeWinnings(2.9)).toBe(20_000);
+  });
+  it("returns 0 for null/undefined/NaN", () => {
+    expect(computeWinnings(null)).toBe(0);
+    expect(computeWinnings(undefined)).toBe(0);
+    expect(computeWinnings(NaN)).toBe(0);
   });
 });

--- a/apps/server/src/services/league-match-summary.ts
+++ b/apps/server/src/services/league-match-summary.ts
@@ -245,3 +245,23 @@ export function isMatchEventKind(v: unknown): v is MatchEventKind {
     (MATCH_EVENT_KINDS as readonly string[]).includes(v)
   );
 }
+
+/**
+ * Polish — Gold gagne par point de "facteur de popularite" (BB : le
+ * resultat du jet de gains / affluence saisi en avant-match). 1 point
+ * = 10 000 po. Heuristique configurable ici ; le commissaire peut
+ * toujours overrider la valeur calculee sur la feuille.
+ */
+export const WINNINGS_PER_POPULARITY = 10_000;
+
+/**
+ * Calcule le gain de tresorerie auto a partir du facteur de
+ * popularite (clampe >= 0). Pur. `null`/undefined -> 0.
+ */
+export function computeWinnings(popularity: number | null | undefined): number {
+  if (typeof popularity !== "number" || !Number.isFinite(popularity)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(popularity)) * WINNINGS_PER_POPULARITY;
+}
+

--- a/apps/web/app/leagues/pairings/[id]/sheet/_components/MatchSheetPanels.tsx
+++ b/apps/web/app/leagues/pairings/[id]/sheet/_components/MatchSheetPanels.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState } from "react";
+
+// Polish — panneaux pre/post-match + invalidation pour la feuille de
+// match. Composants presentational : ils recoivent les valeurs + des
+// callbacks de sauvegarde (la page parent gere les appels API).
+
+const WEATHER_OPTIONS = [
+  "",
+  "sweltering_heat",
+  "very_sunny",
+  "perfect",
+  "pouring_rain",
+  "blizzard",
+];
+
+export interface PreMatchValues {
+  weather: string;
+  popularityHome: number | null;
+  popularityAway: number | null;
+}
+
+export function PreMatchPanel({
+  initial,
+  computedWinningsHome,
+  computedWinningsAway,
+  disabled,
+  onSave,
+}: {
+  initial: PreMatchValues;
+  computedWinningsHome: number;
+  computedWinningsAway: number;
+  disabled?: boolean;
+  onSave: (v: PreMatchValues) => Promise<void>;
+}) {
+  const [weather, setWeather] = useState(initial.weather);
+  const [popH, setPopH] = useState<string>(
+    initial.popularityHome?.toString() ?? "",
+  );
+  const [popA, setPopA] = useState<string>(
+    initial.popularityAway?.toString() ?? "",
+  );
+  const [busy, setBusy] = useState(false);
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      await onSave({
+        weather,
+        popularityHome: popH === "" ? null : Number(popH),
+        popularityAway: popA === "" ? null : Number(popA),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mb-4 rounded border p-3" data-testid="pre-match-panel">
+      <h2 className="mb-2 font-semibold">Avant-match</h2>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="text-xs">
+          Meteo
+          <select
+            value={weather}
+            onChange={(e) => setWeather(e.target.value)}
+            disabled={disabled}
+            className="block rounded border px-2 py-1"
+          >
+            {WEATHER_OPTIONS.map((w) => (
+              <option key={w} value={w}>
+                {w || "—"}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs">
+          Facteur pop. domicile
+          <input
+            type="number"
+            min={0}
+            max={20}
+            value={popH}
+            onChange={(e) => setPopH(e.target.value)}
+            disabled={disabled}
+            className="block w-24 rounded border px-2 py-1"
+            data-testid="popularity-home"
+          />
+          <span className="text-[10px] text-slate-500">
+            → {computedWinningsHome.toLocaleString("fr-FR")} po
+          </span>
+        </label>
+        <label className="text-xs">
+          Facteur pop. exterieur
+          <input
+            type="number"
+            min={0}
+            max={20}
+            value={popA}
+            onChange={(e) => setPopA(e.target.value)}
+            disabled={disabled}
+            className="block w-24 rounded border px-2 py-1"
+            data-testid="popularity-away"
+          />
+          <span className="text-[10px] text-slate-500">
+            → {computedWinningsAway.toLocaleString("fr-FR")} po
+          </span>
+        </label>
+        {!disabled && (
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+            onClick={save}
+            disabled={busy}
+            data-testid="save-pre-match"
+          >
+            Enregistrer
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export interface PostMatchValues {
+  winningsHomeManual: number | null;
+  winningsAwayManual: number | null;
+  dedicatedFansDeltaHome: number;
+  dedicatedFansDeltaAway: number;
+  motmPlayerIds: string[];
+}
+
+export function PostMatchPanel({
+  initial,
+  disabled,
+  onSave,
+}: {
+  initial: PostMatchValues;
+  disabled?: boolean;
+  onSave: (v: PostMatchValues) => Promise<void>;
+}) {
+  const [winH, setWinH] = useState<string>(
+    initial.winningsHomeManual?.toString() ?? "",
+  );
+  const [winA, setWinA] = useState<string>(
+    initial.winningsAwayManual?.toString() ?? "",
+  );
+  const [fansH, setFansH] = useState(initial.dedicatedFansDeltaHome);
+  const [fansA, setFansA] = useState(initial.dedicatedFansDeltaAway);
+  const [motm, setMotm] = useState(initial.motmPlayerIds.join(", "));
+  const [busy, setBusy] = useState(false);
+
+  const save = async () => {
+    setBusy(true);
+    try {
+      await onSave({
+        winningsHomeManual: winH === "" ? null : Number(winH),
+        winningsAwayManual: winA === "" ? null : Number(winA),
+        dedicatedFansDeltaHome: fansH,
+        dedicatedFansDeltaAway: fansA,
+        motmPlayerIds: motm
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mb-4 rounded border p-3" data-testid="post-match-panel">
+      <h2 className="mb-2 font-semibold">Apres-match</h2>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="text-xs">
+          Tresorerie domicile (override)
+          <input
+            type="number"
+            min={0}
+            value={winH}
+            onChange={(e) => setWinH(e.target.value)}
+            disabled={disabled}
+            placeholder="auto"
+            className="block w-28 rounded border px-2 py-1"
+            data-testid="winnings-home"
+          />
+        </label>
+        <label className="text-xs">
+          Tresorerie exterieur (override)
+          <input
+            type="number"
+            min={0}
+            value={winA}
+            onChange={(e) => setWinA(e.target.value)}
+            disabled={disabled}
+            placeholder="auto"
+            className="block w-28 rounded border px-2 py-1"
+            data-testid="winnings-away"
+          />
+        </label>
+        <label className="text-xs">
+          Fans devoues dom.
+          <select
+            value={fansH}
+            onChange={(e) => setFansH(Number(e.target.value))}
+            disabled={disabled}
+            className="block rounded border px-2 py-1"
+          >
+            <option value={-1}>-1</option>
+            <option value={0}>0</option>
+            <option value={1}>+1</option>
+          </select>
+        </label>
+        <label className="text-xs">
+          Fans devoues ext.
+          <select
+            value={fansA}
+            onChange={(e) => setFansA(Number(e.target.value))}
+            disabled={disabled}
+            className="block rounded border px-2 py-1"
+          >
+            <option value={-1}>-1</option>
+            <option value={0}>0</option>
+            <option value={1}>+1</option>
+          </select>
+        </label>
+        <label className="text-xs">
+          Joueur(s) du match (ids, virgule)
+          <input
+            value={motm}
+            onChange={(e) => setMotm(e.target.value)}
+            disabled={disabled}
+            className="block w-48 rounded border px-2 py-1"
+            data-testid="motm-ids"
+          />
+        </label>
+        {!disabled && (
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-1 text-sm text-white disabled:opacity-50"
+            onClick={save}
+            disabled={busy}
+            data-testid="save-post-match"
+          >
+            Enregistrer
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function InvalidateControl({
+  canInvalidate,
+  reasonClosed,
+  onInvalidate,
+}: {
+  canInvalidate: boolean;
+  reasonClosed?: string;
+  onInvalidate: (reason: string) => Promise<void>;
+}) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  if (!canInvalidate) {
+    return (
+      <p className="text-xs text-slate-500" data-testid="invalidate-closed">
+        Invalidation impossible
+        {reasonClosed === "both_teams_played_later"
+          ? " : les 2 equipes ont deja rejoue."
+          : "."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2" data-testid="invalidate-control">
+      <input
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Motif (optionnel)"
+        className="rounded border px-2 py-1 text-sm"
+      />
+      <button
+        type="button"
+        className="rounded bg-red-600 px-3 py-2 text-sm text-white disabled:opacity-50"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          try {
+            await onInvalidate(reason);
+          } finally {
+            setBusy(false);
+          }
+        }}
+        data-testid="invalidate-sheet"
+      >
+        Invalider le match
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/leagues/pairings/[id]/sheet/page.tsx
+++ b/apps/web/app/leagues/pairings/[id]/sheet/page.tsx
@@ -3,6 +3,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { apiRequest, ApiClientError } from "../../../../lib/api-client";
+import {
+  PreMatchPanel,
+  PostMatchPanel,
+  InvalidateControl,
+  type PreMatchValues,
+  type PostMatchValues,
+} from "./_components/MatchSheetPanels";
+
+const WINNINGS_PER_POPULARITY = 10_000;
 
 // Lot G.3 (minimal) — Feuille de match v2 : saisie d'evenements,
 // soumission par coach, validation par commissaire. Le score et les
@@ -50,9 +59,30 @@ interface SheetResponse {
     id: string;
     status: string;
     events?: MatchEvent[];
+    weather?: string | null;
+    popularityHome?: number | null;
+    popularityAway?: number | null;
+    winningsHomeManual?: number | null;
+    winningsAwayManual?: number | null;
+    dedicatedFansDeltaHome?: number | null;
+    dedicatedFansDeltaAway?: number | null;
+    motmPlayerIds?: string[] | string | null;
   };
   summary: Summary;
   viewerRole: "home" | "away" | "commissioner" | "none";
+}
+
+function parseMotm(raw: string[] | string | null | undefined): string[] {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === "string") {
+    try {
+      const p = JSON.parse(raw);
+      return Array.isArray(p) ? p : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
 }
 
 const EVENT_KINDS: EventKind[] = [
@@ -172,6 +202,64 @@ export default function MatchSheetPage() {
       }),
     );
 
+  // Polish — sauvegarde pre/post-match + invalidation.
+  const savePreMatch = (v: PreMatchValues) =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/pre-match`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          weather: v.weather || null,
+          popularityHome: v.popularityHome,
+          popularityAway: v.popularityAway,
+        }),
+      }),
+    );
+
+  const savePostMatch = (v: PostMatchValues) =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/post-match`, {
+        method: "PATCH",
+        body: JSON.stringify({
+          winningsHomeManual: v.winningsHomeManual,
+          winningsAwayManual: v.winningsAwayManual,
+          dedicatedFansDeltaHome: v.dedicatedFansDeltaHome,
+          dedicatedFansDeltaAway: v.dedicatedFansDeltaAway,
+          motmPlayerIds: v.motmPlayerIds,
+        }),
+      }),
+    );
+
+  const invalidate = (reason: string) =>
+    run(() =>
+      apiRequest(`/leagues/pairings/${pairingId}/sheet/invalidate`, {
+        method: "POST",
+        body: JSON.stringify({ reason: reason || undefined }),
+      }),
+    );
+
+  // Eligibilite a l'invalidation (chargee quand la feuille est validee).
+  const [canInval, setCanInval] = useState<{ ok: boolean; reason?: string }>({
+    ok: false,
+  });
+  useEffect(() => {
+    if (data?.sheet.status !== "validated" || data?.viewerRole !== "commissioner") {
+      return;
+    }
+    let cancelled = false;
+    void apiRequest<{ ok: boolean; reason?: string }>(
+      `/leagues/pairings/${pairingId}/sheet/can-invalidate`,
+    )
+      .then((r) => {
+        if (!cancelled) setCanInval(r);
+      })
+      .catch(() => {
+        if (!cancelled) setCanInval({ ok: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [data?.sheet.status, data?.viewerRole, pairingId]);
+
   const events = useMemo(() => data?.sheet.events ?? [], [data]);
   const role = data?.viewerRole ?? "none";
   const status = data?.sheet.status ?? "";
@@ -237,6 +325,25 @@ export default function MatchSheetPage() {
           · Blesses : {data.summary.injuries.length}
         </p>
       </section>
+
+      {/* Avant-match */}
+      {(isCoach || isCommissioner) && (
+        <PreMatchPanel
+          initial={{
+            weather: data.sheet.weather ?? "",
+            popularityHome: data.sheet.popularityHome ?? null,
+            popularityAway: data.sheet.popularityAway ?? null,
+          }}
+          computedWinningsHome={
+            (data.sheet.popularityHome ?? 0) * WINNINGS_PER_POPULARITY
+          }
+          computedWinningsAway={
+            (data.sheet.popularityAway ?? 0) * WINNINGS_PER_POPULARITY
+          }
+          disabled={!editable}
+          onSave={savePreMatch}
+        />
+      )}
 
       {/* Journal d'evenements */}
       <section className="mb-4">
@@ -347,6 +454,21 @@ export default function MatchSheetPage() {
         </section>
       )}
 
+      {/* Apres-match */}
+      {(isCoach || isCommissioner) && (
+        <PostMatchPanel
+          initial={{
+            winningsHomeManual: data.sheet.winningsHomeManual ?? null,
+            winningsAwayManual: data.sheet.winningsAwayManual ?? null,
+            dedicatedFansDeltaHome: data.sheet.dedicatedFansDeltaHome ?? 0,
+            dedicatedFansDeltaAway: data.sheet.dedicatedFansDeltaAway ?? 0,
+            motmPlayerIds: parseMotm(data.sheet.motmPlayerIds),
+          }}
+          disabled={!editable}
+          onSave={savePostMatch}
+        />
+      )}
+
       {/* Actions de workflow */}
       <section className="flex flex-wrap gap-2">
         {isCoach && status !== "validated" && (
@@ -387,6 +509,18 @@ export default function MatchSheetPage() {
           </p>
         )}
       </section>
+
+      {/* Invalidation post-validation (commissaire, fenetre de correction) */}
+      {isCommissioner && status === "validated" && (
+        <section className="mt-4 rounded border border-red-200 bg-red-50 p-3">
+          <h2 className="mb-2 text-sm font-semibold">Corriger ce match</h2>
+          <InvalidateControl
+            canInvalidate={canInval.ok}
+            reasonClosed={canInval.reason}
+            onInvalidate={invalidate}
+          />
+        </section>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Contexte

Finalise les 3 chantiers de **polish** restants de la feuille de match v2 (lots G/H mergés via #887). Aucune nouvelle migration — tous les champs existaient déjà depuis G.1.

## 1. Auto-calcul de la trésorerie (saisissable)

- `computeWinnings(popularity)` pur : `popularité × 10 000 po` (clampé ≥ 0).
- `updatePreMatch` écrit désormais `winningsHome/Away` à partir du facteur de popularité saisi.
- `buildOfflineInputFromSummary` applique **override manuel ?? valeur auto-calculée** → la validation crédite le gain calculé sauf override commissaire.

## 2. Édition après-match

- Nouveau service `updatePostMatch` + route `PATCH /leagues/pairings/:id/sheet/post-match` + schéma Zod : override trésorerie, delta fans dévoués, **erreurs coûteuses**, **achats** (joueurs/relances/staff), **MVP**. Coachs + commissaire, avant validation.

## 3. Fenêtre d'invalidation post-validation

- `canInvalidateMatchSheet` : fenêtre ouverte **tant que les 2 équipes n'ont pas chacune rejoué** un match ultérieur (round > courant, statut terminal).
- `invalidateMatchSheet` (commissaire) : reverse les effets via `reverseOfflineLeagueResult` (classement/SPP/tréso/fans) puis repasse la feuille en `invalidated` pour re-correction. **Abandonne** si la réversion est impossible (mort/saison close/playoffs) → pas d'état incohérent.
- Routes : `GET /sheet/can-invalidate`, `POST /sheet/invalidate`. Nouveaux codes d'erreur `invalidation_window_closed` / `invalidation_failed` → HTTP 409.

## UI

- `_components/MatchSheetPanels.tsx` : `PreMatchPanel` (météo, popularité → winnings calculés en direct), `PostMatchPanel` (override tréso, fans, MVP), `InvalidateControl` (motif + état désactivé selon la fenêtre).
- La page feuille câble les panneaux et charge l'éligibilité à l'invalidation quand le match est validé.

## Tests & vérifs

- **+~20 tests** (computeWinnings, auto-winnings pré-match, updatePostMatch, logique de fenêtre, invalidate reverse/abort, fallback manuel-vs-calculé).
- **160 tests** de la suite ligue verts ; typecheck serveur ✅.
- Aucune migration. La page feuille n'utilise pas `Link` (pas de souci typedRoutes).

## Test plan

- [ ] Saisir un facteur de popularité pré-match → vérifier le gain calculé et son report à la validation (sans override).
- [ ] Override trésorerie post-match → la valeur manuelle prime.
- [ ] Valider un match, puis l'invalider tant qu'une seule équipe a rejoué → OK ; après que les 2 ont rejoué → refus (409).
- [ ] Invalidation d'un match avec un mort → refus `invalidation_failed`.

https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub)_