### PR TITLE
docs(league): session recap + feature-flag rollout guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,3 +508,14 @@ vi.mock("./pro-roster-spp", () => ({
   complete (mini-leagues prediction + Survivor). Q.C (clips MP4)
   differe. 8 nouveaux modeles Prisma. Voir
   [`docs/roadmap/sessions/2026-05-12-sprint-Q.md`](./docs/roadmap/sessions/2026-05-12-sprint-Q.md).
+- **2026-06-06** : Gestion des Ligues (audit "Liste de course Nuffle
+  Arena"), 3 PRs (#886-#888). Lots A/B/C/D/E/F (invitations, withdraw
+  guard, multi-poules + scheduler, override PO, points bonus, saisie
+  manuelle), G/H (feuille de match v2 : events + summarizer pur +
+  validation branchee offline + alerte commissaire), I/J (edition
+  ex-post commissaire + classements joueurs), polish (auto-tresorerie,
+  panneaux pre/post-match, fenetre d'invalidation). 5 migrations, 8
+  feature flags `league*`. Voir
+  [`docs/roadmap/sessions/2026-06-06-league-management.md`](./docs/roadmap/sessions/2026-06-06-league-management.md)
+  + guide rollout
+  [`docs/roadmap/league-feature-flags-rollout.md`](./docs/roadmap/league-feature-flags-rollout.md).

--- a/docs/roadmap/league-feature-flags-rollout.md
+++ b/docs/roadmap/league-feature-flags-rollout.md
@@ -1,0 +1,116 @@
+# Guide d'activation — Feature flags Ligue (rollout au compte-goutte)
+
+> Strategie d'ouverture progressive de la brique "gestion des ligues"
+> (audit 2026-06-06, cf.
+> [`sessions/2026-06-06-league-management.md`](./sessions/2026-06-06-league-management.md)).
+> Toute la surface est OFF par defaut ; on l'ouvre cohorte par cohorte.
+
+## 1. Comment un flag est evalue
+
+Source : `apps/server/src/services/featureFlags.ts`. Un flag est **actif
+pour un utilisateur** si **l'une** de ces conditions est vraie :
+
+1. `FEATURE_FLAGS_FORCE_ENABLED=true` (CI/tests uniquement — jamais en prod) ;
+2. l'utilisateur a le role `admin` (bypass admin) ;
+3. le flag est **globalement** active (`enabled = true`) ;
+4. il existe un **override par-utilisateur** pour `(flag, userId)`.
+
+> Le **compte-goutte** = condition (4) : on ajoute des overrides
+> par-user sans jamais passer le flag en global. Quand la feature est
+> eprouvee, on bascule en global (3).
+>
+> Les **kill-switches** (`maintenance_mode`,
+> `registration_requires_validation`) sont l'exception : ils ne sont PAS
+> force-ON par la CI ni le bypass admin. Aucun flag ligue n'est un
+> kill-switch — ce sont tous des flags d'activation classiques.
+
+## 2. Les 8 flags ligue
+
+| Flag | Gate | Depend de |
+|------|------|-----------|
+| `league` | Hub `/leagues` + tous les ecrans de gestion (creation, edition, saisons, calendrier, classements, level-up, admin). **Porte d'entree.** | — |
+| `league_invitations` | UI invitations coachs (recherche, lien partage, accept/decline). | `league` |
+| `league_pools` | UI multi-poules (editeur de poules, standings/calendrier par poule). | `league` |
+| `league_manual_pairings` | UI saisie manuelle de matchs (rounds custom, ajout/suppression/deplacement). | `league` |
+| `league_bonus_points` | Editeur de points bonus dans la creation/edition de ligue. | `league` |
+| `league_match_sheet` | Feuille de match v2 (saisie joueurs, evenements, validation, panneaux pre/post-match, invalidation). | `league` |
+| `league_leaderboards` | Page classements top-N joueurs par saison. | `league` |
+| `league_commissioner_edit` | Edition ex-post des equipes par le commissaire (SPP/comp/carac/treso, auditee). | `league` |
+
+> **Important** : les sous-flags gatent l'**UI**. Les routes API sont
+> protegees par l'authentification + les roles (commissaire = createur de
+> la ligue, admin global). Activer un sous-flag pour un user lui rend la
+> section visible ; il ne peut agir que sur ses propres ligues.
+
+## 3. Outils d'activation (admin)
+
+### Panneau admin
+`/admin/feature-flags` (liste + toggle global + edition) et
+`/admin/feature-flags/[id]` (overrides par-utilisateur).
+
+### API (reservee admin — `authUser` + `adminOnly`)
+
+| Methode | Route | Effet |
+|---------|-------|-------|
+| `POST` | `/admin/feature-flags/sync` | Cree en base tout flag du code absent (avec `enabled=false`). **A lancer une fois** apres deploiement pour materialiser les 8 flags. |
+| `GET` | `/admin/feature-flags` | Liste les flags + compteur d'overrides. |
+| `PATCH` | `/admin/feature-flags/:id` | Bascule `enabled` global (ou la description). |
+| `GET` | `/admin/feature-flags/:id/users` | Liste les overrides par-user. |
+| `POST` | `/admin/feature-flags/:id/users` | **Ajoute un override** (ouvre le flag a un user). |
+| `DELETE` | `/admin/feature-flags/:id/users/:userId` | Retire l'override (referme pour ce user). |
+
+> Apres tout changement, le cache flags se vide en <= 30 s
+> (`CACHE_TTL_MS`), ou immediatement via `invalidateFeatureFlagsCache()`
+> cote process.
+
+## 4. Sequence de rollout recommandee
+
+### Etape 0 — Materialiser les flags
+Deployer puis `POST /admin/feature-flags/sync`. Verifier que les 8
+flags `league*` apparaissent dans `/admin/feature-flags`, tous OFF.
+
+### Etape 1 — Cohorte pilote sur le coeur
+Choisir 1-3 comptes commissaires de confiance. Pour chacun, ajouter un
+override sur :
+1. `league` (sans lui, rien n'est visible) ;
+2. `league_match_sheet` (le gros morceau a eprouver en premier) ;
+3. `league_invitations` (pour qu'ils remplissent leurs ligues).
+
+Faire jouer un cycle complet : creer une ligue → inviter → demarrer une
+saison → saisir une feuille de match → valider → verifier le classement.
+
+### Etape 2 — Elargir les fonctionnalites a la cohorte pilote
+Quand le coeur est valide, ajouter pour les memes users :
+`league_pools`, `league_bonus_points`, `league_manual_pairings`,
+`league_leaderboards`, `league_commissioner_edit`.
+
+### Etape 3 — Cohorte elargie
+Repliquer les overrides `league` + `league_match_sheet` (+ invitations)
+sur une cohorte plus large (10-50 commissaires). Surveiller les retours.
+
+### Etape 4 — Bascule globale
+Quand la confiance est la, passer `enabled=true` (global) flag par flag,
+en commencant par `league` puis les sous-flags. Retirer les overrides
+par-user devenus redondants (optionnel — sans effet de bord).
+
+## 5. Rollback
+
+- **Couper une feature pour tout le monde** : `PATCH` le flag a
+  `enabled=false`. Les overrides par-user restent et redeviennent
+  actifs ; pour une coupure totale, retirer aussi les overrides.
+- **Couper pour un user** : `DELETE /admin/feature-flags/:id/users/:userId`.
+- Les donnees deja creees (ligues, feuilles de match) ne sont pas
+  supprimees par la coupure d'un flag — seule la **visibilite UI**
+  change. Les effets deja appliques au classement persistent.
+
+## 6. Pieges
+
+- **CI** : `e2e.yml` exporte `FEATURE_FLAGS_FORCE_ENABLED=true` — tous
+  les flags ligue sont donc ON pendant les E2E. Les nouveaux flags
+  ligue etant des flags d'activation (pas des kill-switches), c'est le
+  comportement voulu.
+- **Admin = tout ON** : un compte admin voit toujours toutes les
+  features (bypass). Pour tester l'experience d'un commissaire non-admin,
+  utiliser un compte dedie sans le role admin.
+- **Dependance implicite** : ouvrir un sous-flag sans `league` ne sert a
+  rien (le hub reste masque). Toujours ouvrir `league` en premier.

--- a/docs/roadmap/sessions/2026-06-06-league-management.md
+++ b/docs/roadmap/sessions/2026-06-06-league-management.md
@@ -1,0 +1,116 @@
+# Session Gestion des Ligues — audit "Liste de course Nuffle Arena"
+
+> **2026-06-06** — 3 PRs livrees et auto-mergees (#886, #887, #888)
+> couvrant l'integralite de l'audit "gestion des ligues" remonte par
+> les premiers utilisateurs prod (fichier _Liste de course pour Nuffle
+> Arena_). Toute la surface est derriere des feature flags `league_*`
+> pour un rollout au compte-goutte.
+>
+> Demarrage : audit d'existant (12 points gestion + feuille de match +
+> stats) par un agent d'exploration, puis implementation lot par lot.
+> La PR #886 a aussi corrige un echec CI pre-existant (reference roster
+> High Elf S3 desynchronisee, sans rapport avec la ligue).
+
+## Recap des lots livres
+
+| Lot | Titre | PR | Surface | Besoin (couleur fichier) |
+|-----|-------|----|---------|--------------------------|
+| **B** | Retrait equipe verrouille apres demarrage saison | #886 | server | 🔴 Indispensable |
+| **A** | Invitations coachs (recherche + lien + accept/decline) | #886 | server + web | 🔴 |
+| **F** | Saisie manuelle de rounds / pairings | #886 | server | 🔴/🔵 |
+| **E** | Points bonus configurables (3 TD / 3 cas / clean sheet…) | #886 | server | 🔴 |
+| **C.1** | Multi-poules : schema + CRUD + standings par poule | #886 | server | 🔴 |
+| **D** | Override participants playoffs (desistement tardif) | #886 | server | 🔴 |
+| **J** | Classements top-N joueurs (+ par equipe) | #886 | server + web | 🔴 / 🔵 |
+| **I** | Edition ex-post des equipes par commissaire (audit) | #886 | server | 🔴 |
+| **C.2** | Scheduler round-robin par poule (journees partagees) | #887 | server | 🔴 |
+| **G.1** | Feuille de match v2 : modele + events + summarizer + FSM | #887 | server | 🔴 |
+| **G.2** | Application des effets a la validation (pipeline offline) | #887 | server | 🔴 |
+| **G.3** | UI feuille de match fonctionnelle | #887 | web | 🔴 |
+| **H** | Alerte commissaire + liste des matchs a valider (cloche) | #887 | server + web | 🟢 Souhaitable |
+| **Polish 1** | Panneaux pre/post-match (meteo/pop/inducements/MVP/achats) | #888 | server + web | 🔴 |
+| **Polish 2** | Auto-calcul tresorerie (saisissable) | #888 | server + web | 🔴 |
+| **Polish 3** | Fenetre d'invalidation post-validation | #888 | server + web | 🔴 |
+
+## Modeles Prisma ajoutes (5)
+
+| Modele | Lot | Migration | Description |
+|--------|-----|-----------|-------------|
+| `LeagueInvitation` | A | `20260605120000` | Invitation coach (code unique, statut, expiration 1-90j) |
+| `LeaguePool` | C.1 | `20260605140000` | Poule d'une saison (qualifiesForPlayoffs, order, color) |
+| `LeagueMatchSheet` | G.1 | `20260605160000` | Feuille de match 1-1 pairing (FSM + snapshots pre/post-match) |
+| `LeagueMatchEvent` | G.1 | id. | Evenement unitaire normalise (10 kinds) |
+| (champs) `League.bonusPointsConfig` | E | `20260605130000` | JSON regles de bonus |
+| (champs) `LeaguePairing.bonusPoints*` | E | id. | Snapshot bonus applique + breakdown |
+| (champs) `LeagueParticipant.poolId`, `LeagueRound.poolId` | C.1 | `20260605140000` | Rattachement poule (nullable) |
+
+> Mirror SQLite (`apps/server/prisma/sqlite/schema.prisma`) mis a jour
+> en parallele pour les colonnes Json -> String (cf. CLAUDE.md "parser
+> tolerant PG + sqlite").
+
+## Surfaces backend ajoutees
+
+### Nouveaux services
+- `league-invitation.ts` (A) — createInvitation (idempotent), accept/decline/cancel, expireOldInvitations, code crypto-safe.
+- `league-manual-pairing.ts` (F) — createManualRound/Pairing, delete/update, garde-fous (doublon, played, round completed).
+- `league-bonus-points.ts` (E, **pur**) — evaluateBonusRules + parseBonusConfig (PG/sqlite) + BONUS_PRESETS.
+- `league-pool.ts` (C.1) — createPool/update/delete, assign/auto-assign (snake draft), computeSnakeDraftAssignment (pur).
+- `league-player-stats.ts` (J) — computeLeaderboards (7 categories), computeLeaderboardsByTeam.
+- `commissioner-team-edit.ts` (I) — adjustPlayerSpp/addSkill/removeSkill/adjustCharacteristic/adjustTreasury + AuditLog.
+- `league-match-summary.ts` (G.1, **pur**) — summarizeMatchSheet (score/cas/blesses/stats joueurs), computeWinnings (Polish 2).
+- `league-match-sheet.ts` (G.1/G.2/H/Polish) — FSM complete + validation (branchee sur recordOfflineLeagueResult) + invalidation (reverse) + pending list + notify commissaire.
+
+### Services etendus
+- `league.ts` — withdrawParticipant (LeagueWithdrawError, Lot B), bonusPointsConfig (E), computeSeasonStandingsByPool (C.1).
+- `league-scheduler.ts` — buildSchedule (global vs multi-poules, C.2).
+- `league-schedule.ts` — generateMultiPoolRoundRobin (pur, C.2).
+- `league-playoffs.ts` — overridePlayoffParticipants (D).
+- `league-match-result.ts` — application des points bonus (E).
+- `notification-preferences.ts` / `push-notifications.ts` — NotificationType.LeagueMatchValidation (H).
+
+### Routes
+Toutes montees sous `/leagues` (+ `/admin/leagues` pour le force-withdraw).
+Nouvelles familles : invitations, pools, manual pairings, playoff-bracket
+override, leaderboards, commissioner team-edit, match sheet
+(`/pairings/:id/sheet/*` : get/create/pre-match/post-match/events/
+submit/unsubmit/validate/invalidate/can-invalidate), pending-validations.
+
+## Feature flags (8)
+
+`league` (umbrella historique) + 7 sous-flags : `league_invitations`,
+`league_bonus_points`, `league_manual_pairings`, `league_pools`,
+`league_leaderboards`, `league_commissioner_edit`, `league_match_sheet`.
+
+> Tous OFF par defaut. Strategie d'activation : voir
+> [`docs/roadmap/league-feature-flags-rollout.md`](../league-feature-flags-rollout.md).
+
+## Tests
+
+~260 tests ajoutes (majoritairement unit sur services purs + handlers).
+Suite ligue verte sur les 3 PRs. Pattern de mock : prisma + services
+reutilises mockes (cf. CLAUDE.md). Les fonctions pures (summarizer,
+bonus rules, snake draft, winnings, multi-pool generator) sont
+testees sans DB.
+
+## Pieges rencontres
+
+- **CI rouge pre-existante (#886)** : `validate-season3-rules.test.ts`
+  echouait car le roster High Elf S3 (`season3-rosters.ts`) avait ete
+  reecrit sans mettre a jour `season3-reference-data.ts`. Fix : aligner
+  la reference sur le roster thematique (source de verite Hauts_elfes.md).
+  Lecon : un `.js` compile gitignore peut masquer le `.ts` sous `tsc`
+  nu — supprimer les artefacts pour tester contre la source.
+- **typedRoutes Next.js** : `Link href={template}` echoue sous `tsc` nu
+  (pas de `.next/types`) mais passe au `next build` CI tant que la route
+  existe. Verifie en comparant aux pages deja mergees.
+- **z.record** : signature 2 args (`z.record(z.string(), z.unknown())`)
+  dans la version Zod du repo.
+
+## Reste / pistes futures
+
+- Editeurs riches inducements / prieres de Nuffle / achats detailles
+  (le backend stocke deja le JSON ; l'UI actuelle couvre le coeur).
+- Per-season player stats (les classements Lot J sont sur les totaux
+  carriere ; une agregation par-saison via les events de la feuille de
+  match v2 serait plus precise — categories killer/catapulte/agresseur
+  dependent de ces events).


### PR DESCRIPTION
## Contexte

Documentation récapitulative de la session "gestion des ligues" (audit _Liste de course Nuffle Arena_, 3 PR mergées : #886, #887, #888) + guide d'activation des feature flags pour le rollout progressif demandé.

Docs only — aucune modification de code.

## Contenu

**`docs/roadmap/sessions/2026-06-06-league-management.md`**
- Récap des lots (A→J + C.2 + G + H + polish) avec PR, surface et couleur d'importance du fichier source.
- 5 migrations Prisma + nouveaux modèles (`LeagueInvitation`, `LeaguePool`, `LeagueMatchSheet`, `LeagueMatchEvent`, champs bonus/pool).
- Inventaire des services (purs + étendus) et familles de routes.
- Pièges rencontrés (fix CI roster High Elf, typedRoutes Next.js, `z.record` 2-args).

**`docs/roadmap/league-feature-flags-rollout.md`**
- Règle d'évaluation des flags (force CI / admin / global / override par-user).
- Tableau des 8 flags `league*` + dépendances (le `league` umbrella d'abord).
- API/UI admin (`/admin/feature-flags`, `/sync`, overrides par-user).
- Séquence recommandée : matérialiser → cohorte pilote (coeur) → élargir features → cohorte large → bascule globale.
- Rollback + pièges (CI force-enable, bypass admin, dépendance implicite).

**`CLAUDE.md`** — entrée 2026-06-06 ajoutée à l'historique des sessions (convention du repo).

## Test plan

- [ ] Relecture des deux docs (exactitude des routes, flags, migrations).
- [ ] Liens internes valides.

https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRCfwP5WUfMY6Dc6raNrub)_