### PR TITLE
feat(seo): comparateur de rosters + pages de comparaison SSR + tier-list

### DIFF
--- a/apps/web/app/teams/TeamsListClient.tsx
+++ b/apps/web/app/teams/TeamsListClient.tsx
@@ -125,6 +125,20 @@ export default function TeamsListClient({
         <p className="text-sm sm:text-base text-gray-600">
           {t.teams.allTeamsDescription}
         </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link
+            href="/teams/comparer"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors"
+          >
+            ⚔️ {language === "en" ? "Compare teams" : "Comparer les équipes"}
+          </Link>
+          <Link
+            href="/teams/tier-list"
+            className="inline-flex items-center gap-1.5 rounded-lg border-2 border-blue-200 px-4 py-2 text-sm font-semibold text-blue-800 hover:border-blue-400 transition-colors"
+          >
+            🏆 {language === "en" ? "Tier list" : "Tier list"}
+          </Link>
+        </div>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-4 bg-white p-4 rounded-lg border border-gray-200">

--- a/apps/web/app/teams/[slug]/TeamDetailClient.tsx
+++ b/apps/web/app/teams/[slug]/TeamDetailClient.tsx
@@ -216,7 +216,7 @@ export default function TeamDetailClient({
               )}
             </span>
           </div>
-          <div className="mt-3">
+          <div className="mt-3 flex flex-wrap items-center gap-3">
             <ShareBar
               url={`${SITE_URL}/teams/${slug}`}
               title={
@@ -227,6 +227,12 @@ export default function TeamDetailClient({
               copyLabel={language === "en" ? "Copy link" : "Copier le lien"}
               copiedLabel={language === "en" ? "Link copied!" : "Lien copié !"}
             />
+            <Link
+              href={`/teams/comparer?teams=${slug}`}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-blue-300 px-3 py-1.5 text-xs sm:text-sm font-medium text-blue-700 hover:border-blue-500 hover:bg-blue-50 transition-colors"
+            >
+              ⚔️ {language === "en" ? "Compare this team" : "Comparer cette équipe"}
+            </Link>
           </div>
         </div>
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">

--- a/apps/web/app/teams/comparer/RosterComparatorClient.tsx
+++ b/apps/web/app/teams/comparer/RosterComparatorClient.tsx
@@ -1,0 +1,473 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import TeamLogo from "../../components/TeamLogo";
+import { useLanguage } from "../../contexts/LanguageContext";
+import type { RosterSummary, Season } from "../TeamsListClient";
+import {
+  getRosterMeta,
+  DIFFICULTY_LABELS,
+  DIFFICULTY_RANK,
+  PLAYSTYLE_LABELS,
+  type Lang,
+} from "../roster-meta";
+import { canonicalMatchup } from "../matchup";
+import { COMPARATOR_I18N } from "./comparator-i18n";
+
+const API_BASE_PUBLIC =
+  process.env.NEXT_PUBLIC_API_BASE ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8201";
+
+const MAX_SELECTION = 3;
+const MIN_SELECTION = 2;
+
+interface RosterComparatorClientProps {
+  initialRosters: RosterSummary[];
+  initialSeason: Season;
+  /** Slugs pré-sélectionnés (lien partagé), optionnel. */
+  initialSelected?: string[];
+}
+
+function tierBadgeClass(tier: string): string {
+  switch (tier) {
+    case "I":
+      return "bg-emerald-100 text-emerald-800 ring-emerald-300";
+    case "II":
+      return "bg-sky-100 text-sky-800 ring-sky-300";
+    case "III":
+      return "bg-amber-100 text-amber-800 ring-amber-300";
+    case "IV":
+      return "bg-orange-100 text-orange-800 ring-orange-300";
+    default:
+      return "bg-gray-100 text-gray-700 ring-gray-300";
+  }
+}
+
+/** Petite échelle visuelle 1→3 pour la difficulté (jetons or). */
+function DifficultyScale({ rank }: { rank: number }) {
+  return (
+    <span className="inline-flex items-center gap-1" aria-hidden="true">
+      {[1, 2, 3].map((i) => (
+        <span
+          key={i}
+          className={`h-2.5 w-2.5 rounded-full ${
+            i <= rank ? "bg-nuffle-gold" : "bg-nuffle-bronze/20"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default function RosterComparatorClient({
+  initialRosters,
+  initialSeason,
+  initialSelected,
+}: RosterComparatorClientProps) {
+  const { language } = useLanguage();
+  const lang: Lang = language === "en" ? "en" : "fr";
+  const tr = COMPARATOR_I18N[lang];
+
+  const [rosters, setRosters] = useState<RosterSummary[]>(initialRosters);
+  const [selected, setSelected] = useState<string[]>(() => {
+    const known = new Set(initialRosters.map((r) => r.slug));
+    return (initialSelected ?? []).filter((s) => known.has(s)).slice(0, MAX_SELECTION);
+  });
+  const [query, setQuery] = useState("");
+
+  // Re-fetch English names when the user toggles away from the default (fr).
+  useEffect(() => {
+    if (language === "fr") {
+      setRosters(initialRosters);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch(
+          `${API_BASE_PUBLIC}/api/rosters?lang=en&ruleset=${initialSeason}`,
+        );
+        if (!response.ok) return;
+        const data = await response.json();
+        if (cancelled) return;
+        setRosters(
+          data.rosters.map((r: any) => ({
+            slug: r.slug,
+            name: r.name,
+            budget: r.budget,
+            tier: r.tier,
+            naf: r.naf,
+            positionCount: r._count?.positions ?? 0,
+          })),
+        );
+      } catch {
+        // Keep the initial server-rendered rosters on failure.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [language, initialRosters, initialSeason]);
+
+  const bySlug = useMemo(
+    () => new Map(rosters.map((r) => [r.slug, r])),
+    [rosters],
+  );
+
+  const selectedRosters = useMemo(
+    () => selected.map((s) => bySlug.get(s)).filter((r): r is RosterSummary => Boolean(r)),
+    [selected, bySlug],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const list = q
+      ? rosters.filter((r) => r.name.toLowerCase().includes(q))
+      : rosters;
+    return [...list].sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier.localeCompare(b.tier);
+      return a.name.localeCompare(b.name);
+    });
+  }, [rosters, query]);
+
+  const atMax = selected.length >= MAX_SELECTION;
+
+  function toggle(slug: string) {
+    setSelected((prev) => {
+      if (prev.includes(slug)) return prev.filter((s) => s !== slug);
+      if (prev.length >= MAX_SELECTION) return prev;
+      return [...prev, slug];
+    });
+  }
+
+  // Lien partageable indexable quand exactement 2 équipes sont choisies.
+  const shareMatchup =
+    selectedRosters.length === 2
+      ? canonicalMatchup(selectedRosters[0].slug, selectedRosters[1].slug)
+      : null;
+
+  return (
+    <div className="w-full max-w-6xl mx-auto p-4 sm:p-6 space-y-6 font-body">
+      <nav
+        aria-label="Fil d'Ariane"
+        className="text-sm font-subtitle text-nuffle-bronze/80"
+      >
+        <ol className="flex flex-wrap items-center gap-1.5">
+          <li>
+            <Link href="/" className="hover:text-nuffle-gold transition-colors">
+              {lang === "en" ? "Home" : "Accueil"}
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link href="/teams" className="hover:text-nuffle-gold transition-colors">
+              {lang === "en" ? "Teams" : "Équipes"}
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="text-nuffle-anthracite font-semibold" aria-current="page">
+            {lang === "en" ? "Compare" : "Comparer"}
+          </li>
+        </ol>
+      </nav>
+
+      <header>
+        <h1 className="font-heading font-bold text-3xl sm:text-4xl text-nuffle-anthracite leading-tight">
+          {tr.pageTitle}
+        </h1>
+        <p className="mt-2 text-nuffle-bronze/90 max-w-3xl">{tr.pageIntro}</p>
+        <div className="mt-3 flex flex-wrap gap-3 text-sm font-subtitle">
+          <Link
+            href="/teams/tier-list"
+            className="inline-flex items-center gap-1.5 rounded-full bg-[#1B1610] px-4 py-1.5 font-bold uppercase tracking-wide text-nuffle-gold ring-1 ring-nuffle-gold/50 hover:bg-[#241c12] transition-colors"
+          >
+            🏆 {tr.tierList}
+          </Link>
+          <Link
+            href="/teams"
+            className="inline-flex items-center gap-1.5 rounded-full border-2 border-nuffle-bronze/40 px-4 py-1.5 font-bold uppercase tracking-wide text-nuffle-bronze hover:border-nuffle-gold hover:text-nuffle-anthracite transition-colors"
+          >
+            {tr.backToTeams}
+          </Link>
+        </div>
+      </header>
+
+      {/* Sélecteur d'équipes */}
+      <section className="rounded-2xl bg-[#FBF7EC] border border-nuffle-bronze/20 p-4 sm:p-6 shadow-[0_2px_10px_rgba(107,78,46,0.06)]">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h2 className="font-heading font-bold text-xl text-nuffle-anthracite">
+              {tr.pick}
+            </h2>
+            <p className="text-sm text-nuffle-bronze/80 mt-0.5">{tr.pickHint}</p>
+          </div>
+          {selected.length > 0 && (
+            <button
+              onClick={() => setSelected([])}
+              className="self-start sm:self-auto text-sm font-subtitle font-semibold text-nuffle-red hover:underline"
+            >
+              {tr.clear} ({selected.length})
+            </button>
+          )}
+        </div>
+
+        <div className="mt-4">
+          <label htmlFor="roster-search" className="sr-only">
+            {tr.search}
+          </label>
+          <input
+            id="roster-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={tr.search}
+            className="w-full rounded-xl border border-nuffle-bronze/30 bg-white/70 px-4 py-2.5 text-nuffle-anthracite placeholder:text-nuffle-bronze/50 focus:outline-none focus:ring-2 focus:ring-nuffle-gold/60"
+          />
+        </div>
+
+        {atMax && (
+          <p className="mt-2 text-xs font-subtitle text-nuffle-bronze/70">
+            {tr.maxReached}
+          </p>
+        )}
+
+        <div
+          className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2.5"
+          data-testid="comparator-picker"
+        >
+          {filtered.map((roster) => {
+            const isSelected = selected.includes(roster.slug);
+            const disabled = !isSelected && atMax;
+            return (
+              <button
+                key={roster.slug}
+                type="button"
+                onClick={() => toggle(roster.slug)}
+                disabled={disabled}
+                aria-pressed={isSelected}
+                data-testid={`picker-${roster.slug}`}
+                className={`flex items-center gap-2.5 rounded-xl border px-3 py-2.5 text-left transition-all ${
+                  isSelected
+                    ? "border-nuffle-gold bg-nuffle-gold/10 ring-1 ring-nuffle-gold/50"
+                    : disabled
+                      ? "border-nuffle-bronze/10 bg-white/40 opacity-50 cursor-not-allowed"
+                      : "border-nuffle-bronze/20 bg-white/70 hover:border-nuffle-gold/60 hover:-translate-y-0.5"
+                }`}
+              >
+                <TeamLogo slug={roster.slug} size={32} title={roster.name} />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-subtitle font-semibold text-sm text-nuffle-anthracite">
+                    {roster.name}
+                  </span>
+                  <span className="block text-xs text-nuffle-bronze/70">
+                    {tr.tier} {roster.tier}
+                  </span>
+                </span>
+                {isSelected && (
+                  <span className="text-nuffle-gold font-bold" aria-hidden="true">
+                    ✓
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {filtered.length === 0 && (
+          <p className="mt-4 text-center text-nuffle-bronze/70">{tr.emptyState}</p>
+        )}
+      </section>
+
+      {/* Comparaison */}
+      {selectedRosters.length < MIN_SELECTION ? (
+        <p
+          className="rounded-xl border border-dashed border-nuffle-bronze/30 bg-white/40 px-4 py-6 text-center text-nuffle-bronze/80 font-subtitle"
+          data-testid="comparator-hint"
+        >
+          {tr.minSelection}
+        </p>
+      ) : (
+        <section data-testid="comparator-result" className="space-y-4">
+          {shareMatchup && (
+            <div className="rounded-xl border border-nuffle-bronze/20 bg-white/60 px-4 py-3 text-sm">
+              <span className="font-subtitle font-semibold text-nuffle-bronze">
+                {tr.shareableLink} :{" "}
+              </span>
+              <Link
+                href={`/teams/comparer/${shareMatchup}`}
+                className="font-mono text-nuffle-gold hover:underline break-all"
+              >
+                /teams/comparer/{shareMatchup}
+              </Link>
+            </div>
+          )}
+
+          <div className="overflow-x-auto rounded-2xl border border-nuffle-bronze/20 bg-[#FBF7EC] shadow-[0_2px_10px_rgba(107,78,46,0.06)]">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="sticky left-0 z-10 bg-[#1B1610] text-left px-4 py-3 font-subtitle text-xs uppercase tracking-wide text-nuffle-gold">
+                    {/* coin */}
+                  </th>
+                  {selectedRosters.map((roster) => (
+                    <th
+                      key={roster.slug}
+                      className="bg-[#1B1610] px-4 py-3 text-center align-bottom min-w-[160px]"
+                    >
+                      <span className="flex flex-col items-center gap-2">
+                        <TeamLogo slug={roster.slug} size={44} title={roster.name} />
+                        <span className="font-heading font-bold text-nuffle-ivory leading-tight">
+                          {roster.name}
+                        </span>
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-nuffle-bronze/15">
+                <ComparisonRow label={tr.tier}>
+                  {selectedRosters.map((r) => (
+                    <td key={r.slug} className="px-4 py-3 text-center">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-bold ring-1 ${tierBadgeClass(r.tier)}`}
+                      >
+                        {tr.tier} {r.tier}
+                      </span>
+                    </td>
+                  ))}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.budget}>
+                  {selectedRosters.map((r) => (
+                    <td key={r.slug} className="px-4 py-3 text-center font-score text-lg text-nuffle-anthracite">
+                      {r.budget}k
+                    </td>
+                  ))}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.positions}>
+                  {selectedRosters.map((r) => (
+                    <td key={r.slug} className="px-4 py-3 text-center font-semibold text-nuffle-anthracite">
+                      {r.positionCount}
+                    </td>
+                  ))}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.difficulty}>
+                  {selectedRosters.map((r) => {
+                    const meta = getRosterMeta(r.slug);
+                    return (
+                      <td key={r.slug} className="px-4 py-3">
+                        <span className="flex flex-col items-center gap-1.5">
+                          <DifficultyScale rank={DIFFICULTY_RANK[meta.difficulty]} />
+                          <span className="text-xs font-subtitle text-nuffle-bronze">
+                            {DIFFICULTY_LABELS[lang][meta.difficulty]}
+                          </span>
+                        </span>
+                      </td>
+                    );
+                  })}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.playStyle}>
+                  {selectedRosters.map((r) => {
+                    const meta = getRosterMeta(r.slug);
+                    return (
+                      <td key={r.slug} className="px-4 py-3 text-center">
+                        <span className="inline-flex items-center rounded-full border border-nuffle-bronze/30 bg-white/60 px-3 py-0.5 text-xs font-subtitle font-semibold text-nuffle-bronze">
+                          {PLAYSTYLE_LABELS[lang][meta.playStyle]}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.nafApproved}>
+                  {selectedRosters.map((r) => (
+                    <td key={r.slug} className="px-4 py-3 text-center">
+                      {r.naf ? (
+                        <span className="text-nuffle-gold font-bold">NAF</span>
+                      ) : (
+                        <span className="text-nuffle-bronze/70">{tr.official}</span>
+                      )}
+                    </td>
+                  ))}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.starPlayers}>
+                  {selectedRosters.map((r) => {
+                    const meta = getRosterMeta(r.slug);
+                    return (
+                      <td key={r.slug} className="px-4 py-3 text-center align-top">
+                        {meta.starPlayers.length > 0 ? (
+                          <ul className="space-y-0.5 text-xs text-nuffle-anthracite/80">
+                            {meta.starPlayers.map((sp) => (
+                              <li key={sp}>{sp}</li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <span className="text-nuffle-bronze/50">{tr.noStars}</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </ComparisonRow>
+
+                <ComparisonRow label={tr.summary}>
+                  {selectedRosters.map((r) => {
+                    const meta = getRosterMeta(r.slug);
+                    return (
+                      <td key={r.slug} className="px-4 py-3 align-top text-left text-xs text-nuffle-anthracite/80 leading-relaxed">
+                        {lang === "en" ? meta.shortEn : meta.shortFr}
+                      </td>
+                    );
+                  })}
+                </ComparisonRow>
+
+                <tr>
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-[#FBF7EC] px-4 py-3 text-left font-subtitle text-xs uppercase tracking-wide text-nuffle-bronze/70"
+                  >
+                    {tr.viewDetail}
+                  </th>
+                  {selectedRosters.map((r) => (
+                    <td key={r.slug} className="px-4 py-3 text-center">
+                      <Link
+                        href={`/teams/${r.slug}?ruleset=${initialSeason}`}
+                        className="inline-flex items-center gap-1 rounded-lg bg-nuffle-gold/15 px-3 py-1.5 text-xs font-subtitle font-bold text-nuffle-bronze hover:bg-nuffle-gold/30 transition-colors"
+                      >
+                        {tr.viewDetail} →
+                      </Link>
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ComparisonRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <tr>
+      <th
+        scope="row"
+        className="sticky left-0 z-10 bg-[#FBF7EC] px-4 py-3 text-left font-subtitle text-xs uppercase tracking-wide text-nuffle-bronze/70 whitespace-nowrap"
+      >
+        {label}
+      </th>
+      {children}
+    </tr>
+  );
+}

--- a/apps/web/app/teams/comparer/[matchup]/page.tsx
+++ b/apps/web/app/teams/comparer/[matchup]/page.tsx
@@ -1,0 +1,411 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import {
+  fetchServerJson,
+  safeServerJson,
+  getServerApiBase,
+} from "../../../lib/serverApi";
+import StructuredData from "../../../components/StructuredData";
+import TeamLogo from "../../../components/TeamLogo";
+import { parseMatchup, canonicalMatchup } from "../../matchup";
+import {
+  getRosterMeta,
+  DIFFICULTY_LABELS,
+  DIFFICULTY_RANK,
+  PLAYSTYLE_LABELS,
+} from "../../roster-meta";
+import { buildComparisonSchema } from "../../comparison-structured-data";
+import { buildComparisonSummary } from "../../comparison-summary";
+
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr"
+).replace(/\/$/, "");
+
+// ISR — données de référence. Pas de generateStaticParams pour ne pas
+// dépendre du backend au build : rendu à la demande puis caché (cf.
+// teams/[slug]).
+export const revalidate = 3600;
+
+interface MatchupRoster {
+  slug: string;
+  name: string;
+  budget: number;
+  tier: string;
+  naf: boolean;
+  positionCount: number;
+}
+
+interface MatchupPageProps {
+  params: { matchup: string };
+}
+
+async function fetchRoster(
+  slug: string,
+  throwing: boolean,
+): Promise<MatchupRoster | null> {
+  const base = getServerApiBase();
+  const url = `${base}/api/rosters/${encodeURIComponent(slug)}?lang=fr&ruleset=season_3`;
+  const fetcher = throwing ? fetchServerJson : safeServerJson;
+  const data = await fetcher<{ roster?: any }>(url, {
+    next: { revalidate: 3600 },
+  });
+  if (!data?.roster) return null;
+  const r = data.roster;
+  return {
+    slug: r.slug,
+    name: r.name,
+    budget: r.budget,
+    tier: r.tier,
+    naf: r.naf,
+    positionCount: Array.isArray(r.positions) ? r.positions.length : 0,
+  };
+}
+
+export async function generateMetadata({
+  params,
+}: MatchupPageProps): Promise<Metadata> {
+  const parsed = parseMatchup(params.matchup);
+  if (!parsed) {
+    return { title: "Comparaison introuvable", robots: { index: false, follow: true } };
+  }
+  const canonical = canonicalMatchup(parsed.a, parsed.b);
+  const canonicalUrl = `${BASE_URL}/teams/comparer/${canonical}`;
+  const [a, b] = await Promise.all([
+    fetchRoster(parsed.a, false),
+    fetchRoster(parsed.b, false),
+  ]);
+  if (!a || !b) {
+    return { title: "Comparaison introuvable", robots: { index: false, follow: true } };
+  }
+
+  const title = `${a.name} vs ${b.name} — Comparatif Blood Bowl`;
+  const description = `Comparez ${a.name} (Tier ${a.tier}) et ${b.name} (Tier ${b.tier}) sur Blood Bowl : budget, positions, difficulté, style de jeu et Star Players. Quel roster choisir ?`;
+  return {
+    title,
+    description,
+    keywords: [
+      `${a.name} vs ${b.name}`,
+      `comparatif ${a.name}`,
+      `comparatif ${b.name}`,
+      "Blood Bowl",
+      "comparateur rosters",
+      "Nuffle Arena",
+    ],
+    alternates: {
+      canonical: canonicalUrl,
+      languages: { "fr-FR": canonicalUrl, en: canonicalUrl, "x-default": canonicalUrl },
+    },
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      url: canonicalUrl,
+      siteName: "Nuffle Arena",
+      images: [
+        {
+          url: `${BASE_URL}/images/logo.png`,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+const TIER_BADGE: Record<string, string> = {
+  I: "bg-emerald-100 text-emerald-800 ring-emerald-300",
+  II: "bg-sky-100 text-sky-800 ring-sky-300",
+  III: "bg-amber-100 text-amber-800 ring-amber-300",
+  IV: "bg-orange-100 text-orange-800 ring-orange-300",
+};
+
+function DifficultyScale({ rank }: { rank: number }) {
+  return (
+    <span className="inline-flex items-center gap-1" aria-hidden="true">
+      {[1, 2, 3].map((i) => (
+        <span
+          key={i}
+          className={`h-2.5 w-2.5 rounded-full ${
+            i <= rank ? "bg-nuffle-gold" : "bg-nuffle-bronze/20"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default async function MatchupPage({ params }: MatchupPageProps) {
+  const parsed = parseMatchup(params.matchup);
+  if (!parsed) {
+    notFound();
+  }
+
+  // Canonicalisation : redirige toute variante non triée vers la version
+  // canonique pour éviter le contenu dupliqué (a-vs-b == b-vs-a).
+  const canonical = canonicalMatchup(parsed.a, parsed.b);
+  if (params.matchup !== canonical) {
+    redirect(`/teams/comparer/${canonical}`);
+  }
+
+  const [a, b] = await Promise.all([
+    fetchRoster(parsed.a, true),
+    fetchRoster(parsed.b, true),
+  ]);
+  if (!a || !b) {
+    notFound();
+  }
+
+  const teams: [MatchupRoster, MatchupRoster] = [a, b];
+  const metaA = getRosterMeta(a.slug);
+  const metaB = getRosterMeta(b.slug);
+  const summary = buildComparisonSummary(
+    { name: a.name, tier: a.tier, difficulty: metaA.difficulty, playStyle: metaA.playStyle },
+    { name: b.name, tier: b.tier, difficulty: metaB.difficulty, playStyle: metaB.playStyle },
+    "fr",
+  );
+
+  const rows: Array<{ label: string; render: (t: MatchupRoster) => React.ReactNode }> = [
+    {
+      label: "Tier",
+      render: (t) => (
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-bold ring-1 ${TIER_BADGE[t.tier] ?? "bg-gray-100 text-gray-700 ring-gray-300"}`}
+        >
+          Tier {t.tier}
+        </span>
+      ),
+    },
+    {
+      label: "Budget",
+      render: (t) => (
+        <span className="font-score text-lg text-nuffle-anthracite">{t.budget}k</span>
+      ),
+    },
+    {
+      label: "Positions",
+      render: (t) => (
+        <span className="font-semibold text-nuffle-anthracite">{t.positionCount}</span>
+      ),
+    },
+    {
+      label: "Difficulté",
+      render: (t) => {
+        const meta = getRosterMeta(t.slug);
+        return (
+          <span className="flex flex-col items-center gap-1.5">
+            <DifficultyScale rank={DIFFICULTY_RANK[meta.difficulty]} />
+            <span className="text-xs font-subtitle text-nuffle-bronze">
+              {DIFFICULTY_LABELS.fr[meta.difficulty]}
+            </span>
+          </span>
+        );
+      },
+    },
+    {
+      label: "Style de jeu",
+      render: (t) => {
+        const meta = getRosterMeta(t.slug);
+        return (
+          <span className="inline-flex items-center rounded-full border border-nuffle-bronze/30 bg-white/60 px-3 py-0.5 text-xs font-subtitle font-semibold text-nuffle-bronze">
+            {PLAYSTYLE_LABELS.fr[meta.playStyle]}
+          </span>
+        );
+      },
+    },
+    {
+      label: "Statut NAF",
+      render: (t) =>
+        t.naf ? (
+          <span className="text-nuffle-gold font-bold">NAF</span>
+        ) : (
+          <span className="text-nuffle-bronze/70">Officielle</span>
+        ),
+    },
+    {
+      label: "Star Players emblématiques",
+      render: (t) => {
+        const meta = getRosterMeta(t.slug);
+        return meta.starPlayers.length > 0 ? (
+          <ul className="space-y-0.5 text-xs text-nuffle-anthracite/80">
+            {meta.starPlayers.map((sp) => (
+              <li key={sp}>{sp}</li>
+            ))}
+          </ul>
+        ) : (
+          <span className="text-nuffle-bronze/50">—</span>
+        );
+      },
+    },
+    {
+      label: "En bref",
+      render: (t) => {
+        const meta = getRosterMeta(t.slug);
+        return (
+          <span className="text-xs text-nuffle-anthracite/80 leading-relaxed">
+            {meta.shortFr}
+          </span>
+        );
+      },
+    },
+  ];
+
+  return (
+    <>
+      <StructuredData
+        data={buildComparisonSchema({
+          teams: [
+            { slug: a.slug, name: a.name },
+            { slug: b.slug, name: b.name },
+          ],
+          baseUrl: BASE_URL,
+          lang: "fr",
+        })}
+      />
+
+      <div className="w-full max-w-5xl mx-auto p-4 sm:p-6 space-y-6 font-body">
+        {/* Fil d'Ariane */}
+        <nav
+          aria-label="Fil d'Ariane"
+          className="text-sm font-subtitle text-nuffle-bronze/80"
+        >
+          <ol className="flex flex-wrap items-center gap-1.5">
+            <li>
+              <Link href="/" className="hover:text-nuffle-gold transition-colors">
+                Accueil
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link href="/teams" className="hover:text-nuffle-gold transition-colors">
+                Équipes
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href="/teams/comparer"
+                className="hover:text-nuffle-gold transition-colors"
+              >
+                Comparer
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-nuffle-anthracite font-semibold" aria-current="page">
+              {a.name} vs {b.name}
+            </li>
+          </ol>
+        </nav>
+
+        <header className="rounded-2xl bg-[#FBF7EC] border border-nuffle-bronze/20 p-6 sm:p-8 shadow-[0_2px_10px_rgba(107,78,46,0.06)]">
+          <h1 className="font-heading font-bold text-2xl sm:text-3xl md:text-4xl text-nuffle-anthracite leading-tight">
+            {a.name} <span className="text-nuffle-gold">vs</span> {b.name}
+          </h1>
+          <p className="mt-1 font-subtitle text-nuffle-bronze/80 uppercase tracking-wide text-sm">
+            Comparatif de rosters Blood Bowl — Saison 3
+          </p>
+
+          <div className="mt-5 flex items-center justify-center gap-4 sm:gap-8">
+            <Link
+              href={`/teams/${a.slug}`}
+              className="group flex flex-col items-center gap-2"
+            >
+              <TeamLogo slug={a.slug} size={72} title={a.name} />
+              <span className="font-heading font-bold text-nuffle-anthracite group-hover:text-nuffle-gold transition-colors">
+                {a.name}
+              </span>
+            </Link>
+            <span
+              className="font-score text-3xl sm:text-4xl text-nuffle-bronze/50"
+              aria-hidden="true"
+            >
+              VS
+            </span>
+            <Link
+              href={`/teams/${b.slug}`}
+              className="group flex flex-col items-center gap-2"
+            >
+              <TeamLogo slug={b.slug} size={72} title={b.name} />
+              <span className="font-heading font-bold text-nuffle-anthracite group-hover:text-nuffle-gold transition-colors">
+                {b.name}
+              </span>
+            </Link>
+          </div>
+
+          <p className="mt-6 text-nuffle-anthracite/85 leading-relaxed">{summary}</p>
+        </header>
+
+        {/* Tableau comparatif */}
+        <div className="overflow-x-auto rounded-2xl border border-nuffle-bronze/20 bg-[#FBF7EC] shadow-[0_2px_10px_rgba(107,78,46,0.06)]">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr>
+                <th className="bg-[#1B1610] px-4 py-3 text-left font-subtitle text-xs uppercase tracking-wide text-nuffle-gold" />
+                {teams.map((t) => (
+                  <th
+                    key={t.slug}
+                    className="bg-[#1B1610] px-4 py-3 text-center min-w-[140px]"
+                  >
+                    <span className="font-heading font-bold text-nuffle-ivory">
+                      {t.name}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-nuffle-bronze/15">
+              {rows.map((row) => (
+                <tr key={row.label}>
+                  <th
+                    scope="row"
+                    className="bg-[#FBF7EC] px-4 py-3 text-left font-subtitle text-xs uppercase tracking-wide text-nuffle-bronze/70 whitespace-nowrap align-top"
+                  >
+                    {row.label}
+                  </th>
+                  {teams.map((t) => (
+                    <td
+                      key={t.slug}
+                      className={`px-4 py-3 align-top ${row.label === "En bref" ? "text-left" : "text-center"}`}
+                    >
+                      {row.render(t)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Maillage interne + CTA */}
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={`/teams/${a.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-xl bg-nuffle-gold/15 px-4 py-2.5 text-sm font-subtitle font-bold text-nuffle-bronze hover:bg-nuffle-gold/30 transition-colors"
+          >
+            Roster complet {a.name} →
+          </Link>
+          <Link
+            href={`/teams/${b.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-xl bg-nuffle-gold/15 px-4 py-2.5 text-sm font-subtitle font-bold text-nuffle-bronze hover:bg-nuffle-gold/30 transition-colors"
+          >
+            Roster complet {b.name} →
+          </Link>
+          <Link
+            href={`/teams/comparer?teams=${a.slug},${b.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-xl border-2 border-nuffle-bronze/40 px-4 py-2.5 text-sm font-subtitle font-bold text-nuffle-bronze hover:border-nuffle-gold hover:text-nuffle-anthracite transition-colors"
+          >
+            Comparer d'autres équipes
+          </Link>
+          <Link
+            href="/teams/tier-list"
+            className="inline-flex items-center gap-1.5 rounded-xl border-2 border-nuffle-bronze/40 px-4 py-2.5 text-sm font-subtitle font-bold text-nuffle-bronze hover:border-nuffle-gold hover:text-nuffle-anthracite transition-colors"
+          >
+            🏆 Tier list
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/teams/comparer/comparator-i18n.ts
+++ b/apps/web/app/teams/comparer/comparator-i18n.ts
@@ -1,0 +1,97 @@
+/**
+ * Dictionnaire i18n local au comparateur (fr + en, parité garantie en un seul
+ * endroit). Les pages SSR rendent en français ; le comparateur interactif
+ * bascule via `useLanguage()`.
+ */
+
+import type { Lang } from "../roster-meta";
+
+export interface ComparatorStrings {
+  readonly pageTitle: string;
+  readonly pageIntro: string;
+  readonly pick: string;
+  readonly pickHint: string;
+  readonly add: string;
+  readonly remove: string;
+  readonly compareCta: string;
+  readonly clear: string;
+  readonly search: string;
+  readonly emptyState: string;
+  readonly minSelection: string;
+  readonly maxReached: string;
+  readonly tier: string;
+  readonly budget: string;
+  readonly positions: string;
+  readonly difficulty: string;
+  readonly playStyle: string;
+  readonly starPlayers: string;
+  readonly summary: string;
+  readonly noStars: string;
+  readonly viewDetail: string;
+  readonly shareableLink: string;
+  readonly nafApproved: string;
+  readonly official: string;
+  readonly backToTeams: string;
+  readonly tierList: string;
+}
+
+export const COMPARATOR_I18N: Record<Lang, ComparatorStrings> = {
+  fr: {
+    pageTitle: "Comparateur d'équipes Blood Bowl",
+    pageIntro:
+      "Sélectionnez 2 ou 3 rosters pour les comparer côte à côte : tier, budget, positions, difficulté, style de jeu et Star Players emblématiques.",
+    pick: "Choisir les équipes",
+    pickHint: "Sélectionnez de 2 à 3 équipes à comparer.",
+    add: "Ajouter",
+    remove: "Retirer",
+    compareCta: "Comparer",
+    clear: "Tout effacer",
+    search: "Rechercher une équipe…",
+    emptyState: "Aucune équipe ne correspond à votre recherche.",
+    minSelection: "Sélectionnez au moins 2 équipes pour lancer la comparaison.",
+    maxReached: "Maximum 3 équipes comparées à la fois.",
+    tier: "Tier",
+    budget: "Budget",
+    positions: "Positions",
+    difficulty: "Difficulté",
+    playStyle: "Style de jeu",
+    starPlayers: "Star Players emblématiques",
+    summary: "En bref",
+    noStars: "—",
+    viewDetail: "Voir le roster",
+    shareableLink: "Lien partageable de cette comparaison",
+    nafApproved: "NAF",
+    official: "Officielle",
+    backToTeams: "Toutes les équipes",
+    tierList: "Tier list",
+  },
+  en: {
+    pageTitle: "Blood Bowl team comparator",
+    pageIntro:
+      "Pick 2 or 3 rosters to compare them side by side: tier, budget, positions, difficulty, play style and iconic Star Players.",
+    pick: "Choose teams",
+    pickHint: "Select between 2 and 3 teams to compare.",
+    add: "Add",
+    remove: "Remove",
+    compareCta: "Compare",
+    clear: "Clear all",
+    search: "Search a team…",
+    emptyState: "No team matches your search.",
+    minSelection: "Select at least 2 teams to run the comparison.",
+    maxReached: "Up to 3 teams compared at once.",
+    tier: "Tier",
+    budget: "Budget",
+    positions: "Positions",
+    difficulty: "Difficulty",
+    playStyle: "Play style",
+    starPlayers: "Iconic Star Players",
+    summary: "In short",
+    noStars: "—",
+    viewDetail: "View roster",
+    shareableLink: "Shareable link for this comparison",
+    nafApproved: "NAF",
+    official: "Official",
+    backToTeams: "All teams",
+    tierList: "Tier list",
+  },
+};

--- a/apps/web/app/teams/comparer/layout.tsx
+++ b/apps/web/app/teams/comparer/layout.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+const title = "Comparateur d'équipes Blood Bowl — Comparer les rosters";
+const description =
+  "Comparez 2 à 3 équipes Blood Bowl côte à côte : tier, budget, positions, difficulté, style de jeu et Star Players. Outil interactif pour choisir votre roster.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "Blood Bowl",
+    "comparateur",
+    "comparer équipes",
+    "rosters",
+    "tier",
+    "Nuffle Arena",
+  ],
+  alternates: {
+    canonical: `${BASE_URL}/teams/comparer`,
+    languages: {
+      "fr-FR": `${BASE_URL}/teams/comparer`,
+      en: `${BASE_URL}/teams/comparer`,
+      "x-default": `${BASE_URL}/teams/comparer`,
+    },
+  },
+  openGraph: {
+    title,
+    description,
+    type: "website",
+    url: `${BASE_URL}/teams/comparer`,
+    siteName: "Nuffle Arena",
+    images: [
+      {
+        url: `${BASE_URL}/images/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "Comparateur d'équipes Blood Bowl - Nuffle Arena",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [`${BASE_URL}/images/logo.png`],
+  },
+};
+
+export default function ComparerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/web/app/teams/comparer/page.tsx
+++ b/apps/web/app/teams/comparer/page.tsx
@@ -1,0 +1,58 @@
+import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
+import StructuredData from "../../components/StructuredData";
+import { buildTeamsListSchema } from "../teams-list-structured-data";
+import type { RosterSummary, Season } from "../TeamsListClient";
+import RosterComparatorClient from "./RosterComparatorClient";
+
+const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr"
+).replace(/\/$/, "");
+
+// ISR — données de référence, régénération horaire.
+export const revalidate = 3600;
+
+async function fetchRosters(season: Season): Promise<RosterSummary[]> {
+  const base = getServerApiBase();
+  const data = await fetchServerJson<{ rosters?: any[] }>(
+    `${base}/api/rosters?lang=fr&ruleset=${season}`,
+    { next: { revalidate: 3600 } },
+  );
+  return (data?.rosters ?? []).map((roster: any) => ({
+    slug: roster.slug,
+    name: roster.name,
+    budget: roster.budget,
+    tier: roster.tier,
+    naf: roster.naf,
+    positionCount: roster._count?.positions ?? 0,
+  }));
+}
+
+interface ComparerPageProps {
+  searchParams: { ruleset?: string; teams?: string };
+}
+
+export default async function ComparerPage({ searchParams }: ComparerPageProps) {
+  const season: Season =
+    searchParams.ruleset === "season_2" ? "season_2" : "season_3";
+  const initialRosters = await fetchRosters(season);
+  const initialSelected = (searchParams.teams ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  return (
+    <>
+      <StructuredData
+        data={buildTeamsListSchema({
+          items: initialRosters.map((r) => ({ slug: r.slug, name: r.name })),
+          baseUrl: SITE_URL,
+        })}
+      />
+      <RosterComparatorClient
+        initialRosters={initialRosters}
+        initialSeason={season}
+        initialSelected={initialSelected}
+      />
+    </>
+  );
+}

--- a/apps/web/app/teams/comparison-structured-data.test.ts
+++ b/apps/web/app/teams/comparison-structured-data.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { buildComparisonSchema } from "./comparison-structured-data";
+
+const BASE = "https://nufflearena.fr";
+const TEAMS = [
+  { slug: "skaven", name: "Skavens" },
+  { slug: "orc", name: "Orques" },
+] as const;
+
+function graph(schema: Record<string, unknown>) {
+  return schema["@graph"] as Array<Record<string, unknown>>;
+}
+
+describe("buildComparisonSchema", () => {
+  it("émet CollectionPage + ItemList + BreadcrumbList", () => {
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE });
+    const types = graph(schema).map((n) => n["@type"]);
+    expect(types).toContain("CollectionPage");
+    expect(types).toContain("ItemList");
+    expect(types).toContain("BreadcrumbList");
+  });
+
+  it("liste les deux équipes avec position + URL détail", () => {
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE });
+    const list = graph(schema).find((n) => n["@type"] === "ItemList")!;
+    expect(list.numberOfItems).toBe(2);
+    const els = list.itemListElement as Array<Record<string, unknown>>;
+    expect(els[0]).toMatchObject({
+      position: 1,
+      name: "Skavens",
+      url: `${BASE}/teams/skaven`,
+    });
+    expect(els[1]).toMatchObject({
+      position: 2,
+      name: "Orques",
+      url: `${BASE}/teams/orc`,
+    });
+  });
+
+  it("utilise toujours l'URL canonique (ordre alphabétique des slugs)", () => {
+    // Skaven d'abord, mais l'URL canonique doit trier orc < skaven.
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE });
+    const page = graph(schema).find((n) => n["@type"] === "CollectionPage")!;
+    expect(page.url).toBe(`${BASE}/teams/comparer/orc-vs-skaven`);
+  });
+
+  it("relie la CollectionPage à l'ItemList et à l'Organization", () => {
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE });
+    const page = graph(schema).find((n) => n["@type"] === "CollectionPage")!;
+    expect((page.mainEntity as Record<string, unknown>)["@id"]).toBe(
+      `${BASE}/teams/comparer/orc-vs-skaven#item-list`,
+    );
+    expect((page.isPartOf as Record<string, unknown>)["@id"]).toBe(
+      `${BASE}#organization`,
+    );
+  });
+
+  it("construit un fil d'Ariane à 4 niveaux", () => {
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE });
+    const bc = graph(schema).find((n) => n["@type"] === "BreadcrumbList")!;
+    const els = bc.itemListElement as Array<Record<string, unknown>>;
+    expect(els).toHaveLength(4);
+    expect(els[2]).toMatchObject({ name: "Comparer", item: `${BASE}/teams/comparer` });
+    expect(els[3].item).toBe(`${BASE}/teams/comparer/orc-vs-skaven`);
+  });
+
+  it("traduit les libellés en anglais", () => {
+    const schema = buildComparisonSchema({ teams: TEAMS, baseUrl: BASE, lang: "en" });
+    const bc = graph(schema).find((n) => n["@type"] === "BreadcrumbList")!;
+    const els = bc.itemListElement as Array<Record<string, unknown>>;
+    expect(els[0].name).toBe("Home");
+    expect(els[1].name).toBe("Teams");
+    expect(els[2].name).toBe("Compare");
+  });
+});

--- a/apps/web/app/teams/comparison-structured-data.ts
+++ b/apps/web/app/teams/comparison-structured-data.ts
@@ -1,0 +1,106 @@
+/**
+ * JSON-LD pour une page de comparaison `/teams/comparer/[matchup]`.
+ *
+ * Helper pur (testable sans React) produisant un `@graph` :
+ *   - `ItemList` ordonné des deux équipes comparées, chaque entrée pointant
+ *     vers la page détail `/teams/[slug]` (maillage interne + citabilité LLM :
+ *     « Nuffle Arena compare X et Y »).
+ *   - `BreadcrumbList` : Accueil > Équipes > Comparer > {X vs Y}.
+ *
+ * L'URL de la page utilise toujours le matchup CANONIQUE (ordre alphabétique)
+ * pour éviter de dupliquer l'entité entre `a-vs-b` et `b-vs-a`.
+ */
+
+import { canonicalMatchup } from "./matchup";
+
+const ORG_ID_FRAGMENT = "#organization";
+
+export type Lang = "fr" | "en";
+
+export interface ComparisonTeam {
+  readonly slug: string;
+  readonly name: string;
+}
+
+export interface BuildComparisonSchemaInput {
+  readonly teams: readonly [ComparisonTeam, ComparisonTeam];
+  readonly baseUrl: string;
+  readonly lang?: Lang;
+}
+
+export function buildComparisonSchema(
+  input: BuildComparisonSchemaInput,
+): Record<string, unknown> {
+  const { teams, baseUrl } = input;
+  const lang: Lang = input.lang ?? "fr";
+  const [first, second] = teams;
+  const matchup = canonicalMatchup(first.slug, second.slug);
+  const url = `${baseUrl}/teams/comparer/${matchup}`;
+  const compareUrl = `${baseUrl}/teams/comparer`;
+  const inLanguage = lang === "en" ? "en" : "fr-FR";
+
+  const name =
+    lang === "en"
+      ? `${first.name} vs ${second.name} — Blood Bowl roster comparison`
+      : `${first.name} vs ${second.name} — comparaison de rosters Blood Bowl`;
+
+  const itemList = {
+    "@type": "ItemList",
+    "@id": `${url}#item-list`,
+    name,
+    inLanguage,
+    numberOfItems: 2,
+    itemListElement: teams.map((team, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      name: team.name,
+      url: `${baseUrl}/teams/${team.slug}`,
+    })),
+  };
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${url}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: lang === "en" ? "Home" : "Accueil",
+        item: baseUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: lang === "en" ? "Teams" : "Équipes",
+        item: `${baseUrl}/teams`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: lang === "en" ? "Compare" : "Comparer",
+        item: compareUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: `${first.name} vs ${second.name}`,
+        item: url,
+      },
+    ],
+  };
+
+  const collectionPage = {
+    "@type": "CollectionPage",
+    "@id": `${url}#collection`,
+    url,
+    name,
+    inLanguage,
+    isPartOf: { "@id": `${baseUrl}${ORG_ID_FRAGMENT}` },
+    mainEntity: { "@id": `${url}#item-list` },
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [collectionPage, itemList, breadcrumb],
+  };
+}

--- a/apps/web/app/teams/comparison-summary.test.ts
+++ b/apps/web/app/teams/comparison-summary.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildComparisonSummary, type SummaryTeam } from "./comparison-summary";
+
+const ORC: SummaryTeam = {
+  name: "Orques",
+  tier: "II",
+  difficulty: "beginner",
+  playStyle: "bash",
+};
+const WOOD_ELF: SummaryTeam = {
+  name: "Elfes Sylvains",
+  tier: "I",
+  difficulty: "advanced",
+  playStyle: "agile",
+};
+
+describe("buildComparisonSummary (fr)", () => {
+  it("désigne l'équipe au meilleur tier comme plus compétitive", () => {
+    const text = buildComparisonSummary(ORC, WOOD_ELF);
+    expect(text).toContain("Elfes Sylvains (Tier I) est généralement jugée plus compétitive");
+  });
+
+  it("oppose les styles de jeu différents", () => {
+    const text = buildComparisonSummary(ORC, WOOD_ELF);
+    expect(text.toLowerCase()).toContain("bagarre");
+    expect(text.toLowerCase()).toContain("agile");
+  });
+
+  it("désigne l'équipe la plus accessible aux débutants", () => {
+    const text = buildComparisonSummary(ORC, WOOD_ELF);
+    expect(text).toContain("Orques est plus accessible aux débutants");
+  });
+
+  it("gère deux équipes de même tier", () => {
+    const text = buildComparisonSummary(ORC, {
+      ...WOOD_ELF,
+      name: "Skavens",
+      tier: "II",
+    });
+    expect(text).toContain("appartiennent toutes deux au Tier II");
+  });
+
+  it("gère un style partagé", () => {
+    const text = buildComparisonSummary(ORC, {
+      ...ORC,
+      name: "Nains",
+      tier: "I",
+    });
+    expect(text).toContain("privilégient un jeu bagarre");
+  });
+});
+
+describe("buildComparisonSummary (en)", () => {
+  it("produit un résumé anglais cohérent", () => {
+    const text = buildComparisonSummary(ORC, WOOD_ELF, "en");
+    expect(text).toContain("Elfes Sylvains (Tier I) is generally rated more competitive");
+    expect(text).toContain("Orques is friendlier to newcomers");
+  });
+});

--- a/apps/web/app/teams/comparison-summary.ts
+++ b/apps/web/app/teams/comparison-summary.ts
@@ -1,0 +1,110 @@
+/**
+ * Génère un court résumé comparatif (2-3 phrases) entre deux rosters, en
+ * français ou en anglais. 100 % pur et déterministe (testable sans backend) :
+ * c'est le « contenu réellement comparatif » qui empêche les pages
+ * `/teams/comparer/[matchup]` d'être du contenu mince.
+ */
+
+import {
+  DIFFICULTY_LABELS,
+  DIFFICULTY_RANK,
+  PLAYSTYLE_LABELS,
+  type Difficulty,
+  type Lang,
+  type PlayStyle,
+} from "./roster-meta";
+
+export interface SummaryTeam {
+  readonly name: string;
+  readonly tier: string;
+  readonly difficulty: Difficulty;
+  readonly playStyle: PlayStyle;
+}
+
+const TIER_RANK: Record<string, number> = { I: 1, II: 2, III: 3, IV: 4 };
+
+function tierRank(tier: string): number {
+  return TIER_RANK[tier] ?? 99;
+}
+
+export function buildComparisonSummary(
+  a: SummaryTeam,
+  b: SummaryTeam,
+  lang: Lang = "fr",
+): string {
+  const sentences: string[] = [];
+  const ra = tierRank(a.tier);
+  const rb = tierRank(b.tier);
+
+  if (lang === "en") {
+    // Tier
+    if (ra === rb) {
+      sentences.push(
+        `${a.name} and ${b.name} both sit in Tier ${a.tier}, so they are considered competitively close.`,
+      );
+    } else {
+      const [stronger, weaker] = ra < rb ? [a, b] : [b, a];
+      sentences.push(
+        `${stronger.name} (Tier ${stronger.tier}) is generally rated more competitive than ${weaker.name} (Tier ${weaker.tier}).`,
+      );
+    }
+    // Style
+    if (a.playStyle === b.playStyle) {
+      sentences.push(
+        `Both teams favour a ${PLAYSTYLE_LABELS.en[a.playStyle].toLowerCase()} game.`,
+      );
+    } else {
+      sentences.push(
+        `${a.name} leans towards a ${PLAYSTYLE_LABELS.en[a.playStyle].toLowerCase()} game, whereas ${b.name} relies on a ${PLAYSTYLE_LABELS.en[b.playStyle].toLowerCase()} approach.`,
+      );
+    }
+    // Difficulty
+    const da = DIFFICULTY_RANK[a.difficulty];
+    const db = DIFFICULTY_RANK[b.difficulty];
+    if (da === db) {
+      sentences.push(
+        `They sit at a similar skill ceiling (${DIFFICULTY_LABELS.en[a.difficulty].toLowerCase()}).`,
+      );
+    } else {
+      const [easier, harder] = da < db ? [a, b] : [b, a];
+      sentences.push(
+        `${easier.name} is friendlier to newcomers, while ${harder.name} rewards more experienced coaches.`,
+      );
+    }
+    return sentences.join(" ");
+  }
+
+  // Français
+  if (ra === rb) {
+    sentences.push(
+      `${a.name} et ${b.name} appartiennent toutes deux au Tier ${a.tier}, ce qui les place à un niveau de compétitivité proche.`,
+    );
+  } else {
+    const [stronger, weaker] = ra < rb ? [a, b] : [b, a];
+    sentences.push(
+      `${stronger.name} (Tier ${stronger.tier}) est généralement jugée plus compétitive que ${weaker.name} (Tier ${weaker.tier}).`,
+    );
+  }
+  if (a.playStyle === b.playStyle) {
+    sentences.push(
+      `Les deux équipes privilégient un jeu ${PLAYSTYLE_LABELS.fr[a.playStyle].toLowerCase()}.`,
+    );
+  } else {
+    sentences.push(
+      `${a.name} privilégie un jeu ${PLAYSTYLE_LABELS.fr[a.playStyle].toLowerCase()}, là où ${b.name} mise sur un jeu ${PLAYSTYLE_LABELS.fr[b.playStyle].toLowerCase()}.`,
+    );
+  }
+  const da = DIFFICULTY_RANK[a.difficulty];
+  const db = DIFFICULTY_RANK[b.difficulty];
+  if (da === db) {
+    sentences.push(
+      `Elles demandent une maîtrise comparable (${DIFFICULTY_LABELS.fr[a.difficulty].toLowerCase()}).`,
+    );
+  } else {
+    const [easier, harder] = da < db ? [a, b] : [b, a];
+    sentences.push(
+      `${easier.name} est plus accessible aux débutants, tandis que ${harder.name} récompense les coachs expérimentés.`,
+    );
+  }
+  return sentences.join(" ");
+}

--- a/apps/web/app/teams/matchup.test.ts
+++ b/apps/web/app/teams/matchup.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMatchup,
+  canonicalMatchup,
+  isCanonicalMatchup,
+} from "./matchup";
+
+describe("parseMatchup", () => {
+  it("découpe un matchup valide en deux slugs", () => {
+    expect(parseMatchup("skaven-vs-orc")).toEqual({ a: "skaven", b: "orc" });
+  });
+
+  it("gère les slugs à underscores sans confondre avec le séparateur", () => {
+    expect(parseMatchup("old_world_alliance-vs-chaos_chosen")).toEqual({
+      a: "old_world_alliance",
+      b: "chaos_chosen",
+    });
+  });
+
+  it("rejette un séparateur absent", () => {
+    expect(parseMatchup("skaven_orc")).toBeNull();
+    expect(parseMatchup("skaven")).toBeNull();
+  });
+
+  it("rejette les slugs identiques (comparaison avec soi-même)", () => {
+    expect(parseMatchup("orc-vs-orc")).toBeNull();
+  });
+
+  it("rejette plus de deux participants", () => {
+    expect(parseMatchup("orc-vs-skaven-vs-dwarf")).toBeNull();
+  });
+
+  it("rejette les caractères interdits (majuscules, tirets, espaces)", () => {
+    expect(parseMatchup("Orc-vs-skaven")).toBeNull();
+    expect(parseMatchup("black-orc-vs-skaven")).toBeNull();
+    expect(parseMatchup("orc -vs- skaven")).toBeNull();
+  });
+
+  it("rejette les valeurs vides ou nulles", () => {
+    expect(parseMatchup("")).toBeNull();
+    expect(parseMatchup(undefined)).toBeNull();
+    expect(parseMatchup(null)).toBeNull();
+    expect(parseMatchup("-vs-orc")).toBeNull();
+  });
+});
+
+describe("canonicalMatchup", () => {
+  it("trie les deux slugs par ordre alphabétique", () => {
+    expect(canonicalMatchup("skaven", "orc")).toBe("orc-vs-skaven");
+    expect(canonicalMatchup("orc", "skaven")).toBe("orc-vs-skaven");
+  });
+
+  it("est stable quel que soit l'ordre d'entrée", () => {
+    expect(canonicalMatchup("dwarf", "amazon")).toBe(
+      canonicalMatchup("amazon", "dwarf"),
+    );
+  });
+});
+
+describe("isCanonicalMatchup", () => {
+  it("vrai pour un matchup déjà trié", () => {
+    expect(isCanonicalMatchup("orc-vs-skaven")).toBe(true);
+  });
+
+  it("faux pour l'ordre inverse", () => {
+    expect(isCanonicalMatchup("skaven-vs-orc")).toBe(false);
+  });
+
+  it("faux pour un format invalide", () => {
+    expect(isCanonicalMatchup("skaven")).toBe(false);
+    expect(isCanonicalMatchup("orc-vs-orc")).toBe(false);
+  });
+});

--- a/apps/web/app/teams/matchup.ts
+++ b/apps/web/app/teams/matchup.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers purs pour les slugs de comparaison `/teams/comparer/[matchup]`.
+ *
+ * Un « matchup » est de la forme `skaven-vs-orc`. Les slugs de roster
+ * utilisent des underscores (`old_world_alliance`, `chaos_chosen`) et jamais
+ * le séparateur littéral `-vs-`, ce qui rend le découpage non ambigu.
+ *
+ * ANTI-CONTENU MINCE : on canonicalise l'ordre des deux slugs (ordre
+ * alphabétique). `skaven-vs-orc` et `orc-vs-skaven` désignent la même
+ * comparaison ; seule la version canonique (`orc-vs-skaven`) doit être
+ * indexée. La page redirige les variantes non canoniques et pointe toujours
+ * le canonical vers la version triée.
+ */
+
+export const MATCHUP_SEPARATOR = "-vs-";
+
+export interface ParsedMatchup {
+  readonly a: string;
+  readonly b: string;
+}
+
+/** Forme d'un slug de roster valide : minuscules, chiffres, underscores. */
+const SLUG_RE = /^[a-z0-9_]+$/;
+
+/**
+ * Découpe un paramètre `matchup` en deux slugs. Retourne `null` si le format
+ * est invalide (séparateur absent, slug vide, slugs identiques, caractères
+ * interdits). Ne valide PAS l'existence des rosters — c'est le rôle de la
+ * page (qui 404 via l'API).
+ */
+export function parseMatchup(param: string | undefined | null): ParsedMatchup | null {
+  if (!param) return null;
+  const parts = param.split(MATCHUP_SEPARATOR);
+  if (parts.length !== 2) return null;
+  const [a, b] = parts;
+  if (!a || !b) return null;
+  if (!SLUG_RE.test(a) || !SLUG_RE.test(b)) return null;
+  if (a === b) return null;
+  return { a, b };
+}
+
+/** Construit le slug de matchup canonique (ordre alphabétique des slugs). */
+export function canonicalMatchup(a: string, b: string): string {
+  return [a, b].sort().join(MATCHUP_SEPARATOR);
+}
+
+/**
+ * Indique si un paramètre `matchup` est déjà sous sa forme canonique.
+ * Retourne `false` pour un format invalide.
+ */
+export function isCanonicalMatchup(param: string | undefined | null): boolean {
+  const parsed = parseMatchup(param);
+  if (!parsed) return false;
+  return param === canonicalMatchup(parsed.a, parsed.b);
+}

--- a/apps/web/app/teams/roster-meta.test.ts
+++ b/apps/web/app/teams/roster-meta.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  ROSTER_META,
+  getRosterMeta,
+  BEGINNER_FRIENDLY_SLUGS,
+  DIFFICULTY_RANK,
+  DIFFICULTY_LABELS,
+  PLAYSTYLE_LABELS,
+} from "./roster-meta";
+
+// Les 30 rosters officiels Saison 3 (clés de SEASON_THREE_ROSTERS).
+const EXPECTED_SLUGS = [
+  "old_world_alliance",
+  "amazon",
+  "underworld",
+  "dark_elf",
+  "wood_elf",
+  "chaos_chosen",
+  "gnome",
+  "goblin",
+  "halfling",
+  "high_elf",
+  "lizardmen",
+  "necromantic_horror",
+  "human",
+  "khorne",
+  "undead",
+  "chaos_dwarf",
+  "dwarf",
+  "imperial_nobility",
+  "norse",
+  "nurgle",
+  "ogre",
+  "black_orc",
+  "orc",
+  "chaos_renegade",
+  "tomb_kings",
+  "skaven",
+  "slann",
+  "snotling",
+  "elven_union",
+  "vampire",
+];
+
+describe("ROSTER_META", () => {
+  it("couvre les 30 rosters officiels", () => {
+    expect(Object.keys(ROSTER_META).sort()).toEqual([...EXPECTED_SLUGS].sort());
+  });
+
+  it("fournit une parité fr/en pour chaque résumé", () => {
+    for (const [slug, meta] of Object.entries(ROSTER_META)) {
+      expect(meta.shortFr.length, `${slug} shortFr`).toBeGreaterThan(0);
+      expect(meta.shortEn.length, `${slug} shortEn`).toBeGreaterThan(0);
+    }
+  });
+
+  it("n'utilise que des difficultés et styles connus", () => {
+    for (const [slug, meta] of Object.entries(ROSTER_META)) {
+      expect(DIFFICULTY_LABELS.fr[meta.difficulty], `${slug} difficulty`).toBeTruthy();
+      expect(PLAYSTYLE_LABELS.fr[meta.playStyle], `${slug} playStyle`).toBeTruthy();
+    }
+  });
+});
+
+describe("getRosterMeta", () => {
+  it("retourne la métadonnée curée pour un slug connu", () => {
+    expect(getRosterMeta("skaven").playStyle).toBe("agile");
+  });
+
+  it("retourne un repli sûr pour un slug inconnu", () => {
+    const meta = getRosterMeta("inconnu_xyz");
+    expect(meta.difficulty).toBe("intermediate");
+    expect(meta.starPlayers).toEqual([]);
+  });
+});
+
+describe("BEGINNER_FRIENDLY_SLUGS", () => {
+  it("liste au moins quelques équipes accessibles aux débutants", () => {
+    expect(BEGINNER_FRIENDLY_SLUGS.length).toBeGreaterThanOrEqual(3);
+    expect(BEGINNER_FRIENDLY_SLUGS).toContain("human");
+  });
+
+  it("ne contient que des équipes marquées beginnerFriendly", () => {
+    for (const slug of BEGINNER_FRIENDLY_SLUGS) {
+      expect(ROSTER_META[slug].beginnerFriendly).toBe(true);
+    }
+  });
+});
+
+describe("DIFFICULTY_RANK", () => {
+  it("ordonne du plus accessible au plus exigeant", () => {
+    expect(DIFFICULTY_RANK.beginner).toBeLessThan(DIFFICULTY_RANK.intermediate);
+    expect(DIFFICULTY_RANK.intermediate).toBeLessThan(DIFFICULTY_RANK.advanced);
+  });
+});

--- a/apps/web/app/teams/roster-meta.ts
+++ b/apps/web/app/teams/roster-meta.ts
@@ -1,0 +1,381 @@
+/**
+ * Métadonnées curées par slug pour le comparateur de rosters et la tier-list.
+ *
+ * L'API `/api/rosters` n'expose que { slug, name, budget, tier, naf,
+ * positions }. Les dimensions qualitatives utiles pour comparer deux équipes
+ * — difficulté de prise en main, style de jeu, Star Players emblématiques,
+ * résumé éditorial — ne sont pas dérivables des données brutes. On les
+ * maintient ici dans une carte curée, 100 % pure (testable sans React ni
+ * backend) et réutilisée par :
+ *   - le comparateur interactif `/teams/comparer`
+ *   - les pages de comparaison SSR `/teams/comparer/[matchup]`
+ *   - la tier-list `/teams/tier-list`
+ *
+ * Les libellés sont fournis en français ET en anglais (parité i18n).
+ */
+
+export type Lang = "fr" | "en";
+
+/** Difficulté de prise en main (du plus accessible au plus exigeant). */
+export type Difficulty = "beginner" | "intermediate" | "advanced";
+
+/** Style de jeu dominant. */
+export type PlayStyle = "bash" | "agile" | "balanced" | "stunty" | "hybrid";
+
+export interface RosterMeta {
+  readonly difficulty: Difficulty;
+  readonly playStyle: PlayStyle;
+  /** Star Players emblématiques hirables (noms propres, non traduits). */
+  readonly starPlayers: readonly string[];
+  /** Résumé court orienté comparaison. */
+  readonly shortFr: string;
+  readonly shortEn: string;
+  /** Recommandé pour débuter. */
+  readonly beginnerFriendly?: boolean;
+}
+
+/**
+ * Rang numérique de difficulté — utile pour trier et pour rendre une échelle
+ * (1 = accessible, 3 = exigeant).
+ */
+export const DIFFICULTY_RANK: Record<Difficulty, number> = {
+  beginner: 1,
+  intermediate: 2,
+  advanced: 3,
+};
+
+export const DIFFICULTY_LABELS: Record<Lang, Record<Difficulty, string>> = {
+  fr: {
+    beginner: "Débutant",
+    intermediate: "Intermédiaire",
+    advanced: "Expert",
+  },
+  en: {
+    beginner: "Beginner",
+    intermediate: "Intermediate",
+    advanced: "Advanced",
+  },
+};
+
+export const PLAYSTYLE_LABELS: Record<Lang, Record<PlayStyle, string>> = {
+  fr: {
+    bash: "Bagarre",
+    agile: "Agile",
+    balanced: "Polyvalent",
+    stunty: "Stunty",
+    hybrid: "Hybride",
+  },
+  en: {
+    bash: "Bashy",
+    agile: "Agile",
+    balanced: "Balanced",
+    stunty: "Stunty",
+    hybrid: "Hybrid",
+  },
+};
+
+/**
+ * Carte curée des 30 rosters officiels Saison 3. Les slugs correspondent aux
+ * clés de `SEASON_THREE_ROSTERS` (game-engine) et aux slugs renvoyés par
+ * `/api/rosters`.
+ */
+export const ROSTER_META: Record<string, RosterMeta> = {
+  old_world_alliance: {
+    difficulty: "intermediate",
+    playStyle: "balanced",
+    starPlayers: ["Griff Oberwald", "Grim Ironjaw"],
+    shortFr:
+      "Mélange d'Humains, Nains et Halflings : une équipe polyvalente qui combine vitesse, blocage et fragilité.",
+    shortEn:
+      "A mix of Humans, Dwarves and Halflings: a versatile team blending speed, blocking and fragility.",
+  },
+  amazon: {
+    difficulty: "beginner",
+    playStyle: "balanced",
+    starPlayers: ["Estelle la Veaux"],
+    shortFr:
+      "Esquive et Bond généralisés rendent les Amazones très résistantes au blocage : idéales pour apprendre la défense.",
+    shortEn:
+      "Widespread Dodge and Jump Up make Amazons hard to knock down — a great team to learn defence with.",
+    beginnerFriendly: true,
+  },
+  underworld: {
+    difficulty: "advanced",
+    playStyle: "hybrid",
+    starPlayers: ["Hakflem Skuttlespike", "Glart Smashrip"],
+    shortFr:
+      "Skavens, Gobelins et Trolls : mutations, vitesse et chaos. Puissant mais imprévisible, réservé aux coachs aguerris.",
+    shortEn:
+      "Skaven, Goblins and Trolls: mutations, speed and chaos. Powerful yet unpredictable — for seasoned coaches.",
+  },
+  dark_elf: {
+    difficulty: "intermediate",
+    playStyle: "agile",
+    starPlayers: ["Roxanna Darknail", "Horkon Heartripper"],
+    shortFr:
+      "Élfes polyvalents avec une bonne armure : agiles à la passe comme en défense, sans la fragilité des autres elfes.",
+    shortEn:
+      "Versatile elves with solid armour: agile in passing and defence, without the fragility of other elves.",
+  },
+  wood_elf: {
+    difficulty: "advanced",
+    playStyle: "agile",
+    starPlayers: ["Jordell Freshbreeze"],
+    shortFr:
+      "Les plus rapides et agiles du jeu, mais fragiles. Un jeu de mouvement exigeant qui ne pardonne aucune erreur.",
+    shortEn:
+      "The fastest, most agile team in the game, but fragile. A demanding movement game that punishes every mistake.",
+  },
+  chaos_chosen: {
+    difficulty: "intermediate",
+    playStyle: "bash",
+    starPlayers: ["Lord Borak the Despoiler", "Grashnak Blackhoof"],
+    shortFr:
+      "Brutaux et évolutifs : peu de compétences au départ mais un potentiel énorme grâce aux mutations à la montée.",
+    shortEn:
+      "Brutal and evolving: few starting skills but huge potential thanks to mutations gained on level-up.",
+  },
+  gnome: {
+    difficulty: "advanced",
+    playStyle: "stunty",
+    starPlayers: [],
+    shortFr:
+      "Petite équipe rusée mêlant illusionnistes et arbres : trickster fragile au plafond limité, pour amateurs de défi.",
+    shortEn:
+      "A cunning small team of illusionists and trees: a fragile trickster with a low ceiling, for challenge seekers.",
+  },
+  goblin: {
+    difficulty: "advanced",
+    playStyle: "stunty",
+    starPlayers: ["Bomber Dribblesnot", "Fungus the Loon", "Scrappa Sorehead"],
+    shortFr:
+      "L'équipe gadget par excellence : tronçonneuses, bombes et balle-et-chaîne. Hilarante mais très difficile à gagner.",
+    shortEn:
+      "The ultimate gimmick team: chainsaws, bombs and ball-and-chain. Hilarious but very hard to win with.",
+  },
+  halfling: {
+    difficulty: "advanced",
+    playStyle: "stunty",
+    starPlayers: ["Puggy Baconbreath", "Deeproot Strongbranch"],
+    shortFr:
+      "Minuscules et fragiles, sauvés par leurs Arbres et leurs Chefs-cuisiniers. Le défi ultime du coach Blood Bowl.",
+    shortEn:
+      "Tiny and fragile, saved by their Treemen and Master Chefs. The ultimate Blood Bowl coaching challenge.",
+  },
+  high_elf: {
+    difficulty: "beginner",
+    playStyle: "agile",
+    starPlayers: ["Eldril Sidewinder"],
+    shortFr:
+      "Élfes équilibrés avec une bonne armure : agiles, fiables à la passe et plus pardonnants que les autres elfes.",
+    shortEn:
+      "Balanced elves with decent armour: agile, reliable passers and more forgiving than other elf teams.",
+    beginnerFriendly: true,
+  },
+  lizardmen: {
+    difficulty: "intermediate",
+    playStyle: "balanced",
+    starPlayers: ["Slibli", "Zolcath the Zoat"],
+    shortFr:
+      "Sauruses costauds et Skinks vifs : une combinaison force/agilité redoutable, parfaite pour un jeu de plaquage mobile.",
+    shortEn:
+      "Tough Saurus and nimble Skinks: a fearsome strength/agility combo, perfect for a mobile bashing game.",
+  },
+  necromantic_horror: {
+    difficulty: "intermediate",
+    playStyle: "bash",
+    starPlayers: ["Wilhelm Chaney"],
+    shortFr:
+      "Loups-garous et Golems de chair : résistance, régénération et morsures. Un bash qui se renforce avec le temps.",
+    shortEn:
+      "Werewolves and Flesh Golems: resilience, regeneration and bite. A bashy team that grows stronger over time.",
+  },
+  human: {
+    difficulty: "beginner",
+    playStyle: "balanced",
+    starPlayers: ["Griff Oberwald", "Mighty Zug"],
+    shortFr:
+      "L'équipe d'apprentissage par excellence : équilibrée, sans faiblesse criante, idéale pour comprendre les bases.",
+    shortEn:
+      "The quintessential learning team: balanced, with no glaring weakness — ideal for grasping the fundamentals.",
+    beginnerFriendly: true,
+  },
+  khorne: {
+    difficulty: "intermediate",
+    playStyle: "bash",
+    starPlayers: ["Morg 'n' Thorg"],
+    shortFr:
+      "Furie sanguinaire et Frénésie : une équipe ultra-agressive bâtie pour blesser, au prix d'un contrôle de balle limité.",
+    shortEn:
+      "Bloodlust and Frenzy: a hyper-aggressive team built to injure, at the cost of limited ball control.",
+  },
+  undead: {
+    difficulty: "beginner",
+    playStyle: "bash",
+    starPlayers: ["Ramtut III", "Wilhelm Chaney"],
+    shortFr:
+      "Momies puissantes, Goules agiles et recrutement infini : résistant, pardonnant et excellent pour débuter le bash.",
+    shortEn:
+      "Strong Mummies, agile Ghouls and endless recruits: resilient, forgiving and great for learning bashy play.",
+    beginnerFriendly: true,
+  },
+  chaos_dwarf: {
+    difficulty: "intermediate",
+    playStyle: "bash",
+    starPlayers: ["Hthark the Unstoppable", "Kreek Rustgouger"],
+    shortFr:
+      "Le bash patient : Blocage et Crâne épais de série, Taurus et Hobgobelins. Lent mais d'une solidité écrasante.",
+    shortEn:
+      "Patient bashing: Block and Thick Skull as standard, Bull Centaurs and Hobgoblins. Slow but crushingly solid.",
+  },
+  dwarf: {
+    difficulty: "beginner",
+    playStyle: "bash",
+    starPlayers: ["Grim Ironjaw", "Barik Farblast"],
+    shortFr:
+      "Lents mais blindés : Blocage, Crâne épais et Sûres mains partout. Très pardonnant, idéal pour apprendre le contrôle.",
+    shortEn:
+      "Slow but armoured: Block, Thick Skull and Sure Hands everywhere. Very forgiving, ideal for learning grind play.",
+    beginnerFriendly: true,
+  },
+  imperial_nobility: {
+    difficulty: "intermediate",
+    playStyle: "balanced",
+    starPlayers: ["Griff Oberwald", "Mighty Zug"],
+    shortFr:
+      "Humains relookés avec Gardes du corps et Bowlistes : polyvalence classique agrémentée de quelques outils tactiques.",
+    shortEn:
+      "Humans reimagined with Bodyguards and Bowlers: classic versatility with a few extra tactical tools.",
+  },
+  norse: {
+    difficulty: "intermediate",
+    playStyle: "bash",
+    starPlayers: ["Icepelt Hammerblow"],
+    shortFr:
+      "Blocage généralisé mais armure faible : un bash agressif et risqué qui mise tout sur l'attaque, jamais sur la défense.",
+    shortEn:
+      "Block everywhere but low armour: an aggressive, risky bashing team that bets everything on offence.",
+  },
+  nurgle: {
+    difficulty: "advanced",
+    playStyle: "bash",
+    starPlayers: ["Bilerot Vomitflesh"],
+    shortFr:
+      "Puanteur, Tentacules et Crasse : un rouleau-compresseur lent qui colle l'adversaire au sol. Demande de la patience.",
+    shortEn:
+      "Foul Appearance, Tentacles and Disturbing Presence: a slow grinder that pins opponents down. Requires patience.",
+  },
+  ogre: {
+    difficulty: "advanced",
+    playStyle: "bash",
+    starPlayers: ["Morg 'n' Thorg"],
+    shortFr:
+      "Cinq Ogres surpuissants entourés de Snotlings jetables : une force brute énorme minée par les Os de Tête.",
+    shortEn:
+      "Five mighty Ogres surrounded by expendable Snotlings: enormous raw strength undermined by Bone-head.",
+  },
+  black_orc: {
+    difficulty: "beginner",
+    playStyle: "bash",
+    starPlayers: ["Varag Ghoul-Chewer", "Grashnak Blackhoof"],
+    shortFr:
+      "Orcs Noirs costauds appuyés par des Gobelins : un bash simple et solide, très accessible pour un débutant agressif.",
+    shortEn:
+      "Sturdy Black Orcs backed by Goblins: a simple, solid bashing team, very accessible for an aggressive beginner.",
+    beginnerFriendly: true,
+  },
+  orc: {
+    difficulty: "beginner",
+    playStyle: "bash",
+    starPlayers: ["Varag Ghoul-Chewer", "Grashnak Blackhoof"],
+    shortFr:
+      "Bash résistant et pardonnant : bonne armure, Blitzers solides et Gobelins fourbes. L'une des meilleures portes d'entrée.",
+    shortEn:
+      "Resilient, forgiving bash: good armour, solid Blitzers and sneaky Goblins. One of the best entry points.",
+    beginnerFriendly: true,
+  },
+  chaos_renegade: {
+    difficulty: "advanced",
+    playStyle: "hybrid",
+    starPlayers: ["Max Spleenripper"],
+    shortFr:
+      "Toutes les races du Chaos réunies : Gobelins, Skavens, Orcs et Big Guys. Riche en options mais difficile à équilibrer.",
+    shortEn:
+      "Every Chaos race in one team: Goblins, Skaven, Orcs and Big Guys. Rich in options but hard to balance.",
+  },
+  tomb_kings: {
+    difficulty: "intermediate",
+    playStyle: "balanced",
+    starPlayers: ["Ramtut III"],
+    shortFr:
+      "Momies de Force 5 et Blitz-Ras agiles : du contrôle de ligne brutal compensant un jeu de passe quasi inexistant.",
+    shortEn:
+      "Strength 5 Mummies and agile Blitz-Ras: brutal line control compensating an almost non-existent passing game.",
+  },
+  skaven: {
+    difficulty: "intermediate",
+    playStyle: "agile",
+    starPlayers: ["Hakflem Skuttlespike", "Glart Smashrip"],
+    shortFr:
+      "Vitesse extrême et fragilité assumée : Coureurs des Tempêtes, Rat-Ogre et un Gutter Runner ultra-rapide. Du glass-cannon.",
+    shortEn:
+      "Extreme speed and embraced fragility: Storm Vermin, a Rat Ogre and a lightning Gutter Runner. Pure glass cannon.",
+  },
+  slann: {
+    difficulty: "advanced",
+    playStyle: "agile",
+    starPlayers: ["Slibli"],
+    shortFr:
+      "Sauteurs Très Agiles capables de bonds spectaculaires : un jeu de mouvement aérien unique mais délicat à maîtriser.",
+    shortEn:
+      "Very Agile Leapers capable of spectacular jumps: a unique aerial movement game, but tricky to master.",
+  },
+  snotling: {
+    difficulty: "advanced",
+    playStyle: "stunty",
+    starPlayers: ["Bomber Dribblesnot", "Fungus the Loon"],
+    shortFr:
+      "L'équipe la plus loufoque : Snotlings jetables, Trolls et gadgets en pagaille. Pensée pour le fun, pas pour la victoire.",
+    shortEn:
+      "The zaniest team of all: expendable Snotlings, Trolls and gadgets galore. Built for fun, not for winning.",
+  },
+  elven_union: {
+    difficulty: "intermediate",
+    playStyle: "agile",
+    starPlayers: ["Eldril Sidewinder", "Roxanna Darknail"],
+    shortFr:
+      "L'équipe elfe équilibrée : bons à la passe, agiles et plus accessibles que les Wood Elves, sans excès de fragilité.",
+    shortEn:
+      "The balanced elf team: strong passers, agile and more accessible than Wood Elves, without extreme fragility.",
+  },
+  vampire: {
+    difficulty: "advanced",
+    playStyle: "hybrid",
+    starPlayers: ["Count Luthor von Drakenborg"],
+    shortFr:
+      "Vampires surpuissants mais affamés : la Soif de Sang peut retourner vos propres Thralls. Haut risque, haute récompense.",
+    shortEn:
+      "Mighty but hungry Vampires: Bloodlust can turn on your own Thralls. High risk, high reward.",
+  },
+};
+
+/** Métadonnées de repli pour un slug inconnu (défense en profondeur). */
+const FALLBACK_META: RosterMeta = {
+  difficulty: "intermediate",
+  playStyle: "balanced",
+  starPlayers: [],
+  shortFr: "Roster Blood Bowl officiel.",
+  shortEn: "Official Blood Bowl roster.",
+};
+
+/** Retourne les métadonnées curées d'un roster, avec repli sûr. */
+export function getRosterMeta(slug: string): RosterMeta {
+  return ROSTER_META[slug] ?? FALLBACK_META;
+}
+
+/** Slugs recommandés pour débuter (encart « meilleur roster débutant »). */
+export const BEGINNER_FRIENDLY_SLUGS: readonly string[] = Object.entries(
+  ROSTER_META,
+)
+  .filter(([, meta]) => meta.beginnerFriendly)
+  .map(([slug]) => slug);

--- a/apps/web/app/teams/tier-list-structured-data.test.ts
+++ b/apps/web/app/teams/tier-list-structured-data.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildTierListSchema, sortByTier } from "./tier-list-structured-data";
+
+const BASE = "https://nufflearena.fr";
+const ITEMS = [
+  { slug: "goblin", name: "Gobelins", tier: "IV" },
+  { slug: "skaven", name: "Skavens", tier: "II" },
+  { slug: "amazon", name: "Amazones", tier: "I" },
+  { slug: "dwarf", name: "Nains", tier: "I" },
+];
+
+function graph(schema: Record<string, unknown>) {
+  return schema["@graph"] as Array<Record<string, unknown>>;
+}
+
+describe("sortByTier", () => {
+  it("trie par tier croissant puis par nom", () => {
+    const sorted = sortByTier(ITEMS).map((i) => i.slug);
+    expect(sorted).toEqual(["amazon", "dwarf", "skaven", "goblin"]);
+  });
+
+  it("ne mute pas le tableau d'entrée", () => {
+    const copy = [...ITEMS];
+    sortByTier(ITEMS);
+    expect(ITEMS).toEqual(copy);
+  });
+});
+
+describe("buildTierListSchema", () => {
+  it("émet CollectionPage + ItemList + BreadcrumbList", () => {
+    const schema = buildTierListSchema({ items: ITEMS, baseUrl: BASE });
+    const types = graph(schema).map((n) => n["@type"]);
+    expect(types).toContain("CollectionPage");
+    expect(types).toContain("ItemList");
+    expect(types).toContain("BreadcrumbList");
+  });
+
+  it("ordonne l'ItemList par tier et pointe vers les pages détail", () => {
+    const schema = buildTierListSchema({ items: ITEMS, baseUrl: BASE });
+    const list = graph(schema).find((n) => n["@type"] === "ItemList")!;
+    expect(list.numberOfItems).toBe(4);
+    const els = list.itemListElement as Array<Record<string, unknown>>;
+    expect(els[0]).toMatchObject({ position: 1, url: `${BASE}/teams/amazon` });
+    expect(els[3]).toMatchObject({ position: 4, url: `${BASE}/teams/goblin` });
+  });
+
+  it("relie la CollectionPage à l'ItemList et à l'Organization", () => {
+    const schema = buildTierListSchema({ items: ITEMS, baseUrl: BASE });
+    const page = graph(schema).find((n) => n["@type"] === "CollectionPage")!;
+    expect(page.url).toBe(`${BASE}/teams/tier-list`);
+    expect((page.mainEntity as Record<string, unknown>)["@id"]).toBe(
+      `${BASE}/teams/tier-list#item-list`,
+    );
+    expect((page.isPartOf as Record<string, unknown>)["@id"]).toBe(
+      `${BASE}#organization`,
+    );
+  });
+});

--- a/apps/web/app/teams/tier-list-structured-data.ts
+++ b/apps/web/app/teams/tier-list-structured-data.ts
@@ -1,0 +1,111 @@
+/**
+ * JSON-LD pour la page `/teams/tier-list` : `CollectionPage` + `ItemList`
+ * (les 30 rosters ordonnés par tier) + `BreadcrumbList`. Helper pur.
+ *
+ * L'`ItemList` ordonne les rosters du Tier I au Tier IV (puis alphabétique),
+ * ce qui reflète la hiérarchie éditoriale de la page et nourrit les rich
+ * results « liste » ainsi que la citabilité LLM.
+ */
+
+const ORG_ID_FRAGMENT = "#organization";
+
+export type Lang = "fr" | "en";
+
+export interface TierListItem {
+  readonly slug: string;
+  readonly name: string;
+  readonly tier: string;
+}
+
+export interface BuildTierListSchemaInput {
+  readonly items: readonly TierListItem[];
+  readonly baseUrl: string;
+  readonly lang?: Lang;
+}
+
+const TIER_ORDER: Record<string, number> = { I: 1, II: 2, III: 3, IV: 4 };
+
+function tierRank(tier: string): number {
+  return TIER_ORDER[tier] ?? 99;
+}
+
+/** Trie les rosters par tier croissant puis par nom (ordre éditorial stable). */
+export function sortByTier<T extends { tier: string; name: string }>(
+  items: readonly T[],
+): T[] {
+  return [...items].sort((a, b) => {
+    const ra = tierRank(a.tier);
+    const rb = tierRank(b.tier);
+    if (ra !== rb) return ra - rb;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function buildTierListSchema(
+  input: BuildTierListSchemaInput,
+): Record<string, unknown> {
+  const { baseUrl } = input;
+  const lang: Lang = input.lang ?? "fr";
+  const url = `${baseUrl}/teams/tier-list`;
+  const inLanguage = lang === "en" ? "en" : "fr-FR";
+  const name =
+    lang === "en"
+      ? "Blood Bowl roster tier list (Season 3)"
+      : "Tier list des rosters Blood Bowl (Saison 3)";
+
+  const ordered = sortByTier(input.items);
+
+  const itemList = {
+    "@type": "ItemList",
+    "@id": `${url}#item-list`,
+    name,
+    inLanguage,
+    numberOfItems: ordered.length,
+    itemListElement: ordered.map((item, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      name: item.name,
+      url: `${baseUrl}/teams/${item.slug}`,
+    })),
+  };
+
+  const collectionPage = {
+    "@type": "CollectionPage",
+    "@id": `${url}#collection`,
+    url,
+    name,
+    inLanguage,
+    isPartOf: { "@id": `${baseUrl}${ORG_ID_FRAGMENT}` },
+    mainEntity: { "@id": `${url}#item-list` },
+  };
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${url}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: lang === "en" ? "Home" : "Accueil",
+        item: baseUrl,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: lang === "en" ? "Teams" : "Équipes",
+        item: `${baseUrl}/teams`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: lang === "en" ? "Tier list" : "Tier list",
+        item: url,
+      },
+    ],
+  };
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [collectionPage, itemList, breadcrumb],
+  };
+}

--- a/apps/web/app/teams/tier-list/layout.tsx
+++ b/apps/web/app/teams/tier-list/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr";
+
+const title = "Tier List Blood Bowl — Classement des 30 équipes (Saison 3)";
+const description =
+  "La tier list des 30 rosters Blood Bowl Saison 3, classés du Tier I au Tier IV : compétitivité, difficulté de prise en main et meilleur roster pour débuter.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "Blood Bowl",
+    "tier list",
+    "classement équipes",
+    "meilleure équipe Blood Bowl",
+    "roster débutant",
+    "Saison 3",
+    "Nuffle Arena",
+  ],
+  alternates: {
+    canonical: `${BASE_URL}/teams/tier-list`,
+    languages: {
+      "fr-FR": `${BASE_URL}/teams/tier-list`,
+      en: `${BASE_URL}/teams/tier-list`,
+      "x-default": `${BASE_URL}/teams/tier-list`,
+    },
+  },
+  openGraph: {
+    title,
+    description,
+    type: "article",
+    url: `${BASE_URL}/teams/tier-list`,
+    siteName: "Nuffle Arena",
+    images: [
+      {
+        url: `${BASE_URL}/images/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "Tier List Blood Bowl - Nuffle Arena",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: [`${BASE_URL}/images/logo.png`],
+  },
+};
+
+export default function TierListLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/web/app/teams/tier-list/page.tsx
+++ b/apps/web/app/teams/tier-list/page.tsx
@@ -1,0 +1,298 @@
+import Link from "next/link";
+import { fetchServerJson, getServerApiBase } from "../../lib/serverApi";
+import StructuredData from "../../components/StructuredData";
+import TeamLogo from "../../components/TeamLogo";
+import {
+  getRosterMeta,
+  DIFFICULTY_LABELS,
+  DIFFICULTY_RANK,
+  PLAYSTYLE_LABELS,
+  BEGINNER_FRIENDLY_SLUGS,
+} from "../roster-meta";
+import { buildTierListSchema } from "../tier-list-structured-data";
+
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL || "https://nufflearena.fr"
+).replace(/\/$/, "");
+
+// Rendu dynamique à la demande (SSR) : on n'inscrit PAS cette route statique
+// dans le prerender du build pour ne pas dépendre du backend au build (cf.
+// teams/[slug] et la liste /teams qui esquivent via searchParams). Le résultat
+// du fetch reste mis en cache 3600 s (data cache) pour limiter la charge.
+export const dynamic = "force-dynamic";
+
+interface TierRoster {
+  slug: string;
+  name: string;
+  budget: number;
+  tier: string;
+  naf: boolean;
+  positionCount: number;
+}
+
+async function fetchRosters(): Promise<TierRoster[]> {
+  const base = getServerApiBase();
+  const data = await fetchServerJson<{ rosters?: any[] }>(
+    `${base}/api/rosters?lang=fr&ruleset=season_3`,
+    { next: { revalidate: 3600 } },
+  );
+  return (data?.rosters ?? []).map((r: any) => ({
+    slug: r.slug,
+    name: r.name,
+    budget: r.budget,
+    tier: r.tier,
+    naf: r.naf,
+    positionCount: r._count?.positions ?? 0,
+  }));
+}
+
+const TIERS = ["I", "II", "III", "IV"] as const;
+
+const TIER_INFO: Record<
+  string,
+  { title: string; blurb: string; accent: string }
+> = {
+  I: {
+    title: "Tier I — Élite",
+    blurb:
+      "Les équipes les plus compétitives, fortes dès la création et redoutées en tournoi.",
+    accent: "from-emerald-500/15 border-emerald-400/40 text-emerald-800",
+  },
+  II: {
+    title: "Tier II — Solides",
+    blurb:
+      "Des équipes polyvalentes et fiables, un excellent équilibre entre puissance et souplesse.",
+    accent: "from-sky-500/15 border-sky-400/40 text-sky-800",
+  },
+  III: {
+    title: "Tier III — Exigeantes",
+    blurb:
+      "Des équipes plus situationnelles qui récompensent l'expérience et un jeu précis.",
+    accent: "from-amber-500/15 border-amber-400/40 text-amber-800",
+  },
+  IV: {
+    title: "Tier IV — Stunty & défi",
+    blurb:
+      "Les équipes les plus difficiles (souvent Stunty) : fragiles et farfelues, pensées pour le fun et le challenge.",
+    accent: "from-orange-500/15 border-orange-400/40 text-orange-800",
+  },
+};
+
+function DifficultyScale({ rank }: { rank: number }) {
+  return (
+    <span className="inline-flex items-center gap-1" aria-hidden="true">
+      {[1, 2, 3].map((i) => (
+        <span
+          key={i}
+          className={`h-2 w-2 rounded-full ${
+            i <= rank ? "bg-nuffle-gold" : "bg-nuffle-bronze/20"
+          }`}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default async function TierListPage() {
+  const rosters = await fetchRosters();
+
+  const byTier = new Map<string, TierRoster[]>();
+  for (const tier of TIERS) byTier.set(tier, []);
+  for (const r of rosters) {
+    const bucket = byTier.get(r.tier);
+    if (bucket) bucket.push(r);
+    else byTier.set(r.tier, [r]);
+  }
+  for (const list of byTier.values()) {
+    list.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const beginnerPicks = rosters
+    .filter((r) => BEGINNER_FRIENDLY_SLUGS.includes(r.slug))
+    .sort(
+      (a, b) =>
+        DIFFICULTY_RANK[getRosterMeta(a.slug).difficulty] -
+          DIFFICULTY_RANK[getRosterMeta(b.slug).difficulty] ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, 4);
+
+  return (
+    <>
+      <StructuredData
+        data={buildTierListSchema({
+          items: rosters.map((r) => ({
+            slug: r.slug,
+            name: r.name,
+            tier: r.tier,
+          })),
+          baseUrl: BASE_URL,
+          lang: "fr",
+        })}
+      />
+
+      <div className="w-full max-w-5xl mx-auto p-4 sm:p-6 space-y-8 font-body">
+        {/* Fil d'Ariane */}
+        <nav
+          aria-label="Fil d'Ariane"
+          className="text-sm font-subtitle text-nuffle-bronze/80"
+        >
+          <ol className="flex flex-wrap items-center gap-1.5">
+            <li>
+              <Link href="/" className="hover:text-nuffle-gold transition-colors">
+                Accueil
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link href="/teams" className="hover:text-nuffle-gold transition-colors">
+                Équipes
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-nuffle-anthracite font-semibold" aria-current="page">
+              Tier list
+            </li>
+          </ol>
+        </nav>
+
+        <header>
+          <h1 className="font-heading font-bold text-3xl sm:text-4xl text-nuffle-anthracite leading-tight">
+            Tier list des équipes Blood Bowl
+          </h1>
+          <p className="mt-2 text-nuffle-bronze/90 max-w-3xl">
+            Les 30 rosters officiels de la Saison 3, classés du Tier I (le plus
+            compétitif) au Tier IV. Chaque équipe est accompagnée de sa
+            difficulté de prise en main et de son style de jeu. Hésitant entre
+            deux équipes ?{" "}
+            <Link
+              href="/teams/comparer"
+              className="text-nuffle-gold font-semibold hover:underline"
+            >
+              Utilisez le comparateur
+            </Link>
+            .
+          </p>
+        </header>
+
+        {/* Encart meilleur roster débutant */}
+        {beginnerPicks.length > 0 && (
+          <section
+            className="rounded-2xl bg-[#1B1610] ring-1 ring-nuffle-gold/40 p-5 sm:p-6 text-nuffle-ivory shadow-[0_6px_16px_rgba(27,22,16,0.25)]"
+            data-testid="beginner-picks"
+          >
+            <h2 className="font-heading font-bold text-xl text-nuffle-gold">
+              ⭐ Meilleurs rosters pour débuter
+            </h2>
+            <p className="mt-1 text-sm text-nuffle-ivory/80">
+              Résistantes, pardonnantes et sans piège : les équipes idéales pour
+              vos premiers matchs.
+            </p>
+            <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {beginnerPicks.map((r) => (
+                <Link
+                  key={r.slug}
+                  href={`/teams/${r.slug}`}
+                  className="flex items-center gap-2.5 rounded-xl bg-white/5 ring-1 ring-nuffle-gold/20 px-3 py-2.5 hover:ring-nuffle-gold/60 hover:bg-white/10 transition-all"
+                >
+                  <TeamLogo slug={r.slug} size={36} title={r.name} />
+                  <span className="min-w-0">
+                    <span className="block truncate font-subtitle font-semibold text-sm text-nuffle-ivory">
+                      {r.name}
+                    </span>
+                    <span className="block text-xs text-nuffle-gold/80">
+                      Tier {r.tier}
+                    </span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Groupes par tier */}
+        {TIERS.map((tier) => {
+          const list = byTier.get(tier) ?? [];
+          if (list.length === 0) return null;
+          const info = TIER_INFO[tier];
+          return (
+            <section key={tier} aria-labelledby={`tier-${tier}`}>
+              <div
+                className={`rounded-xl border bg-gradient-to-r to-transparent px-4 py-3 ${info.accent}`}
+              >
+                <h2
+                  id={`tier-${tier}`}
+                  className="font-heading font-bold text-xl text-nuffle-anthracite"
+                >
+                  {info.title}
+                  <span className="ml-2 text-sm font-subtitle font-normal text-nuffle-bronze/70">
+                    ({list.length})
+                  </span>
+                </h2>
+                <p className="text-sm text-nuffle-anthracite/75 mt-0.5">
+                  {info.blurb}
+                </p>
+              </div>
+
+              <ul className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {list.map((r) => {
+                  const meta = getRosterMeta(r.slug);
+                  return (
+                    <li key={r.slug}>
+                      <Link
+                        href={`/teams/${r.slug}`}
+                        className="group flex h-full gap-3 rounded-xl bg-[#FBF7EC] border border-nuffle-bronze/20 p-4 hover:border-nuffle-gold/60 hover:-translate-y-0.5 transition-all"
+                      >
+                        <TeamLogo slug={r.slug} size={48} title={r.name} />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="font-heading font-bold text-nuffle-anthracite group-hover:text-nuffle-gold transition-colors">
+                              {r.name}
+                            </span>
+                            {r.naf && (
+                              <span className="text-[10px] font-bold text-nuffle-gold">
+                                NAF
+                              </span>
+                            )}
+                          </span>
+                          <span className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                            <span className="inline-flex items-center rounded-full border border-nuffle-bronze/30 bg-white/60 px-2 py-0.5 font-subtitle font-semibold text-nuffle-bronze">
+                              {PLAYSTYLE_LABELS.fr[meta.playStyle]}
+                            </span>
+                            <span className="inline-flex items-center gap-1.5 text-nuffle-bronze/80">
+                              <DifficultyScale rank={DIFFICULTY_RANK[meta.difficulty]} />
+                              {DIFFICULTY_LABELS.fr[meta.difficulty]}
+                            </span>
+                          </span>
+                          <span className="mt-1.5 block text-xs text-nuffle-anthracite/75 leading-relaxed">
+                            {meta.shortFr}
+                          </span>
+                        </span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          );
+        })}
+
+        {/* CTA bas de page */}
+        <div className="flex flex-wrap gap-3 pt-2">
+          <Link
+            href="/teams/comparer"
+            className="inline-flex items-center gap-1.5 rounded-xl bg-[#1B1610] px-5 py-2.5 text-sm font-subtitle font-bold uppercase tracking-wide text-nuffle-gold ring-1 ring-nuffle-gold/50 hover:bg-[#241c12] transition-colors"
+          >
+            ⚔️ Comparer deux équipes
+          </Link>
+          <Link
+            href="/teams"
+            className="inline-flex items-center gap-1.5 rounded-xl border-2 border-nuffle-bronze/40 px-5 py-2.5 text-sm font-subtitle font-bold uppercase tracking-wide text-nuffle-bronze hover:border-nuffle-gold hover:text-nuffle-anthracite transition-colors"
+          >
+            Toutes les équipes
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Objectif

Comparateur d'équipes Blood Bowl interactif + son volet SEO programmatique, maillé depuis `/teams`.

## Livrables

### 1. `/teams/comparer` — comparateur interactif (client)
Sélection de 2 à 3 rosters (recherche + grille de jetons), comparaison côte à côte : tier, budget, positions, difficulté (échelle 1→3), style de jeu, statut NAF, Star Players emblématiques, résumé. Lien partageable vers la page matchup canonique. Design parchemin, responsive, i18n fr/en.

### 2. `/teams/comparer/[matchup]` — pages de comparaison indexables (SSR, ISR 3600)
- Contenu réellement comparatif : tableau de stats + résumé prose déterministe.
- `generateMetadata` (title/description/**canonical**), JSON-LD (CollectionPage + ItemList + BreadcrumbList), liens internes vers `/teams/[slug]`.
- **Anti-contenu mince** : ordre canonicalisé (alphabétique). `skaven-vs-orc` → 307 vers `orc-vs-skaven` ; 404 si slug inconnu / format invalide.
- Pas de `generateStaticParams` (aucune dépendance backend au build, cf. `teams/[slug]`).

### 3. `/teams/tier-list` — page SSR
30 rosters groupés par tier I→IV avec descriptif/difficulté/style, encart « meilleurs rosters pour débuter », metadata + JSON-LD.

### Maillage interne
CTA « Comparer les équipes » + « Tier list » sur `/teams`, lien « Comparer cette équipe » sur `/teams/[slug]`.

## Notes techniques
- L'API `/api/rosters` ne renvoyant que `slug/name/budget/tier/naf/positions`, les dimensions qualitatives (difficulté, style, Star Players, résumé) viennent d'une carte curée par slug (`roster-meta.ts`, 30 équipes, parité fr/en).
- `/teams/tier-list` (route statique sans `searchParams`) utilise `dynamic = "force-dynamic"` pour ne pas être prérendue au build sans backend ; le data-cache du fetch reste à 3600 s.

## Plan de test
- [x] Builders/helpers purs testés (vitest) : `matchup`, `comparison-structured-data`, `tier-list-structured-data`, `comparison-summary`, `roster-meta` (52 tests teams)
- [x] `pnpm --filter @bb/web typecheck` ✓
- [x] `pnpm --filter @bb/web build` (next) ✓ — 3 routes dynamiques (ƒ)
- [x] Suite complète web : 1263 tests ✓
- [x] Captures via stub backend : routes 200, redirect canonique, 404, JSON-LD et `<link rel=canonical>` confirmés

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzP6BhG5kvpvavm8uuL7GX)_